### PR TITLE
fix(ui): standardize filter dropdowns across BSOP

### DIFF
--- a/app/dilesa/admin/juntas/page.tsx
+++ b/app/dilesa/admin/juntas/page.tsx
@@ -33,6 +33,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox, type FilterComboboxOption } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -449,52 +450,46 @@ function JuntasInner() {
               className="pl-9 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
             />
           </div>
-          <Select value={filterEstado} onValueChange={(v) => setFilterEstado(v ?? 'all')}>
-            <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Estado" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los estados</SelectItem>
-              {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                <SelectItem key={k} value={k}>
-                  {v.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={filterTipo} onValueChange={(v) => setFilterTipo(v ?? 'all')}>
-            <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Tipo" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los tipos</SelectItem>
-              {TIPO_OPTIONS.map((t) => (
-                <SelectItem key={t.value} value={t.value}>
-                  {t.icon} {t.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={filterMonth} onValueChange={(v) => setFilterMonth(v ?? 'all')}>
-            <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Mes" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los meses</SelectItem>
-              {monthOptions.map((m) => {
-                const [y, mo] = m.split('-');
-                const label = new Date(Number(y), Number(mo) - 1).toLocaleDateString('es-MX', {
-                  month: 'long',
-                  year: 'numeric',
-                });
-                return (
-                  <SelectItem key={m} value={m}>
-                    {label.charAt(0).toUpperCase() + label.slice(1)}
-                  </SelectItem>
-                );
-              })}
-            </SelectContent>
-          </Select>
+          <FilterCombobox
+            value={filterEstado}
+            onChange={setFilterEstado}
+            options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+              id: k,
+              label: v.label,
+            }))}
+            placeholder="Estado"
+            searchPlaceholder="Buscar estado..."
+            clearLabel="Todos los estados"
+            className="w-40"
+          />
+          <FilterCombobox
+            value={filterTipo}
+            onChange={setFilterTipo}
+            options={TIPO_OPTIONS.map((t) => ({
+              id: t.value,
+              label: `${t.icon} ${t.label}`,
+            }))}
+            placeholder="Tipo"
+            searchPlaceholder="Buscar tipo..."
+            clearLabel="Todos los tipos"
+            className="w-40"
+          />
+          <FilterCombobox
+            value={filterMonth}
+            onChange={setFilterMonth}
+            options={monthOptions.map<FilterComboboxOption>((m) => {
+              const [y, mo] = m.split('-');
+              const label = new Date(Number(y), Number(mo) - 1).toLocaleDateString('es-MX', {
+                month: 'long',
+                year: 'numeric',
+              });
+              return { id: m, label: label.charAt(0).toUpperCase() + label.slice(1) };
+            })}
+            placeholder="Mes"
+            searchPlaceholder="Buscar mes..."
+            clearLabel="Todos los meses"
+            className="w-40"
+          />
         </div>
       </div>
 

--- a/app/inicio/juntas/page.tsx
+++ b/app/inicio/juntas/page.tsx
@@ -34,6 +34,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -323,19 +324,18 @@ function JuntasInner() {
               className="pl-9 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
             />
           </div>
-          <Select value={filterEstado} onValueChange={(v) => setFilterEstado(v ?? 'all')}>
-            <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Estado" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los estados</SelectItem>
-              {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                <SelectItem key={k} value={k}>
-                  {v.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <FilterCombobox
+            value={filterEstado}
+            onChange={setFilterEstado}
+            options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+              id: k,
+              label: v.label,
+            }))}
+            placeholder="Estado"
+            searchPlaceholder="Buscar estado..."
+            clearLabel="Todos los estados"
+            className="w-40"
+          />
         </div>
       </div>
 

--- a/app/rdb/admin/juntas/page.tsx
+++ b/app/rdb/admin/juntas/page.tsx
@@ -27,6 +27,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -295,32 +296,30 @@ function JuntasInner() {
               className="pl-9 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
             />
           </div>
-          <Select value={filterEstado} onValueChange={(v) => setFilterEstado(v ?? 'all')}>
-            <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Estado" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los estados</SelectItem>
-              {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                <SelectItem key={k} value={k}>
-                  {v.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={filterTipo} onValueChange={(v) => setFilterTipo(v ?? 'all')}>
-            <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Tipo" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los tipos</SelectItem>
-              {Object.entries(TIPO_CONFIG).map(([k, v]) => (
-                <SelectItem key={k} value={k}>
-                  {v.icon} {v.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <FilterCombobox
+            value={filterEstado}
+            onChange={setFilterEstado}
+            options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+              id: k,
+              label: v.label,
+            }))}
+            placeholder="Estado"
+            searchPlaceholder="Buscar estado..."
+            clearLabel="Todos los estados"
+            className="w-40"
+          />
+          <FilterCombobox
+            value={filterTipo}
+            onChange={setFilterTipo}
+            options={Object.entries(TIPO_CONFIG).map(([k, v]) => ({
+              id: k,
+              label: `${v.icon} ${v.label}`,
+            }))}
+            placeholder="Tipo"
+            searchPlaceholder="Buscar tipo..."
+            clearLabel="Todos los tipos"
+            className="w-40"
+          />
         </div>
       </div>
 

--- a/app/rdb/productos/page.tsx
+++ b/app/rdb/productos/page.tsx
@@ -24,6 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import {
   Sheet,
   SheetContent,
@@ -258,44 +259,41 @@ export default function ProductosPage() {
             />
           </div>
 
-          <Select value={categoriaFilter} onValueChange={(v) => setCategoriaFilter(v ?? 'all')}>
-            <SelectTrigger className="w-44">
-              <SelectValue placeholder="Categoría" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todas las categorías</SelectItem>
-              {categorias.map((cat) => (
-                <SelectItem key={cat} value={cat}>
-                  {cat}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <FilterCombobox
+            value={categoriaFilter}
+            onChange={setCategoriaFilter}
+            options={categorias.map((cat) => ({ id: cat, label: cat }))}
+            placeholder="Categoría"
+            searchPlaceholder="Buscar categoría..."
+            clearLabel="Todas las categorías"
+            className="w-44"
+          />
 
-          <Select
+          <FilterCombobox
             value={inventariableFilter}
-            onValueChange={(v) => setInventariableFilter(v ?? 'all')}
-          >
-            <SelectTrigger className="w-40">
-              <SelectValue placeholder="Tipo" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los tipos</SelectItem>
-              <SelectItem value="true">Inventariable</SelectItem>
-              <SelectItem value="false">Servicio / Varios</SelectItem>
-            </SelectContent>
-          </Select>
+            onChange={setInventariableFilter}
+            options={[
+              { id: 'true', label: 'Inventariable' },
+              { id: 'false', label: 'Servicio / Varios' },
+            ]}
+            placeholder="Tipo"
+            searchPlaceholder="Buscar tipo..."
+            clearLabel="Todos los tipos"
+            className="w-40"
+          />
 
-          <Select value={activoFilter} onValueChange={(v) => setActivoFilter(v ?? 'all')}>
-            <SelectTrigger className="w-36">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos (Activos)</SelectItem>
-              <SelectItem value="true">Solo Activos</SelectItem>
-              <SelectItem value="false">Solo Inactivos</SelectItem>
-            </SelectContent>
-          </Select>
+          <FilterCombobox
+            value={activoFilter}
+            onChange={setActivoFilter}
+            options={[
+              { id: 'true', label: 'Solo Activos' },
+              { id: 'false', label: 'Solo Inactivos' },
+            ]}
+            placeholder="Activos"
+            searchPlaceholder="Buscar..."
+            clearLabel="Todos (Activos)"
+            className="w-36"
+          />
 
           <Button
             variant="outline"

--- a/app/rdb/tasks/page.tsx
+++ b/app/rdb/tasks/page.tsx
@@ -41,6 +41,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -431,45 +432,36 @@ function TasksInner() {
               className="pl-9 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
             />
           </div>
-          <Select value={filterEstado} onValueChange={(v) => setFilterEstado(v ?? 'all')}>
-            <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Estado" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los estados</SelectItem>
-              {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                <SelectItem key={k} value={k}>
-                  {v.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={filterPrioridad} onValueChange={(v) => setFilterPrioridad(v ?? 'all')}>
-            <SelectTrigger className="w-36 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Prioridad" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todas</SelectItem>
-              {PRIORIDAD_OPTIONS.map((p) => (
-                <SelectItem key={p} value={p}>
-                  {p}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Select value={filterAsignado} onValueChange={(v) => setFilterAsignado(v ?? 'all')}>
-            <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Asignado a" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos</SelectItem>
-              {empleados.map((e) => (
-                <SelectItem key={e.id} value={e.id}>
-                  {e.nombre}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <FilterCombobox
+            value={filterEstado}
+            onChange={setFilterEstado}
+            options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+              id: k,
+              label: v.label,
+            }))}
+            placeholder="Estado"
+            searchPlaceholder="Buscar estado..."
+            clearLabel="Todos los estados"
+            className="w-40"
+          />
+          <FilterCombobox
+            value={filterPrioridad}
+            onChange={setFilterPrioridad}
+            options={PRIORIDAD_OPTIONS.map((p) => ({ id: p, label: p }))}
+            placeholder="Prioridad"
+            searchPlaceholder="Buscar prioridad..."
+            clearLabel="Todas"
+            className="w-36"
+          />
+          <FilterCombobox
+            value={filterAsignado}
+            onChange={setFilterAsignado}
+            options={empleados.map((e) => ({ id: e.id, label: e.nombre }))}
+            placeholder="Asignado a"
+            searchPlaceholder="Buscar responsable..."
+            clearLabel="Todos"
+            className="w-40"
+          />
         </div>
       </div>
 

--- a/components/documentos/documentos-module.tsx
+++ b/components/documentos/documentos-module.tsx
@@ -54,6 +54,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { useSortableTable } from '@/hooks/use-sortable-table';
 
 import type { Adjunto, Documento, NotariaOption } from './types';
@@ -423,19 +424,15 @@ export function DocumentosModule({
               className="pl-9 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
             />
           </div>
-          <Select value={filterTipo} onValueChange={(v) => setFilterTipo(v ?? 'all')}>
-            <SelectTrigger className="w-48 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Tipo" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los tipos</SelectItem>
-              {tiposPresentes.map((t) => (
-                <SelectItem key={t} value={t}>
-                  {t}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <FilterCombobox
+            value={filterTipo}
+            onChange={setFilterTipo}
+            options={tiposPresentes.map((t) => ({ id: t, label: t }))}
+            placeholder="Tipo"
+            searchPlaceholder="Buscar tipo..."
+            clearLabel="Todos los tipos"
+            className="w-48"
+          />
         </div>
       </div>
 

--- a/components/playtomic/occupancy-section.tsx
+++ b/components/playtomic/occupancy-section.tsx
@@ -1,10 +1,4 @@
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { OccupancyHeatmap } from './occupancy-heatmap';
 import type { OccupancyRow, ResourceRow, SportFilter } from './types';
 
@@ -29,19 +23,17 @@ export function OccupancySection({
           </p>
         </div>
         <div className="w-full max-w-[220px]">
-          <Select
+          <FilterCombobox
             value={sportFilter}
-            onValueChange={(value) => onSportFilterChange(value as SportFilter)}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Filtrar deporte" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos los deportes</SelectItem>
-              <SelectItem value="PADEL">Solo padel</SelectItem>
-              <SelectItem value="TENNIS">Solo tennis</SelectItem>
-            </SelectContent>
-          </Select>
+            onChange={(value) => onSportFilterChange(value as SportFilter)}
+            options={[
+              { id: 'PADEL', label: 'Solo padel' },
+              { id: 'TENNIS', label: 'Solo tennis' },
+            ]}
+            placeholder="Deporte"
+            searchPlaceholder="Buscar deporte..."
+            clearLabel="Todos los deportes"
+          />
         </div>
       </div>
       <OccupancyHeatmap rows={filteredOccupancy} resources={resources} sportFilter={sportFilter} />

--- a/components/rh/empleados-module.tsx
+++ b/components/rh/empleados-module.tsx
@@ -55,6 +55,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -554,19 +555,15 @@ export function EmpleadosModule({
             />
           </div>
           {showDeptoFilter && (
-            <Select value={filterDepto} onValueChange={(v) => setFilterDepto(v ?? 'all')}>
-              <SelectTrigger className="w-44 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Departamento" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos los deptos</SelectItem>
-                {departamentos.map((d) => (
-                  <SelectItem key={d.id} value={d.nombre}>
-                    {d.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <FilterCombobox
+              value={filterDepto}
+              onChange={setFilterDepto}
+              options={departamentos.map((d) => ({ id: d.nombre, label: d.nombre }))}
+              placeholder="Departamento"
+              searchPlaceholder="Buscar departamento..."
+              clearLabel="Todos los deptos"
+              className="w-44"
+            />
           )}
         </div>
       </div>

--- a/components/rh/puestos-module.tsx
+++ b/components/rh/puestos-module.tsx
@@ -54,6 +54,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -544,19 +545,15 @@ export function PuestosModule({
       {showDeptoFilter && (
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 mb-6">
           <div className="flex flex-wrap gap-3">
-            <Select value={filterDepto} onValueChange={(v) => setFilterDepto(v ?? 'all')}>
-              <SelectTrigger className="w-44 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Departamento" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos los deptos</SelectItem>
-                {departamentos.map((d) => (
-                  <SelectItem key={d.id} value={d.nombre}>
-                    {d.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <FilterCombobox
+              value={filterDepto}
+              onChange={setFilterDepto}
+              options={departamentos.map((d) => ({ id: d.nombre, label: d.nombre }))}
+              placeholder="Departamento"
+              searchPlaceholder="Buscar departamento..."
+              clearLabel="Todos los deptos"
+              className="w-44"
+            />
           </div>
         </div>
       )}

--- a/components/tasks/tasks-filters-bar.tsx
+++ b/components/tasks/tasks-filters-bar.tsx
@@ -14,13 +14,7 @@
 import { useMemo } from 'react';
 import { Search } from 'lucide-react';
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 
 import {
@@ -164,51 +158,36 @@ export function TasksFiltersBar({
           </>
         ) : (
           <>
-            <Select value={filterEstado} onValueChange={(v) => onFilterEstadoChange(v ?? 'all')}>
-              <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Estado" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos los estados</SelectItem>
-                {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                  <SelectItem key={k} value={k}>
-                    {v.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select
+            <FilterCombobox
+              value={filterEstado}
+              onChange={onFilterEstadoChange}
+              options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                id: k,
+                label: v.label,
+              }))}
+              placeholder="Estado"
+              searchPlaceholder="Buscar estado..."
+              clearLabel="Todos los estados"
+              className="w-40"
+            />
+            <FilterCombobox
               value={filterPrioridad}
-              onValueChange={(v) => onFilterPrioridadChange(v ?? 'all')}
-            >
-              <SelectTrigger className="w-36 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Prioridad" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todas</SelectItem>
-                {PRIORIDAD_OPTIONS.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <Select
+              onChange={onFilterPrioridadChange}
+              options={PRIORIDAD_OPTIONS.map((p) => ({ id: p, label: p }))}
+              placeholder="Prioridad"
+              searchPlaceholder="Buscar prioridad..."
+              clearLabel="Todas"
+              className="w-36"
+            />
+            <FilterCombobox
               value={filterAsignado}
-              onValueChange={(v) => onFilterAsignadoChange(v ?? 'all')}
-            >
-              <SelectTrigger className="w-40 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Asignado a" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos</SelectItem>
-                {empleados.map((e) => (
-                  <SelectItem key={e.id} value={e.id}>
-                    {e.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              onChange={onFilterAsignadoChange}
+              options={empleados.map((e) => ({ id: e.id, label: e.nombre }))}
+              placeholder="Asignado a"
+              searchPlaceholder="Buscar responsable..."
+              clearLabel="Todos"
+              className="w-40"
+            />
           </>
         )}
       </div>

--- a/components/ui/filter-combobox.tsx
+++ b/components/ui/filter-combobox.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * FilterCombobox — dropdown estándar de BSOP para filtros de tabla.
+ *
+ * Patrón:
+ *   - Muestra el placeholder (e.g. "Estado", "Tipo") mientras el filtro está
+ *     en "ver todo" — así en glance sabes QUÉ columna filtras.
+ *   - Cuando seleccionas un valor, el trigger muestra el label de ese valor.
+ *   - `allowClear` agrega una opción al tope del dropdown ("Todos" por
+ *     default) que dispara `onChange('all')` y regresa al placeholder.
+ *   - Con `searchPlaceholder` incluye input de búsqueda (shadcn Command).
+ *
+ * Convención de BSOP: el valor "all" representa "sin filtrar". Los filtros
+ * aguas abajo tratan 'all' como no-op (`filter !== 'all' && row.x !== filter`).
+ *
+ * Estandarizar este componente en TODAS las tablas: cualquier tabla con
+ * columnas filtrables por valores enum (estado, tipo, depto, categoría, etc.)
+ * debe usarlo en vez de un <Select> con un SelectItem value="all"
+ * "Todos los..." — ese patrón dejaba "all" literal visible en el trigger.
+ */
+
+import { useState } from 'react';
+import { ChevronsUpDown } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+
+export type FilterComboboxOption = { id: string; label: string };
+
+export function FilterCombobox({
+  value,
+  onChange,
+  options,
+  placeholder = 'Filtrar...',
+  searchPlaceholder = 'Buscar...',
+  emptyText = 'Sin resultados',
+  allowClear = true,
+  clearLabel = 'Todos',
+  className,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: FilterComboboxOption[];
+  /** Texto que aparece cuando `value === 'all'` o vacío. Usar el nombre de la columna filtrada. */
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  /** Agrega opción "Todos" al tope que resetea a `'all'`. Default true para filtros. */
+  allowClear?: boolean;
+  clearLabel?: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = options.find((o) => o.id === value);
+  const isCleared = value === 'all' || value === '';
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        className={`flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--panel)] text-[var(--text)] px-3 h-9 text-sm hover:bg-[var(--panel)]/80 transition-colors ${className ?? 'w-full'}`}
+      >
+        <span className={`truncate ${selected ? '' : 'text-[var(--text)]/50'}`}>
+          {selected ? selected.label : placeholder}
+        </span>
+        <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-40" />
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {allowClear && (
+                <CommandItem
+                  value={`__clear__${clearLabel}`}
+                  onSelect={() => {
+                    onChange('all');
+                    setOpen(false);
+                  }}
+                  data-checked={isCleared}
+                >
+                  {clearLabel}
+                </CommandItem>
+              )}
+              {options.map((o) => (
+                <CommandItem
+                  key={o.id}
+                  value={o.label}
+                  onSelect={() => {
+                    onChange(o.id);
+                    setOpen(false);
+                  }}
+                  data-checked={value === o.id}
+                >
+                  {o.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/ventas/ventas-filters.tsx
+++ b/components/ventas/ventas-filters.tsx
@@ -7,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Search, RefreshCw, CalendarDays } from 'lucide-react';
@@ -76,26 +77,21 @@ export function VentasFilters({
         </SelectContent>
       </Select>
 
-      <Select value={corteFilter} onValueChange={(v) => onCorteFilterChange(v ?? 'all')}>
-        <SelectTrigger className="w-52">
-          <SelectValue placeholder="Todos los cortes" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">Todos los cortes</SelectItem>
-          {cortes.map((corte) => {
-            const label = corte.corte_nombre
-              ? `${corte.corte_nombre}`
-              : `${corte.caja_nombre ?? 'Corte'} ${formatDate(corte.hora_inicio)}`;
-            const estado = corte.estado?.toLowerCase() === 'abierto' ? ' 🟢' : '';
-            return (
-              <SelectItem key={corte.id} value={corte.id}>
-                {label}
-                {estado}
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </Select>
+      <FilterCombobox
+        value={corteFilter}
+        onChange={onCorteFilterChange}
+        options={cortes.map((corte) => {
+          const label = corte.corte_nombre
+            ? `${corte.corte_nombre}`
+            : `${corte.caja_nombre ?? 'Corte'} ${formatDate(corte.hora_inicio)}`;
+          const estado = corte.estado?.toLowerCase() === 'abierto' ? ' 🟢' : '';
+          return { id: corte.id, label: `${label}${estado}` };
+        })}
+        placeholder="Corte"
+        searchPlaceholder="Buscar corte..."
+        clearLabel="Todos los cortes"
+        className="w-52"
+      />
 
       <div className="flex items-center gap-2">
         <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## Summary
Los filtros de tablas mostraban literalmente "all" en el trigger cuando estaban en default, en lugar del nombre de la columna que filtran. Ahora muestran "Estado", "Tipo", "Departamento", etc. como placeholder hasta que selecciones un valor.

### Problema
```tsx
<Select value={filterEstado}>
  <SelectValue placeholder="Estado" />  {/* ← nunca se usaba */}
  <SelectItem value="all">Todos los estados</SelectItem>
  {...}
</Select>
```
Como \`value='all'\` es un option válido, shadcn Select muestra el label del item ("Todos los estados") o peor aún el value literal ("all") — no el placeholder.

### Solución
Nuevo \`<FilterCombobox>\` en \`components/ui/filter-combobox.tsx\`:
- Si \`value === 'all'\` o vacío, trigger muestra el \`placeholder\` (nombre de columna).
- Si tiene un valor real, muestra el \`label\` del option seleccionado.
- El botón "Todos" vive dentro del popover y dispara \`onChange('all')\`.
- Incluye input de búsqueda (útil para listas largas tipo empleados o departamentos).

### Archivos actualizados
Todas las tablas con filtros estilo "all":
- DILESA, RDB, Inicio **juntas**
- RDB **tasks** + \`tasks-filters-bar\` (compartido por múltiples variantes de TasksModule)
- RH **puestos** + **empleados** modules
- **Documentos** module (compartido por DILESA/RDB/Administración)
- **Ventas** filters
- RDB **productos** (3 filtros)
- Playtomic **occupancy** section

Semántica idéntica: \`'all'\` sigue siendo el valor sentinel "sin filtrar".

## Test plan
- [ ] Abrir cualquier tabla con filtros (DILESA juntas, RH empleados, RDB productos, etc.).
- [ ] Los triggers muestran el nombre de la columna ("Estado", "Tipo", etc.) en default, no "all" ni "Todos...".
- [ ] Click en un dropdown → popover con input de búsqueda + botón "Todos" arriba + opciones.
- [ ] Seleccionar un valor → trigger muestra el label.
- [ ] Click "Todos" → regresa al placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)