### PR TITLE
B.1.extra.a — retarget rdb.cortes ghost relation to rdb.v_cortes_lista

### DIFF
--- a/app/rdb/cortes/page.tsx
+++ b/app/rdb/cortes/page.tsx
@@ -96,7 +96,7 @@ type CorteTotales = {
   efectivo_esperado: number | null;
 };
 
-// rdb.movimientos columns
+// erp.movimientos_caja columns (filtered by empresa_id = RDB_EMPRESA_ID)
 type Movimiento = {
   id: string;
   corte_id: string;

--- a/app/rdb/ventas/page.tsx
+++ b/app/rdb/ventas/page.tsx
@@ -433,13 +433,14 @@ export default function VentasPage() {
   const fetchCortes = useCallback(async () => {
     try {
       const supabase = createSupabaseBrowserClient();
-      // TODO(B.1.extra): `rdb.cortes` exists in DB (see supabase/SCHEMA_REF.md)
-      // but was not emitted by the types autogen in PR #10 (likely a grants /
-      // SECURITY DEFINER exclusion). Drop the `as any` once the generator picks
-      // it up.
+      // B.1.extra.a: `rdb.cortes` is a ghost relation (doesn't exist in the DB —
+      // it was never created during the phase-2 `caja` → `rdb` migration).
+      // The canonical proxy for RDB is `rdb.v_cortes_lista`, which already
+      // projects `id, corte_nombre, caja_nombre, hora_inicio, hora_fin, estado`
+      // on top of the shared `erp.cortes_caja` base table.
       let query = supabase
-        .schema('rdb' as any)
-        .from('cortes')
+        .schema('rdb')
+        .from('v_cortes_lista')
         .select('id, corte_nombre, caja_nombre, hora_inicio, hora_fin, estado')
         .order('hora_inicio', { ascending: false });
 


### PR DESCRIPTION
## Context

`rdb.cortes` was being queried from `app/rdb/ventas/page.tsx` but **does not exist in the DB** — ghost relation left over from the phase-2 `caja` → `rdb` migration. Compiled only because of a `.schema('rdb' as any)` escape hatch.

Canonical proxy: `rdb.v_cortes_lista` — projects `id, corte_nombre, caja_nombre, hora_inicio, hora_fin, estado` on top of `erp.cortes_caja`.

## Changes

- `app/rdb/ventas/page.tsx`: retarget `.from('cortes')` → `.from('v_cortes_lista')`, remove `as any`, drop wrong TODO
- `app/rdb/cortes/page.tsx`: stale comment fix (`rdb.movimientos` → `erp.movimientos_caja`)

## Verification

- `pnpm typecheck` → 0
- `pnpm test` → 11/11
- `grep -rn "rdb.*cortes'" app/` → only `v_cortes_lista`

## Related

- Next: B.1.extra.b (create `rdb.v_cortes_productos`), B.1.extra.c (clean `SCHEMA_REF.md`)