### PR TITLE
feat(juntas): avanzadas/terminadas counts + sort fix + TipTap SSR fix

### DIFF
--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   rewriteHtmlImagesToSigned,
   normalizeHtmlImagesToPaths,
 } from '@/lib/adjuntos';
+import { htmlHasCodaImages, importCodaImagesInHtml } from '@/lib/coda-paste-import';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
@@ -187,6 +188,23 @@ function formatDate(s: string | null) {
   return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
+/**
+ * Date + hora, usado en los comentarios de actualizaciones de tareas para
+ * tener contexto de cuándo se capturó cada nota ("18 abr 2026, 10:35").
+ */
+function formatDateTime(s: string | null) {
+  if (!s) return '—';
+  const d = new Date(s);
+  return d.toLocaleString('es-MX', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  });
+}
+
 function FieldLabel({ children, required }: { children: React.ReactNode; required?: boolean }) {
   return (
     <div className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/50 mb-1.5">
@@ -265,7 +283,9 @@ function EditorToolbar({
   editor,
   onInsertImage,
 }: {
-  editor: ReturnType<typeof useEditor>;
+  // Con `immediatelyRender: false` (requerido por Next SSR), `useEditor`
+  // puede devolver null en el primer render antes de hidratar.
+  editor: ReturnType<typeof useEditor> | null;
   onInsertImage: () => void;
 }) {
   if (!editor) return null;
@@ -386,6 +406,10 @@ function JuntaDetailInner() {
   const [isDireccion, setIsDireccion] = useState(false);
 
   const editor = useEditor({
+    // TipTap v3 exige `immediatelyRender: false` cuando corre bajo Next.js
+    // con SSR/RSC. Evita el hydration mismatch entre el HTML del server y
+    // el del cliente (el server no puede renderizar ProseMirror).
+    immediatelyRender: false,
     extensions: [
       StarterKit,
       Underline,
@@ -424,7 +448,7 @@ function JuntaDetailInner() {
         // 2) HTML paste with external Coda <img> URLs (Cmd+A + Cmd+C from Coda junta).
         //    Intercept only when we actually see Coda-hosted image references.
         const html = event.clipboardData?.getData('text/html') || '';
-        if (html && /(codahosted\.io|codaio\.imgix\.net|images-codaio\.imgix\.net)/.test(html)) {
+        if (htmlHasCodaImages(html)) {
           event.preventDefault();
           void handlePasteWithCodaImages(html);
           return true;
@@ -470,55 +494,9 @@ function JuntaDetailInner() {
     if (!editor) return;
     setUploadingImage(true);
     try {
-      // Extract each <img src="..."> that points at a Coda CDN.
-      const imgRe = /<img\b[^>]*?\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)')/gi;
-      const srcs: string[] = [];
-      let m: RegExpExecArray | null;
-      const codaHostPattern = /(codahosted\.io|codaio\.imgix\.net|images-codaio\.imgix\.net)/;
-      while ((m = imgRe.exec(html)) !== null) {
-        const src = m[1] ?? m[2] ?? '';
-        if (src && codaHostPattern.test(src)) srcs.push(src);
-      }
-      const uniqueSrcs = Array.from(new Set(srcs));
-
-      const replacements = new Map<string, string>();
-      let imported = 0;
-      let failed = 0;
-      for (const src of uniqueSrcs) {
-        try {
-          const res = await fetch('/api/adjuntos/import-url', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ url: src, juntaId: id }),
-          });
-          if (!res.ok) {
-            failed += 1;
-            console.warn('[paste] import-url failed for', src.slice(0, 60), res.status);
-            continue;
-          }
-          const data = (await res.json()) as { ok?: boolean; url?: string };
-          if (data.ok && data.url) {
-            replacements.set(src, data.url);
-            imported += 1;
-          } else {
-            failed += 1;
-          }
-        } catch (err) {
-          failed += 1;
-          console.warn('[paste] import-url error', (err as Error).message);
-        }
-      }
-
-      // Apply replacements to the HTML so <img src="codahosted..."> → <img src="/api/adjuntos/...">
-      let rewritten = html;
-      for (const [from, to] of replacements) {
-        const escaped = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        rewritten = rewritten.replace(new RegExp(escaped, 'g'), to);
-      }
-
+      const { html: rewritten, imported, failed } = await importCodaImagesInHtml(html, id);
       // Insert into the editor at the current cursor position.
       editor.chain().focus().insertContent(rewritten).run();
-
       if (failed > 0) {
         alert(
           `Imágenes importadas: ${imported}. Fallaron ${failed} — revisa la consola del navegador.`
@@ -1443,77 +1421,107 @@ function JuntaDetailInner() {
             </div>
           ) : (
             (() => {
+              // Agrupar actualizaciones por tarea y ordenar ASC dentro del
+              // grupo para que se lea como timeline (antigua → reciente).
+              // El fetch global las baja DESC, pero aquí una tarea a la vez
+              // luce más natural cronológicamente.
               const grouped = new Map<string, TaskUpdate[]>();
               for (const u of taskUpdates) {
                 const arr = grouped.get(u.task_id) ?? [];
                 arr.push(u);
                 grouped.set(u.task_id, arr);
               }
+              for (const arr of grouped.values()) {
+                arr.sort(
+                  (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+                );
+              }
+              const tipoCfg: Record<string, { label: string; cls: string }> = {
+                avance: {
+                  label: 'Avance',
+                  cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+                },
+                cambio_estado: {
+                  label: 'Estado',
+                  cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+                },
+                cambio_fecha: {
+                  label: 'Fecha',
+                  cls: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
+                },
+                nota: {
+                  label: 'Nota',
+                  cls: 'bg-[var(--border)]/60 text-[var(--text)]/60 border-[var(--border)]',
+                },
+                cambio_responsable: {
+                  label: 'Responsable',
+                  cls: 'bg-teal-500/15 text-teal-400 border-teal-500/20',
+                },
+              };
               return (
-                <div className="space-y-4">
+                <div className="divide-y divide-[var(--border)]">
                   {Array.from(grouped.entries()).map(([taskId, updates]) => {
                     const task = tasks.find((t) => t.id === taskId);
                     if (!task) return null;
+                    const estadoCfg = ESTADO_TASK[task.estado] ?? {
+                      label: task.estado,
+                      cls: '',
+                    };
+                    const asignado = empleadoMap.get(task.asignado_a ?? '');
                     return (
-                      <div key={taskId} className="space-y-2">
-                        <p className="text-xs font-semibold text-[var(--text)]/50 uppercase tracking-wide">
-                          {task.titulo}
-                        </p>
-                        {updates.map((u) => {
-                          const tipoCfg: Record<string, { label: string; cls: string }> = {
-                            avance: {
-                              label: 'Avance',
-                              cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
-                            },
-                            cambio_estado: {
-                              label: 'Estado',
-                              cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
-                            },
-                            cambio_fecha: {
-                              label: 'Fecha',
-                              cls: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
-                            },
-                            nota: {
-                              label: 'Nota',
-                              cls: 'bg-[var(--border)]/60 text-[var(--text)]/60 border-[var(--border)]',
-                            },
-                            cambio_responsable: {
-                              label: 'Responsable',
-                              cls: 'bg-teal-500/15 text-teal-400 border-teal-500/20',
-                            },
-                          };
-                          const tc = tipoCfg[u.tipo] ?? { label: u.tipo, cls: '' };
-                          return (
-                            <div
-                              key={u.id}
-                              className="rounded-xl border border-[var(--border)] bg-[var(--panel)] px-3 py-2.5"
-                            >
-                              <div className="flex items-center gap-2 mb-1">
-                                <span
-                                  className={`inline-flex items-center rounded-lg border px-2 py-0.5 text-[10px] font-medium ${tc.cls}`}
-                                >
-                                  {tc.label}
-                                </span>
-                                <span className="text-[10px] text-[var(--text)]/40">
-                                  {u.usuario?.nombre ?? 'Sistema'}
-                                </span>
-                                <span className="text-[10px] text-[var(--text)]/30 ml-auto">
-                                  {formatDate(u.created_at)}
-                                </span>
-                              </div>
-                              {u.contenido && (
-                                <p className="text-sm text-[var(--text)]/80">{u.contenido}</p>
-                              )}
-                              {u.valor_anterior != null && u.valor_nuevo != null && (
-                                <p className="text-xs text-[var(--text)]/50">
-                                  {u.tipo === 'cambio_estado'
-                                    ? `${ESTADO_TASK[u.valor_anterior]?.label ?? u.valor_anterior} → ${ESTADO_TASK[u.valor_nuevo]?.label ?? u.valor_nuevo}`
-                                    : `${u.valor_anterior || '—'} → ${u.valor_nuevo || '—'}`}
-                                </p>
-                              )}
-                            </div>
-                          );
-                        })}
+                      <div key={taskId} className="py-2.5 first:pt-0 last:pb-0">
+                        {/* Encabezado compacto: nombre + estado + meta en una
+                            sola línea. Si hay muchas tareas con movimiento
+                            la vista sigue siendo escaneable. */}
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mb-1.5">
+                          <span className="text-sm font-medium text-[var(--text)]">
+                            {task.titulo}
+                          </span>
+                          <span
+                            className={`inline-flex items-center rounded-md border px-1.5 py-px text-[10px] font-medium ${estadoCfg.cls}`}
+                          >
+                            {estadoCfg.label}
+                          </span>
+                          <span className="text-[10px] text-[var(--text)]/45">
+                            {asignado?.nombre ?? '—'}
+                            {task.fecha_vence && ` · vence ${formatDate(task.fecha_vence)}`}
+                            {` · ${updates.length} ${updates.length === 1 ? 'nota' : 'notas'}`}
+                          </span>
+                        </div>
+                        <ul className="space-y-1 pl-2 border-l-2 border-[var(--border)]">
+                          {updates.map((u) => {
+                            const tc = tipoCfg[u.tipo] ?? { label: u.tipo, cls: '' };
+                            const hasDelta = u.valor_anterior != null && u.valor_nuevo != null;
+                            return (
+                              <li key={u.id} className="text-xs leading-snug text-[var(--text)]/80">
+                                <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-[var(--text)]/45">
+                                  <span
+                                    className={`inline-flex items-center rounded border px-1.5 py-px font-medium ${tc.cls}`}
+                                  >
+                                    {tc.label}
+                                  </span>
+                                  <span className="text-[var(--text)]/65">
+                                    {u.usuario?.nombre ?? 'Sistema'}
+                                  </span>
+                                  <span>·</span>
+                                  <span>{formatDateTime(u.created_at)}</span>
+                                </div>
+                                {u.contenido && (
+                                  <p className="text-xs text-[var(--text)]/80 whitespace-pre-wrap">
+                                    {u.contenido}
+                                  </p>
+                                )}
+                                {hasDelta && (
+                                  <p className="text-[11px] text-[var(--text)]/50">
+                                    {u.tipo === 'cambio_estado'
+                                      ? `${ESTADO_TASK[u.valor_anterior!]?.label ?? u.valor_anterior} → ${ESTADO_TASK[u.valor_nuevo!]?.label ?? u.valor_nuevo}`
+                                      : `${u.valor_anterior || '—'} → ${u.valor_nuevo || '—'}`}
+                                  </p>
+                                )}
+                              </li>
+                            );
+                          })}
+                        </ul>
                       </div>
                     );
                   })}

--- a/app/dilesa/admin/juntas/page.tsx
+++ b/app/dilesa/admin/juntas/page.tsx
@@ -202,6 +202,16 @@ function JuntasInner() {
 
   const [asistenciaCounts, setAsistenciaCounts] = useState<Map<string, number>>(new Map());
   const [taskCounts, setTaskCounts] = useState<Map<string, number>>(new Map());
+  // "Avanzadas"  = # tareas de la junta con ≥1 registro en task_updates
+  //                (cuántas salen en la sección "Actualizaciones de tareas"
+  //                del detalle).
+  // "Terminadas" = subconjunto de avanzadas donde la tarea, además de tener
+  //                movimiento en la junta, quedó en estado 'completado'.
+  //                Incluye tanto cierres formales (cambio_estado →
+  //                completado) como tareas que ya estaban cerradas y
+  //                recibieron una nota/conclusión durante la junta.
+  const [taskAvanzadasCounts, setTaskAvanzadasCounts] = useState<Map<string, number>>(new Map());
+  const [taskTerminadasCounts, setTaskTerminadasCounts] = useState<Map<string, number>>(new Map());
   const [search, setSearch] = useState('');
   const [filterEstado, setFilterEstado] = useState('all');
   const [filterTipo, setFilterTipo] = useState('all');
@@ -215,7 +225,7 @@ function JuntasInner() {
   const [tituloOverridden, setTituloOverridden] = useState(false);
 
   const fetchJuntas = useCallback(async () => {
-    const [jRes, aRes, tRes] = await Promise.all([
+    const [jRes, aRes, tRes, uRes] = await Promise.all([
       supabase
         .schema('erp')
         .from('juntas')
@@ -230,25 +240,88 @@ function JuntasInner() {
       supabase
         .schema('erp')
         .from('tasks')
-        .select('entidad_id')
+        .select('id, entidad_id, estado')
         .eq('empresa_id', EMPRESA_ID)
-        .eq('entidad_tipo', 'junta'),
+        .eq('entidad_tipo', 'junta')
+        .limit(50000),
+      // task_updates para todas las tareas de junta de la empresa. Se hace un
+      // !inner join con tasks para poder filtrar por entidad_tipo='junta' y
+      // obtener la junta_id sin un segundo round-trip. Límite alto para que
+      // no se corte con el default de 1000 filas de PostgREST.
+      supabase
+        .schema('erp')
+        .from('task_updates')
+        .select('task_id, tipo, valor_nuevo, tasks!inner(entidad_id, entidad_tipo)')
+        .eq('empresa_id', EMPRESA_ID)
+        .eq('tasks.entidad_tipo', 'junta')
+        .limit(50000),
     ]);
     if (jRes.error) {
       setError(jRes.error.message);
       return;
     }
     setJuntas((jRes.data ?? []) as Junta[]);
+
     const aCounts = new Map<string, number>();
     (aRes.data ?? []).forEach((a: { junta_id: string }) => {
       aCounts.set(a.junta_id, (aCounts.get(a.junta_id) ?? 0) + 1);
     });
     setAsistenciaCounts(aCounts);
+
+    // Map task_id → junta_id + total de tareas por junta + set de tareas
+    // terminadas (estado actual = completado) para poder hacer el match con
+    // task_updates después.
+    const taskToJunta = new Map<string, string>();
+    const completedTasks = new Set<string>();
     const tCounts = new Map<string, number>();
-    (tRes.data ?? []).forEach((t: { entidad_id: string | null }) => {
-      if (t.entidad_id) tCounts.set(t.entidad_id, (tCounts.get(t.entidad_id) ?? 0) + 1);
-    });
+    (tRes.data ?? []).forEach(
+      (t: { id: string; entidad_id: string | null; estado: string | null }) => {
+        if (!t.entidad_id) return;
+        taskToJunta.set(t.id, t.entidad_id);
+        tCounts.set(t.entidad_id, (tCounts.get(t.entidad_id) ?? 0) + 1);
+        if (t.estado === 'completado') completedTasks.add(t.id);
+      }
+    );
     setTaskCounts(tCounts);
+
+    // Avanzadas = # tareas distintas con updates en la junta.
+    // Terminadas = tareas con updates que además:
+    //   (a) están en estado 'completado' ahora mismo, O
+    //   (b) tuvieron un update `cambio_estado` con valor_nuevo='completado'
+    //       (incluso si después fueron reabiertas — el evento de terminación
+    //       en esta junta cuenta).
+    // Esto evita sub-contar cuando la migración desde Coda dejó la `estado`
+    // vacía o fuera del enum esperado y solo queda el rastro en task_updates.
+    // Uso Set<task_id> para no duplicar cuando una tarea tiene varios updates.
+    const avanzadasPerJunta = new Map<string, Set<string>>();
+    const terminadasPerJunta = new Map<string, Set<string>>();
+    (uRes.data ?? []).forEach(
+      (u: { task_id: string; tipo: string | null; valor_nuevo: string | null }) => {
+        const juntaId = taskToJunta.get(u.task_id);
+        if (!juntaId) return;
+        let aSet = avanzadasPerJunta.get(juntaId);
+        if (!aSet) {
+          aSet = new Set<string>();
+          avanzadasPerJunta.set(juntaId, aSet);
+        }
+        aSet.add(u.task_id);
+        const completionEvent = u.tipo === 'cambio_estado' && u.valor_nuevo === 'completado';
+        if (completedTasks.has(u.task_id) || completionEvent) {
+          let tSet = terminadasPerJunta.get(juntaId);
+          if (!tSet) {
+            tSet = new Set<string>();
+            terminadasPerJunta.set(juntaId, tSet);
+          }
+          tSet.add(u.task_id);
+        }
+      }
+    );
+    const avCounts = new Map<string, number>();
+    for (const [j, s] of avanzadasPerJunta) avCounts.set(j, s.size);
+    const teCounts = new Map<string, number>();
+    for (const [j, s] of terminadasPerJunta) teCounts.set(j, s.size);
+    setTaskAvanzadasCounts(avCounts);
+    setTaskTerminadasCounts(teCounts);
   }, [supabase]);
 
   useEffect(() => {
@@ -520,6 +593,22 @@ function JuntasInner() {
                   onSort={onSort}
                   className="w-16"
                 />
+                <SortableHead
+                  sortKey="avanzadas"
+                  label="Avanz."
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                  className="w-16"
+                />
+                <SortableHead
+                  sortKey="terminadas"
+                  label="Term."
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                  className="w-16"
+                />
                 <TableHead className="w-10" />
               </TableRow>
             </TableHeader>
@@ -529,6 +618,8 @@ function JuntasInner() {
                   ...j,
                   asistentes: asistenciaCounts.get(j.id) ?? 0,
                   tareas: taskCounts.get(j.id) ?? 0,
+                  avanzadas: taskAvanzadasCounts.get(j.id) ?? 0,
+                  terminadas: taskTerminadasCounts.get(j.id) ?? 0,
                 }))
               ).map((junta) => (
                 <TableRow
@@ -571,6 +662,30 @@ function JuntasInner() {
                     <span className="text-sm text-[var(--text)]/60">
                       {taskCounts.get(junta.id) ?? 0}
                     </span>
+                  </TableCell>
+                  <TableCell>
+                    {(() => {
+                      const n = taskAvanzadasCounts.get(junta.id) ?? 0;
+                      return (
+                        <span
+                          className={`text-sm ${n > 0 ? 'text-blue-400 font-medium' : 'text-[var(--text)]/30'}`}
+                        >
+                          {n}
+                        </span>
+                      );
+                    })()}
+                  </TableCell>
+                  <TableCell>
+                    {(() => {
+                      const n = taskTerminadasCounts.get(junta.id) ?? 0;
+                      return (
+                        <span
+                          className={`text-sm ${n > 0 ? 'text-green-400 font-medium' : 'text-[var(--text)]/30'}`}
+                        >
+                          {n}
+                        </span>
+                      );
+                    })()}
                   </TableCell>
                   <TableCell>
                     <ChevronRight className="h-4 w-4 text-[var(--text)]/30" />

--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -187,7 +187,7 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
 
 // ─── Tiptap toolbar ──────────────────────────────────────────────────────────
 
-function EditorToolbar({ editor }: { editor: ReturnType<typeof useEditor> }) {
+function EditorToolbar({ editor }: { editor: ReturnType<typeof useEditor> | null }) {
   if (!editor) return null;
 
   const btn = (active: boolean, onClick: () => void, title: string, icon: React.ReactNode) => (
@@ -297,6 +297,9 @@ function JuntaDetailInner() {
 
   // Tiptap editor
   const editor = useEditor({
+    // TipTap v3 exige `immediatelyRender: false` para Next.js SSR/RSC; evita
+    // el hydration mismatch "SSR has been detected".
+    immediatelyRender: false,
     extensions: [
       StarterKit,
       Underline,

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -180,7 +180,7 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   );
 }
 
-function EditorToolbar({ editor }: { editor: ReturnType<typeof useEditor> }) {
+function EditorToolbar({ editor }: { editor: ReturnType<typeof useEditor> | null }) {
   if (!editor) return null;
 
   const btn = (active: boolean, onClick: () => void, title: string, icon: React.ReactNode) => (
@@ -286,6 +286,9 @@ function JuntaDetailInner() {
   const [showTerminarDialog, setShowTerminarDialog] = useState(false);
 
   const editor = useEditor({
+    // TipTap v3 exige `immediatelyRender: false` para Next.js SSR/RSC; evita
+    // el hydration mismatch "SSR has been detected".
+    immediatelyRender: false,
     extensions: [
       StarterKit,
       Underline,

--- a/hooks/use-sortable-table.ts
+++ b/hooks/use-sortable-table.ts
@@ -13,16 +13,22 @@ export function useSortableTable<_T = unknown>(defaultKey: string, defaultDir: S
   const [sortKey, setSortKey] = useState(defaultKey);
   const [sortDir, setSortDir] = useState<SortDir>(defaultDir);
 
-  const onSort = useCallback((key: string) => {
-    setSortKey((prev) => {
-      if (prev === key) {
+  // Bug previo: se llamaba `setSortDir` DENTRO del updater de `setSortKey`.
+  // En strict mode / React 19 los updaters se ejecutan dos veces, así que el
+  // toggle de dirección se cancelaba a sí mismo y los sorts no respondían al
+  // segundo clic. La forma correcta es leer `sortKey` como dependencia del
+  // callback y llamar los dos setters de forma paralela/independiente.
+  const onSort = useCallback(
+    (key: string) => {
+      if (sortKey === key) {
         setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-        return key;
+      } else {
+        setSortKey(key);
+        setSortDir('asc');
       }
-      setSortDir('asc');
-      return key;
-    });
-  }, []);
+    },
+    [sortKey]
+  );
 
   const sortData = useCallback(
     <T extends Record<string, unknown>>(data: T[]): T[] => {

--- a/lib/coda-paste-import.ts
+++ b/lib/coda-paste-import.ts
@@ -1,0 +1,94 @@
+/**
+ * Helpers para importar el HTML que Coda coloca en el portapapeles (Cmd+A +
+ * Cmd+C desde el canvas de una junta) y reescribirlo para que todas las
+ * imágenes queden bajo `/api/adjuntos/...` del bucket privado de BSOP.
+ *
+ * El flujo es el mismo que usa el editor TipTap del detalle de junta (ver
+ * `app/dilesa/admin/juntas/[id]/page.tsx`); se vive aquí para poder
+ * reutilizarlo desde otras partes de la UI (por ejemplo, la columna de
+ * "pegar de Coda" en la tabla principal de juntas).
+ */
+
+/** Patrón de hosts de Coda cuyas imágenes sí se importan. */
+const CODA_HOST_PATTERN = /(codahosted\.io|codaio\.imgix\.net|images-codaio\.imgix\.net)/;
+
+/** Detecta rápido si un blob de HTML trae imágenes que vale la pena importar. */
+export function htmlHasCodaImages(html: string | null | undefined): boolean {
+  if (!html) return false;
+  return CODA_HOST_PATTERN.test(html);
+}
+
+/** Extrae los `src` únicos de todos los `<img>` que apuntan a Coda. */
+export function extractCodaImageSrcs(html: string): string[] {
+  const imgRe = /<img\b[^>]*?\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)')/gi;
+  const srcs: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = imgRe.exec(html)) !== null) {
+    const src = m[1] ?? m[2] ?? '';
+    if (src && CODA_HOST_PATTERN.test(src)) srcs.push(src);
+  }
+  return Array.from(new Set(srcs));
+}
+
+export type CodaImportResult = {
+  /** HTML reescrito con `<img src>` ya apuntando a `/api/adjuntos/...`. */
+  html: string;
+  /** Imágenes que se descargaron y guardaron con éxito. */
+  imported: number;
+  /** Imágenes que fallaron (timeout, 4xx/5xx del upstream, etc.). */
+  failed: number;
+};
+
+/**
+ * Dada una cadena de HTML (típicamente salida del portapapeles tras copiar
+ * de Coda) y un `juntaId`, descarga cada imagen de Coda vía el endpoint
+ * server-side `/api/adjuntos/import-url` — que a su vez las sube al bucket
+ * privado — y devuelve el HTML con los `src` reescritos.
+ *
+ * El HTML se devuelve aunque fallen algunas imágenes: las que sobrevivieron
+ * quedan apuntando a BSOP; las que fallaron conservan su `src` original
+ * (puede romperse después, pero al menos el texto no se pierde).
+ */
+export async function importCodaImagesInHtml(
+  html: string,
+  juntaId: string
+): Promise<CodaImportResult> {
+  const uniqueSrcs = extractCodaImageSrcs(html);
+  const replacements = new Map<string, string>();
+  let imported = 0;
+  let failed = 0;
+
+  for (const src of uniqueSrcs) {
+    try {
+      const res = await fetch('/api/adjuntos/import-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: src, juntaId }),
+      });
+      if (!res.ok) {
+        failed += 1;
+         
+        console.warn('[coda-paste-import] import-url failed for', src.slice(0, 80), res.status);
+        continue;
+      }
+      const data = (await res.json()) as { ok?: boolean; url?: string };
+      if (data.ok && data.url) {
+        replacements.set(src, data.url);
+        imported += 1;
+      } else {
+        failed += 1;
+      }
+    } catch (err) {
+      failed += 1;
+       
+      console.warn('[coda-paste-import] error', (err as Error).message);
+    }
+  }
+
+  let rewritten = html;
+  for (const [from, to] of replacements) {
+    const escaped = from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    rewritten = rewritten.replace(new RegExp(escaped, 'g'), to);
+  }
+  return { html: rewritten, imported, failed };
+}


### PR DESCRIPTION
## Summary
- Tabla principal DILESA: dos columnas nuevas **Avanz.** y **Term.** computadas desde `erp.task_updates`. Avanz. = # tareas distintas con ≥1 update durante la junta. Term. = tareas con update que además están completadas (estado actual o vía evento `cambio_estado → completado`).
- Detalle de junta: sección **"Actualizaciones de tareas"** rediseñada. Encabezado de una línea con título prominente + badge de estado + responsable + fecha de vencimiento + # de notas. Comentarios en lista compacta con fecha+hora + usuario + delta de valor.
- **Fix de sort:** el `useSortableTable` llamaba `setSortDir` dentro del updater de `setSortKey` — en React 19 / strict mode los updaters corren dos veces y el toggle se cancelaba. Clicks en el mismo header no respondían. Arreglado moviendo los setters a paralelos con `sortKey` como dep.
- **Fix TipTap SSR:** los tres editores de juntas (dilesa, inicio, rdb) ahora pasan `immediatelyRender: false`. Elimina el error rojo "SSR has been detected" al abrir una junta.
- `lib/coda-paste-import.ts`: helper extraído del paste handler para compartir la lógica de import de imágenes Coda entre el editor y futuros callsites.

## Test plan
- [ ] Tabla DILESA: clickear dos veces cada header sortable (Título, Tipo, Estado, Fecha, Asist., Tareas, Avanz., Term.) y confirmar que alterna asc/desc.
- [ ] Tabla DILESA: verificar que Avanz. y Term. muestren valores razonables (cruzar con el detalle).
- [ ] Abrir una junta que antes daba el error rojo — ya no aparece.
- [ ] Ver "Actualizaciones de tareas" dentro de una junta con varias tareas y múltiples updates — la vista es compacta y legible.
- [ ] Paste de Coda dentro del editor del detalle sigue funcionando (usa el helper nuevo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)