### PR TITLE
feat(api): Zod input validation helper + apply to /api/impersonate

### DIFF
--- a/app/api/impersonate/route.ts
+++ b/app/api/impersonate/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
+import { z } from 'zod';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { validateQuery } from '@/lib/validation';
+
+const ImpersonateQuerySchema = z.object({
+  userId: z.string().uuid('userId must be a valid UUID'),
+});
 
 export async function GET(req: NextRequest) {
-  const targetUserId = req.nextUrl.searchParams.get('userId');
-  if (!targetUserId) {
-    return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
-  }
+  const parsed = validateQuery(req, ImpersonateQuerySchema);
+  if (!parsed.ok) return parsed.response;
+  const { userId: targetUserId } = parsed.data;
 
   // Verify the caller is an admin
   const cookieStore = await cookies();
@@ -109,7 +114,7 @@ export async function GET(req: NextRequest) {
   const modulos: Record<string, { read: boolean; write: boolean }> = {};
   for (const ue of userEmpresas) {
     if (!ue.rol_id) continue;
-    const rolePerms = allPermisos.filter((p: any) => p.rol_id === ue.rol_id);
+    const rolePerms = allPermisos.filter((p) => p.rol_id === ue.rol_id);
     for (const perm of rolePerms) {
       const moduloSlug = moduloIdToSlug[perm.modulo_id];
       if (!moduloSlug) continue;

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,86 @@
+/**
+ * Validation helpers for Next.js API routes.
+ *
+ * Wraps Zod parse with a consistent shape so route handlers don't
+ * reinvent the 400-response boilerplate. Designed for Next.js App Router
+ * route handlers (`app/api/.../route.ts`).
+ *
+ * @example Body validation
+ *   const parsed = await validateBody(req, WelcomeEmailSchema);
+ *   if (!parsed.ok) return parsed.response;
+ *   const { email, usuarioId } = parsed.data;  // fully typed
+ *
+ * @example Query param validation
+ *   const parsed = validateQuery(req, ImpersonateQuerySchema);
+ *   if (!parsed.ok) return parsed.response;
+ *   const { userId } = parsed.data;
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+export type ValidationResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; response: NextResponse };
+
+function errorResponse(error: z.ZodError): NextResponse {
+  return NextResponse.json(
+    {
+      error: 'Invalid request',
+      issues: error.issues.map((issue) => ({
+        path: issue.path.join('.') || '(root)',
+        message: issue.message,
+        code: issue.code,
+      })),
+    },
+    { status: 400 },
+  );
+}
+
+/**
+ * Parse and validate a JSON request body.
+ *
+ * Handles the common failure modes — missing body, non-JSON content,
+ * schema mismatch — and returns a structured 400 with per-field errors.
+ */
+export async function validateBody<T extends z.ZodTypeAny>(
+  req: NextRequest,
+  schema: T,
+): Promise<ValidationResult<z.infer<T>>> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Invalid JSON body' },
+        { status: 400 },
+      ),
+    };
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return { ok: false, response: errorResponse(parsed.error) };
+  }
+  return { ok: true, data: parsed.data };
+}
+
+/**
+ * Parse and validate a request's query string (searchParams).
+ *
+ * Pass a schema over the object form (e.g. `z.object({ userId: z.string().uuid() })`).
+ * Multi-value query params are not supported by this helper; read them
+ * directly from `req.nextUrl.searchParams` if needed.
+ */
+export function validateQuery<T extends z.ZodTypeAny>(
+  req: NextRequest,
+  schema: T,
+): ValidationResult<z.infer<T>> {
+  const entries = Object.fromEntries(req.nextUrl.searchParams.entries());
+  const parsed = schema.safeParse(entries);
+  if (!parsed.success) {
+    return { ok: false, response: errorResponse(parsed.error) };
+  }
+  return { ok: true, data: parsed.data };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "shadcn": "^4.1.2",
         "tailwind-merge": "^3.5.0",
         "tus-js-client": "^4.3.1",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -7909,7 +7910,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12154,6 +12154,15 @@
         "shadcn": "dist/index.js"
       }
     },
+    "node_modules/shadcn/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -14117,9 +14126,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "shadcn": "^4.1.2",
     "tailwind-merge": "^3.5.0",
     "tus-js-client": "^4.3.1",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",


### PR DESCRIPTION
## Summary

Sprint 1 PR #1 de \`docs/ACTION_PLAN_2026-04-17.md\`. Introduce el helper canónico de validación Zod y lo aplica a la primera ruta crítica.

### Archivos

- **\`lib/validation.ts\`** (nuevo, +86 LOC) — 2 helpers:
  - \`validateBody(req, schema)\` — parse + valida JSON body
  - \`validateQuery(req, schema)\` — valida searchParams
  - Retornan discriminated union \`{ ok: true, data }\` o \`{ ok: false, response }\` con 400 pre-armado que incluye issues de Zod por campo.

- **\`app/api/impersonate/route.ts\`** — primera ruta:
  - Valida \`userId\` es UUID antes de tocar la DB (antes aceptaba cualquier string).
  - Fix tangencial: elimina un \`(p: any) =>\` pre-existente para que lint-staged no bloquee el commit.

- **\`package.json\`** — agrega \`zod\` como dependencia.

### Attack surface cerrado

Antes:
\`\`\`ts
const targetUserId = req.nextUrl.searchParams.get('userId');
if (!targetUserId) return 400;
// ...embedded directly in .eq('id', targetUserId)
\`\`\`

Cualquier string pasaba. Zod ahora exige UUID v1/v4/etc. y corta ahí con 400 + detalle del issue.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npx eslint lib/validation.ts app/api/impersonate/route.ts\` — 0 issues
- [x] \`npm run test:run\` — 25/25 passing
- [ ] CI verde

## Próximos PRs del sprint

- #TBD — Zod en \`/api/welcome-email\` + \`/api/juntas/terminar\`
- #TBD — Zod en \`/api/health/ingest\` (payload Apple Health, complejo)
- #TBD — CSP + security headers en \`next.config.ts\`
- Rate limiting se pospone hasta que haya Upstash/Vercel KV configurado

🤖 Generated with [Claude Code](https://claude.com/claude-code)