### PR TITLE
fix(adjuntos): proxy endpoint replaces signed-URL rewrite dance

### DIFF
--- a/app/api/adjuntos/[...path]/route.ts
+++ b/app/api/adjuntos/[...path]/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+
+/**
+ * GET /api/adjuntos/<path...>
+ *
+ * Same-origin, cookie-authenticated proxy that streams any object from the
+ * private `adjuntos` bucket. Replaces the signed-URL-rewriter dance: instead
+ * of mutating every <img src> on load to a short-lived signed URL, we leave
+ * the src pointing at this endpoint and do the auth check + stream here.
+ *
+ * Why not signed URLs?
+ *   - Client-side rewriting has race conditions with TipTap setContent.
+ *   - Signed URLs expire; editing/refreshing after expiry breaks images.
+ *   - Browser caching of error responses prevents recovery.
+ *
+ * Auth contract:
+ *   - Caller must have a valid Supabase session cookie (i.e. be logged in).
+ *   - Matches the storage.objects RLS policy `adjuntos_read` which grants
+ *     SELECT on bucket=adjuntos to any `authenticated` role.
+ *   - We do NOT enforce empresa-level access here because the RLS policy
+ *     itself doesn't; this mirrors current bucket access rules. If finer
+ *     control is needed later, read the path's owner row from erp.adjuntos
+ *     and check against core.usuarios_empresas.
+ *
+ * Cache: 1h private — safe because objects are immutable once uploaded
+ * (filenames include a timestamp + random suffix).
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path } = await params;
+  if (!path || path.length === 0) {
+    return NextResponse.json({ error: 'Missing path' }, { status: 400 });
+  }
+
+  // Auth check via cookie-bound supabase client.
+  const sessionClient = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await sessionClient.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error' }, { status: 500 });
+  }
+
+  const objectPath = path.join('/');
+  const { data, error } = await admin.storage.from('adjuntos').download(objectPath);
+
+  if (error || !data) {
+    console.error('[adjuntos-proxy] download failed', {
+      objectPath,
+      userId: user.id,
+      errorMessage: error?.message,
+    });
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  // `data` is a Blob. NextResponse can stream it directly.
+  return new NextResponse(data, {
+    headers: {
+      'Content-Type': data.type || 'application/octet-stream',
+      'Cache-Control': 'private, max-age=3600, must-revalidate',
+      'Content-Length': String(data.size),
+    },
+  });
+}

--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -457,15 +457,13 @@ function JuntaDetailInner() {
         alert(`Error al subir imagen: ${uploadErr.message}`);
         return;
       }
-      // Bucket is private. Use a signed URL for in-editor display so the user
-      // sees the image immediately, but the save path (handleSave, autoSave,
-      // flushSave) normalizes <img src> back to the bare object path so the
-      // DB never holds a soon-to-expire signed URL.
-      const signedForEditor = await getAdjuntoSignedUrl(supabase, path, 6 * 3600);
+      // Use the same-origin proxy URL. It persists as-is in the DB and the
+      // browser authenticates via session cookie — no signed URL expiry,
+      // no rewrite race, no broken images on reload.
       editor
         .chain()
         .focus()
-        .setImage({ src: signedForEditor || path })
+        .setImage({ src: `/api/adjuntos/${path}` })
         .run();
     } finally {
       setUploadingImage(false);

--- a/lib/adjuntos.test.ts
+++ b/lib/adjuntos.test.ts
@@ -257,11 +257,11 @@ describe('normalizeHtmlImagesToPaths', () => {
     expect(normalizeHtmlImagesToPaths('')).toBe('');
   });
 
-  it('rewrites a single double-quoted src', () => {
+  it('rewrites a single double-quoted src to the /api/adjuntos/ proxy URL', () => {
     const html =
       '<p>hi</p><img src="https://x.supabase.co/storage/v1/object/public/adjuntos/a/b.png" alt="x">';
     const out = normalizeHtmlImagesToPaths(html);
-    expect(out).toContain('src="a/b.png"');
+    expect(out).toContain('src="/api/adjuntos/a/b.png"');
     expect(out).not.toContain('/object/public/');
   });
 
@@ -269,7 +269,7 @@ describe('normalizeHtmlImagesToPaths', () => {
     const html =
       "<img src='https://x.supabase.co/storage/v1/object/sign/adjuntos/a/b.png?token=abc' />";
     const out = normalizeHtmlImagesToPaths(html);
-    expect(out).toContain('src="a/b.png"');
+    expect(out).toContain('src="/api/adjuntos/a/b.png"');
     expect(out).not.toContain('?token=');
   });
 
@@ -277,8 +277,8 @@ describe('normalizeHtmlImagesToPaths', () => {
     const html =
       '<p><img src="https://x.supabase.co/storage/v1/object/public/adjuntos/a.png"><img src="https://x.supabase.co/storage/v1/object/public/adjuntos/b.png"></p>';
     const out = normalizeHtmlImagesToPaths(html);
-    expect(out).toContain('src="a.png"');
-    expect(out).toContain('src="b.png"');
+    expect(out).toContain('src="/api/adjuntos/a.png"');
+    expect(out).toContain('src="/api/adjuntos/b.png"');
   });
 
   it('is a no-op on HTML with no images', () => {
@@ -286,10 +286,16 @@ describe('normalizeHtmlImagesToPaths', () => {
     expect(normalizeHtmlImagesToPaths(html)).toBe(html);
   });
 
-  it('leaves an already-bare-path src untouched', () => {
+  it('rewrites a bare-path src to the proxy URL', () => {
     const html = '<img src="a/b.png">';
     const out = normalizeHtmlImagesToPaths(html);
-    expect(out).toContain('src="a/b.png"');
+    expect(out).toContain('src="/api/adjuntos/a/b.png"');
+  });
+
+  it('is idempotent on already-proxied URLs', () => {
+    const html = '<img src="/api/adjuntos/a/b.png">';
+    const out = normalizeHtmlImagesToPaths(html);
+    expect(out).toContain('src="/api/adjuntos/a/b.png"');
   });
 });
 
@@ -621,6 +627,11 @@ describe('rewriteTiptapImagesToSigned', () => {
 // ─── rewriteHtmlImagesToSigned ───────────────────────────────────────────
 
 describe('rewriteHtmlImagesToSigned', () => {
+  // NOTE: The function kept its name for backward compatibility but the
+  // semantics changed. It now rewrites <img src> to the same-origin
+  // `/api/adjuntos/<path>` proxy URL instead of calling createSignedUrls().
+  // The `supabase` arg is accepted but unused — no API call happens.
+
   it('returns empty string for null / undefined / empty without calling the API', async () => {
     const createSignedUrls = vi.fn();
     const { client } = makeSupabaseMock({
@@ -644,72 +655,46 @@ describe('rewriteHtmlImagesToSigned', () => {
     expect(createSignedUrls).not.toHaveBeenCalled();
   });
 
-  it('calls the batch API exactly once even with multiple imgs', async () => {
-    const createSignedUrls = vi
-      .fn<(paths: string[], expiresIn: number) => Promise<CreateSignedUrlsResult>>()
-      .mockResolvedValue({
-        data: [
-          { path: 'a.png', signedUrl: 'signed://a' },
-          { path: 'b.png', signedUrl: 'signed://b' },
-        ],
-        error: null,
-      });
+  it('never calls the Supabase API regardless of how many imgs', async () => {
+    const createSignedUrls = vi.fn();
     const { client } = makeSupabaseMock({
       createSignedUrl: vi.fn(),
       createSignedUrls,
     });
     const html = '<img src="a.png"><img src="b.png">';
     await rewriteHtmlImagesToSigned(client, html);
-    expect(createSignedUrls).toHaveBeenCalledTimes(1);
+    expect(createSignedUrls).not.toHaveBeenCalled();
   });
 
-  it('rewrites img srcs to signed URLs (double-quoted)', async () => {
-    const createSignedUrls = vi
-      .fn<(paths: string[], expiresIn: number) => Promise<CreateSignedUrlsResult>>()
-      .mockResolvedValue({
-        data: [{ path: 'a.png', signedUrl: 'signed://a' }],
-        error: null,
-      });
+  it('rewrites img srcs to /api/adjuntos/ (double-quoted)', async () => {
     const { client } = makeSupabaseMock({
       createSignedUrl: vi.fn(),
-      createSignedUrls,
+      createSignedUrls: vi.fn(),
     });
     const html = '<img src="a.png" alt="x">';
     const out = await rewriteHtmlImagesToSigned(client, html);
-    expect(out).toContain('src="signed://a"');
+    expect(out).toContain('src="/api/adjuntos/a.png"');
     // Other attrs preserved.
     expect(out).toContain('alt="x"');
   });
 
   it('rewrites single-quoted srcs (coerced to double quotes on output)', async () => {
-    const createSignedUrls = vi
-      .fn<(paths: string[], expiresIn: number) => Promise<CreateSignedUrlsResult>>()
-      .mockResolvedValue({
-        data: [{ path: 'a.png', signedUrl: 'signed://a' }],
-        error: null,
-      });
     const { client } = makeSupabaseMock({
       createSignedUrl: vi.fn(),
-      createSignedUrls,
+      createSignedUrls: vi.fn(),
     });
     const html = "<img src='a.png'>";
     const out = await rewriteHtmlImagesToSigned(client, html);
-    expect(out).toContain('src="signed://a"');
+    expect(out).toContain('src="/api/adjuntos/a.png"');
   });
 
-  it('leaves src untouched when the API returns no URL for it', async () => {
-    const createSignedUrls = vi
-      .fn<(paths: string[], expiresIn: number) => Promise<CreateSignedUrlsResult>>()
-      .mockResolvedValue({
-        data: [],
-        error: null,
-      });
+  it('rewrites a bare-path src to the proxy URL (no API lookup needed)', async () => {
     const { client } = makeSupabaseMock({
       createSignedUrl: vi.fn(),
-      createSignedUrls,
+      createSignedUrls: vi.fn(),
     });
     const html = '<img src="a.png">';
     const out = await rewriteHtmlImagesToSigned(client, html);
-    expect(out).toContain('src="a.png"');
+    expect(out).toContain('src="/api/adjuntos/a.png"');
   });
 });

--- a/lib/adjuntos.ts
+++ b/lib/adjuntos.ts
@@ -15,17 +15,37 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 const PUBLIC_URL_MARKER = '/object/public/adjuntos/';
 const SIGNED_URL_MARKER = '/object/sign/adjuntos/';
 const AUTHENTICATED_URL_MARKER = '/object/authenticated/adjuntos/';
+// Same-origin proxy path served by app/api/adjuntos/[...path]/route.ts.
+// This is the preferred canonical format going forward because it avoids
+// signed-URL expiry + client-side rewrite races.
+const PROXY_PREFIX = '/api/adjuntos/';
 
 /**
- * Normalize a value that may be a bare path, a legacy public URL, or a
- * (stale) signed URL into the object path inside the `adjuntos` bucket.
+ * Builds the canonical same-origin URL for an adjunto from a bare object path.
+ * Pass the result straight to <img src="…"> or <a href="…">. Loads go through
+ * the cookie-authenticated proxy route, no signing needed.
+ */
+export function getAdjuntoProxyUrl(pathOrUrl: string | null | undefined): string {
+  const path = getAdjuntoPath(pathOrUrl);
+  return path ? `${PROXY_PREFIX}${path}` : '';
+}
+
+/**
+ * Normalize a value that may be a bare path, a legacy public URL, a (stale)
+ * signed URL, or an /api/adjuntos/ proxy URL into the object path inside
+ * the `adjuntos` bucket.
  */
 export function getAdjuntoPath(urlOrPath: string | null | undefined): string | null {
   if (!urlOrPath) return null;
   const value = String(urlOrPath).trim();
   if (!value) return null;
 
-  for (const marker of [PUBLIC_URL_MARKER, SIGNED_URL_MARKER, AUTHENTICATED_URL_MARKER]) {
+  for (const marker of [
+    PUBLIC_URL_MARKER,
+    SIGNED_URL_MARKER,
+    AUTHENTICATED_URL_MARKER,
+    PROXY_PREFIX,
+  ]) {
     const idx = value.indexOf(marker);
     if (idx >= 0) {
       // Strip the host prefix and any query string (signed URLs have `?token=…`).
@@ -172,16 +192,6 @@ export function normalizeTiptapImagesToPaths(tree: unknown): unknown {
 // BSOP's juntas descripcion stores HTML, not prosemirror JSON. These
 // helpers mutate the `src` attribute on every <img> tag.
 
-function extractImgSrcs(html: string): string[] {
-  const out: string[] = [];
-  const re = /<img\b[^>]*?\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(html)) !== null) {
-    out.push(match[1] ?? match[2] ?? '');
-  }
-  return out;
-}
-
 function replaceImgSrcs(html: string, transform: (src: string) => string): string {
   return html.replace(
     /(<img\b[^>]*?\bsrc\s*=\s*)(?:"([^"]*)"|'([^']*)')/gi,
@@ -194,31 +204,47 @@ function replaceImgSrcs(html: string, transform: (src: string) => string): strin
 }
 
 /**
- * Rewrites every `<img src="…">` in an HTML string to a signed URL.
- * Safe to call on HTML that has no adjuntos images (it's a no-op).
+ * Rewrites every `<img src="…">` in an HTML string to the same-origin
+ * `/api/adjuntos/<path>` proxy URL. This is a **synchronous** pure-string
+ * transform — no Supabase round-trip, no expiring tokens, no race
+ * conditions with TipTap setContent.
+ *
+ * Kept named `rewriteHtmlImagesToSigned` for backward compatibility with
+ * existing callers that await it. The `supabase` and `expiresInSeconds`
+ * args are accepted but unused; mark them as such to avoid misuse in
+ * future changes.
  */
 export async function rewriteHtmlImagesToSigned(
-  supabase: SupabaseClient,
+  _supabase: SupabaseClient,
   html: string | null | undefined,
-  expiresInSeconds = 3600
+  _expiresInSeconds = 3600
 ): Promise<string> {
+  return rewriteHtmlImagesToProxy(html);
+}
+
+/**
+ * Pure synchronous version. Replaces every <img src> with `/api/adjuntos/<path>`.
+ * Safe to call on HTML that has no adjuntos images (no-op when no <img>).
+ */
+export function rewriteHtmlImagesToProxy(html: string | null | undefined): string {
   if (!html) return '';
-  const srcs = extractImgSrcs(html);
-  if (srcs.length === 0) return html;
-  const signedMap = await getAdjuntoSignedUrls(supabase, srcs, expiresInSeconds);
   return replaceImgSrcs(html, (src) => {
     const path = getAdjuntoPath(src);
     if (!path) return src;
-    return signedMap.get(path) ?? src;
+    return `/api/adjuntos/${path}`;
   });
 }
 
 /**
- * Rewrites every `<img src="…">` in an HTML string to the bare object
- * path — call in the save path so the DB never holds soon-to-expire
- * signed URLs.
+ * Normalize every `<img src="…">` in an HTML string to the canonical
+ * `/api/adjuntos/<path>` form. Call this in the save path so the DB
+ * always holds the same format (no signed URLs, no legacy public URLs).
+ *
+ * Name kept for backward compatibility — despite "ToPaths", the output
+ * is now the proxy URL, not the bare path. Callers just need a value
+ * that the read side will correctly render; the proxy URL fits both
+ * roles and works in <img src> directly without any rewriter step.
  */
 export function normalizeHtmlImagesToPaths(html: string | null | undefined): string {
-  if (!html) return '';
-  return replaceImgSrcs(html, (src) => getAdjuntoPath(src) ?? src);
+  return rewriteHtmlImagesToProxy(html);
 }


### PR DESCRIPTION
Resuelve definitivamente el bug de imágenes que no cargaban en juntas. En lugar de depender de un rewriter async en el cliente (race-prone), todas las imágenes se sirven via `/api/adjuntos/<path>` — proxy autenticado por cookie que stream del bucket privado. Ver commit message para detalles completos.