### PR TITLE
B.4.3 — refactor(supabase): type erp schema in juntas domain (7 files)

### DIFF
--- a/app/api/juntas/terminar/route.ts
+++ b/app/api/juntas/terminar/route.ts
@@ -176,7 +176,7 @@ export async function POST(req: NextRequest) {
   // Use created_at (server timestamp at real start) instead of fecha_hora
   // (datetime-local input stored without timezone, often off by UTC offset)
   const { data: existing } = await supabase
-    .schema('erp' as any).from('juntas').select('fecha_hora, created_at').eq('id', juntaId).single();
+    .schema('erp').from('juntas').select('fecha_hora, created_at').eq('id', juntaId).single();
 
   const now = new Date();
   const startRef = existing?.created_at ?? existing?.fecha_hora;
@@ -186,7 +186,7 @@ export async function POST(req: NextRequest) {
 
   // ── Update junta: completada + auto duration ───────────────────────────────
   const { data: junta, error: jErr } = await supabase
-    .schema('erp' as any)
+    .schema('erp')
     .from('juntas')
     .update({
       estado: 'completada',
@@ -203,7 +203,7 @@ export async function POST(req: NextRequest) {
 
   // ── Fetch attendees ────────────────────────────────────────────────────────
   const { data: asistencia } = await supabase
-    .schema('erp' as any)
+    .schema('erp')
     .from('juntas_asistencia')
     .select('asistio, persona:persona_id(nombre, apellido_paterno, email)')
     .eq('junta_id', juntaId);
@@ -220,7 +220,7 @@ export async function POST(req: NextRequest) {
 
   // ── Fetch tasks linked to this meeting ─────────────────────────────────────
   const { data: tasksData } = await supabase
-    .schema('erp' as any)
+    .schema('erp')
     .from('tasks')
     .select('titulo, estado, fecha_compromiso, asignado_a')
     .eq('entidad_tipo', 'junta')
@@ -228,7 +228,7 @@ export async function POST(req: NextRequest) {
 
   const empleadoIds = [...new Set((tasksData ?? []).map((t: any) => t.asignado_a).filter(Boolean))];
   const { data: empData } = empleadoIds.length > 0
-    ? await supabase.schema('erp' as any).from('empleados').select('id, persona:persona_id(nombre, apellido_paterno)').in('id', empleadoIds)
+    ? await supabase.schema('erp').from('empleados').select('id, persona:persona_id(nombre, apellido_paterno)').in('id', empleadoIds)
     : { data: [] };
   const empMap = new Map((empData ?? []).map((e: any) => [e.id, [e.persona?.nombre, e.persona?.apellido_paterno].filter(Boolean).join(' ')]));
 
@@ -247,7 +247,7 @@ export async function POST(req: NextRequest) {
   let actualizaciones: { tarea: string; contenido: string; tipo: string; autor: string }[] = [];
   if (taskIds.length > 0) {
     const { data: updatesData } = await supabase
-      .schema('erp' as any).from('task_updates').select('task_id, tipo, contenido, valor_anterior, valor_nuevo, creado_por')
+      .schema('erp').from('task_updates').select('task_id, tipo, contenido, valor_anterior, valor_nuevo, creado_por')
       .in('task_id', taskIds);
 
     if (updatesData && updatesData.length > 0) {

--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -67,7 +67,7 @@ type Junta = {
   titulo: string;
   descripcion: string | null;
   fecha_hora: string;
-  duracion_minutos: number;
+  duracion_minutos: number | null;
   lugar: string | null;
   estado: 'programada' | 'en_curso' | 'completada' | 'cancelada';
   tipo: string | null;
@@ -82,7 +82,7 @@ type Asistencia = {
   persona_id: string | null;
   asistio: boolean | null;
   notas: string | null;
-  persona?: { nombre: string; apellido_paterno: string | null };
+  persona?: { nombre: string; apellido_paterno: string | null } | null;
 };
 
 type JuntaTask = {
@@ -359,27 +359,27 @@ function JuntaDetailInner() {
   };
 
   const fetchAll = useCallback(async () => {
-    const { data: juntaData, error: jErr } = await supabase.schema('erp' as any).from('juntas').select('*').eq('id', id).single();
+    const { data: juntaData, error: jErr } = await supabase.schema('erp').from('juntas').select('*').eq('id', id).single();
     if (jErr || !juntaData) { setError(jErr?.message ?? 'Junta no encontrada'); setLoading(false); return; }
 
-    setJunta(juntaData);
+    setJunta(juntaData as Junta);
     setTitulo(juntaData.titulo);
     setFechaHora(toDatetimeLocal(juntaData.fecha_hora));
     setDuracion(String(juntaData.duracion_minutos ?? 60));
     setLugar(juntaData.lugar ?? '');
-    setEstado(juntaData.estado);
+    setEstado(juntaData.estado as Junta['estado']);
     setTipo(juntaData.tipo ?? '');
     // Content is set in a separate useEffect that depends on editor readiness
 
-    const { data: asistData } = await supabase.schema('erp' as any).from('juntas_asistencia').select('*, persona:persona_id(nombre, apellido_paterno)').eq('junta_id', id).order('created_at');
-    setAsistencia(asistData ?? []);
+    const { data: asistData } = await supabase.schema('erp').from('juntas_asistencia').select('*, persona:persona_id(nombre, apellido_paterno)').eq('junta_id', id).order('created_at');
+    setAsistencia((asistData ?? []) as Asistencia[]);
 
-    const { data: tasksData } = await supabase.schema('erp' as any).from('tasks').select('id, titulo, estado, asignado_a, fecha_vence').eq('entidad_tipo', 'junta').eq('entidad_id', id).order('created_at');
-    setTasks(tasksData ?? []);
+    const { data: tasksData } = await supabase.schema('erp').from('tasks').select('id, titulo, estado, asignado_a, fecha_vence').eq('entidad_tipo', 'junta').eq('entidad_id', id).order('created_at');
+    setTasks((tasksData ?? []) as JuntaTask[]);
 
     const taskIds = (tasksData ?? []).map((t: any) => t.id);
     if (taskIds.length > 0) {
-      const { data: updatesData } = await supabase.schema('erp' as any).from('task_updates').select('*').in('task_id', taskIds).order('created_at', { ascending: false });
+      const { data: updatesData } = await supabase.schema('erp').from('task_updates').select('*').in('task_id', taskIds).order('created_at', { ascending: false });
       if (updatesData && updatesData.length > 0) {
         const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
         const { data: usersData } = userIds.length > 0
@@ -392,10 +392,10 @@ function JuntaDetailInner() {
       }
     }
 
-    const { data: personasData } = await supabase.schema('erp' as any).from('personas').select('id, nombre, apellido_paterno').eq('empresa_id', juntaData.empresa_id).eq('activo', true).is('deleted_at', null).order('nombre');
+    const { data: personasData } = await supabase.schema('erp').from('personas').select('id, nombre, apellido_paterno').eq('empresa_id', juntaData.empresa_id).eq('activo', true).is('deleted_at', null).order('nombre');
     setPersonas((personasData ?? []).map((p: any) => ({ id: p.id, nombre: [p.nombre, p.apellido_paterno].filter(Boolean).join(' ') })));
 
-    const { data: empData } = await supabase.schema('erp' as any).from('empleados').select('id, persona:persona_id(nombre, apellido_paterno)').eq('empresa_id', juntaData.empresa_id).eq('activo', true).is('deleted_at', null);
+    const { data: empData } = await supabase.schema('erp').from('empleados').select('id, persona:persona_id(nombre, apellido_paterno)').eq('empresa_id', juntaData.empresa_id).eq('activo', true).is('deleted_at', null);
     setEmpleados((empData ?? []).map((e: any) => ({ id: e.id, nombre: [e.persona?.nombre, e.persona?.apellido_paterno].filter(Boolean).join(' ') })));
 
     // Check if user is admin/direccion
@@ -424,7 +424,7 @@ function JuntaDetailInner() {
     if (!junta) return;
     setSaving(true);
     const notesHtml = editor?.getHTML() ?? null;
-    const { error: err } = await supabase.schema('erp' as any).from('juntas').update({
+    const { error: err } = await supabase.schema('erp').from('juntas').update({
       titulo: titulo.trim(), fecha_hora: fechaHora,
       lugar: lugar.trim() || null, estado, tipo: tipo || null,
       descripcion: notesHtml && notesHtml !== '<p></p>' ? notesHtml : null,
@@ -453,7 +453,7 @@ function JuntaDetailInner() {
         const currentHtml = editor.getHTML();
         if (currentHtml === lastSavedHtmlRef.current) return;
         setAutoSaveStatus('saving');
-        const { error: err } = await supabase.schema('erp' as any).from('juntas').update({
+        const { error: err } = await supabase.schema('erp').from('juntas').update({
           descripcion: currentHtml && currentHtml !== '<p></p>' ? currentHtml : null,
         }).eq('id', junta.id);
         if (!err) {
@@ -485,7 +485,7 @@ function JuntaDetailInner() {
       const html = editor.getHTML();
       if (html !== lastSavedHtmlRef.current && html !== '<p></p>') {
         // Fire-and-forget save
-        supabase.schema('erp' as any).from('juntas').update({
+        supabase.schema('erp').from('juntas').update({
           descripcion: html,
         }).eq('id', juntaId).then(() => { lastSavedHtmlRef.current = html; });
       }
@@ -520,7 +520,7 @@ function JuntaDetailInner() {
       try {
         // Refresh junta description (only if user is NOT actively editing)
         if (!isEditingRef.current && editor) {
-          const { data: fresh } = await supabase.schema('erp' as any).from('juntas')
+          const { data: fresh } = await supabase.schema('erp').from('juntas')
             .select('descripcion').eq('id', juntaId).maybeSingle();
           if (fresh) {
             const remoteHtml = fresh.descripcion ?? '';
@@ -532,14 +532,14 @@ function JuntaDetailInner() {
           }
         }
         // Refresh tasks
-        const { data: tasksData } = await supabase.schema('erp' as any).from('tasks')
+        const { data: tasksData } = await supabase.schema('erp').from('tasks')
           .select('id, titulo, estado, asignado_a, fecha_vence')
           .eq('entidad_tipo', 'junta').eq('entidad_id', juntaId).order('created_at');
         if (tasksData) {
-          setTasks(tasksData);
+          setTasks(tasksData as JuntaTask[]);
           const tIds = tasksData.map((t: any) => t.id);
           if (tIds.length > 0) {
-            const { data: updData } = await supabase.schema('erp' as any).from('task_updates')
+            const { data: updData } = await supabase.schema('erp').from('task_updates')
               .select('*').in('task_id', tIds).order('created_at', { ascending: false });
             if (updData) {
               const uIds = [...new Set(updData.map((u: any) => u.creado_por).filter(Boolean))];
@@ -552,10 +552,10 @@ function JuntaDetailInner() {
           }
         }
         // Refresh attendance
-        const { data: asistData } = await supabase.schema('erp' as any).from('juntas_asistencia')
+        const { data: asistData } = await supabase.schema('erp').from('juntas_asistencia')
           .select('*, persona:persona_id(nombre, apellido_paterno)')
           .eq('junta_id', juntaId).order('created_at');
-        if (asistData) setAsistencia(asistData);
+        if (asistData) setAsistencia(asistData as Asistencia[]);
         setLastPoll(new Date().toLocaleTimeString());
       } catch { /* ignore poll errors */ }
     };
@@ -567,24 +567,24 @@ function JuntaDetailInner() {
 
   const handleToggleAsistio = async (asistId: string, current: boolean | null) => {
     const next = current === null ? true : current === true ? false : null;
-    await supabase.schema('erp' as any).from('juntas_asistencia').update({ asistio: next }).eq('id', asistId);
+    await supabase.schema('erp').from('juntas_asistencia').update({ asistio: next }).eq('id', asistId);
     setAsistencia((prev) => prev.map((a) => (a.id === asistId ? { ...a, asistio: next } : a)));
   };
 
   const handleRemoveParticipant = async (asistId: string) => {
-    await supabase.schema('erp' as any).from('juntas_asistencia').delete().eq('id', asistId);
+    await supabase.schema('erp').from('juntas_asistencia').delete().eq('id', asistId);
     setAsistencia((prev) => prev.filter((a) => a.id !== asistId));
   };
 
   const handleAddParticipant = async (personaId: string) => {
     if (!personaId || !junta) return;
     setAddingPersona(true);
-    const { data, error: err } = await supabase.schema('erp' as any).from('juntas_asistencia')
+    const { data, error: err } = await supabase.schema('erp').from('juntas_asistencia')
       .insert({ empresa_id: junta.empresa_id, junta_id: junta.id, persona_id: personaId })
       .select('*, persona:persona_id(nombre, apellido_paterno)').single();
     setAddingPersona(false);
     if (err) { alert(`Error al agregar participante: ${err.message}`); return; }
-    setAsistencia((prev) => [...prev, data]);
+    setAsistencia((prev) => [...prev, data as Asistencia]);
     setShowAddPersona(false);
   };
 
@@ -593,14 +593,14 @@ function JuntaDetailInner() {
     setAddingTask(true);
     const { data: { user } } = await supabase.auth.getUser();
     const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
-    const { data: newTask, error: err } = await supabase.schema('erp' as any).from('tasks').insert({
+    const { data: newTask, error: err } = await supabase.schema('erp').from('tasks').insert({
       empresa_id: junta.empresa_id, titulo: taskForm.titulo.trim(),
       asignado_a: taskForm.asignado_a || null, prioridad: taskForm.prioridad, estado: taskForm.estado,
       fecha_compromiso: taskForm.fecha_vence || null, creado_por: coreUser?.id ?? null, entidad_tipo: 'junta', entidad_id: junta.id,
     }).select('id, titulo, estado, asignado_a, fecha_vence').single();
     setAddingTask(false);
     if (err) { alert(`Error al crear tarea: ${err.message}`); return; }
-    setTasks((prev) => [...prev, newTask]);
+    setTasks((prev) => [...prev, newTask as JuntaTask]);
     setTaskForm({ titulo: '', prioridad: '', asignado_a: '', estado: 'pendiente', fecha_vence: '' });
     setShowAddTask(false);
   };
@@ -625,7 +625,7 @@ function JuntaDetailInner() {
       inserts.push({ task_id: taskId, empresa_id: junta.empresa_id, tipo: 'cambio_fecha', valor_anterior: task.fecha_vence ?? '', valor_nuevo: updateForm.nuevaFecha, creado_por: userId });
     }
 
-    const { error: insErr } = await supabase.schema('erp' as any).from('task_updates').insert(inserts);
+    const { error: insErr } = await supabase.schema('erp').from('task_updates').insert(inserts);
     if (insErr) { alert(`Error: ${insErr.message}`); setSavingUpdate(false); return; }
 
     const taskPatch: any = {};
@@ -638,7 +638,7 @@ function JuntaDetailInner() {
       taskPatch.fecha_vence = updateForm.nuevaFecha;
     }
     if (Object.keys(taskPatch).length > 0) {
-      await supabase.schema('erp' as any).from('tasks').update(taskPatch).eq('id', taskId);
+      await supabase.schema('erp').from('tasks').update(taskPatch).eq('id', taskId);
       setTasks(prev => prev.map(t => t.id === taskId ? { ...t, ...taskPatch } : t));
     }
 
@@ -667,7 +667,7 @@ function JuntaDetailInner() {
     try {
       // Auto-save notes before finishing to ensure they are in the email/DB
       const notesHtml = editor?.getHTML() ?? null;
-      await supabase.schema('erp' as any).from('juntas').update({
+      await supabase.schema('erp').from('juntas').update({
         descripcion: notesHtml && notesHtml !== '<p></p>' ? notesHtml : null,
       }).eq('id', junta.id);
 
@@ -687,9 +687,9 @@ function JuntaDetailInner() {
     setDeleting(true);
     try {
       // Delete related records first
-      await supabase.schema('erp' as any).from('juntas_asistencia').delete().eq('junta_id', junta.id);
-      await supabase.schema('erp' as any).from('tasks').update({ entidad_tipo: null, entidad_id: null }).eq('entidad_tipo', 'junta').eq('entidad_id', junta.id);
-      const { error: err } = await supabase.schema('erp' as any).from('juntas').delete().eq('id', junta.id);
+      await supabase.schema('erp').from('juntas_asistencia').delete().eq('junta_id', junta.id);
+      await supabase.schema('erp').from('tasks').update({ entidad_tipo: null, entidad_id: null }).eq('entidad_tipo', 'junta').eq('entidad_id', junta.id);
+      const { error: err } = await supabase.schema('erp').from('juntas').delete().eq('id', junta.id);
       if (err) { alert(`Error al eliminar: ${err.message}`); return; }
       router.push('/dilesa/admin/juntas');
     } finally { setDeleting(false); }
@@ -905,7 +905,7 @@ function JuntaDetailInner() {
                     disabled={completingTask === task.id}
                     onClick={async () => {
                       setCompletingTask(task.id);
-                      const { error: err } = await supabase.schema('erp' as any).from('tasks').update({ estado: 'completado', porcentaje_avance: 100 }).eq('id', task.id);
+                      const { error: err } = await supabase.schema('erp').from('tasks').update({ estado: 'completado', porcentaje_avance: 100 }).eq('id', task.id);
                       setCompletingTask(null);
                       if (err) { alert(`Error: ${err.message}`); return; }
                       setTasks((prev) => prev.map((t) => t.id === task.id ? { ...t, estado: 'completado' } : t));

--- a/app/dilesa/admin/juntas/page.tsx
+++ b/app/dilesa/admin/juntas/page.tsx
@@ -37,7 +37,7 @@ type Junta = {
   titulo: string;
   descripcion: string | null;
   fecha_hora: string;
-  duracion_minutos: number;
+  duracion_minutos: number | null;
   lugar: string | null;
   estado: 'programada' | 'en_curso' | 'completada' | 'cancelada';
   tipo: string | null;
@@ -137,22 +137,22 @@ function JuntasInner() {
 
   const fetchJuntas = useCallback(async () => {
     const [jRes, aRes, tRes] = await Promise.all([
-      supabase.schema('erp' as any).from('juntas').select('*')
+      supabase.schema('erp').from('juntas').select('*')
         .eq('empresa_id', EMPRESA_ID).order('fecha_hora', { ascending: false }),
-      supabase.schema('erp' as any).from('juntas_asistencia').select('junta_id')
+      supabase.schema('erp').from('juntas_asistencia').select('junta_id')
         .eq('empresa_id', EMPRESA_ID),
-      supabase.schema('erp' as any).from('tasks').select('entidad_id')
+      supabase.schema('erp').from('tasks').select('entidad_id')
         .eq('empresa_id', EMPRESA_ID).eq('entidad_tipo', 'junta'),
     ]);
     if (jRes.error) { setError(jRes.error.message); return; }
-    setJuntas(jRes.data ?? []);
+    setJuntas((jRes.data ?? []) as Junta[]);
     const aCounts = new Map<string, number>();
     (aRes.data ?? []).forEach((a: { junta_id: string }) => {
       aCounts.set(a.junta_id, (aCounts.get(a.junta_id) ?? 0) + 1);
     });
     setAsistenciaCounts(aCounts);
     const tCounts = new Map<string, number>();
-    (tRes.data ?? []).forEach((t: { entidad_id: string }) => {
+    (tRes.data ?? []).forEach((t: { entidad_id: string | null }) => {
       if (t.entidad_id) tCounts.set(t.entidad_id, (tCounts.get(t.entidad_id) ?? 0) + 1);
     });
     setTaskCounts(tCounts);
@@ -192,7 +192,7 @@ function JuntasInner() {
 
     const titulo = createTitulo.trim() || generateTitulo(createFechaHora, createTipo);
     const { data: newJunta, error: err } = await supabase
-      .schema('erp' as any).from('juntas').insert({
+      .schema('erp').from('juntas').insert({
         empresa_id: EMPRESA_ID,
         titulo,
         fecha_hora: createFechaHora,

--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -62,7 +62,7 @@ type Junta = {
   titulo: string;
   descripcion: string | null;
   fecha_hora: string;
-  duracion_minutos: number;
+  duracion_minutos: number | null;
   lugar: string | null;
   estado: 'programada' | 'en_curso' | 'completada' | 'cancelada';
   tipo: string | null;
@@ -77,7 +77,7 @@ type Asistencia = {
   persona_id: string | null;
   asistio: boolean | null;
   notas: string | null;
-  persona?: { nombre: string; apellido_paterno: string | null };
+  persona?: { nombre: string; apellido_paterno: string | null } | null;
 };
 
 type JuntaTask = {
@@ -287,7 +287,7 @@ function JuntaDetailInner() {
   const fetchAll = useCallback(async () => {
     // Load junta
     const { data: juntaData, error: jErr } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas')
       .select('*')
       .eq('id', id)
@@ -299,12 +299,12 @@ function JuntaDetailInner() {
       return;
     }
 
-    setJunta(juntaData);
+    setJunta(juntaData as Junta);
     setTitulo(juntaData.titulo);
     setFechaHora(toDatetimeLocal(juntaData.fecha_hora));
     setDuracion(String(juntaData.duracion_minutos ?? 60));
     setLugar(juntaData.lugar ?? '');
-    setEstado(juntaData.estado);
+    setEstado(juntaData.estado as Junta['estado']);
     setTipo(juntaData.tipo ?? '');
 
     if (editor && juntaData.descripcion) {
@@ -313,28 +313,28 @@ function JuntaDetailInner() {
 
     // Load asistencia with personas
     const { data: asistData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas_asistencia')
       .select('*, persona:persona_id(nombre, apellido_paterno)')
       .eq('junta_id', id)
       .order('created_at');
 
-    setAsistencia(asistData ?? []);
+    setAsistencia((asistData ?? []) as Asistencia[]);
 
     // Load related tasks
     const { data: tasksData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .select('id, titulo, estado, asignado_a, fecha_vence')
       .eq('entidad_tipo', 'junta')
       .eq('entidad_id', id)
       .order('created_at');
 
-    setTasks(tasksData ?? []);
+    setTasks((tasksData ?? []) as JuntaTask[]);
 
     const taskIds = (tasksData ?? []).map((t: any) => t.id);
     if (taskIds.length > 0) {
-      const { data: updatesData } = await supabase.schema('erp' as any).from('task_updates').select('*').in('task_id', taskIds).order('created_at', { ascending: false });
+      const { data: updatesData } = await supabase.schema('erp').from('task_updates').select('*').in('task_id', taskIds).order('created_at', { ascending: false });
       if (updatesData && updatesData.length > 0) {
         const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
         const { data: usersData } = userIds.length > 0
@@ -349,7 +349,7 @@ function JuntaDetailInner() {
 
     // Load personas for this empresa
     const { data: personasData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('personas')
       .select('id, nombre, apellido_paterno')
       .eq('empresa_id', juntaData.empresa_id)
@@ -366,7 +366,7 @@ function JuntaDetailInner() {
 
     // Load empleados for task assignment
     const { data: empData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .select('id, persona:persona_id(nombre, apellido_paterno)')
       .eq('empresa_id', juntaData.empresa_id)
@@ -401,7 +401,7 @@ function JuntaDetailInner() {
     const notesHtml = editor?.getHTML() ?? null;
 
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas')
       .update({
         titulo: titulo.trim(),
@@ -437,7 +437,7 @@ function JuntaDetailInner() {
         const currentHtml = editor.getHTML();
         if (currentHtml === lastSavedHtmlRef.current) return;
         setAutoSaveStatus('saving');
-        const { error: err } = await supabase.schema('erp' as any).from('juntas').update({
+        const { error: err } = await supabase.schema('erp').from('juntas').update({
           descripcion: currentHtml && currentHtml !== '<p></p>' ? currentHtml : null,
         }).eq('id', junta.id);
         if (!err) {
@@ -460,7 +460,7 @@ function JuntaDetailInner() {
     const flushSave = () => {
       const html = editor.getHTML();
       if (html !== lastSavedHtmlRef.current && html !== '<p></p>') {
-        supabase.schema('erp' as any).from('juntas').update({ descripcion: html }).eq('id', juntaId).then(() => { lastSavedHtmlRef.current = html; });
+        supabase.schema('erp').from('juntas').update({ descripcion: html }).eq('id', juntaId).then(() => { lastSavedHtmlRef.current = html; });
       }
     };
     const handleVisChange = () => { if (document.visibilityState === 'hidden') flushSave(); };
@@ -488,7 +488,7 @@ function JuntaDetailInner() {
     const poll = async () => {
       try {
         if (!isEditingRef.current && editor) {
-          const { data: fresh } = await supabase.schema('erp' as any).from('juntas').select('descripcion').eq('id', juntaId).maybeSingle();
+          const { data: fresh } = await supabase.schema('erp').from('juntas').select('descripcion').eq('id', juntaId).maybeSingle();
           if (fresh) {
             const remoteHtml = fresh.descripcion ?? '';
             const localHtml = editor.getHTML();
@@ -498,12 +498,12 @@ function JuntaDetailInner() {
             }
           }
         }
-        const { data: tasksData } = await supabase.schema('erp' as any).from('tasks').select('id, titulo, estado, asignado_a, fecha_vence').eq('entidad_tipo', 'junta').eq('entidad_id', juntaId).order('created_at');
+        const { data: tasksData } = await supabase.schema('erp').from('tasks').select('id, titulo, estado, asignado_a, fecha_vence').eq('entidad_tipo', 'junta').eq('entidad_id', juntaId).order('created_at');
         if (tasksData) {
-          setTasks(tasksData);
+          setTasks(tasksData as JuntaTask[]);
           const tIds = tasksData.map((t: any) => t.id);
           if (tIds.length > 0) {
-            const { data: updData } = await supabase.schema('erp' as any).from('task_updates')
+            const { data: updData } = await supabase.schema('erp').from('task_updates')
               .select('*').in('task_id', tIds).order('created_at', { ascending: false });
             if (updData) {
               const uIds = [...new Set(updData.map((u: any) => u.creado_por).filter(Boolean))];
@@ -515,8 +515,8 @@ function JuntaDetailInner() {
             }
           }
         }
-        const { data: asistData } = await supabase.schema('erp' as any).from('juntas_asistencia').select('*, persona:persona_id(nombre, apellido_paterno)').eq('junta_id', juntaId).order('created_at');
-        if (asistData) setAsistencia(asistData);
+        const { data: asistData } = await supabase.schema('erp').from('juntas_asistencia').select('*, persona:persona_id(nombre, apellido_paterno)').eq('junta_id', juntaId).order('created_at');
+        if (asistData) setAsistencia(asistData as Asistencia[]);
         setLastPoll(new Date().toLocaleTimeString());
       } catch { /* ignore */ }
     };
@@ -529,7 +529,7 @@ function JuntaDetailInner() {
     // Cycle: null → true → false → null
     const next = current === null ? true : current === true ? false : null;
     await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas_asistencia')
       .update({ asistio: next })
       .eq('id', asistId);
@@ -541,7 +541,7 @@ function JuntaDetailInner() {
 
   const handleRemoveParticipant = async (asistId: string) => {
     await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas_asistencia')
       .delete()
       .eq('id', asistId);
@@ -554,7 +554,7 @@ function JuntaDetailInner() {
     setAddingPersona(true);
 
     const { data, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas_asistencia')
       .insert({
         empresa_id: junta.empresa_id,
@@ -571,7 +571,7 @@ function JuntaDetailInner() {
       return;
     }
 
-    setAsistencia((prev) => [...prev, data]);
+    setAsistencia((prev) => [...prev, data as Asistencia]);
     setSelectedPersonaId('');
     setShowAddPersona(false);
   };
@@ -589,7 +589,7 @@ function JuntaDetailInner() {
       .maybeSingle();
 
     const { data: newTask, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .insert({
         empresa_id: junta.empresa_id,
@@ -613,7 +613,7 @@ function JuntaDetailInner() {
       return;
     }
 
-    setTasks((prev) => [...prev, newTask]);
+    setTasks((prev) => [...prev, newTask as JuntaTask]);
     setTaskForm({ titulo: '', descripcion: '', asignado_a: '', prioridad: '', estado: 'pendiente', fecha_vence: '' });
     setShowAddTask(false);
   };
@@ -667,7 +667,7 @@ function JuntaDetailInner() {
       inserts.push({ task_id: taskId, empresa_id: junta.empresa_id, tipo: 'cambio_fecha', valor_anterior: task.fecha_vence ?? '', valor_nuevo: updateForm.nuevaFecha, creado_por: userId });
     }
 
-    const { error: insErr } = await supabase.schema('erp' as any).from('task_updates').insert(inserts);
+    const { error: insErr } = await supabase.schema('erp').from('task_updates').insert(inserts);
     if (insErr) { alert(`Error: ${insErr.message}`); setSavingUpdate(false); return; }
 
     const taskPatch: any = {};
@@ -680,7 +680,7 @@ function JuntaDetailInner() {
       taskPatch.fecha_vence = updateForm.nuevaFecha;
     }
     if (Object.keys(taskPatch).length > 0) {
-      await supabase.schema('erp' as any).from('tasks').update(taskPatch).eq('id', taskId);
+      await supabase.schema('erp').from('tasks').update(taskPatch).eq('id', taskId);
       setTasks(prev => prev.map(t => t.id === taskId ? { ...t, ...taskPatch } : t));
     }
 
@@ -1100,7 +1100,7 @@ function JuntaDetailInner() {
                     disabled={completingTask === task.id}
                     onClick={async () => {
                       setCompletingTask(task.id);
-                      const { error: err } = await supabase.schema('erp' as any).from('tasks').update({ estado: 'completado', porcentaje_avance: 100 }).eq('id', task.id);
+                      const { error: err } = await supabase.schema('erp').from('tasks').update({ estado: 'completado', porcentaje_avance: 100 }).eq('id', task.id);
                       setCompletingTask(null);
                       if (err) { alert(`Error: ${err.message}`); return; }
                       setTasks((prev) => prev.map((t) => t.id === task.id ? { ...t, estado: 'completado' } : t));

--- a/app/inicio/juntas/page.tsx
+++ b/app/inicio/juntas/page.tsx
@@ -41,7 +41,7 @@ type Junta = {
   titulo: string;
   descripcion: string | null;
   fecha_hora: string;
-  duracion_minutos: number;
+  duracion_minutos: number | null;
   lugar: string | null;
   estado: 'programada' | 'en_curso' | 'completada' | 'cancelada';
   tipo: string | null;
@@ -161,14 +161,14 @@ function JuntasInner() {
   const fetchJuntas = useCallback(async (ids: string[]) => {
     if (ids.length === 0) { setJuntas([]); return; }
     const { data, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas')
       .select('*')
       .in('empresa_id', ids)
       .order('fecha_hora', { ascending: false });
 
     if (err) { setError(err.message); return; }
-    setJuntas(data ?? []);
+    setJuntas((data ?? []) as Junta[]);
   }, [supabase]);
 
   useEffect(() => {
@@ -199,7 +199,7 @@ function JuntasInner() {
       .eq('email', (user?.email ?? '').toLowerCase())
       .maybeSingle();
 
-    const payload: Record<string, unknown> = {
+    const payload = {
       empresa_id: empresaIds[0],
       titulo: createForm.titulo.trim(),
       fecha_hora: createForm.fecha_hora,
@@ -211,7 +211,7 @@ function JuntasInner() {
     };
 
     const { data: newJunta, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas')
       .insert(payload)
       .select()

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -61,7 +61,7 @@ type Junta = {
   titulo: string;
   descripcion: string | null;
   fecha_hora: string;
-  duracion_minutos: number;
+  duracion_minutos: number | null;
   lugar: string | null;
   estado: 'programada' | 'en_curso' | 'completada' | 'cancelada';
   tipo: string | null;
@@ -76,7 +76,7 @@ type Asistencia = {
   persona_id: string | null;
   asistio: boolean | null;
   notas: string | null;
-  persona?: { nombre: string; apellido_paterno: string | null };
+  persona?: { nombre: string; apellido_paterno: string | null } | null;
 };
 
 type JuntaTask = {
@@ -273,7 +273,7 @@ function JuntaDetailInner() {
 
   const fetchAll = useCallback(async () => {
     const { data: juntaData, error: jErr } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas')
       .select('*')
       .eq('id', id)
@@ -285,12 +285,12 @@ function JuntaDetailInner() {
       return;
     }
 
-    setJunta(juntaData);
+    setJunta(juntaData as Junta);
     setTitulo(juntaData.titulo);
     setFechaHora(toDatetimeLocal(juntaData.fecha_hora));
     setDuracion(String(juntaData.duracion_minutos ?? 60));
     setLugar(juntaData.lugar ?? '');
-    setEstado(juntaData.estado);
+    setEstado(juntaData.estado as Junta['estado']);
     setTipo(juntaData.tipo ?? '');
 
     if (editor && juntaData.descripcion) {
@@ -298,27 +298,27 @@ function JuntaDetailInner() {
     }
 
     const { data: asistData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas_asistencia')
       .select('*, persona:persona_id(nombre, apellido_paterno)')
       .eq('junta_id', id)
       .order('created_at');
 
-    setAsistencia(asistData ?? []);
+    setAsistencia((asistData ?? []) as Asistencia[]);
 
     const { data: tasksData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .select('id, titulo, estado, asignado_a, fecha_vence')
       .eq('entidad_tipo', 'junta')
       .eq('entidad_id', id)
       .order('created_at');
 
-    setTasks(tasksData ?? []);
+    setTasks((tasksData ?? []) as JuntaTask[]);
 
     const taskIds = (tasksData ?? []).map((t: any) => t.id);
     if (taskIds.length > 0) {
-      const { data: updatesData } = await supabase.schema('erp' as any).from('task_updates').select('*').in('task_id', taskIds).order('created_at', { ascending: false });
+      const { data: updatesData } = await supabase.schema('erp').from('task_updates').select('*').in('task_id', taskIds).order('created_at', { ascending: false });
       if (updatesData && updatesData.length > 0) {
         const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
         const { data: usersData } = userIds.length > 0
@@ -332,7 +332,7 @@ function JuntaDetailInner() {
     }
 
     const { data: personasData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('personas')
       .select('id, nombre, apellido_paterno')
       .eq('empresa_id', EMPRESA_ID)
@@ -348,7 +348,7 @@ function JuntaDetailInner() {
     );
 
     const { data: empData } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('empleados')
       .select('id, persona:persona_id(nombre, apellido_paterno)')
       .eq('empresa_id', EMPRESA_ID)
@@ -382,7 +382,7 @@ function JuntaDetailInner() {
     const notesHtml = editor?.getHTML() ?? null;
 
     const { error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas')
       .update({
         titulo: titulo.trim(),
@@ -418,7 +418,7 @@ function JuntaDetailInner() {
         const currentHtml = editor.getHTML();
         if (currentHtml === lastSavedHtmlRef.current) return;
         setAutoSaveStatus('saving');
-        const { error: err } = await supabase.schema('erp' as any).from('juntas').update({
+        const { error: err } = await supabase.schema('erp').from('juntas').update({
           descripcion: currentHtml && currentHtml !== '<p></p>' ? currentHtml : null,
         }).eq('id', junta.id);
         if (!err) {
@@ -441,7 +441,7 @@ function JuntaDetailInner() {
     const flushSave = () => {
       const html = editor.getHTML();
       if (html !== lastSavedHtmlRef.current && html !== '<p></p>') {
-        supabase.schema('erp' as any).from('juntas').update({ descripcion: html }).eq('id', juntaId).then(() => { lastSavedHtmlRef.current = html; });
+        supabase.schema('erp').from('juntas').update({ descripcion: html }).eq('id', juntaId).then(() => { lastSavedHtmlRef.current = html; });
       }
     };
     const handleVisChange = () => { if (document.visibilityState === 'hidden') flushSave(); };
@@ -469,7 +469,7 @@ function JuntaDetailInner() {
     const poll = async () => {
       try {
         if (!isEditingRef.current && editor) {
-          const { data: fresh } = await supabase.schema('erp' as any).from('juntas').select('descripcion').eq('id', juntaId).maybeSingle();
+          const { data: fresh } = await supabase.schema('erp').from('juntas').select('descripcion').eq('id', juntaId).maybeSingle();
           if (fresh) {
             const remoteHtml = fresh.descripcion ?? '';
             const localHtml = editor.getHTML();
@@ -479,12 +479,12 @@ function JuntaDetailInner() {
             }
           }
         }
-        const { data: tasksData } = await supabase.schema('erp' as any).from('tasks').select('id, titulo, estado, asignado_a, fecha_vence').eq('entidad_tipo', 'junta').eq('entidad_id', juntaId).order('created_at');
+        const { data: tasksData } = await supabase.schema('erp').from('tasks').select('id, titulo, estado, asignado_a, fecha_vence').eq('entidad_tipo', 'junta').eq('entidad_id', juntaId).order('created_at');
         if (tasksData) {
-          setTasks(tasksData);
+          setTasks(tasksData as JuntaTask[]);
           const tIds = tasksData.map((t: any) => t.id);
           if (tIds.length > 0) {
-            const { data: updData } = await supabase.schema('erp' as any).from('task_updates')
+            const { data: updData } = await supabase.schema('erp').from('task_updates')
               .select('*').in('task_id', tIds).order('created_at', { ascending: false });
             if (updData) {
               const uIds = [...new Set(updData.map((u: any) => u.creado_por).filter(Boolean))];
@@ -496,8 +496,8 @@ function JuntaDetailInner() {
             }
           }
         }
-        const { data: asistData } = await supabase.schema('erp' as any).from('juntas_asistencia').select('*, persona:persona_id(nombre, apellido_paterno)').eq('junta_id', juntaId).order('created_at');
-        if (asistData) setAsistencia(asistData);
+        const { data: asistData } = await supabase.schema('erp').from('juntas_asistencia').select('*, persona:persona_id(nombre, apellido_paterno)').eq('junta_id', juntaId).order('created_at');
+        if (asistData) setAsistencia(asistData as Asistencia[]);
         setLastPoll(new Date().toLocaleTimeString());
       } catch { /* ignore */ }
     };
@@ -509,7 +509,7 @@ function JuntaDetailInner() {
   const handleToggleAsistio = async (asistId: string, current: boolean | null) => {
     const next = current === null ? true : current === true ? false : null;
     await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas_asistencia')
       .update({ asistio: next })
       .eq('id', asistId);
@@ -521,7 +521,7 @@ function JuntaDetailInner() {
 
   const handleRemoveParticipant = async (asistId: string) => {
     await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas_asistencia')
       .delete()
       .eq('id', asistId);
@@ -534,7 +534,7 @@ function JuntaDetailInner() {
     setAddingPersona(true);
 
     const { data, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas_asistencia')
       .insert({
         empresa_id: EMPRESA_ID,
@@ -551,7 +551,7 @@ function JuntaDetailInner() {
       return;
     }
 
-    setAsistencia((prev) => [...prev, data]);
+    setAsistencia((prev) => [...prev, data as Asistencia]);
     setSelectedPersonaId('');
     setShowAddPersona(false);
   };
@@ -569,7 +569,7 @@ function JuntaDetailInner() {
       .maybeSingle();
 
     const { data: newTask, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('tasks')
       .insert({
         empresa_id: EMPRESA_ID,
@@ -593,7 +593,7 @@ function JuntaDetailInner() {
       return;
     }
 
-    setTasks((prev) => [...prev, newTask]);
+    setTasks((prev) => [...prev, newTask as JuntaTask]);
     setTaskForm({ titulo: '', descripcion: '', asignado_a: '', prioridad: '', estado: 'pendiente', fecha_vence: '' });
     setShowAddTask(false);
   };
@@ -647,7 +647,7 @@ function JuntaDetailInner() {
       inserts.push({ task_id: taskId, empresa_id: EMPRESA_ID, tipo: 'cambio_fecha', valor_anterior: task.fecha_vence ?? '', valor_nuevo: updateForm.nuevaFecha, creado_por: userId });
     }
 
-    const { error: insErr } = await supabase.schema('erp' as any).from('task_updates').insert(inserts);
+    const { error: insErr } = await supabase.schema('erp').from('task_updates').insert(inserts);
     if (insErr) { alert(`Error: ${insErr.message}`); setSavingUpdate(false); return; }
 
     const taskPatch: any = {};
@@ -660,7 +660,7 @@ function JuntaDetailInner() {
       taskPatch.fecha_vence = updateForm.nuevaFecha;
     }
     if (Object.keys(taskPatch).length > 0) {
-      await supabase.schema('erp' as any).from('tasks').update(taskPatch).eq('id', taskId);
+      await supabase.schema('erp').from('tasks').update(taskPatch).eq('id', taskId);
       setTasks(prev => prev.map(t => t.id === taskId ? { ...t, ...taskPatch } : t));
     }
 
@@ -1072,7 +1072,7 @@ function JuntaDetailInner() {
                     disabled={completingTask === task.id}
                     onClick={async () => {
                       setCompletingTask(task.id);
-                      const { error: err } = await supabase.schema('erp' as any).from('tasks').update({ estado: 'completado', porcentaje_avance: 100 }).eq('id', task.id);
+                      const { error: err } = await supabase.schema('erp').from('tasks').update({ estado: 'completado', porcentaje_avance: 100 }).eq('id', task.id);
                       setCompletingTask(null);
                       if (err) { alert(`Error: ${err.message}`); return; }
                       setTasks((prev) => prev.map((t) => t.id === task.id ? { ...t, estado: 'completado' } : t));

--- a/app/rdb/admin/juntas/page.tsx
+++ b/app/rdb/admin/juntas/page.tsx
@@ -37,7 +37,7 @@ type Junta = {
   titulo: string;
   descripcion: string | null;
   fecha_hora: string;
-  duracion_minutos: number;
+  duracion_minutos: number | null;
   lugar: string | null;
   estado: 'programada' | 'en_curso' | 'completada' | 'cancelada';
   tipo: string | null;
@@ -127,22 +127,22 @@ function JuntasInner() {
 
   const fetchJuntas = useCallback(async () => {
     const [jRes, aRes, tRes] = await Promise.all([
-      supabase.schema('erp' as any).from('juntas').select('*')
+      supabase.schema('erp').from('juntas').select('*')
         .eq('empresa_id', EMPRESA_ID).order('fecha_hora', { ascending: false }),
-      supabase.schema('erp' as any).from('juntas_asistencia').select('junta_id')
+      supabase.schema('erp').from('juntas_asistencia').select('junta_id')
         .eq('empresa_id', EMPRESA_ID),
-      supabase.schema('erp' as any).from('tasks').select('entidad_id')
+      supabase.schema('erp').from('tasks').select('entidad_id')
         .eq('empresa_id', EMPRESA_ID).eq('entidad_tipo', 'junta'),
     ]);
     if (jRes.error) { setError(jRes.error.message); return; }
-    setJuntas(jRes.data ?? []);
+    setJuntas((jRes.data ?? []) as Junta[]);
     const aCounts = new Map<string, number>();
     (aRes.data ?? []).forEach((a: { junta_id: string }) => {
       aCounts.set(a.junta_id, (aCounts.get(a.junta_id) ?? 0) + 1);
     });
     setAsistenciaCounts(aCounts);
     const tCounts = new Map<string, number>();
-    (tRes.data ?? []).forEach((t: { entidad_id: string }) => {
+    (tRes.data ?? []).forEach((t: { entidad_id: string | null }) => {
       if (t.entidad_id) tCounts.set(t.entidad_id, (tCounts.get(t.entidad_id) ?? 0) + 1);
     });
     setTaskCounts(tCounts);
@@ -174,7 +174,7 @@ function JuntasInner() {
       .eq('email', (user?.email ?? '').toLowerCase())
       .maybeSingle();
 
-    const payload: Record<string, unknown> = {
+    const payload = {
       empresa_id: EMPRESA_ID,
       titulo: createForm.titulo.trim(),
       fecha_hora: createForm.fecha_hora,
@@ -186,7 +186,7 @@ function JuntasInner() {
     };
 
     const { data: newJunta, error: err } = await supabase
-      .schema('erp' as any)
+      .schema('erp')
       .from('juntas')
       .insert(payload)
       .select()


### PR DESCRIPTION
## Summary

Cuarto sub-PR del bloque **B.4 — erp schema typed migration**. Quita los `.schema('erp' as any)` del dominio **juntas** y los deja fuertemente tipados contra `Database['erp']`.

**Alcance (7 archivos, 80 usages):**
- `app/dilesa/admin/juntas/[id]/page.tsx` (24)
- `app/dilesa/admin/juntas/page.tsx` (4)
- `app/rdb/admin/juntas/[id]/page.tsx` (20)
- `app/rdb/admin/juntas/page.tsx` (4)
- `app/inicio/juntas/[id]/page.tsx` (20)
- `app/inicio/juntas/page.tsx` (2)
- `app/api/juntas/terminar/route.ts` (6)

**Tablas cubiertas:** `juntas`, `juntas_asistencia`, `tasks`, `task_updates`, `empleados`, `personas`. Este PR absorbe los `tasks`/`task_updates` que viven dentro de páginas de juntas (quedaron fuera del B.4.2 por ubicación, no por tabla).

## Drift fixes

- **Widen `Junta.duracion_minutos`**: `number` → `number | null` en los 6 tipos locales (alineado con la columna nullable del autogen).
- **Widen `Asistencia.persona`**: `{...} | undefined` → `{...} | null | undefined` en los 3 detail pages (el embed de Supabase devuelve `null` cuando no hay fila relacionada).
- **Hydration asserts**: `as Junta[]` / `as JuntaTask[]` / `as Asistencia[]` en los `setState(...)` donde el `estado` es literal-union local pero el autogen lo expone como `string`. Misma técnica aplicada en B.4.2 tasks — segura porque DB CHECK garantiza el subconjunto.
- **Widen `entidad_id`**: callback params `(t: { entidad_id: string })` → `string | null` en los listings dilesa/rdb (la columna `tasks.entidad_id` es nullable).
- **Drop `Record<string, unknown>`**: 2 payloads de `insert` en juntas (rdb, inicio) dejados con inferencia del literal para que TS valide las columnas contra el schema.

## Out of scope

- `.schema('core' as any)` — persiste (B.5, futuro).
- Resto del B.4: `documentos` (B.4.4), `rdb procurement` (B.4.5), `scripts` (B.4.6).

## Test plan

- [x] `npx tsc --noEmit` → EXIT=0
- [x] `npm run test:run` → 11/11 passing
- [ ] Smoke en preview (dilesa y rdb):
  - [ ] Crear una junta (form), confirmar que aparece en la lista
  - [ ] Abrir una junta existente, agregar asistente, togglear `asistio`
  - [ ] Crear tarea desde la vista de junta
  - [ ] Terminar una junta (`/api/juntas/terminar`) y validar que arranca tareas pendientes

🤖 Generated with [Claude Code](https://claude.com/claude-code)