### PR TITLE
B.5.2 — refactor: type core schema in juntas domain (7 files)

### DIFF
--- a/app/api/juntas/terminar/route.ts
+++ b/app/api/juntas/terminar/route.ts
@@ -254,9 +254,9 @@ export async function POST(req: NextRequest) {
       const taskTitleMap = new Map((tasksData ?? []).map((t: any) => [t.id, t.titulo as string]));
       const updateUserIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
       const { data: updateUsersData } = updateUserIds.length > 0
-        ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', updateUserIds)
+        ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', updateUserIds)
         : { data: [] };
-      const updateUserMap = new Map((updateUsersData ?? []).map((u: any) => [u.id, u.nombre as string]));
+      const updateUserMap = new Map((updateUsersData ?? []).map((u: any) => [u.id, (u.first_name as string | null) ?? '']));
 
       const tipoLabels: Record<string, string> = { avance: 'Avance', cambio_estado: 'Cambio de estado', cambio_fecha: 'Cambio de fecha', nota: 'Nota', cambio_responsable: 'Cambio responsable' };
       actualizaciones = updatesData.map((u: any) => {

--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -383,9 +383,9 @@ function JuntaDetailInner() {
       if (updatesData && updatesData.length > 0) {
         const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
         const { data: usersData } = userIds.length > 0
-          ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', userIds)
+          ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', userIds)
           : { data: [] };
-        const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.nombre]));
+        const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.first_name]));
         setTaskUpdates(updatesData.map((u: any) => ({ ...u, usuario: u.creado_por ? { nombre: userMap.get(u.creado_por) ?? 'Usuario' } : null })));
       } else {
         setTaskUpdates([]);
@@ -401,7 +401,7 @@ function JuntaDetailInner() {
     // Check if user is admin/direccion
     const { data: { user } } = await supabase.auth.getUser();
     if (user?.email) {
-      const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('rol').eq('email', user.email).maybeSingle();
+      const { data: coreUser } = await supabase.schema('core').from('usuarios').select('rol').eq('email', user.email).maybeSingle();
       if (coreUser?.rol === 'admin') setIsDireccion(true);
     }
 
@@ -544,9 +544,9 @@ function JuntaDetailInner() {
             if (updData) {
               const uIds = [...new Set(updData.map((u: any) => u.creado_por).filter(Boolean))];
               const { data: uData } = uIds.length > 0
-                ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', uIds)
+                ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', uIds)
                 : { data: [] };
-              const uMap = new Map((uData ?? []).map((u: any) => [u.id, u.nombre]));
+              const uMap = new Map((uData ?? []).map((u: any) => [u.id, u.first_name]));
               setTaskUpdates(updData.map((u: any) => ({ ...u, usuario: u.creado_por ? { nombre: uMap.get(u.creado_por) ?? 'Usuario' } : null })));
             }
           }
@@ -592,7 +592,7 @@ function JuntaDetailInner() {
     if (!taskForm.titulo.trim() || !taskForm.prioridad || !taskForm.asignado_a || !taskForm.fecha_vence || !junta) return;
     setAddingTask(true);
     const { data: { user } } = await supabase.auth.getUser();
-    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
     const { data: newTask, error: err } = await supabase.schema('erp').from('tasks').insert({
       empresa_id: junta.empresa_id, titulo: taskForm.titulo.trim(),
       asignado_a: taskForm.asignado_a || null, prioridad: taskForm.prioridad, estado: taskForm.estado,
@@ -610,9 +610,9 @@ function JuntaDetailInner() {
     if (!taskId || !updateForm.contenido.trim() || !junta) return;
     setSavingUpdate(true);
     const { data: { user } } = await supabase.auth.getUser();
-    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id, nombre').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id, first_name').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
     const userId = coreUser?.id ?? null;
-    const userName = coreUser?.nombre ?? 'Usuario';
+    const userName = coreUser?.first_name ?? 'Usuario';
 
     const inserts: any[] = [];
     inserts.push({ task_id: taskId, empresa_id: junta.empresa_id, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId });

--- a/app/dilesa/admin/juntas/page.tsx
+++ b/app/dilesa/admin/juntas/page.tsx
@@ -188,7 +188,7 @@ function JuntasInner() {
     if (!createTipo || !createFechaHora) return;
     setCreating(true);
     const { data: { user } } = await supabase.auth.getUser();
-    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
 
     const titulo = createTitulo.trim() || generateTitulo(createFechaHora, createTipo);
     const { data: newJunta, error: err } = await supabase

--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -338,9 +338,9 @@ function JuntaDetailInner() {
       if (updatesData && updatesData.length > 0) {
         const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
         const { data: usersData } = userIds.length > 0
-          ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', userIds)
+          ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', userIds)
           : { data: [] };
-        const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.nombre]));
+        const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.first_name]));
         setTaskUpdates(updatesData.map((u: any) => ({ ...u, usuario: u.creado_por ? { nombre: userMap.get(u.creado_por) ?? 'Usuario' } : null })));
       } else {
         setTaskUpdates([]);
@@ -508,9 +508,9 @@ function JuntaDetailInner() {
             if (updData) {
               const uIds = [...new Set(updData.map((u: any) => u.creado_por).filter(Boolean))];
               const { data: uData } = uIds.length > 0
-                ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', uIds)
+                ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', uIds)
                 : { data: [] };
-              const uMap = new Map((uData ?? []).map((u: any) => [u.id, u.nombre]));
+              const uMap = new Map((uData ?? []).map((u: any) => [u.id, u.first_name]));
               setTaskUpdates(updData.map((u: any) => ({ ...u, usuario: u.creado_por ? { nombre: uMap.get(u.creado_por) ?? 'Usuario' } : null })));
             }
           }
@@ -582,7 +582,7 @@ function JuntaDetailInner() {
 
     const { data: { user } } = await supabase.auth.getUser();
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user?.email ?? '').toLowerCase())
@@ -652,9 +652,9 @@ function JuntaDetailInner() {
     if (!taskId || !updateForm.contenido.trim() || !junta) return;
     setSavingUpdate(true);
     const { data: { user } } = await supabase.auth.getUser();
-    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id, nombre').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id, first_name').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
     const userId = coreUser?.id ?? null;
-    const userName = coreUser?.nombre ?? 'Usuario';
+    const userName = coreUser?.first_name ?? 'Usuario';
 
     const inserts: any[] = [];
     inserts.push({ task_id: taskId, empresa_id: junta.empresa_id, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId });

--- a/app/inicio/juntas/page.tsx
+++ b/app/inicio/juntas/page.tsx
@@ -138,7 +138,7 @@ function JuntasInner() {
     if (!user) return [];
 
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user.email ?? '').toLowerCase())
@@ -147,7 +147,7 @@ function JuntasInner() {
     if (!coreUser) return [];
 
     const { data: ueData } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios_empresas')
       .select('empresa_id')
       .eq('usuario_id', coreUser.id)
@@ -193,7 +193,7 @@ function JuntasInner() {
 
     const { data: { user } } = await supabase.auth.getUser();
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user?.email ?? '').toLowerCase())

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -322,9 +322,9 @@ function JuntaDetailInner() {
       if (updatesData && updatesData.length > 0) {
         const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
         const { data: usersData } = userIds.length > 0
-          ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', userIds)
+          ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', userIds)
           : { data: [] };
-        const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.nombre]));
+        const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.first_name]));
         setTaskUpdates(updatesData.map((u: any) => ({ ...u, usuario: u.creado_por ? { nombre: userMap.get(u.creado_por) ?? 'Usuario' } : null })));
       } else {
         setTaskUpdates([]);
@@ -489,9 +489,9 @@ function JuntaDetailInner() {
             if (updData) {
               const uIds = [...new Set(updData.map((u: any) => u.creado_por).filter(Boolean))];
               const { data: uData } = uIds.length > 0
-                ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', uIds)
+                ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', uIds)
                 : { data: [] };
-              const uMap = new Map((uData ?? []).map((u: any) => [u.id, u.nombre]));
+              const uMap = new Map((uData ?? []).map((u: any) => [u.id, u.first_name]));
               setTaskUpdates(updData.map((u: any) => ({ ...u, usuario: u.creado_por ? { nombre: uMap.get(u.creado_por) ?? 'Usuario' } : null })));
             }
           }
@@ -562,7 +562,7 @@ function JuntaDetailInner() {
 
     const { data: { user } } = await supabase.auth.getUser();
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user?.email ?? '').toLowerCase())
@@ -632,9 +632,9 @@ function JuntaDetailInner() {
     if (!taskId || !updateForm.contenido.trim() || !junta) return;
     setSavingUpdate(true);
     const { data: { user } } = await supabase.auth.getUser();
-    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id, nombre').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id, first_name').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
     const userId = coreUser?.id ?? null;
-    const userName = coreUser?.nombre ?? 'Usuario';
+    const userName = coreUser?.first_name ?? 'Usuario';
 
     const inserts: any[] = [];
     inserts.push({ task_id: taskId, empresa_id: EMPRESA_ID, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId });

--- a/app/rdb/admin/juntas/page.tsx
+++ b/app/rdb/admin/juntas/page.tsx
@@ -168,7 +168,7 @@ function JuntasInner() {
 
     const { data: { user } } = await supabase.auth.getUser();
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user?.email ?? '').toLowerCase())


### PR DESCRIPTION
## Summary

Segundo sub-PR del bloque **B.5 — core schema typed migration**. Migra el dominio de juntas (tanto páginas cliente como el API route de "terminar junta") del escape hatch `.schema('core' as any)` al cliente tipado `.schema('core')`.

Dominios:
- `app/inicio/juntas/page.tsx` (3 usages)
- `app/inicio/juntas/[id]/page.tsx` (4 usages)
- `app/rdb/admin/juntas/page.tsx` (1 usage)
- `app/rdb/admin/juntas/[id]/page.tsx` (4 usages)
- `app/dilesa/admin/juntas/page.tsx` (1 usage)
- `app/dilesa/admin/juntas/[id]/page.tsx` (5 usages)
- `app/api/juntas/terminar/route.ts` (1 usage)

Total: **19 usages en 7 archivos**.

## Changes

### Migración de schema
- `19 × .schema('core' as any)` → `.schema('core')` (cliente ya tipado en B.3).

### Drift fix (Pattern X — columna inexistente en autogen)

La tabla `core.usuarios` **no tiene una columna `nombre`**; el campo real es `first_name` (verificado contra la DB viva).

El uso previo `.schema('core' as any).from('usuarios').select('id, nombre')` compilaba por el `as any`, pero a runtime devolvía filas sin `nombre`, por lo que todos los `userMap.get(...)` caían al fallback `'Usuario'` — el nombre del autor de updates **nunca se estaba mostrando**.

Al activar tipado, Supabase emite `SelectQueryError<"column 'nombre' does not exist on 'usuarios'">`. Fix:

```ts
// antes
.select('id, nombre')
const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.nombre]));

// después
.select('id, first_name')
const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.first_name]));
```

Se aplicó el mismo patrón a los 4 archivos afectados: `inicio/[id]`, `rdb/admin/[id]`, `dilesa/admin/[id]`, y `api/juntas/terminar/route.ts`. Semántica preservada: el fallback `'Usuario'` sigue cubriendo el caso `first_name IS NULL`; usuarios con `first_name` poblado ahora sí se muestran correctamente (bug latente corregido por la migración tipada).

Los callsites que solo hacían `.select('id')` o `.select('rol')` no requirieron drift fix.

## Roadmap B.5

- [x] **B.5.1** `lib/permissions.ts` (12 usages) — merged #17
- [x] **B.5.2** juntas (7 archivos, 19 usages) — este PR
- [ ] **B.5.3** tasks (5 archivos, 15 usages)
- [ ] **B.5.4** documentos (3 archivos, 8 usages)
- [ ] **B.5.5** rh (3 archivos, 6 usages)
- [ ] **B.5.6** settings/empresas (1 archivo, 2 usages)

## Test plan

- [x] `npx tsc --noEmit` → EXIT=0
- [x] `npm run test:run` → 11/11 passing
- [ ] Smoke en preview: abrir junta con task_updates; verificar que el autor aparece con `first_name` cuando está disponible y cae a `'Usuario'` cuando no; terminar junta y confirmar que el correo de minuta se envía correctamente