### PR TITLE
feat: add per-module error boundaries (P3.3.12)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,16 +40,16 @@ Complemento de [`SCHEMA_ARCHITECTURE.md`](./SCHEMA_ARCHITECTURE.md) (que cubre e
 
 ## Stack
 
-| Capa | Elección | Por qué |
-|------|----------|---------|
-| Framework | Next.js 15 App Router | RSC, streaming, data fetching server-side, routing por filesystem |
-| UI | Tailwind + shadcn/ui + Base UI | Primitivos accesibles + diseño tipado por utilidades |
-| Auth | Supabase Auth (cookie-based SSR) | Misma fuente que la DB, RLS integrado |
-| Datos | Supabase Postgres | Postgres completo + RLS + realtime + storage en una plataforma |
-| Rich text | TipTap | Editor extensible (juntas, documentos, tareas) |
-| Estado del servidor | Fetches server-side directos | No hay React Query todavía; candidato a introducir |
-| i18n | Custom provider (`lib/i18n.tsx`) | Ligero, suficiente para ES/EN |
-| Tests | Vitest + Playwright | Stack estándar de Next |
+| Capa                | Elección                         | Por qué                                                           |
+| ------------------- | -------------------------------- | ----------------------------------------------------------------- |
+| Framework           | Next.js 15 App Router            | RSC, streaming, data fetching server-side, routing por filesystem |
+| UI                  | Tailwind + shadcn/ui + Base UI   | Primitivos accesibles + diseño tipado por utilidades              |
+| Auth                | Supabase Auth (cookie-based SSR) | Misma fuente que la DB, RLS integrado                             |
+| Datos               | Supabase Postgres                | Postgres completo + RLS + realtime + storage en una plataforma    |
+| Rich text           | TipTap                           | Editor extensible (juntas, documentos, tareas)                    |
+| Estado del servidor | Fetches server-side directos     | No hay React Query todavía; candidato a introducir                |
+| i18n                | Custom provider (`lib/i18n.tsx`) | Ligero, suficiente para ES/EN                                     |
+| Tests               | Vitest + Playwright              | Stack estándar de Next                                            |
 
 ---
 
@@ -91,14 +91,14 @@ app/<módulo>/
 
 ### `app/api/` — API routes
 
-| Ruta | Método | Propósito | Auth |
-|------|--------|-----------|------|
-| `auth/google/route.ts` | GET | Redirect a Google OAuth | Anónimo |
-| `health/ingest/route.ts` | POST | Ingesta de datos de Apple Health | Token (`HEALTH_INGEST_TOKEN`) |
-| `impersonate/route.ts` | GET | Admin: ver la plataforma como otro usuario | Admin |
-| `juntas/terminar/route.ts` | POST | Cerrar junta + enviar email resumen | Session |
-| `usage/*` | GET | Dashboard de uso Claude/AI | Session |
-| `welcome-email/route.ts` | POST | Enviar email de bienvenida a usuario nuevo | Service role |
+| Ruta                       | Método | Propósito                                  | Auth                          |
+| -------------------------- | ------ | ------------------------------------------ | ----------------------------- |
+| `auth/google/route.ts`     | GET    | Redirect a Google OAuth                    | Anónimo                       |
+| `health/ingest/route.ts`   | POST   | Ingesta de datos de Apple Health           | Token (`HEALTH_INGEST_TOKEN`) |
+| `impersonate/route.ts`     | GET    | Admin: ver la plataforma como otro usuario | Admin                         |
+| `juntas/terminar/route.ts` | POST   | Cerrar junta + enviar email resumen        | Session                       |
+| `usage/*`                  | GET    | Dashboard de uso Claude/AI                 | Session                       |
+| `welcome-email/route.ts`   | POST   | Enviar email de bienvenida a usuario nuevo | Service role                  |
 
 ### `components/`
 
@@ -113,26 +113,27 @@ Tres capas:
 
 Lógica compartida, framework-agnostic donde sea posible.
 
-| Archivo | Rol |
-|---------|-----|
-| `supabase.ts`, `supabase-browser.ts`, `supabase-server.ts`, `supabase-admin.ts` | Factories de clientes según contexto |
-| `permissions.ts` | RBAC: `fetchUserPermissions`, `canAccessModulo`, `ROUTE_TO_MODULE` |
-| `i18n.tsx` | Provider de i18n (`lib/locales/en.json`, `es.json`) |
-| `timezone.ts` | Helpers de parseo/formato con timezone (crítico para cortes) |
-| `health.ts` | Utilidades del módulo Health |
-| `welcome-email.ts` | Generación del email de bienvenida |
-| `utils.ts` | Utilidades genéricas (`cn`, etc.) |
+| Archivo                                                                         | Rol                                                                |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `supabase.ts`, `supabase-browser.ts`, `supabase-server.ts`, `supabase-admin.ts` | Factories de clientes según contexto                               |
+| `permissions.ts`                                                                | RBAC: `fetchUserPermissions`, `canAccessModulo`, `ROUTE_TO_MODULE` |
+| `i18n.tsx`                                                                      | Provider de i18n (`lib/locales/en.json`, `es.json`)                |
+| `timezone.ts`                                                                   | Helpers de parseo/formato con timezone (crítico para cortes)       |
+| `health.ts`                                                                     | Utilidades del módulo Health                                       |
+| `welcome-email.ts`                                                              | Generación del email de bienvenida                                 |
+| `utils.ts`                                                                      | Utilidades genéricas (`cn`, etc.)                                  |
 
 ### `hooks/`
 
-| Hook | Rol |
-|------|-----|
-| `use-presence.ts` | Sincroniza presencia en realtime |
-| `use-sortable-table.ts` | Ordenamiento de tablas |
+| Hook                    | Rol                              |
+| ----------------------- | -------------------------------- |
+| `use-presence.ts`       | Sincroniza presencia en realtime |
+| `use-sortable-table.ts` | Ordenamiento de tablas           |
 
 ### `proxy.ts` — middleware
 
 Se ejecuta en cada request antes del renderizado:
+
 1. Hidrata la sesión de Supabase desde cookies.
 2. Determina el módulo objetivo según la ruta (`ROUTE_TO_MODULE`).
 3. Consulta permisos en `core.permisos_rol` + `core.permisos_usuario_excepcion`.
@@ -170,14 +171,14 @@ Ver [`SCHEMA_ARCHITECTURE.md`](./SCHEMA_ARCHITECTURE.md) para el mapa completo.
 
 Resumen:
 
-| Schema | Rol |
-|--------|-----|
-| `core` | Auth + acceso (plataforma) |
-| `erp` | Multi-empresa (todas las entidades compartidas) |
-| `rdb` | Lógica exclusiva de Rincón del Bosque (Waitry POS) |
-| `dilesa` | (Reservado) lógica exclusiva de DILESA |
-| `playtomic` | Sync de canchas deportivas |
-| `public` | Salud personal, usage tracking |
+| Schema      | Rol                                                |
+| ----------- | -------------------------------------------------- |
+| `core`      | Auth + acceso (plataforma)                         |
+| `erp`       | Multi-empresa (todas las entidades compartidas)    |
+| `rdb`       | Lógica exclusiva de Rincón del Bosque (Waitry POS) |
+| `dilesa`    | (Reservado) lógica exclusiva de DILESA             |
+| `playtomic` | Sync de canchas deportivas                         |
+| `public`    | Salud personal, usage tracking                     |
 
 **Migraciones**: todas en `supabase/migrations/`, nombradas con timestamp.
 
@@ -194,13 +195,13 @@ Resumen:
 
 ## Integraciones externas
 
-| Sistema | Propósito | Dónde se usa |
-|---------|-----------|--------------|
-| Resend | Emails transaccionales | `/api/welcome-email`, `/api/juntas/terminar`, `app/settings/acceso/actions.ts` |
-| Playtomic | Sync de reservas de canchas | `supabase/functions/playtomic-sync/` |
-| Apple Health | Ingesta de datos de salud | `/api/health/ingest` + shortcut iOS del usuario |
-| Coda | Migración histórica (read-only) | `scripts/migrate_dilesa_*.ts` (retirados después de migrar) |
-| Google OAuth | Login | `/api/auth/google` + `/auth/callback` |
+| Sistema      | Propósito                       | Dónde se usa                                                                   |
+| ------------ | ------------------------------- | ------------------------------------------------------------------------------ |
+| Resend       | Emails transaccionales          | `/api/welcome-email`, `/api/juntas/terminar`, `app/settings/acceso/actions.ts` |
+| Playtomic    | Sync de reservas de canchas     | `supabase/functions/playtomic-sync/`                                           |
+| Apple Health | Ingesta de datos de salud       | `/api/health/ingest` + shortcut iOS del usuario                                |
+| Coda         | Migración histórica (read-only) | `scripts/migrate_dilesa_*.ts` (retirados después de migrar)                    |
+| Google OAuth | Login                           | `/api/auth/google` + `/auth/callback`                                          |
 
 ---
 
@@ -310,15 +311,42 @@ Dos razones para preferir soft-delete frente a `DELETE`:
 
 ### Activo vs eliminado — cuándo usar cuál
 
-| Estado | Columna | UI | Significado |
-|--------|---------|----|-------------|
-| Activo | `activo = true`, `deleted_at IS NULL` | Fila normal | Aparece en selectores y reportes. |
-| Inactivo | `activo = false`, `deleted_at IS NULL` | Fila tenue / badge `Inactivo` | Fuera de uso operativo pero consultable. |
-| Eliminado | `deleted_at IS NOT NULL` | No aparece | Fuera de listados. Recuperable manualmente. |
+| Estado    | Columna                                | UI                            | Significado                                 |
+| --------- | -------------------------------------- | ----------------------------- | ------------------------------------------- |
+| Activo    | `activo = true`, `deleted_at IS NULL`  | Fila normal                   | Aparece en selectores y reportes.           |
+| Inactivo  | `activo = false`, `deleted_at IS NULL` | Fila tenue / badge `Inactivo` | Fuera de uso operativo pero consultable.    |
+| Eliminado | `deleted_at IS NOT NULL`               | No aparece                    | Fuera de listados. Recuperable manualmente. |
 
-### Smoke test sugerido (Playwright)
+### Error boundaries por módulo (`components/shared/module-error.tsx`)
 
-Ubicación propuesta: `tests/e2e/rh-row-actions.spec.ts`. Cubre por empresa (`/rh`, `/rdb/rh`, `/dilesa/rh`) y por recurso (`departamentos`, `puestos`, `empleados`) los tres caminos: editar-cancelar, toggle activo, eliminar-con-confirm. Ver tarea #9.
+Cada módulo top-level (`app/rh`, `app/rdb`, `app/dilesa`, `app/settings`, `app/administracion`, `app/health`, `app/travel`, `app/family`, …) tiene un `error.tsx` que delega en el componente canónico `ModuleError`:
+
+```tsx
+// app/<modulo>/error.tsx
+'use client';
+
+import { ModuleError } from '@/components/shared/module-error';
+
+export default function ModuloError(props: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <ModuleError {...props} moduleName="RH" />;
+}
+```
+
+`ModuleError`:
+
+- Renderiza título (`Error en {moduleName}`), mensaje del error, y el `digest` de Next.js para correlación con logs del servidor.
+- Expone un botón "Reintentar" cableado al `reset` de Next.js.
+- Loguea al console en `useEffect` con prefix `[{moduleName}]` — visible en preview deploys sin Sentry.
+- Tiene `role="alert"` + `aria-live="polite"` para lectores de pantalla.
+
+Rutas de submódulo pueden tener su propio `error.tsx` si necesitan un label más específico (p. ej. `app/rdb/requisiciones/error.tsx` usa `moduleName="Requisiciones"`).
+
+### Smoke test Playwright (RowActions)
+
+Ubicación: `tests/e2e/smoke/auth-rh-row-actions.spec.ts`. Cubre por empresa (`/rh`, `/rdb/rh`, `/dilesa/rh`) y por recurso (`departamentos`, `puestos`, `empleados`) los tres caminos: kebab aria-label, menú con Editar+Toggle+Eliminar, ConfirmDialog con Cancelar. Read-only por diseño (siempre cancela).
 
 ---
 

--- a/app/administracion/error.tsx
+++ b/app/administracion/error.tsx
@@ -2,9 +2,9 @@
 
 import { ModuleError } from '@/components/shared/module-error';
 
-export default function RdbRequisicionesError(props: {
+export default function AdministracionError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  return <ModuleError {...props} moduleName="Requisiciones" />;
+  return <ModuleError {...props} moduleName="Administración" />;
 }

--- a/app/dilesa/error.tsx
+++ b/app/dilesa/error.tsx
@@ -2,9 +2,9 @@
 
 import { ModuleError } from '@/components/shared/module-error';
 
-export default function RdbRequisicionesError(props: {
+export default function DilesaError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  return <ModuleError {...props} moduleName="Requisiciones" />;
+  return <ModuleError {...props} moduleName="DILESA" />;
 }

--- a/app/family/error.tsx
+++ b/app/family/error.tsx
@@ -2,9 +2,9 @@
 
 import { ModuleError } from '@/components/shared/module-error';
 
-export default function RdbRequisicionesError(props: {
+export default function FamilyError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  return <ModuleError {...props} moduleName="Requisiciones" />;
+  return <ModuleError {...props} moduleName="Family" />;
 }

--- a/app/health/error.tsx
+++ b/app/health/error.tsx
@@ -2,9 +2,9 @@
 
 import { ModuleError } from '@/components/shared/module-error';
 
-export default function RdbRequisicionesError(props: {
+export default function HealthError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  return <ModuleError {...props} moduleName="Requisiciones" />;
+  return <ModuleError {...props} moduleName="Health" />;
 }

--- a/app/rdb/error.tsx
+++ b/app/rdb/error.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ModuleError } from '@/components/shared/module-error';
+
+export default function RdbError(props: { error: Error & { digest?: string }; reset: () => void }) {
+  return <ModuleError {...props} moduleName="RDB" />;
+}

--- a/app/rh/error.tsx
+++ b/app/rh/error.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ModuleError } from '@/components/shared/module-error';
+
+export default function RhError(props: { error: Error & { digest?: string }; reset: () => void }) {
+  return <ModuleError {...props} moduleName="RH" />;
+}

--- a/app/settings/acceso/error.tsx
+++ b/app/settings/acceso/error.tsx
@@ -1,33 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { ModuleError } from '@/components/shared/module-error';
 
-export default function AccesoError({
-  error,
-  reset,
-}: {
+export default function AccesoError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  useEffect(() => {
-    console.error('Acceso page error:', error);
-  }, [error]);
-
-  return (
-    <div className="flex flex-col items-center justify-center py-24 text-center">
-      <div className="text-4xl">⚠️</div>
-      <h2 className="mt-4 text-xl font-semibold dark:text-white text-[var(--text)]">
-        Error al cargar la página
-      </h2>
-      <p className="mt-2 max-w-md text-sm dark:text-white/55 text-[var(--text)]/55">
-        {error.message || 'Ocurrió un error inesperado. Intenta de nuevo.'}
-      </p>
-      <button
-        onClick={reset}
-        className="mt-4 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium hover:bg-white/20 transition-colors"
-      >
-        Reintentar
-      </button>
-    </div>
-  );
+  return <ModuleError {...props} moduleName="Acceso" />;
 }

--- a/app/settings/error.tsx
+++ b/app/settings/error.tsx
@@ -2,9 +2,9 @@
 
 import { ModuleError } from '@/components/shared/module-error';
 
-export default function RdbRequisicionesError(props: {
+export default function SettingsError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  return <ModuleError {...props} moduleName="Requisiciones" />;
+  return <ModuleError {...props} moduleName="Settings" />;
 }

--- a/app/travel/error.tsx
+++ b/app/travel/error.tsx
@@ -2,9 +2,9 @@
 
 import { ModuleError } from '@/components/shared/module-error';
 
-export default function RdbRequisicionesError(props: {
+export default function TravelError(props: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  return <ModuleError {...props} moduleName="Requisiciones" />;
+  return <ModuleError {...props} moduleName="Travel" />;
 }

--- a/components/shared/module-error.tsx
+++ b/components/shared/module-error.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+/**
+ * Canonical module-level error boundary.
+ *
+ * Wraps Next.js `error.tsx` boundaries with a consistent look & feel:
+ *   - scoped title ("Error en <module>")
+ *   - the underlying error message (when present)
+ *   - `error.digest` for correlating with server logs (truncated, monospace)
+ *   - a "Reintentar" button wired to the `reset` callback
+ *
+ * This is the UX standard referenced by `ARCHITECTURE.md § UI Standards`.
+ * Per-module `error.tsx` files should be thin wrappers around this component
+ * so the presentation stays uniform across the product.
+ *
+ * @example
+ *   // app/rh/error.tsx
+ *   'use client';
+ *   import { ModuleError } from '@/components/shared/module-error';
+ *   export default function Error(props: {
+ *     error: Error & { digest?: string };
+ *     reset: () => void;
+ *   }) {
+ *     return <ModuleError {...props} moduleName="RH" />;
+ *   }
+ */
+export type ModuleErrorProps = {
+  /**
+   * Human-readable module label — e.g. `"RH"`, `"RDB"`, `"Settings"`.
+   * Shown in the heading ("Error en {moduleName}") and in the console log.
+   */
+  moduleName: string;
+  /**
+   * Optional override for the default message shown under the heading.
+   * Defaults to the error's own `message`, then to a generic fallback.
+   */
+  description?: string;
+  /**
+   * The error thrown while rendering. Next.js augments the error with an
+   * opaque `digest` used to look the error up in server logs.
+   */
+  error: Error & { digest?: string };
+  /**
+   * Reset callback provided by Next.js. Re-renders the boundary's segment.
+   */
+  reset: () => void;
+};
+
+export function ModuleError({ moduleName, description, error, reset }: ModuleErrorProps) {
+  useEffect(() => {
+    // Surface the error to the browser console so it's visible in Sentry-less
+    // preview deploys. Format matches the pre-existing `app/rdb/requisiciones`
+    // and `app/settings/acceso` boundaries.
+    console.error(`[${moduleName}] error boundary:`, error);
+  }, [moduleName, error]);
+
+  const message =
+    description ?? error.message ?? 'Ocurrió un error inesperado al renderizar esta pantalla.';
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="mx-auto my-10 max-w-2xl rounded-xl border border-destructive/30 bg-destructive/10 p-6"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 flex-none text-destructive" aria-hidden="true" />
+        <div className="min-w-0 flex-1 space-y-3">
+          <div>
+            <h2 className="text-lg font-semibold text-destructive">Error en {moduleName}</h2>
+            <p className="mt-1 text-sm text-destructive/90 break-words">{message}</p>
+          </div>
+
+          {error.digest ? (
+            <p className="font-mono text-xs text-destructive/70">Digest: {error.digest}</p>
+          ) : null}
+
+          <div className="pt-1">
+            <Button variant="outline" size="sm" onClick={reset} className="gap-1.5">
+              <RefreshCw className="h-3.5 w-3.5" />
+              Reintentar
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements **P3.3.12** from `docs/REPORT_RH_UI_2026-04-17.md` — introduces a canonical per-module error boundary so that every top-level module segment (`/rh`, `/rdb`, `/dilesa`, `/settings`, `/administracion`, `/health`, `/travel`, `/family`) renders a consistent, accessible error UI instead of falling back to the framework default or diverging per page.

## What changed

### New canonical component
- `components/shared/module-error.tsx` — single `ModuleError` component used by every module's `error.tsx`. Renders:
  - `role="alert"` + `aria-live="polite"` container
  - Scoped heading (`"Error en {moduleName}"`) + underlying error message + generic Spanish fallback
  - `error.digest` in monospace for Sentry-less correlation with server logs
  - "Reintentar" button wired to Next.js's `reset` callback
  - Console `error` with `[${moduleName}]` prefix, matching pre-existing boundaries

### 8 new module-level boundaries
Each is a 9-line wrapper that just delegates to `ModuleError` with a `moduleName` prop:
- `app/rh/error.tsx` → `"RH"`
- `app/rdb/error.tsx` → `"RDB"`
- `app/dilesa/error.tsx` → `"DILESA"`
- `app/settings/error.tsx` → `"Settings"`
- `app/administracion/error.tsx` → `"Administración"`
- `app/health/error.tsx` → `"Health"`
- `app/travel/error.tsx` → `"Travel"`
- `app/family/error.tsx` → `"Family"`

### 2 existing boundaries migrated
Removed ~60 lines of divergent inline markup:
- `app/rdb/requisiciones/error.tsx` (was a hand-rolled 31-line card with "Intentar de nuevo" button) → now uses `ModuleError` with `moduleName="Requisiciones"`
- `app/settings/acceso/error.tsx` (was a centered 33-line layout with ⚠️ emoji and raw `<button>`) → now uses `ModuleError` with `moduleName="Acceso"`

### Docs
- `ARCHITECTURE.md § UI Standards` — new "Error boundaries por módulo" subsection documenting the canonical pattern and the 1-line rule for new `error.tsx` files

## Motivation

Prior to this PR, only two module-level boundaries existed (`rdb/requisiciones`, `settings/acceso`) and they diverged in markup, copy, and button style. Any unhandled error inside `/rh`, `/dilesa`, etc. would bubble to the Next.js global boundary, producing a less useful UX and no per-module context in the console.

Adding a canonical component mirrors the `RowActions` + `ConfirmDialog` pattern we landed in PR #24 and establishes a third UI standard in `components/shared/`.

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 issues
- [x] `pnpm test:run` — 25/25 pass
- [ ] Vercel Preview — Preview deploy READY + smoke
- [ ] Manual: force an error in a module page and confirm the scoped boundary renders with the right heading and Reintentar button

🤖 Generated with [Claude Code](https://claude.com/claude-code)