### PR TITLE
chore: add db:check script + soft-delete convention to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,34 @@ Reglas prácticas:
 - Actualiza [`SCHEMA_ARCHITECTURE.md`](./SCHEMA_ARCHITECTURE.md) y [`supabase/SCHEMA_REF.md`](./supabase/SCHEMA_REF.md) cuando agregues/muevas/borres tablas o columnas.
 - Antes de merger a `main`, corre la migración en un branch de Supabase o staging y valida.
 
+### Soft-delete (convención)
+
+Toda tabla de **dominio operativo** (departamentos, puestos, empleados, cortes, movimientos, documentos, etc.) debe soportar borrado lógico. El borrado físico se reserva para tablas efímeras (caches, logs, colas).
+
+**Checklist al crear una tabla de dominio:**
+
+- [ ] Columna `deleted_at timestamptz` — `NULL` = activa, valor = fecha/hora del borrado lógico.
+- [ ] Índice **parcial** sobre la clave de acceso más común, filtrando activas:
+  ```sql
+  CREATE INDEX <tabla>_deleted_idx
+    ON <schema>.<tabla> (empresa_id)  -- o la clave principal de filtrado
+    WHERE deleted_at IS NULL;
+  ```
+- [ ] `COMMENT ON COLUMN <tabla>.deleted_at IS 'Soft-delete timestamp. NULL = active row.'`.
+- [ ] Todas las queries de lista usan `.is('deleted_at', null)`.
+- [ ] UI de "Eliminar" pasa por `<ConfirmDialog>` (ver `ARCHITECTURE.md § UI Standards`), nunca `window.confirm`.
+
+**Activo vs Eliminado** — son semánticas distintas, no se deben mezclar:
+
+| Concepto | Columna | Semántica |
+|----------|---------|-----------|
+| **Activo** | `activo boolean` | Estado operativo (pausado/activo). Se puede togglear. |
+| **Eliminado** | `deleted_at timestamptz` | Soft-delete. Una vez eliminado no se "re-activa" — se recrea. |
+
+**Tablas que siguen el patrón hoy:** `erp.personas`, `erp.empleados`, `erp.documentos`, `erp.departamentos`, `erp.puestos`.
+
+**Si una tabla operativa no lo tiene**, añádelo en una migración antes de tocar su UI — ver ejemplo `supabase/migrations/20260417122412_add_soft_delete_to_erp_departamentos_puestos.sql`.
+
 ---
 
 ## Seguridad

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "audit:ui": "npx tsx scripts/audit-ui.ts",
     "audit:ui:json": "npx tsx scripts/audit-ui.ts --json",
     "db:types": "supabase gen types typescript --project-id ybklderteyhuugzfmxbi --schema public --schema core --schema erp --schema rdb --schema dilesa --schema playtomic > types/supabase.ts",
+    "db:check": "npm run db:types && git diff --exit-code types/supabase.ts",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Primer follow-up del reporte [`docs/REPORT_RH_UI_2026-04-17.md`](./docs/REPORT_RH_UI_2026-04-17.md) (items P0 §3.1 y §3.3). Cambios de DX/docs sin tocar runtime ni schema.

**`package.json`**
- `db:check` — corre `db:types` y luego `git diff --exit-code types/supabase.ts`. Check local antes de pushear, complementando el workflow semanal [`.github/workflows/db-types.yml`](./.github/workflows/db-types.yml).

**`CONTRIBUTING.md § Base de datos`**
- Nueva subsección **Soft-delete (convención)**:
  - Checklist al crear una tabla de dominio (columna + índice parcial + comment + queries + UI).
  - Tabla **Activo vs Eliminado** para clarificar semánticas (`activo boolean` vs `deleted_at timestamptz`).
  - Tablas que ya siguen el patrón: `erp.personas`, `erp.empleados`, `erp.documentos`, `erp.departamentos`, `erp.puestos`.

## Riesgo

Ninguno. Solo docs + un npm script nuevo no invocado por CI.

## Test plan

- [x] `git diff --stat` muestra solo los dos archivos esperados.
- [ ] CI verde (typecheck + vitest).
- [ ] Preview deploy READY.
- [ ] `npm run db:check` corre en local (requiere `SUPABASE_ACCESS_TOKEN`).

🤖 Generated with [Claude](https://claude.com/claude-code)