### PR TITLE
B.3 — refactor(supabase): type all clients with Database + migrate rdb

### DIFF
--- a/app/api/health/ingest/route.ts
+++ b/app/api/health/ingest/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import type { Json } from '@/types/supabase';
 
 const METRIC_NAME_NORMALIZE: Record<string, string> = {
   resting_heart_rate: 'Resting Heart Rate',
@@ -208,7 +209,7 @@ function normalizeWorkouts(workouts: unknown[]) {
       heart_rate_avg: parseNumber(avgHeartRate?.qty) ?? parseNumber(heartRate?.avg && typeof heartRate.avg === 'object' ? (heartRate.avg as Record<string, unknown>).qty : null),
       heart_rate_max: parseNumber(maxHeartRate?.qty) ?? parseNumber(heartRate?.max && typeof heartRate.max === 'object' ? (heartRate.max as Record<string, unknown>).qty : null),
       source: typeof row.source === 'string' ? row.source : 'Health Auto Export',
-      raw_json: row,
+      raw_json: row as Json,
     }];
   });
 }
@@ -224,7 +225,7 @@ function normalizeEcg(ecg: unknown[]) {
       date,
       classification: typeof row.classification === 'string' ? row.classification : null,
       heart_rate: parseNumber(row.averageHeartRate),
-      raw_json: row,
+      raw_json: row as Json,
     }];
   });
 }
@@ -240,7 +241,7 @@ function normalizeMedications(medications: unknown[]) {
       date,
       name: typeof row.displayText === 'string' ? row.displayText : typeof row.nickname === 'string' ? row.nickname : null,
       dose: row.dosage == null ? null : String(row.dosage),
-      raw_json: row,
+      raw_json: row as Json,
     }];
   });
 }

--- a/app/api/impersonate/route.ts
+++ b/app/api/impersonate/route.ts
@@ -113,7 +113,10 @@ export async function GET(req: NextRequest) {
     for (const perm of rolePerms) {
       const moduloSlug = moduloIdToSlug[perm.modulo_id];
       if (!moduloSlug) continue;
-      modulos[moduloSlug] = { read: perm.acceso_lectura, write: perm.acceso_escritura };
+      modulos[moduloSlug] = {
+        read: perm.acceso_lectura ?? false,
+        write: perm.acceso_escritura ?? false,
+      };
     }
   }
 
@@ -121,7 +124,10 @@ export async function GET(req: NextRequest) {
   for (const exc of userExcepciones) {
     const moduloSlug = moduloIdToSlug[exc.modulo_id];
     if (!moduloSlug) continue;
-    modulos[moduloSlug] = { read: exc.acceso_lectura, write: exc.acceso_escritura };
+    modulos[moduloSlug] = {
+      read: exc.acceso_lectura ?? false,
+      write: exc.acceso_escritura ?? false,
+    };
   }
 
   return NextResponse.json({

--- a/app/rdb/cortes/page.tsx
+++ b/app/rdb/cortes/page.tsx
@@ -668,8 +668,12 @@ export default function CortesPage() {
           .eq('corte_id', corte.id)
           .order('created_at', { ascending: true })
           .limit(100),
+        // TODO(B.1.extra): `rdb.v_cortes_productos` exists in DB (see
+        // supabase/SCHEMA_REF.md) but was not emitted by the types autogen in
+        // PR #10 (likely a grants / SECURITY DEFINER exclusion on the view).
+        // Drop the `as any` once the generator picks it up.
         supabase
-          .schema('rdb')
+          .schema('rdb' as any)
           .from('v_cortes_productos')
           .select('*')
           .eq('corte_id', corte.id)

--- a/app/rdb/requisiciones/actions.ts
+++ b/app/rdb/requisiciones/actions.ts
@@ -244,13 +244,13 @@ export async function generarOrdenCompra(
   if (ocErr) throw new Error(ocErr.message);
   if (!oc) throw new Error('Error al crear la orden de compra');
 
-  // Copy items
+  // Copy items — `reqItems` is typed from the select('*') against erp.requisiciones_detalle
   if (reqItems && reqItems.length > 0) {
     const { error: ocItemsErr } = await supabase
       .schema('erp')
       .from('ordenes_compra_detalle')
       .insert(
-        reqItems.map((item: Record<string, unknown>) => ({
+        reqItems.map((item) => ({
           empresa_id: RDB_EMPRESA_ID,
           orden_compra_id: oc.id,
           producto_id: item.producto_id ?? null,

--- a/app/rdb/ventas/page.tsx
+++ b/app/rdb/ventas/page.tsx
@@ -433,8 +433,12 @@ export default function VentasPage() {
   const fetchCortes = useCallback(async () => {
     try {
       const supabase = createSupabaseBrowserClient();
+      // TODO(B.1.extra): `rdb.cortes` exists in DB (see supabase/SCHEMA_REF.md)
+      // but was not emitted by the types autogen in PR #10 (likely a grants /
+      // SECURITY DEFINER exclusion). Drop the `as any` once the generator picks
+      // it up.
       let query = supabase
-        .schema('rdb')
+        .schema('rdb' as any)
         .from('cortes')
         .select('id, corte_nombre, caja_nombre, hora_inicio, hora_fin, estado')
         .order('hora_inicio', { ascending: false });
@@ -443,7 +447,7 @@ export default function VentasPage() {
       if (dateTo) query = query.lte('hora_inicio', getLocalDayBoundsUtc(dateTo, TZ).end);
 
       const { data } = await query;
-      setCortes(data ?? []);
+      setCortes((data ?? []) as CorteOption[]);
     } catch {
       // non-fatal
     }
@@ -498,18 +502,23 @@ export default function VentasPage() {
 
     try {
       const supabase = createSupabaseBrowserClient();
+      if (!pedido.order_id) {
+        setLoadingDetail(false);
+        return;
+      }
+      const orderId = pedido.order_id;
       const [itemsRes, pagosRes] = await Promise.all([
         supabase
           .schema('rdb')
           .from('waitry_productos')
           .select('*')
-          .eq('order_id', pedido.order_id)
+          .eq('order_id', orderId)
           .limit(50),
         supabase
           .schema('rdb')
           .from('waitry_pagos')
           .select('*')
-          .eq('order_id', pedido.order_id)
+          .eq('order_id', orderId)
           .limit(20),
       ]);
 

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabase';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -8,7 +9,7 @@ export function getSupabaseAdminClient() {
     return null;
   }
 
-  return createClient(supabaseUrl, supabaseServiceRoleKey, {
+  return createClient<Database>(supabaseUrl, supabaseServiceRoleKey, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -1,16 +1,17 @@
 'use client';
 
 import { createBrowserClient } from '@supabase/ssr';
+import type { Database } from '@/types/supabase';
 
 export function createSupabaseBrowserClient() {
-  return createBrowserClient(
+  return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
   );
 }
 
 /**
- * Alias — same singleton client. 
- * Pages that need erp tables must use .schema('erp') explicitly.
+ * Alias — same singleton client.
+ * Pages that need non-public schemas must use .schema('erp'|'rdb'|...) explicitly.
  */
 export const createSupabaseERPClient = createSupabaseBrowserClient;

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,10 +1,11 @@
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
+import type { Database } from '@/types/supabase';
 
 export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
 
-  return createServerClient(
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabase';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -8,7 +9,7 @@ export function getSupabaseClient() {
     return null;
   }
 
-  return createClient(supabaseUrl, supabaseAnonKey, {
+  return createClient<Database>(supabaseUrl, supabaseAnonKey, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,


### PR DESCRIPTION
## Summary

Bloque B.3 — foundation for the multi-schema type safety migration.

### Commit 1 — `refactor(supabase): type clients with Database generic + collateral null-safety`
Applies the `Database` generic to all 4 Supabase client factories so `tsc` can detect drift between code and schema:

- `lib/supabase.ts` — `createClient<Database>` (anon)
- `lib/supabase-admin.ts` — `createClient<Database>` (service role)
- `lib/supabase-browser.ts` — `createBrowserClient<Database>` (SSR)
- `lib/supabase-server.ts` — `createServerClient<Database>` (SSR cookies-aware)

Collateral fixes surfaced by the generic:
- `app/api/impersonate/route.ts` — `acceso_lectura`/`acceso_escritura` are nullable booleans in DB; code assumed non-null. Defaults to `false` with `??` (deny permission on null, safer than silent undefined).
- `app/api/health/ingest/route.ts` — `raw_json` is `Record<string, unknown>` at the normalize boundary but Supabase's recursive `Json` type at insert. Imports `Json` and casts at the boundary.

### Commit 2 — `refactor(rdb): narrow null order_id + infer types on requisitions mapper`
With the clients typed, `tsc` surfaced three classes of drift in the rdb module:

1. **`app/rdb/ventas/page.tsx`** — `pedido.order_id` is `string | null`, failing on `.eq()`. Early-return when null (no order to lookup), then narrow to a non-null local before the two queries.

2. **`app/rdb/requisiciones/actions.ts`** — the mapper was annotated as `(item: Record<string, unknown>)`, which erased the typed result of `select('*')`. Dropping the annotation lets TS infer the Row type, so `producto_id`, `descripcion` and `cantidad` match the `ordenes_compra_detalle` Insert shape.

3. **`rdb.cortes` (table) and `rdb.v_cortes_productos` (view)** — exist in DB per `supabase/SCHEMA_REF.md` but were **not** emitted by the types autogen in PR #10 — likely a grants / SECURITY DEFINER exclusion filtered by the generator. Keeping `.schema('rdb' as any)` locally at those two call-sites with a `TODO(B.1.extra)` comment so the gap is discoverable. All other rdb/erp call-sites stay fully typed.

### Why this matters
This is the foundation for B.4 (erp, 284 usages), B.5 (core, 104), B.6 (playtomic, 8). Without typed clients, `tsc` cannot detect schema drift — which is exactly what we need to migrate those schemas safely against a live system.

### Risk assessment
Low — no runtime behavior change.
- Clients: only add TS generic, no runtime change.
- `impersonate`: defensive — `null`→`false` on nullable permission columns (previously silent bug if column came null).
- `health/ingest`: type-only cast (`row as Json`), payload unchanged.
- `ventas.openDetail`: early-return when `order_id` is null (no-op on a pedido that wouldn't have queried anything anyway).
- `requisiciones.generarOrdenCompra`: stricter typing, same data flow.

### Follow-up (B.1.extra)
Investigate why `rdb.cortes` and `rdb.v_cortes_productos` are missing from the autogen output despite existing in DB. Likely a `GRANT` / `SECURITY DEFINER` filter in the gen workflow. Separate PR.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test:run` — 11/11 passing
- [ ] Smoke-test on preview deploy:
  - [ ] `/rdb/ventas` — date range filter + open pedido drawer (verifies `order_id` narrowing + 3 typed waitry queries).
  - [ ] `/rdb/cortes` — open corte drawer (verifies `v_cortes_totales` typed + `v_cortes_productos` with TODO escape hatch).
  - [ ] `/rdb/requisiciones` → "Generar OC" on an authorized requisición (verifies `reqItems` inference + `ordenes_compra_detalle` insert shape).
  - [ ] Admin "view as user" in `/admin/usuarios` (verifies `null → false` permission default doesn't regress the UI).
  - [ ] POST to `/api/health/ingest` with an Apple Health Auto Export payload (verifies `Json` cast roundtrips `raw_json`).

🤖 Generated with Claude Code