### PR TITLE
feat(security): add Content-Security-Policy + hardening headers to all routes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,73 @@
 import type { NextConfig } from 'next';
-const nextConfig: NextConfig = { reactStrictMode: true };
+
+/**
+ * Security headers applied to every HTML response.
+ *
+ * Design rationale:
+ *   - CSP starts permissive on `script-src` / `style-src` (Next.js injects
+ *     inline styles + inline bootstrap scripts) and strict on everything
+ *     that doesn't require `unsafe-inline`.
+ *   - `connect-src` allows self + Supabase REST / realtime / storage. Add
+ *     more origins here as new integrations go client-side.
+ *   - `frame-ancestors 'none'` + `X-Frame-Options: DENY` make clickjacking
+ *     infeasible. Both are set because some browsers still only honor
+ *     X-Frame-Options.
+ *   - Vercel already adds `Strict-Transport-Security` in prod; we mirror it
+ *     explicitly so dev/self-hosted deployments also benefit.
+ *   - Permissions-Policy disables APIs the app never uses (camera, mic,
+ *     geolocation, payment). Tighten further only after auditing.
+ */
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' blob: data: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://vitals.vercel-insights.com",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "upgrade-insecure-requests",
+].join('; ');
+
+const permissionsPolicy = [
+  'camera=()',
+  'microphone=()',
+  'geolocation=()',
+  'payment=()',
+  'usb=()',
+  'accelerometer=()',
+  'gyroscope=()',
+  'magnetometer=()',
+].join(', ');
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: csp },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: permissionsPolicy },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+];
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        // Apply to every route. For fine-grained overrides (e.g. letting a
+        // specific page relax CSP), add more entries before or after this
+        // block — Next.js merges matching blocks in order.
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
+
 export default nextConfig;


### PR DESCRIPTION
## Summary

Sprint 1 PR #4 (último). Cierra el ítem **S5** del audit (\`Sin CSP, sin headers de seguridad\`).

## Qué headers agrega

Aplicados a \`/:path*\` (todo el tree):

| Header | Valor | Para qué |
|---|---|---|
| \`Content-Security-Policy\` | self + Supabase REST/WS + Vercel Speed Insights | Bloquea XSS por inyección de scripts externos |
| \`X-Frame-Options\` | \`DENY\` | Anti-clickjacking (navegadores viejos) |
| \`X-Content-Type-Options\` | \`nosniff\` | Evita MIME confusion → XSS |
| \`Referrer-Policy\` | \`strict-origin-when-cross-origin\` | No leak de path/query a terceros |
| \`Permissions-Policy\` | camera/mic/geo/payment/usb/motion = \`()\` | Revoca APIs que el app no usa |
| \`Strict-Transport-Security\` | \`max-age=63072000; includeSubDomains; preload\` | HSTS (Vercel ya lo pone en prod; explicit para dev/self-host) |
| \`X-DNS-Prefetch-Control\` | \`on\` | Perf menor |

## CSP details

- \`default-src 'self'\`
- \`script-src\` con \`'unsafe-inline' 'unsafe-eval'\` — necesarios para bootstrap scripts de Next.js y styled-jsx. **Las partes estrictas** son las que de verdad importan: \`object-src 'none'\`, \`frame-ancestors 'none'\`, \`base-uri 'self'\`, \`form-action 'self'\`.
- \`connect-src\` permite \`https://*.supabase.co\` + \`wss://*.supabase.co\` (realtime) + Vercel Insights.
- \`img-src 'self' blob: data: https:\` — permisivo porque tenemos logos y uploads; se puede apretar después.

## Riesgo de merge

**Mediano** — CSP puede romper la app si alguna página usa un origen externo que no listé. Para validar:

1. Abre el deploy preview en: \`https://vercel.com/adalberto-santos-projects-b5c16a94/bsop\` (la URL del preview estará en este PR).
2. Navega por las vistas principales: login, inicio, rdb/cortes, dilesa/rh, settings.
3. Abre DevTools → Console. Si ves \`Refused to load the …\`, el origen que falta hay que agregarlo a la directiva correspondiente en \`next.config.ts\`.
4. Si todo funciona → seguro mergear.

### Qué hacer si algo se rompe post-merge

Identifica el origen en el log de consola y agrega a la directiva que corresponda. Ejemplos comunes:

\`\`\`ts
// Añadir un nuevo dominio de API:
"connect-src 'self' ... https://api.nuevodominio.com",

// Añadir una CDN de imágenes:
"img-src 'self' ... https://cdn.nuevodominio.com",
\`\`\`

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm run test:run\` — 25/25 passing
- [ ] CI verde
- [ ] **MANUAL**: abrir preview, verificar console sin errores \`Refused to load\` en login + inicio + rdb/cortes

## Cierre de Sprint 1

Con este merge se cierra Sprint 1 del \`ACTION_PLAN_2026-04-17.md\`:
- [x] PR #33 — lib/validation helper + /api/impersonate
- [x] PR #34 — /api/welcome-email + /api/juntas/terminar
- [x] PR #35 — /api/health/ingest (envelope + 5MB limit)
- [x] PR #36 — CSP + security headers (este)

Rate limiting deferido: requiere crear Upstash Redis o Vercel KV (cuenta externa, necesita acción tuya).

🤖 Generated with [Claude Code](https://claude.com/claude-code)