### PR TITLE
refactor(storage): make adjuntos bucket private, use signed URLs everywhere

### DIFF
--- a/app/administracion/documentos/page.tsx
+++ b/app/administracion/documentos/page.tsx
@@ -4,6 +4,7 @@ import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useState } from 'react';
 import * as tus from 'tus-js-client';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { getAdjuntoPath, getAdjuntoSignedUrls } from '@/lib/adjuntos';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
@@ -235,11 +236,12 @@ function AdjuntosSection({
         }
       } catch (ex: any) { err = ex?.message ?? 'Error'; }
       if (err) { alert(`Error: ${err}`); break; }
-      const { data: urlData } = supabase.storage.from('adjuntos').getPublicUrl(path);
+      // Bucket is private. Store ONLY the object path — UI generates short-lived
+      // signed URLs on render (see lib/adjuntos.ts).
       const { data: cu } = await supabase.schema('core').from('usuarios').select('id').eq('email', (await supabase.auth.getUser()).data.user?.email?.toLowerCase() ?? '').maybeSingle();
       await supabase.schema('erp').from('adjuntos').insert({
         empresa_id: empresaId, entidad_tipo: 'documento', entidad_id: documentoId,
-        uploaded_by: cu?.id ?? null, nombre: file.name, url: urlData.publicUrl,
+        uploaded_by: cu?.id ?? null, nombre: file.name, url: path,
         tipo_mime: file.type || null, tamano_bytes: file.size, rol: uploadRole,
       });
     }
@@ -806,11 +808,17 @@ function DocumentosInner() {
   const fetchAdjuntosBulk = useCallback(async (docIds: string[]) => {
     if (docIds.length === 0) { setAdjuntosPorDoc({}); return; }
     const { data } = await supabase.schema('erp').from('adjuntos').select('id, nombre, url, tipo_mime, tamano_bytes, created_at, entidad_id, rol').eq('entidad_tipo', 'documento').in('entidad_id', docIds).order('created_at', { ascending: false });
+
+    // Bucket is private — enrich each row with a short-lived signed URL.
+    const signedMap = await getAdjuntoSignedUrls(supabase, (data ?? []).map((a: { url: string }) => a.url));
+
     const map: Record<string, Adjunto[]> = {};
     for (const a of data ?? []) {
       const key = a.entidad_id as string;
       if (!map[key]) map[key] = [];
-      map[key].push({ id: a.id, nombre: a.nombre, url: a.url, tipo_mime: a.tipo_mime, tamano_bytes: a.tamano_bytes, rol: a.rol ?? 'anexo', created_at: a.created_at });
+      const path = getAdjuntoPath(a.url);
+      const signedUrl = path ? signedMap.get(path) : null;
+      map[key].push({ id: a.id, nombre: a.nombre, url: signedUrl ?? a.url, tipo_mime: a.tipo_mime, tamano_bytes: a.tamano_bytes, rol: a.rol ?? 'anexo', created_at: a.created_at });
     }
     setAdjuntosPorDoc(map);
   }, [supabase]);

--- a/app/dilesa/admin/documentos/page.tsx
+++ b/app/dilesa/admin/documentos/page.tsx
@@ -3,6 +3,7 @@
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useState } from 'react';
 import * as tus from 'tus-js-client';
+import { getAdjuntoPath, getAdjuntoSignedUrls } from '@/lib/adjuntos';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
@@ -237,11 +238,13 @@ function AdjuntosSection({
         }
       } catch (ex: any) { err = ex?.message ?? 'Error'; }
       if (err) { alert(`Error: ${err}`); break; }
-      const { data: urlData } = supabase.storage.from('adjuntos').getPublicUrl(path);
+      // Bucket is private. Store ONLY the object path — UI generates short-lived
+      // signed URLs on render (see lib/adjuntos.ts). Legacy rows with full URLs
+      // still render correctly because getAdjuntoPath() normalizes both forms.
       const { data: cu } = await supabase.schema('core').from('usuarios').select('id').eq('email', (await supabase.auth.getUser()).data.user?.email?.toLowerCase() ?? '').maybeSingle();
       await supabase.schema('erp').from('adjuntos').insert({
         empresa_id: empresaId, entidad_tipo: 'documento', entidad_id: documentoId,
-        uploaded_by: cu?.id ?? null, nombre: file.name, url: urlData.publicUrl,
+        uploaded_by: cu?.id ?? null, nombre: file.name, url: path,
         tipo_mime: file.type || null, tamano_bytes: file.size, rol: uploadRole,
       });
     }
@@ -786,11 +789,19 @@ function DocumentosInner() {
   const fetchAdjuntosBulk = useCallback(async (docIds: string[]) => {
     if (docIds.length === 0) { setAdjuntosPorDoc({}); return; }
     const { data } = await supabase.schema('erp').from('adjuntos').select('id, nombre, url, tipo_mime, tamano_bytes, created_at, entidad_id, rol').eq('entidad_tipo', 'documento').in('entidad_id', docIds).order('created_at', { ascending: false });
+
+    // Bucket is private — enrich each row with a short-lived signed URL so
+    // the existing `a.url` read sites don't need to change. Legacy rows with
+    // full public URLs are normalized to their path by getAdjuntoSignedUrls.
+    const signedMap = await getAdjuntoSignedUrls(supabase, (data ?? []).map((a: { url: string }) => a.url));
+
     const map: Record<string, Adjunto[]> = {};
     for (const a of data ?? []) {
       const key = a.entidad_id as string;
       if (!map[key]) map[key] = [];
-      map[key].push({ id: a.id, nombre: a.nombre, url: a.url, tipo_mime: a.tipo_mime, tamano_bytes: a.tamano_bytes, rol: a.rol ?? 'anexo', created_at: a.created_at });
+      const path = getAdjuntoPath(a.url);
+      const signedUrl = path ? signedMap.get(path) : null;
+      map[key].push({ id: a.id, nombre: a.nombre, url: signedUrl ?? a.url, tipo_mime: a.tipo_mime, tamano_bytes: a.tamano_bytes, rol: a.rol ?? 'anexo', created_at: a.created_at });
     }
     setAdjuntosPorDoc(map);
   }, [supabase]);

--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -4,6 +4,11 @@ import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import {
+  getAdjuntoSignedUrl,
+  rewriteHtmlImagesToSigned,
+  normalizeHtmlImagesToPaths,
+} from '@/lib/adjuntos';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
@@ -341,8 +346,12 @@ function JuntaDetailInner() {
       const path = `juntas/${id}/${filename}`;
       const { error: uploadErr } = await supabase.storage.from('adjuntos').upload(path, file, { upsert: false });
       if (uploadErr) { alert(`Error al subir imagen: ${uploadErr.message}`); return; }
-      const { data: urlData } = supabase.storage.from('adjuntos').getPublicUrl(path);
-      editor.chain().focus().setImage({ src: urlData.publicUrl }).run();
+      // Bucket is private. Use a signed URL for in-editor display so the user
+      // sees the image immediately, but the save path (handleSave, autoSave,
+      // flushSave) normalizes <img src> back to the bare object path so the
+      // DB never holds a soon-to-expire signed URL.
+      const signedForEditor = await getAdjuntoSignedUrl(supabase, path, 6 * 3600);
+      editor.chain().focus().setImage({ src: signedForEditor || path }).run();
     } finally {
       setUploadingImage(false);
     }
@@ -412,18 +421,25 @@ function JuntaDetailInner() {
   useEffect(() => { void fetchAll(); }, [fetchAll]);
   useEffect(() => {
     if (editor && junta?.descripcion) {
-      // Always set content when editor becomes ready or junta data changes
+      // Always set content when editor becomes ready or junta data changes.
+      // Rewrite any stored <img src> (bare path or legacy public URL) to a
+      // signed URL so the private bucket renders inside the editor.
       const currentContent = editor.getHTML();
       if (currentContent === '' || currentContent === '<p></p>') {
-        editor.commands.setContent(junta.descripcion);
+        void (async () => {
+          const hydrated = await rewriteHtmlImagesToSigned(supabase, junta.descripcion, 6 * 3600);
+          editor.commands.setContent(hydrated);
+        })();
       }
     }
-  }, [editor, junta]);
+  }, [editor, junta, supabase]);
 
   const handleSave = async () => {
     if (!junta) return;
     setSaving(true);
-    const notesHtml = editor?.getHTML() ?? null;
+    // Normalize signed URLs back to bare paths so the DB never holds a
+    // soon-to-expire URL — getAdjuntoPath handles legacy rows too.
+    const notesHtml = normalizeHtmlImagesToPaths(editor?.getHTML() ?? null) || null;
     const { error: err } = await supabase.schema('erp').from('juntas').update({
       titulo: titulo.trim(), fecha_hora: fechaHora,
       lugar: lugar.trim() || null, estado, tipo: tipo || null,
@@ -453,8 +469,9 @@ function JuntaDetailInner() {
         const currentHtml = editor.getHTML();
         if (currentHtml === lastSavedHtmlRef.current) return;
         setAutoSaveStatus('saving');
+        const persisted = normalizeHtmlImagesToPaths(currentHtml) || null;
         const { error: err } = await supabase.schema('erp').from('juntas').update({
-          descripcion: currentHtml && currentHtml !== '<p></p>' ? currentHtml : null,
+          descripcion: persisted && persisted !== '<p></p>' ? persisted : null,
         }).eq('id', junta.id);
         if (!err) {
           lastSavedHtmlRef.current = currentHtml;
@@ -484,9 +501,10 @@ function JuntaDetailInner() {
     const flushSave = () => {
       const html = editor.getHTML();
       if (html !== lastSavedHtmlRef.current && html !== '<p></p>') {
-        // Fire-and-forget save
+        // Fire-and-forget save — normalize image URLs to bare paths first.
+        const persisted = normalizeHtmlImagesToPaths(html);
         supabase.schema('erp').from('juntas').update({
-          descripcion: html,
+          descripcion: persisted || null,
         }).eq('id', juntaId).then(() => { lastSavedHtmlRef.current = html; });
       }
     };

--- a/app/rdb/admin/documentos/page.tsx
+++ b/app/rdb/admin/documentos/page.tsx
@@ -4,6 +4,7 @@ import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useState } from 'react';
 import * as tus from 'tus-js-client';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { getAdjuntoPath, getAdjuntoSignedUrls } from '@/lib/adjuntos';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table';
@@ -237,11 +238,12 @@ function AdjuntosSection({
         }
       } catch (ex: any) { err = ex?.message ?? 'Error'; }
       if (err) { alert(`Error: ${err}`); break; }
-      const { data: urlData } = supabase.storage.from('adjuntos').getPublicUrl(path);
+      // Bucket is private. Store ONLY the object path — UI generates short-lived
+      // signed URLs on render (see lib/adjuntos.ts).
       const { data: cu } = await supabase.schema('core').from('usuarios').select('id').eq('email', (await supabase.auth.getUser()).data.user?.email?.toLowerCase() ?? '').maybeSingle();
       await supabase.schema('erp').from('adjuntos').insert({
         empresa_id: empresaId, entidad_tipo: 'documento', entidad_id: documentoId,
-        uploaded_by: cu?.id ?? null, nombre: file.name, url: urlData.publicUrl,
+        uploaded_by: cu?.id ?? null, nombre: file.name, url: path,
         tipo_mime: file.type || null, tamano_bytes: file.size, rol: uploadRole,
       });
     }
@@ -786,11 +788,17 @@ function DocumentosInner() {
   const fetchAdjuntosBulk = useCallback(async (docIds: string[]) => {
     if (docIds.length === 0) { setAdjuntosPorDoc({}); return; }
     const { data } = await supabase.schema('erp').from('adjuntos').select('id, nombre, url, tipo_mime, tamano_bytes, created_at, entidad_id, rol').eq('entidad_tipo', 'documento').in('entidad_id', docIds).order('created_at', { ascending: false });
+
+    // Bucket is private — enrich each row with a short-lived signed URL.
+    const signedMap = await getAdjuntoSignedUrls(supabase, (data ?? []).map((a: { url: string }) => a.url));
+
     const map: Record<string, Adjunto[]> = {};
     for (const a of data ?? []) {
       const key = a.entidad_id as string;
       if (!map[key]) map[key] = [];
-      map[key].push({ id: a.id, nombre: a.nombre, url: a.url, tipo_mime: a.tipo_mime, tamano_bytes: a.tamano_bytes, rol: a.rol ?? 'anexo', created_at: a.created_at });
+      const path = getAdjuntoPath(a.url);
+      const signedUrl = path ? signedMap.get(path) : null;
+      map[key].push({ id: a.id, nombre: a.nombre, url: signedUrl ?? a.url, tipo_mime: a.tipo_mime, tamano_bytes: a.tamano_bytes, rol: a.rol ?? 'anexo', created_at: a.created_at });
     }
     setAdjuntosPorDoc(map);
   }, [supabase]);

--- a/lib/adjuntos.ts
+++ b/lib/adjuntos.ts
@@ -1,0 +1,227 @@
+/**
+ * Adjuntos storage helpers — bucket is private, all reads go through
+ * signed URLs. Write callers should store ONLY the object path (not a
+ * public URL) in `erp.adjuntos.url` and in TipTap JSON image nodes.
+ *
+ * Backward compatibility: `getAdjuntoPath()` accepts either a bare
+ * path (`dilesa/escrituras/foo.pdf`) or a legacy full public URL
+ * (`https://ybklderteyhuugzfmxbi.supabase.co/storage/v1/object/public/adjuntos/dilesa/escrituras/foo.pdf`)
+ * and always returns just the path. That lets the app keep working
+ * with rows that were inserted before this refactor while new writes
+ * settle on the clean format.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const PUBLIC_URL_MARKER = '/object/public/adjuntos/';
+const SIGNED_URL_MARKER = '/object/sign/adjuntos/';
+const AUTHENTICATED_URL_MARKER = '/object/authenticated/adjuntos/';
+
+/**
+ * Normalize a value that may be a bare path, a legacy public URL, or a
+ * (stale) signed URL into the object path inside the `adjuntos` bucket.
+ */
+export function getAdjuntoPath(urlOrPath: string | null | undefined): string | null {
+  if (!urlOrPath) return null;
+  const value = String(urlOrPath).trim();
+  if (!value) return null;
+
+  for (const marker of [PUBLIC_URL_MARKER, SIGNED_URL_MARKER, AUTHENTICATED_URL_MARKER]) {
+    const idx = value.indexOf(marker);
+    if (idx >= 0) {
+      // Strip the host prefix and any query string (signed URLs have `?token=…`).
+      const tail = value.slice(idx + marker.length);
+      const q = tail.indexOf('?');
+      return q >= 0 ? tail.slice(0, q) : tail;
+    }
+  }
+
+  // Already a path. Trim any leading slash just in case.
+  return value.replace(/^\/+/, '');
+}
+
+/**
+ * Generate a short-lived signed URL for an attachment. Returns an empty
+ * string if the input is falsy or if the storage call fails — callers
+ * should fall back gracefully (hide the image, show a broken-file icon,
+ * etc.).
+ *
+ * @param expiresInSeconds — default 1 hour. Align longer expiries with
+ *   the page's cache policy; shorter is preferred when the URL is
+ *   handed straight to an <img> tag that won't refresh.
+ */
+export async function getAdjuntoSignedUrl(
+  supabase: SupabaseClient,
+  urlOrPath: string | null | undefined,
+  expiresInSeconds = 3600,
+): Promise<string> {
+  const path = getAdjuntoPath(urlOrPath);
+  if (!path) return '';
+  const { data, error } = await supabase.storage
+    .from('adjuntos')
+    .createSignedUrl(path, expiresInSeconds);
+  if (error || !data?.signedUrl) {
+    console.warn('[adjuntos] createSignedUrl failed for', path, error?.message);
+    return '';
+  }
+  return data.signedUrl;
+}
+
+/**
+ * Batch variant — cheaper than calling `getAdjuntoSignedUrl` in a loop
+ * because Supabase's `createSignedUrls` does one round-trip.
+ */
+export async function getAdjuntoSignedUrls(
+  supabase: SupabaseClient,
+  urlsOrPaths: Array<string | null | undefined>,
+  expiresInSeconds = 3600,
+): Promise<Map<string, string>> {
+  const pathByIndex = urlsOrPaths.map(getAdjuntoPath);
+  const uniquePaths = Array.from(new Set(pathByIndex.filter((p): p is string => Boolean(p))));
+  const result = new Map<string, string>();
+  if (uniquePaths.length === 0) return result;
+
+  const { data, error } = await supabase.storage
+    .from('adjuntos')
+    .createSignedUrls(uniquePaths, expiresInSeconds);
+
+  if (error || !data) {
+    console.warn('[adjuntos] createSignedUrls failed:', error?.message);
+    return result;
+  }
+
+  for (const entry of data) {
+    if (entry.path && entry.signedUrl) {
+      result.set(entry.path, entry.signedUrl);
+    }
+  }
+  return result;
+}
+
+// ─── TipTap JSON traversal ────────────────────────────────────────────────
+
+/**
+ * Walk a TipTap / ProseMirror JSON tree and call `visit` on every node
+ * whose type is `image`. Mutates the tree in place (so pass a clone if
+ * the original must stay untouched).
+ */
+export function walkTiptapImages(
+  node: unknown,
+  visit: (imageNode: { attrs?: Record<string, unknown> }) => void,
+): void {
+  if (!node || typeof node !== 'object') return;
+  const n = node as { type?: string; content?: unknown[]; attrs?: Record<string, unknown> };
+  if (n.type === 'image') visit(n as { attrs?: Record<string, unknown> });
+  if (Array.isArray(n.content)) {
+    for (const child of n.content) walkTiptapImages(child, visit);
+  }
+}
+
+/**
+ * Rewrites every image `src` in a TipTap JSON tree to a signed URL.
+ * Pass the tree as-loaded from the DB; returns a clone with fresh URLs
+ * suitable for handing to the editor.
+ */
+export async function rewriteTiptapImagesToSigned(
+  supabase: SupabaseClient,
+  tree: unknown,
+  expiresInSeconds = 3600,
+): Promise<unknown> {
+  if (!tree) return tree;
+  const clone = JSON.parse(JSON.stringify(tree));
+
+  // Gather all srcs first so we can batch the signed-URL lookup.
+  const srcs: string[] = [];
+  walkTiptapImages(clone, (img) => {
+    const src = img.attrs?.src;
+    if (typeof src === 'string') srcs.push(src);
+  });
+
+  const urlMap = await getAdjuntoSignedUrls(supabase, srcs, expiresInSeconds);
+
+  walkTiptapImages(clone, (img) => {
+    const src = img.attrs?.src;
+    if (typeof src !== 'string' || !img.attrs) return;
+    const path = getAdjuntoPath(src);
+    if (!path) return;
+    const signed = urlMap.get(path);
+    if (signed) img.attrs.src = signed;
+  });
+
+  return clone;
+}
+
+/**
+ * Inverse of `rewriteTiptapImagesToSigned` — strip any signed / public
+ * URL down to the bare path before persisting. Call this in the editor's
+ * save path so the DB never holds a soon-to-expire signed URL.
+ */
+export function normalizeTiptapImagesToPaths(tree: unknown): unknown {
+  if (!tree) return tree;
+  const clone = JSON.parse(JSON.stringify(tree));
+  walkTiptapImages(clone, (img) => {
+    const src = img.attrs?.src;
+    if (typeof src !== 'string' || !img.attrs) return;
+    const path = getAdjuntoPath(src);
+    if (path) img.attrs.src = path;
+  });
+  return clone;
+}
+
+// ─── HTML image rewrite (for components that store TipTap output as HTML) ──
+//
+// BSOP's juntas descripcion stores HTML, not prosemirror JSON. These
+// helpers mutate the `src` attribute on every <img> tag.
+
+function extractImgSrcs(html: string): string[] {
+  const out: string[] = [];
+  const re = /<img\b[^>]*?\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(html)) !== null) {
+    out.push(match[1] ?? match[2] ?? '');
+  }
+  return out;
+}
+
+function replaceImgSrcs(
+  html: string,
+  transform: (src: string) => string,
+): string {
+  return html.replace(
+    /(<img\b[^>]*?\bsrc\s*=\s*)(?:"([^"]*)"|'([^']*)')/gi,
+    (_full, prefix, dq, sq) => {
+      const src = dq ?? sq ?? '';
+      const next = transform(src);
+      return `${prefix}"${next.replace(/"/g, '&quot;')}"`;
+    },
+  );
+}
+
+/**
+ * Rewrites every `<img src="…">` in an HTML string to a signed URL.
+ * Safe to call on HTML that has no adjuntos images (it's a no-op).
+ */
+export async function rewriteHtmlImagesToSigned(
+  supabase: SupabaseClient,
+  html: string | null | undefined,
+  expiresInSeconds = 3600,
+): Promise<string> {
+  if (!html) return '';
+  const srcs = extractImgSrcs(html);
+  if (srcs.length === 0) return html;
+  const signedMap = await getAdjuntoSignedUrls(supabase, srcs, expiresInSeconds);
+  return replaceImgSrcs(html, (src) => {
+    const path = getAdjuntoPath(src);
+    if (!path) return src;
+    return signedMap.get(path) ?? src;
+  });
+}
+
+/**
+ * Rewrites every `<img src="…">` in an HTML string to the bare object
+ * path — call in the save path so the DB never holds soon-to-expire
+ * signed URLs.
+ */
+export function normalizeHtmlImagesToPaths(html: string | null | undefined): string {
+  if (!html) return '';
+  return replaceImgSrcs(html, (src) => getAdjuntoPath(src) ?? src);
+}

--- a/supabase/migrations/20260417210000_bucket_adjuntos_private.sql
+++ b/supabase/migrations/20260417210000_bucket_adjuntos_private.sql
@@ -1,0 +1,25 @@
+-- Flip the `adjuntos` bucket to private so direct URLs no longer serve
+-- files without a short-lived signed token.
+--
+-- This migration is PAIRED with the app refactor in PR
+-- `refactor/private-adjuntos-signed-urls`:
+--   * lib/adjuntos.ts centralizes `getAdjuntoSignedUrl` / HTML & JSON
+--     rewrite helpers.
+--   * Every consumer of adjuntos (3 document admin pages + the junta
+--     TipTap editor) now generates signed URLs on render and normalizes
+--     back to the bare object path on save.
+--   * Legacy rows with full public URLs in `erp.adjuntos.url` keep
+--     rendering because `getAdjuntoPath()` handles both formats.
+--
+-- Apply order: merge the app refactor first, wait for the prod deploy to
+-- be live, THEN apply this migration. The reverse order (flip before
+-- code is live) would 403 every page that embeds a stored public URL.
+--
+-- Rollback:
+--   UPDATE storage.buckets SET public = true WHERE id = 'adjuntos';
+-- Stored public URLs start working again immediately (the object data
+-- never moved).
+
+UPDATE storage.buckets
+   SET public = false
+ WHERE id = 'adjuntos';


### PR DESCRIPTION
## Summary

Flip \`adjuntos\` bucket a privado + refactor de todo consumer para usar signed URLs. Cierra el último WARN del advisor sobre bucket público.

## Cambios

**Nuevo: \`lib/adjuntos.ts\`** (~225 LOC)
Helpers centralizados:
- \`getAdjuntoPath\` — normaliza path bare / URL pública legacy / URL signed → path
- \`getAdjuntoSignedUrl\` / \`getAdjuntoSignedUrls\` — generan signed URLs (singular / batched)
- Helpers HTML + JSON para TipTap: rewrite (signed) + normalize (path)

**Uploaders** (3 admin/documentos pages):
- Antes: guardaban \`urlData.publicUrl\` completa en \`erp.adjuntos.url\`
- Después: guardan solo el \`path\` (limpio going forward)
- Legacy rows siguen renderizando (el helper extrae el path)

**Readers** (mismos 3 pages):
- \`fetchAdjuntosBulk\` ahora enriquece cada row con signed URL via \`getAdjuntoSignedUrls\` (batched, un round-trip)
- Los \`<a href>\` y \`<img src>\` consumen \`a.url\` que ya trae la signed URL

**TipTap editor de juntas** (\`dilesa/admin/juntas/[id]\`):
- Load: \`rewriteHtmlImagesToSigned\` antes de \`setContent\` → imágenes renderizan en editor
- Save (manual, auto-save, visibility flush): \`normalizeHtmlImagesToPaths\` → DB guarda solo paths
- Upload desde toolbar: inserta signed URL (6h expiry) en el editor, pero al save normaliza a path

**Migration \`20260417210000_bucket_adjuntos_private.sql\`**
Un \`UPDATE storage.buckets SET public = false\`. **NO aplicada en este PR** — se aplica en prod AFTER el merge para evitar ventana donde el código viejo renderice URLs públicas que ya 403ean.

## Orden de deploy

1. Merge este PR
2. Esperar deploy prod confirmado
3. Aplicar la migración (\`UPDATE storage.buckets\`) via Supabase CLI/MCP/Dashboard
4. Verificar:
   - Subir un documento nuevo en /dilesa/admin/documentos → se ve ✅
   - Abrir un documento viejo → se ve ✅ (legacy URL normalizada)
   - Abrir una junta con imágenes embebidas → se ven ✅
   - Intentar una URL pública cruda del bucket → 400 (ya no accesible sin token) ✅

## Riesgos

- **Preview en este PR** todavía tiene bucket público, entonces la app se comporta como siempre (signed URLs funcionan sobre buckets públicos y privados).
- **Emails transaccionales** (welcome-email, juntas/terminar): los que referencian imágenes del bucket quedarían rotos cuando el email se abre DESPUÉS de 6h del send, porque el signed URL expira. No hay código en BSOP que embeba adjuntos en emails (los logos vienen de \`bsop.io\`, no storage). Pero si algún email futuro referencia adjuntos, habrá que usar URLs de re-firmado on-demand.
- **Largas sesiones de edición de juntas** (>6h): los signed URLs en el editor expiran. Si el usuario queda en la misma página 7h, las imágenes empezarán a 403ear hasta refresh.

## Test plan

- [x] \`npm run typecheck\` — 0 errors
- [x] \`npm run test:run\` — 25/25 passing
- [ ] CI verde
- [ ] Preview deploy: subir 1 imagen en junta + 1 doc → verificar render
- [ ] Post-merge: aplicar migración + verificar los 4 escenarios arriba

## Sprint 3 status

El subagente corrió su investigación en paralelo — 309 policies always-true reales (el advisor dedupea a 165). Plan de 9 PRs guardado, arrancamos después de este merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)