### PR TITLE
B.5.3 — refactor: type core schema in tasks domain (5 files)

### DIFF
--- a/app/dilesa/admin/tasks/page.tsx
+++ b/app/dilesa/admin/tasks/page.tsx
@@ -276,7 +276,7 @@ function TasksInner() {
       supabase.schema('erp').from('empleados')
         .select('id, persona:persona_id(nombre, apellido_paterno)')
         .eq('empresa_id', EMPRESA_ID).eq('activo', true).is('deleted_at', null),
-      supabase.schema('core' as any).from('usuarios')
+      supabase.schema('core').from('usuarios')
         .select('id, rol').eq('email', email).maybeSingle(),
     ]);
 
@@ -306,13 +306,13 @@ function TasksInner() {
 
       if (!coreUserRes.data || coreUserRes.data.rol !== 'admin') {
         const { data: ue } = await supabase
-          .schema('core' as any).from('usuarios_empresas').select('rol_id')
+          .schema('core').from('usuarios_empresas').select('rol_id')
           .eq('usuario_id', coreUserRes.data?.id ?? '').eq('empresa_id', EMPRESA_ID)
           .eq('activo', true).maybeSingle();
 
         if (ue?.rol_id) {
           const { data: role } = await supabase
-            .schema('core' as any).from('roles').select('nombre')
+            .schema('core').from('roles').select('nombre')
             .eq('id', ue.rol_id).maybeSingle();
           if (role?.nombre?.toLowerCase() === 'direccion' || role?.nombre?.toLowerCase() === 'dirección') {
             setIsDireccion(true);
@@ -499,9 +499,9 @@ function TasksInner() {
     if (updatesData && updatesData.length > 0) {
       const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
       const { data: usersData } = userIds.length > 0
-        ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', userIds)
+        ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', userIds)
         : { data: [] };
-      const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.nombre]));
+      const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.first_name]));
       setTaskUpdates(updatesData.map((u: any) => ({ ...u, usuario: u.creado_por ? { nombre: userMap.get(u.creado_por) ?? 'Usuario' } : null })));
     } else {
       setTaskUpdates([]);
@@ -520,9 +520,9 @@ function TasksInner() {
     if (!taskId || !updateForm.contenido.trim()) return;
     setSavingUpdate(true);
     const { data: { user } } = await supabase.auth.getUser();
-    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id, nombre').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id, first_name').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
     const userId = coreUser?.id ?? null;
-    const userName = coreUser?.nombre ?? 'Usuario';
+    const userName = coreUser?.first_name ?? 'Usuario';
 
     const { error: insErr } = await supabase.schema('erp').from('task_updates').insert({
       task_id: taskId, empresa_id: EMPRESA_ID, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId,
@@ -1186,9 +1186,9 @@ function TasksInner() {
                     if (!selectedTask || !updateForm.contenido.trim()) return;
                     setSavingUpdate(true);
                     const { data: { user } } = await supabase.auth.getUser();
-                    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id, nombre').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+                    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id, first_name').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
                     const userId = coreUser?.id ?? null;
-                    const userName = coreUser?.nombre ?? 'Usuario';
+                    const userName = coreUser?.first_name ?? 'Usuario';
                     const { error: insErr } = await supabase.schema('erp').from('task_updates').insert({
                       task_id: selectedTask.id, empresa_id: EMPRESA_ID, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId,
                     });

--- a/app/inicio/tasks/page.tsx
+++ b/app/inicio/tasks/page.tsx
@@ -173,7 +173,7 @@ function TasksInner() {
     if (!user) return [];
 
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user.email ?? '').toLowerCase())
@@ -182,7 +182,7 @@ function TasksInner() {
     if (!coreUser) return [];
 
     const { data: ueData } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios_empresas')
       .select('empresa_id')
       .eq('usuario_id', coreUser.id)
@@ -266,7 +266,7 @@ function TasksInner() {
       data: { user },
     } = await supabase.auth.getUser();
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user?.email ?? '').toLowerCase())

--- a/app/rdb/admin/tasks/page.tsx
+++ b/app/rdb/admin/tasks/page.tsx
@@ -118,7 +118,7 @@ function TasksInner() {
     if (!createForm.titulo.trim()) return;
     setCreating(true);
     const { data: { user } } = await supabase.auth.getUser();
-    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
     const { error: err } = await supabase.schema('erp').from('tasks').insert({
       empresa_id: EMPRESA_ID, titulo: createForm.titulo.trim(), descripcion: createForm.descripcion.trim() || null,
       prioridad: createForm.prioridad || null, asignado_a: createForm.asignado_a || null,

--- a/app/rdb/tasks/[id]/page.tsx
+++ b/app/rdb/tasks/[id]/page.tsx
@@ -150,7 +150,7 @@ function TaskDetailInner() {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user?.email) return;
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', user.email.toLowerCase())
@@ -185,9 +185,9 @@ function TaskDetailInner() {
     if (updatesData && updatesData.length > 0) {
       const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
       const { data: usersData } = userIds.length > 0
-        ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', userIds)
+        ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', userIds)
         : { data: [] };
-      const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.nombre]));
+      const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.first_name]));
       setTaskUpdates(
         updatesData.map((u: any) => ({
           ...u,

--- a/app/rdb/tasks/page.tsx
+++ b/app/rdb/tasks/page.tsx
@@ -203,7 +203,7 @@ function TasksInner() {
 
     const { data: { user } } = await supabase.auth.getUser();
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user?.email ?? '').toLowerCase())
@@ -243,9 +243,9 @@ function TasksInner() {
     if (updatesData && updatesData.length > 0) {
       const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
       const { data: usersData } = userIds.length > 0
-        ? await supabase.schema('core' as any).from('usuarios').select('id, nombre').in('id', userIds)
+        ? await supabase.schema('core').from('usuarios').select('id, first_name').in('id', userIds)
         : { data: [] };
-      const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.nombre]));
+      const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.first_name]));
       setTaskUpdates(updatesData.map((u: any) => ({ ...u, usuario: u.creado_por ? { nombre: userMap.get(u.creado_por) ?? 'Usuario' } : null })));
     } else {
       setTaskUpdates([]);
@@ -264,9 +264,9 @@ function TasksInner() {
     if (!taskId || !updateForm.contenido.trim()) return;
     setSavingUpdate(true);
     const { data: { user } } = await supabase.auth.getUser();
-    const { data: coreUser } = await supabase.schema('core' as any).from('usuarios').select('id, nombre').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
+    const { data: coreUser } = await supabase.schema('core').from('usuarios').select('id, first_name').eq('email', (user?.email ?? '').toLowerCase()).maybeSingle();
     const userId = coreUser?.id ?? null;
-    const userName = coreUser?.nombre ?? 'Usuario';
+    const userName = coreUser?.first_name ?? 'Usuario';
 
     const { error: insErr } = await supabase.schema('erp').from('task_updates').insert({
       task_id: taskId, empresa_id: EMPRESA_ID, tipo: 'avance', contenido: updateForm.contenido.trim(), creado_por: userId,


### PR DESCRIPTION
- Remove .schema('core' as any) escape hatches across 5 task-domain pages.
- 15 usages migrated to typed .schema('core').
- Pattern X drift fix: core.usuarios has first_name (nullable), not nombre. Affected: dilesa/admin/tasks (3x), rdb/tasks (2x), rdb/tasks/[id] (1x). Updated both .select() strings and downstream property access (u.nombre → u.first_name, coreUser?.nombre → coreUser?.first_name).
- core.roles.nombre kept as-is (column exists, no drift).
- Bare .select('id'), .select('rol'), .select('rol_id') untouched beyond schema swap.

Test plan:
- npx tsc --noEmit → EXIT=0
- npm run test:run → 11/11 passing