### PR TITLE
fix(security): replace hardcoded admin email + drop RESEND_API_KEY log

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -38,6 +38,13 @@ SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 
 
+# ─── Admin bypass (opcional, transitorio) ──────────────────────────────────
+# Email que puede entrar aunque no tenga row en core.usuarios. Usado por
+# `proxy.ts` como fallback de emergencia. Dejar vacío en prod una vez que
+# todos los admins estén provisionados en core.usuarios.
+# ADMIN_BYPASS_EMAIL=
+
+
 # ─── Health ingest (Apple Health → BSOP) ────────────────────────────────────
 # Token compartido que valida requests del shortcut / script que envía
 # datos de Apple Health a `/api/health/ingest`. Elige una string larga

--- a/app/api/welcome-email/route.ts
+++ b/app/api/welcome-email/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'RESEND_API_KEY not configured' }, { status: 500 });
   }
 
-  console.log('[welcome-email-api] RESEND_API_KEY found:', resendKey.substring(0, 6) + '...');
+  console.log('[welcome-email-api] RESEND_API_KEY configured');
 
   // Fetch usuario_empresas
   const adminRes = await fetch(`${supabaseUrl}/rest/v1/usuarios_empresas?usuario_id=eq.${usuarioId}&select=empresa_id,roles:rol_id(nombre),empresas:empresa_id(slug,nombre)`, {

--- a/proxy.ts
+++ b/proxy.ts
@@ -91,12 +91,23 @@ export default async function proxy(request: NextRequest) {
     .eq('activo', true)
     .maybeSingle();
 
-  if (!usuario && email !== 'beto@anorte.com') {
+  // Admin bypass: if the user is authenticated via Supabase but has no row in
+  // core.usuarios yet, optionally let them through if their email matches the
+  // ADMIN_BYPASS_EMAIL env var. Without that env var, the app defaults to the
+  // safest behavior (deny). This bypass should be temporary — once all admins
+  // are provisioned in core.usuarios, remove the var and this branch.
+  const adminBypassEmail = process.env.ADMIN_BYPASS_EMAIL?.toLowerCase();
+  if (!usuario && email !== adminBypassEmail) {
     await supabase.auth.signOut();
     const loginUrl = request.nextUrl.clone();
     loginUrl.pathname = '/login';
     loginUrl.search = '?error=unauthorized';
     return NextResponse.redirect(loginUrl, { headers: response.headers });
+  }
+
+  if (!usuario && adminBypassEmail) {
+    // Surface admin bypass usage in runtime logs so it stays visible.
+    console.warn(`[proxy] ADMIN_BYPASS_EMAIL used by ${email}`);
   }
 
   if (pathname === '/login') {


### PR DESCRIPTION
## Summary

Sprint 0 de `docs/ACTION_PLAN_2026-04-17.md` — dos leaks de seguridad del audit del 2026-04-16.

### S1 — \`proxy.ts\` admin email hardcodeado

**Antes:**
\`\`\`ts
if (!usuario && email !== 'beto@anorte.com') {
\`\`\`

**Después:**
\`\`\`ts
const adminBypassEmail = process.env.ADMIN_BYPASS_EMAIL?.toLowerCase();
if (!usuario && email !== adminBypassEmail) { ... }

if (!usuario && adminBypassEmail) {
  console.warn(\`[proxy] ADMIN_BYPASS_EMAIL used by \${email}\`);
}
\`\`\`

- Sin env var: deny-all (safer default)
- Con env var: bypass para ese email, pero loguea warning con el email para trazabilidad
- Valor se cambia sin deploy

### S2 — \`app/api/welcome-email/route.ts:30\` log de API key

**Antes:**
\`\`\`ts
console.log('[welcome-email-api] RESEND_API_KEY found:', resendKey.substring(0, 6) + '...');
\`\`\`

**Después:**
\`\`\`ts
console.log('[welcome-email-api] RESEND_API_KEY configured');
\`\`\`

El prefijo \`re_EWsVst\` estaba quedándose en los logs de Vercel. No se rota la key en este PR (es opcional — si quieres rotarla, avisa).

### \`.env.local.example\`

Agregado bloque documentando \`ADMIN_BYPASS_EMAIL\` como opcional/transitorio.

## Test plan

- [ ] Pre-merge: **agregar \`ADMIN_BYPASS_EMAIL=beto@anorte.com\` en Vercel env vars para prod** (Production + Preview). Sin eso, después del merge te bloqueas si tu row en \`core.usuarios\` tiene algún problema.
- [ ] Post-merge: login en prod funciona normalmente
- [ ] Post-merge: verificar en Vercel logs que ya no aparece \`RESEND_API_KEY found: re_\` en llamadas a \`/api/welcome-email\`

## Notas

- Cuando todos los admins estén provisionados en \`core.usuarios\` y tu propio row sea estable, quita \`ADMIN_BYPASS_EMAIL\` de Vercel y este PR (#TBD) elimina el bypass entero.
- Este PR no toca otros \`console.log\` del route handler (line 15, 41, 71, 88) porque solo logean email + response de Resend — PII pero no secrets. Scope intencionalmente acotado al leak del audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)