### PR TITLE
fix(juntas): apply signed-URL rewriter to inicio and rdb juntas pages

### DIFF
--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -9,6 +9,7 @@ import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { normalizeHtmlImagesToPaths, rewriteHtmlImagesToSigned } from '@/lib/adjuntos';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
@@ -454,18 +455,25 @@ function JuntaDetailInner() {
     void fetchAll();
   }, [fetchAll]);
 
-  // Sync editor content once junta loads (editor might not be ready on first render)
+  // Sync editor content once junta loads (editor might not be ready on first render).
+  // Rewrite any stored <img src> (bare path or legacy public URL) to a signed URL
+  // so the private `adjuntos` bucket renders correctly.
   useEffect(() => {
     if (editor && junta?.descripcion && editor.isEmpty) {
-      editor.commands.setContent(junta.descripcion);
+      void (async () => {
+        const hydrated = await rewriteHtmlImagesToSigned(supabase, junta.descripcion, 6 * 3600);
+        editor.commands.setContent(hydrated);
+      })();
     }
-  }, [editor, junta]);
+  }, [editor, junta, supabase]);
 
   const handleSave = async () => {
     if (!junta) return;
     setSaving(true);
 
-    const notesHtml = editor?.getHTML() ?? null;
+    // Normalize signed URLs back to bare paths so the DB never holds a
+    // soon-to-expire URL — getAdjuntoPath handles legacy rows too.
+    const notesHtml = normalizeHtmlImagesToPaths(editor?.getHTML() ?? null) || null;
 
     const { error: err } = await supabase
       .schema('erp')

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -9,6 +9,7 @@ import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { normalizeHtmlImagesToPaths, rewriteHtmlImagesToSigned } from '@/lib/adjuntos';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
@@ -436,17 +437,24 @@ function JuntaDetailInner() {
     void fetchAll();
   }, [fetchAll]);
 
+  // Rewrite any stored <img src> (bare path or legacy public URL) to a signed URL
+  // so the private `adjuntos` bucket renders correctly.
   useEffect(() => {
     if (editor && junta?.descripcion && editor.isEmpty) {
-      editor.commands.setContent(junta.descripcion);
+      void (async () => {
+        const hydrated = await rewriteHtmlImagesToSigned(supabase, junta.descripcion, 6 * 3600);
+        editor.commands.setContent(hydrated);
+      })();
     }
-  }, [editor, junta]);
+  }, [editor, junta, supabase]);
 
   const handleSave = async () => {
     if (!junta) return;
     setSaving(true);
 
-    const notesHtml = editor?.getHTML() ?? null;
+    // Normalize signed URLs back to bare paths so the DB never holds a
+    // soon-to-expire URL — getAdjuntoPath handles legacy rows too.
+    const notesHtml = normalizeHtmlImagesToPaths(editor?.getHTML() ?? null) || null;
 
     const { error: err } = await supabase
       .schema('erp')


### PR DESCRIPTION
## Summary

Fixes images in junta descriptions not rendering on \`/inicio/juntas/[id]\` and \`/rdb/admin/juntas/[id]\`.

## Root cause

- The \`adjuntos\` bucket is private (PR #41).
- Only \`dilesa/admin/juntas/[id]\` was calling \`rewriteHtmlImagesToSigned\` on load and \`normalizeHtmlImagesToPaths\` on save.
- The other two junta pages passed \`junta.descripcion\` directly into the editor, so \`/object/public/adjuntos/*\` URLs returned 403 → images appeared as broken/empty.
- After today's \`rescue_junta_images.ts\` run (160 images pulled from codahosted.io → Supabase Storage), this became visible because every historical junta's images live under those \`/public/\` URLs.

## Fix

Mirror the dilesa page pattern into:
- \`app/inicio/juntas/[id]/page.tsx\`
- \`app/rdb/admin/juntas/[id]/page.tsx\`

Specifically:
1. On load, rewrite HTML img src → signed URL (6h expiry) before setting editor content.
2. On save, normalize signed URLs back to bare paths so the DB never stores an expiring token.

## Verification

- \`npm run typecheck\` — clean
- \`npx eslint\` on touched files — 0 errors (4 pre-existing warnings)
- \`npx prettier --check\` — clean

## Test plan

- [ ] Open a historical junta from Coda (e.g., 2024-01-02 Comite Ejecutivo) via \`/inicio/juntas/[id]\` — images should render inline where text discusses them
- [ ] Same via \`/rdb/admin/juntas/[id]\`
- [ ] Edit + save a junta description; verify images persist on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)