### PR TITLE
feat(api): rate limiting on public API routes via Upstash Redis

### DIFF
--- a/app/api/health/ingest/route.ts
+++ b/app/api/health/ingest/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { healthIngestRateLimiter, extractIdentifier } from '@/lib/ratelimit';
 import type { Json } from '@/types/supabase';
 
 // Envelope schema — validates only the top-level shape. Sample-level
@@ -280,6 +281,12 @@ export async function POST(request: NextRequest) {
   if (!expectedToken || !providedToken || providedToken !== expectedToken) {
     return unauthorized();
   }
+
+  // Rate limit AFTER auth so invalid tokens don't consume counter slots for
+  // the legitimate shortcut. Identifier prefers the bearer token (stable),
+  // falls back to IP.
+  const rate = await healthIngestRateLimiter.check(extractIdentifier(request));
+  if (!rate.ok) return rate.response;
 
   const supabase = getSupabaseAdminClient();
   if (!supabase) {

--- a/app/api/impersonate/route.ts
+++ b/app/api/impersonate/route.ts
@@ -4,12 +4,16 @@ import { createServerClient } from '@supabase/ssr';
 import { z } from 'zod';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { validateQuery } from '@/lib/validation';
+import { impersonateRateLimiter, extractIdentifier } from '@/lib/ratelimit';
 
 const ImpersonateQuerySchema = z.object({
   userId: z.string().uuid('userId must be a valid UUID'),
 });
 
 export async function GET(req: NextRequest) {
+  const rate = await impersonateRateLimiter.check(extractIdentifier(req));
+  if (!rate.ok) return rate.response;
+
   const parsed = validateQuery(req, ImpersonateQuerySchema);
   if (!parsed.ok) return parsed.response;
   const { userId: targetUserId } = parsed.data;

--- a/app/api/welcome-email/route.ts
+++ b/app/api/welcome-email/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { generateWelcomeHtml, type WelcomeEmpresa } from '@/lib/welcome-email';
 import { validateBody } from '@/lib/validation';
+import { welcomeEmailRateLimiter, extractIdentifier } from '@/lib/ratelimit';
 
 const LOGO_MAP: Record<string, string> = {
   rdb: 'https://bsop.io/logo-rdb.png',
@@ -17,6 +18,9 @@ const WelcomeEmailSchema = z.object({
 });
 
 export async function POST(req: NextRequest) {
+  const rate = await welcomeEmailRateLimiter.check(extractIdentifier(req));
+  if (!rate.ok) return rate.response;
+
   const parsed = await validateBody(req, WelcomeEmailSchema);
   if (!parsed.ok) return parsed.response;
   const { email, firstName, usuarioId } = parsed.data;

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -1,0 +1,147 @@
+/**
+ * Rate limiting for BSOP API routes, backed by Upstash Redis.
+ *
+ * Why:
+ *   Even with Zod validation on payloads, a public-ish endpoint can be
+ *   abused by repeat requests — draining Resend quota, filling the DB,
+ *   or stress-testing our Supabase connection pool. A sliding-window
+ *   limiter per identity (IP, bearer token, etc.) caps the damage
+ *   without affecting normal traffic.
+ *
+ * Infra:
+ *   Uses the Upstash Redis integration added via Vercel Marketplace.
+ *   The env vars `KV_REST_API_URL` / `KV_REST_API_TOKEN` are auto-injected
+ *   by Vercel on every environment (prod, preview, dev). If those aren't
+ *   set we fail open (skip the check and log a warning) so a misconfigured
+ *   preview doesn't 500 every request.
+ *
+ * Usage:
+ *   import { healthIngestRateLimiter, extractIdentifier } from '@/lib/ratelimit';
+ *
+ *   const check = await healthIngestRateLimiter.check(extractIdentifier(req));
+ *   if (!check.ok) return check.response;
+ */
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+import { NextRequest, NextResponse } from 'next/server';
+
+// ─── Redis client ─────────────────────────────────────────────────────────────
+
+function getRedis(): Redis | null {
+  const url = process.env.KV_REST_API_URL;
+  const token = process.env.KV_REST_API_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+const redis = getRedis();
+
+// ─── Per-route limiters ───────────────────────────────────────────────────────
+//
+// Tuned for BSOP's actual traffic. The numbers can be bumped later — Upstash
+// free tier allows 10K commands/day and each `limit()` call is ~2 commands.
+//
+// Naming convention: `<routeSlug>:<identifier>` so prefixes don't collide
+// across routes that might share an identifier (e.g. same IP hitting both
+// health/ingest and welcome-email). `@upstash/ratelimit` adds its own
+// internal prefix too.
+
+function buildLimiter(prefix: string, requests: number, window: `${number} ${'s' | 'm' | 'h'}`) {
+  if (!redis) return null;
+  return new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(requests, window),
+    prefix: `bsop:${prefix}`,
+    analytics: true,
+  });
+}
+
+const limiters = {
+  // Apple Health shortcut sends batches every few minutes. 60/min leaves
+  // ample headroom; higher than that is almost certainly abuse.
+  healthIngest: buildLimiter('health-ingest', 60, '1 m'),
+
+  // Internal trigger; rarely fires. 5/min per IP catches spray attacks
+  // without blocking legitimate retries from the provisioning flow.
+  welcomeEmail: buildLimiter('welcome-email', 5, '1 m'),
+
+  // Admin-only tool. 10/min per IP covers batch debugging without being
+  // permissive enough for automated scraping of permission data.
+  impersonate: buildLimiter('impersonate', 10, '1 m'),
+};
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export type RateLimitCheck =
+  | { ok: true }
+  | { ok: false; response: NextResponse };
+
+/**
+ * Pull a stable identifier out of the request: authorization bearer / x-api-key
+ * first, then forwarded IP. Falls back to "unknown" so that misconfigured
+ * proxies still bucket into a single identity rather than short-circuiting.
+ */
+export function extractIdentifier(req: NextRequest): string {
+  const auth = req.headers.get('authorization');
+  if (auth?.toLowerCase().startsWith('bearer ')) {
+    const token = auth.slice(7).trim();
+    if (token) return `bearer:${token.slice(0, 32)}`;
+  }
+  const apiKey = req.headers.get('x-api-key')?.trim();
+  if (apiKey) return `apikey:${apiKey.slice(0, 32)}`;
+
+  const fwd = req.headers.get('x-forwarded-for');
+  const ip = fwd?.split(',')[0]?.trim() || req.headers.get('x-real-ip')?.trim();
+  return `ip:${ip ?? 'unknown'}`;
+}
+
+async function runCheck(
+  limiter: Ratelimit | null,
+  identifier: string,
+): Promise<RateLimitCheck> {
+  if (!limiter) {
+    // Fail-open: if Redis env vars aren't set (e.g. a dev running without
+    // the Vercel integration attached), log once and let the request through.
+    // Production + preview always have the vars thanks to the integration.
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn('[ratelimit] Upstash Redis not configured, skipping check');
+    }
+    return { ok: true };
+  }
+
+  const { success, limit, remaining, reset } = await limiter.limit(identifier);
+  if (success) return { ok: true };
+
+  const retryAfterSeconds = Math.max(0, Math.ceil((reset - Date.now()) / 1000));
+
+  return {
+    ok: false,
+    response: NextResponse.json(
+      {
+        error: 'Too many requests',
+        limit,
+        remaining,
+        retryAfterSeconds,
+      },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfterSeconds),
+          'X-RateLimit-Limit': String(limit),
+          'X-RateLimit-Remaining': String(remaining),
+          'X-RateLimit-Reset': String(Math.ceil(reset / 1000)),
+        },
+      },
+    ),
+  };
+}
+
+export const healthIngestRateLimiter = {
+  check: (identifier: string) => runCheck(limiters.healthIngest, identifier),
+};
+export const welcomeEmailRateLimiter = {
+  check: (identifier: string) => runCheck(limiters.welcomeEmail, identifier),
+};
+export const impersonateRateLimiter = {
+  check: (identifier: string) => runCheck(limiters.impersonate, identifier),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@tiptap/extension-table-row": "^3.22.3",
         "@tiptap/react": "^3.22.3",
         "@tiptap/starter-kit": "^3.22.3",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.37.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -4957,6 +4959,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
@@ -13256,6 +13291,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@tiptap/extension-table-row": "^3.22.3",
     "@tiptap/react": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.37.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary

Sprint 1.5 — cierra el gap de rate limiting que difirió Sprint 1 (\`ACTION_PLAN_2026-04-17.md\`). Ahora es posible porque Upstash for Redis quedó conectado al proyecto Vercel (auto-inyecta \`KV_REST_API_URL\` / \`KV_REST_API_TOKEN\` en prod/preview/dev).

## Cambios

**\`lib/ratelimit.ts\`** (nuevo, ~140 LOC) centraliza 3 limiters sliding-window:

| Route | Límite | Justificación |
|---|---|---|
| \`/api/health/ingest\` | 60 req / 1 min | Shortcut iOS manda batches cada varios min; 60 es amplio |
| \`/api/welcome-email\` | 5 req / 1 min | Trigger interno, raramente se dispara; 5 permite retries |
| \`/api/impersonate\` | 10 req / 1 min | Admin, debugging manual OK, bloquea scraping |

**Identifier stable**: \`extractIdentifier()\` prefiere bearer token / x-api-key (prefix de 32 chars), cae a x-forwarded-for, luego x-real-ip, luego 'unknown'. Así mismo IP con token distinto no colisiona.

**Over-limit response**: 429 + \`Retry-After\` + \`X-RateLimit-*\` headers para back-off limpio del cliente.

**Fail-open**: si las env vars Upstash no están (dev sin integración), loguea warning y deja pasar. Prod/preview siempre las tienen.

## Orden de checks en cada route

- \`/api/impersonate\` — rate limit → Zod → cookies/admin check
- \`/api/welcome-email\` — rate limit → Zod → DB work
- \`/api/health/ingest\` — token auth → **rate limit** → size/envelope → DB work
  (rate limit después del token para que tokens inválidos no quemen slots legítimos)

## Test plan

- [x] typecheck 0 errors
- [x] eslint 0 issues
- [x] \`npm run test:run\` 25/25 passing
- [ ] CI verde
- [ ] Post-merge: verificar que el shortcut de iOS sigue ingestando sin 429s
- [ ] Post-merge: opcional, curl de prueba contra \`/api/welcome-email\` sin auth — debería pegar 400 (Zod) tras ~5 requests hits 429

## Costo

Free tier de Upstash Redis: 10K comandos/día. Cada \`limiter.limit()\` = ~2 comandos. Con el volumen actual de BSOP (health/ingest es el más pesado, <100 req/día), estamos en <1 % del tier gratis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)