### PR TITLE
docs: bancos+gastos audit and dashboard inicio design

### DIFF
--- a/docs/coda-migration/bancos-y-gastos.md
+++ b/docs/coda-migration/bancos-y-gastos.md
@@ -1,0 +1,345 @@
+# Bancos + Gastos — Deep Audit y Propuesta de Rediseño
+
+> Deep audit de los 2 módulos cross-empresa Tier 2 con más leverage.
+>
+> **Fuentes**: Coda REST API (2026-04-18) + inspección de schema actual en Supabase.
+> **Objetivo**: definir el schema + UX óptimos en BSOP, extendiendo las tablas ya creadas (0 rows).
+
+---
+
+## 1. Estado actual en Coda
+
+### SR Group — Gastos (3,496 rows)
+
+```
+Tabla: Gastos (grid-j66Im4cf5H)
+Parent: "Gastos"
+
+Columns:
+  Fecha             date
+  Descripción       text
+  Monto             currency
+  Categoría         lookup → Sub-Categoría Gasto.Categoría
+  Sub-Categoría     lookup → Sub-Categoría Gasto
+  Imagen            image[]          ← attachment / comprobante
+  #Pago             formula          (contador)
+  Año               formula          (extraído de Fecha)
+  Mes               formula          (extraído de Fecha)
+  50/30/20 Rule     formula          (Need / Want / Savings, heredado de Sub-Categoría)
+```
+
+**Sub-Categorías**: 73 filas con estructura `(sub_categoria, categoria, clasificacion_50_30_20)`. Categorías con emojis embebidos: Salud🏥, Transporte 🚘, Diversión🎟️, Servicios🧾, Rancho🚜, Educación🎓, Personal👥, Hogar🏠, etc.
+
+### SR Group — Bancos personales (emails forwarded)
+
+Tres tablas de movimientos con **el mismo flow manual**:
+
+| Tabla | Rows | Moneda | Particularidad |
+|---|---:|---|---|
+| Movimientos AMEX | 2,610 | USD → MXN | Emails de `americanexpress.com` |
+| Movimientos Banamex | 2,421 | MXN | Emails de Citibanamex |
+| Movimientos IBC | 1,523 | USD → MXN | Emails de Interamerican Bank |
+
+```
+Schema común (Banamex — MXN):
+  Fecha             date
+  Descripción       text         ← email forward COMPLETO (HTML-stripped)
+  Monto             currency     ← inicialmente $0.00, Beto lo llena a mano
+  Tipo de Gasto     lookup       ← categoría
+  Sub-Categoría     lookup
+  Registrado        checkbox     ← false hasta que Beto procesa
+  *Traspasa         button       ← flow manual
+  *Registra         button
+  *Traspasa Gasto   button       ← dispara creación de row en Gastos + marca Registrado=true
+  Ingreso Sueldo    button       ← para abonos tipo sueldo
+
+Schema AMEX / IBC (USD):
+  + Monto Dolares, Tipo de Cambio, Monto Pesos (formula)
+  + Quien Carga (AMEX only)
+```
+
+**Flow Coda actual**:
+1. Bank envía email → forward a Coda → nueva row (Monto=$0, Registrado=false)
+2. Beto abre "Registros Pendientes X" (view filtrada por Registrado=false)
+3. Lee descripción (el monto está EN EL TEXTO del email, ej. "$43.28"), lo captura en Monto
+4. Elige Tipo + Sub-Categoría
+5. Click "Traspasa Gasto" → crea fila en `Gastos` + marca `Registrado=true`
+
+### ANSA — BBVA Bancomer (569 rows)
+
+**Flow DIFERENTE**. No son emails, es export de estado de cuenta:
+
+```
+Schema:
+  Dia              text "DD-MM-YYYY"
+  Concepto/Ref     text           ← línea del banco, sin HTML
+  Cargo            currency       ← salidas
+  Abono            currency       ← entradas
+  Saldo            currency       ← saldo corrido
+```
+
+No hay procesamiento / categorización. Solo historial.
+
+### Registros Pendientes × 3
+
+Son **tablas view-like** con FK a Movimientos. Exponen los mismos campos + los botones. No son fuentes de datos — son UI filtradas en Coda.
+
+---
+
+## 2. Pain points observados
+
+1. **Flujo manual**: cada movimiento AMEX/Banamex/IBC requiere que Beto lea el email, extraiga el monto, lo capture, asigne categoría, y apriete botón. **1,405 rows pendientes acumuladas** (Registros Pendientes Banamex 796 + IBC 331 + AMEX 193 + 85 facturas pendientes).
+2. **Monto no está estructurado**: vive dentro del texto de la descripción. Humano tiene que leer.
+3. **Categorías como emojis en el nombre**: dificulta agrupación / reporting / filtrado.
+4. **3 tablas separadas por banco**: cada cuenta es su propia tabla. Cruzar = imposible sin exportar.
+5. **BBVA es otro schema**: no hay forma de agregar AMEX+Banamex+IBC+BBVA en un mismo reporte.
+6. **No hay conciliación**: no se cruza contra facturas o gastos reales.
+7. **Emoji mess en descripción**: los emails son dumps gigantes con ruido visual y trackers.
+
+---
+
+## 3. Estado actual en BSOP (Supabase)
+
+Todas las tablas YA EXISTEN pero están **vacías** (0 rows):
+
+```sql
+erp.cuentas_bancarias          0 rows    -- base accounts
+erp.movimientos_bancarios      0 rows    -- unified bank movements
+erp.conciliaciones             0 rows    -- bank movement ↔ gasto/factura
+erp.gastos                     0 rows    -- expense ledger
+erp.facturas                   0 rows    -- SAT invoices
+```
+
+Esto significa: **schema listo, sin datos, sin UI**. La migración necesita definir columnas + construir UI + importar rows.
+
+---
+
+## 4. Propuesta de rediseño (extendiendo schema existente)
+
+### 4.1 `erp.cuentas_bancarias` — 1 fila por cuenta
+
+```sql
+-- Seed con 6-8 cuentas
+id                uuid pk
+empresa_id        uuid fk → core.empresas
+nombre            text                 -- "AMEX Beto Personal", "BBVA Empresa ANSA", etc
+banco             text                 -- "American Express", "Citibanamex", "BBVA", "IBC"
+numero_cuenta     text                 -- últimos 4 dígitos
+moneda            text                 -- "MXN" | "USD"
+tipo              text                 -- "tarjeta_credito" | "debito" | "cheques" | "inversion"
+activa            boolean default true
+emisor_fuente     text                 -- "email_amex" | "email_banamex" | "email_ibc" | "export_bbva" | "manual"
+email_forward     text                 -- dirección a la que reenviar emails (para parser)
+created_at/updated_at
+```
+
+### 4.2 `erp.movimientos_bancarios` — 1 fila por movimiento
+
+```sql
+id                uuid pk
+cuenta_id         uuid fk → erp.cuentas_bancarias
+empresa_id        uuid fk → core.empresas       -- denormalizado para RLS
+fecha             date NOT NULL
+fecha_hora        timestamptz                    -- si está disponible
+descripcion_raw   text                           -- email completo / línea export
+descripcion_parsed text                          -- merchant extraído (ej. "TARGET COM 800 591 3869")
+cargo             numeric(14,2)                  -- salida, siempre positivo
+abono             numeric(14,2)                  -- entrada, siempre positivo
+moneda            text                           -- MXN / USD
+tipo_cambio       numeric(10,4)                  -- si moneda ≠ MXN
+monto_mxn         numeric(14,2) generated ...    -- monto normalizado
+saldo             numeric(14,2)                  -- si viene en el export
+autorizacion      text                           -- número de autorización del banco
+tipo              text                           -- "cargo_tarjeta" | "retiro" | "deposito" | "spei_entrada" | "spei_salida" | "pago" | "comision" | ...
+categoria_id      uuid fk → erp.categorias_gasto -- categorizado manual o automático
+subcategoria_id   uuid fk → erp.subcategorias_gasto
+fuente            text                           -- "email" | "export" | "manual"
+fuente_email_id   text                           -- Message-ID para dedup
+categorizado      boolean default false
+gasto_id          uuid fk → erp.gastos           -- si generó un gasto
+factura_id        uuid fk → erp.facturas         -- si está conciliado con factura
+notas             text
+created_by        uuid
+created_at/updated_at
+
+UNIQUE (cuenta_id, fuente_email_id) WHERE fuente_email_id IS NOT NULL  -- dedup de emails
+INDEX (empresa_id, fecha DESC)
+INDEX (cuenta_id, fecha DESC)
+INDEX WHERE categorizado = false                  -- "pendientes por categorizar"
+```
+
+### 4.3 `erp.categorias_gasto` + `erp.subcategorias_gasto`
+
+```sql
+-- Reemplaza el lookup de Coda (emojis dentro del nombre)
+erp.categorias_gasto
+  id              uuid pk
+  empresa_id      uuid fk | NULL   -- NULL = categoría global
+  nombre          text             -- "Salud"
+  emoji           text             -- "🏥"
+  color           text             -- hex para UI
+  orden           int
+
+erp.subcategorias_gasto
+  id              uuid pk
+  categoria_id    uuid fk
+  nombre          text             -- "Padel"
+  clasificacion   text             -- "Need" | "Want" | "Savings" | NULL
+```
+
+**Beneficio**: emoji separado del nombre → filtrado limpio + emoji visible en UI.
+
+### 4.4 `erp.gastos` — ya existe, a extender
+
+```sql
+-- Columnas clave a asegurar:
+id                uuid pk
+empresa_id        uuid fk
+fecha             date
+concepto          text             -- descripción corta
+descripcion       text             -- extendida
+monto             numeric(14,2)
+moneda            text
+tipo_cambio       numeric(10,4)
+monto_mxn         numeric(14,2) generated
+categoria_id      uuid fk
+subcategoria_id   uuid fk
+movimiento_id     uuid fk → movimientos_bancarios  -- inverso
+factura_id        uuid fk → facturas
+comprobante_url   text              -- adjunto (signed URL pattern)
+created_by        uuid
+created_at/updated_at
+```
+
+---
+
+## 5. Pipeline de ingesta (lo que automatiza lo manual)
+
+### 5.1 Email → movimiento (AMEX/Banamex/IBC)
+
+**Nuevo**: endpoint `POST /api/bancos/email-webhook`
+- Configurar forwarding del email del banco a una dirección de Resend/Postmark inbound
+- Ese servicio hace POST al endpoint con el email parseado
+- Endpoint:
+  1. Identifica cuenta por `From:` header
+  2. Ejecuta parser específico por banco (regex para extraer `$MONTO`, `merchant`, `fecha_operacion`)
+  3. Inserta en `movimientos_bancarios` con `fuente='email'`, `fuente_email_id=<Message-ID>`
+  4. Categorización automática por reglas (ej. "TARGET COM" → "Hogar/Despensa")
+  5. Si categoría clara → `categorizado=true`, crea `gasto` automáticamente
+  6. Si no → queda pendiente de revisión
+
+**Parsers por banco**:
+```typescript
+// lib/bancos/parsers/amex.ts
+// lib/bancos/parsers/banamex.ts
+// lib/bancos/parsers/ibc.ts
+// lib/bancos/parsers/bbva.ts  (opcional, por si BBVA manda emails también)
+```
+
+Cada parser extrae `{ merchant, monto, moneda, autorizacion, fecha_operacion }` del raw text.
+
+### 5.2 Export bancario → batch import (BBVA ANSA)
+
+**Nuevo**: UI de upload en `/<empresa>/bancos/<cuenta>/import`
+- CSV / OFX / PDF-parse
+- Dedup contra `movimientos_bancarios` (por fecha + monto + concepto hash)
+- Preview antes de importar
+
+### 5.3 Reglas de categorización automática
+
+**Nueva tabla** `erp.reglas_categorizacion`:
+```sql
+id, empresa_id, cuenta_id | NULL, patron_regex, categoria_id, subcategoria_id, activa
+```
+
+Se aplica en el webhook + en un cron que limpia los "sin categorizar" periódicamente.
+
+---
+
+## 6. UI BSOP propuesta
+
+### `/<empresa>/bancos` — dashboard
+
+```
+┌─ Saldos por cuenta ───────────────────────────────────────┐
+│ AMEX Beto        $ -12,450   ⚠️ 3 pendientes de categorizar│
+│ Banamex Cheques  $ 234,800   ✅                            │
+│ IBC USD          $   5,200   ⚠️ 12 pendientes              │
+│ BBVA Empresa     $1,200,435  ✅                            │
+└─────────────────────────────────────────────────────────────┘
+
+┌─ Movimientos recientes (7 días) ──────────────────────────┐
+│ [filtros: cuenta, fecha, estado, tipo]                    │
+│                                                            │
+│ Fecha      Cuenta   Descripción          Monto    Categoría│
+│ ...                                                        │
+└─────────────────────────────────────────────────────────────┘
+
+┌─ Pendientes de categorizar [1,405] ───────────────────────┐
+│ [tabla con quick-actions: categorizar, marcar ignorar]    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### `/<empresa>/gastos` — ledger
+
+```
+┌─ Gastos del mes — $ 68,450 ───────────────────────────────┐
+│ Categoría    Monto       %     Barra                       │
+│ Salud        $22,500    33%    ████████                    │
+│ Transporte   $15,200    22%    █████                       │
+│ ...                                                         │
+└─────────────────────────────────────────────────────────────┘
+
+┌─ Lista de gastos [filtros]                                │
+│ Fecha  Concepto  Monto  Categoría  Origen  Comprobante    │
+│                                  (auto/manual) (img)       │
+└─────────────────────────────────────────────────────────────┘
+
+[+ Registrar gasto manualmente]
+```
+
+### `/<empresa>/conciliaciones`
+
+Cross entre `movimientos_bancarios` × `gastos` × `facturas`. Detecta y propone matches automáticos (fecha±2d + monto exacto).
+
+---
+
+## 7. Orden de implementación
+
+**Semana A — Base**
+1. Migration: seed de `erp.cuentas_bancarias` con 6-10 cuentas reales
+2. Migration: `erp.categorias_gasto` + `erp.subcategorias_gasto` + seed inicial desde Coda (~25 categorías × 73 subcategorías)
+3. Script: `scripts/migrate_sr_gastos.ts` — copia `Gastos` de Coda → `erp.gastos` (3,496 rows)
+
+**Semana B — Ingesta bancaria**
+4. Endpoint: `POST /api/bancos/email-webhook` con parsers AMEX/Banamex/IBC
+5. Script: `scripts/migrate_sr_movimientos.ts` — copia históricos 6,554 rows
+6. UI read-only: `/sr-group/bancos` (ver saldos + movimientos)
+
+**Semana C — Categorización + conciliación**
+7. `erp.reglas_categorizacion` + UI de config
+8. UI write: "categorizar pendiente" → crea gasto
+9. Algoritmo de conciliación automática
+
+**Semana D — Cross-empresa**
+10. UI para ANSA (BBVA import via CSV/PDF)
+11. UI DILESA cuando decida migrar
+12. Cutover parcial: AMEX primero, luego Banamex, luego IBC (un banco por semana)
+
+**Duración total estimada**: 3-4 semanas con 1 operador + agents.
+
+---
+
+## 8. Decisiones pendientes antes de empezar
+
+| Pregunta | Opciones | Mi sugerencia |
+|---|---|---|
+| ¿Seguir con emails forwarded o usar API bancaria (Plaid / Belvo)? | Plaid no cubre MX bien. Belvo sí pero tiene costo. | **Emails por ahora**, evaluar Belvo en 6 meses |
+| ¿Categorías globales o por empresa? | Global reutilizable vs custom | **Mixto**: seed global + override por empresa |
+| ¿Gasto vs movimiento: 1-a-1 o N-a-1? | Un movimiento puede dividirse en N gastos | **N-a-1** (un movimiento genera varios gastos si se divide) |
+| ¿Soft-delete o hard? | Audit requiere soft-delete | **Soft** (`deleted_at timestamptz`) |
+| ¿Currency store bruto o normalizado? | Separar `moneda+monto+TC` vs solo `monto_mxn` | **Ambos**: campos brutos + `monto_mxn` generated |
+
+---
+
+_Este documento es el punto de partida cuando aterricemos Bancos. Tras aprobación, se materializa en migrations + PRs incrementales._

--- a/docs/design/dashboard-inicio.md
+++ b/docs/design/dashboard-inicio.md
@@ -1,0 +1,341 @@
+# Dashboard de Inicio — Propuesta de Diseño
+
+> Home personalizado con pendientes + KPIs por usuario y rol.
+>
+> **Objetivo**: cada persona al entrar a BSOP ve en 5 segundos qué tiene que hacer hoy y cómo van las métricas de sus empresas.
+
+---
+
+## 1. Quién lo ve
+
+BSOP tiene estos tipos de usuario (según `core.usuarios.rol` + `core.usuarios_empresas`):
+
+| Perfil | Ejemplo | Qué le importa |
+|---|---|---|
+| **Admin global** | Beto | Todo, cross-empresa |
+| **Operativo RDB** | cajero, hostess, admin RDB | Turno actual, cortes del día, stock crítico, reservas |
+| **Financiero SR** | Beto (hat financiero), contador | Movimientos sin categorizar, gastos del mes, vencimientos fiscales |
+| **Operativo DILESA** | supervisor obra, admin DILESA | Avance lotes, entregas esta semana, RUV pendientes |
+| **Operativo ANSA** | asesor ventas, servicio | Citas del día, unidades disponibles, ventas del mes |
+| **Familia / Grupo SR** | miembros familiares | Salud, viajes, contenido personal |
+
+El dashboard adapta lo que muestra según:
+1. Rol (admin vs usuario regular)
+2. Empresas asignadas en `core.usuarios_empresas`
+3. Módulos accesibles en `core.permisos_rol`
+
+---
+
+## 2. Layout global
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Sidebar                  Header (BSOP / greeting / clock / theme)   │
+│                                                                       │
+│  ┌──────────────────────── MAIN ──────────────────────────────────┐  │
+│  │                                                                 │  │
+│  │  Row 1 — SALUDO + ATENCIÓN INMEDIATA                           │  │
+│  │  ┌──────────────────┬──────────────────┬──────────────────┐    │  │
+│  │  │ Hola, Beto       │ 3 tareas hoy     │ 2 juntas         │    │  │
+│  │  │ Martes 21 abr    │ 1 vencida  ⚠️    │ 09:00 / 14:00    │    │  │
+│  │  └──────────────────┴──────────────────┴──────────────────┘    │  │
+│  │                                                                 │  │
+│  │  Row 2 — TUS PENDIENTES (sección grande)                       │  │
+│  │  [tabs]  Tareas  Juntas  Aprobaciones  Categorizar  Recepción  │  │
+│  │  ┌─────────────────────────────────────────────────────────┐   │  │
+│  │  │  [tabla de pendientes según tab activo]                 │   │  │
+│  │  │  Cada row: descripción + empresa + fecha + quick action  │   │  │
+│  │  └─────────────────────────────────────────────────────────┘   │  │
+│  │                                                                 │  │
+│  │  Row 3 — KPIs POR EMPRESA (grid adaptativo)                    │  │
+│  │  ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐      │  │
+│  │  │ RDB       │ │ DILESA    │ │ ANSA      │ │ SR Group  │      │  │
+│  │  │ [ KPIs ]  │ │ [ KPIs ]  │ │ [ KPIs ]  │ │ [ KPIs ]  │      │  │
+│  │  └───────────┘ └───────────┘ └───────────┘ └───────────┘      │  │
+│  │                                                                 │  │
+│  │  Row 4 — ACTIVIDAD RECIENTE / PULSO (opcional)                 │  │
+│  │  - Últimas 5 juntas con resumen                                │  │
+│  │  - Tareas completadas hoy por el equipo                        │  │
+│  │  - Alertas (stock crítico, vencimientos, robos caja)           │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Row 1 — Atención inmediata (4 tarjetas)
+
+Siempre visibles, siempre priorizadas:
+
+| Tarjeta | Fuente | Ejemplo |
+|---|---|---|
+| **Saludo + fecha** | `core.usuarios.nombre` | "Buenos días, Beto · Martes 21 de abril" |
+| **Tareas del día** | `erp.tasks WHERE asignado_a = me AND fecha_vence <= today AND estado NOT IN (completado, cancelado)` | "3 tareas · 1 vencida ⚠️" |
+| **Juntas hoy** | `erp.juntas WHERE fecha_hora::date = today AND asistentes @> me` | "2 juntas · 09:00 y 14:00" |
+| **Acción ejecutiva** | depende de rol | Admin: "10 sin categorizar" · Cajero: "abrir caja" · Supervisor: "3 lotes en inspección" |
+
+Cada tarjeta es clickeable → lleva a la sección correspondiente.
+
+---
+
+## 4. Row 2 — Tus pendientes (tabs)
+
+Estructura tipo inbox. Un tab por tipo. Cada tab muestra el **count** en el label.
+
+```
+[ Tareas (12) ] [ Juntas (3) ] [ Aprobaciones (2) ] [ Categorizar (45) ] [ Recepciones (0) ]
+```
+
+### Tab: Tareas
+- Fuente: `erp.tasks` asignadas al usuario + sin cerrar
+- Columnas: estado badge · título · empresa · prioridad · fecha venc · [botón Completar]
+- Orden: vencidas primero, luego por fecha de vencimiento
+- Filtro rápido: "hoy" / "esta semana" / "todas"
+
+### Tab: Juntas
+- Fuente: `erp.juntas_asistencia` próximas (next 7 days)
+- Columnas: fecha + hora · título · empresa · lugar · [botón Abrir]
+- Separador: "Hoy" · "Esta semana" · "Después"
+
+### Tab: Aprobaciones (según rol)
+- Fuente: `erp.aprobaciones WHERE aprobador = me AND estado = 'pendiente'`
+- Columnas: entidad (OC, Requisición, Gasto, etc) · monto/total · solicitante · fecha
+- Quick action: [Aprobar] [Rechazar] [Ver detalle]
+
+### Tab: Categorizar bancos (admin financiero)
+- Fuente: `erp.movimientos_bancarios WHERE categorizado = false AND empresa_id ∈ user_empresas`
+- Agrupado por cuenta
+- Quick action: selecciona categoría inline → marca categorizado
+
+### Tab: Recepciones (admin compras)
+- Fuente: `erp.ordenes_compra WHERE estado = 'por_recibir' AND fecha_entrega <= today + 3`
+- Quick action: marcar recibida
+
+---
+
+## 5. Row 3 — KPIs por empresa (grid)
+
+Un card por empresa a la que el usuario tiene acceso. Cada card tiene 4-6 KPIs.
+
+### RDB card
+
+```
+┌─ 🌲 Rincón del Bosque ─────────────────────────┐
+│                                                  │
+│  Ventas hoy         $ 24,580    ↑ 12% vs ayer   │
+│  Corte actual       Abierto 08:30h              │
+│  Reservas hoy       18 (6 tarde)                │
+│  Stock crítico      3 productos ⚠️              │
+│  Top producto       Padel 1h Premium            │
+│                                                  │
+│  [→ Ver RDB completo]                           │
+└──────────────────────────────────────────────────┘
+```
+
+Fuentes:
+- Ventas hoy: `rdb.waitry_pedidos WHERE fecha::date = today`
+- Corte: `erp.cortes_caja WHERE estado = 'abierto'`
+- Reservas: `playtomic.bookings WHERE starts_at::date = today`
+- Stock crítico: `erp.inventario WHERE stock <= min_stock`
+
+### DILESA card
+
+```
+┌─ 🏗️ DILESA ────────────────────────────────────┐
+│                                                  │
+│  Lotes en obra      27  (14 LDS, 8 LDV, 5 LDE) │
+│  Entregas semana    3 pendientes                │
+│  DTUs por vencer    2 (CUV-12849 en 15 días)   │
+│  Escrituras mes     8 cerradas                  │
+│  Gastos obra mes    $ 1.2M                      │
+│                                                  │
+│  [→ Ver DILESA completo]                        │
+└──────────────────────────────────────────────────┘
+```
+
+### ANSA card
+
+```
+┌─ 🚗 ANSA ──────────────────────────────────────┐
+│                                                  │
+│  Citas hoy          12 (8 servicio, 4 venta)   │
+│  Inventario vehicles 87 (Jeep: 22, Ram: 18...)  │
+│  Ventas mes         14 unidades · $ 5.8M       │
+│  Cobranza pendiente $ 2.3M                      │
+│                                                  │
+│  [→ Ver ANSA completo]                          │
+└──────────────────────────────────────────────────┘
+```
+
+### SR Group card (admin)
+
+```
+┌─ 💼 SR Group ──────────────────────────────────┐
+│                                                  │
+│  Sin categorizar    45 movimientos ⚠️          │
+│  Gastos mes         $ 68,450                    │
+│  Facturas emitidas  5 este mes                  │
+│  Pagos provisionales ISR Abril — pendiente     │
+│                                                  │
+│  [→ Ver SR Group]                               │
+└──────────────────────────────────────────────────┘
+```
+
+### Family card (opcional, visible para miembros familia)
+
+```
+┌─ 👨‍👩‍👧‍👦 Familia / Grupo SR ──────────────────┐
+│                                                  │
+│  Próximo viaje      SD → Seattle · Mayo 10     │
+│  Salud Beto         HR 68 · Sleep 7.2h (ayer)  │
+│  Cumpleaños próximo Grecia · 26 mar (en 3d)    │
+│                                                  │
+└──────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Row 4 — Pulso / actividad (opcional)
+
+Feed horizontal estilo timeline. Solo admin o si usuario tiene >1 empresa.
+
+```
+Últimas actualizaciones
+───────────────────────────────────────────
+• Hace 15 min · Ale completó "Revisión contrato Lomas del Sol"
+• Hace 1 h     · Corte RDB turno mañana · $ 8,450
+• Hace 3 h     · Junta Comité Ejecutivo agregada · viernes 09:00
+• Ayer         · 45 movimientos IBC ingeridos (pendientes de categorizar)
+```
+
+Fuente: `core.audit_log` cuando esté operativo.
+
+---
+
+## 7. Lógica de personalización
+
+```typescript
+// Pseudo-código del servidor que arma el dashboard
+async function getDashboard(userId: string) {
+  const user = await getUserWithEmpresas(userId);
+
+  return {
+    row1: await buildAtencionInmediata(user),   // siempre
+    row2: {
+      tareas:       await fetchTasks(user),
+      juntas:       await fetchJuntas(user),
+      aprobaciones: hasPermission(user, 'aprobaciones.ver')
+                       ? await fetchAprobaciones(user) : null,
+      categorizar:  hasEmpresa(user, 'sr-group')
+                       ? await fetchPendientesCategorizar(user) : null,
+      recepciones:  hasPermission(user, 'compras.ver')
+                       ? await fetchRecepciones(user) : null,
+    },
+    row3: await Promise.all(
+      user.empresas.map(e => buildEmpresaCard(e, user))
+    ),
+    row4: user.isAdmin ? await fetchActivity(user) : null,
+  };
+}
+```
+
+### Reglas de visibilidad
+
+| Componente | Visible si |
+|---|---|
+| Row 1 · Tareas hoy | tiene tareas asignadas (siempre, pero se oculta si 0) |
+| Row 1 · Juntas hoy | tiene juntas próximas |
+| Row 1 · Acción ejecutiva | `user.isAdmin` O tiene permisos específicos |
+| Row 2 · Aprobaciones | `permisos_rol.aprobaciones.ver = true` |
+| Row 2 · Categorizar | tiene acceso a SR Group + empresa financiera |
+| Row 2 · Recepciones | tiene acceso a compras |
+| Row 3 · RDB | user ∈ usuarios_empresas(rdb) |
+| Row 3 · DILESA | user ∈ usuarios_empresas(dilesa) |
+| Row 4 · Actividad | user.isAdmin |
+
+---
+
+## 8. Datos que faltan en Supabase (para construir esto bien)
+
+Antes de poder construir el dashboard 100% funcional:
+
+| KPI | Falta | Estado |
+|---|---|---|
+| Ventas hoy RDB | ✅ existe (`rdb.waitry_pedidos`) | ready |
+| Corte actual RDB | ✅ existe (`erp.cortes_caja`) | ready |
+| Reservas hoy Playtomic | ✅ existe (`playtomic.bookings`) | ready |
+| Stock crítico | ⚠️ necesita columna `min_stock` en `erp.productos` | schema change |
+| Lotes DILESA | ❌ `erp.lotes` está en 0 rows | migración pendiente |
+| Entregas DILESA | ❌ schema "entregas" no existe como tabla aparte | diseñar |
+| DTUs por vencer | ❌ RUV no migrado | muy lejos |
+| Citas ANSA hoy | ❌ `erp.citas` en 0 rows | migración pendiente |
+| Inventario vehículos | ❌ `erp.vehiculos` en 0 rows | migración pendiente |
+| Ventas mes ANSA | ❌ `erp.ventas_autos` en 0 rows | migración pendiente |
+| Cobranza pendiente | ❌ `erp.cobranza` en 0 rows | migración pendiente |
+| Sin categorizar SR | ❌ `erp.movimientos_bancarios` en 0 rows | ver `bancos-y-gastos.md` |
+| Gastos mes SR | ❌ `erp.gastos` en 0 rows | ver `bancos-y-gastos.md` |
+
+**Orden que propone el dashboard**:
+1. **MVP v1**: lo que YA hay — tareas, juntas, RDB ventas/corte/reservas, Familia salud/viajes
+2. **v2** (post-migración bancos/gastos): agregar KPIs SR Group + categorizar
+3. **v3** (post-migración ANSA citas): agregar card ANSA completo
+4. **v4** (post-migración DILESA inmobiliario): agregar card DILESA completo
+
+---
+
+## 9. Implementación técnica
+
+### Archivos nuevos
+
+```
+app/page.tsx                           -- orchestrator (refactorizar el actual)
+components/dashboard/
+  ├── dashboard.tsx                    -- orchestrator visual
+  ├── types.ts
+  ├── attention-row.tsx                -- row 1
+  ├── pending-tabs.tsx                 -- row 2
+  ├── empresa-card.tsx                 -- row 3 genérico
+  ├── rdb-kpis.tsx                     -- row 3 específico
+  ├── dilesa-kpis.tsx
+  ├── ansa-kpis.tsx
+  ├── sr-kpis.tsx
+  ├── family-kpis.tsx
+  ├── activity-feed.tsx                -- row 4
+  └── use-dashboard-data.ts            -- fetch hook
+```
+
+### Endpoint
+
+```
+GET /api/dashboard
+  → returns all rows prebuilt server-side
+  cache: 30 segundos (revalidate on mutation vía tags)
+```
+
+Usa `next/cache` con tags `dashboard:<userId>` para invalidar cuando cambian tareas/juntas/corte/etc.
+
+### Performance
+
+- Row 1 y Row 2: must be fast (~200ms total) — hits small indexed queries
+- Row 3 por empresa: paralelizable, cacheado 60s
+- Row 4: cacheado 5min
+
+---
+
+## 10. Preguntas para Beto
+
+1. **¿Te gusta el layout 4-rows o prefieres algo distinto?** (ej. 2 columnas, side-by-side, card-grid)
+2. **¿Qué KPIs por empresa son los que MÁS te importan?** (para priorizar)
+3. **¿Habilitar widgets custom por usuario?** (cada quien reordena / esconde)
+4. **¿Empezamos con MVP v1** (lo que ya hay) **mientras migramos bancos/gastos/citas en paralelo**?
+5. **¿Familia debe ser su propia card o se mezcla con SR Group?**
+
+---
+
+_Mi recomendación:_
+
+- **Empezar con MVP v1 esta semana/siguiente** — se puede construir ya con tareas + juntas + RDB + Familia/Salud. Se lanza como una página de inicio decente desde el día 1.
+- **v2-v3-v4 en paralelo** — conforme van cerrando las migraciones Coda, se van encendiendo las cards vacías.
+- **Layout flexible desde el inicio** — construir como componentes independientes para que en el futuro puedas reordenar/esconder sin refactor.
+
+Si lo apruebas, puedo lanzar un agent que construya el MVP v1 con cero riesgo (solo lee tablas que ya existen, no toca schema).


### PR DESCRIPTION
## Summary

Two design docs written during autonomous work while Beto was away, unblocking the next phase.

## Docs

### \`docs/coda-migration/bancos-y-gastos.md\`
Deep audit + rediseño para los módulos cross-empresa con más leverage (4 empresas).

- **Mapeo completo**: 4 tablas de bancos (AMEX 2,610 / Banamex 2,421 / IBC 1,523 / BBVA 569) + Gastos (3,496)
- **2 flows distintos detectados**: email-forwarded (SR personal) vs export-estados-de-cuenta (BBVA empresa)
- **Schema propuesto**: extiende \`erp.cuentas_bancarias\`, \`erp.movimientos_bancarios\`, \`erp.gastos\` + 3 tablas nuevas (\`categorias_gasto\`, \`subcategorias_gasto\`, \`reglas_categorizacion\`)
- **Pipeline de ingesta**: webhook de email + parsers por banco + categorización automática por reglas
- **UI propuesta**: dashboards de bancos + gastos + conciliación
- **Roadmap 3-4 semanas**

### \`docs/design/dashboard-inicio.md\`
Home page personalizada con pendientes + KPIs por rol.

- **4 rows**: atención inmediata / pendientes (tabs) / empresa cards / actividad
- **Personalización por rol + empresas asignadas** (usa \`core.usuarios_empresas\` + \`core.permisos_rol\`)
- **Data readiness matrix**: qué KPIs se pueden mostrar HOY vs cuáles esperan migraciones Coda
- **MVP v1**: lanzable esta semana con tareas + juntas + RDB ventas/corte/reservas + Familia/Salud
- **v2-v4**: se van encendiendo a medida que aterrizan bancos/gastos/citas/lotes

## Next steps

Necesita aprobación de Beto para:
1. Confirmar el schema de bancos-y-gastos
2. Confirmar el layout del dashboard (4-row vs otro)
3. Priorizar MVP v1 vs esperar más migraciones

Zero code changes en esta PR — solo docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)