### PR TITLE
B.5.1 — refactor(lib): type core schema in permissions (1 file)

### DIFF
--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabase';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -72,7 +73,7 @@ export const ADMIN_ONLY_ROUTES = new Set(['/agents', '/usage', '/rnd']);
 // ── Fetcher ────────────────────────────────────────────────────────────────
 
 export async function fetchPermissionsForUserId(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
   userId: string,
 ): Promise<UserPermissions> {
   const empty: UserPermissions = {
@@ -85,7 +86,7 @@ export async function fetchPermissionsForUserId(
 
   // Look up core.usuarios by ID
   const { data: coreUser } = await supabase
-    .schema('core' as any)
+    .schema('core')
     .from('usuarios')
     .select('id, email, rol, activo')
     .eq('id', userId)
@@ -104,22 +105,22 @@ export async function fetchPermissionsForUserId(
   const [empresasRes, modulosRes, permisosRolRes, excepcionesRes, allEmpresasRes] =
     await Promise.all([
       supabase
-        .schema('core' as any)
+        .schema('core')
         .from('usuarios_empresas')
         .select('empresa_id, rol_id, activo')
         .eq('usuario_id', coreUser.id)
         .eq('activo', true),
-      supabase.schema('core' as any).from('modulos').select('id, slug'),
+      supabase.schema('core').from('modulos').select('id, slug'),
       supabase
-        .schema('core' as any)
+        .schema('core')
         .from('permisos_rol')
         .select('rol_id, modulo_id, acceso_lectura, acceso_escritura'),
       supabase
-        .schema('core' as any)
+        .schema('core')
         .from('permisos_usuario_excepcion')
         .select('empresa_id, modulo_id, acceso_lectura, acceso_escritura')
         .eq('usuario_id', coreUser.id),
-      supabase.schema('core' as any).from('empresas').select('id, slug'),
+      supabase.schema('core').from('empresas').select('id, slug'),
     ]);
 
   const userEmpresas = empresasRes.data ?? [];
@@ -142,25 +143,31 @@ export async function fetchPermissionsForUserId(
   const modulos = new Map<string, AccessLevel>();
   for (const ue of userEmpresas) {
     if (!ue.rol_id) continue;
-    const rolePerms = allPermisos.filter((p: any) => p.rol_id === ue.rol_id);
+    const rolePerms = allPermisos.filter((p) => p.rol_id === ue.rol_id);
     for (const perm of rolePerms) {
       const moduloSlug = moduloIdToSlug.get(perm.modulo_id);
       if (!moduloSlug) continue;
-      modulos.set(moduloSlug, { read: perm.acceso_lectura, write: perm.acceso_escritura });
+      modulos.set(moduloSlug, {
+        read: perm.acceso_lectura ?? false,
+        write: perm.acceso_escritura ?? false,
+      });
     }
   }
 
   for (const exc of userExcepciones) {
     const moduloSlug = moduloIdToSlug.get(exc.modulo_id);
     if (!moduloSlug) continue;
-    modulos.set(moduloSlug, { read: exc.acceso_lectura, write: exc.acceso_escritura });
+    modulos.set(moduloSlug, {
+      read: exc.acceso_lectura ?? false,
+      write: exc.acceso_escritura ?? false,
+    });
   }
 
   return { isAdmin: false, loading: false, email, empresas, modulos };
 }
 
 export async function fetchUserPermissions(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient<Database>,
 ): Promise<UserPermissions> {
   const empty: UserPermissions = {
     isAdmin: false,
@@ -180,7 +187,7 @@ export async function fetchUserPermissions(
 
   // 2. Look up core.usuarios
   const { data: coreUser } = await supabase
-    .schema('core' as any)
+    .schema('core')
     .from('usuarios')
     .select('id, rol, activo')
     .eq('email', email)
@@ -197,22 +204,22 @@ export async function fetchUserPermissions(
   const [empresasRes, modulosRes, permisosRolRes, excepcionesRes, allEmpresasRes] =
     await Promise.all([
       supabase
-        .schema('core' as any)
+        .schema('core')
         .from('usuarios_empresas')
         .select('empresa_id, rol_id, activo')
         .eq('usuario_id', coreUser.id)
         .eq('activo', true),
-      supabase.schema('core' as any).from('modulos').select('id, slug'),
+      supabase.schema('core').from('modulos').select('id, slug'),
       supabase
-        .schema('core' as any)
+        .schema('core')
         .from('permisos_rol')
         .select('rol_id, modulo_id, acceso_lectura, acceso_escritura'),
       supabase
-        .schema('core' as any)
+        .schema('core')
         .from('permisos_usuario_excepcion')
         .select('empresa_id, modulo_id, acceso_lectura, acceso_escritura')
         .eq('usuario_id', coreUser.id),
-      supabase.schema('core' as any).from('empresas').select('id, slug'),
+      supabase.schema('core').from('empresas').select('id, slug'),
     ]);
 
   const userEmpresas = empresasRes.data ?? [];
@@ -244,14 +251,14 @@ export async function fetchUserPermissions(
     if (!ue.rol_id) continue;
 
     // Find role permisos
-    const rolePerms = allPermisos.filter((p: any) => p.rol_id === ue.rol_id);
+    const rolePerms = allPermisos.filter((p) => p.rol_id === ue.rol_id);
 
     for (const perm of rolePerms) {
       const moduloSlug = moduloIdToSlug.get(perm.modulo_id);
       if (!moduloSlug) continue;
       modulos.set(moduloSlug, {
-        read: perm.acceso_lectura,
-        write: perm.acceso_escritura,
+        read: perm.acceso_lectura ?? false,
+        write: perm.acceso_escritura ?? false,
       });
     }
   }
@@ -261,8 +268,8 @@ export async function fetchUserPermissions(
     const moduloSlug = moduloIdToSlug.get(exc.modulo_id);
     if (!moduloSlug) continue;
     modulos.set(moduloSlug, {
-      read: exc.acceso_lectura,
-      write: exc.acceso_escritura,
+      read: exc.acceso_lectura ?? false,
+      write: exc.acceso_escritura ?? false,
     });
   }
 


### PR DESCRIPTION
## Summary

Primer sub-PR del bloque **B.5 — core schema typed migration** (continúa el patrón de B.4 pero para el schema `core`).

Dominio: `lib/permissions.ts` — fetcher crítico del sistema de permisos (corre en cada page mount para resolver acceso a empresas/módulos).

## Changes

**Tipado del cliente Supabase**

Ambas funciones recibían `SupabaseClient` sin generic. Se agrega `<Database>`:

```ts
import type { Database } from '@/types/supabase';

fetchPermissionsForUserId(supabase: SupabaseClient<Database>, userId: string)
fetchUserPermissions(supabase: SupabaseClient<Database>)
```

Los callers ya pasan clientes tipados (B.3), así que no hay drift corriente arriba.

**Migración de schema**

- 12 × `.schema('core' as any)` → `.schema('core')`
- 2 × `(p: any) =>` en callbacks de `.filter()` → `(p) =>` (la inferencia ya funciona)

**Drift fix (Pattern B — null widening)**

Autogen expone `permisos_rol.acceso_lectura`, `permisos_rol.acceso_escritura`, `permisos_usuario_excepcion.acceso_lectura`, `permisos_usuario_excepcion.acceso_escritura` como `boolean | null`, mientras el tipo local `AccessLevel` es `{ read: boolean; write: boolean }`.

Coalescencia con `?? false` en 4 sitios de asignación (rolePerms + excepciones, en ambas funciones):

```ts
modulos.set(moduloSlug, {
  read: perm.acceso_lectura ?? false,
  write: perm.acceso_escritura ?? false,
});
```

Semántica preservada: un valor null en una fila de permisos significa "sin acceso", que es el default seguro.

## Roadmap B.5

- **B.5.1** `lib/permissions.ts` (12 usages) — este PR
- **B.5.2** juntas (7 archivos, 19 usages)
- **B.5.3** tasks (5 archivos, 15 usages)
- **B.5.4** documentos (3 archivos, 8 usages)
- **B.5.5** rh (3 archivos, 6 usages)
- **B.5.6** settings/empresas (1 archivo, 2 usages)

Total: 63 usages en 20 archivos.

## Test plan

- [x] `npx tsc --noEmit` → EXIT=0
- [x] `npm run test:run` → 11/11 passing
- [ ] Smoke en preview: login, navegación por empresas, acceso por módulo respeta los permisos actuales
