### PR TITLE
chore: add scripts/gen-schema-ref.ts generator for supabase/SCHEMA_REF.md

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -23,6 +23,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # commitea por accidente.
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Connection string de Postgres para scripts de introspección
+# (`npm run schema:ref`, backfills puntuales). NO se usa en runtime.
+# Dashboard → Project Settings → Database → Connection string (URI).
+# Puede ser la URL del pooler (5432/6543); no requiere service-role JWT.
+# SUPABASE_DB_URL=postgres://postgres.xxxxx:...@aws-0-us-east-1.pooler.supabase.com:5432/postgres
+
 
 # ─── Resend (emails transaccionales) ────────────────────────────────────────
 # https://resend.com/api-keys

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,19 +19,20 @@ Si vas a correr E2E tests, copia también `.env.test.local.example` → `.env.te
 
 Siempre partir de `main` actualizado.
 
-| Prefijo | Uso |
-|---------|-----|
-| `feat/` | Funcionalidad nueva |
-| `fix/` | Corrección de bug |
+| Prefijo     | Uso                                 |
+| ----------- | ----------------------------------- |
+| `feat/`     | Funcionalidad nueva                 |
+| `fix/`      | Corrección de bug                   |
 | `refactor/` | Cambio que no altera comportamiento |
-| `chore/` | Mantenimiento, tooling, build, deps |
-| `docs/` | Solo documentación |
-| `test/` | Solo tests |
-| `perf/` | Mejora de performance |
+| `chore/`    | Mantenimiento, tooling, build, deps |
+| `docs/`     | Solo documentación                  |
+| `test/`     | Solo tests                          |
+| `perf/`     | Mejora de performance               |
 
 Nombre de rama: `<prefijo>/descripcion-corta-en-kebab-case`.
 
 Ejemplos:
+
 - `fix/rdb-cortes-timezone-drift`
 - `feat/juntas-recordatorio-email`
 - `chore/eslint-prettier-husky`
@@ -61,6 +62,7 @@ fix: CSF viewer uses signed URLs for private storage bucket
 ```
 
 Reglas prácticas:
+
 - **Imperativo, no pasado** — "add feature", no "added feature".
 - **≤ 72 caracteres** en la línea de asunto.
 - **Un solo tema por commit** cuando sea razonable.
@@ -107,7 +109,8 @@ Reglas prácticas:
 - Todos los cambios de schema van por **migración versionada** en `supabase/migrations/`.
 - Nombra con timestamp: `YYYYMMDDHHMMSS_descripcion.sql`.
 - **Nunca** edites tablas directamente en el dashboard de producción.
-- Actualiza [`SCHEMA_ARCHITECTURE.md`](./SCHEMA_ARCHITECTURE.md) y [`supabase/SCHEMA_REF.md`](./supabase/SCHEMA_REF.md) cuando agregues/muevas/borres tablas o columnas.
+- Actualiza [`SCHEMA_ARCHITECTURE.md`](./SCHEMA_ARCHITECTURE.md) manualmente cuando cambie la forma general del schema (nuevo schema, nuevas relaciones entre módulos).
+- [`supabase/SCHEMA_REF.md`](./supabase/SCHEMA_REF.md) se **regenera automáticamente** con `npm run schema:ref` desde el `information_schema` real. Corre `npm run schema:check` antes de abrir PR para detectar drift entre la DB y el archivo versionado. Requiere `SUPABASE_DB_URL` en `.env.local` (ver `.env.local.example`).
 - Antes de merger a `main`, corre la migración en un branch de Supabase o staging y valida.
 
 ### Soft-delete (convención)
@@ -129,9 +132,9 @@ Toda tabla de **dominio operativo** (departamentos, puestos, empleados, cortes, 
 
 **Activo vs Eliminado** — son semánticas distintas, no se deben mezclar:
 
-| Concepto | Columna | Semántica |
-|----------|---------|-----------|
-| **Activo** | `activo boolean` | Estado operativo (pausado/activo). Se puede togglear. |
+| Concepto      | Columna                  | Semántica                                                     |
+| ------------- | ------------------------ | ------------------------------------------------------------- |
+| **Activo**    | `activo boolean`         | Estado operativo (pausado/activo). Se puede togglear.         |
 | **Eliminado** | `deleted_at timestamptz` | Soft-delete. Una vez eliminado no se "re-activa" — se recrea. |
 
 **Tablas que siguen el patrón hoy:** `erp.personas`, `erp.empleados`, `erp.documentos`, `erp.departamentos`, `erp.puestos`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "latest",
         "@types/node": "latest",
+        "@types/pg": "^8.20.0",
         "@types/react": "latest",
         "@types/react-dom": "latest",
         "@vitest/coverage-v8": "^3.2.0",
@@ -44,6 +45,7 @@
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
+        "pg": "^8.20.0",
         "prettier": "^3.8.3",
         "tailwindcss": "latest",
         "typescript": "latest",
@@ -4371,6 +4373,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -10879,6 +10893,103 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10987,6 +11098,49 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/powershell-utils": {
@@ -12225,6 +12379,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -13789,6 +13953,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "audit:ui:json": "npx tsx scripts/audit-ui.ts --json",
     "db:types": "supabase gen types typescript --project-id ybklderteyhuugzfmxbi --schema public --schema core --schema erp --schema rdb --schema dilesa --schema playtomic > types/supabase.ts",
     "db:check": "npm run db:types && git diff --exit-code types/supabase.ts",
+    "schema:ref": "npx tsx scripts/gen-schema-ref.ts",
+    "schema:check": "npm run schema:ref && git diff --exit-code supabase/SCHEMA_REF.md",
     "prepare": "husky"
   },
   "dependencies": {
@@ -54,6 +56,7 @@
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "latest",
     "@types/node": "latest",
+    "@types/pg": "^8.20.0",
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "@vitest/coverage-v8": "^3.2.0",
@@ -62,6 +65,7 @@
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "pg": "^8.20.0",
     "prettier": "^3.8.3",
     "tailwindcss": "latest",
     "typescript": "latest",

--- a/scripts/gen-schema-ref.test.ts
+++ b/scripts/gen-schema-ref.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatSchemaRef, type SchemaData, type FormatOptions } from './gen-schema-ref';
+
+/**
+ * Tests para `formatSchemaRef` — la función pura que convierte los datos
+ * crudos de `information_schema` al markdown determinístico de
+ * `supabase/SCHEMA_REF.md`.
+ *
+ * La intención es lockear tres propiedades críticas:
+ *   1. Determinismo — mismo input siempre produce el mismo output
+ *      (sin esto los PRs de regeneración tendrían diffs espurios).
+ *   2. Orden canónico — schemas/tablas alfabéticos, columnas por ordinal.
+ *   3. Render correcto de PK, FK, nullable, default, tipo de objeto
+ *      (tabla / vista / materialized view) y comentarios de tabla.
+ */
+
+const GENERATED_AT = '2026-04-17T10:00:00Z';
+
+function opts(schemas: string[]): FormatOptions {
+  return { schemas, generatedAt: GENERATED_AT };
+}
+
+describe('formatSchemaRef — structure', () => {
+  it('renders header + schemas-covered blurb', () => {
+    const out = formatSchemaRef(
+      { tables: [], columns: [], pks: [], fks: [] },
+      opts(['core', 'erp'])
+    );
+    expect(out).toContain('# BSOP Supabase Schema Reference');
+    expect(out).toContain(`Last regenerated: ${GENERATED_AT}`);
+    expect(out).toContain('Schemas: core, erp');
+    expect(out).toContain('**Schemas cubiertos:** `core` · `erp`');
+  });
+
+  it('renders "sin tablas ni vistas" when a schema is empty', () => {
+    const out = formatSchemaRef({ tables: [], columns: [], pks: [], fks: [] }, opts(['core']));
+    expect(out).toContain('## Schema `core`');
+    expect(out).toContain('_(sin tablas ni vistas)_');
+  });
+
+  it('ends with exactly one trailing newline', () => {
+    const out = formatSchemaRef({ tables: [], columns: [], pks: [], fks: [] }, opts(['core']));
+    expect(out.endsWith('\n')).toBe(true);
+    expect(out.endsWith('\n\n')).toBe(false);
+  });
+});
+
+describe('formatSchemaRef — determinism & ordering', () => {
+  const data: SchemaData = {
+    tables: [
+      { schema: 'erp', name: 'puestos', kind: 'table', comment: null },
+      { schema: 'core', name: 'usuarios', kind: 'table', comment: null },
+      { schema: 'erp', name: 'departamentos', kind: 'table', comment: null },
+      { schema: 'core', name: 'empresas', kind: 'table', comment: null },
+    ],
+    columns: [
+      // Intencionalmente desordenados.
+      {
+        schema: 'core',
+        table: 'empresas',
+        name: 'nombre',
+        type: 'text',
+        nullable: true,
+        defaultExpr: null,
+        ordinal: 3,
+      },
+      {
+        schema: 'core',
+        table: 'empresas',
+        name: 'id',
+        type: 'uuid',
+        nullable: false,
+        defaultExpr: 'gen_random_uuid()',
+        ordinal: 1,
+      },
+      {
+        schema: 'core',
+        table: 'empresas',
+        name: 'slug',
+        type: 'text',
+        nullable: false,
+        defaultExpr: null,
+        ordinal: 2,
+      },
+    ],
+    pks: [{ schema: 'core', table: 'empresas', columns: ['id'] }],
+    fks: [],
+  };
+
+  it('orders schemas alphabetically in opts.schemas', () => {
+    const out = formatSchemaRef(data, opts(['erp', 'core']));
+    const coreIdx = out.indexOf('## Schema `core`');
+    const erpIdx = out.indexOf('## Schema `erp`');
+    expect(coreIdx).toBeGreaterThan(-1);
+    expect(erpIdx).toBeGreaterThan(coreIdx);
+  });
+
+  it('orders tables alphabetically within a schema', () => {
+    const out = formatSchemaRef(data, opts(['core', 'erp']));
+    const dep = out.indexOf('### `erp.departamentos`');
+    const pue = out.indexOf('### `erp.puestos`');
+    expect(dep).toBeGreaterThan(-1);
+    expect(pue).toBeGreaterThan(dep);
+  });
+
+  it('orders columns by ordinal_position, not insertion order', () => {
+    const out = formatSchemaRef(data, opts(['core', 'erp']));
+    const idIdx = out.indexOf('**id**');
+    const slugIdx = out.indexOf('**slug**');
+    const nombreIdx = out.indexOf('**nombre**');
+    expect(idIdx).toBeLessThan(slugIdx);
+    expect(slugIdx).toBeLessThan(nombreIdx);
+  });
+
+  it('is stable — same input produces byte-identical output twice', () => {
+    const a = formatSchemaRef(data, opts(['core', 'erp']));
+    const b = formatSchemaRef(data, opts(['core', 'erp']));
+    expect(a).toBe(b);
+  });
+});
+
+describe('formatSchemaRef — column rendering', () => {
+  it('emits NOT NULL and DEFAULT markers', () => {
+    const out = formatSchemaRef(
+      {
+        tables: [{ schema: 'core', name: 't', kind: 'table', comment: null }],
+        columns: [
+          {
+            schema: 'core',
+            table: 't',
+            name: 'activo',
+            type: 'boolean',
+            nullable: false,
+            defaultExpr: 'true',
+            ordinal: 1,
+          },
+        ],
+        pks: [],
+        fks: [],
+      },
+      opts(['core'])
+    );
+    expect(out).toContain('**activo** `boolean` NOT NULL DEFAULT `true`');
+  });
+
+  it('emits PK suffix for primary-key columns', () => {
+    const out = formatSchemaRef(
+      {
+        tables: [{ schema: 'core', name: 't', kind: 'table', comment: null }],
+        columns: [
+          {
+            schema: 'core',
+            table: 't',
+            name: 'id',
+            type: 'uuid',
+            nullable: false,
+            defaultExpr: null,
+            ordinal: 1,
+          },
+        ],
+        pks: [{ schema: 'core', table: 't', columns: ['id'] }],
+        fks: [],
+      },
+      opts(['core'])
+    );
+    expect(out).toMatch(/\*\*id\*\* `uuid` NOT NULL — PK/);
+  });
+
+  it('emits FK suffix with schema.table(column)', () => {
+    const out = formatSchemaRef(
+      {
+        tables: [{ schema: 'erp', name: 'empleados', kind: 'table', comment: null }],
+        columns: [
+          {
+            schema: 'erp',
+            table: 'empleados',
+            name: 'empresa_id',
+            type: 'uuid',
+            nullable: false,
+            defaultExpr: null,
+            ordinal: 1,
+          },
+        ],
+        pks: [],
+        fks: [
+          {
+            schema: 'erp',
+            table: 'empleados',
+            column: 'empresa_id',
+            refSchema: 'core',
+            refTable: 'empresas',
+            refColumn: 'id',
+          },
+        ],
+      },
+      opts(['erp'])
+    );
+    expect(out).toContain('**empresa_id** `uuid` NOT NULL — FK → `core.empresas(id)`');
+  });
+
+  it('combines PK and FK suffixes when both apply', () => {
+    const out = formatSchemaRef(
+      {
+        tables: [{ schema: 'erp', name: 't', kind: 'table', comment: null }],
+        columns: [
+          {
+            schema: 'erp',
+            table: 't',
+            name: 'empresa_id',
+            type: 'uuid',
+            nullable: false,
+            defaultExpr: null,
+            ordinal: 1,
+          },
+        ],
+        pks: [{ schema: 'erp', table: 't', columns: ['empresa_id'] }],
+        fks: [
+          {
+            schema: 'erp',
+            table: 't',
+            column: 'empresa_id',
+            refSchema: 'core',
+            refTable: 'empresas',
+            refColumn: 'id',
+          },
+        ],
+      },
+      opts(['erp'])
+    );
+    expect(out).toContain('— PK, FK → `core.empresas(id)`');
+  });
+});
+
+describe('formatSchemaRef — object kinds & comments', () => {
+  it('labels views as _(view)_', () => {
+    const out = formatSchemaRef(
+      {
+        tables: [{ schema: 'rdb', name: 'v_cortes_totales', kind: 'view', comment: null }],
+        columns: [
+          {
+            schema: 'rdb',
+            table: 'v_cortes_totales',
+            name: 'corte_id',
+            type: 'uuid',
+            nullable: true,
+            defaultExpr: null,
+            ordinal: 1,
+          },
+        ],
+        pks: [],
+        fks: [],
+      },
+      opts(['rdb'])
+    );
+    expect(out).toContain('### `rdb.v_cortes_totales` _(view)_');
+  });
+
+  it('labels materialized views as _(materialized view)_', () => {
+    const out = formatSchemaRef(
+      {
+        tables: [{ schema: 'rdb', name: 'mv_algo', kind: 'mview', comment: null }],
+        columns: [],
+        pks: [],
+        fks: [],
+      },
+      opts(['rdb'])
+    );
+    expect(out).toContain('### `rdb.mv_algo` _(materialized view)_');
+  });
+
+  it('renders table comment as blockquote', () => {
+    const out = formatSchemaRef(
+      {
+        tables: [
+          {
+            schema: 'core',
+            name: 'empresas',
+            kind: 'table',
+            comment: 'Registry of empresas.\nCross-tenant.',
+          },
+        ],
+        columns: [
+          {
+            schema: 'core',
+            table: 'empresas',
+            name: 'id',
+            type: 'uuid',
+            nullable: false,
+            defaultExpr: null,
+            ordinal: 1,
+          },
+        ],
+        pks: [],
+        fks: [],
+      },
+      opts(['core'])
+    );
+    expect(out).toContain('> Registry of empresas.');
+    expect(out).toContain('> Cross-tenant.');
+  });
+});

--- a/scripts/gen-schema-ref.ts
+++ b/scripts/gen-schema-ref.ts
@@ -1,0 +1,429 @@
+#!/usr/bin/env npx tsx
+/**
+ * BSOP — Supabase schema reference generator
+ *
+ * Regenera `supabase/SCHEMA_REF.md` a partir del `information_schema` del
+ * proyecto Supabase. El output es determinístico (orden alfabético
+ * por schema → tabla → `ordinal_position` de columnas) para que los
+ * diffs en PRs sean fáciles de revisar.
+ *
+ * Uso:
+ *   SUPABASE_DB_URL=postgres://... npm run schema:ref
+ *   SUPABASE_DB_URL=postgres://... npm run schema:check
+ *
+ * Flags:
+ *   --schemas core,erp     Limita los schemas procesados (default:
+ *                          public,core,erp,rdb,dilesa,playtomic).
+ *   --out supabase/REF.md  Ruta de salida (default:
+ *                          supabase/SCHEMA_REF.md).
+ *   --dry-run              Escribe a stdout en lugar del archivo.
+ *
+ * Requiere `SUPABASE_DB_URL` en el entorno (connection string de Postgres con
+ * permiso de lectura sobre los schemas). La URL se obtiene en el dashboard
+ * de Supabase → Project Settings → Database → Connection string (URI).
+ * Úsala **solo localmente o en CI** — nunca la commitees.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Client } from 'pg';
+
+// ── CLI flags ─────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+
+function flagValue(flag: string, fallback: string): string {
+  const i = args.indexOf(flag);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+}
+
+const SCHEMAS = flagValue('--schemas', 'public,core,erp,rdb,dilesa,playtomic')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const OUT_PATH = path.resolve(process.cwd(), flagValue('--out', 'supabase/SCHEMA_REF.md'));
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type TableKind = 'table' | 'view' | 'mview';
+
+export interface TableRow {
+  schema: string;
+  name: string;
+  kind: TableKind;
+  comment: string | null;
+}
+
+export interface ColumnRow {
+  schema: string;
+  table: string;
+  name: string;
+  type: string;
+  nullable: boolean;
+  defaultExpr: string | null;
+  ordinal: number;
+}
+
+export interface PkInfo {
+  schema: string;
+  table: string;
+  columns: string[];
+}
+
+export interface FkInfo {
+  schema: string;
+  table: string;
+  column: string;
+  refSchema: string;
+  refTable: string;
+  refColumn: string;
+}
+
+export interface SchemaData {
+  tables: TableRow[];
+  columns: ColumnRow[];
+  pks: PkInfo[];
+  fks: FkInfo[];
+}
+
+// ── Pure formatter (exported for tests) ───────────────────────────────────────
+
+export interface FormatOptions {
+  schemas: string[];
+  generatedAt: string;
+}
+
+const KIND_LABEL: Record<TableKind, string> = {
+  table: '',
+  view: ' _(view)_',
+  mview: ' _(materialized view)_',
+};
+
+/**
+ * Formatea `SchemaData` como markdown determinístico.
+ *
+ * Contrato:
+ * - Schemas en el orden alfabético de `opts.schemas`.
+ * - Dentro de cada schema, tablas en orden alfabético.
+ * - Dentro de cada tabla, columnas en orden por `ordinal`.
+ * - Cada columna en una línea con tipo, nullable, default (si existe),
+ *   y marcas PK / FK si aplican.
+ */
+export function formatSchemaRef(data: SchemaData, opts: FormatOptions): string {
+  const sortedSchemas = [...opts.schemas].sort();
+
+  // Index helpers para lookup O(1) dentro del render.
+  const pkByTable = new Map<string, Set<string>>(); // key = schema.table
+  for (const pk of data.pks) {
+    pkByTable.set(`${pk.schema}.${pk.table}`, new Set(pk.columns));
+  }
+
+  const fkByColumn = new Map<string, FkInfo>(); // key = schema.table.column
+  for (const fk of data.fks) {
+    fkByColumn.set(`${fk.schema}.${fk.table}.${fk.column}`, fk);
+  }
+
+  const tablesBySchema = new Map<string, TableRow[]>();
+  for (const t of data.tables) {
+    const arr = tablesBySchema.get(t.schema) ?? [];
+    arr.push(t);
+    tablesBySchema.set(t.schema, arr);
+  }
+  for (const arr of tablesBySchema.values()) {
+    arr.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  const colsByTable = new Map<string, ColumnRow[]>(); // key = schema.table
+  for (const c of data.columns) {
+    const key = `${c.schema}.${c.table}`;
+    const arr = colsByTable.get(key) ?? [];
+    arr.push(c);
+    colsByTable.set(key, arr);
+  }
+  for (const arr of colsByTable.values()) {
+    arr.sort((a, b) => a.ordinal - b.ordinal);
+  }
+
+  // ── Header ─────────────────────────────────────────────────────────────────
+  const lines: string[] = [];
+  lines.push('# BSOP Supabase Schema Reference');
+  lines.push('');
+  lines.push('<!--');
+  lines.push('  Auto-generated by `scripts/gen-schema-ref.ts`.');
+  lines.push(`  Last regenerated: ${opts.generatedAt}`);
+  lines.push(`  Schemas: ${sortedSchemas.join(', ')}`);
+  lines.push('  DO NOT EDIT BY HAND.');
+  lines.push('  Regenerate via: `npm run schema:ref` (requires SUPABASE_DB_URL).');
+  lines.push('-->');
+  lines.push('');
+  lines.push(
+    `Referencia completa de tablas, vistas y columnas de BSOP en Supabase, tal como existen en el momento de la última regeneración. Para cambiar esta referencia, **aplica la migración correspondiente** y vuelve a correr \`npm run schema:ref\`.`
+  );
+  lines.push('');
+  lines.push(`**Schemas cubiertos:** ${sortedSchemas.map((s) => `\`${s}\``).join(' · ')}`);
+  lines.push('');
+
+  // ── Per-schema sections ────────────────────────────────────────────────────
+  for (const schema of sortedSchemas) {
+    lines.push('---');
+    lines.push('');
+    lines.push(`## Schema \`${schema}\``);
+    lines.push('');
+
+    const tables = tablesBySchema.get(schema) ?? [];
+    if (tables.length === 0) {
+      lines.push('_(sin tablas ni vistas)_');
+      lines.push('');
+      continue;
+    }
+
+    for (const t of tables) {
+      lines.push(`### \`${t.schema}.${t.name}\`${KIND_LABEL[t.kind]}`);
+      lines.push('');
+      if (t.comment) {
+        // El comentario puede ser multi-línea; lo citamos como blockquote.
+        for (const ln of t.comment.split(/\r?\n/)) {
+          lines.push(`> ${ln}`);
+        }
+        lines.push('');
+      }
+
+      const pkCols = pkByTable.get(`${t.schema}.${t.name}`) ?? new Set<string>();
+      const cols = colsByTable.get(`${t.schema}.${t.name}`) ?? [];
+
+      if (cols.length === 0) {
+        lines.push('_(sin columnas)_');
+      } else {
+        for (const c of cols) {
+          const parts: string[] = [];
+          parts.push(`\`${c.type}\``);
+          if (!c.nullable) parts.push('NOT NULL');
+          if (c.defaultExpr) parts.push(`DEFAULT \`${c.defaultExpr}\``);
+          const suffix: string[] = [];
+          if (pkCols.has(c.name)) suffix.push('PK');
+          const fk = fkByColumn.get(`${t.schema}.${t.name}.${c.name}`);
+          if (fk) suffix.push(`FK → \`${fk.refSchema}.${fk.refTable}(${fk.refColumn})\``);
+          const suffixStr = suffix.length ? ` — ${suffix.join(', ')}` : '';
+          lines.push(`- **${c.name}** ${parts.join(' ')}${suffixStr}`);
+        }
+      }
+      lines.push('');
+    }
+  }
+
+  // Normalizar trailing newline único.
+  return lines.join('\n').replace(/\n+$/, '') + '\n';
+}
+
+// ── Postgres fetch layer ──────────────────────────────────────────────────────
+
+async function fetchSchemaData(client: Client, schemas: string[]): Promise<SchemaData> {
+  // Tablas y vistas + comentario.
+  //
+  // pg_description(objoid, 'pg_class') trae el COMMENT ON TABLE/VIEW.
+  const tablesRes = await client.query<{
+    schema: string;
+    name: string;
+    relkind: 'r' | 'v' | 'm';
+    comment: string | null;
+  }>(
+    `
+    SELECT
+      n.nspname   AS schema,
+      c.relname   AS name,
+      c.relkind   AS relkind,
+      obj_description(c.oid, 'pg_class') AS comment
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = ANY($1::text[])
+      AND c.relkind IN ('r','v','m')
+    ORDER BY n.nspname, c.relname
+    `,
+    [schemas]
+  );
+
+  const tables: TableRow[] = tablesRes.rows.map((r) => ({
+    schema: r.schema,
+    name: r.name,
+    kind: r.relkind === 'r' ? 'table' : r.relkind === 'v' ? 'view' : 'mview',
+    comment: r.comment,
+  }));
+
+  // Columnas.
+  //
+  // `data_type` de information_schema es legible ("timestamp with time zone")
+  // en lugar del nombre interno de pg_type ("timestamptz"), lo cual prefiero
+  // para el SCHEMA_REF.md.
+  const colsRes = await client.query<{
+    schema: string;
+    table: string;
+    name: string;
+    type: string;
+    nullable: string;
+    default_expr: string | null;
+    ordinal: number;
+  }>(
+    `
+    SELECT
+      table_schema     AS schema,
+      table_name       AS "table",
+      column_name      AS name,
+      data_type        AS type,
+      is_nullable      AS nullable,
+      column_default   AS default_expr,
+      ordinal_position AS ordinal
+    FROM information_schema.columns
+    WHERE table_schema = ANY($1::text[])
+    ORDER BY table_schema, table_name, ordinal_position
+    `,
+    [schemas]
+  );
+
+  const columns: ColumnRow[] = colsRes.rows.map((r) => ({
+    schema: r.schema,
+    table: r.table,
+    name: r.name,
+    type: r.type,
+    nullable: r.nullable === 'YES',
+    defaultExpr: r.default_expr,
+    ordinal: r.ordinal,
+  }));
+
+  // Primary keys.
+  const pksRes = await client.query<{
+    schema: string;
+    table: string;
+    column: string;
+  }>(
+    `
+    SELECT
+      tc.table_schema AS schema,
+      tc.table_name   AS "table",
+      kcu.column_name AS "column"
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name   = kcu.constraint_name
+     AND tc.constraint_schema = kcu.constraint_schema
+    WHERE tc.constraint_type = 'PRIMARY KEY'
+      AND tc.table_schema = ANY($1::text[])
+    ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position
+    `,
+    [schemas]
+  );
+
+  const pkMap = new Map<string, string[]>(); // key = schema.table
+  for (const row of pksRes.rows) {
+    const key = `${row.schema}.${row.table}`;
+    const arr = pkMap.get(key) ?? [];
+    arr.push(row.column);
+    pkMap.set(key, arr);
+  }
+  const pks: PkInfo[] = [...pkMap.entries()].map(([key, columns]) => {
+    const [schema, table] = key.split('.');
+    return { schema, table, columns };
+  });
+
+  // Foreign keys.
+  //
+  // `constraint_column_usage` es válido para FKs simples (1 columna origen).
+  // Para FKs compuestas (raro en BSOP), solo tomamos la primera pareja — es
+  // suficiente como pista en el SCHEMA_REF.
+  const fksRes = await client.query<{
+    schema: string;
+    table: string;
+    column: string;
+    ref_schema: string;
+    ref_table: string;
+    ref_column: string;
+  }>(
+    `
+    SELECT
+      tc.table_schema  AS schema,
+      tc.table_name    AS "table",
+      kcu.column_name  AS "column",
+      ccu.table_schema AS ref_schema,
+      ccu.table_name   AS ref_table,
+      ccu.column_name  AS ref_column
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name   = kcu.constraint_name
+     AND tc.constraint_schema = kcu.constraint_schema
+    JOIN information_schema.constraint_column_usage ccu
+      ON ccu.constraint_name   = tc.constraint_name
+     AND ccu.constraint_schema = tc.constraint_schema
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+      AND tc.table_schema = ANY($1::text[])
+    ORDER BY tc.table_schema, tc.table_name, kcu.ordinal_position
+    `,
+    [schemas]
+  );
+
+  const fks: FkInfo[] = fksRes.rows.map((r) => ({
+    schema: r.schema,
+    table: r.table,
+    column: r.column,
+    refSchema: r.ref_schema,
+    refTable: r.ref_table,
+    refColumn: r.ref_column,
+  }));
+
+  return { tables, columns, pks, fks };
+}
+
+// ── CLI entry ─────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const connectionString = process.env.SUPABASE_DB_URL;
+  if (!connectionString) {
+    console.error(
+      '✖ SUPABASE_DB_URL no está definida.\n' +
+        '  Obtén el connection string en Supabase Dashboard → Project Settings → Database → Connection string (URI).\n' +
+        '  Ejemplo: SUPABASE_DB_URL=postgres://... npm run schema:ref'
+    );
+    process.exit(1);
+  }
+
+  const client = new Client({ connectionString });
+  await client.connect();
+  let output: string;
+  try {
+    const data = await fetchSchemaData(client, SCHEMAS);
+    output = formatSchemaRef(data, {
+      schemas: SCHEMAS,
+      generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    });
+  } finally {
+    await client.end();
+  }
+
+  if (DRY_RUN) {
+    process.stdout.write(output);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
+  fs.writeFileSync(OUT_PATH, output, 'utf8');
+  console.log(
+    `✔ Escrito ${path.relative(process.cwd(), OUT_PATH)} (${output.length.toLocaleString()} bytes, schemas: ${SCHEMAS.join(', ')})`
+  );
+}
+
+// Ejecutar solo cuando se invoca directamente (no al importar desde tests).
+const isMainModule = (() => {
+  try {
+    const invoked = process.argv[1] ? path.resolve(process.argv[1]) : '';
+    const here = path.resolve(__filename);
+    return invoked === here;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMainModule) {
+  main().catch((err) => {
+    console.error('✖ Error al regenerar SCHEMA_REF.md:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Resumen

Generador determinístico de `supabase/SCHEMA_REF.md` desde `information_schema`.
Cierra el gap del reporte P0 §3.2 (`docs/REPORT_RH_UI_2026-04-17.md`).

El `SCHEMA_REF.md` actual (339 líneas) es un inventario parcial editado a mano, inconsistente (mezcla `### cajas` sin prefijo con `### erp.task_updates` con prefijo) y solo documenta tablas de `rdb`. `CLAUDE.md` instruye a **siempre** referir ese archivo para nombres exactos — imposible de cumplir hoy.

## Qué cambia

- **`scripts/gen-schema-ref.ts`** — CLI con `pg.Client`. Formatter puro `formatSchemaRef()` exportado para test, queries a `information_schema` (tablas, columnas, PKs, FKs) y `pg_description` (comentarios). Flags: `--schemas`, `--out`, `--dry-run`.
- **`scripts/gen-schema-ref.test.ts`** — 14 tests sobre el formatter: determinismo (mismo input → output byte-idéntico), orden canónico (schemas alfa, tablas alfa, columnas por `ordinal_position`), rendering de PK/FK/NOT NULL/DEFAULT, labels `_(view)_` y `_(materialized view)_`, blockquote de comentarios multi-línea.
- **`package.json`**:
  - `schema:ref` — regenera el archivo.
  - `schema:check` — regenera + `git diff --exit-code` (drift detection, análogo a `db:check`).
  - `pg` + `@types/pg` en `devDependencies`.
- **`.env.local.example`** — documenta `SUPABASE_DB_URL` (opcional, solo scripts admin).
- **`CONTRIBUTING.md` § Base de datos** — actualizado: `SCHEMA_REF.md` se regenera, `schema:check` se corre antes de abrir PR.

## Por qué

1. Evita drift silencioso entre DB y documentación.
2. Output determinístico → diffs revisables en PRs cuando cambie el schema.
3. Desbloquea la instrucción de `CLAUDE.md` sobre usar el ref como fuente de verdad para nombres.

## Cómo probar

```bash
npm ci
npm run typecheck          # 0 errores
npm run test:run           # 25/25 passing (14 nuevos del formatter)
SUPABASE_DB_URL=postgres://... npm run schema:ref -- --dry-run
```

## Riesgos

Bajos — script no toca runtime:

- Solo añade archivos bajo `scripts/` (no se bundlea en Next build).
- `pg` es devDep, no se incluye en la app.
- `SCHEMA_REF.md` **no** se regenera en este PR (la regeneración real requiere `SUPABASE_DB_URL` + red hacia Supabase). Primera corrida local/CI posterior será un PR separado con el output completo.

## Verificación local

- `npx tsc --noEmit` → ✓ 0 errores
- `npx vitest run scripts/gen-schema-ref.test.ts` → ✓ 14/14
- `npm run test:run` → ✓ 25/25
- `npx eslint scripts/gen-schema-ref.ts scripts/gen-schema-ref.test.ts` → ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)