### PR TITLE
B.4.1 — refactor(supabase): type erp schema in rh domain

### DIFF
--- a/app/dilesa/rh/departamentos/page.tsx
+++ b/app/dilesa/rh/departamentos/page.tsx
@@ -26,7 +26,7 @@ type Departamento = {
   padre_id: string | null; activo: boolean; padre: { nombre: string } | null;
 };
 
-type EmpleadoCount = { departamento_id: string };
+type EmpleadoCount = { departamento_id: string | null };
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return <div className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/50 mb-1.5">{children}</div>;
@@ -47,10 +47,10 @@ function DepartamentosInner() {
 
   const fetchAll = useCallback(async () => {
     const [deptRes, empRes] = await Promise.all([
-      supabase.schema('erp' as any).from('departamentos')
+      supabase.schema('erp').from('departamentos')
         .select('id, empresa_id, nombre, codigo, padre_id, activo, padre:padre_id(nombre)')
         .eq('empresa_id', EMPRESA_ID).order('nombre'),
-      supabase.schema('erp' as any).from('empleados')
+      supabase.schema('erp').from('empleados')
         .select('departamento_id')
         .eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null),
     ]);
@@ -78,10 +78,10 @@ function DepartamentosInner() {
   const handleSubmit = async () => {
     if (!form.nombre.trim()) return;
     setSubmitting(true);
-    const payload: Record<string, unknown> = { nombre: form.nombre.trim(), codigo: form.codigo.trim() || null, padre_id: form.padre_id || null };
+    const payload = { nombre: form.nombre.trim(), codigo: form.codigo.trim() || null, padre_id: form.padre_id || null };
     let err: { message: string } | null = null;
-    if (editingId) { const res = await supabase.schema('erp' as any).from('departamentos').update(payload).eq('id', editingId); err = res.error; }
-    else { const res = await supabase.schema('erp' as any).from('departamentos').insert({ ...payload, empresa_id: EMPRESA_ID }); err = res.error; }
+    if (editingId) { const res = await supabase.schema('erp').from('departamentos').update(payload).eq('id', editingId); err = res.error; }
+    else { const res = await supabase.schema('erp').from('departamentos').insert({ ...payload, empresa_id: EMPRESA_ID }); err = res.error; }
     setSubmitting(false);
     if (err) { alert(`Error: ${err.message}`); return; }
     setShowDialog(false);
@@ -89,7 +89,7 @@ function DepartamentosInner() {
   };
 
   const handleToggleActivo = async (dept: Departamento) => {
-    await supabase.schema('erp' as any).from('departamentos').update({ activo: !dept.activo }).eq('id', dept.id);
+    await supabase.schema('erp').from('departamentos').update({ activo: !dept.activo }).eq('id', dept.id);
     await fetchAll();
   };
 

--- a/app/dilesa/rh/empleados/[id]/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/page.tsx
@@ -143,7 +143,7 @@ function EmpleadoDetailInner() {
 
   const fetchAll = useCallback(async () => {
     const { data: emp, error: eErr } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .select('id, empresa_id, numero_empleado, fecha_ingreso, fecha_baja, motivo_baja, nss, fecha_nacimiento, telefono_empresa, extension, email_empresa, activo, persona:persona_id(id, nombre, apellido_paterno, apellido_materno, email, telefono, rfc, curp, nss, fecha_nacimiento), departamento:departamento_id(id, nombre), puesto:puesto_id(id, nombre)')
       .eq('id', id)
@@ -173,9 +173,9 @@ function EmpleadoDetailInner() {
     setEmailEmpresa(emp.email_empresa ?? '');
 
     const [deptRes, puestosRes, compRes] = await Promise.all([
-      supabase.schema('erp' as any).from('departamentos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
-      supabase.schema('erp' as any).from('puestos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
-      supabase.schema('erp' as any).from('empleados_compensacion')
+      supabase.schema('erp').from('departamentos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('puestos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('empleados_compensacion')
         .select('id, sueldo_mensual, sueldo_diario, comisiones_mensuales, bonificaciones_mensuales, compensaciones_mensuales, sdi, tipo_contrato, frecuencia_pago')
         .eq('empleado_id', id).eq('vigente', true).maybeSingle(),
     ]);
@@ -191,7 +191,7 @@ function EmpleadoDetailInner() {
     if (!empleado) return;
     setSaving(true);
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .update({
         numero_empleado: numeroEmpleado.trim() || null,
@@ -215,7 +215,7 @@ function EmpleadoDetailInner() {
     if (!empleado) return;
     setGivingBaja(true);
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .update({
         activo: false,

--- a/app/dilesa/rh/empleados/page.tsx
+++ b/app/dilesa/rh/empleados/page.tsx
@@ -67,13 +67,13 @@ function EmpleadosInner() {
 
   const fetchAll = useCallback(async () => {
     const [empRes, personasRes, deptRes, puestosRes] = await Promise.all([
-      supabase.schema('erp' as any).from('empleados')
+      supabase.schema('erp').from('empleados')
         .select('id, empresa_id, numero_empleado, fecha_ingreso, fecha_baja, activo, persona:persona_id(nombre, apellido_paterno, apellido_materno, email), departamento:departamento_id(nombre), puesto:puesto_id(nombre)')
         .eq('empresa_id', EMPRESA_ID).is('deleted_at', null).order('created_at', { ascending: false }),
-      supabase.schema('erp' as any).from('personas').select('id, nombre, apellido_paterno')
+      supabase.schema('erp').from('personas').select('id, nombre, apellido_paterno')
         .eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null).order('nombre'),
-      supabase.schema('erp' as any).from('departamentos').select('id, nombre').eq('empresa_id', EMPRESA_ID).eq('activo', true).order('nombre'),
-      supabase.schema('erp' as any).from('puestos').select('id, nombre').eq('empresa_id', EMPRESA_ID).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('departamentos').select('id, nombre').eq('empresa_id', EMPRESA_ID).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('puestos').select('id, nombre').eq('empresa_id', EMPRESA_ID).eq('activo', true).order('nombre'),
     ]);
     if (empRes.error) { setError(empRes.error.message); return; }
     setEmpleados((empRes.data ?? []).map((e: any) => ({
@@ -98,7 +98,7 @@ function EmpleadosInner() {
   const handleCreate = async () => {
     if (!createForm.persona_id) return;
     setCreating(true);
-    const { data: newEmp, error: err } = await supabase.schema('erp' as any).from('empleados')
+    const { data: newEmp, error: err } = await supabase.schema('erp').from('empleados')
       .insert({
         empresa_id: EMPRESA_ID, persona_id: createForm.persona_id,
         departamento_id: createForm.departamento_id || null, puesto_id: createForm.puesto_id || null,

--- a/app/dilesa/rh/puestos/page.tsx
+++ b/app/dilesa/rh/puestos/page.tsx
@@ -51,17 +51,17 @@ function PuestosInner() {
 
   const fetchAll = useCallback(async () => {
     const [pRes, dRes, empRes] = await Promise.all([
-      supabase.schema('erp' as any).from('puestos')
+      supabase.schema('erp').from('puestos')
         .select('id, empresa_id, nombre, nivel, sueldo_min, sueldo_max, objetivo, perfil, requisitos, esquema_pago, reporta_a, activo, departamento:departamento_id(nombre)')
         .eq('empresa_id', EMPRESA_ID).order('nombre'),
-      supabase.schema('erp' as any).from('departamentos').select('id, nombre').eq('empresa_id', EMPRESA_ID).eq('activo', true).order('nombre'),
-      supabase.schema('erp' as any).from('empleados').select('puesto_id').eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null),
+      supabase.schema('erp').from('departamentos').select('id, nombre').eq('empresa_id', EMPRESA_ID).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('empleados').select('puesto_id').eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null),
     ]);
     if (pRes.error) { setError(pRes.error.message); return; }
     setPuestos((pRes.data ?? []).map((p: any) => ({ ...p, departamento: Array.isArray(p.departamento) ? (p.departamento[0] ?? null) : p.departamento })) as Puesto[]);
     setDepartamentos(dRes.data ?? []);
     const counts = new Map<string, number>();
-    (empRes.data ?? []).forEach((e: { puesto_id: string }) => {
+    (empRes.data ?? []).forEach((e: { puesto_id: string | null }) => {
       if (e.puesto_id) counts.set(e.puesto_id, (counts.get(e.puesto_id) ?? 0) + 1);
     });
     setEmpleadoCounts(counts);
@@ -85,15 +85,15 @@ function PuestosInner() {
   const handleSubmit = async () => {
     if (!form.nombre.trim()) return;
     setSubmitting(true);
-    const payload: Record<string, unknown> = {
+    const payload = {
       nombre: form.nombre.trim(), nivel: form.nivel.trim() || null, departamento_id: form.departamento_id || null,
       sueldo_min: form.sueldo_min ? parseFloat(form.sueldo_min) : null, sueldo_max: form.sueldo_max ? parseFloat(form.sueldo_max) : null,
       objetivo: form.objetivo.trim() || null, perfil: form.perfil.trim() || null, requisitos: form.requisitos.trim() || null,
       esquema_pago: form.esquema_pago.trim() || null, reporta_a: form.reporta_a || null,
     };
     let err: { message: string } | null = null;
-    if (editingId) { const res = await supabase.schema('erp' as any).from('puestos').update(payload).eq('id', editingId); err = res.error; }
-    else { const res = await supabase.schema('erp' as any).from('puestos').insert({ ...payload, empresa_id: EMPRESA_ID }); err = res.error; }
+    if (editingId) { const res = await supabase.schema('erp').from('puestos').update(payload).eq('id', editingId); err = res.error; }
+    else { const res = await supabase.schema('erp').from('puestos').insert({ ...payload, empresa_id: EMPRESA_ID }); err = res.error; }
     setSubmitting(false);
     if (err) { alert(`Error: ${err.message}`); return; }
     setShowDialog(false);

--- a/app/rdb/rh/departamentos/page.tsx
+++ b/app/rdb/rh/departamentos/page.tsx
@@ -65,10 +65,10 @@ function DepartamentosInner() {
 
   const fetchAll = useCallback(async () => {
     const [deptRes, empRes] = await Promise.all([
-      supabase.schema('erp' as any).from('departamentos')
+      supabase.schema('erp').from('departamentos')
         .select('id, empresa_id, nombre, codigo, padre_id, activo, padre:padre_id(nombre)')
         .eq('empresa_id', EMPRESA_ID).order('nombre'),
-      supabase.schema('erp' as any).from('empleados')
+      supabase.schema('erp').from('empleados')
         .select('departamento_id')
         .eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null),
     ]);
@@ -79,7 +79,7 @@ function DepartamentosInner() {
     })) as Departamento[];
     setDepartamentos(normalized);
     const counts = new Map<string, number>();
-    (empRes.data ?? []).forEach((e: { departamento_id: string }) => {
+    (empRes.data ?? []).forEach((e: { departamento_id: string | null }) => {
       if (e.departamento_id) counts.set(e.departamento_id, (counts.get(e.departamento_id) ?? 0) + 1);
     });
     setEmpleadoCounts(counts);
@@ -107,7 +107,7 @@ function DepartamentosInner() {
   const handleSubmit = async () => {
     if (!form.nombre.trim()) return;
     setSubmitting(true);
-    const payload: Record<string, unknown> = {
+    const payload = {
       nombre: form.nombre.trim(),
       codigo: form.codigo.trim() || null,
       padre_id: form.padre_id || null,
@@ -115,10 +115,10 @@ function DepartamentosInner() {
 
     let err: { message: string } | null = null;
     if (editingId) {
-      const res = await supabase.schema('erp' as any).from('departamentos').update(payload).eq('id', editingId);
+      const res = await supabase.schema('erp').from('departamentos').update(payload).eq('id', editingId);
       err = res.error;
     } else {
-      const res = await supabase.schema('erp' as any).from('departamentos').insert({ ...payload, empresa_id: EMPRESA_ID });
+      const res = await supabase.schema('erp').from('departamentos').insert({ ...payload, empresa_id: EMPRESA_ID });
       err = res.error;
     }
 
@@ -129,7 +129,7 @@ function DepartamentosInner() {
   };
 
   const handleToggleActivo = async (dept: Departamento) => {
-    await supabase.schema('erp' as any).from('departamentos').update({ activo: !dept.activo }).eq('id', dept.id);
+    await supabase.schema('erp').from('departamentos').update({ activo: !dept.activo }).eq('id', dept.id);
     await fetchAll();
   };
 

--- a/app/rdb/rh/empleados/[id]/page.tsx
+++ b/app/rdb/rh/empleados/[id]/page.tsx
@@ -143,7 +143,7 @@ function EmpleadoDetailInner() {
 
   const fetchAll = useCallback(async () => {
     const { data: emp, error: eErr } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .select('id, empresa_id, numero_empleado, fecha_ingreso, fecha_baja, motivo_baja, nss, fecha_nacimiento, telefono_empresa, extension, email_empresa, activo, persona:persona_id(id, nombre, apellido_paterno, apellido_materno, email, telefono, rfc, curp, nss, fecha_nacimiento), departamento:departamento_id(id, nombre), puesto:puesto_id(id, nombre)')
       .eq('id', id)
@@ -173,9 +173,9 @@ function EmpleadoDetailInner() {
     setEmailEmpresa(emp.email_empresa ?? '');
 
     const [deptRes, puestosRes, compRes] = await Promise.all([
-      supabase.schema('erp' as any).from('departamentos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
-      supabase.schema('erp' as any).from('puestos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
-      supabase.schema('erp' as any).from('empleados_compensacion')
+      supabase.schema('erp').from('departamentos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('puestos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('empleados_compensacion')
         .select('id, sueldo_mensual, sueldo_diario, comisiones_mensuales, bonificaciones_mensuales, compensaciones_mensuales, sdi, tipo_contrato, frecuencia_pago')
         .eq('empleado_id', id).eq('vigente', true).maybeSingle(),
     ]);
@@ -191,7 +191,7 @@ function EmpleadoDetailInner() {
     if (!empleado) return;
     setSaving(true);
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .update({
         numero_empleado: numeroEmpleado.trim() || null,
@@ -215,7 +215,7 @@ function EmpleadoDetailInner() {
     if (!empleado) return;
     setGivingBaja(true);
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .update({
         activo: false,

--- a/app/rdb/rh/empleados/page.tsx
+++ b/app/rdb/rh/empleados/page.tsx
@@ -98,14 +98,14 @@ function EmpleadosInner() {
   const fetchAll = useCallback(async () => {
     const [empRes, personasRes, deptRes, puestosRes] = await Promise.all([
       supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('empleados')
         .select('id, empresa_id, numero_empleado, fecha_ingreso, fecha_baja, activo, persona:persona_id(nombre, apellido_paterno, apellido_materno, email), departamento:departamento_id(nombre), puesto:puesto_id(nombre)')
         .eq('empresa_id', EMPRESA_ID)
         .is('deleted_at', null)
         .order('created_at', { ascending: false }),
       supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('personas')
         .select('id, nombre, apellido_paterno')
         .eq('empresa_id', EMPRESA_ID)
@@ -113,14 +113,14 @@ function EmpleadosInner() {
         .is('deleted_at', null)
         .order('nombre'),
       supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('departamentos')
         .select('id, nombre')
         .eq('empresa_id', EMPRESA_ID)
         .eq('activo', true)
         .order('nombre'),
       supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('puestos')
         .select('id, nombre')
         .eq('empresa_id', EMPRESA_ID)
@@ -156,7 +156,7 @@ function EmpleadosInner() {
   const handleCreate = async () => {
     if (!createForm.persona_id) return;
     setCreating(true);
-    const payload: Record<string, unknown> = {
+    const payload = {
       empresa_id: EMPRESA_ID,
       persona_id: createForm.persona_id,
       departamento_id: createForm.departamento_id || null,
@@ -166,7 +166,7 @@ function EmpleadosInner() {
       activo: true,
     };
     const { data: newEmp, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .insert(payload)
       .select()

--- a/app/rdb/rh/puestos/page.tsx
+++ b/app/rdb/rh/puestos/page.tsx
@@ -86,12 +86,12 @@ function PuestosInner() {
 
   const fetchAll = useCallback(async () => {
     const [pRes, dRes, empRes] = await Promise.all([
-      supabase.schema('erp' as any).from('puestos')
+      supabase.schema('erp').from('puestos')
         .select('id, empresa_id, nombre, nivel, sueldo_min, sueldo_max, objetivo, perfil, requisitos, esquema_pago, reporta_a, activo, departamento:departamento_id(nombre)')
         .eq('empresa_id', EMPRESA_ID).order('nombre'),
-      supabase.schema('erp' as any).from('departamentos')
+      supabase.schema('erp').from('departamentos')
         .select('id, nombre').eq('empresa_id', EMPRESA_ID).eq('activo', true).order('nombre'),
-      supabase.schema('erp' as any).from('empleados').select('puesto_id').eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null),
+      supabase.schema('erp').from('empleados').select('puesto_id').eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null),
     ]);
     if (pRes.error) { setError(pRes.error.message); return; }
     const normalizedPuestos = (pRes.data ?? []).map((p: any) => ({
@@ -101,7 +101,7 @@ function PuestosInner() {
     setPuestos(normalizedPuestos);
     setDepartamentos(dRes.data ?? []);
     const counts = new Map<string, number>();
-    (empRes.data ?? []).forEach((e: { puesto_id: string }) => {
+    (empRes.data ?? []).forEach((e: { puesto_id: string | null }) => {
       if (e.puesto_id) counts.set(e.puesto_id, (counts.get(e.puesto_id) ?? 0) + 1);
     });
     setEmpleadoCounts(counts);
@@ -140,7 +140,7 @@ function PuestosInner() {
   const handleSubmit = async () => {
     if (!form.nombre.trim()) return;
     setSubmitting(true);
-    const payload: Record<string, unknown> = {
+    const payload = {
       nombre: form.nombre.trim(),
       nivel: form.nivel.trim() || null,
       departamento_id: form.departamento_id || null,
@@ -155,10 +155,10 @@ function PuestosInner() {
 
     let err: { message: string } | null = null;
     if (editingId) {
-      const res = await supabase.schema('erp' as any).from('puestos').update(payload).eq('id', editingId);
+      const res = await supabase.schema('erp').from('puestos').update(payload).eq('id', editingId);
       err = res.error;
     } else {
-      const res = await supabase.schema('erp' as any).from('puestos').insert({ ...payload, empresa_id: EMPRESA_ID });
+      const res = await supabase.schema('erp').from('puestos').insert({ ...payload, empresa_id: EMPRESA_ID });
       err = res.error;
     }
 

--- a/app/rh/departamentos/page.tsx
+++ b/app/rh/departamentos/page.tsx
@@ -87,7 +87,7 @@ function DepartamentosInner() {
   const fetchAll = useCallback(async (ids: string[]) => {
     if (ids.length === 0) { setDepartamentos([]); return; }
     const { data, error: err } = await supabase
-      .schema('erp' as any).from('departamentos')
+      .schema('erp').from('departamentos')
       .select('id, empresa_id, nombre, codigo, padre_id, activo, padre:padre_id(nombre)')
       .in('empresa_id', ids)
       .order('nombre');
@@ -124,7 +124,7 @@ function DepartamentosInner() {
   const handleSubmit = async () => {
     if (!form.nombre.trim() || empresaIds.length === 0) return;
     setSubmitting(true);
-    const payload: Record<string, unknown> = {
+    const payload = {
       nombre: form.nombre.trim(),
       codigo: form.codigo.trim() || null,
       padre_id: form.padre_id || null,
@@ -132,10 +132,10 @@ function DepartamentosInner() {
 
     let err: { message: string } | null = null;
     if (editingId) {
-      const res = await supabase.schema('erp' as any).from('departamentos').update(payload).eq('id', editingId);
+      const res = await supabase.schema('erp').from('departamentos').update(payload).eq('id', editingId);
       err = res.error;
     } else {
-      const res = await supabase.schema('erp' as any).from('departamentos').insert({ ...payload, empresa_id: empresaIds[0] });
+      const res = await supabase.schema('erp').from('departamentos').insert({ ...payload, empresa_id: empresaIds[0] });
       err = res.error;
     }
 
@@ -146,7 +146,7 @@ function DepartamentosInner() {
   };
 
   const handleToggleActivo = async (dept: Departamento) => {
-    await supabase.schema('erp' as any).from('departamentos').update({ activo: !dept.activo }).eq('id', dept.id);
+    await supabase.schema('erp').from('departamentos').update({ activo: !dept.activo }).eq('id', dept.id);
     await fetchAll(empresaIds);
   };
 

--- a/app/rh/empleados/[id]/page.tsx
+++ b/app/rh/empleados/[id]/page.tsx
@@ -132,7 +132,7 @@ function EmpleadoDetailInner() {
 
   const fetchAll = useCallback(async () => {
     const { data: emp, error: eErr } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .select('id, empresa_id, numero_empleado, fecha_ingreso, fecha_baja, motivo_baja, nss, fecha_nacimiento, telefono_empresa, extension, activo, persona:persona_id(id, nombre, apellido_paterno, apellido_materno, email, telefono, rfc, curp), departamento:departamento_id(id, nombre), puesto:puesto_id(id, nombre)')
       .eq('id', id)
@@ -161,8 +161,8 @@ function EmpleadoDetailInner() {
     setExtension(emp.extension ?? '');
 
     const [deptRes, puestosRes] = await Promise.all([
-      supabase.schema('erp' as any).from('departamentos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
-      supabase.schema('erp' as any).from('puestos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('departamentos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
+      supabase.schema('erp').from('puestos').select('id, nombre').eq('empresa_id', emp.empresa_id).eq('activo', true).order('nombre'),
     ]);
     setDepartamentos(deptRes.data ?? []);
     setPuestos(puestosRes.data ?? []);
@@ -176,7 +176,7 @@ function EmpleadoDetailInner() {
     if (!empleado) return;
     setSaving(true);
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .update({
         numero_empleado: numeroEmpleado.trim() || null,
@@ -198,7 +198,7 @@ function EmpleadoDetailInner() {
     if (!empleado) return;
     setGivingBaja(true);
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .update({
         activo: false,

--- a/app/rh/empleados/page.tsx
+++ b/app/rh/empleados/page.tsx
@@ -130,14 +130,14 @@ function EmpleadosInner() {
 
     const [empRes, personasRes, deptRes, puestosRes] = await Promise.all([
       supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('empleados')
         .select('id, empresa_id, numero_empleado, fecha_ingreso, fecha_baja, activo, persona:persona_id(nombre, apellido_paterno, apellido_materno, email), departamento:departamento_id(nombre), puesto:puesto_id(nombre)')
         .in('empresa_id', ids)
         .is('deleted_at', null)
         .order('created_at', { ascending: false }),
       supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('personas')
         .select('id, nombre, apellido_paterno')
         .in('empresa_id', ids)
@@ -145,14 +145,14 @@ function EmpleadosInner() {
         .is('deleted_at', null)
         .order('nombre'),
       supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('departamentos')
         .select('id, nombre')
         .in('empresa_id', ids)
         .eq('activo', true)
         .order('nombre'),
       supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('puestos')
         .select('id, nombre')
         .in('empresa_id', ids)
@@ -190,7 +190,7 @@ function EmpleadosInner() {
   const handleCreate = async () => {
     if (!createForm.persona_id || empresaIds.length === 0) return;
     setCreating(true);
-    const payload: Record<string, unknown> = {
+    const payload = {
       empresa_id: empresaIds[0],
       persona_id: createForm.persona_id,
       departamento_id: createForm.departamento_id || null,
@@ -200,7 +200,7 @@ function EmpleadosInner() {
       activo: true,
     };
     const { data: newEmp, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .insert(payload)
       .select()

--- a/app/rh/puestos/page.tsx
+++ b/app/rh/puestos/page.tsx
@@ -108,10 +108,10 @@ function PuestosInner() {
   const fetchAll = useCallback(async (ids: string[]) => {
     if (ids.length === 0) { setPuestos([]); return; }
     const [pRes, dRes] = await Promise.all([
-      supabase.schema('erp' as any).from('puestos')
+      supabase.schema('erp').from('puestos')
         .select('id, empresa_id, nombre, nivel, sueldo_min, sueldo_max, objetivo, perfil, requisitos, esquema_pago, reporta_a, activo, departamento:departamento_id(nombre)')
         .in('empresa_id', ids).order('nombre'),
-      supabase.schema('erp' as any).from('departamentos')
+      supabase.schema('erp').from('departamentos')
         .select('id, nombre').in('empresa_id', ids).eq('activo', true).order('nombre'),
     ]);
     if (pRes.error) { setError(pRes.error.message); return; }
@@ -158,7 +158,7 @@ function PuestosInner() {
   const handleSubmit = async () => {
     if (!form.nombre.trim() || empresaIds.length === 0) return;
     setSubmitting(true);
-    const payload: Record<string, unknown> = {
+    const payload = {
       nombre: form.nombre.trim(),
       nivel: form.nivel.trim() || null,
       departamento_id: form.departamento_id || null,
@@ -173,10 +173,10 @@ function PuestosInner() {
 
     let err: { message: string } | null = null;
     if (editingId) {
-      const res = await supabase.schema('erp' as any).from('puestos').update(payload).eq('id', editingId);
+      const res = await supabase.schema('erp').from('puestos').update(payload).eq('id', editingId);
       err = res.error;
     } else {
-      const res = await supabase.schema('erp' as any).from('puestos').insert({ ...payload, empresa_id: empresaIds[0] });
+      const res = await supabase.schema('erp').from('puestos').insert({ ...payload, empresa_id: empresaIds[0] });
       err = res.error;
     }
 


### PR DESCRIPTION
## Qué

Elimina `.schema('erp' as any)` en los 12 archivos del dominio **HR** (departamentos, puestos, empleados — list + detail) en las 3 rutas de empresa (`app/rh`, `app/rdb/rh`, `app/dilesa/rh`).

Insert/update payloads ahora infieren su tipo del `Database` generado, en vez de widening a `Record<string, unknown>`. Eso permite a PostgREST rechazar columnas sobrantes o faltantes en tiempo de compilación.

## Por qué

Parte de B.4 — eliminar el último escape hatch genérico en el schema `erp` para dejar todo el tipado sólido. Se sub-divide B.4 por dominio para reducir el blast radius de cada PR en un sistema LIVE. Este es el primero de 6 sub-PRs.

## Drift fixes (necesarios tras quitar el cast)

- Remover anotación `Record<string, unknown>` en payloads de insert/update (dejar que TS infiera)
- Ampliar tipo de callback en `.forEach` para `EmpleadoCount.departamento_id` / `puesto_id` a `string | null` (la columna es nullable)

## Alcance

- 12 archivos, 72 inserciones / 72 supresiones (cambio mecánico + pequeños ajustes de tipos)
- **No toca** `.schema('core' as any)` — eso cae en B.5

## Riesgos

- Bajo: el cambio es sólo de tipos; el payload enviado a Supabase es idéntico byte-a-byte.
- Si faltara alguna columna obligatoria en el insert, TS lo detectaría — y ya compila limpio.

## Verificación

- [x] `npx tsc --noEmit` → 0 errores
- [x] `npm run test:run` → 11/11 passing
- [x] `grep -rn "schema('erp' as any)" app/rh app/rdb/rh app/dilesa/rh` → 0 matches
- [ ] Smoke manual en preview: crear/editar departamento, puesto y empleado en las 3 empresas

## Sub-PRs restantes de B.4

- B.4.2 tasks
- B.4.3 juntas
- B.4.4 documentos
- B.4.5 rdb procurement (requisiciones/órdenes compra)
- B.4.6 scripts