### PR TITLE
chore(types): scaffold typed Supabase database types + auto-regen workflow

### DIFF
--- a/.github/workflows/db-types.yml
+++ b/.github/workflows/db-types.yml
@@ -1,0 +1,112 @@
+name: DB Types
+
+# Regenera `types/supabase.ts` a partir del esquema real de Supabase.
+#
+# Se ejecuta:
+#   - Manualmente desde la pestaña Actions (workflow_dispatch)
+#   - Automáticamente cada lunes a las 07:00 UTC (como red de seguridad)
+#
+# Cuando detecta cambios en los tipos, abre un PR automático a `main`.
+#
+# Requisitos:
+#   - Secret SUPABASE_ACCESS_TOKEN (Personal Access Token de Supabase)
+#     Generar en: https://supabase.com/dashboard/account/tokens
+#     Configurar en: Settings -> Secrets and variables -> Actions
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 1'
+
+concurrency:
+  group: db-types-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    name: Regenerate supabase types
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      SUPABASE_PROJECT_REF: ybklderteyhuugzfmxbi
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Generate TypeScript types (all schemas)
+        run: |
+          supabase gen types typescript \
+            --project-id "$SUPABASE_PROJECT_REF" \
+            --schema public \
+            --schema core \
+            --schema erp \
+            --schema rdb \
+            --schema dilesa \
+            --schema playtomic \
+            > types/supabase.ts.new
+
+          # Anteponer header con metadatos
+          {
+            echo "// =============================================================================="
+            echo "// Auto-generated Supabase database types."
+            echo "// Last regenerated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo "// Project ref: $SUPABASE_PROJECT_REF"
+            echo "// Schemas: public, core, erp, rdb, dilesa, playtomic"
+            echo "//"
+            echo "// DO NOT EDIT BY HAND. Regenerate via:"
+            echo "//   - GitHub Actions: trigger 'DB Types' workflow manually"
+            echo "//   - Local: npm run db:types (requiere supabase CLI + SUPABASE_ACCESS_TOKEN)"
+            echo "// =============================================================================="
+            echo ""
+            cat types/supabase.ts.new
+          } > types/supabase.ts
+
+          rm types/supabase.ts.new
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet types/supabase.ts; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes in supabase types."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Supabase types changed."
+          fi
+
+      - name: Create Pull Request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/supabase-types-autogen
+          base: main
+          commit-message: 'chore(types): regenerate supabase database types'
+          title: 'chore(types): regenerate supabase database types'
+          body: |
+            Automated regeneration of `types/supabase.ts` from the live Supabase schema.
+
+            **Schemas incluidos:** public, core, erp, rdb, dilesa, playtomic
+
+            Este PR lo abrió el workflow `.github/workflows/db-types.yml`.
+            Revisa el diff con cuidado antes de mergear — cualquier cambio aquí
+            refleja un cambio real en la base de datos.
+          labels: |
+            automated
+            types
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -67,6 +67,37 @@ npm run dev
 | `npm run test:e2e:anon` | Solo specs anónimas |
 | `npm run test:e2e:auth` | Solo specs autenticadas (requiere `.env.test.local`) |
 | `npm run audit:ui` | Audit heurístico de la UI |
+| `npm run db:types` | Regenera `types/supabase.ts` desde el schema real (requiere supabase CLI + `SUPABASE_ACCESS_TOKEN`) |
+
+---
+
+## Tipos de base de datos
+
+El archivo `types/supabase.ts` es la **única fuente de verdad** para tipar queries y mutaciones contra Supabase en el frontend/backend del app.
+
+- Cubre los schemas: `public`, `core`, `erp`, `rdb`, `dilesa`, `playtomic`.
+- Se consume vía el generic `Database` que se pasa a `createClient<Database>(...)`.
+- **No editar a mano** — se regenera desde el schema real.
+
+### Regenerar los tipos
+
+**Opción A — GitHub Actions (recomendada):**
+
+1. Ir a la pestaña **Actions** → **DB Types** → **Run workflow**.
+2. Si hay cambios vs. la copia en `main`, el workflow abre un PR automático (`chore/supabase-types-autogen`).
+3. Revisar el diff, validar que no haya drift accidental de schema, y mergear.
+
+También corre en schedule semanal (lunes 07:00 UTC) como red de seguridad.
+
+**Opción B — Local:**
+
+```bash
+export SUPABASE_ACCESS_TOKEN=<tu-PAT-de-supabase>
+npm run db:types
+git diff types/supabase.ts    # revisar
+```
+
+Generar el PAT en: https://supabase.com/dashboard/account/tokens
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:report": "playwright show-report",
     "audit:ui": "npx tsx scripts/audit-ui.ts",
     "audit:ui:json": "npx tsx scripts/audit-ui.ts --json",
+    "db:types": "supabase gen types typescript --project-id ybklderteyhuugzfmxbi --schema public --schema core --schema erp --schema rdb --schema dilesa --schema playtomic > types/supabase.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,0 +1,325 @@
+// =============================================================================
+// Supabase TypeScript types — AUTO-GENERATED. DO NOT EDIT BY HAND.
+// =============================================================================
+//
+// Este archivo se regenera a partir del esquema vivo del proyecto Supabase
+// `ybklderteyhuugzfmxbi` (db.ybklderteyhuugzfmxbi.supabase.co).
+//
+// Cómo regenerarlo:
+//
+//   1. En GitHub → Actions → "Supabase Types" → Run workflow.
+//      Requiere el secret `SUPABASE_ACCESS_TOKEN` configurado a nivel repo.
+//      El workflow corre `supabase gen types typescript` contra todos los
+//      esquemas de negocio (core, erp, rdb, dilesa, playtomic, public) y
+//      commitea el resultado si hubo cambios.
+//
+//   2. Localmente (requiere el Supabase CLI):
+//      npm run db:types
+//
+// El contenido inicial de este archivo corresponde SOLO al esquema `public`
+// generado vía la MCP de Supabase. Los esquemas de negocio (core, erp, rdb,
+// dilesa, playtomic) se llenarán en el primer run del workflow.
+// =============================================================================
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: '13.0.4';
+  };
+  public: {
+    Tables: {
+      expense_splits: {
+        Row: {
+          expense_id: string | null;
+          id: string;
+          participant_id: string | null;
+        };
+        Insert: {
+          expense_id?: string | null;
+          id?: string;
+          participant_id?: string | null;
+        };
+        Update: {
+          expense_id?: string | null;
+          id?: string;
+          participant_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'expense_splits_expense_id_fkey';
+            columns: ['expense_id'];
+            isOneToOne: false;
+            referencedRelation: 'trip_expenses';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'expense_splits_participant_id_fkey';
+            columns: ['participant_id'];
+            isOneToOne: false;
+            referencedRelation: 'trip_participants';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      profile: {
+        Row: {
+          avatar_url: string | null;
+          created_at: string | null;
+          email: string;
+          first_name: string | null;
+          id: string;
+          is_active: boolean | null;
+          last_name: string | null;
+          locale: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          avatar_url?: string | null;
+          created_at?: string | null;
+          email?: string;
+          first_name?: string | null;
+          id: string;
+          is_active?: boolean | null;
+          last_name?: string | null;
+          locale?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          avatar_url?: string | null;
+          created_at?: string | null;
+          email?: string;
+          first_name?: string | null;
+          id?: string;
+          is_active?: boolean | null;
+          last_name?: string | null;
+          locale?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
+      user_presence: {
+        Row: {
+          avatar_url: string | null;
+          created_at: string;
+          current_module: string;
+          current_path: string;
+          display_name: string | null;
+          email: string;
+          last_seen_at: string;
+          status: string;
+          user_id: string;
+        };
+        Insert: {
+          avatar_url?: string | null;
+          created_at?: string;
+          current_module?: string;
+          current_path?: string;
+          display_name?: string | null;
+          email: string;
+          last_seen_at?: string;
+          status?: string;
+          user_id: string;
+        };
+        Update: {
+          avatar_url?: string | null;
+          created_at?: string;
+          current_module?: string;
+          current_path?: string;
+          display_name?: string | null;
+          email?: string;
+          last_seen_at?: string;
+          status?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+  // Los siguientes esquemas se llenarán al correr el workflow "Supabase Types".
+  // Por ahora quedan como `never` para que TypeScript no rompa si alguien
+  // referencia el tipo Database antes del primer run.
+  core: {
+    Tables: { [_ in never]: never };
+    Views: { [_ in never]: never };
+    Functions: { [_ in never]: never };
+    Enums: { [_ in never]: never };
+    CompositeTypes: { [_ in never]: never };
+  };
+  erp: {
+    Tables: { [_ in never]: never };
+    Views: { [_ in never]: never };
+    Functions: { [_ in never]: never };
+    Enums: { [_ in never]: never };
+    CompositeTypes: { [_ in never]: never };
+  };
+  rdb: {
+    Tables: { [_ in never]: never };
+    Views: { [_ in never]: never };
+    Functions: { [_ in never]: never };
+    Enums: { [_ in never]: never };
+    CompositeTypes: { [_ in never]: never };
+  };
+  dilesa: {
+    Tables: { [_ in never]: never };
+    Views: { [_ in never]: never };
+    Functions: { [_ in never]: never };
+    Enums: { [_ in never]: never };
+    CompositeTypes: { [_ in never]: never };
+  };
+  playtomic: {
+    Tables: { [_ in never]: never };
+    Views: { [_ in never]: never };
+    Functions: { [_ in never]: never };
+    Enums: { [_ in never]: never };
+    CompositeTypes: { [_ in never]: never };
+  };
+};
+
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>];
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] &
+        DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema['Tables']
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema['Tables']
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema['Enums']
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+    : never;
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema['CompositeTypes']
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+    : never;
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+  core: { Enums: {} },
+  erp: { Enums: {} },
+  rdb: { Enums: {} },
+  dilesa: { Enums: {} },
+  playtomic: { Enums: {} },
+} as const;


### PR DESCRIPTION
## Resumen

Segundo PR del Bloque B (profesionalización). Prepara la infraestructura para tipar queries de Supabase end-to-end, reemplazando el patrón actual `.schema('x' as any).from(...)` que aparece **174 veces en 30 archivos**.

Este PR **no toca código de la app** todavía — es puramente scaffolding + tooling. La migración por módulo viene en PRs siguientes.

## Cambios

### `types/supabase.ts` (nuevo)
- Scaffold del tipo `Database` con el schema `public` real (tablas `expense_splits`, `profile`, `user_presence`) generado vía Supabase MCP.
- Placeholders vacíos (`[_ in never]: never`) para los schemas de negocio: `core`, `erp`, `rdb`, `dilesa`, `playtomic`. Se llenan automáticamente cuando corra el workflow `DB Types` (siguiente punto).
- Exporta los helpers estándar de supabase-js v2: `Tables<>`, `TablesInsert<>`, `TablesUpdate<>`, `Enums<>`, `CompositeTypes<>`.
- Constants export con los 6 schemas.

### `.github/workflows/db-types.yml` (nuevo)
Workflow que regenera `types/supabase.ts` desde el schema real:
- **Trigger manual** (`workflow_dispatch`) — correr desde la pestaña Actions cuando haya cambios de schema.
- **Schedule semanal** (lunes 07:00 UTC) como red de seguridad.
- Corre `supabase gen types typescript` con los 6 schemas (`public, core, erp, rdb, dilesa, playtomic`).
- Si detecta drift vs. `main`, abre un PR automático `chore/supabase-types-autogen` para review.

**Requisito:** secret `SUPABASE_ACCESS_TOKEN` ya configurado en Settings → Secrets and variables → Actions.

### `package.json`
Nuevo script `npm run db:types` para regenerar localmente (requiere supabase CLI instalada + `SUPABASE_ACCESS_TOKEN` en env).

### `README.md`
Nueva sección **"Tipos de base de datos"** documentando:
- Qué cubre `types/supabase.ts` y por qué es la única fuente de verdad.
- Cómo regenerarlos vía GitHub Actions (opción A) o local (opción B).
- Referencia al PAT de Supabase.

## Por qué

1. **Fin del `as any`.** Hoy todo módulo fuera del schema `public` pierde tipado porque no tenemos los tipos de los otros 5 schemas. Esto enmascara drift de schema y bugs de runtime.
2. **MCP no basta.** El `generate_typescript_types` del MCP solo devuelve `public`. Necesitamos CLI con PAT — y desde CI es la única forma escalable.
3. **Sin drift silencioso.** El schedule semanal atrapa cambios de schema que no vinieron por PR (migraciones manuales, etc.).

## Alcance explícito

Este PR **NO** hace:
- ❌ Reemplazar `.schema('x' as any)` en código de la app (viene después, uno por módulo).
- ❌ Cambiar el cliente Supabase (`lib/supabase/*.ts`).
- ❌ Correr el workflow por primera vez — eso se hará como primer merge validation.

## Verificación

- ✅ `npm run typecheck` — pasa.
- ✅ `npm run test:run` — 11/11 tests.
- ✅ Los tipos `public` son correctos (generados desde el schema real).
- ⏳ Post-merge: correr manualmente el workflow **DB Types** desde la pestaña Actions para llenar los 5 schemas pendientes.

## Riesgo

**Muy bajo.** `types/supabase.ts` todavía no es importado por ningún archivo de la app, y el workflow solo se activa manualmente o semanalmente.

## Siguiente paso (B.3)

Primer módulo migrado (sugerido: `rdb`) usando el generic `Database` real. PR separado.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)