### PR TITLE
B.4.2 — refactor(supabase): type erp schema in tasks domain

### DIFF
--- a/app/dilesa/admin/tasks/page.tsx
+++ b/app/dilesa/admin/tasks/page.tsx
@@ -3,6 +3,9 @@
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import type { TablesUpdate } from '@/types/supabase';
+
+type TasksUpdate = TablesUpdate<{ schema: 'erp' }, 'tasks'>;
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
@@ -270,7 +273,7 @@ function TasksInner() {
     const email = user?.email?.toLowerCase() ?? '';
 
     const [empRes, coreUserRes] = await Promise.all([
-      supabase.schema('erp' as any).from('empleados')
+      supabase.schema('erp').from('empleados')
         .select('id, persona:persona_id(nombre, apellido_paterno)')
         .eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null),
       supabase.schema('core' as any).from('usuarios')
@@ -290,12 +293,12 @@ function TasksInner() {
 
     if (email) {
       const { data: persona } = await supabase
-        .schema('erp' as any).from('personas').select('id')
+        .schema('erp').from('personas').select('id')
         .eq('empresa_id', EMPRESA_ID).eq('email', email).maybeSingle();
 
       if (persona) {
         const { data: empleado } = await supabase
-          .schema('erp' as any).from('empleados').select('id')
+          .schema('erp').from('empleados').select('id')
           .eq('empresa_id', EMPRESA_ID).eq('persona_id', persona.id)
           .eq('activo', true).maybeSingle();
         if (empleado) setCurrentEmpleadoId(empleado.id);
@@ -321,10 +324,10 @@ function TasksInner() {
 
   const fetchTasks = useCallback(async () => {
     const { data, error: err } = await supabase
-      .schema('erp' as any).from('tasks').select('*')
+      .schema('erp').from('tasks').select('*')
       .eq('empresa_id', EMPRESA_ID).order('created_at', { ascending: false });
     if (err) { setError(err.message); return; }
-    setTasks(data ?? []);
+    setTasks((data ?? []) as ErpTask[]);
   }, [supabase]);
 
   useEffect(() => {
@@ -351,7 +354,7 @@ function TasksInner() {
     if (!createForm.titulo.trim() || !createForm.prioridad || !createForm.asignado_a || !createForm.fecha_compromiso) return;
     setCreating(true);
     // Auto-link to active junta if one exists
-    const { data: activeJunta } = await supabase.schema('erp' as any).from('juntas')
+    const { data: activeJunta } = await supabase.schema('erp').from('juntas')
       .select('id')
       .eq('empresa_id', EMPRESA_ID)
       .eq('estado', 'en_curso')
@@ -359,7 +362,7 @@ function TasksInner() {
       .limit(1)
       .maybeSingle();
     const { error: err } = await supabase
-      .schema('erp' as any).from('tasks').insert({
+      .schema('erp').from('tasks').insert({
         empresa_id: EMPRESA_ID,
         titulo: createForm.titulo.trim(),
         descripcion: createForm.descripcion.trim() || null,
@@ -414,7 +417,7 @@ function TasksInner() {
   const handleUpdate = async () => {
     if (!selectedTask || !editForm.titulo.trim()) return;
     setSaving(true);
-    const updatePayload: Record<string, unknown> = {
+    const updatePayload: TasksUpdate = {
       titulo: editForm.titulo.trim(),
       descripcion: editForm.descripcion.trim() || null,
       prioridad: editForm.prioridad || null,
@@ -430,7 +433,7 @@ function TasksInner() {
       updatePayload.motivo_bloqueo = editForm.estado === 'bloqueado' ? (editForm.motivo_bloqueo.trim() || null) : null;
     }
     const { error: err } = await supabase
-      .schema('erp' as any).from('tasks').update(updatePayload).eq('id', selectedTask.id);
+      .schema('erp').from('tasks').update(updatePayload).eq('id', selectedTask.id);
     setSaving(false);
     if (err) { alert(`Error al guardar tarea: ${err.message}`); return; }
     setShowEdit(false);
@@ -443,7 +446,7 @@ function TasksInner() {
     if (!confirm('¿Eliminar esta tarea? Esta acción no se puede deshacer.')) return;
     setDeleting(true);
     const { error: err } = await supabase
-      .schema('erp' as any).from('tasks').delete().eq('id', selectedTask.id);
+      .schema('erp').from('tasks').delete().eq('id', selectedTask.id);
     setDeleting(false);
     if (err) { alert(`Error al eliminar: ${err.message}`); return; }
     setShowEdit(false);
@@ -454,7 +457,7 @@ function TasksInner() {
   const handleQuickComplete = async (taskId: string) => {
     setCompletingTaskId(taskId);
     const { error: err } = await supabase
-      .schema('erp' as any).from('tasks')
+      .schema('erp').from('tasks')
       .update({ estado: 'completado', porcentaje_avance: 100, completado_por: currentEmpleadoId })
       .eq('id', taskId);
     setCompletingTaskId(null);
@@ -463,7 +466,7 @@ function TasksInner() {
   };
 
   const handleInlineEstadoSave = async (taskId: string, estado: ErpTask['estado']) => {
-    const update: Record<string, unknown> = { estado };
+    const update: TasksUpdate = { estado };
     if (estado === 'completado') {
       update.completado_por = currentEmpleadoId;
       update.porcentaje_avance = 100;
@@ -475,24 +478,24 @@ function TasksInner() {
     } else {
       update.motivo_bloqueo = null;
     }
-    await supabase.schema('erp' as any).from('tasks').update(update).eq('id', taskId);
+    await supabase.schema('erp').from('tasks').update(update).eq('id', taskId);
     await fetchTasks();
   };
 
   const handleInlineAvanceSave = async (taskId: string, value: number) => {
-    const update: Record<string, unknown> = { porcentaje_avance: value };
+    const update: TasksUpdate = { porcentaje_avance: value };
     if (value === 100) {
       update.estado = 'completado';
       update.completado_por = currentEmpleadoId;
     }
-    await supabase.schema('erp' as any).from('tasks').update(update).eq('id', taskId);
+    await supabase.schema('erp').from('tasks').update(update).eq('id', taskId);
     setInlineAvance(null);
     await fetchTasks();
   };
 
   const fetchUpdatesForTask = async (taskId: string) => {
     setLoadingUpdates(true);
-    const { data: updatesData } = await supabase.schema('erp' as any).from('task_updates').select('*').eq('task_id', taskId).order('created_at', { ascending: false });
+    const { data: updatesData } = await supabase.schema('erp').from('task_updates').select('*').eq('task_id', taskId).order('created_at', { ascending: false });
     if (updatesData && updatesData.length > 0) {
       const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
       const { data: usersData } = userIds.length > 0
@@ -521,7 +524,7 @@ function TasksInner() {
     const userId = coreUser?.id ?? null;
     const userName = coreUser?.nombre ?? 'Usuario';
 
-    const { error: insErr } = await supabase.schema('erp' as any).from('task_updates').insert({
+    const { error: insErr } = await supabase.schema('erp').from('task_updates').insert({
       task_id: taskId, empresa_id: EMPRESA_ID, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId,
     });
     if (insErr) { alert(`Error: ${insErr.message}`); setSavingUpdate(false); return; }
@@ -1186,7 +1189,7 @@ function TasksInner() {
                     const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id, nombre').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
                     const userId = coreUser?.id ?? null;
                     const userName = coreUser?.nombre ?? 'Usuario';
-                    const { error: insErr } = await supabase.schema('erp' as any).from('task_updates').insert({
+                    const { error: insErr } = await supabase.schema('erp').from('task_updates').insert({
                       task_id: selectedTask.id, empresa_id: EMPRESA_ID, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId,
                     });
                     if (insErr) { alert(`Error: ${insErr.message}`); setSavingUpdate(false); return; }

--- a/app/inicio/tasks/page.tsx
+++ b/app/inicio/tasks/page.tsx
@@ -3,6 +3,9 @@
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useState } from 'react';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import type { TablesInsert } from '@/types/supabase';
+
+type TasksInsert = TablesInsert<{ schema: 'erp' }, 'tasks'>;
 import {
   Table,
   TableBody,
@@ -190,7 +193,7 @@ function TasksInner() {
 
     if (ids.length > 0) {
       const { data: empData } = await supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('empleados')
         .select('id, persona:persona_id(nombre, apellido_paterno)')
         .in('empresa_id', ids)
@@ -214,7 +217,7 @@ function TasksInner() {
         return;
       }
       const { data, error: err } = await supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('tasks')
         .select('*')
         .in('empresa_id', ids)
@@ -224,7 +227,7 @@ function TasksInner() {
         setError(err.message);
         return;
       }
-      setTasks(data ?? []);
+      setTasks((data ?? []) as ErpTask[]);
     },
     [supabase],
   );
@@ -269,7 +272,7 @@ function TasksInner() {
       .eq('email', (user?.email ?? '').toLowerCase())
       .maybeSingle();
 
-    const payload: Record<string, unknown> = {
+    const payload: TasksInsert = {
       empresa_id: empresaIds[0],
       titulo: createForm.titulo.trim(),
       descripcion: createForm.descripcion.trim() || null,
@@ -281,7 +284,7 @@ function TasksInner() {
     };
 
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .insert(payload);
 
@@ -315,7 +318,7 @@ function TasksInner() {
     setSaving(true);
 
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .update({
         titulo: editForm.titulo.trim(),

--- a/app/rdb/admin/tasks/page.tsx
+++ b/app/rdb/admin/tasks/page.tsx
@@ -93,14 +93,14 @@ function TasksInner() {
   const [saving, setSaving] = useState(false);
 
   const fetchRefData = useCallback(async () => {
-    const { data: empRes } = await supabase.schema('erp' as any).from('empleados').select('id, persona:persona_id(nombre, apellido_paterno)').eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null);
+    const { data: empRes } = await supabase.schema('erp').from('empleados').select('id, persona:persona_id(nombre, apellido_paterno)').eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null);
     setEmpleados((empRes ?? []).map((e: any) => ({ id: e.id, nombre: [e.persona?.nombre, e.persona?.apellido_paterno].filter(Boolean).join(' ') })));
   }, [supabase]);
 
   const fetchTasks = useCallback(async () => {
-    const { data, error: err } = await supabase.schema('erp' as any).from('tasks').select('*').eq('empresa_id', EMPRESA_ID).order('created_at', { ascending: false });
+    const { data, error: err } = await supabase.schema('erp').from('tasks').select('*').eq('empresa_id', EMPRESA_ID).order('created_at', { ascending: false });
     if (err) { setError(err.message); return; }
-    setTasks(data ?? []);
+    setTasks((data ?? []) as ErpTask[]);
   }, [supabase]);
 
   useEffect(() => {
@@ -119,7 +119,7 @@ function TasksInner() {
     setCreating(true);
     const { data: { user } } = await supabase.auth.getUser();
     const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
-    const { error: err } = await supabase.schema('erp' as any).from('tasks').insert({
+    const { error: err } = await supabase.schema('erp').from('tasks').insert({
       empresa_id: EMPRESA_ID, titulo: createForm.titulo.trim(), descripcion: createForm.descripcion.trim() || null,
       prioridad: createForm.prioridad || null, asignado_a: createForm.asignado_a || null,
       estado: createForm.estado, fecha_vence: createForm.fecha_vence || null, creado_por: coreUser?.id ?? null,
@@ -138,7 +138,7 @@ function TasksInner() {
   const handleUpdate = async () => {
     if (!selectedTask || !editForm.titulo.trim()) return;
     setSaving(true);
-    const { error: err } = await supabase.schema('erp' as any).from('tasks').update({
+    const { error: err } = await supabase.schema('erp').from('tasks').update({
       titulo: editForm.titulo.trim(), descripcion: editForm.descripcion.trim() || null,
       prioridad: editForm.prioridad || null, asignado_a: editForm.asignado_a || null,
       estado: editForm.estado, fecha_vence: editForm.fecha_vence || null,

--- a/app/rdb/tasks/[id]/page.tsx
+++ b/app/rdb/tasks/[id]/page.tsx
@@ -132,7 +132,7 @@ function TaskDetailInner() {
 
   const fetchRefData = useCallback(async () => {
     const { data: empRes } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .select('id, persona:persona_id(nombre, apellido_paterno)')
       .eq('empresa_id', EMPRESA_ID)
@@ -160,7 +160,7 @@ function TaskDetailInner() {
 
   const fetchTask = useCallback(async () => {
     const { data, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .select('*')
       .eq('id', taskId)
@@ -169,14 +169,14 @@ function TaskDetailInner() {
       setError(err?.message ?? 'Tarea no encontrada');
       return null;
     }
-    setTask(data);
+    setTask(data as ErpTask);
     return data as ErpTask;
   }, [supabase, taskId]);
 
   const fetchUpdates = useCallback(async () => {
     setUpdatesLoading(true);
     const { data: updatesData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('task_updates')
       .select('*')
       .eq('task_id', taskId)
@@ -227,7 +227,7 @@ function TaskDetailInner() {
       if (!task) return;
       setSaving(true);
       const { data, error: err } = await supabase
-        .schema('erp' as any)
+        .schema('erp')
         .from('tasks')
         .update({ ...updates, updated_at: new Date().toISOString() })
         .eq('id', task.id)
@@ -290,7 +290,7 @@ function TaskDetailInner() {
     }
 
     if (inserts.length > 0) {
-      await supabase.schema('erp' as any).from('task_updates').insert(inserts);
+      await supabase.schema('erp').from('task_updates').insert(inserts);
     }
 
     const taskPatch: Partial<ErpTask> = {};

--- a/app/rdb/tasks/page.tsx
+++ b/app/rdb/tasks/page.tsx
@@ -146,7 +146,7 @@ function TasksInner() {
 
   const fetchRefData = useCallback(async () => {
     const { data: empRes } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .select('id, persona:persona_id(nombre, apellido_paterno)')
       .eq('empresa_id', EMPRESA_ID)
@@ -162,7 +162,7 @@ function TasksInner() {
 
   const fetchTasks = useCallback(async () => {
     const { data, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .select('*')
       .eq('empresa_id', EMPRESA_ID)
@@ -171,7 +171,7 @@ function TasksInner() {
       setError(err.message);
       return;
     }
-    setTasks(data ?? []);
+    setTasks((data ?? []) as ErpTask[]);
   }, [supabase]);
 
   useEffect(() => {
@@ -210,7 +210,7 @@ function TasksInner() {
       .maybeSingle();
 
     const { data: newTask, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .insert({
         empresa_id: EMPRESA_ID,
@@ -239,7 +239,7 @@ function TasksInner() {
 
   const fetchUpdatesForTask = async (taskId: string) => {
     setLoadingUpdates(true);
-    const { data: updatesData } = await supabase.schema('erp' as any).from('task_updates').select('*').eq('task_id', taskId).order('created_at', { ascending: false });
+    const { data: updatesData } = await supabase.schema('erp').from('task_updates').select('*').eq('task_id', taskId).order('created_at', { ascending: false });
     if (updatesData && updatesData.length > 0) {
       const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
       const { data: usersData } = userIds.length > 0
@@ -268,7 +268,7 @@ function TasksInner() {
     const userId = coreUser?.id ?? null;
     const userName = coreUser?.nombre ?? 'Usuario';
 
-    const { error: insErr } = await supabase.schema('erp' as any).from('task_updates').insert({
+    const { error: insErr } = await supabase.schema('erp').from('task_updates').insert({
       task_id: taskId, empresa_id: EMPRESA_ID, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId,
     });
     if (insErr) { alert(`Error: ${insErr.message}`); setSavingUpdate(false); return; }


### PR DESCRIPTION
## Qué

Elimina `.schema('erp' as any)` en los 5 archivos del dominio **tasks** (admin + vista usuario para las rutas inicio, rdb y dilesa). Payloads de `insert`/`update` sobre `tasks` y `task_updates` ahora usan los helpers `TablesInsert` / `TablesUpdate` autogenerados en vez de widening a `Record<string, unknown>`.

## Por qué

2º de los 6 sub-PRs de B.4 — eliminar el escape hatch de `erp` dominio por dominio para reducir blast radius en un sistema LIVE. B.4.1 (rh) quedó mergeado en #12.

## Drift fixes

### Pattern X — nuevo, específico de tasks

El type local `ErpTask` narra `estado` como unión de literales (`'pendiente' | 'en_progreso' | 'bloqueado' | 'completado' | 'cancelado'`), pero el autogen tipa la columna como `string` (el CHECK constraint de la DB no se expone al typegen). Al hidratar state con `setTasks(data ?? [])`, TS rechaza la incompatibilidad en 5 sitios.

**Fix:** `setTasks((data ?? []) as ErpTask[])` (y equivalente para `setTask`). La DB garantiza el subset vía CHECK, el assertion es seguro. Precedente existente en `app/rdb/tasks/[id]/page.tsx:237` (antes de este PR), que usaba ese mismo patrón.

### Pattern A — conocido de B.4.1

`Record<string, unknown>` payload en `insert`/`update` no satisface el tipo estricto. Aquí los payloads se construyen **dinámicamente** (se asignan props después del literal inicial), así que remover la anotación no basta (TS inferiría del literal inicial y rechazaría `.estado = ...`). 

**Fix:** importar `TablesUpdate<{ schema: 'erp' }, 'tasks'>` / `TablesInsert<{ schema: 'erp' }, 'tasks'>` desde `@/types/supabase` y alias local. Mantiene la flexibilidad dinámica y a la vez detecta columnas inventadas.

## Alcance

- 5 archivos, 47 inserciones / 41 supresiones
- 32 usages de `.schema('erp' as any)` eliminados

## Riesgos

- Bajo. Payload enviado a Supabase es idéntico byte-a-byte. El `as ErpTask[]` es una aserción segura respaldada por el CHECK de DB.
- Si el CHECK alguna vez cambiara (nuevo estado permitido en DB), el cast seguiría funcionando pero el type local `ErpTask` quedaría desactualizado — tendríamos que ampliar el union literal. Low-risk follow-up natural.

## Verificación

- [x] `npx tsc --noEmit` → 0 errores
- [x] `npm run test:run` → 11/11 passing
- [x] `grep -rn "schema('erp' as any)" app/dilesa/admin/tasks app/rdb/admin/tasks app/rdb/tasks app/inicio/tasks` → 0 matches
- [ ] Smoke manual en preview: crear/editar/completar/eliminar tarea en las 3 empresas; probar "inline estado" y "inline avance"

## Sub-PRs restantes de B.4

- B.4.3 juntas (incluye las referencias a `tasks` y `task_updates` que viven en páginas de juntas)
- B.4.4 documentos
- B.4.5 rdb procurement
- B.4.6 scripts