### PR TITLE
auth: unify OAuth on /auth/callback, remove bridge; fix middleware & signin redirect (Ticket 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BSOP
-
+ 
 Plataforma de gestión **multiempresa** construida con **Next.js (App Router)** y **TypeScript**.
 
 [![CI](https://github.com/beto-sudo/BSOP/actions/workflows/ci.yml/badge.svg)](https://github.com/beto-sudo/BSOP/actions/workflows/ci.yml)

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -1,51 +1,25 @@
-"use client";
-
-import { useMemo, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import { supabaseBrowser } from "@/lib/supabaseBrowser";
+'use client';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
 export default function SignInPage() {
-  const qp = useSearchParams();
-  const redirect = useMemo(() => qp.get("redirect") ?? "/", [qp]);
-  const [loading, setLoading] = useState(false);
+  const supabase = createClientComponentClient();
 
-  const onClick = async () => {
-    setLoading(true);
-    const supabase = supabaseBrowser();
+  async function handleSignIn() {
+    // “next” viene del query ?redirect=/ruta (opcional)
+    const params = new URLSearchParams(window.location.search);
+    const next = params.get('redirect') || '/';
+    const origin = window.location.origin;
+    const redirectTo = `${origin}/auth/callback?redirect=${encodeURIComponent(next)}`;
 
-    // Usa SIEMPRE el origen actual para evitar mismatch apex/www/alpha
-    const origin =
-      typeof window !== "undefined"
-        ? window.location.origin
-        : (process.env.NEXT_PUBLIC_APP_URL || "").replace(/\/$/, "");
-
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: "google",
-      options: {
-        flowType: "pkce",
-        redirectTo: `${origin}/auth/bridge?redirect=${encodeURIComponent(redirect)}`,
-        queryParams: { prompt: "select_account" },
-      } as any,
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: { redirectTo }
     });
-
-    if (error) {
-      console.error(error);
-      setLoading(false);
-    }
-  };
+  }
 
   return (
-    <div className="flex min-h-[60vh] items-center justify-center">
-      <div className="rounded-xl border p-8 shadow-sm bg-white">
-        <h1 className="mb-6 text-xl font-semibold">Inicia sesión</h1>
-        <button
-          onClick={onClick}
-          disabled={loading}
-          className="rounded-md bg-black px-4 py-2 text-white disabled:opacity-50"
-        >
-          {loading ? "Redirigiendo…" : "Continuar con Google"}
-        </button>
-      </div>
-    </div>
+    <button onClick={handleSignIn} className="btn btn-primary">
+      Continuar con Google
+    </button>
   );
 }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,44 +1,24 @@
-// app/auth/callback/route.ts
-import { NextResponse, type NextRequest } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 
-function redirectWithError(origin: string, redirect: string, code: string, detail?: string) {
-  const url = new URL("/signin", origin);
-  url.searchParams.set("redirect", redirect || "/");
-  url.searchParams.set("err", code);
-  if (detail) url.searchParams.set("detail", detail.slice(0, 200));
-  return NextResponse.redirect(url);
-}
-
-export async function GET(req: NextRequest) {
+export async function GET(req: Request) {
   const url = new URL(req.url);
-  const redirect = url.searchParams.get("redirect") || "/";
-  const res = NextResponse.redirect(new URL(redirect, url.origin));
+  const redirect = url.searchParams.get('redirect') || '/';
+  const code = url.searchParams.get('code');
 
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => req.cookies.getAll(),
-        setAll: (cookiesToSet) => {
-          cookiesToSet.forEach(({ name, value, options }) =>
-            res.cookies.set(name, value, options)
-          );
-        },
-      },
-    }
-  );
+  if (!code) {
+    // Manejo de error simple (puedes enviar a /signin con msg)
+    return NextResponse.redirect(new URL(`/signin?error=missing_code`, url.origin));
+  }
 
-  const { error } = await supabase.auth.exchangeCodeForSession(req.url);
+  const cookieStore = cookies();
+  const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
   if (error) {
-    return redirectWithError(url.origin, redirect, "oauth", error.message || error.name);
+    return NextResponse.redirect(new URL(`/signin?error=${encodeURIComponent(error.message)}`, url.origin));
   }
 
-  const { data: sessionData, error: sessErr } = await supabase.auth.getSession();
-  if (sessErr || !sessionData?.session) {
-    return redirectWithError(url.origin, redirect, "no_session", sessErr?.message || "No session after exchange");
-  }
-
-  return res;
+  return NextResponse.redirect(new URL(redirect, url.origin));
 }


### PR DESCRIPTION
## Contexto
Unifica la estrategia OAuth en `/auth/callback` (server) y elimina `bridge`. Ajusta `signin` para construir `redirectTo` con `window.location.origin` y limpia excepciones en `middleware`.

## Cambios
- `app/(auth)/signin/page.tsx`: redirectTo con `window.location.origin`.
- `app/auth/callback/route.ts`: exchangeCodeForSession + redirect robusto.
- `middleware.ts`: excepciones públicas y redirección con ?redirect=.
- Eliminado: `/auth/bridge` y referencias/handlers asociados.

## Pruebas
- [ ] Login en `http://localhost:3000` sin loops.
- [ ] Login en `https://staging.bsop.io` sin loops (redirecciona correctamente a `?redirect=`).
- [ ] Acceso a `/signin` ya logueado → redirige a `/`.
- [ ] No se usa `NEXT_PUBLIC_APP_URL` para OAuth.

## Riesgos
- Posibles URLs de callback faltantes en Supabase Auth (agregar si faltan).

## Checklist
- [ ] Solo archivos del Ticket 1.
- [ ] CI/Checks verdes.
- [ ] Preview en Vercel funciona.

