### PR TITLE
feat(rnd): Session selector, i18n ES/EN, dark/light mode

### DIFF
--- a/app/rnd/[id]/page.tsx
+++ b/app/rnd/[id]/page.tsx
@@ -1,6 +1,10 @@
+'use client';
+
 import { notFound } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import councilData from '@/data/rnd-council.json';
 import { Shell, Surface } from '@/components/ui';
+import { useLocale } from '@/lib/i18n';
 
 const memberTone: Record<string, string> = {
   strategist: 'border-amber-300/30 bg-amber-300/8 text-amber-200',
@@ -25,19 +29,21 @@ const priorityTone: Record<string, string> = {
 const statusTone: Record<string, string> = {
   'next-up': 'border-amber-400/30 bg-amber-400/10 text-amber-200',
   planning: 'border-sky-400/30 bg-sky-400/10 text-sky-200',
-  monitoring: 'border-white/15 bg-white/8 text-white/75',
+  monitoring: 'border-[var(--border)] bg-[var(--card)] text-[var(--text)]/75',
   shipped: 'border-emerald-400/30 bg-emerald-400/10 text-emerald-200',
 };
 
 const councilById = Object.fromEntries(councilData.config.council.map((member) => [member.id, member]));
 
-export default async function RndMemoDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const memo = councilData.memos.find((entry) => entry.id === id);
+export default function RndMemoDetailPage() {
+  const params = useParams();
+  const id = params.id as string;
+  const { t, locale } = useLocale();
 
+  const memo = councilData.memos.find((entry) => entry.id === id);
   if (!memo) notFound();
 
-  const lastRun = new Date(memo.runStarted).toLocaleString('en-US', {
+  const lastRun = new Date(memo.runStarted).toLocaleString(locale === 'es' ? 'es-MX' : 'en-US', {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
@@ -49,12 +55,12 @@ export default async function RndMemoDetailPage({ params }: { params: Promise<{ 
     <Shell>
       <section className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <Surface className="overflow-hidden border-amber-300/15 bg-[linear-gradient(180deg,rgba(251,191,36,0.08),rgba(255,255,255,0.02))] p-6 sm:p-8">
-          <div className="text-xs font-semibold uppercase tracking-[0.28em] text-amber-200/80">AI Operations</div>
+          <div className="text-xs font-semibold uppercase tracking-[0.28em] text-amber-200/80">{t('rnd.detail.eyebrow')}</div>
           <div className="mt-4 flex flex-wrap items-start justify-between gap-4">
             <div>
-              <div className="text-sm text-white/45">Memo · {memo.date}</div>
-              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">{memo.title}</h1>
-              <p className="mt-4 max-w-3xl text-sm leading-7 text-white/60 sm:text-base">{memo.summary}</p>
+              <div className="text-sm text-[var(--text)]/45">{t('rnd.detail.memo_label', { date: memo.date })}</div>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--text)] sm:text-4xl">{memo.title}</h1>
+              <p className="mt-4 max-w-3xl text-sm leading-7 text-[var(--muted)] sm:text-base">{memo.summary}</p>
             </div>
             <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium ${badgeTone[memo.status] ?? badgeTone.running}`}>
               {memo.status === 'running' ? <span className="h-2 w-2 animate-pulse rounded-full bg-amber-300" /> : null}
@@ -64,15 +70,15 @@ export default async function RndMemoDetailPage({ params }: { params: Promise<{ 
         </Surface>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          {[
-            ['Last Run', lastRun],
-            ['Next Run', councilData.config.schedule],
-            ['Ideas', `${memo.ideas.length} in this session`],
-            ['Recommendations', `${memo.recommendations.length} ranked outputs`],
-          ].map(([label, value]) => (
-            <Surface key={String(label)} className="p-5">
-              <div className="text-xs uppercase tracking-[0.22em] text-white/35">{label}</div>
-              <div className="mt-3 text-lg font-semibold text-white">{value}</div>
+          {([
+            [t('rnd.detail.stat.last_run'), lastRun],
+            [t('rnd.detail.stat.next_run'), councilData.config.schedule],
+            [t('rnd.detail.stat.ideas'), t('rnd.detail.stat.ideas_val', { count: memo.ideas.length })],
+            [t('rnd.detail.stat.recs'), t('rnd.detail.stat.recs_val', { count: memo.recommendations.length })],
+          ] as [string, string][]).map(([label, value]) => (
+            <Surface key={label} className="p-5">
+              <div className="text-xs uppercase tracking-[0.22em] text-[var(--text)]/35">{label}</div>
+              <div className="mt-3 text-lg font-semibold text-[var(--text)]">{value}</div>
             </Surface>
           ))}
         </div>
@@ -80,32 +86,32 @@ export default async function RndMemoDetailPage({ params }: { params: Promise<{ 
 
       <section className="mt-10 grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <Surface className="p-6">
-          <h2 className="text-xl font-semibold text-white">Full idea list</h2>
-          <p className="mt-2 text-sm text-white/55">Each proposal with attribution, impact/effort scoring, and explicit council voting.</p>
+          <h2 className="text-xl font-semibold text-[var(--text)]">{t('rnd.detail.ideas_title')}</h2>
+          <p className="mt-2 text-sm text-[var(--muted)]">{t('rnd.detail.ideas_desc')}</p>
           <div className="mt-6 space-y-4">
             {memo.ideas.map((idea) => {
               const proposer = councilById[idea.proposedBy];
               return (
-                <div key={idea.id} className="rounded-3xl border border-white/8 bg-white/4 p-5">
+                <div key={idea.id} className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
-                      <div className={`inline-flex rounded-full border px-3 py-1 text-xs font-medium ${memberTone[idea.proposedBy] ?? 'border-white/10 bg-white/5 text-white/70'}`}>
+                      <div className={`inline-flex rounded-full border px-3 py-1 text-xs font-medium ${memberTone[idea.proposedBy] ?? 'border-[var(--border)] bg-[var(--card)] text-[var(--text)]/70'}`}>
                         {proposer?.emoji} {proposer?.name}
                       </div>
-                      <h3 className="mt-3 text-lg font-semibold text-white">{idea.title}</h3>
+                      <h3 className="mt-3 text-lg font-semibold text-[var(--text)]">{idea.title}</h3>
                     </div>
                     <div className="flex flex-wrap gap-2 text-xs">
                       <span className="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1 text-emerald-200">Impact {idea.impact}/10</span>
                       <span className="rounded-full border border-sky-400/20 bg-sky-400/10 px-3 py-1 text-sky-200">Effort {idea.effort}/10</span>
                     </div>
                   </div>
-                  <p className="mt-4 text-sm leading-7 text-white/60">{idea.summary}</p>
+                  <p className="mt-4 text-sm leading-7 text-[var(--muted)]">{idea.summary}</p>
                   <div className="mt-4 grid gap-3 sm:grid-cols-5">
                     {Object.entries(idea.votes).map(([memberId, score]) => (
-                      <div key={memberId} className="rounded-2xl border border-white/8 bg-black/10 px-3 py-3 text-center">
+                      <div key={memberId} className="rounded-2xl border border-[var(--border)] bg-[var(--bg)]/10 px-3 py-3 text-center">
                         <div className="text-lg">{councilById[memberId]?.emoji}</div>
-                        <div className="mt-2 text-[11px] uppercase tracking-[0.18em] text-white/35">{councilById[memberId]?.name}</div>
-                        <div className="mt-1 text-sm font-medium text-white/85">{score}/10</div>
+                        <div className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[var(--text)]/35">{councilById[memberId]?.name}</div>
+                        <div className="mt-1 text-sm font-medium text-[var(--text)]/85">{score}/10</div>
                       </div>
                     ))}
                   </div>
@@ -116,23 +122,23 @@ export default async function RndMemoDetailPage({ params }: { params: Promise<{ 
         </Surface>
 
         <Surface className="p-6">
-          <h2 className="text-xl font-semibold text-white">Scoring matrix</h2>
-          <p className="mt-2 text-sm text-white/55">Impact versus effort to show which ideas are attractive now versus later.</p>
+          <h2 className="text-xl font-semibold text-[var(--text)]">{t('rnd.detail.scoring_title')}</h2>
+          <p className="mt-2 text-sm text-[var(--muted)]">{t('rnd.detail.scoring_desc')}</p>
           <div className="mt-6 grid grid-cols-[88px_repeat(10,minmax(0,1fr))] gap-2 text-xs">
             <div />
             {Array.from({ length: 10 }, (_, index) => (
-              <div key={`x-${index + 1}`} className="text-center text-white/35">{index + 1}</div>
+              <div key={`x-${index + 1}`} className="text-center text-[var(--text)]/35">{index + 1}</div>
             ))}
             {Array.from({ length: 10 }, (_, rowIndex) => {
               const impact = 10 - rowIndex;
               return (
                 <>
-                  <div key={`y-${impact}`} className="flex items-center text-white/35">Impact {impact}</div>
+                  <div key={`y-${impact}`} className="flex items-center text-[var(--text)]/35">{t('rnd.detail.impact_label', { n: impact })}</div>
                   {Array.from({ length: 10 }, (_, colIndex) => {
                     const effort = colIndex + 1;
                     const match = memo.ideas.find((idea) => idea.impact === impact && idea.effort === effort);
                     return (
-                      <div key={`${impact}-${effort}`} className="flex aspect-square items-center justify-center rounded-2xl border border-white/8 bg-black/10 p-1 text-center">
+                      <div key={`${impact}-${effort}`} className="flex aspect-square items-center justify-center rounded-2xl border border-[var(--border)] bg-[var(--bg)]/10 p-1 text-center">
                         {match ? (
                           <div className="rounded-xl border border-amber-300/20 bg-amber-300/12 px-2 py-1 text-[10px] font-medium text-amber-100">
                             {match.title.split(' ').slice(0, 2).join(' ')}
@@ -145,13 +151,13 @@ export default async function RndMemoDetailPage({ params }: { params: Promise<{ 
               );
             })}
           </div>
-          <div className="mt-4 text-right text-xs uppercase tracking-[0.2em] text-white/35">Effort →</div>
+          <div className="mt-4 text-right text-xs uppercase tracking-[0.2em] text-[var(--text)]/35">{t('rnd.detail.effort_arrow')}</div>
 
           <div className="mt-8 grid gap-3 sm:grid-cols-2">
             {Object.entries(memo.scores).map(([label, value]) => (
-              <div key={label} className="rounded-2xl border border-white/8 bg-white/4 px-4 py-4">
-                <div className="text-xs uppercase tracking-[0.2em] text-white/35">{label.replace(/([A-Z])/g, ' $1').trim()}</div>
-                <div className="mt-2 text-2xl font-semibold text-white">{Number(value).toFixed(1)}</div>
+              <div key={label} className="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-4 py-4">
+                <div className="text-xs uppercase tracking-[0.2em] text-[var(--text)]/35">{label.replace(/([A-Z])/g, ' $1').trim()}</div>
+                <div className="mt-2 text-2xl font-semibold text-[var(--text)]">{Number(value).toFixed(1)}</div>
               </div>
             ))}
           </div>
@@ -160,25 +166,25 @@ export default async function RndMemoDetailPage({ params }: { params: Promise<{ 
 
       <section className="mt-10 grid gap-6 xl:grid-cols-[1fr_1fr]">
         <Surface className="p-6">
-          <h2 className="text-xl font-semibold text-white">Debate transcript</h2>
-          <p className="mt-2 text-sm text-white/55">Collapsible round-by-round discussion thread from the council.</p>
+          <h2 className="text-xl font-semibold text-[var(--text)]">{t('rnd.detail.debate_title')}</h2>
+          <p className="mt-2 text-sm text-[var(--muted)]">{t('rnd.detail.debate_desc')}</p>
           <div className="mt-6 space-y-4">
             {memo.debate.map((round, index) => (
-              <details key={round.round} className="group rounded-3xl border border-white/8 bg-white/4 p-5" open={index === 0}>
+              <details key={round.round} className="group rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5" open={index === 0}>
                 <summary className="cursor-pointer list-none">
                   <div className="flex items-center justify-between gap-4">
                     <div>
-                      <div className="text-xs uppercase tracking-[0.2em] text-white/35">Round {round.round}</div>
-                      <div className="mt-2 text-lg font-semibold text-white">{round.topic}</div>
+                      <div className="text-xs uppercase tracking-[0.2em] text-[var(--text)]/35">{t('rnd.detail.round_label', { n: round.round })}</div>
+                      <div className="mt-2 text-lg font-semibold text-[var(--text)]">{round.topic}</div>
                     </div>
                     <div className="text-sm text-amber-300 transition group-open:rotate-90">›</div>
                   </div>
                 </summary>
-                <div className="mt-5 space-y-3 border-t border-white/8 pt-5">
+                <div className="mt-5 space-y-3 border-t border-[var(--border)] pt-5">
                   {round.highlights.map((entry, highlightIndex) => (
-                    <div key={`${round.round}-${highlightIndex}`} className="rounded-2xl border border-white/6 bg-black/10 px-4 py-4">
-                      <div className="text-sm font-medium text-white">{councilById[entry.speaker]?.emoji} {councilById[entry.speaker]?.name}</div>
-                      <p className="mt-2 text-sm leading-7 text-white/60">{entry.message}</p>
+                    <div key={`${round.round}-${highlightIndex}`} className="rounded-2xl border border-[var(--border)] bg-[var(--bg)]/10 px-4 py-4">
+                      <div className="text-sm font-medium text-[var(--text)]">{councilById[entry.speaker]?.emoji} {councilById[entry.speaker]?.name}</div>
+                      <p className="mt-2 text-sm leading-7 text-[var(--muted)]">{entry.message}</p>
                     </div>
                   ))}
                 </div>
@@ -188,26 +194,26 @@ export default async function RndMemoDetailPage({ params }: { params: Promise<{ 
         </Surface>
 
         <Surface className="p-6">
-          <h2 className="text-xl font-semibold text-white">Recommendations & implementation status</h2>
-          <p className="mt-2 text-sm text-white/55">Priority-ranked actions with clear ownership and current execution posture.</p>
+          <h2 className="text-xl font-semibold text-[var(--text)]">{t('rnd.detail.recs_title')}</h2>
+          <p className="mt-2 text-sm text-[var(--muted)]">{t('rnd.detail.recs_desc')}</p>
           <div className="mt-6 space-y-4">
             {memo.recommendations.map((recommendation, index) => (
-              <div key={recommendation.id} className="rounded-3xl border border-white/8 bg-white/4 p-5">
+              <div key={recommendation.id} className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
-                    <div className="text-sm text-white/45">#{index + 1}</div>
-                    <h3 className="mt-2 text-lg font-semibold text-white">{recommendation.title}</h3>
+                    <div className="text-sm text-[var(--text)]/45">{t('rnd.detail.rec_n', { n: index + 1 })}</div>
+                    <h3 className="mt-2 text-lg font-semibold text-[var(--text)]">{recommendation.title}</h3>
                   </div>
                   <div className="flex flex-wrap gap-2">
                     <span className={`rounded-full border px-3 py-1 text-xs font-medium ${priorityTone[recommendation.priority] ?? priorityTone.P2}`}>{recommendation.priority}</span>
                     <span className={`rounded-full border px-3 py-1 text-xs font-medium ${statusTone[recommendation.implementationStatus] ?? statusTone.monitoring}`}>{recommendation.implementationStatus}</span>
                   </div>
                 </div>
-                <p className="mt-3 text-sm leading-7 text-white/60">{recommendation.rationale}</p>
-                <div className="mt-4 text-sm text-white/75">Owner: <span className="text-white">{recommendation.owner}</span></div>
+                <p className="mt-3 text-sm leading-7 text-[var(--muted)]">{recommendation.rationale}</p>
+                <div className="mt-4 text-sm text-[var(--text)]/75">{t('rnd.detail.owner')} <span className="text-[var(--text)]">{recommendation.owner}</span></div>
                 <div className="mt-5 space-y-2">
                   {recommendation.actionItems.map((item, itemIndex) => (
-                    <div key={item} className="flex items-start gap-3 rounded-2xl border border-white/6 bg-black/10 px-4 py-3 text-sm text-white/60">
+                    <div key={item} className="flex items-start gap-3 rounded-2xl border border-[var(--border)] bg-[var(--bg)]/10 px-4 py-3 text-sm text-[var(--muted)]">
                       <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full border border-amber-300/20 bg-amber-300/10 text-[11px] font-medium text-amber-200">{itemIndex + 1}</span>
                       <span>{item}</span>
                     </div>

--- a/app/rnd/page.tsx
+++ b/app/rnd/page.tsx
@@ -1,6 +1,10 @@
+'use client';
+
+import { useState } from 'react';
 import Link from 'next/link';
 import councilData from '@/data/rnd-council.json';
 import { SectionHeading, Shell, Surface } from '@/components/ui';
+import { useLocale } from '@/lib/i18n';
 
 const memberTone: Record<string, string> = {
   strategist: 'border-amber-300/30 bg-amber-300/8',
@@ -23,35 +27,41 @@ const priorityTone: Record<string, string> = {
 };
 
 const councilById = Object.fromEntries(councilData.config.council.map((member) => [member.id, member]));
-const latestMemo = councilData.memos[0];
-const lastRun = new Date(latestMemo.runStarted).toLocaleString('en-US', {
-  month: 'short',
-  day: 'numeric',
-  hour: 'numeric',
-  minute: '2-digit',
-});
 
 export default function RndCouncilPage() {
+  const { t, locale } = useLocale();
+  const [selectedMemoId, setSelectedMemoId] = useState(councilData.memos[0].id);
+
+  const selectedMemo = councilData.memos.find((m) => m.id === selectedMemoId) ?? councilData.memos[0];
+  const isLatest = selectedMemoId === councilData.memos[0].id;
+
+  const lastRun = new Date(selectedMemo.runStarted).toLocaleString(locale === 'es' ? 'es-MX' : 'en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
   return (
     <Shell>
       <section className="relative overflow-hidden rounded-[2rem] border border-amber-300/15 bg-[linear-gradient(180deg,rgba(251,191,36,0.08),rgba(255,255,255,0.02))] p-6 sm:p-8">
         <div className="absolute inset-y-0 right-0 w-1/2 bg-[radial-gradient(circle_at_top_right,rgba(251,191,36,0.15),transparent_55%)]" />
         <div className="relative grid gap-8 xl:grid-cols-[1.15fr_0.85fr]">
           <SectionHeading
-            eyebrow="AI Operations"
-            title="R&D Council"
-            copy="An autonomous research team of five AI models that pressure-test ideas, argue from different angles, and turn debate into clear operating memos for BSOP and the businesses around it."
+            eyebrow={t('rnd.eyebrow')}
+            title={t('rnd.title')}
+            copy={t('rnd.copy')}
           />
           <div className="grid gap-4 sm:grid-cols-2">
-            {[
-              ['Last Run', lastRun],
-              ['Next Run', councilData.config.schedule],
-              ['Coverage', `${councilData.config.scope.length} focus areas`],
-              ['Council Size', `${councilData.config.council.length} models`],
-            ].map(([label, value]) => (
-              <Surface key={String(label)} className="border-amber-300/15 bg-black/20 p-5">
-                <div className="text-xs uppercase tracking-[0.24em] text-white/35">{label}</div>
-                <div className="mt-3 text-lg font-semibold text-white">{value}</div>
+            {([
+              [t('rnd.stat.last_run'), lastRun],
+              [t('rnd.stat.next_run'), councilData.config.schedule],
+              [t('rnd.stat.coverage'), t('rnd.stat.focus_areas', { count: councilData.config.scope.length })],
+              [t('rnd.stat.council_size'), t('rnd.stat.models', { count: councilData.config.council.length })],
+            ] as [string, string][]).map(([label, value]) => (
+              <Surface key={label} className="border-amber-300/15 bg-[var(--bg)]/20 p-5">
+                <div className="text-xs uppercase tracking-[0.24em] text-[var(--text)]/35">{label}</div>
+                <div className="mt-3 text-lg font-semibold text-[var(--text)]">{value}</div>
               </Surface>
             ))}
           </div>
@@ -60,34 +70,34 @@ export default function RndCouncilPage() {
 
       <section className="mt-10">
         <div className="mb-4">
-          <h2 className="text-xl font-semibold text-white">Council members</h2>
-          <p className="mt-2 text-sm text-white/55">Five lenses, one memo: strategy, engineering, analysis, criticism, and synthesis.</p>
+          <h2 className="text-xl font-semibold text-[var(--text)]">{t('rnd.members.title')}</h2>
+          <p className="mt-2 text-sm text-[var(--muted)]">{t('rnd.members.desc')}</p>
         </div>
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
           {councilData.config.council.map((member) => (
-            <Surface key={member.id} className={`p-5 ${memberTone[member.id] ?? 'border-white/10 bg-white/4'}`}>
+            <Surface key={member.id} className={`p-5 ${memberTone[member.id] ?? 'border-[var(--border)] bg-[var(--card)]'}`}>
               <div className="flex items-center justify-between gap-3">
                 <div className="text-3xl">{member.emoji}</div>
-                <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/75">{member.model}</div>
+                <div className="rounded-full border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-xs font-medium text-[var(--text)]/75">{member.model}</div>
               </div>
-              <h3 className="mt-4 text-lg font-semibold text-white">{member.name}</h3>
-              <p className="mt-3 text-sm leading-7 text-white/60">{member.role}</p>
+              <h3 className="mt-4 text-lg font-semibold text-[var(--text)]">{member.name}</h3>
+              <p className="mt-3 text-sm leading-7 text-[var(--muted)]">{member.role}</p>
             </Surface>
           ))}
         </div>
       </section>
 
       <section className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {[
-          ['Total sessions', String(councilData.stats.totalSessions), 'Council runs recorded'],
-          ['Ideas generated', String(councilData.stats.totalIdeas), 'Across all sessions'],
-          ['Implemented ideas', String(councilData.stats.implementedIdeas), 'Moved into execution'],
-          ['Avg impact score', councilData.stats.avgScore.toFixed(1), 'Council-weighted average'],
-        ].map(([label, value, sub]) => (
-          <Surface key={String(label)} className="p-5">
-            <div className="text-xs uppercase tracking-[0.24em] text-white/35">{label}</div>
-            <div className="mt-3 text-3xl font-semibold text-white">{value}</div>
-            <div className="mt-2 text-sm text-white/55">{sub}</div>
+        {([
+          [t('rnd.stats.total_sessions'), String(councilData.stats.totalSessions), t('rnd.stats.total_sessions_sub')],
+          [t('rnd.stats.ideas'), String(councilData.stats.totalIdeas), t('rnd.stats.ideas_sub')],
+          [t('rnd.stats.implemented'), String(councilData.stats.implementedIdeas), t('rnd.stats.implemented_sub')],
+          [t('rnd.stats.avg_score'), councilData.stats.avgScore.toFixed(1), t('rnd.stats.avg_score_sub')],
+        ] as [string, string, string][]).map(([label, value, sub]) => (
+          <Surface key={label} className="p-5">
+            <div className="text-xs uppercase tracking-[0.24em] text-[var(--text)]/35">{label}</div>
+            <div className="mt-3 text-3xl font-semibold text-[var(--text)]">{value}</div>
+            <div className="mt-2 text-sm text-[var(--muted)]">{sub}</div>
           </Surface>
         ))}
       </section>
@@ -95,32 +105,32 @@ export default function RndCouncilPage() {
       <section className="mt-10 grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
         <div>
           <div className="mb-4">
-            <h2 className="text-xl font-semibold text-white">Memo archive</h2>
-            <p className="mt-2 text-sm text-white/55">Every council run is stored as a strategic memo with ideas, debate rounds, and ranked recommendations.</p>
+            <h2 className="text-xl font-semibold text-[var(--text)]">{t('rnd.archive.title')}</h2>
+            <p className="mt-2 text-sm text-[var(--muted)]">{t('rnd.archive.desc')}</p>
           </div>
           <div className="space-y-4">
             {councilData.memos.map((memo) => (
               <Link key={memo.id} href={`/rnd/${memo.id}`}>
-                <Surface className="p-5 transition hover:border-amber-300/30 hover:bg-white/6">
+                <Surface className="p-5 transition hover:border-amber-300/30 hover:bg-[var(--card)]">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
-                      <div className="text-xs uppercase tracking-[0.22em] text-white/35">{memo.date}</div>
-                      <h3 className="mt-2 text-lg font-semibold text-white">{memo.title}</h3>
+                      <div className="text-xs uppercase tracking-[0.22em] text-[var(--text)]/35">{memo.date}</div>
+                      <h3 className="mt-2 text-lg font-semibold text-[var(--text)]">{memo.title}</h3>
                     </div>
                     <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium ${badgeTone[memo.status] ?? badgeTone.running}`}>
                       {memo.status === 'running' ? <span className="h-2 w-2 animate-pulse rounded-full bg-amber-300" /> : null}
                       {memo.status}
                     </span>
                   </div>
-                  <p className="mt-4 text-sm leading-7 text-white/60">{memo.summary}</p>
+                  <p className="mt-4 text-sm leading-7 text-[var(--muted)]">{memo.summary}</p>
                   <div className="mt-5 grid gap-3 sm:grid-cols-2">
-                    <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3">
-                      <div className="text-xs uppercase tracking-[0.2em] text-white/35">Ideas</div>
-                      <div className="mt-2 text-sm font-medium text-white/80">{memo.ideas.length} proposals</div>
+                    <div className="rounded-2xl border border-[var(--border)] bg-[var(--bg)]/10 px-4 py-3">
+                      <div className="text-xs uppercase tracking-[0.2em] text-[var(--text)]/35">{t('rnd.archive.ideas')}</div>
+                      <div className="mt-2 text-sm font-medium text-[var(--text)]/80">{t('rnd.archive.proposals', { count: memo.ideas.length })}</div>
                     </div>
-                    <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3">
-                      <div className="text-xs uppercase tracking-[0.2em] text-white/35">Recommendations</div>
-                      <div className="mt-2 text-sm font-medium text-white/80">{memo.recommendations.length} ranked actions</div>
+                    <div className="rounded-2xl border border-[var(--border)] bg-[var(--bg)]/10 px-4 py-3">
+                      <div className="text-xs uppercase tracking-[0.2em] text-[var(--text)]/35">{t('rnd.archive.recommendations')}</div>
+                      <div className="mt-2 text-sm font-medium text-[var(--text)]/80">{t('rnd.archive.ranked', { count: memo.recommendations.length })}</div>
                     </div>
                   </div>
                 </Surface>
@@ -130,51 +140,75 @@ export default function RndCouncilPage() {
         </div>
 
         <div>
-          <div className="mb-4 flex items-center justify-between gap-4">
-            <div>
-              <h2 className="text-xl font-semibold text-white">Latest memo</h2>
-              <p className="mt-2 text-sm text-white/55">Expanded by default while the council is still in session.</p>
+          <div className="mb-4">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h2 className="text-xl font-semibold text-[var(--text)]">
+                  {isLatest ? t('rnd.latest.title') : t('rnd.selected.title')}
+                </h2>
+                <p className="mt-2 text-sm text-[var(--muted)]">
+                  {isLatest ? t('rnd.latest.desc') : t('rnd.selected.desc')}
+                </p>
+              </div>
+              <Link href={`/rnd/${selectedMemo.id}`} className="shrink-0 text-sm font-medium text-amber-300 transition hover:text-[var(--text)]">
+                {t('rnd.latest.open')}
+              </Link>
             </div>
-            <Link href={`/rnd/${latestMemo.id}`} className="text-sm font-medium text-amber-300 transition hover:text-white">
-              Open full memo →
-            </Link>
+            <div className="mt-3 flex items-center gap-3">
+              <label htmlFor="memo-selector" className="text-xs uppercase tracking-[0.2em] text-[var(--text)]/35">
+                {t('rnd.selector.label')}
+              </label>
+              <select
+                id="memo-selector"
+                value={selectedMemoId}
+                onChange={(e) => setSelectedMemoId(e.target.value)}
+                className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-sm text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-amber-300/30"
+              >
+                {councilData.memos.map((memo) => (
+                  <option key={memo.id} value={memo.id}>
+                    {memo.date} — {memo.title}
+                  </option>
+                ))}
+              </select>
+            </div>
           </div>
+
           <Surface className="overflow-hidden p-6">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <div className="text-xs uppercase tracking-[0.22em] text-white/35">{latestMemo.date}</div>
-                <h3 className="mt-2 text-2xl font-semibold text-white">{latestMemo.title}</h3>
+                <div className="text-xs uppercase tracking-[0.22em] text-[var(--text)]/35">{selectedMemo.date}</div>
+                <h3 className="mt-2 text-2xl font-semibold text-[var(--text)]">{selectedMemo.title}</h3>
               </div>
-              <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium ${badgeTone[latestMemo.status] ?? badgeTone.running}`}>
+              <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium ${badgeTone[selectedMemo.status] ?? badgeTone.running}`}>
                 <span className="h-2 w-2 animate-pulse rounded-full bg-amber-300" />
-                {latestMemo.status}
+                {selectedMemo.status}
               </span>
             </div>
 
             <section className="mt-8">
-              <h4 className="text-sm font-semibold uppercase tracking-[0.22em] text-white/45">Ideas in play</h4>
+              <h4 className="text-sm font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">{t('rnd.memo.ideas_section')}</h4>
               <div className="mt-4 space-y-4">
-                {latestMemo.ideas.map((idea) => {
+                {selectedMemo.ideas.map((idea) => {
                   const proposer = councilById[idea.proposedBy];
                   return (
-                    <div key={idea.id} className="rounded-3xl border border-white/8 bg-white/4 p-5">
+                    <div key={idea.id} className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5">
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div>
                           <div className="text-sm text-amber-300">{proposer?.emoji} {proposer?.name}</div>
-                          <h5 className="mt-2 text-lg font-semibold text-white">{idea.title}</h5>
+                          <h5 className="mt-2 text-lg font-semibold text-[var(--text)]">{idea.title}</h5>
                         </div>
-                        <div className="flex gap-2 text-xs text-white/70">
-                          <span className="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1">Impact {idea.impact}/10</span>
-                          <span className="rounded-full border border-sky-400/20 bg-sky-400/10 px-3 py-1">Effort {idea.effort}/10</span>
+                        <div className="flex gap-2 text-xs text-[var(--text)]/70">
+                          <span className="rounded-full border border-emerald-400/20 bg-emerald-400/10 px-3 py-1">{t('rnd.memo.impact', { score: idea.impact })}</span>
+                          <span className="rounded-full border border-sky-400/20 bg-sky-400/10 px-3 py-1">{t('rnd.memo.effort', { score: idea.effort })}</span>
                         </div>
                       </div>
-                      <p className="mt-3 text-sm leading-7 text-white/60">{idea.summary}</p>
+                      <p className="mt-3 text-sm leading-7 text-[var(--muted)]">{idea.summary}</p>
                       <div className="mt-4 grid gap-3 sm:grid-cols-5">
                         {Object.entries(idea.votes).map(([memberId, score]) => (
-                          <div key={memberId} className="rounded-2xl border border-white/8 bg-black/10 px-3 py-3 text-center">
+                          <div key={memberId} className="rounded-2xl border border-[var(--border)] bg-[var(--bg)]/10 px-3 py-3 text-center">
                             <div className="text-lg">{councilById[memberId]?.emoji}</div>
-                            <div className="mt-2 text-[11px] uppercase tracking-[0.18em] text-white/35">Vote</div>
-                            <div className="mt-1 text-sm font-medium text-white/85">{score}/10</div>
+                            <div className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[var(--text)]/35">{t('rnd.memo.vote')}</div>
+                            <div className="mt-1 text-sm font-medium text-[var(--text)]/85">{score}/10</div>
                           </div>
                         ))}
                       </div>
@@ -185,16 +219,16 @@ export default function RndCouncilPage() {
             </section>
 
             <section className="mt-8">
-              <h4 className="text-sm font-semibold uppercase tracking-[0.22em] text-white/45">Debate highlights</h4>
+              <h4 className="text-sm font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">{t('rnd.memo.debate_section')}</h4>
               <div className="mt-4 space-y-4">
-                {latestMemo.debate.map((round) => (
-                  <div key={round.round} className="rounded-3xl border border-white/8 bg-black/10 p-5">
-                    <div className="text-xs uppercase tracking-[0.2em] text-white/35">Round {round.round} · {round.topic}</div>
+                {selectedMemo.debate.map((round) => (
+                  <div key={round.round} className="rounded-3xl border border-[var(--border)] bg-[var(--bg)]/10 p-5">
+                    <div className="text-xs uppercase tracking-[0.2em] text-[var(--text)]/35">{t('rnd.memo.round', { n: round.round, topic: round.topic })}</div>
                     <div className="mt-4 space-y-3">
                       {round.highlights.map((entry, index) => (
-                        <div key={`${round.round}-${index}`} className="rounded-2xl border border-white/6 bg-white/4 px-4 py-3">
-                          <div className="text-sm font-medium text-white">{councilById[entry.speaker]?.emoji} {councilById[entry.speaker]?.name}</div>
-                          <p className="mt-2 text-sm leading-7 text-white/60">{entry.message}</p>
+                        <div key={`${round.round}-${index}`} className="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-4 py-3">
+                          <div className="text-sm font-medium text-[var(--text)]">{councilById[entry.speaker]?.emoji} {councilById[entry.speaker]?.name}</div>
+                          <p className="mt-2 text-sm leading-7 text-[var(--muted)]">{entry.message}</p>
                         </div>
                       ))}
                     </div>
@@ -204,22 +238,22 @@ export default function RndCouncilPage() {
             </section>
 
             <section className="mt-8">
-              <h4 className="text-sm font-semibold uppercase tracking-[0.22em] text-white/45">Ranked recommendations</h4>
+              <h4 className="text-sm font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">{t('rnd.memo.recs_section')}</h4>
               <div className="mt-4 space-y-4">
-                {latestMemo.recommendations.map((recommendation, index) => (
-                  <div key={recommendation.id} className="rounded-3xl border border-white/8 bg-white/4 p-5">
+                {selectedMemo.recommendations.map((recommendation, index) => (
+                  <div key={recommendation.id} className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-5">
                     <div className="flex flex-wrap items-start justify-between gap-3">
                       <div>
-                        <div className="text-sm text-white/45">Recommendation #{index + 1}</div>
-                        <h5 className="mt-2 text-lg font-semibold text-white">{recommendation.title}</h5>
+                        <div className="text-sm text-[var(--text)]/45">{t('rnd.memo.rec_n', { n: index + 1 })}</div>
+                        <h5 className="mt-2 text-lg font-semibold text-[var(--text)]">{recommendation.title}</h5>
                       </div>
                       <span className={`rounded-full border px-3 py-1 text-xs font-medium ${priorityTone[recommendation.priority] ?? priorityTone.P2}`}>{recommendation.priority}</span>
                     </div>
-                    <p className="mt-3 text-sm leading-7 text-white/60">{recommendation.rationale}</p>
-                    <div className="mt-4 text-sm text-white/75">Owner: <span className="text-white">{recommendation.owner}</span></div>
-                    <ul className="mt-4 space-y-2 text-sm text-white/60">
+                    <p className="mt-3 text-sm leading-7 text-[var(--muted)]">{recommendation.rationale}</p>
+                    <div className="mt-4 text-sm text-[var(--text)]/75">{t('rnd.memo.owner')} <span className="text-[var(--text)]">{recommendation.owner}</span></div>
+                    <ul className="mt-4 space-y-2 text-sm text-[var(--muted)]">
                       {recommendation.actionItems.map((item) => (
-                        <li key={item} className="flex gap-3 rounded-2xl border border-white/6 bg-black/10 px-4 py-3">
+                        <li key={item} className="flex gap-3 rounded-2xl border border-[var(--border)] bg-[var(--bg)]/10 px-4 py-3">
                           <span className="text-amber-300">•</span>
                           <span>{item}</span>
                         </li>

--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -18,8 +18,8 @@ export function SectionHeading({
   return (
     <div className="mb-8 max-w-3xl">
       <div className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-[var(--accent-soft)]">{eyebrow}</div>
-      <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">{title}</h1>
-      <p className="mt-3 text-sm leading-7 text-white/60 sm:text-base">{copy}</p>
+      <h1 className="text-3xl font-semibold tracking-tight text-[var(--text)] sm:text-4xl">{title}</h1>
+      <p className="mt-3 text-sm leading-7 text-[var(--muted)] sm:text-base">{copy}</p>
     </div>
   );
 }
@@ -54,12 +54,12 @@ export function PlaceholderSection({
           Under Construction
         </div>
         <div className="mt-6 flex items-start gap-4">
-          <div className="flex h-16 w-16 items-center justify-center rounded-3xl border border-[var(--border)] bg-white/5 text-3xl">
+          <div className="flex h-16 w-16 items-center justify-center rounded-3xl border border-[var(--border)] bg-[var(--card)] text-3xl">
             {icon}
           </div>
           <div>
-            <h1 className="text-3xl font-semibold text-white sm:text-4xl">{title}</h1>
-            <p className="mt-3 max-w-2xl text-sm leading-7 text-white/60 sm:text-base">{description}</p>
+            <h1 className="text-3xl font-semibold text-[var(--text)] sm:text-4xl">{title}</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-[var(--muted)] sm:text-base">{description}</p>
           </div>
         </div>
       </Surface>


### PR DESCRIPTION
## Cambios

### 1. Selector de sesiones
- Dropdown en la página principal del R&D Council para navegar entre todos los memos anteriores
- La sección derecha muestra el memo seleccionado (no solo el último)
- Preparado para cuando haya múltiples sesiones en el JSON

### 2. Internacionalización (ES/EN)
- Toggle de idioma en el header (ES | EN)
- Sistema simple con React Context + diccionarios JSON (`lib/i18n.tsx`)
- Diccionarios completos en `lib/locales/es.json` y `en.json`
- Default: español
- Persistencia en localStorage
- Toda la UI del R&D Council y app-shell traducida

### 3. Dark/Light mode
- Toggle de tema en el header (sol/luna)
- Integración con `next-themes`
- Variables CSS para ambos modos en `globals.css`
- Paleta light nueva: fondo claro, cards blancos, texto oscuro
- Dark mode mantiene exactamente el mismo look actual
- Persistencia en localStorage

### Archivos modificados
- 12 archivos, +595 / -211 líneas
- Build compila limpio (29 páginas estáticas)