### PR TITLE
fix(sync-cortes): restore movimientos upsert + export edge fns to repo

### DIFF
--- a/scripts/backfill_coda_movimientos_2026_04_17.py
+++ b/scripts/backfill_coda_movimientos_2026_04_17.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Backfill one-shot (2026-04-17) de erp.movimientos_caja desde Coda.
+
+Contexto:
+  El edge function `sync-cortes` corre cada 5 min y llama a rdb.upsert_movimiento,
+  pero sólo procesa los últimos 3 días. Rows más viejos que quedaron fuera de esa
+  ventana no se sincronizan.
+
+  Este script pagina TODOS los rows de Coda (grid-6gzoL-bk1R, doc yvrM3UilPt)
+  y los manda uno por uno a rdb.upsert_movimiento vía PostgREST. Es idempotente:
+  rows con `referencia = coda_id` ya presentes se UPDATEan; los faltantes se INSERTan.
+
+Uso:
+  export CODA_API_KEY=...
+  export NEXT_PUBLIC_SUPABASE_URL=...
+  export SUPABASE_SERVICE_ROLE_KEY=...
+  python3 scripts/backfill_coda_movimientos_2026_04_17.py
+
+Después de correr, ejecutar la migración 20260417181500_dedup_movimientos_caja_name_refs.sql
+para eliminar rows viejos cuyo `referencia` es un nombre de cajera (no un coda_id).
+
+Nota: este script queda archivado como one-shot. NO correrlo en producción a menos
+que se audite primero el estado de la tabla.
+"""
+
+import urllib.request, json, os, time, re
+
+CODA   = os.environ['CODA_API_KEY']
+SB_URL = os.environ['NEXT_PUBLIC_SUPABASE_URL']
+SR_KEY = os.environ['SUPABASE_SERVICE_ROLE_KEY']
+
+DOC_ID  = 'yvrM3UilPt'
+TBL_MOV = 'grid-6gzoL-bk1R'
+
+
+def parse_num(v):
+    if v is None or v == '':
+        return None
+    s = re.sub(r'[^0-9.\-]', '', str(v))
+    return float(s) if s else None
+
+
+def parse_ts(v):
+    if not v or str(v).strip() == '' or '1899' in str(v):
+        return None
+    return str(v)
+
+
+def fetch_all_coda_rows():
+    url = f'https://coda.io/apis/v1/docs/{DOC_ID}/tables/{TBL_MOV}/rows?useColumnNames=true&limit=200'
+    rows = []
+    while url:
+        req = urllib.request.Request(url, headers={'Authorization': f'Bearer {CODA}'})
+        data = json.loads(urllib.request.urlopen(req).read())
+        rows.extend(data['items'])
+        url = data.get('nextPageLink')
+    return rows
+
+
+def upsert_row(r):
+    v = r['values']
+    reg = v.get('Registró', None)
+    if isinstance(reg, dict):
+        reg = reg.get('name') or str(reg)
+    payload = {
+        'p_coda_id':        r['id'],
+        'p_corte_nombre':   v.get('Corte'),
+        'p_fecha_hora':     parse_ts(v.get('Fecha/Hora')),
+        'p_tipo':           v.get('Tipo'),
+        'p_monto':          parse_num(v.get('Monto')),
+        'p_nota':           v.get('Nota'),
+        'p_registrado_por': reg,
+    }
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f'{SB_URL}/rest/v1/rpc/upsert_movimiento',
+        data=body, method='POST', headers={
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {SR_KEY}',
+            'apikey': SR_KEY,
+            'Accept-Profile': 'rdb',
+            'Content-Profile': 'rdb',
+        })
+    try:
+        urllib.request.urlopen(req).read()
+        return None
+    except urllib.error.HTTPError as e:
+        return f"{r['id']}: {e.code} {e.read()[:200].decode()}"
+
+
+def main():
+    rows = fetch_all_coda_rows()
+    print(f"Coda rows fetched: {len(rows)}")
+
+    ok, err = 0, 0
+    errors = []
+    for r in rows:
+        error = upsert_row(r)
+        if error:
+            err += 1
+            if len(errors) < 5:
+                errors.append(error)
+        else:
+            ok += 1
+        time.sleep(0.04)  # Rate limit (~25 req/s)
+
+    print(f"Upserted: {ok} | Errors: {err}")
+    for e in errors:
+        print(f"  ERR: {e}")
+
+
+if __name__ == '__main__':
+    main()

--- a/supabase/functions/sync-cortes/index.ts
+++ b/supabase/functions/sync-cortes/index.ts
@@ -1,0 +1,191 @@
+/**
+ * sync-cortes
+ * Pulls cortes and movimientos from Coda API and upserts into Supabase.
+ * Designed to run every 5 minutes via pg_cron + http extension.
+ *
+ * Arquitectura:
+ *   Coda (doc yvrM3UilPt, grids Fn_BELDxbK + 6gzoL-bk1R)
+ *     ↓ fetch últimas 3 días
+ *   PostgREST RPC con Accept-Profile: rdb
+ *     ↓
+ *   rdb.upsert_corte  → INSERT/UPDATE en erp.cortes_caja
+ *   rdb.upsert_movimiento → INSERT/UPDATE en erp.movimientos_caja
+ *
+ * Shim: `rdb.upsert_*` son fachadas en schema rdb; internamente escriben a erp.
+ * Cuando BSOP se use nativamente para cortes este cron y las RPCs se pueden retirar.
+ */
+
+const CODA_API_KEY = Deno.env.get('CODA_API_KEY')!;
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const SERVICE_KEY  = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+const DOC_ID             = 'yvrM3UilPt';
+const TABLE_CORTES_ID    = 'grid-Fn_BELDxbK';
+const TABLE_MOVIMIENTOS_ID = 'grid-6gzoL-bk1R';
+
+const RPC_CORTE_URL      = `${SUPABASE_URL}/rest/v1/rpc/upsert_corte`;
+const RPC_MOVIMIENTO_URL = `${SUPABASE_URL}/rest/v1/rpc/upsert_movimiento`;
+
+const SB_HEADERS = {
+  'Content-Type': 'application/json',
+  'Authorization': `Bearer ${SERVICE_KEY}`,
+  'apikey': SERVICE_KEY,
+  'Accept-Profile': 'rdb',
+  'Content-Profile': 'rdb',
+};
+
+function parseNum(v: unknown): number | null {
+  if (v === null || v === undefined || v === '') return null;
+  const n = parseFloat(String(v).replace(/[^0-9.-]/g, ''));
+  return isNaN(n) ? null : n;
+}
+
+function parseTs(v: unknown): string | null {
+  if (!v || String(v).trim() === '') return null;
+  try {
+    const d = new Date(String(v));
+    if (isNaN(d.getTime())) return null;
+    if (String(v).includes('1899')) return null;
+    return d.toISOString();
+  } catch { return null; }
+}
+
+function parseDate(v: unknown): string | null {
+  if (!v || String(v).trim() === '') return null;
+  try {
+    return new Date(String(v)).toISOString().split('T')[0];
+  } catch { return null; }
+}
+
+function mapEstado(e: string): string {
+  const m: Record<string,string> = {
+    'Abierto': 'abierto', 'Cerrado': 'cerrado',
+    'Auto Cerrado': 'auto_cerrado', 'Validado': 'validado',
+  };
+  return m[e] ?? e.toLowerCase();
+}
+
+async function fetchCodaRows(tableId: string, cutoffDays: number, dateColName: string): Promise<any[]> {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - cutoffDays);
+
+  let rows: any[] = [];
+  let pageToken: string | null = null;
+  const urlBase = `https://coda.io/apis/v1/docs/${DOC_ID}/tables/${tableId}/rows`;
+
+  do {
+    const url = new URL(urlBase);
+    url.searchParams.set('useColumnNames', 'true');
+    url.searchParams.set('limit', '50');
+    if (pageToken) url.searchParams.set('pageToken', pageToken);
+
+    const resp = await fetch(url.toString(), {
+      headers: { 'Authorization': `Bearer ${CODA_API_KEY}` }
+    });
+
+    if (!resp.ok) throw new Error(`Coda API error for ${tableId}: ${resp.status}`);
+    const data = await resp.json();
+
+    for (const row of data.items) {
+      const v = row.values;
+      const dateVal = parseTs(v[dateColName]);
+      if (dateVal && new Date(dateVal) >= cutoff) {
+        rows.push({ rowId: row.id, values: v });
+      }
+    }
+
+    pageToken = data.nextPageToken ?? null;
+    if (data.items.length > 0) {
+      const lastDate = parseTs(data.items[data.items.length - 1].values[dateColName]);
+      if (lastDate && new Date(lastDate) < cutoff) pageToken = null;
+    }
+  } while (pageToken);
+
+  return rows;
+}
+
+async function upsertCorte(rowId: string, v: Record<string,any>): Promise<any> {
+  const payload = {
+    p_coda_id:              rowId,
+    p_corte_nombre:         v['ID Corte'] ?? null,
+    p_caja_nombre:          typeof v['Caja'] === 'object' ? v['Caja']?.name ?? String(v['Caja']) : v['Caja'] ?? null,
+    p_estado:               v['Estado'] ? mapEstado(v['Estado']) : null,
+    p_turno:                v['Turno'] ?? null,
+    p_responsable_apertura: v['Responsable Apertura'] ?? null,
+    p_responsable_cierre:   v['Responsable Cierre'] ?? null,
+    p_observaciones:        v['Observaciones'] ?? null,
+    p_efectivo_inicial:     parseNum(v['Efectivo Inicial']),
+    p_efectivo_contado:     parseNum(v['Efectivo Contado al Cierre']),
+    p_hora_inicio:          parseTs(v['Apertura']),
+    p_hora_fin:             parseTs(v['Cierre']),
+    p_fecha_operativa:      parseDate(v['Fecha Operativa']),
+    p_tipo:                 'normal',
+  };
+
+  const resp = await fetch(RPC_CORTE_URL, {
+    method: 'POST',
+    headers: SB_HEADERS,
+    body: JSON.stringify(payload),
+  });
+
+  const result = await resp.json();
+  if (!resp.ok) return { ok: false, error: JSON.stringify(result) };
+  return { ok: true, action: result.action ?? 'upserted' };
+}
+
+async function upsertMovimiento(rowId: string, v: Record<string,any>): Promise<any> {
+  const payload = {
+    p_coda_id:        rowId,
+    p_corte_nombre:   v['Corte'] ?? null,
+    p_fecha_hora:     parseTs(v['Fecha/Hora']),
+    p_tipo:           v['Tipo'] ?? null,
+    p_monto:          parseNum(v['Monto']),
+    p_nota:           v['Nota'] ?? null,
+    p_registrado_por: typeof v['Registró'] === 'object' ? v['Registró']?.name ?? String(v['Registró']) : v['Registró'] ?? null,
+  };
+
+  const resp = await fetch(RPC_MOVIMIENTO_URL, {
+    method: 'POST',
+    headers: SB_HEADERS,
+    body: JSON.stringify(payload),
+  });
+
+  const result = await resp.json();
+  if (!resp.ok) return { ok: false, error: JSON.stringify(result) };
+  return { ok: true, action: 'upserted' };
+}
+
+Deno.serve(async (_req) => {
+  const log: string[] = [];
+  try {
+    // 1. Sync Cortes (last 3 days)
+    log.push('Syncing Cortes...');
+    const cortes = await fetchCodaRows(TABLE_CORTES_ID, 3, 'Apertura');
+    let c_upd = 0, c_err = 0;
+    for (const { rowId, values } of cortes) {
+      const res = await upsertCorte(rowId, values);
+      if (res.ok) c_upd++; else { c_err++; log.push(`  ❌ Corte ${values['ID Corte']}: ${res.error}`); }
+      await new Promise(r => setTimeout(r, 50));
+    }
+    log.push(`Cortes: ${c_upd} upserted, ${c_err} errors`);
+
+    // 2. Sync Movimientos (last 3 days)
+    log.push('Syncing Movimientos...');
+    const movs = await fetchCodaRows(TABLE_MOVIMIENTOS_ID, 3, 'Fecha/Hora');
+    let m_upd = 0, m_err = 0;
+    for (const { rowId, values } of movs) {
+      const res = await upsertMovimiento(rowId, values);
+      if (res.ok) m_upd++; else { m_err++; log.push(`  ❌ Movimiento ${rowId}: ${res.error}`); }
+      await new Promise(r => setTimeout(r, 50));
+    }
+    log.push(`Movimientos: ${m_upd} upserted, ${m_err} errors`);
+
+    return new Response(JSON.stringify({ ok: true, log }), {
+      status: 200, headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (err: any) {
+    return new Response(JSON.stringify({ ok: false, error: err.message, log }), {
+      status: 500, headers: { 'Content-Type': 'application/json' }
+    });
+  }
+});

--- a/supabase/functions/waitry-webhook/index.ts
+++ b/supabase/functions/waitry-webhook/index.ts
@@ -1,0 +1,736 @@
+/**
+ * waitry-webhook
+ *
+ * Recibe POSTs del POS Waitry con cada pedido/actualización.
+ * Flujo:
+ *   1. Persiste el payload crudo en rdb.waitry_inbound (audit trail + retry).
+ *   2. Desgloza a rdb.waitry_pedidos / _productos / _pagos.
+ *   3. Espeja a Coda (grids pedidos/productos/pagos) vía Coda API.
+ *
+ * Exportado al repo 2026-04-17 desde Supabase Dashboard (v18, ezbr_sha256 cc3808c7...).
+ * Verify JWT: false (Waitry no envía bearer; se valida por el path secreto).
+ */
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const CODA_API_BASE = 'https://coda.io/apis/v1'
+const CODA_DOC_ID = 'yvrM3UilPt'
+const CODA_TABLES = {
+  pedidos: 'grid-qrrVxRy-_F',
+  productos: 'grid-JR7mvLylN_',
+  pagos: 'grid-NVkBKyMZAd',
+}
+
+const PEDIDOS_COLS = {
+  IDPEDIDO: 'c-c5XrezM2oo',
+  STATUS: 'c-xbkZ__XlCn',
+  PAID: 'c-MVL9iNtzDN',
+  TIMESTAMP: 'c-9e3LGnM8Xt',
+  PLACEID: 'c-1love2nACV',
+  PLACENAME: 'c-PSR2hD-Bgd',
+  TABLENAME: 'c-G1M9EA9UnI',
+  LAYOUTNAME: 'c-VG6OClX0SJ',
+  TOTALAMOUNT: 'c-F1bs1TAYEe',
+  TOTALDISCOUNT: 'c-gf0_uIbSrU',
+  SERVICECHARGE: 'c-xCAZbSULl1',
+  TAX: 'c-T_5TNYryCM',
+  EXTDELIVERYID: 'c-JtXbilGjP9',
+  NOTES: 'c-bViSP899JZ',
+  LASTACTIONAT: 'c-XQ-c9WPDD5',
+} as const
+
+const PRODUCTOS_COLS = {
+  PK: 'c-Vz_DvOHrnr',
+  IDPEDIDO: 'c-8BiNoBFp3J',
+  ITEMID: 'c-R3oGZGYXmj',
+  NOMBRE: 'c--crdKQfErD',
+  CANTIDAD: 'c-Bd5BfhWt--',
+  PRECIO: 'c-th_hOTIDhk',
+  DISCOUNTPRICE: 'c-feUk588nG3',
+  SUBTOTAL: 'c-DFU8inaAyP',
+  CANCELADO: 'c-yh4CA1bvYC',
+  TIMESTAMP: 'c-2NBuwn9z7i',
+  USUARIO: 'c-E9ZG50UuaC',
+} as const
+
+const PAGOS_COLS = {
+  PK: 'c-Sielbb-7s8',
+  IDPEDIDO: 'c-rCZLJSEYAl',
+  GATEWAY: 'c-mYztdmvKfT',
+  METHOD: 'c--r7N1AJn1t',
+  AMOUNT: 'c-cCW_YxwB72',
+  STATUS: 'c-0AAz8tyBGv',
+  CREATEDAT: 'c-m4D-2Yqubc',
+  ESREFUND: 'c-QpwfCbA3KO',
+} as const
+
+type Json = Record<string, any>
+
+function j(v: unknown) {
+  if (!v) return null
+  if (typeof v === 'string') {
+    try {
+      return JSON.parse(v)
+    } catch {
+      return null
+    }
+  }
+  return typeof v === 'object' ? v : null
+}
+
+function unwrapPayload(raw: any): any {
+  if (typeof raw === 'string') {
+    const parsed = j(raw)
+    return parsed ? unwrapPayload(parsed) : raw
+  }
+  if (!raw || typeof raw !== 'object') return raw
+  const candidates = [
+    raw.payload,
+    raw.body,
+    raw.data,
+    raw.message,
+    typeof raw.payload === 'string' ? j(raw.payload) : null,
+    typeof raw.body === 'string' ? j(raw.body) : null,
+    typeof raw.data === 'string' ? j(raw.data) : null,
+  ].filter(Boolean)
+  return candidates[0] || raw
+}
+
+function firstNonEmpty(...vals: any[]) {
+  for (const v of vals) {
+    if (v == null) continue
+    if (Array.isArray(v)) {
+      const found = v.find((x) => x != null && String(x).trim() !== '')
+      if (found != null && String(found).trim() !== '') return String(found).trim()
+      continue
+    }
+    const s = String(v).trim()
+    if (s) return s
+  }
+  return undefined
+}
+
+function zonedDateTimeToUtcIso(raw: string, timeZone: string): string | null {
+  const match = String(raw).trim().match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/)
+  if (!match) return null
+
+  const [, y, m, d, hh, mm, ss] = match
+  const year = Number(y)
+  const month = Number(m)
+  const day = Number(d)
+  const hour = Number(hh)
+  const minute = Number(mm)
+  const second = Number(ss)
+  const target = Date.UTC(year, month - 1, day, hour, minute, second)
+
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  })
+
+  let guess = target
+
+  for (let i = 0; i < 5; i += 1) {
+    const parts = formatter.formatToParts(new Date(guess))
+    const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]))
+    const observed = Date.UTC(
+      Number(lookup.year),
+      Number(lookup.month) - 1,
+      Number(lookup.day),
+      Number(lookup.hour),
+      Number(lookup.minute),
+      Number(lookup.second),
+    )
+    const delta = target - observed
+    guess += delta
+    if (delta === 0) break
+  }
+
+  return new Date(guess).toISOString()
+}
+
+function toISOFromAR(src: any): string | null {
+  if (src == null) return null
+
+  if (typeof src === 'object') {
+    const date = src.date || src.datetime || src.timestamp || src.createdAt || src.updatedAt || null
+    const timeZone = src.timezone || src.timeZone || 'America/Argentina/Buenos_Aires'
+    if (!date) return null
+    return zonedDateTimeToUtcIso(String(date), String(timeZone)) ?? null
+  }
+
+  const s = String(src).trim()
+  if (!s) return null
+  if (/Z$|[+\-]\d{2}:\d{2}$/.test(s)) return s.includes('T') ? s : s.replace(' ', 'T')
+  return zonedDateTimeToUtcIso(s, 'America/Argentina/Buenos_Aires')
+}
+
+function flattenNotes(x: any): string | undefined {
+  if (x == null) return undefined
+  if (Array.isArray(x)) {
+    const parts = x.map(flattenNotes).filter(Boolean)
+    return parts.length ? parts.join(' | ') : undefined
+  }
+  if (typeof x === 'object') return flattenNotes(x.text ?? x.note ?? x.notes ?? x.comment ?? x.comments)
+  const s = String(x).trim()
+  return s || undefined
+}
+
+function computeOrderId(p: any) {
+  return p?.orderId ?? p?.order?.id ?? p?.id ?? p?.orderID ?? p?.OrderId ?? null
+}
+
+function computeExternalDeliveryId(p: any) {
+  return firstNonEmpty(
+    p?.externalDeliveryId,
+    p?.delivery?.externalId,
+    p?.delivery?.externalDeliveryId,
+    p?.delivery?.id,
+    p?.deliveryId,
+    p?.externalId,
+    p?.order?.externalDeliveryId,
+    p?.order?.delivery?.externalId,
+    p?.order?.deliveryId,
+    p?.order?.externalId,
+    p?.meta?.externalDeliveryId,
+    p?.meta?.externalId,
+    p?.options?.externalDeliveryId,
+    p?.options?.externalId,
+  )
+}
+
+function computeNotes(p: any) {
+  return flattenNotes(firstNonEmpty(
+    p?.notes, p?.note, p?.comments, p?.comment,
+    p?.customerNote, p?.customerNotes, p?.orderNotes, p?.kitchenNotes,
+    p?.deliveryNotes, p?.specialInstructions, p?.instructions,
+    p?.observations, p?.observation, p?.posNote, p?.posNotes,
+    p?.order?.notes, p?.order?.note, p?.order?.comments, p?.order?.comment,
+    p?.table?.note, p?.table?.notes, p?.place?.note, p?.place?.notes,
+    p?.meta?.notes, p?.meta?.note, p?.extra?.notes, p?.extra?.note,
+  ))
+}
+
+function computeLastActionAt(p: any) {
+  const unwrap = (x: any) => (x && typeof x === 'object' && (x.date || x.datetime || x.timestamp)) ? (x.date || x.datetime || x.timestamp) : x
+  const list = []
+    .concat(Array.isArray(p?.orderActions) ? p.orderActions.flatMap((a: any) => [unwrap(a?.timestamp), unwrap(a?.createdAt), unwrap(a?.actionDate)]) : [])
+    .concat(Array.isArray(p?.actions) ? p.actions.map((a: any) => unwrap(a?.timestamp)) : [])
+    .concat([unwrap(p?.lastActionAt), unwrap(p?.updatedAt), unwrap(p?.statusChangedAt), unwrap(p?.stateChangedAt)])
+    .concat([unwrap(p?.order?.lastActionAt), unwrap(p?.order?.updatedAt), unwrap(p?.order?.closedAt)])
+    .concat([unwrap(p?.timestamp), unwrap(p?.createdAt)])
+  const norm = list.map(toISOFromAR).filter(Boolean) as string[]
+  if (!norm.length) return null
+  return norm.reduce((a, b) => new Date(a) > new Date(b) ? a : b)
+}
+
+function normalizeName(n: any) {
+  if (n == null) return undefined
+  const s = String(n).trim()
+  return s || undefined
+}
+
+function nameFromPerson(person: any) {
+  if (!person || typeof person !== 'object') return undefined
+  const direct = normalizeName(person.fullName ?? person.fullname ?? person.displayName ?? person.name)
+  if (direct) return direct
+  const first = person.firstName ?? person.firstname ?? person.givenName ?? person.given_name ?? person.name
+  const last = person.lastName ?? person.lastname ?? person.familyName ?? person.family_name
+  return normalizeName(`${first ?? ''} ${last ?? ''}`.trim())
+}
+
+function nameFromObj(o: any) {
+  if (!o || typeof o !== 'object') return undefined
+  const personName = nameFromPerson(o.person)
+  if (personName) return personName
+  const direct = normalizeName(o.name ?? o.fullName ?? o.fullname ?? o.displayName ?? o.username ?? o.userName ?? o.operatorName ?? o.staffName ?? o.employeeName)
+  if (direct) return direct
+  const first = o.firstName ?? o.firstname ?? o.givenName ?? o.given_name ?? o.nameFirst
+  const last = o.lastName ?? o.lastname ?? o.familyName ?? o.family_name ?? o.nameLast
+  return normalizeName(`${first ?? ''} ${last ?? ''}`.trim())
+}
+
+function computeUser(it: any, p: any) {
+  const direct = normalizeName(it?.userName ?? it?.username ?? it?.addedByName ?? it?.createdByName ?? it?.updatedByName ?? p?.userName ?? p?.username ?? p?.createdByName ?? p?.updatedByName)
+  if (direct) return direct
+  const itemCandidates = [it?.user, it?.addedBy, it?.addedByUser, it?.createdBy, it?.updatedBy, it?.employee, it?.staff, it?.waiter, it?.server, it?.cashier, it?.attendant, it?.operator, it?.owner]
+  for (const o of itemCandidates) {
+    const n = nameFromObj(o)
+    if (n) return n
+  }
+  const payloadCandidates = [p?.user, p?.createdBy, p?.updatedBy, p?.waiter, p?.server, p?.cashier, p?.attendant, p?.operator, p?.owner, p?.order?.user, p?.order?.createdBy, p?.order?.updatedBy, p?.order?.waiter]
+  for (const o of payloadCandidates) {
+    const n = nameFromObj(o)
+    if (n) return n
+  }
+  return undefined
+}
+
+function strHasCancelish(x: any) {
+  if (!x) return false
+  const s = String(x).toLowerCase()
+  return s.includes('cancel') || s.includes('anul') || s.includes('void') || s.includes('anulad')
+}
+
+function isOrderCancelled(p: any) {
+  if ([p?.cancelled, p?.canceled, p?.isCancelled, p?.isCanceled, p?.order?.cancelled, p?.order?.canceled].some(Boolean)) return true
+  if ([p?.event, p?.status, p?.state, p?.order?.status, p?.order?.state].some(strHasCancelish)) return true
+  const acts = Array.isArray(p?.orderActions) ? p.orderActions : []
+  return acts.some((a: any) => strHasCancelish(a?.orderActionType?.name) || strHasCancelish(a?.type) || strHasCancelish(a?.name))
+}
+
+function isItemCancelled(it: any, p: any) {
+  if ([it?.void, it?.isVoid, it?.cancelled, it?.canceled, it?.isCancelled, it?.isCanceled, !!it?.deletedAt, !!it?.removedAt, !!it?.removed].some(Boolean)) return true
+  if ([it?.status, it?.state, it?.action, it?.reason].some(strHasCancelish)) return true
+  return isOrderCancelled(p)
+}
+
+function cell(column: string, value: unknown) {
+  if (!column || value === undefined || value === null) return null
+  if (typeof value === 'number' && !Number.isFinite(value)) return null
+  return { column, value }
+}
+
+function compactCells(cells: Array<{ column: string; value: unknown } | null>) {
+  return cells.filter(Boolean) as Array<{ column: string; value: unknown }>
+}
+
+function mapPedidoRow(p: any) {
+  const orderId = String(computeOrderId(p) ?? '')
+  if (!orderId) return null
+  return {
+    cells: compactCells([
+      cell(PEDIDOS_COLS.IDPEDIDO, orderId),
+      cell(PEDIDOS_COLS.STATUS, p?.event ?? p?.status ?? p?.state ?? (Array.isArray(p?.orderActions) && p.orderActions[0]?.orderActionType?.name)),
+      cell(PEDIDOS_COLS.PAID, !!(p?.paid ?? p?.isPaid)),
+      cell(PEDIDOS_COLS.TIMESTAMP, toISOFromAR(p?.timestamp?.date ?? p?.timestamp ?? p?.createdAt ?? p?.order?.createdAt)),
+      cell(PEDIDOS_COLS.PLACEID, p?.table?.place?.placeId ?? p?.place?.placeId ?? p?.placeId ?? p?.place?.id),
+      cell(PEDIDOS_COLS.PLACENAME, p?.table?.place?.name ?? p?.place?.name ?? p?.placeName ?? p?.venueName),
+      cell(PEDIDOS_COLS.TABLENAME, p?.table?.name ?? p?.posName ?? p?.table?.tableName),
+      cell(PEDIDOS_COLS.LAYOUTNAME, p?.table?.layout?.name ?? p?.layoutName),
+      cell(PEDIDOS_COLS.TOTALAMOUNT, p?.totalAmount ?? p?.totals?.total ?? p?.order?.total),
+      cell(PEDIDOS_COLS.TOTALDISCOUNT, p?.totalDiscount ?? p?.totals?.discount),
+      cell(PEDIDOS_COLS.SERVICECHARGE, p?.serviceCharge ?? p?.serviceChargeAmount ?? p?.totals?.service),
+      cell(PEDIDOS_COLS.TAX, p?.table?.place?.tax ?? p?.totals?.tax),
+      cell(PEDIDOS_COLS.EXTDELIVERYID, computeExternalDeliveryId(p)),
+      cell(PEDIDOS_COLS.NOTES, computeNotes(p)),
+      cell(PEDIDOS_COLS.LASTACTIONAT, computeLastActionAt(p)),
+    ]),
+  }
+}
+
+function mapProductoRows(p: any) {
+  const orderId = String(computeOrderId(p) ?? '')
+  if (!orderId) return []
+  const items = []
+    .concat(Array.isArray(p?.order?.items) ? p.order.items : [])
+    .concat(Array.isArray(p?.items) ? p.items : [])
+    .concat(Array.isArray(p?.orderItems) ? p.orderItems : [])
+    .concat(Array.isArray(p?.order?.orderItems) ? p.order.orderItems : [])
+
+  const rows: Array<{ cells: Array<{ column: string; value: unknown }> }> = []
+
+  items.forEach((it: any, idx: number) => {
+    const rawId = it?.orderItemId ?? it?.id ?? it?.itemId ?? `noid-${idx}`
+    const qty = Number(it?.quantity ?? it?.count ?? 1)
+    const baseUnit = Number(it?.item?.price ?? 0)
+    const unitListed = Number(typeof it?.price === 'number' ? it.price : baseUnit)
+    const unitDisc = Number(typeof it?.discountPrice === 'number' ? it.discountPrice : NaN)
+    const canceled = isItemCancelled(it, p)
+    const tsLocal = toISOFromAR(it?.timestamp?.date ?? it?.timestamp ?? it?.createdAt)
+    const user = computeUser(it, p)
+    const variations = Array.isArray(it?.orderItemVariations) ? it.orderItemVariations : []
+
+    let baseSubtotal: number | undefined
+
+    if (variations.length === 0) {
+      const effectiveUnit = Number.isFinite(unitDisc) ? unitDisc : (Number.isFinite(unitListed) ? unitListed : baseUnit)
+      baseSubtotal = Number.isFinite(effectiveUnit) ? effectiveUnit * qty : undefined
+    } else {
+      const baseAmount0 = (Number.isFinite(baseUnit) ? baseUnit : 0) * qty
+      const totalBefore = (Number.isFinite(unitListed) ? unitListed : (Number.isFinite(baseUnit) ? baseUnit : 0)) * qty
+      const varAmount0 = Math.max(0, totalBefore - baseAmount0)
+      const totalAfter = Number.isFinite(unitDisc) ? unitDisc * qty : totalBefore
+      const discTotal = Math.max(0, totalBefore - totalAfter)
+      const total0 = baseAmount0 + varAmount0
+      let baseFinal = baseAmount0
+      let varFinal = varAmount0
+
+      if (total0 > 0 && discTotal > 0) {
+        const rateBase = baseAmount0 / total0
+        const rateVar = varAmount0 / total0
+        baseFinal = Math.max(0, baseAmount0 - discTotal * rateBase)
+        varFinal = Math.max(0, varAmount0 - discTotal * rateVar)
+      }
+
+      baseSubtotal = baseFinal
+
+      const perVarTotal = variations.length > 0 ? (varFinal / variations.length) : 0
+      const unitVar = qty > 0 && variations.length > 0 ? (perVarTotal / qty) : 0
+
+      variations.forEach((v: any, j: number) => {
+        const vId = v?.orderItemVariationId ?? v?.id ?? `var-${idx}-${j}`
+        const vName = v?.itemVariation?.item?.name ?? v?.itemVariation?.name ?? 'Variación'
+        rows.push({
+          cells: compactCells([
+            cell(PRODUCTOS_COLS.PK, `${orderId}:${rawId}:var:${vId}`),
+            cell(PRODUCTOS_COLS.IDPEDIDO, orderId),
+            cell(PRODUCTOS_COLS.ITEMID, rawId),
+            cell(PRODUCTOS_COLS.NOMBRE, vName),
+            cell(PRODUCTOS_COLS.CANTIDAD, qty),
+            cell(PRODUCTOS_COLS.PRECIO, unitVar),
+            cell(PRODUCTOS_COLS.SUBTOTAL, perVarTotal),
+            cell(PRODUCTOS_COLS.CANCELADO, canceled),
+            cell(PRODUCTOS_COLS.TIMESTAMP, tsLocal),
+          ]),
+        })
+      })
+    }
+
+    rows.push({
+      cells: compactCells([
+        cell(PRODUCTOS_COLS.PK, `${orderId}:${rawId}`),
+        cell(PRODUCTOS_COLS.IDPEDIDO, orderId),
+        cell(PRODUCTOS_COLS.ITEMID, rawId),
+        cell(PRODUCTOS_COLS.NOMBRE, it?.productName ?? it?.name ?? it?.item?.name),
+        cell(PRODUCTOS_COLS.CANTIDAD, it?.quantity ?? it?.count),
+        cell(PRODUCTOS_COLS.PRECIO, it?.price ?? it?.item?.price),
+        cell(PRODUCTOS_COLS.DISCOUNTPRICE, it?.discountPrice),
+        cell(PRODUCTOS_COLS.SUBTOTAL, baseSubtotal),
+        cell(PRODUCTOS_COLS.CANCELADO, canceled),
+        cell(PRODUCTOS_COLS.TIMESTAMP, tsLocal),
+        cell(PRODUCTOS_COLS.USUARIO, user),
+      ]),
+    })
+  })
+
+  return rows.filter((r) => r.cells.length > 0)
+}
+
+function mapPagoRows(p: any) {
+  const orderId = String(computeOrderId(p) ?? '')
+  if (!orderId) return []
+  const pays = []
+    .concat(Array.isArray(p?.payments) ? p.payments : [])
+    .concat(Array.isArray(p?.orderPayments) ? p.orderPayments : [])
+    .concat(Array.isArray(p?.order?.payments) ? p.order.payments : [])
+
+  return pays.map((pay: any, idx: number) => {
+    const paymentId = pay?.paymentId ?? pay?.id ?? pay?.orderPaymentId ?? `noid-${idx}`
+    const amount = typeof pay?.amount === 'number' ? pay.amount : (typeof pay?.total === 'number' ? pay.total : undefined)
+    const esRefund = typeof amount === 'number' ? amount < 0 : !!pay?.isRefund
+    return {
+      cells: compactCells([
+        cell(PAGOS_COLS.PK, `${orderId}:${paymentId}`),
+        cell(PAGOS_COLS.IDPEDIDO, orderId),
+        cell(PAGOS_COLS.GATEWAY, pay?.gateway ?? pay?.processor ?? pay?.source),
+        cell(PAGOS_COLS.METHOD, pay?.method ?? pay?.type ?? pay?.paymentType?.name),
+        cell(PAGOS_COLS.AMOUNT, amount),
+        cell(PAGOS_COLS.STATUS, pay?.status),
+        cell(PAGOS_COLS.CREATEDAT, toISOFromAR(pay?.createdAt?.date ?? pay?.createdAt ?? pay?.timestamp?.date ?? pay?.timestamp)),
+        cell(PAGOS_COLS.ESREFUND, esRefund),
+      ]),
+    }
+  }).filter((r) => r.cells.length > 0)
+}
+
+function buildRdbPedidoRow(p: any) {
+  const orderId = String(computeOrderId(p) ?? '')
+  if (!orderId) return null
+
+  return {
+    order_id: orderId,
+    status: p?.event ?? p?.status ?? p?.state ?? null,
+    paid: !!(p?.paid ?? p?.isPaid),
+    timestamp: toISOFromAR(p?.timestamp),
+    place_id: p?.table?.place?.placeId ?? p?.place?.placeId ?? p?.placeId ?? p?.place?.id ?? null,
+    place_name: p?.table?.place?.name ?? p?.place?.name ?? p?.placeName ?? p?.venueName ?? null,
+    table_name: p?.table?.name ?? p?.posName ?? p?.table?.tableName ?? null,
+    layout_name: p?.table?.layout?.name ?? p?.layoutName ?? null,
+    total_amount: p?.totalAmount ?? p?.totals?.total ?? p?.order?.total ?? null,
+    total_discount: p?.totalDiscount ?? p?.totals?.discount ?? null,
+    service_charge: p?.serviceCharge ?? p?.serviceChargeAmount ?? p?.totals?.service ?? null,
+    tax: p?.table?.place?.tax ?? p?.totals?.tax ?? p?.tax ?? null,
+    external_delivery_id: computeExternalDeliveryId(p) ?? null,
+    notes: computeNotes(p) ?? null,
+    last_action_at: computeLastActionAt(p),
+    updated_at: new Date().toISOString(),
+  }
+}
+
+function buildRdbProductoRows(p: any) {
+  const orderId = String(computeOrderId(p) ?? '')
+  if (!orderId) return []
+
+  const items = []
+    .concat(Array.isArray(p?.orderItems) ? p.orderItems : [])
+    .concat(Array.isArray(p?.items) ? p.items : [])
+    .concat(Array.isArray(p?.order?.items) ? p.order.items : [])
+    .concat(Array.isArray(p?.order?.orderItems) ? p.order.orderItems : [])
+
+  const deduped = new Map<string, any>()
+
+  items
+    .filter((item: any) => !isItemCancelled(item, p))
+    .forEach((item: any, idx: number) => {
+      const productId = item?.item?.itemId ?? item?.itemId ?? item?.productId ?? `noid-${idx}`
+      const productName = item?.item?.name ?? item?.name ?? item?.productName
+      if (!productName) return
+
+      const quantity = Number(item?.count ?? item?.quantity ?? 1)
+      const unitPrice = Number.isFinite(Number(item?.discountPrice))
+        ? Number(item.discountPrice)
+        : Number.isFinite(Number(item?.item?.price))
+          ? Number(item.item.price)
+          : Number.isFinite(Number(item?.price))
+            ? Number(item.price)
+            : null
+      const totalPrice = Number.isFinite(Number(item?.subtotal))
+        ? Number(item.subtotal)
+        : unitPrice != null
+          ? quantity * unitPrice
+          : null
+
+      deduped.set(`${orderId}::${String(productId)}::${String(productName)}`, {
+        order_id: orderId,
+        product_id: String(productId),
+        product_name: String(productName),
+        quantity,
+        unit_price: unitPrice,
+        total_price: totalPrice,
+        notes: flattenNotes(item?.notes) ?? null,
+      })
+    })
+
+  return Array.from(deduped.values())
+}
+
+function buildRdbPagoRows(p: any) {
+  const orderId = String(computeOrderId(p) ?? '')
+  if (!orderId) return []
+
+  const pays = []
+    .concat(Array.isArray(p?.payments) ? p.payments : [])
+    .concat(Array.isArray(p?.orderPayments) ? p.orderPayments : [])
+    .concat(Array.isArray(p?.order?.payments) ? p.order.payments : [])
+
+  const deduped = new Map<string, any>()
+
+  pays.forEach((pay: any, idx: number) => {
+    const paymentId = String(pay?.orderPaymentId ?? pay?.paymentId ?? pay?.id ?? pay?.paidId ?? `noid-${idx}`)
+    deduped.set(`${orderId}::${paymentId}`, {
+      order_id: orderId,
+      payment_id: paymentId,
+      payment_method: pay?.paymentType?.name ?? pay?.method ?? pay?.type ?? pay?.gateway ?? null,
+      amount: typeof pay?.amount === 'number' ? pay.amount : (typeof pay?.total === 'number' ? pay.total : null),
+      created_at: toISOFromAR(pay?.createdAt ?? pay?.timestamp) ?? new Date().toISOString(),
+    })
+  })
+
+  return Array.from(deduped.values())
+}
+
+async function syncRdbTables(supabase: any, payload: any) {
+  const pedidoRow = buildRdbPedidoRow(payload)
+  if (!pedidoRow?.order_id) return { skipped: true, reason: 'missing order_id' }
+
+  const productoRows = buildRdbProductoRows(payload)
+  const pagoRows = buildRdbPagoRows(payload)
+
+  const { error: pedidoError } = await supabase
+    .from('waitry_pedidos')
+    .upsert(pedidoRow, { onConflict: 'order_id' })
+
+  if (pedidoError) throw pedidoError
+
+  const orderId = pedidoRow.order_id
+
+  const { error: deleteProductosError } = await supabase
+    .from('waitry_productos')
+    .delete()
+    .eq('order_id', orderId)
+
+  if (deleteProductosError) throw deleteProductosError
+
+  if (productoRows.length) {
+    const { error: productosError } = await supabase
+      .from('waitry_productos')
+      .insert(productoRows)
+
+    if (productosError) throw productosError
+  }
+
+  const { error: deletePagosError } = await supabase
+    .from('waitry_pagos')
+    .delete()
+    .eq('order_id', orderId)
+
+  if (deletePagosError) throw deletePagosError
+
+  if (pagoRows.length) {
+    const { error: pagosError } = await supabase
+      .from('waitry_pagos')
+      .insert(pagoRows)
+
+    if (pagosError) throw pagosError
+  }
+
+  const { error: inboundUpdateError } = await supabase
+    .from('waitry_inbound')
+    .update({ processed: true, error: null })
+    .eq('order_id', orderId)
+
+  if (inboundUpdateError) throw inboundUpdateError
+
+  return {
+    ok: true,
+    order_id: orderId,
+    productos: productoRows.length,
+    pagos: pagoRows.length,
+  }
+}
+
+async function codaUpsertRows(apiKey: string, tableId: string, keyColumns: string[], rows: Array<{ cells: Array<{ column: string; value: unknown }> }>) {
+  if (!rows.length) return { skipped: true, rows: 0 }
+  const url = `${CODA_API_BASE}/docs/${CODA_DOC_ID}/tables/${encodeURIComponent(tableId)}/rows`
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ keyColumns, rows }),
+  })
+  const text = await resp.text().catch(() => '')
+  if (!resp.ok) throw new Error(`Coda upsert failed ${resp.status}: ${text}`)
+  return text ? JSON.parse(text) : { ok: true }
+}
+
+async function pushToCodaMirror(payload: any) {
+  const apiKey = Deno.env.get('CODA_API_KEY')
+  if (!apiKey) {
+    console.warn('[CODA] skipped: missing CODA_API_KEY')
+    return { skipped: true, reason: 'missing CODA_API_KEY' }
+  }
+
+  const pedidoRow = mapPedidoRow(payload)
+  const productoRows = mapProductoRows(payload)
+  const pagoRows = mapPagoRows(payload)
+
+  const result = {
+    pedidos: { skipped: true } as any,
+    productos: { skipped: true } as any,
+    pagos: { skipped: true } as any,
+  }
+
+  result.pedidos = pedidoRow
+    ? await codaUpsertRows(apiKey, CODA_TABLES.pedidos, [PEDIDOS_COLS.IDPEDIDO], [pedidoRow])
+    : { skipped: true, reason: 'no pedido row' }
+
+  result.productos = await codaUpsertRows(apiKey, CODA_TABLES.productos, [PRODUCTOS_COLS.PK], productoRows)
+  result.pagos = await codaUpsertRows(apiKey, CODA_TABLES.pagos, [PAGOS_COLS.PK], pagoRows)
+
+  return result
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const rawBody = await req.text()
+    let payload: Json
+
+    try {
+      payload = JSON.parse(rawBody)
+    } catch {
+      return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const inner = unwrapPayload(payload?.payload ?? payload)
+    const orderId = String(inner?.orderId ?? inner?.order?.id ?? inner?.id ?? 'unknown')
+    const event = inner?.event ?? inner?.status ?? 'unknown'
+
+    const encoder = new TextEncoder()
+    const data = encoder.encode(rawBody)
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+    const hashArray = Array.from(new Uint8Array(hashBuffer))
+    const payloadHash = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseKey, {
+      db: { schema: 'rdb' },
+    })
+
+    const { error } = await supabase
+      .from('waitry_inbound')
+      .upsert(
+        {
+          order_id: orderId,
+          event,
+          payload_json: payload,
+          payload_hash: payloadHash,
+          received_at: new Date().toISOString(),
+          processed: false,
+          attempts: 0,
+          error: null,
+        },
+        { onConflict: 'order_id' },
+      )
+
+    if (error) {
+      console.error('Insert error:', error)
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    let rdbSync: any = { skipped: true }
+    try {
+      rdbSync = await syncRdbTables(supabase, inner)
+    } catch (err) {
+      console.error('[RDB] sync failed:', err)
+      await supabase.from('waitry_inbound').update({ processed: false, error: String((err as Error)?.message ?? err) }).eq('order_id', orderId)
+      return new Response(JSON.stringify({ error: String((err as Error)?.message ?? err), order_id: orderId }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    let codaMirrorV1: any = { skipped: true }
+    try {
+      codaMirrorV1 = await pushToCodaMirror(inner)
+    } catch (err) {
+      console.error('[CODA-V1] push failed:', err)
+      codaMirrorV1 = { ok: false, error: String((err as Error)?.message ?? err) }
+    }
+
+    return new Response(JSON.stringify({ ok: true, order_id: orderId, rdb_sync: rdbSync, coda_mirror_v1: codaMirrorV1 }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    console.error('Unexpected error:', err)
+    return new Response(JSON.stringify({ error: 'Internal error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+})

--- a/supabase/migrations/20260417180900_movimientos_caja_add_tipo_detalle_and_realizado_por_nombre.sql
+++ b/supabase/migrations/20260417180900_movimientos_caja_add_tipo_detalle_and_realizado_por_nombre.sql
@@ -1,0 +1,21 @@
+-- Agrega dos columnas a erp.movimientos_caja:
+--   tipo_detalle:         sub-categoría de negocio (caja_negra, propina, retiro_efectivo, etc.)
+--                         complementa `tipo` (direccional: entrada/salida/fondo/devolucion).
+--   realizado_por_nombre: nombre raw de quien registró el movimiento.
+--                         complementa `realizado_por` (uuid FK a erp.empleados) cuando el
+--                         empleado no está cargado en la DB (ej. durante sync con Coda).
+
+ALTER TABLE erp.movimientos_caja
+  ADD COLUMN tipo_detalle text,
+  ADD COLUMN realizado_por_nombre text;
+
+COMMENT ON COLUMN erp.movimientos_caja.tipo_detalle IS
+  'Sub-categoría de negocio (caja_negra, retiro_efectivo, propina, repartidor, proveedor, aporta_efectivo, etc.). Para reportes. NULL hasta que se poble.';
+
+COMMENT ON COLUMN erp.movimientos_caja.realizado_por_nombre IS
+  'Nombre raw de quien registró el movimiento. Útil cuando realizado_por (uuid) no puede resolverse a un empleado. En BSOP nativo se llena automáticamente desde la sesión.';
+
+-- Índice para consultas por tipo_detalle (muy común en reports)
+CREATE INDEX IF NOT EXISTS erp_movimientos_caja_tipo_detalle_idx
+  ON erp.movimientos_caja (empresa_id, tipo_detalle)
+  WHERE tipo_detalle IS NOT NULL;

--- a/supabase/migrations/20260417180952_create_rdb_upsert_movimiento.sql
+++ b/supabase/migrations/20260417180952_create_rdb_upsert_movimiento.sql
@@ -1,0 +1,122 @@
+-- rdb.upsert_movimiento
+--
+-- Shim en el schema `rdb` para que el Edge Function `sync-cortes` pueda
+-- POSTear movimientos sin cambios (usa Accept-Profile: rdb).
+-- Internamente escribe a erp.movimientos_caja con el mismo patrón que
+-- rdb.upsert_corte escribe a erp.cortes_caja.
+--
+-- Idempotente: usa `referencia = p_coda_id` como natural key.
+-- Cuando cortes se abran nativamente en BSOP esta función se puede DROP.
+
+CREATE OR REPLACE FUNCTION rdb.upsert_movimiento(
+  p_coda_id        text        DEFAULT NULL,
+  p_corte_nombre   text        DEFAULT NULL,
+  p_fecha_hora     timestamptz DEFAULT NULL,
+  p_tipo           text        DEFAULT NULL,
+  p_monto          numeric     DEFAULT NULL,
+  p_nota           text        DEFAULT NULL,
+  p_registrado_por text        DEFAULT NULL
+)
+RETURNS erp.movimientos_caja
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'erp', 'rdb', 'public'
+AS $function$
+DECLARE
+  v_result       erp.movimientos_caja;
+  v_empresa_id   uuid := 'e52ac307-9373-4115-b65e-1178f0c4e1aa'::uuid;  -- Rincón del Bosque
+  v_corte_id     uuid;
+  v_tipo         text;
+  v_tipo_detalle text;
+  v_concepto     text;
+BEGIN
+  -- 1. Mapear tipo direccional (CHECK constraint: entrada/salida/fondo/devolucion)
+  v_tipo := CASE lower(trim(coalesce(p_tipo, '')))
+    WHEN 'aporta efectivo' THEN 'entrada'
+    WHEN 'fondo'           THEN 'fondo'
+    WHEN 'fondo inicial'   THEN 'fondo'
+    WHEN 'devolucion'      THEN 'devolucion'
+    WHEN 'devolución'      THEN 'devolucion'
+    ELSE 'salida'  -- caja negra, retiro efectivo, repartidor, proveedor, propina, y cualquier otro → salida
+  END;
+
+  -- 2. Normalizar tipo a snake_case para tipo_detalle
+  v_tipo_detalle := CASE lower(trim(coalesce(p_tipo, '')))
+    WHEN 'caja negra'       THEN 'caja_negra'
+    WHEN 'retiro efectivo'  THEN 'retiro_efectivo'
+    WHEN 'repartidor'       THEN 'repartidor'
+    WHEN 'aporta efectivo'  THEN 'aporta_efectivo'
+    WHEN 'propina'          THEN 'propina'
+    WHEN 'proveedor'        THEN 'proveedor'
+    WHEN ''                 THEN NULL
+    ELSE lower(regexp_replace(trim(p_tipo), '\s+', '_', 'g'))
+  END;
+
+  -- 3. Concepto = nota tal cual (el tipo original vive en tipo_detalle; el nombre en realizado_por_nombre)
+  v_concepto := NULLIF(trim(coalesce(p_nota, '')), '');
+
+  -- 4. Resolver corte_id por corte_nombre
+  IF p_corte_nombre IS NOT NULL AND trim(p_corte_nombre) <> '' THEN
+    SELECT id INTO v_corte_id
+    FROM erp.cortes_caja
+    WHERE empresa_id = v_empresa_id
+      AND corte_nombre = p_corte_nombre
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1;
+  END IF;
+
+  -- 5. Idempotencia: buscar por coda_id en referencia
+  IF p_coda_id IS NOT NULL THEN
+    SELECT * INTO v_result
+    FROM erp.movimientos_caja
+    WHERE empresa_id = v_empresa_id
+      AND referencia = p_coda_id
+    ORDER BY created_at DESC
+    LIMIT 1;
+  END IF;
+
+  IF v_result.id IS NOT NULL THEN
+    -- UPDATE existente
+    UPDATE erp.movimientos_caja
+    SET corte_id             = COALESCE(v_corte_id, corte_id),
+        tipo                 = v_tipo,
+        tipo_detalle         = COALESCE(v_tipo_detalle, tipo_detalle),
+        monto                = COALESCE(p_monto, monto),
+        concepto             = COALESCE(v_concepto, concepto),
+        realizado_por_nombre = COALESCE(p_registrado_por, realizado_por_nombre),
+        created_at           = COALESCE(p_fecha_hora, created_at)
+    WHERE id = v_result.id
+    RETURNING * INTO v_result;
+  ELSE
+    -- INSERT nuevo
+    INSERT INTO erp.movimientos_caja (
+      empresa_id,
+      corte_id,
+      tipo,
+      tipo_detalle,
+      monto,
+      concepto,
+      referencia,
+      realizado_por_nombre,
+      created_at
+    ) VALUES (
+      v_empresa_id,
+      v_corte_id,
+      v_tipo,
+      v_tipo_detalle,
+      p_monto,
+      v_concepto,
+      p_coda_id,
+      NULLIF(trim(coalesce(p_registrado_por, '')), ''),
+      COALESCE(p_fecha_hora, NOW())
+    )
+    RETURNING * INTO v_result;
+  END IF;
+
+  RETURN v_result;
+END;
+$function$;
+
+-- Grants para que PostgREST + service_role puedan invocarla
+GRANT EXECUTE ON FUNCTION rdb.upsert_movimiento(text, text, timestamptz, text, numeric, text, text)
+  TO service_role, authenticated;

--- a/supabase/migrations/20260417181500_dedup_movimientos_caja_name_refs.sql
+++ b/supabase/migrations/20260417181500_dedup_movimientos_caja_name_refs.sql
@@ -1,0 +1,25 @@
+-- Deduplicación post-backfill de erp.movimientos_caja (2026-04-17)
+--
+-- Contexto:
+--   Durante la migración rdb → erp (2026-04-14), los 396 rows históricos
+--   se copiaron a erp.movimientos_caja con un patrón de `referencia` mixto:
+--     - Rows viejos (antes del 2026-04-09): referencia = nombre de cajera (ej. "Laisha Martinez")
+--     - Rows nuevos (2026-04-09 en adelante): referencia = coda rowId (ej. "i-PwItJd_27q")
+--
+--   El 2026-04-17 se corrió un backfill completo desde Coda vía
+--   rdb.upsert_movimiento (ver scripts/backfill_coda_movimientos_2026_04_17.py).
+--   Ese upsert usa `referencia = p_coda_id` como natural key — los rows con
+--   nombre en referencia NO hicieron match, así que terminaron como duplicados
+--   junto a los insertados frescos desde Coda.
+--
+--   Análisis previo confirmó 0 grupos huérfanos (todo name-row tiene su twin coda_id)
+--   y 0 grupos donde #name > #coda → safe to drop.
+--
+-- Migración:
+--   Borra los 390 rows con nombre en referencia (preservando el evento vía
+--   el row nuevo que lleva coda_id y `realizado_por_nombre`).
+
+DELETE FROM erp.movimientos_caja
+WHERE referencia IS NOT NULL
+  AND referencia <> ''
+  AND referencia NOT LIKE 'i-%';


### PR DESCRIPTION
## Summary

- **Problema**: El cron `sync-cortes` (cada 5 min) venía fallando silenciosamente la mitad de movimientos desde el 2026-04-14. La función RPC `rdb.upsert_movimiento` nunca se creó durante la migración `rdb → erp` (solo se mantuvo `rdb.upsert_corte`), y el edge function seguía POSTeando a un endpoint inexistente.
- **Impacto**: ~8 días de movimientos de caja (entradas/salidas de Coda) no llegaron a Supabase. Cortes sí funcionaban.
- **Fix**: nueva función fachada `rdb.upsert_movimiento` que escribe a `erp.movimientos_caja`, backfill completo desde Coda, y export de las 2 edge functions al repo (antes solo vivían en el dashboard).

## Cambios (6 archivos, +1209 líneas)

### Schema
- **`20260417180900`** — `ALTER TABLE erp.movimientos_caja` agrega 2 columnas:
  - `tipo_detalle` — sub-categoría de negocio (caja_negra, retiro_efectivo, propina, repartidor, proveedor, aporta_efectivo). Complementa `tipo` (direccional entrada/salida/fondo/devolucion).
  - `realizado_por_nombre` — nombre raw de la cajera. Se preserva cuando no se puede resolver a `erp.empleados` (RDB aún no tiene empleados cargados).
- **`20260417180952`** — `CREATE FUNCTION rdb.upsert_movimiento` — shim que internamente escribe a `erp.movimientos_caja`. Idempotente por `referencia = coda_rowId`. Mapeo de tipo validado con el usuario.
- **`20260417181500`** — `DELETE` de 390 rows duplicados (históricos tenían nombres de cajeras en `referencia` en vez de coda_ids). 0 eventos perdidos — análisis previo confirmó twin con coda_id para cada uno.

### Edge functions (exportadas al repo)
- **`supabase/functions/sync-cortes/index.ts`** (v5 desde dashboard, sin cambios — solo el backend cambió)
- **`supabase/functions/waitry-webhook/index.ts`** (v18 desde dashboard, sin cambios — se exporta para no perderlo)

### Scripts
- **`scripts/backfill_coda_movimientos_2026_04_17.py`** — backfill one-shot (404 rows Coda → DB). Idempotente, safe re-run.

## Verificación post-fix

| Métrica | Antes | Después |
|---|---|---|
| DB rows | 396 (con 8-row gap) | **404** (= Coda) |
| Con coda_id en referencia | mixto | 404 (100%) |
| Con cajera preservada | 0 | 404 (100%) |
| Cron errores movimientos | N (100% fallaba) | **0** |
| Cron respuesta actual | `"Movimientos: 0 upserted, N errors"` | `"Movimientos: 4 upserted, 0 errors"` |

## Test plan

- [x] `rdb.upsert_movimiento` ya existe y la DB tiene 404 rows sincronizados
- [x] Cron `sync-cortes-5min` succeeded en últimas 5 corridas (checked `cron.job_run_details`)
- [x] Invocación manual del edge function devuelve `ok: true` sin errores
- [ ] Reviewer valida el mapeo de tipo_detalle en `rdb.upsert_movimiento` (caja_negra/retiro_efectivo/etc.)
- [ ] Reviewer valida la lógica del DELETE de dedup (0 grupos huérfanos confirmado en análisis previo)
- [ ] Opcional: correr `npm run db:types` después del merge para regenerar types

## Notas

- La columna `realizado_por` (uuid FK a erp.empleados) queda NULL hasta que se carguen empleados de RDB. Cuando BSOP sea nativo, se llenará desde la sesión del usuario y ya no se necesitará Coda.
- `rdb.upsert_movimiento` y `rdb.upsert_corte` son temporales (shims). Se pueden dropear cuando apaguemos el sync de Coda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)