### PR TITLE
docs(coda-migration): add inventory, migration plan, and module map

### DIFF
--- a/docs/coda-migration/INVENTORY.md
+++ b/docs/coda-migration/INVENTORY.md
@@ -1,0 +1,178 @@
+# Coda → BSOP — Inventory & Migration Map
+
+> **Fuente de este audit**: combinación de
+> - Datos previos de OpenClaw (`data/coda.json`, auditoría 2026-03-23)
+> - Coda REST API directa (este audit, 2026-04-18) — `CODA_API_KEY` en 1Password
+> - Supabase MCP listing de `ybklderteyhuugzfmxbi` (este audit)
+>
+> **Regla operativa**: nada se mueve/modifica en Coda sin aprobación explícita de Beto. Este documento es **solo inventario y plan**.
+
+---
+
+## 1. Docs Coda — estado actual
+
+Los 5 docs siguen activos (todos `updatedAt` esta semana). Owner: `beto@anorte.com`.
+
+| Doc | docId | Tablas (API) | Pages | Health* | Last update |
+|---|---|---:|---:|---:|---|
+| DILESA | `ZNxWl_DI2D` | 256 | 100 | 0.62 avg · 26 high-risk | 2026-04-18 |
+| ANSA | `pnqM3j0Yal` | 59 | 76 | 0.32 avg · 1 high-risk | 2026-04-18 |
+| ANSA Ventas | `vVmCl2wBfC` | 77 | 74 | 0.27 avg · 4 high-risk | 2026-04-18 |
+| RDB | `yvrM3UilPt` | 45 | 46 | 0.20 avg · 2 high-risk | 2026-04-18 |
+| SR Group | `MaXoDlRxXE` | 58 | 43 | 0.05 avg · 0 high-risk | 2026-04-12 |
+| **Total** | | **495** | **339** | | |
+
+_*Health score del audit OpenClaw: 0=clean, 7=max risk. "High-risk" = tablas con score ≥ 5 (exceso de columnas, lógica sobrecargada, fórmulas anidadas)._
+
+### Patrón común observado
+
+Cada doc repite la misma estructura mental:
+- **Tablas fuente** (los datos reales) — p. ej. `Personal`, `Citas`, `Cortes de Caja`
+- **Tablas de captura/alta** (`Alta X`, `Registra X`) — formularios one-shot que escriben a la fuente
+- **Tablas de consulta** (`Consulta X`) — views/filtros
+- **Tablas de reporte** (`Resumen X`, `Reporte X`) — agregados
+- **Tablas espejo/staging** (`Temp X`, `View of X`, `*X`) — cache intermedia
+
+En BSOP **no reproducimos este modelo**. Un CRUD en una tabla fuente reemplaza todos estos niveles.
+
+---
+
+## 2. Módulos Coda por doc
+
+### DILESA (100 pages, 256 tablas)
+
+6 módulos top-level:
+- **Administración** → Recursos Humanos (Personal, Puestos, Depts, Competencias, KPIs, Políticas), Depósitos, Juntas, Tareas, Escrituras, Saldos Bancos
+- **Presupuestos** → Partidas presupuestales, Gastos
+- **Proyectos** → Terrenos, Anteproyectos, Proyectos, Lotes, Documentos
+  - **Urbanización** (19 sub-módulos: excavación, líneas sanitaria/agua, pozos, transformadores, carpetas, banquetas, liberaciones CFE/SIMAS…)
+  - **RUV** → Altas/Consultas frente RUV, DTUs, Extracción, Pago seguro
+- **Maquinaria** → Equipos, Clientes, Proyectos, Cargas combustible, Acarreos, Horas máquina
+- **Construcción** → Contratos, Contratistas, Supervisión (bitácora, termina vivienda), Prototipos, Costo materiales, Checklist
+- **Ventas** → Inventario, Fase de Venta, Comité, Solicitud asignación
+
+### ANSA (76 pages, 59 tablas)
+
+3 módulos:
+- **Citas** → catálogo, Citas del Día Servicio, Citas del Día Ventas, Reporte
+- **Administración** → Personal (alta/baja/consulta), Puestos, Departamentos, Activos, Proveedores, Resguardos
+- **Recursos Humanos** → Competencias, Funciones, KPIs, Cumpleañeros
+
+### ANSA Ventas (74 pages, 77 tablas)
+
+2 módulos:
+- **Administración** → Catálogos CFDI, Catálogo vehículos (12 versiones mensuales!), Carga Factura, Asignación/Apartado, Beneficiarios controladores, Accesorios
+- **Asesores** → Asesores de ventas, Mis Clientes
+
+### RDB (46 pages, 45 tablas)
+
+7 módulos:
+- **Productos** → Catálogo, Categorías, IVA, Estatus
+- **Inventario** → Ajustes, Almacenes, Carga física, Cierres, Conteos, Entradas/Salidas, Inventario a fecha
+- **Requisiciones** → Nueva, Detalle, Autoriza, Convierte a OC
+- **Orden de Compra** → OCs, Detalle, Consulta, Impresión
+- **Cortes de Caja** → Cortes, Movimientos, Denominaciones, Corte Actual
+- **Ventas** → (Waitry POS integration)
+- **Datos** — catálogos base
+
+### SR Group (43 pages, 58 tablas)
+
+11 módulos (financieros/personales):
+- **Recibos Casa SR** (rentas)
+- **Pagos Provisionales** (ISR)
+- **Declaraciones** (anual y provisional)
+- **Registros / Budget / Estado de Resultados / Ingresos / Gastos / Flujo / Activos / Fiscal**
+- Movimientos bancarios AMEX, Banamex, BBVA, IBC
+
+---
+
+## 3. Estado BSOP/Supabase (lo que ya existe)
+
+Schema de producción: `ybklderteyhuugzfmxbi`. Fuente: `supabase/SCHEMA_REF.md` + MCP listing.
+
+### ✅ Operativo con datos
+
+| Área | Tablas | Rows | Origen |
+|---|---|---:|---|
+| Auth/RBAC | `core.usuarios, empresas, modulos, roles, permisos_rol, usuarios_empresas` | 5/6/22/5/66/14 | BSOP nativo |
+| RH cross-empresa | `erp.personas, empleados, empleados_compensacion` | 260/212/85 | Migrado Coda DILESA/RDB |
+| RH organigrama | `erp.departamentos, puestos` | 8/53 | Migrado Coda |
+| Proveedores | `erp.proveedores` | 48 | Migrado Coda |
+| Productos/precios | `erp.productos, productos_precios` | 310/310 | BSOP + waitry map |
+| Inventario | `erp.almacenes, inventario, movimientos_inventario` | 1/283/14,895 | BSOP activo |
+| Compras | `erp.requisiciones, _detalle, ordenes_compra, _detalle` | 188/4/160/656 | Migrado desde rdb.* |
+| Tasks | `erp.tasks, task_updates, task_comentarios` | 1253/5/— | BSOP nativo |
+| Juntas | `erp.juntas, juntas_asistencia, juntas_notas` | 720/5/0 | Migrado Coda DILESA |
+| Cortes RDB | `erp.cortes_caja, movimientos_caja, cajas` | 433/409/5 | Migrado Coda + Waitry sync |
+| Docs legales | `erp.documentos` | 60 | Migrado escrituras DILESA |
+| Waitry POS | `rdb.waitry_inbound, pedidos, productos, pagos` | 10,746/10,746/15,214/10,846 | Cron sync-cortes |
+| Playtomic | `playtomic.bookings, players, participants, resources, sync_log` | 1,442/705/4,179/19/377 | Cron sync |
+
+### ⚠️ Estructura lista, 0 rows (tablas creadas esperando UI + migración)
+
+| Área | Tablas | Empresa principal | Coda fuente |
+|---|---|---|---|
+| Clientes | `erp.clientes` | Cross-empresa | Coda `Clientes` |
+| Citas | `erp.citas` | ANSA (servicio/ventas), DILESA | Coda Citas |
+| Aprobaciones | `erp.aprobaciones` | Cross-empresa | Nuevo — no existe en Coda |
+| Turnos | `erp.turnos` | RDB (cajeros), ANSA | Coda parcial |
+| Bancos | `erp.cuentas_bancarias, movimientos_bancarios, conciliaciones` | SR Group, DILESA, ANSA | Coda SR movimientos AMEX/Banamex/BBVA/IBC |
+| Gastos | `erp.gastos` | SR Group, DILESA, ANSA | Coda Gastos |
+| Fiscal | `erp.facturas, pagos_provisionales` | SR Group | Coda SR Fiscal |
+| Recepciones | `erp.recepciones, _detalle` | Cross-empresa | Coda Entradas Almacén |
+| Activos | `erp.activos, activos_mantenimiento` | ANSA (resguardos), SR Group | Coda Activos |
+| Conteo denomin. | `erp.corte_conteo_denominaciones` | RDB | Coda Denominaciones |
+| **DILESA inmobiliario** | `erp.proyectos, lotes, ventas_inmobiliarias, contratos, cobranza, pagos` | DILESA | Coda DILESA Proyectos+Ventas |
+| **ANSA automotriz** | `erp.vehiculos, ventas_autos, ventas_tickets, ventas_refacciones_detalle, taller_servicio` | ANSA | Coda ANSA+ANSA Ventas |
+
+### ❌ No existe en BSOP todavía
+
+Todo lo de DILESA **Urbanización** (19 sub-módulos de construcción civil detallada), **RUV** (DTUs, trámites INFONAVIT), **Presupuestos** (partidas, gastos), **Construcción** (contratos, supervisión, prototipos). Tampoco ANSA **Competencias Laborales** / **KPIs** / **Resguardos activos**. Tampoco SR Group nada (budget, flujo, pagos provisionales, declaraciones).
+
+---
+
+## 4. Patrón de mapeo observado
+
+Para cada módulo Coda, **no copiamos la estructura — rediseñamos**:
+
+### Lo que NO se traduce
+- Tablas espejo (`*Tabla`, `View of X`, `Temp X`) → UI filtros/views en BSOP
+- Tablas formulario (`Alta X`, `Registra X`, `Captura X`) → dialog/sheet CRUD en BSOP
+- Tablas reporte (`Resumen X`, `Consulta X`) → views SQL o memoized selectors en UI
+- Tablas catálogo de catálogos (`Catálogo Vehículos Enero 2023`, `...Febrero 2023`, etc.) → 1 tabla con columna temporal
+
+### Lo que SÍ se traduce
+- Tabla fuente → tabla Supabase
+- Columnas de datos → columnas Postgres (parseando tipos de Coda)
+- Relaciones referenciales → foreign keys
+- Fórmulas/botones → lógica de servidor en endpoints BSOP
+- Automation rules de Coda → cron jobs o triggers de Postgres
+
+### Ejemplos ya aplicados
+| Coda | BSOP |
+|---|---|
+| DILESA `Personal` + `Alta Personal` + `Consulta Personal` + `Baja Personal` | `erp.empleados` + `EmpleadosModule` |
+| RDB `Cortes de Caja` + `*Cortes de Caja` + `Denominaciones` + `Corte Actual` | `erp.cortes_caja` + `movimientos_caja` + edge function `sync-cortes` |
+| DILESA `Captura Juntas` (×3) + `Tareas Creadas y Terminadas en Junta` | `erp.juntas` + `juntas_asistencia` + `juntas_notas` + `erp.tasks` |
+
+---
+
+## 5. Próximos pasos (ver MIGRATION_PLAN.md)
+
+1. **Inventario data-level por tabla fuente** — para cada módulo Coda priorizado, query ligera vía API Coda para contar rows y extraer schema de columnas → documentar en `docs/coda-migration/<doc>/<modulo>.md`
+2. **Cruzar con tablas Supabase existentes** — si ya hay destino, planear el sync; si no, diseñar schema nuevo
+3. **Priorizar orden de migración** — ver MIGRATION_PLAN.md
+
+---
+
+## Apéndice: Archivos fuente de este audit
+
+Todos los archivos crudos del audit quedaron en `/tmp/coda-audit/` (local, no versionado):
+
+- `dilesa-tables.json`, `dilesa-pages.json`
+- `ansa-tables.json`, `ansa-pages.json`
+- `ansa-ventas-tables.json`, `ansa-ventas-pages.json`
+- `rdb-tables.json`, `rdb-pages.json`
+- `sr-group-tables.json`, `sr-group-pages.json`
+
+Si se requiere refrescar, correr los mismos curl comandos del `CODA_API_KEY` (ver `~/.openclaw/.env`).

--- a/docs/coda-migration/MIGRATION_PLAN.md
+++ b/docs/coda-migration/MIGRATION_PLAN.md
@@ -1,0 +1,227 @@
+# Coda → BSOP — Plan Maestro de Migración y Rediseño
+
+> **Premisa**: BSOP es nuestra fuente de verdad a futuro. Coda es legacy. El plan no es copiar — es **rediseñar cada módulo con lo aprendido** + automatizar todo lo que se pueda + dejar flexibilidad para cambios futuros.
+>
+> Ver [`INVENTORY.md`](./INVENTORY.md) para el mapa completo de qué existe dónde.
+
+---
+
+## Principios rectores
+
+1. **Datos sí, estructura no.** Migramos rows. NO reproducimos formularios de captura, tablas espejo, ni views redundantes.
+2. **Rediseño por módulo.** Cada módulo pasa por: (a) entender proceso actual en Coda, (b) diseñar mejor versión en BSOP, (c) migrar data, (d) cutover.
+3. **Audit trail siempre.** `core.audit_log` registra toda escritura importante (creado/modificado/eliminado, por quién, cuándo).
+4. **Multi-empresa primero.** Toda tabla nueva lleva `empresa_id`. RLS force-scope por empresa vía `core.fn_has_empresa()`.
+5. **Flexibilidad > replicación.** Si en Coda había 12 versiones de "Catálogo Vehículos Mes-Año", en BSOP es **1 tabla con columna temporal**.
+6. **Automatización antes que UI.** Si un flujo se puede cron-schedule, `trigger`-ear o event-drive, preferir sobre que el usuario lo corra a mano.
+7. **Incremental y reversible.** Cada módulo = su propio PR + su propio ADR. Nunca "big bang".
+
+---
+
+## Fases (por módulo)
+
+Cada módulo sigue estas 6 fases. Cada una es una PR individual:
+
+### Fase 1 — Deep audit del módulo
+**Output**: `docs/coda-migration/<doc>/<modulo>.md` con:
+- Tablas fuente (las que contienen datos reales)
+- Schema de columnas (tipos, relaciones)
+- Row count por tabla
+- Flows actuales (cómo se usa: formularios, botones, automations)
+- Stakeholders (quién lo usa a diario)
+- Pain points actuales
+- Propuesta de rediseño para BSOP (schema + UI + automation)
+
+**Duración**: 1 sesión. Sin código.
+
+### Fase 2 — Schema design + ADR
+**Output**:
+- Migration SQL en `supabase/migrations/YYYYMMDDHHMMSS_<modulo>.sql`
+- ADR en `docs/adr/NNNN-<modulo>-schema.md`
+- RLS policies con helpers (`core.fn_has_empresa()`, `core.fn_is_admin()`)
+- Audit trigger si aplica
+
+**Si la tabla ya existe** en BSOP con estructura correcta: skip esta fase.
+
+### Fase 3 — Sync unidireccional Coda → BSOP (bridge)
+**Output**: `supabase/functions/coda-sync-<modulo>/` — edge function que:
+- Se conecta a Coda API con `CODA_API_KEY`
+- Lee rows de la tabla fuente de Coda
+- Upserta en Supabase (idempotente, dedup por `coda_id`)
+- Registra en `core.audit_log` con `origen='coda-sync'`
+- Schedule: cron cada N minutos (empieza con hora, baja a 15min cuando se pruebe)
+
+Durante esta fase, **Coda sigue siendo source-of-truth**. BSOP es **read-only**.
+
+### Fase 4 — UI BSOP (read-only primero)
+**Output**: componente módulo siguiendo el patrón EmpleadosModule/TasksModule
+- `components/<area>/<modulo>-module.tsx` con scope=`'empresa'` | `'user-empresas'`
+- Pages por empresa bajo `app/<empresa>/<area>/<modulo>/page.tsx`
+- Navegación en `app-shell/nav-config.ts`
+
+**Criterio de aceptación**: usuarios pueden ver todos los datos migrados y validar que son correctos.
+
+### Fase 5 — Write-path en BSOP + dual-write
+**Output**: mutations en BSOP que escriben a Supabase Y también push a Coda (durante transición)
+- Feature flag `COMPAT_CODA_WRITE_<modulo>=true` (default: true)
+- Cuando flag está activa: BSOP mutation → Supabase + POST a Coda API
+- Cuando flag está inactiva: solo Supabase
+
+Esto mantiene Coda "vivo" temporalmente para stakeholders que lo siguen consultando.
+
+### Fase 6 — Cutover
+**Checklist por tabla**:
+1. [ ] Sync diff: `SELECT count(*) FROM bsop.X` == rows en Coda.X ± 0
+2. [ ] Stakeholders notificados (mínimo 72h aviso)
+3. [ ] Apagar cron Coda → BSOP (Fase 3)
+4. [ ] Apagar write-back a Coda (flag off)
+5. [ ] Coda tabla: agregar watermark en top `⚠️ Migrado a BSOP — read-only desde YYYY-MM-DD`
+6. [ ] Backup dump a `docs/coda-migration/<doc>/<modulo>/backup-YYYY-MM-DD.json`
+7. [ ] Mantener Coda accesible 60 días como historical reference
+8. [ ] ADR update con "status: migrated"
+
+---
+
+## Priorización — orden sugerido
+
+### Tier 1 — Completar módulos en vuelo (rows>0, más UI/flows)
+
+Ya tienen datos migrados y UI inicial. Pulir y cerrar gaps:
+
+| Módulo | Empresas | Gap |
+|---|---|---|
+| Empleados / Puestos / Departamentos | DILESA, RDB | Ya completo. Faltan compensaciones UI. |
+| Tasks + Juntas | DILESA, RDB | Ya completo. Faltan KPIs operativos. |
+| Cortes de Caja (RDB) | RDB | Ya completo. Falta conteo denominaciones UI. |
+| Requisiciones + OCs | RDB (+ DILESA futuro) | Ya completo. Falta flujo de recepciones. |
+| Productos + Inventario | RDB | Ya completo. Falta UI de ajustes manuales + reportes. |
+
+**Duración estimada**: 2-3 sprints paralelos de 1-2 agents c/u.
+
+### Tier 2 — Módulos con estructura lista (tablas 0 rows)
+
+| Módulo | Empresa | Priority | Razón |
+|---|---|---|---|
+| **Citas (ANSA)** | ANSA | alta | Usado a diario en servicio + ventas |
+| **Cuentas + Movimientos bancarios** | DILESA, ANSA, SR | alta | Control financiero, reglas duras CLAUDE.md |
+| **Gastos** | DILESA, ANSA, SR, RDB | alta | Control financiero |
+| **Facturas + Pagos provisionales** | SR Group | media | Fiscal, time-sensitive |
+| **Clientes** | DILESA, ANSA | media | Prerequisito para ventas |
+| **Recepciones de OC** | RDB, DILESA | media | Cierra el ciclo de compras |
+| **Activos + Mantenimiento** | ANSA, SR Group | media | Resguardos automotriz |
+| **Turnos** | RDB | baja | Se puede hardcodear por ahora |
+| **Aprobaciones** | Cross-empresa | baja | Hasta que haya workflow que lo requiera |
+| **Conteo denominaciones** | RDB | baja | Feature nueva, no urgente |
+
+### Tier 3 — Módulos complejos (schema nuevo, data grande)
+
+| Módulo | Doc origen | Complejidad | Notas |
+|---|---|---|---|
+| **DILESA Inmobiliario** (proyectos, lotes, ventas, contratos, cobranza) | DILESA Proyectos + Ventas | alta | Schema ya existe, falta UI + migración |
+| **DILESA Urbanización** (19 sub-módulos civil) | DILESA Urbanización | MUY alta | Repensar: agruparlo como "avances de obra por partida" más que 19 tablas |
+| **DILESA RUV** (DTUs, INFONAVIT) | DILESA Proyectos/RUV | alta | Dependencia externa (RUV portal), posible scraping |
+| **DILESA Maquinaria** (equipos, acarreos, combustible, horas) | DILESA Maquinaria | media | Buen candidato para re-modelar con "recurso + asignación + uso" |
+| **DILESA Construcción** (contratos, contratistas, supervisión, prototipos) | DILESA Construcción | media | Overlap con Proveedores |
+| **DILESA Presupuestos** | DILESA Presupuestos | media | Partidas + Gastos — ya hay tabla gastos |
+| **ANSA Automotriz** (vehículos, ventas autos, taller, refacciones) | ANSA + ANSA Ventas | alta | Schema ya existe, falta UI; refacciones tiene overlap con Inventario |
+| **ANSA Competencias + KPIs** | ANSA RH | baja | Nice-to-have, extiende RH |
+| **SR Group Fiscal completo** (declaraciones, budget, flujo, estado de resultados) | SR Group | alta | Muchas tablas relacionadas, oportunidad de unificar |
+
+### Tier 4 — Data personal SR
+
+El doc SR Group tiene info personal/familiar (recibos Casa SR, budget 50/30/20). Decidir si migra a BSOP o se queda en Coda como uso personal.
+
+---
+
+## Roadmap sugerido (realista)
+
+Considerando: torneo activo esta semana, 1 operador activo (Beto + Claude), necesidad de no romper producción, ciclos de ~1-2 semanas por módulo grande.
+
+### Abril-Mayo 2026 (4 semanas)
+- ✅ Frente 1.1: bulk lint + format (en progreso)
+- **Semana 1**: Frente 2 Sprint A (RDB operativos: playtomic, cortes, ventas) + INVENTORY.md de módulos Tier 2
+- **Semana 2**: Postgres upgrade (madrugada) + Tier 2: Citas ANSA (Fases 1-3)
+- **Semana 3**: Tier 2 Citas ANSA (Fases 4-6) + inicio Cuentas bancarias (Fase 1-2)
+- **Semana 4**: Cuentas bancarias (Fases 3-6) + Frente 2 Sprint B (juntas × 3 → JuntasModule)
+
+### Junio 2026 (4 semanas)
+- Gastos cross-empresa (Fases 1-6)
+- Tier 2: Clientes + Recepciones
+- Frente 2 Sprints C y D (documentos × 3, acceso-client)
+
+### Julio-Agosto 2026
+- Tier 3: DILESA Inmobiliario (empezando por Proyectos + Lotes)
+- SR Group Fiscal (declaraciones + pagos provisionales)
+- ANSA Automotriz (empezando por vehículos + ventas)
+
+### Septiembre+
+- DILESA Urbanización (rediseñado, no 1-a-1)
+- DILESA RUV
+- ANSA Competencias/KPIs
+- Consolidación + cleanups
+
+---
+
+## Guardrails durante la migración
+
+1. **Nada se borra de Coda** hasta Fase 6 completa + 60 días de gracia.
+2. **Dual-write preserva Coda vivo** durante transición (Fase 5).
+3. **Feature flags por módulo** para rollback instantáneo.
+4. **ADRs obligatorios** para cada schema nuevo — `docs/adr/NNNN-*.md`.
+5. **Audit trail en `core.audit_log`** en toda escritura importante.
+6. **Tests unitarios** para cada endpoint nuevo (estándar del repo: Vitest).
+7. **E2E smoke** para cada módulo (estándar Playwright del repo).
+8. **Preview deploy en Vercel** antes de merge a main.
+9. **No big-bang cutovers**. Máximo 1 módulo migrando a la vez por empresa.
+
+---
+
+## Tooling común a construir (una vez)
+
+Estos se construyen **una sola vez** y los usan todos los módulos:
+
+### `scripts/coda-diff.ts`
+CLI: `npx tsx scripts/coda-diff.ts <doc> <tabla-coda> <tabla-supabase>` → reporta row count diff + sample de diferencias.
+
+### `lib/coda-client.ts`
+Wrapper tipado del REST API de Coda con retry + rate-limit handling.
+
+### `supabase/functions/coda-sync-*`
+Template reusable: recibe `{ docId, tableId, targetSchema, targetTable, mapping }` y hace el upsert. Fases 3/5.
+
+### Vista `/settings/coda-migration` (dashboard)
+- Lista de módulos con status (tier, fase actual, last sync, row diff)
+- Health alerts si un sync falla
+- Log de cutovers
+
+### `core.audit_log` (ya existe, 0 rows)
+Activar escritura en todas las migraciones Tier 2+. Schema:
+```
+(id, empresa_id, user_id, table_name, record_id, action, old_values, new_values, ip, user_agent, created_at)
+```
+
+---
+
+## Riesgos conocidos
+
+| Riesgo | Mitigación |
+|---|---|
+| Datos inconsistentes en Coda (Tablas "god" con 175+ columnas) | Deep audit (Fase 1) identifica campos clave vs basura; migrar solo lo útil |
+| Flujos manuales que dependen de automations de Coda | Documentar en Fase 1; reimplementar como cron + edge function |
+| Stakeholders que resisten el cambio | Dual-write (Fase 5) mantiene Coda funcional hasta confianza total |
+| Migrations grandes (e.g., 10k+ rows) pueden tumbar Supabase | Migrar en batches de 500 con pauses; correr en horarios de bajo tráfico |
+| Coda API rate limit (100 req/min default) | Retry con backoff; correr sync en off-peak |
+| Pérdida de fórmulas/KPIs | Deep audit las enumera; decidir caso por caso si se traducen o se redistribuyen |
+
+---
+
+## Qué necesito de Beto para empezar
+
+1. **Aprobación de este plan** (o ajustes)
+2. **Priorización personal** entre Tier 2: ¿qué módulo te desbloquea más pronto?
+3. **Lista de stakeholders por módulo**: quién usa cada cosa en Coda a diario
+4. **Pain points actuales** en Coda que NO queremos replicar en BSOP
+
+---
+
+_Versión: 1.0 — 2026-04-18 · Autor: Claude + Beto (audit conjunto)_

--- a/docs/coda-migration/MODULE_MAP.md
+++ b/docs/coda-migration/MODULE_MAP.md
@@ -1,0 +1,277 @@
+# Mapa de módulos — Coda real vs BSOP objetivo
+
+> Este documento responde: **¿qué se usa de verdad en Coda?** (con row counts reales del audit 2026-04-18) y **¿en qué orden conviene migrar?** dados (a) el uso real y (b) la leverage cross-empresa.
+>
+> Ver también: [`INVENTORY.md`](./INVENTORY.md), [`MIGRATION_PLAN.md`](./MIGRATION_PLAN.md).
+
+---
+
+## Legend
+
+- ★★★ = módulo con miles de rows, uso diario, migrar prioridad
+- ★★ = cientos de rows, uso activo
+- ★ = docenas de rows, uso ocasional
+- ∅ = 0 rows o views/formularios muertos, no migrar
+- 🔁 = sirve a múltiples empresas (cross-empresa leverage)
+- ✅ = ya en BSOP (Supabase) con datos
+- ⚠️ = estructura lista en BSOP (0 rows), falta UI + migración
+- ❌ = schema NO existe en BSOP todavía
+
+---
+
+## 1. Ranking por volumen de data real (top 30 tablas con >500 rows)
+
+| Rows | Doc | Tabla fuente | Estado BSOP |
+|---:|---|---|---|
+| **18,644** | DILESA | Tareas Construcción Terminadas | ❌ (relacionada a `erp.tasks` pero es historial de construcción) |
+| **8,372** | DILESA | Cargas Combustible | ❌ |
+| **6,968** | DILESA | Horas Máquina | ❌ |
+| **4,921** | DILESA | Acarreos | ❌ |
+| **4,749** | ANSA | Citas | ⚠️ `erp.citas` (0 rows) |
+| **4,539** | ANSA | Citas del Día Servicio | same |
+| **3,496** | SR Group | Gastos | ⚠️ `erp.gastos` |
+| **2,995** | RDB | Detalle Conteo | ❌ (audits físicos inventario) |
+| **2,953** | RDB | Productos del Pedido | ✅ `rdb.waitry_productos` (15,214) |
+| **2,610** | SR Group | Movimientos AMEX | ⚠️ `erp.movimientos_bancarios` |
+| **2,421** | SR Group | Movimientos Banamex | same |
+| **2,115** | DILESA | Lotes | ⚠️ `erp.lotes` |
+| **1,929** | ANSA-Ventas | Cliente | ⚠️ `erp.clientes` |
+| **1,748** | DILESA | Plantilla Tareas Construcción | ❌ |
+| **1,706** | ANSA-Ventas | Facturas Compra Unidades | ⚠️ `erp.vehiculos` + `erp.facturas` |
+| **1,611** | RDB | Pedidos Waitry | ✅ `rdb.waitry_pedidos` (10,746) |
+| **1,590** | DILESA | Inventario (inmobiliario) | ⚠️ `erp.lotes` |
+| **1,541** | ANSA-Ventas | Facturas Venta Unidades | ⚠️ `erp.ventas_autos` + `erp.facturas` |
+| **1,523** | SR Group | Movimientos IBC | ⚠️ `erp.movimientos_bancarios` |
+| **1,462** | ANSA-Ventas | Avanzadas (ventas planificadas) | ⚠️ `erp.ventas_autos` |
+| **1,449** | RDB | Pagos Waitry | ✅ `rdb.waitry_pagos` |
+| **1,443** | ANSA-Ventas | Programación de Entrega | ⚠️ `erp.ventas_autos` |
+| **1,411** | DILESA | Clientes DILESA | ⚠️ `erp.clientes` |
+| **1,372** | DILESA | Construcción por Lote | ❌ |
+| **1,249** | DILESA | Tareas | ✅ `erp.tasks` (1,253) — **match casi perfecto** |
+| **1,240** | DILESA | Urbanización por Lote | ❌ |
+| **1,132** | DILESA | CUV (RUV) | ❌ |
+| **1,079** | DILESA | Escrituración Total | ⚠️ `erp.documentos` (60) — parcial |
+| **1,060** | DILESA | Depósitos Clientes | ❌ (pagos inmobiliarios) |
+| **918** | RDB | Entradas inventario | ✅ `erp.movimientos_inventario` (14,895) |
+| **796** | SR Group | Registros Pendientes Banamex | ⚠️ `erp.conciliaciones` |
+| **719** | DILESA | Juntas | ✅ `erp.juntas` (720) — **match perfecto** |
+| **698** | RDB | Detalle Requisición | ✅ |
+| **517** | SR Group | Facturas | ⚠️ `erp.facturas` |
+
+---
+
+## 2. Módulos agrupados por estado
+
+### ✅ Ya en BSOP con datos (RDB prácticamente completo)
+
+| Módulo BSOP | Origen Coda | Rows BSOP | Estado |
+|---|---|---:|---|
+| Empleados/Puestos/Depts | DILESA + RDB | 212/53/8 | ✅ funcional |
+| Tasks | DILESA + RDB | 1,253 | ✅ funcional, pegado a Coda DILESA (1,249) |
+| Juntas | DILESA | 720 | ✅ pegado a Coda DILESA (719) |
+| Cortes de caja | RDB | 433 | ✅ funcional |
+| Movimientos caja | RDB | 409 | ✅ funcional |
+| Productos | RDB | 310 | ✅ funcional |
+| Inventario + movimientos | RDB | 283 + 14,895 | ✅ funcional |
+| Requisiciones | RDB | 188 | ✅ funcional |
+| OCs | RDB | 160 | ✅ funcional |
+| Proveedores | RDB + DILESA | 48 | ✅ funcional |
+| Documentos (escrituras) | DILESA parcial | 60 | ⚠️ falta 1,019 de Escrituración Total |
+| Waitry POS | RDB | 10,746 pedidos | ✅ funcional (cron sync) |
+| Playtomic | RDB | 1,442 bookings | ✅ funcional (cron sync) |
+
+**Insight**: RDB está **casi 100% migrado**. Solo faltan: Carga Física / Cierres (audits 247+235 rows) y el reporte de conteo (2,995 rows que son detail de carga física).
+
+### ⚠️ Estructura en BSOP, 0 rows, falta migrar + UI
+
+Ordenado por **uso real en Coda** + **leverage cross-empresa**:
+
+| Módulo | Empresas que lo usan | Rows Coda | Prioridad | Razón |
+|---|---|---:|---|---|
+| **Gastos** 🔁 | SR + DILESA + ANSA + RDB | 3,496 (SR) + desglose 81 | **alta** | 4 empresas, volumen alto, control financiero |
+| **Movimientos bancarios** 🔁 | SR (AMEX+Banamex+IBC) + ANSA (BBVA) + DILESA | 6,554 SR + 569 ANSA + ? DILESA | **alta** | Cross-empresa, volumen altísimo |
+| **Cuentas bancarias** 🔁 | Base de Movimientos bancarios | ~10 cuentas | **alta** | Prerequisito para movimientos |
+| **Citas** | ANSA (servicio + ventas) + DILESA (visitas obra futuro) | 4,749 + 4,539 + 150 | **alta** | ANSA lo usa A DIARIO |
+| **Facturas** 🔁 | SR (fiscal) + ANSA (compra/venta autos) + DILESA futuro | 517 SR + 1,706 compra + 1,541 venta | **alta** | Fiscal + operativo |
+| **Clientes** 🔁 | DILESA + ANSA Ventas | 1,411 + 1,929 | **alta** | Prerequisito para ventas inmobiliaria y autos |
+| **Conciliaciones bancarias** 🔁 | SR (Registros Pendientes) | 796+331+193+85 = 1,405 | media | Depende de Movimientos |
+| **Pagos provisionales** | SR (fiscal ISR) | 219 | media | Time-sensitive |
+| **Recepciones de OC** 🔁 | RDB + DILESA + ANSA futuro | ~cantidad de OCs | media | Cierra ciclo de compras |
+| **Lotes (inmobiliario)** | DILESA | 2,115 | media | Grande pero DILESA-exclusivo |
+| **Proyectos** | DILESA | ~50 proyectos | media | Prerequisito para Lotes/Ventas |
+| **Ventas inmobiliarias** | DILESA | ~1,000 (deducido) | media | Depende de Lotes + Clientes |
+| **Ventas autos** | ANSA Ventas | 1,541 venta + 1,462 avanzadas | media | ANSA-exclusivo |
+| **Vehículos (inventario autos)** | ANSA Ventas | 1,706 VINs | media | ANSA-exclusivo |
+| **Turnos** 🔁 | RDB + ANSA + DILESA | catálogo | baja | Se puede hardcodear |
+| **Activos** 🔁 | ANSA (resguardos) + SR | varios | baja | Nice-to-have |
+| **Conteo denominaciones** | RDB | 0 en Coda | baja | Feature nueva |
+
+### ❌ Schema NO existe en BSOP — diseñar nuevo
+
+| Módulo Coda | Empresas | Rows Coda | Vale la pena? | Comentario |
+|---|---|---:|---|---|
+| **Cargas Combustible** | DILESA Maquinaria | 8,372 | sí | Alto uso. Reddiseñable como "movimientos de activo" |
+| **Horas Máquina** | DILESA Maquinaria | 6,968 | sí | Alto uso. Same pattern |
+| **Acarreos** | DILESA Maquinaria | 4,921 | sí | Alto uso. Same pattern |
+| **Tareas Construcción Terminadas** | DILESA | 18,644 | sí | Historia de construcción; tal vez fundir con `erp.tasks` |
+| **Plantilla Tareas Construcción** | DILESA | 1,748 | sí | Templates; podría ser `erp.task_templates` |
+| **Construcción por Lote** | DILESA | 1,372 | sí | Avance de obra |
+| **Urbanización por Lote** | DILESA | 1,240 | sí | Avance urbanización |
+| **Depósitos Clientes** | DILESA | 1,060 | sí | Pagos inmobiliarios (ligado a cobranza) |
+| **CUV** (RUV) | DILESA | 1,132 | sí | Clave Única de Vivienda |
+| **Documentos RUV** | DILESA | 169 | sí | INFONAVIT trámites |
+| **Urgencias RUV** | DILESA | 256 | sí | same |
+| **Sueldos y Salarios** | SR Group | 162 | sí | Fiscal personal |
+| **Tablas ISR** | SR Group | 989 | **NO** | Catálogo SAT, reference data — usar servicio externo |
+| **Activos financieros SR** | SR Group | <50 | baja | Inversiones personales |
+| **Urbanización** (19 sub-módulos) | DILESA | cada uno bajo 1k | **NO replicar** | Rediseñar como "avances por partida" |
+
+### ∅ Views/formularios muertos — NO migrar
+
+- Todas las tablas `View of X`, `*X`, `Temp X`, `Alta X`, `Consulta X`, `Captura X`, `Resumen X` — son UI de Coda que en BSOP ya no necesitamos (se resuelve con CRUD nativo).
+- **Catálogos de Vehículos Mensuales** (ANSA-Ventas tiene 12 snapshots) — 1 tabla + columna temporal.
+
+---
+
+## 3. Orden propuesto (post-torneo)
+
+Basado en: uso real + leverage cross-empresa + dependencias + tu guía de "habilitar los que realmente utilizamos".
+
+### **Semana 1 (post-torneo) — Terminar RH "all-in"**
+
+Objetivo: sacar RH de Coda para DILESA + RDB + empezar en ANSA.
+
+1. **Polir Empleados/Puestos/Depts** en BSOP (ya existen):
+   - Agregar `erp.empleados_compensacion` UI (ya tiene 85 rows, sin UI)
+   - Agregar `Actividades Laborales` de ANSA (272 rows) → `erp.empleados_actividades` (schema nuevo)
+   - Agregar `Funciones Laborales` (143 rows) → puede ir como `erp.puestos.funciones` (JSONB)
+   - Agregar `Ex-Empleados` (DILESA 205 + ANSA 85) como vista de `erp.empleados WHERE activo = false` + fechas baja
+2. **Cutover RH** en Coda DILESA + RDB + ANSA: watermark "migrado"
+
+**Entregable**: RH 100% en BSOP para 3 empresas, Coda read-only para RH.
+
+### **Semana 2 — Cuentas + Movimientos bancarios (cross-empresa)** 🔁
+
+Objetivo: control financiero unificado. Construir **una vez**, usar en 4 empresas.
+
+1. **Schema `erp.cuentas_bancarias`** ya existe (0 rows)
+   - Definir 6-10 cuentas (AMEX SR, Banamex SR, IBC SR, BBVA ANSA, cuentas DILESA)
+2. **Migrar `erp.movimientos_bancarios`**:
+   - AMEX (2,610) → Banamex (2,421) → IBC (1,523) → BBVA ANSA (569)
+   - Total: ~7,100 movimientos
+3. **UI `BancosModule`** siguiendo el patrón:
+   - `components/bancos/bancos-module.tsx` con scope empresa/user-empresas
+   - Filtros: cuenta, rango fechas, tipo movimiento, estado (conciliado/pendiente)
+4. **Conciliaciones** (SR Pendientes = 1,405 rows)
+   - Matching automático por fecha+monto con `erp.gastos` y `erp.facturas`
+   - Reglas por banco
+
+**Entregable**: Beto puede ver movimientos de las 4 empresas en un solo dashboard BSOP.
+
+### **Semana 3 — Gastos (cross-empresa)** 🔁
+
+Objetivo: el módulo financiero más usado (3,496 gastos SR).
+
+1. **Migrar `erp.gastos`** de SR (3,496) + diseñar captura para DILESA/ANSA/RDB
+2. **Sub-categorías** (SR: 73 sub-categorías)
+3. **UI GastosModule**:
+   - Captura rápida (móvil-friendly)
+   - Asociación con factura (si hay) y movimiento bancario (si ya se pagó)
+4. **Reportes**: gasto mensual por empresa, por categoría
+
+**Entregable**: Gastos unificados en BSOP para las 4 empresas.
+
+### **Semana 4 — Citas (ANSA)**
+
+Objetivo: desbloquear ANSA completo (es lo que más usan a diario).
+
+1. **Migrar `erp.citas`** de ANSA (4,749 + 4,539 día = 9,288 rows)
+2. **UI `CitasModule`**:
+   - Vista día (Citas del Día Servicio + Día Ventas)
+   - Filtros por asesor, estado, tipo
+   - Integración con `erp.empleados` (asesor) y `erp.personas` (cliente)
+
+**Entregable**: ANSA Servicio operando en BSOP.
+
+### **Semana 5-6 — Facturas + Fiscal** 🔁
+
+Objetivo: pipeline fiscal básico.
+
+1. **`erp.facturas`** — compra (ANSA 1,706) + venta (ANSA 1,541) + SR (517)
+2. **`erp.pagos_provisionales`** (SR 219)
+3. **UI FiscalModule** + relación con Gastos y Movimientos bancarios
+
+### **Semana 7-8 — Clientes + DILESA Inmobiliario (fase 1)**
+
+Objetivo: arrancar el núcleo inmobiliario de DILESA.
+
+1. **`erp.clientes`** (DILESA 1,411 + ANSA Ventas 1,929 = 3,340)
+2. **`erp.proyectos`** (pocos, ~50)
+3. **`erp.lotes`** (2,115)
+4. **UI ProyectosModule + LotesModule**
+
+### **Semana 9+ — DILESA Maquinaria**
+
+Rediseño grande: 3 tablas Coda (combustible/horas/acarreos) → 1 tabla unificada `erp.maquinaria_movimientos` con tipo + equipo + proyecto + cantidad.
+
+### **Semana 10+ — Ventas inmobiliarias + contratos + cobranza DILESA**
+
+Completar el ciclo de venta DILESA.
+
+### **Más adelante (lower priority)**
+
+- ANSA Automotriz (vehiculos + ventas autos + taller) — 6-8 semanas
+- DILESA Construcción (contratos contratistas, supervisión, prototipos) — 4-6 semanas
+- DILESA Urbanización (rediseñado) — 4-6 semanas
+- DILESA RUV (CUV + DTUs + INFONAVIT) — 3-4 semanas
+- SR Group Budget/Flujo/Estado de Resultados — features de reporte que dependen de Gastos + Facturas
+
+---
+
+## 4. Cross-empresa winners (build once, use N times)
+
+Esto es donde **ganamos leverage real**. Un solo módulo BSOP sirve a múltiples empresas:
+
+| Módulo | Empresas servidas | Leverage |
+|---|---|---:|
+| Gastos | 4 (DILESA, ANSA, SR, RDB) | 4x |
+| Facturas | 3+ (SR fiscal, ANSA autos, DILESA futuro) | 3x |
+| Movimientos bancarios | 4 | 4x |
+| Conciliaciones | 4 | 4x |
+| Cuentas bancarias | 4 | 4x |
+| Clientes | 3 (DILESA, ANSA, RDB futuro) | 3x |
+| Citas | 2+ (ANSA, DILESA futuro) | 2x |
+| Empleados/RH | 4 (todas) | 4x — ya hecho ✅ |
+| Tasks | 4 (todas) | 4x — ya hecho ✅ |
+| Juntas | 4 (todas) | 4x — ya hecho ✅ |
+| Proveedores | 3 (DILESA, RDB, ANSA futuro) | 3x — ya hecho ✅ |
+| Documentos | 4 (todas — escrituras, contratos, facturas, recibos) | 4x — ya hecho ✅ |
+| Activos | 3 (ANSA, SR, DILESA maquinaria) | 3x |
+
+**Insight**: los siguientes 5-6 módulos que salgan (Gastos, Bancos, Citas, Facturas, Clientes, Conciliaciones) resuelven **muchísimo** para las 4 empresas de un solo golpe.
+
+---
+
+## 5. Lo que ANSA-Ventas tiene pero no atacamos aún
+
+ANSA-Ventas es el doc más grande en densidad de uso (8k+ rows activos). Complejo porque toca: vehículos VIN, facturación SAT, programación entregas, asignación, costeo.
+
+**Estrategia sugerida**: no arrancar ANSA-Ventas hasta que esté el módulo Facturas genérico + Clientes cross-empresa + Vehículos. Cuando esos 3 estén, ANSA-Ventas se arma con 60% menos esfuerzo.
+
+---
+
+## 6. Lo que DILESA Urbanización realmente necesita
+
+Los 19 sub-módulos de urbanización (excavación sanitaria, línea agua, pozo visita, transformador, carpeta asfáltica, etc.) son el "god module" de DILESA. No tiene sentido crear 19 tablas en BSOP.
+
+**Propuesta de rediseño** (para cuando toquemos esto):
+```
+erp.obra_partidas (id, nombre, categoria, unidad, costo_estandar)
+erp.obra_avances (id, lote_id, partida_id, fecha, cantidad, costo_real, responsable, evidencia_url)
+```
+
+Un solo par de tablas + `categoria` = "urbanización" | "construcción" + `partida` identifica el tipo de avance. **Reemplaza 19 tablas con 2**.
+
+---
+
+_Actualizado: 2026-04-18 (post row-count audit de los 5 docs)._


### PR DESCRIPTION
## Summary

Adds the master reference for the Coda → BSOP migration under \`docs/coda-migration/\`. Three documents:

- \`INVENTORY.md\` — full map of 495 Coda tables across 5 docs, cross-referenced with current Supabase schema
- \`MIGRATION_PLAN.md\` — 6-phase per-module approach, 4-tier priority, 5-month roadmap, guardrails, shared tooling
- \`MODULE_MAP.md\` — ordered sprint plan based on real Coda row counts (live API audit 2026-04-18) + cross-empresa leverage analysis

## Context

Beto asked for a complete structural map before committing to an order. This audit ingested all 5 Coda docs directly via REST API (\`CODA_API_KEY\` from 1Password, token: "OpenClaw") and produced row counts per table to distinguish real data vs form/view/temp tables.

Key findings:
- **RDB is ~90% migrated already** to BSOP
- **SR Group is the financial tresure** (Gastos 3,496 / AMEX 2,610 / Banamex 2,421 / IBC 1,523)
- **DILESA has 18k+ rows in construction tasks** alone
- **ANSA Citas = 4,749** (heavy daily use)
- **6 cross-empresa modules identified** (Gastos, Bancos, Facturas, Clientes, Conciliaciones, Activos) — build once, use in 3-4 empresas

## Proposed order (post-tournament)

Week 1: finish RH migration → all empresas  
Week 2: Bancos cross-empresa (build once, serve 4)  
Week 3: Gastos cross-empresa (4 empresas)  
Week 4: Citas ANSA (4,749 rows, daily use)  
Week 5-6: Facturas + Fiscal  
Week 7+: DILESA Inmobiliario  
...

See \`MODULE_MAP.md\` § 3 for full sequence.

## Test plan

- [ ] Review the three docs for accuracy
- [ ] Confirm priority order matches Beto's preference (especially post-tournament)
- [ ] Flag any missing modules or misclassified tables

## Files touched

- \`docs/coda-migration/INVENTORY.md\` (new, 178 lines)
- \`docs/coda-migration/MIGRATION_PLAN.md\` (new, 227 lines)
- \`docs/coda-migration/MODULE_MAP.md\` (new, 277 lines)

Zero code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)