### PR TITLE
B.5.5 — refactor: type core schema in rh domain (3 files)

### DIFF
--- a/app/rh/departamentos/page.tsx
+++ b/app/rh/departamentos/page.tsx
@@ -73,11 +73,11 @@ function DepartamentosInner() {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return [];
     const { data: coreUser } = await supabase
-      .schema('core' as any).from('usuarios').select('id')
+      .schema('core').from('usuarios').select('id')
       .eq('email', (user.email ?? '').toLowerCase()).maybeSingle();
     if (!coreUser) return [];
     const { data: ueData } = await supabase
-      .schema('core' as any).from('usuarios_empresas').select('empresa_id')
+      .schema('core').from('usuarios_empresas').select('empresa_id')
       .eq('usuario_id', coreUser.id).eq('activo', true);
     const ids = (ueData ?? []).map((r: any) => r.empresa_id as string);
     setEmpresaIds(ids);

--- a/app/rh/empleados/page.tsx
+++ b/app/rh/empleados/page.tsx
@@ -108,14 +108,14 @@ function EmpleadosInner() {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return [];
     const { data: coreUser } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios')
       .select('id')
       .eq('email', (user.email ?? '').toLowerCase())
       .maybeSingle();
     if (!coreUser) return [];
     const { data: ueData } = await supabase
-      .schema('core' as any)
+      .schema('core')
       .from('usuarios_empresas')
       .select('empresa_id')
       .eq('usuario_id', coreUser.id)

--- a/app/rh/puestos/page.tsx
+++ b/app/rh/puestos/page.tsx
@@ -94,11 +94,11 @@ function PuestosInner() {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return [];
     const { data: coreUser } = await supabase
-      .schema('core' as any).from('usuarios').select('id')
+      .schema('core').from('usuarios').select('id')
       .eq('email', (user.email ?? '').toLowerCase()).maybeSingle();
     if (!coreUser) return [];
     const { data: ueData } = await supabase
-      .schema('core' as any).from('usuarios_empresas').select('empresa_id')
+      .schema('core').from('usuarios_empresas').select('empresa_id')
       .eq('usuario_id', coreUser.id).eq('activo', true);
     const ids = (ueData ?? []).map((r: any) => r.empresa_id as string);
     setEmpresaIds(ids);


### PR DESCRIPTION
- Remove .schema('core' as any) across 3 generic RH pages.
- 6 usages migrated to typed .schema('core').
- All usages are bare .select('id') or .select('empresa_id') — no Pattern X drift fixes required.

Test plan:
- npx tsc --noEmit → EXIT=0
- npm run test:run → 11/11 passing