### PR TITLE
fix(juntas): rewrite <img> URLs during fetchAll

### DIFF
--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -361,7 +361,10 @@ function JuntaDetailInner() {
     setTipo(juntaData.tipo ?? '');
 
     if (editor && juntaData.descripcion) {
-      editor.commands.setContent(juntaData.descripcion);
+      // Rewrite bare paths / legacy public URLs to signed URLs so the private
+      // adjuntos bucket renders inside the editor.
+      const hydrated = await rewriteHtmlImagesToSigned(supabase, juntaData.descripcion, 6 * 3600);
+      editor.commands.setContent(hydrated);
     }
 
     // Load asistencia with personas

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -347,7 +347,10 @@ function JuntaDetailInner() {
     setTipo(juntaData.tipo ?? '');
 
     if (editor && juntaData.descripcion) {
-      editor.commands.setContent(juntaData.descripcion);
+      // Rewrite bare paths / legacy public URLs to signed URLs so the private
+      // adjuntos bucket renders inside the editor.
+      const hydrated = await rewriteHtmlImagesToSigned(supabase, juntaData.descripcion, 6 * 3600);
+      editor.commands.setContent(hydrated);
     }
 
     const { data: asistData } = await supabase


### PR DESCRIPTION
## Summary

Followup to PR #70 — the rewriter was added to a useEffect guarded by \`editor.isEmpty\`, but \`fetchAll\` was calling \`editor.commands.setContent(juntaData.descripcion)\` earlier in the flow with the raw public URL. That made the editor non-empty and the useEffect skipped the rewrite, so images still showed as broken.

This PR moves the rewriter into \`fetchAll\` itself (mirroring the dilesa page pattern that actually works), so the editor content is hydrated with signed URLs from the first \`setContent\` call.

## Files

- \`app/inicio/juntas/[id]/page.tsx\`
- \`app/rdb/admin/juntas/[id]/page.tsx\`

## Verification

- \`npm run typecheck\` — clean
- Local lint + format clean

## Test plan

- [ ] Reload a historical junta (e.g., 2024-01-02 Comite) via \`/inicio/juntas/[id]\` — images should render inline
- [ ] Same via \`/rdb/admin/juntas/[id]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)