### PR TITLE
chore(lint,format): tighten ignores for worktrees and legacy scripts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,11 +1,18 @@
-# Build output
+# Build output (including nested .next/ inside git worktrees)
 .next/
+**/.next/
 dist/
 build/
 out/
 
 # Dependencies
 node_modules/
+
+# Git worktrees created by agents — never format checked-out copies of the repo.
+.claude/worktrees/
+
+# Untracked ad-hoc scratch folder.
+tmp/
 
 # Coverage / test artifacts
 coverage/
@@ -23,6 +30,13 @@ yarn.lock
 
 # Archived legacy content — do not reformat
 docs/archive/
+
+# One-off migration / rescue / backfill scripts — kept outside archive/ as
+# historical references, untracked in git. Mirrored here to match eslint ignore.
+scripts/migrate_*.ts
+scripts/rescue_*.ts
+scripts/fix_*.mjs
+scripts/backfill_*.js
 
 # Env & credentials
 .env*

--- a/docs/coda-migration/INVENTORY.md
+++ b/docs/coda-migration/INVENTORY.md
@@ -1,6 +1,7 @@
 # Coda → BSOP — Inventory & Migration Map
 
 > **Fuente de este audit**: combinación de
+>
 > - Datos previos de OpenClaw (`data/coda.json`, auditoría 2026-03-23)
 > - Coda REST API directa (este audit, 2026-04-18) — `CODA_API_KEY` en 1Password
 > - Supabase MCP listing de `ybklderteyhuugzfmxbi` (este audit)
@@ -13,20 +14,21 @@
 
 Los 5 docs siguen activos (todos `updatedAt` esta semana). Owner: `beto@anorte.com`.
 
-| Doc | docId | Tablas (API) | Pages | Health* | Last update |
-|---|---|---:|---:|---:|---|
-| DILESA | `ZNxWl_DI2D` | 256 | 100 | 0.62 avg · 26 high-risk | 2026-04-18 |
-| ANSA | `pnqM3j0Yal` | 59 | 76 | 0.32 avg · 1 high-risk | 2026-04-18 |
-| ANSA Ventas | `vVmCl2wBfC` | 77 | 74 | 0.27 avg · 4 high-risk | 2026-04-18 |
-| RDB | `yvrM3UilPt` | 45 | 46 | 0.20 avg · 2 high-risk | 2026-04-18 |
-| SR Group | `MaXoDlRxXE` | 58 | 43 | 0.05 avg · 0 high-risk | 2026-04-12 |
-| **Total** | | **495** | **339** | | |
+| Doc         | docId        | Tablas (API) |   Pages |                Health\* | Last update |
+| ----------- | ------------ | -----------: | ------: | ----------------------: | ----------- |
+| DILESA      | `ZNxWl_DI2D` |          256 |     100 | 0.62 avg · 26 high-risk | 2026-04-18  |
+| ANSA        | `pnqM3j0Yal` |           59 |      76 |  0.32 avg · 1 high-risk | 2026-04-18  |
+| ANSA Ventas | `vVmCl2wBfC` |           77 |      74 |  0.27 avg · 4 high-risk | 2026-04-18  |
+| RDB         | `yvrM3UilPt` |           45 |      46 |  0.20 avg · 2 high-risk | 2026-04-18  |
+| SR Group    | `MaXoDlRxXE` |           58 |      43 |  0.05 avg · 0 high-risk | 2026-04-12  |
+| **Total**   |              |      **495** | **339** |                         |             |
 
-_*Health score del audit OpenClaw: 0=clean, 7=max risk. "High-risk" = tablas con score ≥ 5 (exceso de columnas, lógica sobrecargada, fórmulas anidadas)._
+_\*Health score del audit OpenClaw: 0=clean, 7=max risk. "High-risk" = tablas con score ≥ 5 (exceso de columnas, lógica sobrecargada, fórmulas anidadas)._
 
 ### Patrón común observado
 
 Cada doc repite la misma estructura mental:
+
 - **Tablas fuente** (los datos reales) — p. ej. `Personal`, `Citas`, `Cortes de Caja`
 - **Tablas de captura/alta** (`Alta X`, `Registra X`) — formularios one-shot que escriben a la fuente
 - **Tablas de consulta** (`Consulta X`) — views/filtros
@@ -42,6 +44,7 @@ En BSOP **no reproducimos este modelo**. Un CRUD en una tabla fuente reemplaza t
 ### DILESA (100 pages, 256 tablas)
 
 6 módulos top-level:
+
 - **Administración** → Recursos Humanos (Personal, Puestos, Depts, Competencias, KPIs, Políticas), Depósitos, Juntas, Tareas, Escrituras, Saldos Bancos
 - **Presupuestos** → Partidas presupuestales, Gastos
 - **Proyectos** → Terrenos, Anteproyectos, Proyectos, Lotes, Documentos
@@ -54,6 +57,7 @@ En BSOP **no reproducimos este modelo**. Un CRUD en una tabla fuente reemplaza t
 ### ANSA (76 pages, 59 tablas)
 
 3 módulos:
+
 - **Citas** → catálogo, Citas del Día Servicio, Citas del Día Ventas, Reporte
 - **Administración** → Personal (alta/baja/consulta), Puestos, Departamentos, Activos, Proveedores, Resguardos
 - **Recursos Humanos** → Competencias, Funciones, KPIs, Cumpleañeros
@@ -61,12 +65,14 @@ En BSOP **no reproducimos este modelo**. Un CRUD en una tabla fuente reemplaza t
 ### ANSA Ventas (74 pages, 77 tablas)
 
 2 módulos:
+
 - **Administración** → Catálogos CFDI, Catálogo vehículos (12 versiones mensuales!), Carga Factura, Asignación/Apartado, Beneficiarios controladores, Accesorios
 - **Asesores** → Asesores de ventas, Mis Clientes
 
 ### RDB (46 pages, 45 tablas)
 
 7 módulos:
+
 - **Productos** → Catálogo, Categorías, IVA, Estatus
 - **Inventario** → Ajustes, Almacenes, Carga física, Cierres, Conteos, Entradas/Salidas, Inventario a fecha
 - **Requisiciones** → Nueva, Detalle, Autoriza, Convierte a OC
@@ -78,6 +84,7 @@ En BSOP **no reproducimos este modelo**. Un CRUD en una tabla fuente reemplaza t
 ### SR Group (43 pages, 58 tablas)
 
 11 módulos (financieros/personales):
+
 - **Recibos Casa SR** (rentas)
 - **Pagos Provisionales** (ISR)
 - **Declaraciones** (anual y provisional)
@@ -92,38 +99,38 @@ Schema de producción: `ybklderteyhuugzfmxbi`. Fuente: `supabase/SCHEMA_REF.md` 
 
 ### ✅ Operativo con datos
 
-| Área | Tablas | Rows | Origen |
-|---|---|---:|---|
-| Auth/RBAC | `core.usuarios, empresas, modulos, roles, permisos_rol, usuarios_empresas` | 5/6/22/5/66/14 | BSOP nativo |
-| RH cross-empresa | `erp.personas, empleados, empleados_compensacion` | 260/212/85 | Migrado Coda DILESA/RDB |
-| RH organigrama | `erp.departamentos, puestos` | 8/53 | Migrado Coda |
-| Proveedores | `erp.proveedores` | 48 | Migrado Coda |
-| Productos/precios | `erp.productos, productos_precios` | 310/310 | BSOP + waitry map |
-| Inventario | `erp.almacenes, inventario, movimientos_inventario` | 1/283/14,895 | BSOP activo |
-| Compras | `erp.requisiciones, _detalle, ordenes_compra, _detalle` | 188/4/160/656 | Migrado desde rdb.* |
-| Tasks | `erp.tasks, task_updates, task_comentarios` | 1253/5/— | BSOP nativo |
-| Juntas | `erp.juntas, juntas_asistencia, juntas_notas` | 720/5/0 | Migrado Coda DILESA |
-| Cortes RDB | `erp.cortes_caja, movimientos_caja, cajas` | 433/409/5 | Migrado Coda + Waitry sync |
-| Docs legales | `erp.documentos` | 60 | Migrado escrituras DILESA |
-| Waitry POS | `rdb.waitry_inbound, pedidos, productos, pagos` | 10,746/10,746/15,214/10,846 | Cron sync-cortes |
-| Playtomic | `playtomic.bookings, players, participants, resources, sync_log` | 1,442/705/4,179/19/377 | Cron sync |
+| Área              | Tablas                                                                     |                        Rows | Origen                     |
+| ----------------- | -------------------------------------------------------------------------- | --------------------------: | -------------------------- |
+| Auth/RBAC         | `core.usuarios, empresas, modulos, roles, permisos_rol, usuarios_empresas` |              5/6/22/5/66/14 | BSOP nativo                |
+| RH cross-empresa  | `erp.personas, empleados, empleados_compensacion`                          |                  260/212/85 | Migrado Coda DILESA/RDB    |
+| RH organigrama    | `erp.departamentos, puestos`                                               |                        8/53 | Migrado Coda               |
+| Proveedores       | `erp.proveedores`                                                          |                          48 | Migrado Coda               |
+| Productos/precios | `erp.productos, productos_precios`                                         |                     310/310 | BSOP + waitry map          |
+| Inventario        | `erp.almacenes, inventario, movimientos_inventario`                        |                1/283/14,895 | BSOP activo                |
+| Compras           | `erp.requisiciones, _detalle, ordenes_compra, _detalle`                    |               188/4/160/656 | Migrado desde rdb.\*       |
+| Tasks             | `erp.tasks, task_updates, task_comentarios`                                |                    1253/5/— | BSOP nativo                |
+| Juntas            | `erp.juntas, juntas_asistencia, juntas_notas`                              |                     720/5/0 | Migrado Coda DILESA        |
+| Cortes RDB        | `erp.cortes_caja, movimientos_caja, cajas`                                 |                   433/409/5 | Migrado Coda + Waitry sync |
+| Docs legales      | `erp.documentos`                                                           |                          60 | Migrado escrituras DILESA  |
+| Waitry POS        | `rdb.waitry_inbound, pedidos, productos, pagos`                            | 10,746/10,746/15,214/10,846 | Cron sync-cortes           |
+| Playtomic         | `playtomic.bookings, players, participants, resources, sync_log`           |      1,442/705/4,179/19/377 | Cron sync                  |
 
 ### ⚠️ Estructura lista, 0 rows (tablas creadas esperando UI + migración)
 
-| Área | Tablas | Empresa principal | Coda fuente |
-|---|---|---|---|
-| Clientes | `erp.clientes` | Cross-empresa | Coda `Clientes` |
-| Citas | `erp.citas` | ANSA (servicio/ventas), DILESA | Coda Citas |
-| Aprobaciones | `erp.aprobaciones` | Cross-empresa | Nuevo — no existe en Coda |
-| Turnos | `erp.turnos` | RDB (cajeros), ANSA | Coda parcial |
-| Bancos | `erp.cuentas_bancarias, movimientos_bancarios, conciliaciones` | SR Group, DILESA, ANSA | Coda SR movimientos AMEX/Banamex/BBVA/IBC |
-| Gastos | `erp.gastos` | SR Group, DILESA, ANSA | Coda Gastos |
-| Fiscal | `erp.facturas, pagos_provisionales` | SR Group | Coda SR Fiscal |
-| Recepciones | `erp.recepciones, _detalle` | Cross-empresa | Coda Entradas Almacén |
-| Activos | `erp.activos, activos_mantenimiento` | ANSA (resguardos), SR Group | Coda Activos |
-| Conteo denomin. | `erp.corte_conteo_denominaciones` | RDB | Coda Denominaciones |
-| **DILESA inmobiliario** | `erp.proyectos, lotes, ventas_inmobiliarias, contratos, cobranza, pagos` | DILESA | Coda DILESA Proyectos+Ventas |
-| **ANSA automotriz** | `erp.vehiculos, ventas_autos, ventas_tickets, ventas_refacciones_detalle, taller_servicio` | ANSA | Coda ANSA+ANSA Ventas |
+| Área                    | Tablas                                                                                     | Empresa principal              | Coda fuente                               |
+| ----------------------- | ------------------------------------------------------------------------------------------ | ------------------------------ | ----------------------------------------- |
+| Clientes                | `erp.clientes`                                                                             | Cross-empresa                  | Coda `Clientes`                           |
+| Citas                   | `erp.citas`                                                                                | ANSA (servicio/ventas), DILESA | Coda Citas                                |
+| Aprobaciones            | `erp.aprobaciones`                                                                         | Cross-empresa                  | Nuevo — no existe en Coda                 |
+| Turnos                  | `erp.turnos`                                                                               | RDB (cajeros), ANSA            | Coda parcial                              |
+| Bancos                  | `erp.cuentas_bancarias, movimientos_bancarios, conciliaciones`                             | SR Group, DILESA, ANSA         | Coda SR movimientos AMEX/Banamex/BBVA/IBC |
+| Gastos                  | `erp.gastos`                                                                               | SR Group, DILESA, ANSA         | Coda Gastos                               |
+| Fiscal                  | `erp.facturas, pagos_provisionales`                                                        | SR Group                       | Coda SR Fiscal                            |
+| Recepciones             | `erp.recepciones, _detalle`                                                                | Cross-empresa                  | Coda Entradas Almacén                     |
+| Activos                 | `erp.activos, activos_mantenimiento`                                                       | ANSA (resguardos), SR Group    | Coda Activos                              |
+| Conteo denomin.         | `erp.corte_conteo_denominaciones`                                                          | RDB                            | Coda Denominaciones                       |
+| **DILESA inmobiliario** | `erp.proyectos, lotes, ventas_inmobiliarias, contratos, cobranza, pagos`                   | DILESA                         | Coda DILESA Proyectos+Ventas              |
+| **ANSA automotriz**     | `erp.vehiculos, ventas_autos, ventas_tickets, ventas_refacciones_detalle, taller_servicio` | ANSA                           | Coda ANSA+ANSA Ventas                     |
 
 ### ❌ No existe en BSOP todavía
 
@@ -136,12 +143,14 @@ Todo lo de DILESA **Urbanización** (19 sub-módulos de construcción civil deta
 Para cada módulo Coda, **no copiamos la estructura — rediseñamos**:
 
 ### Lo que NO se traduce
+
 - Tablas espejo (`*Tabla`, `View of X`, `Temp X`) → UI filtros/views en BSOP
 - Tablas formulario (`Alta X`, `Registra X`, `Captura X`) → dialog/sheet CRUD en BSOP
 - Tablas reporte (`Resumen X`, `Consulta X`) → views SQL o memoized selectors en UI
 - Tablas catálogo de catálogos (`Catálogo Vehículos Enero 2023`, `...Febrero 2023`, etc.) → 1 tabla con columna temporal
 
 ### Lo que SÍ se traduce
+
 - Tabla fuente → tabla Supabase
 - Columnas de datos → columnas Postgres (parseando tipos de Coda)
 - Relaciones referenciales → foreign keys
@@ -149,11 +158,12 @@ Para cada módulo Coda, **no copiamos la estructura — rediseñamos**:
 - Automation rules de Coda → cron jobs o triggers de Postgres
 
 ### Ejemplos ya aplicados
-| Coda | BSOP |
-|---|---|
-| DILESA `Personal` + `Alta Personal` + `Consulta Personal` + `Baja Personal` | `erp.empleados` + `EmpleadosModule` |
+
+| Coda                                                                         | BSOP                                                                 |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| DILESA `Personal` + `Alta Personal` + `Consulta Personal` + `Baja Personal`  | `erp.empleados` + `EmpleadosModule`                                  |
 | RDB `Cortes de Caja` + `*Cortes de Caja` + `Denominaciones` + `Corte Actual` | `erp.cortes_caja` + `movimientos_caja` + edge function `sync-cortes` |
-| DILESA `Captura Juntas` (×3) + `Tareas Creadas y Terminadas en Junta` | `erp.juntas` + `juntas_asistencia` + `juntas_notas` + `erp.tasks` |
+| DILESA `Captura Juntas` (×3) + `Tareas Creadas y Terminadas en Junta`        | `erp.juntas` + `juntas_asistencia` + `juntas_notas` + `erp.tasks`    |
 
 ---
 

--- a/docs/coda-migration/MIGRATION_PLAN.md
+++ b/docs/coda-migration/MIGRATION_PLAN.md
@@ -23,7 +23,9 @@
 Cada módulo sigue estas 6 fases. Cada una es una PR individual:
 
 ### Fase 1 — Deep audit del módulo
+
 **Output**: `docs/coda-migration/<doc>/<modulo>.md` con:
+
 - Tablas fuente (las que contienen datos reales)
 - Schema de columnas (tipos, relaciones)
 - Row count por tabla
@@ -35,7 +37,9 @@ Cada módulo sigue estas 6 fases. Cada una es una PR individual:
 **Duración**: 1 sesión. Sin código.
 
 ### Fase 2 — Schema design + ADR
+
 **Output**:
+
 - Migration SQL en `supabase/migrations/YYYYMMDDHHMMSS_<modulo>.sql`
 - ADR en `docs/adr/NNNN-<modulo>-schema.md`
 - RLS policies con helpers (`core.fn_has_empresa()`, `core.fn_is_admin()`)
@@ -44,7 +48,9 @@ Cada módulo sigue estas 6 fases. Cada una es una PR individual:
 **Si la tabla ya existe** en BSOP con estructura correcta: skip esta fase.
 
 ### Fase 3 — Sync unidireccional Coda → BSOP (bridge)
+
 **Output**: `supabase/functions/coda-sync-<modulo>/` — edge function que:
+
 - Se conecta a Coda API con `CODA_API_KEY`
 - Lee rows de la tabla fuente de Coda
 - Upserta en Supabase (idempotente, dedup por `coda_id`)
@@ -54,7 +60,9 @@ Cada módulo sigue estas 6 fases. Cada una es una PR individual:
 Durante esta fase, **Coda sigue siendo source-of-truth**. BSOP es **read-only**.
 
 ### Fase 4 — UI BSOP (read-only primero)
+
 **Output**: componente módulo siguiendo el patrón EmpleadosModule/TasksModule
+
 - `components/<area>/<modulo>-module.tsx` con scope=`'empresa'` | `'user-empresas'`
 - Pages por empresa bajo `app/<empresa>/<area>/<modulo>/page.tsx`
 - Navegación en `app-shell/nav-config.ts`
@@ -62,7 +70,9 @@ Durante esta fase, **Coda sigue siendo source-of-truth**. BSOP es **read-only**.
 **Criterio de aceptación**: usuarios pueden ver todos los datos migrados y validar que son correctos.
 
 ### Fase 5 — Write-path en BSOP + dual-write
+
 **Output**: mutations en BSOP que escriben a Supabase Y también push a Coda (durante transición)
+
 - Feature flag `COMPAT_CODA_WRITE_<modulo>=true` (default: true)
 - Cuando flag está activa: BSOP mutation → Supabase + POST a Coda API
 - Cuando flag está inactiva: solo Supabase
@@ -70,7 +80,9 @@ Durante esta fase, **Coda sigue siendo source-of-truth**. BSOP es **read-only**.
 Esto mantiene Coda "vivo" temporalmente para stakeholders que lo siguen consultando.
 
 ### Fase 6 — Cutover
+
 **Checklist por tabla**:
+
 1. [ ] Sync diff: `SELECT count(*) FROM bsop.X` == rows en Coda.X ± 0
 2. [ ] Stakeholders notificados (mínimo 72h aviso)
 3. [ ] Apagar cron Coda → BSOP (Fase 3)
@@ -88,44 +100,44 @@ Esto mantiene Coda "vivo" temporalmente para stakeholders que lo siguen consulta
 
 Ya tienen datos migrados y UI inicial. Pulir y cerrar gaps:
 
-| Módulo | Empresas | Gap |
-|---|---|---|
-| Empleados / Puestos / Departamentos | DILESA, RDB | Ya completo. Faltan compensaciones UI. |
-| Tasks + Juntas | DILESA, RDB | Ya completo. Faltan KPIs operativos. |
-| Cortes de Caja (RDB) | RDB | Ya completo. Falta conteo denominaciones UI. |
-| Requisiciones + OCs | RDB (+ DILESA futuro) | Ya completo. Falta flujo de recepciones. |
-| Productos + Inventario | RDB | Ya completo. Falta UI de ajustes manuales + reportes. |
+| Módulo                              | Empresas              | Gap                                                   |
+| ----------------------------------- | --------------------- | ----------------------------------------------------- |
+| Empleados / Puestos / Departamentos | DILESA, RDB           | Ya completo. Faltan compensaciones UI.                |
+| Tasks + Juntas                      | DILESA, RDB           | Ya completo. Faltan KPIs operativos.                  |
+| Cortes de Caja (RDB)                | RDB                   | Ya completo. Falta conteo denominaciones UI.          |
+| Requisiciones + OCs                 | RDB (+ DILESA futuro) | Ya completo. Falta flujo de recepciones.              |
+| Productos + Inventario              | RDB                   | Ya completo. Falta UI de ajustes manuales + reportes. |
 
 **Duración estimada**: 2-3 sprints paralelos de 1-2 agents c/u.
 
 ### Tier 2 — Módulos con estructura lista (tablas 0 rows)
 
-| Módulo | Empresa | Priority | Razón |
-|---|---|---|---|
-| **Citas (ANSA)** | ANSA | alta | Usado a diario en servicio + ventas |
-| **Cuentas + Movimientos bancarios** | DILESA, ANSA, SR | alta | Control financiero, reglas duras CLAUDE.md |
-| **Gastos** | DILESA, ANSA, SR, RDB | alta | Control financiero |
-| **Facturas + Pagos provisionales** | SR Group | media | Fiscal, time-sensitive |
-| **Clientes** | DILESA, ANSA | media | Prerequisito para ventas |
-| **Recepciones de OC** | RDB, DILESA | media | Cierra el ciclo de compras |
-| **Activos + Mantenimiento** | ANSA, SR Group | media | Resguardos automotriz |
-| **Turnos** | RDB | baja | Se puede hardcodear por ahora |
-| **Aprobaciones** | Cross-empresa | baja | Hasta que haya workflow que lo requiera |
-| **Conteo denominaciones** | RDB | baja | Feature nueva, no urgente |
+| Módulo                              | Empresa               | Priority | Razón                                      |
+| ----------------------------------- | --------------------- | -------- | ------------------------------------------ |
+| **Citas (ANSA)**                    | ANSA                  | alta     | Usado a diario en servicio + ventas        |
+| **Cuentas + Movimientos bancarios** | DILESA, ANSA, SR      | alta     | Control financiero, reglas duras CLAUDE.md |
+| **Gastos**                          | DILESA, ANSA, SR, RDB | alta     | Control financiero                         |
+| **Facturas + Pagos provisionales**  | SR Group              | media    | Fiscal, time-sensitive                     |
+| **Clientes**                        | DILESA, ANSA          | media    | Prerequisito para ventas                   |
+| **Recepciones de OC**               | RDB, DILESA           | media    | Cierra el ciclo de compras                 |
+| **Activos + Mantenimiento**         | ANSA, SR Group        | media    | Resguardos automotriz                      |
+| **Turnos**                          | RDB                   | baja     | Se puede hardcodear por ahora              |
+| **Aprobaciones**                    | Cross-empresa         | baja     | Hasta que haya workflow que lo requiera    |
+| **Conteo denominaciones**           | RDB                   | baja     | Feature nueva, no urgente                  |
 
 ### Tier 3 — Módulos complejos (schema nuevo, data grande)
 
-| Módulo | Doc origen | Complejidad | Notas |
-|---|---|---|---|
-| **DILESA Inmobiliario** (proyectos, lotes, ventas, contratos, cobranza) | DILESA Proyectos + Ventas | alta | Schema ya existe, falta UI + migración |
-| **DILESA Urbanización** (19 sub-módulos civil) | DILESA Urbanización | MUY alta | Repensar: agruparlo como "avances de obra por partida" más que 19 tablas |
-| **DILESA RUV** (DTUs, INFONAVIT) | DILESA Proyectos/RUV | alta | Dependencia externa (RUV portal), posible scraping |
-| **DILESA Maquinaria** (equipos, acarreos, combustible, horas) | DILESA Maquinaria | media | Buen candidato para re-modelar con "recurso + asignación + uso" |
-| **DILESA Construcción** (contratos, contratistas, supervisión, prototipos) | DILESA Construcción | media | Overlap con Proveedores |
-| **DILESA Presupuestos** | DILESA Presupuestos | media | Partidas + Gastos — ya hay tabla gastos |
-| **ANSA Automotriz** (vehículos, ventas autos, taller, refacciones) | ANSA + ANSA Ventas | alta | Schema ya existe, falta UI; refacciones tiene overlap con Inventario |
-| **ANSA Competencias + KPIs** | ANSA RH | baja | Nice-to-have, extiende RH |
-| **SR Group Fiscal completo** (declaraciones, budget, flujo, estado de resultados) | SR Group | alta | Muchas tablas relacionadas, oportunidad de unificar |
+| Módulo                                                                            | Doc origen                | Complejidad | Notas                                                                    |
+| --------------------------------------------------------------------------------- | ------------------------- | ----------- | ------------------------------------------------------------------------ |
+| **DILESA Inmobiliario** (proyectos, lotes, ventas, contratos, cobranza)           | DILESA Proyectos + Ventas | alta        | Schema ya existe, falta UI + migración                                   |
+| **DILESA Urbanización** (19 sub-módulos civil)                                    | DILESA Urbanización       | MUY alta    | Repensar: agruparlo como "avances de obra por partida" más que 19 tablas |
+| **DILESA RUV** (DTUs, INFONAVIT)                                                  | DILESA Proyectos/RUV      | alta        | Dependencia externa (RUV portal), posible scraping                       |
+| **DILESA Maquinaria** (equipos, acarreos, combustible, horas)                     | DILESA Maquinaria         | media       | Buen candidato para re-modelar con "recurso + asignación + uso"          |
+| **DILESA Construcción** (contratos, contratistas, supervisión, prototipos)        | DILESA Construcción       | media       | Overlap con Proveedores                                                  |
+| **DILESA Presupuestos**                                                           | DILESA Presupuestos       | media       | Partidas + Gastos — ya hay tabla gastos                                  |
+| **ANSA Automotriz** (vehículos, ventas autos, taller, refacciones)                | ANSA + ANSA Ventas        | alta        | Schema ya existe, falta UI; refacciones tiene overlap con Inventario     |
+| **ANSA Competencias + KPIs**                                                      | ANSA RH                   | baja        | Nice-to-have, extiende RH                                                |
+| **SR Group Fiscal completo** (declaraciones, budget, flujo, estado de resultados) | SR Group                  | alta        | Muchas tablas relacionadas, oportunidad de unificar                      |
 
 ### Tier 4 — Data personal SR
 
@@ -138,6 +150,7 @@ El doc SR Group tiene info personal/familiar (recibos Casa SR, budget 50/30/20).
 Considerando: torneo activo esta semana, 1 operador activo (Beto + Claude), necesidad de no romper producción, ciclos de ~1-2 semanas por módulo grande.
 
 ### Abril-Mayo 2026 (4 semanas)
+
 - ✅ Frente 1.1: bulk lint + format (en progreso)
 - **Semana 1**: Frente 2 Sprint A (RDB operativos: playtomic, cortes, ventas) + INVENTORY.md de módulos Tier 2
 - **Semana 2**: Postgres upgrade (madrugada) + Tier 2: Citas ANSA (Fases 1-3)
@@ -145,16 +158,19 @@ Considerando: torneo activo esta semana, 1 operador activo (Beto + Claude), nece
 - **Semana 4**: Cuentas bancarias (Fases 3-6) + Frente 2 Sprint B (juntas × 3 → JuntasModule)
 
 ### Junio 2026 (4 semanas)
+
 - Gastos cross-empresa (Fases 1-6)
 - Tier 2: Clientes + Recepciones
 - Frente 2 Sprints C y D (documentos × 3, acceso-client)
 
 ### Julio-Agosto 2026
+
 - Tier 3: DILESA Inmobiliario (empezando por Proyectos + Lotes)
 - SR Group Fiscal (declaraciones + pagos provisionales)
 - ANSA Automotriz (empezando por vehículos + ventas)
 
 ### Septiembre+
+
 - DILESA Urbanización (rediseñado, no 1-a-1)
 - DILESA RUV
 - ANSA Competencias/KPIs
@@ -181,21 +197,27 @@ Considerando: torneo activo esta semana, 1 operador activo (Beto + Claude), nece
 Estos se construyen **una sola vez** y los usan todos los módulos:
 
 ### `scripts/coda-diff.ts`
+
 CLI: `npx tsx scripts/coda-diff.ts <doc> <tabla-coda> <tabla-supabase>` → reporta row count diff + sample de diferencias.
 
 ### `lib/coda-client.ts`
+
 Wrapper tipado del REST API de Coda con retry + rate-limit handling.
 
 ### `supabase/functions/coda-sync-*`
+
 Template reusable: recibe `{ docId, tableId, targetSchema, targetTable, mapping }` y hace el upsert. Fases 3/5.
 
 ### Vista `/settings/coda-migration` (dashboard)
+
 - Lista de módulos con status (tier, fase actual, last sync, row diff)
 - Health alerts si un sync falla
 - Log de cutovers
 
 ### `core.audit_log` (ya existe, 0 rows)
+
 Activar escritura en todas las migraciones Tier 2+. Schema:
+
 ```
 (id, empresa_id, user_id, table_name, record_id, action, old_values, new_values, ip, user_agent, created_at)
 ```
@@ -204,14 +226,14 @@ Activar escritura en todas las migraciones Tier 2+. Schema:
 
 ## Riesgos conocidos
 
-| Riesgo | Mitigación |
-|---|---|
-| Datos inconsistentes en Coda (Tablas "god" con 175+ columnas) | Deep audit (Fase 1) identifica campos clave vs basura; migrar solo lo útil |
-| Flujos manuales que dependen de automations de Coda | Documentar en Fase 1; reimplementar como cron + edge function |
-| Stakeholders que resisten el cambio | Dual-write (Fase 5) mantiene Coda funcional hasta confianza total |
-| Migrations grandes (e.g., 10k+ rows) pueden tumbar Supabase | Migrar en batches de 500 con pauses; correr en horarios de bajo tráfico |
-| Coda API rate limit (100 req/min default) | Retry con backoff; correr sync en off-peak |
-| Pérdida de fórmulas/KPIs | Deep audit las enumera; decidir caso por caso si se traducen o se redistribuyen |
+| Riesgo                                                        | Mitigación                                                                      |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Datos inconsistentes en Coda (Tablas "god" con 175+ columnas) | Deep audit (Fase 1) identifica campos clave vs basura; migrar solo lo útil      |
+| Flujos manuales que dependen de automations de Coda           | Documentar en Fase 1; reimplementar como cron + edge function                   |
+| Stakeholders que resisten el cambio                           | Dual-write (Fase 5) mantiene Coda funcional hasta confianza total               |
+| Migrations grandes (e.g., 10k+ rows) pueden tumbar Supabase   | Migrar en batches de 500 con pauses; correr en horarios de bajo tráfico         |
+| Coda API rate limit (100 req/min default)                     | Retry con backoff; correr sync en off-peak                                      |
+| Pérdida de fórmulas/KPIs                                      | Deep audit las enumera; decidir caso por caso si se traducen o se redistribuyen |
 
 ---
 

--- a/docs/coda-migration/MODULE_MAP.md
+++ b/docs/coda-migration/MODULE_MAP.md
@@ -21,42 +21,42 @@
 
 ## 1. Ranking por volumen de data real (top 30 tablas con >500 rows)
 
-| Rows | Doc | Tabla fuente | Estado BSOP |
-|---:|---|---|---|
-| **18,644** | DILESA | Tareas Construcción Terminadas | ❌ (relacionada a `erp.tasks` pero es historial de construcción) |
-| **8,372** | DILESA | Cargas Combustible | ❌ |
-| **6,968** | DILESA | Horas Máquina | ❌ |
-| **4,921** | DILESA | Acarreos | ❌ |
-| **4,749** | ANSA | Citas | ⚠️ `erp.citas` (0 rows) |
-| **4,539** | ANSA | Citas del Día Servicio | same |
-| **3,496** | SR Group | Gastos | ⚠️ `erp.gastos` |
-| **2,995** | RDB | Detalle Conteo | ❌ (audits físicos inventario) |
-| **2,953** | RDB | Productos del Pedido | ✅ `rdb.waitry_productos` (15,214) |
-| **2,610** | SR Group | Movimientos AMEX | ⚠️ `erp.movimientos_bancarios` |
-| **2,421** | SR Group | Movimientos Banamex | same |
-| **2,115** | DILESA | Lotes | ⚠️ `erp.lotes` |
-| **1,929** | ANSA-Ventas | Cliente | ⚠️ `erp.clientes` |
-| **1,748** | DILESA | Plantilla Tareas Construcción | ❌ |
-| **1,706** | ANSA-Ventas | Facturas Compra Unidades | ⚠️ `erp.vehiculos` + `erp.facturas` |
-| **1,611** | RDB | Pedidos Waitry | ✅ `rdb.waitry_pedidos` (10,746) |
-| **1,590** | DILESA | Inventario (inmobiliario) | ⚠️ `erp.lotes` |
-| **1,541** | ANSA-Ventas | Facturas Venta Unidades | ⚠️ `erp.ventas_autos` + `erp.facturas` |
-| **1,523** | SR Group | Movimientos IBC | ⚠️ `erp.movimientos_bancarios` |
-| **1,462** | ANSA-Ventas | Avanzadas (ventas planificadas) | ⚠️ `erp.ventas_autos` |
-| **1,449** | RDB | Pagos Waitry | ✅ `rdb.waitry_pagos` |
-| **1,443** | ANSA-Ventas | Programación de Entrega | ⚠️ `erp.ventas_autos` |
-| **1,411** | DILESA | Clientes DILESA | ⚠️ `erp.clientes` |
-| **1,372** | DILESA | Construcción por Lote | ❌ |
-| **1,249** | DILESA | Tareas | ✅ `erp.tasks` (1,253) — **match casi perfecto** |
-| **1,240** | DILESA | Urbanización por Lote | ❌ |
-| **1,132** | DILESA | CUV (RUV) | ❌ |
-| **1,079** | DILESA | Escrituración Total | ⚠️ `erp.documentos` (60) — parcial |
-| **1,060** | DILESA | Depósitos Clientes | ❌ (pagos inmobiliarios) |
-| **918** | RDB | Entradas inventario | ✅ `erp.movimientos_inventario` (14,895) |
-| **796** | SR Group | Registros Pendientes Banamex | ⚠️ `erp.conciliaciones` |
-| **719** | DILESA | Juntas | ✅ `erp.juntas` (720) — **match perfecto** |
-| **698** | RDB | Detalle Requisición | ✅ |
-| **517** | SR Group | Facturas | ⚠️ `erp.facturas` |
+|       Rows | Doc         | Tabla fuente                    | Estado BSOP                                                      |
+| ---------: | ----------- | ------------------------------- | ---------------------------------------------------------------- |
+| **18,644** | DILESA      | Tareas Construcción Terminadas  | ❌ (relacionada a `erp.tasks` pero es historial de construcción) |
+|  **8,372** | DILESA      | Cargas Combustible              | ❌                                                               |
+|  **6,968** | DILESA      | Horas Máquina                   | ❌                                                               |
+|  **4,921** | DILESA      | Acarreos                        | ❌                                                               |
+|  **4,749** | ANSA        | Citas                           | ⚠️ `erp.citas` (0 rows)                                          |
+|  **4,539** | ANSA        | Citas del Día Servicio          | same                                                             |
+|  **3,496** | SR Group    | Gastos                          | ⚠️ `erp.gastos`                                                  |
+|  **2,995** | RDB         | Detalle Conteo                  | ❌ (audits físicos inventario)                                   |
+|  **2,953** | RDB         | Productos del Pedido            | ✅ `rdb.waitry_productos` (15,214)                               |
+|  **2,610** | SR Group    | Movimientos AMEX                | ⚠️ `erp.movimientos_bancarios`                                   |
+|  **2,421** | SR Group    | Movimientos Banamex             | same                                                             |
+|  **2,115** | DILESA      | Lotes                           | ⚠️ `erp.lotes`                                                   |
+|  **1,929** | ANSA-Ventas | Cliente                         | ⚠️ `erp.clientes`                                                |
+|  **1,748** | DILESA      | Plantilla Tareas Construcción   | ❌                                                               |
+|  **1,706** | ANSA-Ventas | Facturas Compra Unidades        | ⚠️ `erp.vehiculos` + `erp.facturas`                              |
+|  **1,611** | RDB         | Pedidos Waitry                  | ✅ `rdb.waitry_pedidos` (10,746)                                 |
+|  **1,590** | DILESA      | Inventario (inmobiliario)       | ⚠️ `erp.lotes`                                                   |
+|  **1,541** | ANSA-Ventas | Facturas Venta Unidades         | ⚠️ `erp.ventas_autos` + `erp.facturas`                           |
+|  **1,523** | SR Group    | Movimientos IBC                 | ⚠️ `erp.movimientos_bancarios`                                   |
+|  **1,462** | ANSA-Ventas | Avanzadas (ventas planificadas) | ⚠️ `erp.ventas_autos`                                            |
+|  **1,449** | RDB         | Pagos Waitry                    | ✅ `rdb.waitry_pagos`                                            |
+|  **1,443** | ANSA-Ventas | Programación de Entrega         | ⚠️ `erp.ventas_autos`                                            |
+|  **1,411** | DILESA      | Clientes DILESA                 | ⚠️ `erp.clientes`                                                |
+|  **1,372** | DILESA      | Construcción por Lote           | ❌                                                               |
+|  **1,249** | DILESA      | Tareas                          | ✅ `erp.tasks` (1,253) — **match casi perfecto**                 |
+|  **1,240** | DILESA      | Urbanización por Lote           | ❌                                                               |
+|  **1,132** | DILESA      | CUV (RUV)                       | ❌                                                               |
+|  **1,079** | DILESA      | Escrituración Total             | ⚠️ `erp.documentos` (60) — parcial                               |
+|  **1,060** | DILESA      | Depósitos Clientes              | ❌ (pagos inmobiliarios)                                         |
+|    **918** | RDB         | Entradas inventario             | ✅ `erp.movimientos_inventario` (14,895)                         |
+|    **796** | SR Group    | Registros Pendientes Banamex    | ⚠️ `erp.conciliaciones`                                          |
+|    **719** | DILESA      | Juntas                          | ✅ `erp.juntas` (720) — **match perfecto**                       |
+|    **698** | RDB         | Detalle Requisición             | ✅                                                               |
+|    **517** | SR Group    | Facturas                        | ⚠️ `erp.facturas`                                                |
 
 ---
 
@@ -64,21 +64,21 @@
 
 ### ✅ Ya en BSOP con datos (RDB prácticamente completo)
 
-| Módulo BSOP | Origen Coda | Rows BSOP | Estado |
-|---|---|---:|---|
-| Empleados/Puestos/Depts | DILESA + RDB | 212/53/8 | ✅ funcional |
-| Tasks | DILESA + RDB | 1,253 | ✅ funcional, pegado a Coda DILESA (1,249) |
-| Juntas | DILESA | 720 | ✅ pegado a Coda DILESA (719) |
-| Cortes de caja | RDB | 433 | ✅ funcional |
-| Movimientos caja | RDB | 409 | ✅ funcional |
-| Productos | RDB | 310 | ✅ funcional |
-| Inventario + movimientos | RDB | 283 + 14,895 | ✅ funcional |
-| Requisiciones | RDB | 188 | ✅ funcional |
-| OCs | RDB | 160 | ✅ funcional |
-| Proveedores | RDB + DILESA | 48 | ✅ funcional |
-| Documentos (escrituras) | DILESA parcial | 60 | ⚠️ falta 1,019 de Escrituración Total |
-| Waitry POS | RDB | 10,746 pedidos | ✅ funcional (cron sync) |
-| Playtomic | RDB | 1,442 bookings | ✅ funcional (cron sync) |
+| Módulo BSOP              | Origen Coda    |      Rows BSOP | Estado                                     |
+| ------------------------ | -------------- | -------------: | ------------------------------------------ |
+| Empleados/Puestos/Depts  | DILESA + RDB   |       212/53/8 | ✅ funcional                               |
+| Tasks                    | DILESA + RDB   |          1,253 | ✅ funcional, pegado a Coda DILESA (1,249) |
+| Juntas                   | DILESA         |            720 | ✅ pegado a Coda DILESA (719)              |
+| Cortes de caja           | RDB            |            433 | ✅ funcional                               |
+| Movimientos caja         | RDB            |            409 | ✅ funcional                               |
+| Productos                | RDB            |            310 | ✅ funcional                               |
+| Inventario + movimientos | RDB            |   283 + 14,895 | ✅ funcional                               |
+| Requisiciones            | RDB            |            188 | ✅ funcional                               |
+| OCs                      | RDB            |            160 | ✅ funcional                               |
+| Proveedores              | RDB + DILESA   |             48 | ✅ funcional                               |
+| Documentos (escrituras)  | DILESA parcial |             60 | ⚠️ falta 1,019 de Escrituración Total      |
+| Waitry POS               | RDB            | 10,746 pedidos | ✅ funcional (cron sync)                   |
+| Playtomic                | RDB            | 1,442 bookings | ✅ funcional (cron sync)                   |
 
 **Insight**: RDB está **casi 100% migrado**. Solo faltan: Carga Física / Cierres (audits 247+235 rows) y el reporte de conteo (2,995 rows que son detail de carga física).
 
@@ -86,45 +86,45 @@
 
 Ordenado por **uso real en Coda** + **leverage cross-empresa**:
 
-| Módulo | Empresas que lo usan | Rows Coda | Prioridad | Razón |
-|---|---|---:|---|---|
-| **Gastos** 🔁 | SR + DILESA + ANSA + RDB | 3,496 (SR) + desglose 81 | **alta** | 4 empresas, volumen alto, control financiero |
-| **Movimientos bancarios** 🔁 | SR (AMEX+Banamex+IBC) + ANSA (BBVA) + DILESA | 6,554 SR + 569 ANSA + ? DILESA | **alta** | Cross-empresa, volumen altísimo |
-| **Cuentas bancarias** 🔁 | Base de Movimientos bancarios | ~10 cuentas | **alta** | Prerequisito para movimientos |
-| **Citas** | ANSA (servicio + ventas) + DILESA (visitas obra futuro) | 4,749 + 4,539 + 150 | **alta** | ANSA lo usa A DIARIO |
-| **Facturas** 🔁 | SR (fiscal) + ANSA (compra/venta autos) + DILESA futuro | 517 SR + 1,706 compra + 1,541 venta | **alta** | Fiscal + operativo |
-| **Clientes** 🔁 | DILESA + ANSA Ventas | 1,411 + 1,929 | **alta** | Prerequisito para ventas inmobiliaria y autos |
-| **Conciliaciones bancarias** 🔁 | SR (Registros Pendientes) | 796+331+193+85 = 1,405 | media | Depende de Movimientos |
-| **Pagos provisionales** | SR (fiscal ISR) | 219 | media | Time-sensitive |
-| **Recepciones de OC** 🔁 | RDB + DILESA + ANSA futuro | ~cantidad de OCs | media | Cierra ciclo de compras |
-| **Lotes (inmobiliario)** | DILESA | 2,115 | media | Grande pero DILESA-exclusivo |
-| **Proyectos** | DILESA | ~50 proyectos | media | Prerequisito para Lotes/Ventas |
-| **Ventas inmobiliarias** | DILESA | ~1,000 (deducido) | media | Depende de Lotes + Clientes |
-| **Ventas autos** | ANSA Ventas | 1,541 venta + 1,462 avanzadas | media | ANSA-exclusivo |
-| **Vehículos (inventario autos)** | ANSA Ventas | 1,706 VINs | media | ANSA-exclusivo |
-| **Turnos** 🔁 | RDB + ANSA + DILESA | catálogo | baja | Se puede hardcodear |
-| **Activos** 🔁 | ANSA (resguardos) + SR | varios | baja | Nice-to-have |
-| **Conteo denominaciones** | RDB | 0 en Coda | baja | Feature nueva |
+| Módulo                           | Empresas que lo usan                                    |                           Rows Coda | Prioridad | Razón                                         |
+| -------------------------------- | ------------------------------------------------------- | ----------------------------------: | --------- | --------------------------------------------- |
+| **Gastos** 🔁                    | SR + DILESA + ANSA + RDB                                |            3,496 (SR) + desglose 81 | **alta**  | 4 empresas, volumen alto, control financiero  |
+| **Movimientos bancarios** 🔁     | SR (AMEX+Banamex+IBC) + ANSA (BBVA) + DILESA            |      6,554 SR + 569 ANSA + ? DILESA | **alta**  | Cross-empresa, volumen altísimo               |
+| **Cuentas bancarias** 🔁         | Base de Movimientos bancarios                           |                         ~10 cuentas | **alta**  | Prerequisito para movimientos                 |
+| **Citas**                        | ANSA (servicio + ventas) + DILESA (visitas obra futuro) |                 4,749 + 4,539 + 150 | **alta**  | ANSA lo usa A DIARIO                          |
+| **Facturas** 🔁                  | SR (fiscal) + ANSA (compra/venta autos) + DILESA futuro | 517 SR + 1,706 compra + 1,541 venta | **alta**  | Fiscal + operativo                            |
+| **Clientes** 🔁                  | DILESA + ANSA Ventas                                    |                       1,411 + 1,929 | **alta**  | Prerequisito para ventas inmobiliaria y autos |
+| **Conciliaciones bancarias** 🔁  | SR (Registros Pendientes)                               |              796+331+193+85 = 1,405 | media     | Depende de Movimientos                        |
+| **Pagos provisionales**          | SR (fiscal ISR)                                         |                                 219 | media     | Time-sensitive                                |
+| **Recepciones de OC** 🔁         | RDB + DILESA + ANSA futuro                              |                    ~cantidad de OCs | media     | Cierra ciclo de compras                       |
+| **Lotes (inmobiliario)**         | DILESA                                                  |                               2,115 | media     | Grande pero DILESA-exclusivo                  |
+| **Proyectos**                    | DILESA                                                  |                       ~50 proyectos | media     | Prerequisito para Lotes/Ventas                |
+| **Ventas inmobiliarias**         | DILESA                                                  |                   ~1,000 (deducido) | media     | Depende de Lotes + Clientes                   |
+| **Ventas autos**                 | ANSA Ventas                                             |       1,541 venta + 1,462 avanzadas | media     | ANSA-exclusivo                                |
+| **Vehículos (inventario autos)** | ANSA Ventas                                             |                          1,706 VINs | media     | ANSA-exclusivo                                |
+| **Turnos** 🔁                    | RDB + ANSA + DILESA                                     |                            catálogo | baja      | Se puede hardcodear                           |
+| **Activos** 🔁                   | ANSA (resguardos) + SR                                  |                              varios | baja      | Nice-to-have                                  |
+| **Conteo denominaciones**        | RDB                                                     |                           0 en Coda | baja      | Feature nueva                                 |
 
 ### ❌ Schema NO existe en BSOP — diseñar nuevo
 
-| Módulo Coda | Empresas | Rows Coda | Vale la pena? | Comentario |
-|---|---|---:|---|---|
-| **Cargas Combustible** | DILESA Maquinaria | 8,372 | sí | Alto uso. Reddiseñable como "movimientos de activo" |
-| **Horas Máquina** | DILESA Maquinaria | 6,968 | sí | Alto uso. Same pattern |
-| **Acarreos** | DILESA Maquinaria | 4,921 | sí | Alto uso. Same pattern |
-| **Tareas Construcción Terminadas** | DILESA | 18,644 | sí | Historia de construcción; tal vez fundir con `erp.tasks` |
-| **Plantilla Tareas Construcción** | DILESA | 1,748 | sí | Templates; podría ser `erp.task_templates` |
-| **Construcción por Lote** | DILESA | 1,372 | sí | Avance de obra |
-| **Urbanización por Lote** | DILESA | 1,240 | sí | Avance urbanización |
-| **Depósitos Clientes** | DILESA | 1,060 | sí | Pagos inmobiliarios (ligado a cobranza) |
-| **CUV** (RUV) | DILESA | 1,132 | sí | Clave Única de Vivienda |
-| **Documentos RUV** | DILESA | 169 | sí | INFONAVIT trámites |
-| **Urgencias RUV** | DILESA | 256 | sí | same |
-| **Sueldos y Salarios** | SR Group | 162 | sí | Fiscal personal |
-| **Tablas ISR** | SR Group | 989 | **NO** | Catálogo SAT, reference data — usar servicio externo |
-| **Activos financieros SR** | SR Group | <50 | baja | Inversiones personales |
-| **Urbanización** (19 sub-módulos) | DILESA | cada uno bajo 1k | **NO replicar** | Rediseñar como "avances por partida" |
+| Módulo Coda                        | Empresas          |        Rows Coda | Vale la pena?   | Comentario                                               |
+| ---------------------------------- | ----------------- | ---------------: | --------------- | -------------------------------------------------------- |
+| **Cargas Combustible**             | DILESA Maquinaria |            8,372 | sí              | Alto uso. Reddiseñable como "movimientos de activo"      |
+| **Horas Máquina**                  | DILESA Maquinaria |            6,968 | sí              | Alto uso. Same pattern                                   |
+| **Acarreos**                       | DILESA Maquinaria |            4,921 | sí              | Alto uso. Same pattern                                   |
+| **Tareas Construcción Terminadas** | DILESA            |           18,644 | sí              | Historia de construcción; tal vez fundir con `erp.tasks` |
+| **Plantilla Tareas Construcción**  | DILESA            |            1,748 | sí              | Templates; podría ser `erp.task_templates`               |
+| **Construcción por Lote**          | DILESA            |            1,372 | sí              | Avance de obra                                           |
+| **Urbanización por Lote**          | DILESA            |            1,240 | sí              | Avance urbanización                                      |
+| **Depósitos Clientes**             | DILESA            |            1,060 | sí              | Pagos inmobiliarios (ligado a cobranza)                  |
+| **CUV** (RUV)                      | DILESA            |            1,132 | sí              | Clave Única de Vivienda                                  |
+| **Documentos RUV**                 | DILESA            |              169 | sí              | INFONAVIT trámites                                       |
+| **Urgencias RUV**                  | DILESA            |              256 | sí              | same                                                     |
+| **Sueldos y Salarios**             | SR Group          |              162 | sí              | Fiscal personal                                          |
+| **Tablas ISR**                     | SR Group          |              989 | **NO**          | Catálogo SAT, reference data — usar servicio externo     |
+| **Activos financieros SR**         | SR Group          |              <50 | baja            | Inversiones personales                                   |
+| **Urbanización** (19 sub-módulos)  | DILESA            | cada uno bajo 1k | **NO replicar** | Rediseñar como "avances por partida"                     |
 
 ### ∅ Views/formularios muertos — NO migrar
 
@@ -232,21 +232,21 @@ Completar el ciclo de venta DILESA.
 
 Esto es donde **ganamos leverage real**. Un solo módulo BSOP sirve a múltiples empresas:
 
-| Módulo | Empresas servidas | Leverage |
-|---|---|---:|
-| Gastos | 4 (DILESA, ANSA, SR, RDB) | 4x |
-| Facturas | 3+ (SR fiscal, ANSA autos, DILESA futuro) | 3x |
-| Movimientos bancarios | 4 | 4x |
-| Conciliaciones | 4 | 4x |
-| Cuentas bancarias | 4 | 4x |
-| Clientes | 3 (DILESA, ANSA, RDB futuro) | 3x |
-| Citas | 2+ (ANSA, DILESA futuro) | 2x |
-| Empleados/RH | 4 (todas) | 4x — ya hecho ✅ |
-| Tasks | 4 (todas) | 4x — ya hecho ✅ |
-| Juntas | 4 (todas) | 4x — ya hecho ✅ |
-| Proveedores | 3 (DILESA, RDB, ANSA futuro) | 3x — ya hecho ✅ |
-| Documentos | 4 (todas — escrituras, contratos, facturas, recibos) | 4x — ya hecho ✅ |
-| Activos | 3 (ANSA, SR, DILESA maquinaria) | 3x |
+| Módulo                | Empresas servidas                                    |         Leverage |
+| --------------------- | ---------------------------------------------------- | ---------------: |
+| Gastos                | 4 (DILESA, ANSA, SR, RDB)                            |               4x |
+| Facturas              | 3+ (SR fiscal, ANSA autos, DILESA futuro)            |               3x |
+| Movimientos bancarios | 4                                                    |               4x |
+| Conciliaciones        | 4                                                    |               4x |
+| Cuentas bancarias     | 4                                                    |               4x |
+| Clientes              | 3 (DILESA, ANSA, RDB futuro)                         |               3x |
+| Citas                 | 2+ (ANSA, DILESA futuro)                             |               2x |
+| Empleados/RH          | 4 (todas)                                            | 4x — ya hecho ✅ |
+| Tasks                 | 4 (todas)                                            | 4x — ya hecho ✅ |
+| Juntas                | 4 (todas)                                            | 4x — ya hecho ✅ |
+| Proveedores           | 3 (DILESA, RDB, ANSA futuro)                         | 3x — ya hecho ✅ |
+| Documentos            | 4 (todas — escrituras, contratos, facturas, recibos) | 4x — ya hecho ✅ |
+| Activos               | 3 (ANSA, SR, DILESA maquinaria)                      |               3x |
 
 **Insight**: los siguientes 5-6 módulos que salgan (Gastos, Bancos, Citas, Facturas, Clientes, Conciliaciones) resuelven **muchísimo** para las 4 empresas de un solo golpe.
 
@@ -265,6 +265,7 @@ ANSA-Ventas es el doc más grande en densidad de uso (8k+ rows activos). Complej
 Los 19 sub-módulos de urbanización (excavación sanitaria, línea agua, pozo visita, transformador, carpeta asfáltica, etc.) son el "god module" de DILESA. No tiene sentido crear 19 tablas en BSOP.
 
 **Propuesta de rediseño** (para cuando toquemos esto):
+
 ```
 erp.obra_partidas (id, nombre, categoria, unidad, costo_estandar)
 erp.obra_avances (id, lote_id, partida_id, fecha, cantidad, costo_real, responsable, evidencia_url)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,8 +9,14 @@ const nextTypeScript = require('eslint-config-next/typescript');
 const eslintConfig = [
   {
     ignores: [
-      '.next/**',
+      // Build output (including nested inside git worktrees at .claude/worktrees/*/.next/).
+      '**/.next/**',
       'node_modules/**',
+      // Git worktrees created by agents — never lint checked-out copies of the repo.
+      '.claude/worktrees/**',
+      // Untracked ad-hoc scratch folder. Already .gitignore'd; mirror here so
+      // local lint matches CI.
+      'tmp/**',
       'docs/archive/**',
       'coverage/**',
       'playwright-report/**',
@@ -20,8 +26,14 @@ const eslintConfig = [
       // One-off historical migration scripts — kept for reference only, not
       // part of the active codebase. Per CONTRIBUTING.md they are not touched.
       'scripts/archive/**',
+      // Additional one-off migration / rescue scripts kept outside archive/
+      // for historical reference; untracked in git, mirrored here for parity.
+      'scripts/migrate_*.ts',
+      'scripts/rescue_*.ts',
+      'scripts/fix_*.mjs',
       // One-off backfill scripts run ad-hoc from node; use CommonJS require().
       'scripts/backfill_coda_*.js',
+      'scripts/backfill_manual_*.js',
     ],
   },
   ...nextCoreWebVitals,


### PR DESCRIPTION
## Summary

Tightens \`eslint.config.mjs\` and \`.prettierignore\` so local runs match CI.

## Problem

After merging PRs #66/#67/#68 (Sprint A refactors), local \`npm run lint\` reported 1,560 errors and \`npm run format:check\` 181 warnings — all from files that CI never sees:

1. **Nested worktree build output**: \`.claude/worktrees/objective-goodall-c9abc3/.next/dev/**\` — the \`.next/**\` pattern in eslint config only matched top-level. Needs \`**/.next/**\` + explicit \`.claude/worktrees/**\`.
2. **Untracked legacy scripts**: \`scripts/migrate_dilesa_*.ts\`, \`scripts/rescue_*.ts\`, etc. — these live in the main repo filesystem but are .gitignored / never tracked. CI does \`npm ci\` from scratch so never sees them; local has them.
3. **docs/coda-migration/*.md**: landed via PR #65 (docs-only) without going through lint-staged, so picked up minor markdown whitespace that prettier catches.

## Fix

- \`eslint.config.mjs\`: add \`.claude/worktrees/**\`, \`**/.next/**\`, \`tmp/**\`, \`scripts/migrate_*.ts\`, \`scripts/rescue_*.ts\`, \`scripts/fix_*.mjs\`, \`scripts/backfill_manual_*.js\` to ignores.
- \`.prettierignore\`: mirror the same ignores.
- Re-format 3 markdown files via \`prettier --write\`.

## Verification

All clean post-fix:
- \`npm run typecheck\` — clean
- \`npm run lint\` — 0 errors (65 pre-existing warnings, all non-blocking \`<img>\` + tsbuildinfo)
- \`npm run format:check\` — clean
- \`npm run test:run\` — 156/156 passing

## Test plan

- [ ] Confirm CI passes green on this PR
- [ ] Confirm future PRs don't re-trigger the worktree ignore issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)