### PR TITLE
feat(rh): contrato individual + finiquito imprimible con cálculo LFT

### DIFF
--- a/app/dilesa/rh/empleados/[id]/contrato/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/contrato/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/set-state-in-effect --
+ * Supabase row mapping is dynamic; tightening types requires generated
+ * Database shape refinements that are out of scope for the contrato
+ * printable route. El useEffect con fetchAll es el patrón estándar
+ * de la app para carga inicial de datos.
+ */
+
+import { RequireAccess } from '@/components/require-access';
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ArrowLeft, Printer } from 'lucide-react';
+import { ContratoPrintable, type ContratoEmpleado } from '@/components/rh/contrato-printable';
+
+function Inner() {
+  const params = useParams();
+  const router = useRouter();
+  const id = params.id as string;
+  const supabase = createSupabaseERPClient();
+
+  const [data, setData] = useState<ContratoEmpleado | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    const { data: emp, error: eErr } = await supabase
+      .schema('erp')
+      .from('empleados')
+      .select(
+        `id, empresa_id, numero_empleado, fecha_ingreso, tipo_contrato,
+         periodo_prueba_dias, periodo_prueba_numero, horario, lugar_trabajo,
+         dia_pago, funciones,
+         persona:persona_id(nombre, apellido_paterno, apellido_materno,
+           nacionalidad, sexo, estado_civil, fecha_nacimiento, lugar_nacimiento,
+           rfc, curp, nss, domicilio, telefono),
+         departamento:departamento_id(nombre),
+         puesto:puesto_id(nombre)`
+      )
+      .eq('id', id)
+      .single();
+
+    if (eErr || !emp) {
+      setError(eErr?.message ?? 'Empleado no encontrado');
+      setLoading(false);
+      return;
+    }
+
+    const [compRes, benefRes] = await Promise.all([
+      supabase
+        .schema('erp')
+        .from('empleados_compensacion')
+        .select('sueldo_mensual, sueldo_diario')
+        .eq('empleado_id', id)
+        .eq('vigente', true)
+        .maybeSingle(),
+      supabase
+        .schema('erp')
+        .from('empleado_beneficiarios')
+        .select('nombre, parentesco, porcentaje')
+        .eq('empleado_id', id)
+        .order('orden'),
+    ]);
+
+    const p = Array.isArray((emp as any).persona) ? (emp as any).persona[0] : (emp as any).persona;
+    const dep = Array.isArray((emp as any).departamento)
+      ? (emp as any).departamento[0]
+      : (emp as any).departamento;
+    const pue = Array.isArray((emp as any).puesto) ? (emp as any).puesto[0] : (emp as any).puesto;
+
+    setData({
+      nombre: p?.nombre ?? '',
+      apellido_paterno: p?.apellido_paterno ?? null,
+      apellido_materno: p?.apellido_materno ?? null,
+      nacionalidad: p?.nacionalidad ?? 'Mexicana',
+      sexo: p?.sexo ?? null,
+      estado_civil: p?.estado_civil ?? null,
+      fecha_nacimiento: p?.fecha_nacimiento ?? null,
+      lugar_nacimiento: p?.lugar_nacimiento ?? null,
+      rfc: p?.rfc ?? null,
+      curp: p?.curp ?? null,
+      nss: p?.nss ?? null,
+      domicilio: p?.domicilio ?? null,
+      telefono: p?.telefono ?? null,
+      numero_empleado: (emp as any).numero_empleado ?? null,
+      fecha_ingreso: (emp as any).fecha_ingreso ?? null,
+      tipo_contrato: (emp as any).tipo_contrato ?? null,
+      periodo_prueba_dias: (emp as any).periodo_prueba_dias ?? null,
+      periodo_prueba_numero: (emp as any).periodo_prueba_numero ?? null,
+      horario: (emp as any).horario ?? null,
+      lugar_trabajo: (emp as any).lugar_trabajo ?? null,
+      dia_pago: (emp as any).dia_pago ?? null,
+      funciones: (emp as any).funciones ?? null,
+      puesto: pue?.nombre ?? null,
+      departamento: dep?.nombre ?? null,
+      sueldo_mensual: (compRes.data as any)?.sueldo_mensual ?? null,
+      sueldo_diario: (compRes.data as any)?.sueldo_diario ?? null,
+      beneficiarios: (benefRes.data ?? []) as ContratoEmpleado['beneficiarios'],
+    });
+    setLoading(false);
+  }, [id, supabase]);
+
+  useEffect(() => {
+    void fetchAll();
+  }, [fetchAll]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-[600px] w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <p className="text-red-400">{error ?? 'Empleado no encontrado'}</p>
+        <Button variant="outline" onClick={() => router.back()} className="mt-4 rounded-xl">
+          <ArrowLeft className="mr-2 h-4 w-4" /> Volver
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="no-print flex items-center justify-between">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push(`/dilesa/rh/empleados/${id}`)}
+          className="rounded-xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" /> Volver al empleado
+        </Button>
+        <Button
+          onClick={() => window.print()}
+          className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
+        >
+          <Printer className="h-4 w-4" /> Imprimir contrato
+        </Button>
+      </div>
+
+      <div className="rounded-2xl border border-[var(--border)] bg-white shadow-sm">
+        <ContratoPrintable empleado={data} />
+      </div>
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa">
+      <Inner />
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/rh/empleados/[id]/finiquito/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/finiquito/page.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/set-state-in-effect --
+ * Supabase row mapping is dynamic; data-sync en useEffect es el patrón
+ * estándar de la app.
+ */
+
+import { RequireAccess } from '@/components/require-access';
+import { useCallback, useEffect, useState, useMemo } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { FieldLabel } from '@/components/ui/field-label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ArrowLeft, Printer } from 'lucide-react';
+import {
+  FiniquitoPrintable,
+  type FiniquitoEmpleadoData,
+} from '@/components/rh/finiquito-printable';
+import {
+  calcularFiniquito,
+  CAUSA_LABELS,
+  type CausaTerminacion,
+} from '@/lib/hr/calcular-finiquito';
+
+// Salario mínimo diario 2026 (zona libre de frontera norte — Piedras Negras).
+// ⚠️ Ajustar anualmente o extraer a una tabla en DB si es necesario.
+// Fuente: CONASAMI. Al 2026 el SMG general es $248.93/día, zona frontera
+// $374.89/día. DILESA opera en Coahuila (zona frontera).
+const SALARIO_MINIMO_DIARIO_ZLFN_2026 = 374.89;
+
+function Inner() {
+  const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const id = params.id as string;
+  const supabase = createSupabaseERPClient();
+
+  const [empleado, setEmpleado] = useState<FiniquitoEmpleadoData | null>(null);
+  const [fechaIngreso, setFechaIngreso] = useState<string>('');
+  const [fechaBajaGuardada, setFechaBajaGuardada] = useState<string | null>(null);
+  const [motivoBajaGuardado, setMotivoBajaGuardado] = useState<string | null>(null);
+  const [sueldoDiario, setSueldoDiario] = useState<number>(0);
+  const [sdi, setSdi] = useState<number>(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form de ajustes en vivo (la fecha y causa pueden cambiar antes de generar)
+  const [fechaBaja, setFechaBaja] = useState<string>('');
+  const [causa, setCausa] = useState<CausaTerminacion>('mutuo_consentimiento');
+  const [diasPend, setDiasPend] = useState<string>('0');
+  const [vacsTomadas, setVacsTomadas] = useState<string>('0');
+  const [motivoDetalle, setMotivoDetalle] = useState<string>('');
+  const [salarioMinimo, setSalarioMinimo] = useState<number>(SALARIO_MINIMO_DIARIO_ZLFN_2026);
+
+  const fetchAll = useCallback(async () => {
+    const { data: emp, error: eErr } = await supabase
+      .schema('erp')
+      .from('empleados')
+      .select(
+        `id, numero_empleado, fecha_ingreso, fecha_baja, motivo_baja,
+         persona:persona_id(nombre, apellido_paterno, apellido_materno, rfc, nss),
+         departamento:departamento_id(nombre),
+         puesto:puesto_id(nombre)`
+      )
+      .eq('id', id)
+      .single();
+
+    if (eErr || !emp) {
+      setError(eErr?.message ?? 'Empleado no encontrado');
+      setLoading(false);
+      return;
+    }
+
+    const { data: comp } = await supabase
+      .schema('erp')
+      .from('empleados_compensacion')
+      .select('sueldo_diario, sueldo_mensual, sdi')
+      .eq('empleado_id', id)
+      .eq('vigente', true)
+      .maybeSingle();
+
+    const p = Array.isArray((emp as any).persona) ? (emp as any).persona[0] : (emp as any).persona;
+    const dep = Array.isArray((emp as any).departamento)
+      ? (emp as any).departamento[0]
+      : (emp as any).departamento;
+    const pue = Array.isArray((emp as any).puesto) ? (emp as any).puesto[0] : (emp as any).puesto;
+
+    setEmpleado({
+      nombre: p?.nombre ?? '',
+      apellido_paterno: p?.apellido_paterno ?? null,
+      apellido_materno: p?.apellido_materno ?? null,
+      rfc: p?.rfc ?? null,
+      nss: p?.nss ?? null,
+      puesto: pue?.nombre ?? null,
+      departamento: dep?.nombre ?? null,
+      numero_empleado: (emp as any).numero_empleado ?? null,
+    });
+
+    const fi = (emp as any).fecha_ingreso as string | null;
+    const fb = (emp as any).fecha_baja as string | null;
+    setFechaIngreso(fi ?? '');
+    setFechaBajaGuardada(fb);
+    setMotivoBajaGuardado((emp as any).motivo_baja ?? null);
+    setFechaBaja(fb ?? new Date().toISOString().split('T')[0]);
+
+    const sueldoD =
+      (comp as any)?.sueldo_diario ??
+      ((comp as any)?.sueldo_mensual ? Number((comp as any).sueldo_mensual) / 30 : 0);
+    setSueldoDiario(Number(sueldoD) || 0);
+    setSdi(Number((comp as any)?.sdi) || 0);
+
+    // Prellenar causa si viene por query param (desde el dialog de baja)
+    const qCausa = searchParams.get('causa') as CausaTerminacion | null;
+    if (qCausa && qCausa in CAUSA_LABELS) setCausa(qCausa);
+
+    setLoading(false);
+  }, [id, supabase, searchParams]);
+
+  useEffect(() => {
+    void fetchAll();
+  }, [fetchAll]);
+
+  const calculo = useMemo(() => {
+    if (!fechaIngreso || !fechaBaja || sueldoDiario <= 0) return null;
+    return calcularFiniquito({
+      fechaIngreso,
+      fechaBaja,
+      sueldoDiario,
+      sdi: sdi || null,
+      salarioMinimoDiario: salarioMinimo,
+      causa,
+      diasPendientesPago: Number(diasPend) || 0,
+      diasVacacionesTomadasAnioActual: Number(vacsTomadas) || 0,
+    });
+  }, [fechaIngreso, fechaBaja, sueldoDiario, sdi, salarioMinimo, causa, diasPend, vacsTomadas]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-[600px] w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (error || !empleado) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <p className="text-red-400">{error ?? 'Empleado no encontrado'}</p>
+        <Button variant="outline" onClick={() => router.back()} className="mt-4 rounded-xl">
+          <ArrowLeft className="mr-2 h-4 w-4" /> Volver
+        </Button>
+      </div>
+    );
+  }
+
+  const hayDatosFaltantes = sueldoDiario <= 0 || !fechaIngreso;
+
+  return (
+    <div className="space-y-4">
+      <div className="no-print flex items-center justify-between">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => router.push(`/dilesa/rh/empleados/${id}`)}
+          className="rounded-xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]"
+        >
+          <ArrowLeft className="h-4 w-4 mr-1" /> Volver al empleado
+        </Button>
+        {calculo && (
+          <Button
+            onClick={() => window.print()}
+            className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
+          >
+            <Printer className="h-4 w-4" /> Imprimir finiquito
+          </Button>
+        )}
+      </div>
+
+      {/* Panel de ajustes (oculto al imprimir) */}
+      <div className="no-print rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-widest text-[var(--text)]/60">
+          Parámetros de cálculo
+        </h2>
+        {hayDatosFaltantes && (
+          <p className="text-xs text-amber-400">
+            ⚠️ Este empleado no tiene sueldo diario capturado en erp.empleados_compensacion o carece
+            de fecha de ingreso. Captura los datos antes de generar el finiquito.
+          </p>
+        )}
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div>
+            <FieldLabel>Fecha de baja</FieldLabel>
+            <Input
+              type="date"
+              value={fechaBaja}
+              onChange={(e) => setFechaBaja(e.target.value)}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
+          </div>
+          <div>
+            <FieldLabel>Causa de terminación</FieldLabel>
+            <Select value={causa} onValueChange={(v) => setCausa(v as CausaTerminacion)}>
+              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(CAUSA_LABELS).map(([k, label]) => (
+                  <SelectItem key={k} value={k}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <FieldLabel>Salario mínimo diario</FieldLabel>
+            <Input
+              type="number"
+              step="0.01"
+              value={salarioMinimo}
+              onChange={(e) => setSalarioMinimo(Number(e.target.value) || 0)}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
+            <p className="mt-1 text-[10px] text-[var(--text)]/40">
+              Zona libre frontera norte 2026: $374.89. Ajustar si cambia vigencia.
+            </p>
+          </div>
+          <div>
+            <FieldLabel>Días pendientes de pago</FieldLabel>
+            <Input
+              type="number"
+              min="0"
+              value={diasPend}
+              onChange={(e) => setDiasPend(e.target.value)}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
+          </div>
+          <div>
+            <FieldLabel>Vacaciones ya tomadas en el año</FieldLabel>
+            <Input
+              type="number"
+              min="0"
+              step="0.5"
+              value={vacsTomadas}
+              onChange={(e) => setVacsTomadas(e.target.value)}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
+          </div>
+          <div>
+            <FieldLabel>Sueldo diario (auto)</FieldLabel>
+            <Input
+              type="number"
+              step="0.01"
+              value={sueldoDiario}
+              onChange={(e) => setSueldoDiario(Number(e.target.value) || 0)}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
+          </div>
+          <div className="sm:col-span-3">
+            <FieldLabel>Motivo / detalle adicional</FieldLabel>
+            <Input
+              value={motivoDetalle || motivoBajaGuardado || ''}
+              onChange={(e) => setMotivoDetalle(e.target.value)}
+              placeholder="Texto que se agrega a la cláusula de causa…"
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
+          </div>
+        </div>
+        {fechaBajaGuardada && fechaBaja !== fechaBajaGuardada && (
+          <p className="text-[10px] text-amber-400">
+            La fecha de baja guardada en BSOP es {fechaBajaGuardada}; estás calculando con{' '}
+            {fechaBaja}. El cálculo es en vivo — no modifica la fecha guardada.
+          </p>
+        )}
+      </div>
+
+      {/* Plantilla printable */}
+      {calculo && (
+        <div className="rounded-2xl border border-[var(--border)] bg-white shadow-sm">
+          <FiniquitoPrintable
+            empleado={empleado}
+            calculo={calculo}
+            motivoDetalle={motivoDetalle || motivoBajaGuardado || undefined}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa">
+      <Inner />
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/rh/empleados/[id]/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/page.tsx
@@ -33,7 +33,7 @@ import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Separator } from '@/components/ui/separator';
-import { ArrowLeft, Save, Loader2, UserX, Pencil, X } from 'lucide-react';
+import { ArrowLeft, Save, Loader2, UserX, Pencil, X, FileText, FileSignature } from 'lucide-react';
 
 const EMPRESA_SLUG = 'dilesa';
 
@@ -648,7 +648,7 @@ function EmpleadoDetailInner() {
     await fetchAll();
   };
 
-  const handleBaja = async () => {
+  const handleBaja = async (generarFiniquito = false) => {
     if (!empleado) return;
     setGivingBaja(true);
     const { error: err } = await supabase
@@ -666,6 +666,10 @@ function EmpleadoDetailInner() {
       return;
     }
     setShowBajaDialog(false);
+    if (generarFiniquito) {
+      router.push(`/${EMPRESA_SLUG}/rh/empleados/${empleado.id}/finiquito`);
+      return;
+    }
     await fetchAll();
   };
 
@@ -749,6 +753,26 @@ function EmpleadoDetailInner() {
         </div>
         {isAdmin && (
           <div className="flex items-center gap-2 shrink-0">
+            <Button
+              variant="outline"
+              onClick={() => router.push(`/${EMPRESA_SLUG}/rh/empleados/${empleado.id}/contrato`)}
+              className="gap-1.5 rounded-xl border-[var(--border)] text-[var(--text)]"
+              title="Generar contrato individual de trabajo"
+            >
+              <FileText className="h-4 w-4" /> Contrato
+            </Button>
+            {isBaja && (
+              <Button
+                variant="outline"
+                onClick={() =>
+                  router.push(`/${EMPRESA_SLUG}/rh/empleados/${empleado.id}/finiquito`)
+                }
+                className="gap-1.5 rounded-xl border-[var(--border)] text-[var(--text)]"
+                title="Generar convenio de terminación y finiquito"
+              >
+                <FileSignature className="h-4 w-4" /> Finiquito
+              </Button>
+            )}
             {!isBaja && (
               <Button
                 variant="outline"
@@ -1385,16 +1409,29 @@ function EmpleadoDetailInner() {
               Cancelar
             </Button>
             <Button
-              onClick={handleBaja}
+              onClick={() => handleBaja(false)}
               disabled={givingBaja}
-              className="gap-1.5 rounded-xl bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+              variant="outline"
+              className="gap-1.5 rounded-xl border-red-500/40 text-red-500 hover:bg-red-500/10 disabled:opacity-60"
             >
               {givingBaja ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
                 <UserX className="h-4 w-4" />
               )}{' '}
-              Confirmar baja
+              Solo dar de baja
+            </Button>
+            <Button
+              onClick={() => handleBaja(true)}
+              disabled={givingBaja}
+              className="gap-1.5 rounded-xl bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+            >
+              {givingBaja ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <FileSignature className="h-4 w-4" />
+              )}{' '}
+              Baja + generar finiquito
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/components/rh/contrato-printable.tsx
+++ b/components/rh/contrato-printable.tsx
@@ -1,0 +1,416 @@
+'use client';
+
+/**
+ * ContratoPrintable — plantilla de contrato individual de trabajo conforme
+ * al Art. 25 de la Ley Federal del Trabajo (México).
+ *
+ * ⚠️  DISCLAIMER LEGAL:
+ *   Esta plantilla es un borrador generado a partir de los requisitos
+ *   mínimos del Art. 25 LFT. DEBE ser revisada y firmada por un abogado
+ *   laboral antes de usarse con un empleado real. BSOP / Claude no
+ *   sustituye asesoría profesional. DILESA asume la responsabilidad de
+ *   la redacción final, cláusulas adicionales, y cumplimiento específico
+ *   al caso (tipo de contrato, riesgo del trabajo, capacitación, etc.).
+ *
+ * El contenido está estructurado en secciones numeradas. El CSS
+ * `@media print` en `contrato-print.css` (global) oculta el app-shell y
+ * deja sólo esta plantilla para impresión.
+ */
+
+import { composeFullName } from '@/lib/name-case';
+import { formatMoneda } from '@/lib/hr/calcular-finiquito';
+
+export interface ContratoEmpleado {
+  // Persona
+  nombre: string;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
+  nacionalidad: string | null;
+  sexo: string | null;
+  estado_civil: string | null;
+  fecha_nacimiento: string | null;
+  lugar_nacimiento: string | null;
+  rfc: string | null;
+  curp: string | null;
+  nss: string | null;
+  domicilio: string | null;
+  telefono: string | null;
+
+  // Empleado
+  numero_empleado: string | null;
+  fecha_ingreso: string | null;
+  tipo_contrato: string | null;
+  periodo_prueba_dias: number | null;
+  periodo_prueba_numero: number | null;
+  horario: string | null;
+  lugar_trabajo: string | null;
+  dia_pago: string | null;
+  funciones: string | null;
+  puesto: string | null;
+  departamento: string | null;
+
+  // Compensación
+  sueldo_mensual: number | null;
+  sueldo_diario: number | null;
+
+  // Beneficiarios
+  beneficiarios: Array<{ nombre: string; parentesco: string | null; porcentaje: number | null }>;
+}
+
+export interface ContratoPatron {
+  razonSocial: string;
+  rfc: string;
+  domicilio: string;
+  representanteLegal: string;
+  cargoRepresentante: string;
+  giro: string;
+}
+
+// Patrón DILESA — valores por default. Si después necesitamos otro empresa
+// con datos distintos, parametrizamos desde la pg.
+export const PATRON_DILESA: ContratoPatron = {
+  razonSocial: 'Desarrollos Inmobiliarios de la Laguna, S.A. de C.V.',
+  rfc: 'DIL000000XXX', // ⚠️ REEMPLAZAR con RFC real de DILESA
+  domicilio:
+    'Av. ________________________, Col. ________________, Piedras Negras, Coahuila, C.P. 26000',
+  representanteLegal: 'Adalberto Santos de los Santos',
+  cargoRepresentante: 'Administrador Único',
+  giro: 'Desarrollo inmobiliario y construcción',
+};
+
+function formatDateLarga(iso: string | null): string {
+  if (!iso) return '__________________';
+  const d = new Date(iso.includes('T') ? iso : `${iso}T00:00:00`);
+  return d.toLocaleDateString('es-MX', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function blank(v: string | number | null | undefined, placeholder = '__________________'): string {
+  if (v === null || v === undefined || v === '') return placeholder;
+  return String(v);
+}
+
+const TIPO_CONTRATO_TEXTO: Record<string, string> = {
+  indefinido: 'por tiempo indeterminado',
+  determinado: 'por tiempo determinado',
+  obra: 'por obra determinada',
+  temporada: 'por temporada',
+  capacitacion_inicial: 'de capacitación inicial',
+  prueba: 'sujeto a periodo de prueba',
+};
+
+export function ContratoPrintable({
+  empleado,
+  patron = PATRON_DILESA,
+  fechaContrato,
+}: {
+  empleado: ContratoEmpleado;
+  patron?: ContratoPatron;
+  fechaContrato?: string;
+}) {
+  const fechaHoy = fechaContrato ?? new Date().toISOString().split('T')[0];
+  const nombreCompleto = composeFullName(
+    empleado.nombre,
+    empleado.apellido_paterno,
+    empleado.apellido_materno
+  );
+
+  const tipoTexto =
+    empleado.tipo_contrato && TIPO_CONTRATO_TEXTO[empleado.tipo_contrato]
+      ? TIPO_CONTRATO_TEXTO[empleado.tipo_contrato]
+      : 'por tiempo indeterminado';
+
+  const esPrueba = empleado.tipo_contrato === 'prueba';
+
+  return (
+    <article className="contrato-print-root max-w-[800px] mx-auto p-10 text-[13px] leading-relaxed text-black bg-white">
+      <style>{`
+        .contrato-print-root { font-family: 'Times New Roman', Times, serif; color: #000; }
+        .contrato-print-root h1 { text-align: center; font-size: 15px; font-weight: bold; margin: 0 0 8px; text-transform: uppercase; letter-spacing: 0.5px; }
+        .contrato-print-root h2 { font-size: 13px; font-weight: bold; margin: 14px 0 6px; text-transform: uppercase; }
+        .contrato-print-root p { margin: 6px 0; text-align: justify; }
+        .contrato-print-root ol, .contrato-print-root ul { margin: 4px 0 4px 24px; padding: 0; }
+        .contrato-print-root li { margin: 3px 0; text-align: justify; }
+        .contrato-print-root .firmas { margin-top: 48px; display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+        .contrato-print-root .firma { border-top: 1px solid #000; padding-top: 4px; text-align: center; font-size: 11px; }
+        .contrato-print-root .datos-box { border: 1px solid #000; padding: 8px 10px; margin: 8px 0; font-size: 12px; }
+        .contrato-print-root strong { font-weight: bold; }
+        @media print {
+          body * { visibility: hidden !important; }
+          .contrato-print-root, .contrato-print-root * { visibility: visible !important; }
+          .contrato-print-root { position: absolute; left: 0; top: 0; width: 100%; max-width: none; margin: 0; padding: 24mm 18mm; box-shadow: none; }
+          .no-print { display: none !important; }
+        }
+      `}</style>
+
+      <h1>Contrato individual de trabajo</h1>
+      <p className="text-center text-[11px]">
+        Celebrado al amparo de los artículos 24, 25, 35 y demás relativos de la Ley Federal del
+        Trabajo vigente en los Estados Unidos Mexicanos.
+      </p>
+
+      <p>
+        En la ciudad de Piedras Negras, Coahuila de Zaragoza, a los{' '}
+        <strong>{formatDateLarga(fechaHoy)}</strong>, comparecen por una parte{' '}
+        <strong>{patron.razonSocial}</strong>, con Registro Federal de Contribuyentes{' '}
+        <strong>{patron.rfc}</strong>, con domicilio en <strong>{patron.domicilio}</strong>, cuyo
+        giro es <em>{patron.giro}</em>, representada en este acto por su{' '}
+        <strong>{patron.cargoRepresentante}</strong>, el señor(a){' '}
+        <strong>{patron.representanteLegal}</strong>, a quien en lo sucesivo se le denominará{' '}
+        <strong>«EL PATRÓN»</strong>; y por la otra parte el señor(a){' '}
+        <strong>{blank(nombreCompleto)}</strong>, a quien en lo sucesivo se le denominará{' '}
+        <strong>«EL TRABAJADOR»</strong>, al tenor de las siguientes declaraciones y cláusulas:
+      </p>
+
+      <h2>Declaraciones</h2>
+
+      <p>
+        <strong>I. Declara EL TRABAJADOR:</strong>
+      </p>
+      <div className="datos-box">
+        <p>
+          <strong>Nombre completo:</strong> {blank(nombreCompleto)}
+        </p>
+        <p>
+          <strong>Nacionalidad:</strong> {blank(empleado.nacionalidad)} · <strong>Sexo:</strong>{' '}
+          {blank(empleado.sexo)} · <strong>Estado civil:</strong> {blank(empleado.estado_civil)}
+        </p>
+        <p>
+          <strong>Fecha de nacimiento:</strong> {formatDateLarga(empleado.fecha_nacimiento)} ·{' '}
+          <strong>Lugar:</strong> {blank(empleado.lugar_nacimiento)}
+        </p>
+        <p>
+          <strong>CURP:</strong> {blank(empleado.curp)} · <strong>RFC:</strong>{' '}
+          {blank(empleado.rfc)} · <strong>NSS:</strong> {blank(empleado.nss)}
+        </p>
+        <p>
+          <strong>Domicilio:</strong> {blank(empleado.domicilio)}
+        </p>
+        <p>
+          <strong>Teléfono:</strong> {blank(empleado.telefono)}
+        </p>
+        {empleado.numero_empleado && (
+          <p>
+            <strong>No. de empleado:</strong> {empleado.numero_empleado}
+          </p>
+        )}
+        <p className="mt-2 text-[11px]">
+          Declara bajo protesta de decir verdad que los datos asentados son correctos, que cuenta
+          con la capacidad física y mental para desempeñar el trabajo contratado, y que acepta
+          libremente las condiciones que se estipulan.
+        </p>
+      </div>
+
+      <p>
+        <strong>II. Declara EL PATRÓN:</strong>
+      </p>
+      <p>
+        Ser una sociedad legalmente constituida conforme a las leyes mexicanas, contar con la
+        capacidad jurídica y administrativa para celebrar este contrato, y requerir los servicios
+        personales subordinados del TRABAJADOR para desempeñar el puesto y funciones que más
+        adelante se describen.
+      </p>
+
+      <h2>Cláusulas</h2>
+
+      <p>
+        <strong>PRIMERA. Objeto.</strong> EL TRABAJADOR se obliga a prestar a EL PATRÓN sus
+        servicios personales subordinados en el puesto de <strong>{blank(empleado.puesto)}</strong>
+        {empleado.departamento ? (
+          <>
+            , adscrito al departamento de <strong>{empleado.departamento}</strong>
+          </>
+        ) : null}
+        , desempeñando las siguientes funciones de manera enunciativa más no limitativa:
+      </p>
+      <div className="datos-box">
+        {empleado.funciones ? (
+          empleado.funciones.split('\n').map((l, i) => (
+            <p key={i} className="mb-1">
+              {l}
+            </p>
+          ))
+        ) : (
+          <p className="text-[11px] italic">
+            [Detallar funciones específicas del puesto — Art. 25-III LFT exige precisión máxima.]
+          </p>
+        )}
+      </div>
+
+      <p>
+        <strong>SEGUNDA. Duración.</strong> El presente contrato es <strong>{tipoTexto}</strong>{' '}
+        (Art. {empleado.tipo_contrato === 'prueba' ? '39-A' : '35'} LFT).
+        {esPrueba && (
+          <>
+            {' '}
+            Las partes convienen un periodo de prueba de{' '}
+            <strong>{blank(empleado.periodo_prueba_dias, '30')} días</strong> naturales contados a
+            partir de la fecha de inicio de labores. Es el periodo de prueba número{' '}
+            <strong>{blank(empleado.periodo_prueba_numero, '1')}</strong> (de hasta 3 permitidos por
+            la política interna de DILESA antes de otorgar planta). Durante este periodo, si a
+            juicio del patrón EL TRABAJADOR no acredita competencia para el puesto, la relación se
+            da por terminada sin responsabilidad para el patrón (Art. 39-A párrafo segundo). De
+            acreditarse competencia al término de este periodo, la relación se convertirá en{' '}
+            <strong>por tiempo indeterminado</strong>.
+          </>
+        )}
+      </p>
+
+      <p>
+        <strong>TERCERA. Fecha de inicio.</strong> La prestación de servicios iniciará el día{' '}
+        <strong>{formatDateLarga(empleado.fecha_ingreso)}</strong>.
+      </p>
+
+      <p>
+        <strong>CUARTA. Lugar de trabajo.</strong> EL TRABAJADOR prestará sus servicios en{' '}
+        <strong>{blank(empleado.lugar_trabajo)}</strong> (Art. 25-IV LFT), pudiendo ser comisionado
+        temporalmente a otras instalaciones o proyectos de EL PATRÓN dentro de la misma zona
+        geográfica cuando las necesidades del servicio lo requieran.
+      </p>
+
+      <p>
+        <strong>QUINTA. Jornada y horario.</strong> La jornada es{' '}
+        <strong>{blank(empleado.horario)}</strong>. El tiempo destinado al alimento se cuenta como
+        tiempo de descanso cuando EL TRABAJADOR permanece en el centro de trabajo (Art. 63 LFT). Los
+        días de descanso obligatorios son los previstos en el Art. 74 LFT.
+      </p>
+
+      <p>
+        <strong>SEXTA. Salario.</strong> EL PATRÓN pagará a EL TRABAJADOR un salario mensual de{' '}
+        <strong>
+          {empleado.sueldo_mensual != null
+            ? formatMoneda(empleado.sueldo_mensual)
+            : '__________________'}
+        </strong>{' '}
+        M.N.
+        {empleado.sueldo_diario != null && (
+          <>
+            {' '}
+            (equivalente a <strong>{formatMoneda(empleado.sueldo_diario)}</strong> diarios).
+          </>
+        )}{' '}
+        El pago se realizará los{' '}
+        <strong>{blank(empleado.dia_pago, 'días viernes de cada quincena')}</strong>.
+      </p>
+
+      <p>
+        <strong>SÉPTIMA. Prestaciones.</strong> EL TRABAJADOR gozará de las prestaciones mínimas
+        previstas en la LFT: aguinaldo anual de cuando menos 15 días de salario (Art. 87),
+        vacaciones conforme a la tabla del Art. 76 (12 días el primer año con incrementos
+        escalonados), prima vacacional del 25% sobre el salario de vacaciones (Art. 80),
+        participación en las utilidades (PTU) conforme a la ley (Art. 117), y el alta ante el
+        Instituto Mexicano del Seguro Social, INFONAVIT y SAR.
+      </p>
+
+      <p>
+        <strong>OCTAVA. Capacitación y adiestramiento.</strong> EL PATRÓN se obliga a proporcionar a
+        EL TRABAJADOR la capacitación y adiestramiento que requiera para el desempeño del puesto,
+        conforme a los planes y programas que al efecto se establezcan (Art. 25-VIII LFT).
+      </p>
+
+      <p>
+        <strong>NOVENA. Confidencialidad.</strong> EL TRABAJADOR se obliga a guardar absoluta
+        reserva sobre la información, documentos, datos de clientes, proveedores, estrategias
+        comerciales y secretos industriales a los que tenga acceso con motivo de la relación de
+        trabajo, durante la vigencia de este contrato y después de su terminación.
+      </p>
+
+      <p>
+        <strong>DÉCIMA. Reglamento interior.</strong> EL TRABAJADOR declara conocer y aceptar el
+        Reglamento Interior de Trabajo de EL PATRÓN, comprometiéndose a su cumplimiento, así como a
+        todas las políticas internas que se le notifiquen en forma documentada.
+      </p>
+
+      <p>
+        <strong>DÉCIMA PRIMERA. Causales de rescisión.</strong> Son causales de rescisión sin
+        responsabilidad para EL PATRÓN las previstas en el Art. 47 de la LFT. Sin limitación de las
+        anteriores, son consideradas faltas graves el abandono del trabajo por más de 3 días sin
+        causa justificada dentro de un periodo de 30 días, el incurrir en violencia verbal o física
+        contra compañeros o superiores, y el quebranto de la confidencialidad pactada en la cláusula
+        anterior.
+      </p>
+
+      <p>
+        <strong>DÉCIMA SEGUNDA. Designación de beneficiarios.</strong> De conformidad con el Art.
+        501 LFT, EL TRABAJADOR designa como beneficiarios de las prestaciones y salarios no cobrados
+        en caso de su fallecimiento a las siguientes personas:
+      </p>
+      <div className="datos-box">
+        {empleado.beneficiarios.length === 0 ? (
+          <p className="text-[11px] italic">
+            [Sin beneficiarios designados — capturar antes de firmar.]
+          </p>
+        ) : (
+          <ol>
+            {empleado.beneficiarios.map((b, i) => (
+              <li key={i}>
+                <strong>{b.nombre}</strong>
+                {b.parentesco ? ` (${b.parentesco})` : ''}
+                {b.porcentaje != null ? ` — ${b.porcentaje}%` : ''}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+
+      <p>
+        <strong>DÉCIMA TERCERA. Jurisdicción.</strong> Para la interpretación y cumplimiento de este
+        contrato, las partes se someten a la jurisdicción del Centro Federal de Conciliación y
+        Registro Laboral y de los Tribunales Laborales del Estado de Coahuila, renunciando a
+        cualquier otro fuero que por razón de domicilio actual o futuro pudiera corresponderles.
+      </p>
+
+      <p className="mt-4">
+        Leído y entendido el presente contrato por ambas partes, lo firman por duplicado a los{' '}
+        <strong>{formatDateLarga(fechaHoy)}</strong>, quedando un ejemplar en poder de cada parte
+        (Art. 24 LFT).
+      </p>
+
+      <div className="firmas">
+        <div>
+          <div className="firma">
+            <div className="mb-1">{patron.representanteLegal}</div>
+            <div className="text-[11px]">
+              {patron.cargoRepresentante} de {patron.razonSocial}
+            </div>
+            <div className="text-[11px] italic mt-0.5">EL PATRÓN</div>
+          </div>
+        </div>
+        <div>
+          <div className="firma">
+            <div className="mb-1">{nombreCompleto}</div>
+            <div className="text-[11px]">{empleado.rfc ?? ''}</div>
+            <div className="text-[11px] italic mt-0.5">EL TRABAJADOR</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="firmas mt-6">
+        <div>
+          <div className="firma">
+            <div className="mb-1">__________________________</div>
+            <div className="text-[11px] italic">TESTIGO</div>
+          </div>
+        </div>
+        <div>
+          <div className="firma">
+            <div className="mb-1">__________________________</div>
+            <div className="text-[11px] italic">TESTIGO</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 text-[10px] text-gray-500 border-t pt-2 no-print">
+        <p>
+          <strong>Nota legal:</strong> Documento generado por BSOP como borrador del contrato
+          individual de trabajo. Debe ser revisado por abogado laboral antes de firmarse. No
+          sustituye asesoría profesional. Versión basada en LFT vigente al{' '}
+          {formatDateLarga(fechaHoy)}.
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/components/rh/finiquito-printable.tsx
+++ b/components/rh/finiquito-printable.tsx
@@ -1,0 +1,338 @@
+'use client';
+
+/**
+ * FiniquitoPrintable — convenio de terminación laboral y finiquito conforme
+ * a LFT Art. 53 (causas de terminación), 87 (aguinaldo), 76/80
+ * (vacaciones/prima vacacional), 162 (prima de antigüedad) y 50 (indemnización).
+ *
+ * ⚠️  DISCLAIMER: Para validez total del convenio como cosa juzgada se
+ *   requiere RATIFICACIÓN ante el Centro Federal de Conciliación y Registro
+ *   Laboral (Art. 33 LFT, reforma 2019). Sin ratificación, el trabajador
+ *   puede impugnar los términos aunque haya firmado. El documento debe ser
+ *   revisado por abogado laboral antes de usarse.
+ */
+
+import { composeFullName } from '@/lib/name-case';
+import {
+  CAUSA_LABELS,
+  formatMoneda,
+  type CausaTerminacion,
+  type FiniquitoCalculado,
+} from '@/lib/hr/calcular-finiquito';
+import { PATRON_DILESA, type ContratoPatron } from './contrato-printable';
+
+export interface FiniquitoEmpleadoData {
+  nombre: string;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
+  rfc: string | null;
+  nss: string | null;
+  puesto: string | null;
+  departamento: string | null;
+  numero_empleado: string | null;
+}
+
+function formatDateLarga(iso: string): string {
+  const d = new Date(iso.includes('T') ? iso : `${iso}T00:00:00`);
+  return d.toLocaleDateString('es-MX', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+export function FiniquitoPrintable({
+  empleado,
+  calculo,
+  motivoDetalle,
+  patron = PATRON_DILESA,
+  fechaConvenio,
+}: {
+  empleado: FiniquitoEmpleadoData;
+  calculo: FiniquitoCalculado;
+  motivoDetalle?: string;
+  patron?: ContratoPatron;
+  fechaConvenio?: string;
+}) {
+  const fechaHoy = fechaConvenio ?? new Date().toISOString().split('T')[0];
+  const nombreCompleto = composeFullName(
+    empleado.nombre,
+    empleado.apellido_paterno,
+    empleado.apellido_materno
+  );
+
+  const causa: CausaTerminacion = calculo.causa;
+  const esRenuncia = causa === 'renuncia';
+
+  const totalIndemnizacion = calculo.totalIndemnizacion;
+  const totalFiniquito = calculo.totalFiniquito;
+  const totalGeneral = calculo.totalGeneral;
+
+  const conceptosFiniquito = calculo.conceptos.filter(
+    (c) =>
+      !c.concepto.toLowerCase().includes('indemnización') && !c.concepto.includes('20 días por año')
+  );
+  const conceptosIndemnizacion = calculo.conceptos.filter(
+    (c) =>
+      c.concepto.toLowerCase().includes('indemnización') || c.concepto.includes('20 días por año')
+  );
+
+  return (
+    <article className="finiquito-print-root max-w-[800px] mx-auto p-10 text-[13px] leading-relaxed text-black bg-white">
+      <style>{`
+        .finiquito-print-root { font-family: 'Times New Roman', Times, serif; color: #000; }
+        .finiquito-print-root h1 { text-align: center; font-size: 15px; font-weight: bold; margin: 0 0 8px; text-transform: uppercase; letter-spacing: 0.5px; }
+        .finiquito-print-root h2 { font-size: 13px; font-weight: bold; margin: 14px 0 6px; text-transform: uppercase; }
+        .finiquito-print-root p { margin: 6px 0; text-align: justify; }
+        .finiquito-print-root table { width: 100%; border-collapse: collapse; margin: 8px 0; font-size: 12px; }
+        .finiquito-print-root th, .finiquito-print-root td { border: 1px solid #000; padding: 4px 8px; text-align: left; }
+        .finiquito-print-root th { background: #eee; font-weight: bold; }
+        .finiquito-print-root td.num { text-align: right; font-variant-numeric: tabular-nums; }
+        .finiquito-print-root .firmas { margin-top: 48px; display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+        .finiquito-print-root .firma { border-top: 1px solid #000; padding-top: 4px; text-align: center; font-size: 11px; }
+        .finiquito-print-root .datos-box { border: 1px solid #000; padding: 8px 10px; margin: 8px 0; font-size: 12px; }
+        .finiquito-print-root .total-row td { background: #f6f6f6; font-weight: bold; }
+        @media print {
+          body * { visibility: hidden !important; }
+          .finiquito-print-root, .finiquito-print-root * { visibility: visible !important; }
+          .finiquito-print-root { position: absolute; left: 0; top: 0; width: 100%; max-width: none; margin: 0; padding: 24mm 18mm; box-shadow: none; }
+          .no-print { display: none !important; }
+        }
+      `}</style>
+
+      <h1>Convenio de terminación laboral y finiquito</h1>
+
+      <p>
+        En la ciudad de Piedras Negras, Coahuila, a los <strong>{formatDateLarga(fechaHoy)}</strong>
+        , comparecen <strong>{patron.razonSocial}</strong>, representada por su{' '}
+        <strong>{patron.cargoRepresentante}</strong>, el señor(a){' '}
+        <strong>{patron.representanteLegal}</strong>, a quien en lo sucesivo se denominará{' '}
+        <strong>«EL PATRÓN»</strong>, y por la otra parte el señor(a){' '}
+        <strong>{nombreCompleto}</strong>, a quien en lo sucesivo se denominará{' '}
+        <strong>«EL TRABAJADOR»</strong>, para celebrar el presente convenio de terminación laboral
+        y finiquito al tenor de las siguientes:
+      </p>
+
+      <h2>Antecedentes</h2>
+
+      <div className="datos-box">
+        <p>
+          <strong>Trabajador:</strong> {nombreCompleto}
+          {empleado.rfc ? ` · RFC: ${empleado.rfc}` : ''}
+          {empleado.nss ? ` · NSS: ${empleado.nss}` : ''}
+          {empleado.numero_empleado ? ` · No. Empleado: ${empleado.numero_empleado}` : ''}
+        </p>
+        <p>
+          <strong>Puesto:</strong> {empleado.puesto ?? '—'}
+          {empleado.departamento ? ` · Depto.: ${empleado.departamento}` : ''}
+        </p>
+        <p>
+          <strong>Fecha de ingreso:</strong> {formatDateLarga(calculo.fechaIngreso)}
+        </p>
+        <p>
+          <strong>Fecha de terminación:</strong> {formatDateLarga(calculo.fechaBaja)}
+        </p>
+        <p>
+          <strong>Antigüedad:</strong> {calculo.antiguedad.anios} año(s), {calculo.antiguedad.meses}{' '}
+          mes(es), {calculo.antiguedad.dias} día(s).
+        </p>
+        <p>
+          <strong>Salario diario base:</strong> {formatMoneda(calculo.sueldoDiario)}
+          {calculo.sdi !== calculo.sueldoDiario && <> · SDI: {formatMoneda(calculo.sdi)}</>}
+        </p>
+      </div>
+
+      <h2>Causa de terminación</h2>
+
+      <p>
+        Las partes declaran que la relación de trabajo termina por{' '}
+        <strong>{CAUSA_LABELS[causa]}</strong>
+        {esRenuncia && ' presentada por el trabajador en forma libre y espontánea'}
+        {motivoDetalle ? `. ${motivoDetalle}` : '.'}
+      </p>
+
+      {causa === 'mutuo_consentimiento' && (
+        <p>
+          Ambas partes manifiestan estar de acuerdo en dar por terminada la relación laboral sin
+          represalia ni presión de ninguna índole, con fundamento en el artículo 53 fracción I de la
+          Ley Federal del Trabajo.
+        </p>
+      )}
+
+      <h2>Desglose del finiquito</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Concepto</th>
+            <th className="num">Días</th>
+            <th className="num">Base</th>
+            <th className="num">Monto</th>
+          </tr>
+        </thead>
+        <tbody>
+          {conceptosFiniquito.map((c, i) => (
+            <tr key={i}>
+              <td>
+                {c.concepto}
+                {c.nota && <div className="text-[10px] text-gray-600">{c.nota}</div>}
+              </td>
+              <td className="num">{c.dias != null ? c.dias.toFixed(2) : '—'}</td>
+              <td className="num">{c.tasa != null ? formatMoneda(c.tasa) : '—'}</td>
+              <td className="num">{formatMoneda(c.monto)}</td>
+            </tr>
+          ))}
+          <tr className="total-row">
+            <td colSpan={3}>TOTAL FINIQUITO</td>
+            <td className="num">{formatMoneda(totalFiniquito)}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      {conceptosIndemnizacion.length > 0 && (
+        <>
+          <h2>Indemnización constitucional</h2>
+          <p className="text-[11px]">
+            Aplicable en caso de despido injustificado (Art. 50 LFT), a elección del trabajador en
+            vez de la reinstalación (Art. 49).
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Concepto</th>
+                <th className="num">Días</th>
+                <th className="num">Base</th>
+                <th className="num">Monto</th>
+              </tr>
+            </thead>
+            <tbody>
+              {conceptosIndemnizacion.map((c, i) => (
+                <tr key={i}>
+                  <td>{c.concepto}</td>
+                  <td className="num">{c.dias != null ? c.dias.toFixed(2) : '—'}</td>
+                  <td className="num">{c.tasa != null ? formatMoneda(c.tasa) : '—'}</td>
+                  <td className="num">{formatMoneda(c.monto)}</td>
+                </tr>
+              ))}
+              <tr className="total-row">
+                <td colSpan={3}>TOTAL INDEMNIZACIÓN</td>
+                <td className="num">{formatMoneda(totalIndemnizacion)}</td>
+              </tr>
+            </tbody>
+          </table>
+        </>
+      )}
+
+      <h2 className="mt-4">Total a pagar</h2>
+      <table>
+        <tbody>
+          <tr className="total-row">
+            <td style={{ fontSize: '14px' }}>SUMA TOTAL</td>
+            <td className="num" style={{ fontSize: '14px' }}>
+              {formatMoneda(totalGeneral)}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      {calculo.notas.length > 0 && (
+        <div className="datos-box mt-3">
+          <p className="text-[11px] font-bold">Notas:</p>
+          <ul className="text-[11px]" style={{ margin: '2px 0 0 16px', padding: 0 }}>
+            {calculo.notas.map((n, i) => (
+              <li key={i}>{n}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <h2>Cláusulas</h2>
+
+      <p>
+        <strong>PRIMERA.</strong> EL PATRÓN entrega en este acto a EL TRABAJADOR la cantidad de{' '}
+        <strong>{formatMoneda(totalGeneral)}</strong> ({formatMoneda(totalGeneral).replace('$', '')}{' '}
+        pesos M.N.), correspondiente al desglose descrito, mediante{' '}
+        <em>[efectivo / cheque / transferencia bancaria nº ________________]</em>.
+      </p>
+
+      <p>
+        <strong>SEGUNDA. Descargo amplio.</strong> EL TRABAJADOR manifiesta recibir a su entera
+        satisfacción el importe convenido y declara que EL PATRÓN no le queda a deber cantidad
+        alguna por concepto de sueldos, salarios, horas extras, aguinaldo, prima vacacional,
+        vacaciones, prima de antigüedad, indemnización, participación en las utilidades, ni por
+        ningún otro concepto derivado de la relación laboral, otorgándole el más amplio y total
+        finiquito que en derecho proceda y renunciando a cualquier acción legal futura por estos
+        conceptos.
+      </p>
+
+      <p>
+        <strong>TERCERA. Terminación.</strong> Las partes acuerdan que a partir de la fecha arriba
+        señalada queda formalmente extinguida la relación laboral que los unía, sin responsabilidad
+        legal recíproca más allá del cumplimiento del presente convenio.
+      </p>
+
+      <p>
+        <strong>CUARTA. Confidencialidad.</strong> EL TRABAJADOR se obliga a mantener la
+        confidencialidad sobre la información, documentos, clientes, proveedores y secretos
+        industriales a los que haya tenido acceso durante la relación laboral, aún después de la
+        terminación de la misma.
+      </p>
+
+      <p>
+        <strong>QUINTA. Entrega de equipo y documentos.</strong> EL TRABAJADOR manifiesta haber
+        entregado al momento de su separación todo el equipo, herramienta, documentación, llaves,
+        accesos electrónicos y demás bienes propiedad de EL PATRÓN que tenía bajo su resguardo.
+      </p>
+
+      <p>
+        <strong>SEXTA. Ratificación.</strong> Las partes manifiestan su voluntad de ratificar el
+        presente convenio ante el Centro Federal de Conciliación y Registro Laboral con jurisdicción
+        en Coahuila, a fin de que adquiera la calidad de cosa juzgada conforme al Art. 33 de la LFT.
+      </p>
+
+      <p className="mt-4">
+        Leído y entendido el presente convenio por las partes y conforme a su alcance legal, lo
+        firman por duplicado al margen y al calce, quedando un ejemplar en poder de cada parte.
+      </p>
+
+      <div className="firmas">
+        <div>
+          <div className="firma">
+            <div className="mb-1">{patron.representanteLegal}</div>
+            <div className="text-[11px]">
+              {patron.cargoRepresentante} de {patron.razonSocial}
+            </div>
+            <div className="text-[11px] italic mt-0.5">EL PATRÓN</div>
+          </div>
+        </div>
+        <div>
+          <div className="firma">
+            <div className="mb-1">{nombreCompleto}</div>
+            <div className="text-[11px]">{empleado.rfc ?? ''}</div>
+            <div className="text-[11px] italic mt-0.5">EL TRABAJADOR</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="firmas mt-6">
+        <div>
+          <div className="firma">
+            <div className="mb-1">__________________________</div>
+            <div className="text-[11px] italic">TESTIGO</div>
+          </div>
+        </div>
+        <div>
+          <div className="firma">
+            <div className="mb-1">__________________________</div>
+            <div className="text-[11px] italic">TESTIGO</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 text-[10px] text-gray-500 border-t pt-2 no-print">
+        <p>
+          <strong>Nota legal:</strong> Borrador generado por BSOP basado en LFT vigente. Los montos
+          son una aproximación — el cálculo final debe ser revisado por contador/abogado laboral
+          antes del pago. Para efectos legales plenos de descargo, este convenio debe ratificarse
+          ante el Centro Federal de Conciliación (Art. 33 LFT).
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/lib/hr/calcular-finiquito.ts
+++ b/lib/hr/calcular-finiquito.ts
@@ -1,0 +1,348 @@
+/**
+ * calcular-finiquito.ts
+ *
+ * Funciones puras para calcular el finiquito o liquidación de un empleado
+ * según la Ley Federal del Trabajo de México (LFT).
+ *
+ * Referencias legales principales:
+ *   - Art. 76 LFT (vacaciones, reforma 2023 "Vacaciones Dignas"):
+ *       Año 1: 12 días · Año 2: 14 · Año 3: 16 · Año 4: 18 · Año 5: 20
+ *       De Año 6 a 10: 22 · Año 11-15: 24 · Año 16-20: 26 · etc. (+2 por cada 5 años)
+ *   - Art. 80 LFT: Prima vacacional — 25% mínimo sobre salario de vacaciones.
+ *   - Art. 87 LFT: Aguinaldo — mínimo 15 días antes del 20 de diciembre.
+ *   - Art. 162 LFT: Prima de antigüedad — 12 días por año con tope de 2× salario
+ *     mínimo diario. Se paga si:
+ *       a) El trabajador renuncia con 15 o más años de antigüedad, O
+ *       b) El patrón lo separa sin causa justificada, O
+ *       c) Terminación por causas no imputables al trabajador, O
+ *       d) Muerte del trabajador.
+ *   - Art. 50 LFT: Indemnización por despido injustificado — 3 meses de salario
+ *     + 20 días por año trabajado (a elección del trabajador en vez de
+ *     reinstalación, Art. 49).
+ *   - Art. 48 LFT: Salarios caídos (si el despido es injustificado, se deben
+ *     hasta por 12 meses + 2% mensual después) — NO se incluyen en el cálculo
+ *     automático porque dependen de juicio laboral.
+ *
+ * ⚠️  IMPORTANTE: Este cálculo es una aproximación para tener un punto de
+ *    partida en el finiquito. El cálculo final debe ser revisado por
+ *    contador/abogado laboral antes de pagarse. La ley puede haber cambiado
+ *    desde la última revisión de este archivo. No sustituye asesoría
+ *    profesional.
+ */
+
+export type CausaTerminacion =
+  /** Renuncia voluntaria del trabajador (Art. 51 LFT). */
+  | 'renuncia'
+  /** Mutuo consentimiento (Art. 53-I LFT). */
+  | 'mutuo_consentimiento'
+  /** Terminación de contrato por tiempo/obra determinada (Art. 37/53-III). */
+  | 'termino_contrato'
+  /** Rescisión SIN responsabilidad para el patrón (Art. 47 — falta grave). */
+  | 'despido_justificado'
+  /** Rescisión CON responsabilidad para el patrón (despido injustificado). */
+  | 'despido_injustificado'
+  /** Muerte del trabajador (Art. 53-IV). */
+  | 'muerte'
+  /** Incapacidad permanente (Art. 53-V). */
+  | 'incapacidad';
+
+export interface FiniquitoInput {
+  /** Fecha de ingreso (ISO YYYY-MM-DD). */
+  fechaIngreso: string;
+  /** Fecha efectiva de terminación (ISO YYYY-MM-DD). */
+  fechaBaja: string;
+  /** Salario diario integrado o mensual/30. Usa el que corresponda a LFT (SDI para primas, diario para días trabajados). */
+  sueldoDiario: number;
+  /** Salario diario integrado (SDI) — preferente para primas si está disponible. */
+  sdi?: number | null;
+  /** Salario mínimo diario vigente en la zona (para tope de prima de antigüedad, Art. 162-II). */
+  salarioMinimoDiario: number;
+  /** Causa de la terminación. */
+  causa: CausaTerminacion;
+  /** Días trabajados del periodo corriente aún no pagados. */
+  diasPendientesPago?: number;
+  /** Días de vacaciones ya tomadas del año en curso (no las del derecho histórico). */
+  diasVacacionesTomadasAnioActual?: number;
+  /** Si el trabajador ya cobró el aguinaldo del año anterior. Default true. */
+  aguinaldoAnteriorCobrado?: boolean;
+  /** Días mínimos de aguinaldo por año según política (LFT mínimo = 15). */
+  diasAguinaldoPorAnio?: number;
+}
+
+export interface FiniquitoConcepto {
+  concepto: string;
+  dias?: number;
+  tasa?: number;
+  monto: number;
+  nota?: string;
+}
+
+export interface FiniquitoCalculado {
+  fechaIngreso: string;
+  fechaBaja: string;
+  antiguedad: {
+    anios: number;
+    meses: number;
+    dias: number;
+    totalDias: number;
+  };
+  sueldoDiario: number;
+  sdi: number;
+  causa: CausaTerminacion;
+  conceptos: FiniquitoConcepto[];
+  totalFiniquito: number;
+  totalIndemnizacion: number;
+  totalGeneral: number;
+  notas: string[];
+}
+
+// ─── Utilidades de fecha ────────────────────────────────────────────────────
+
+function parseDate(iso: string): Date {
+  // Usar medianoche local para evitar corrimiento por TZ al restar fechas.
+  return new Date(`${iso.slice(0, 10)}T00:00:00`);
+}
+
+function daysBetween(a: Date, b: Date): number {
+  const msDay = 1000 * 60 * 60 * 24;
+  return Math.floor((b.getTime() - a.getTime()) / msDay);
+}
+
+function diffYearsMonthsDays(start: Date, end: Date) {
+  let y = end.getFullYear() - start.getFullYear();
+  let m = end.getMonth() - start.getMonth();
+  let d = end.getDate() - start.getDate();
+  if (d < 0) {
+    m -= 1;
+    // días del mes previo del end
+    const prevMonthEnd = new Date(end.getFullYear(), end.getMonth(), 0);
+    d += prevMonthEnd.getDate();
+  }
+  if (m < 0) {
+    y -= 1;
+    m += 12;
+  }
+  return { anios: y, meses: m, dias: d };
+}
+
+// ─── LFT tablas ─────────────────────────────────────────────────────────────
+
+/**
+ * Tabla de días de vacaciones por año de antigüedad completo según Art. 76
+ * LFT (vigente desde la reforma "Vacaciones Dignas" del 1-ene-2023).
+ *
+ * Se aplica al número de años CUMPLIDOS. Ejemplo: 4 años y 11 meses → 4
+ * años cumplidos → 18 días.
+ */
+export function diasVacacionesPorAntiguedad(aniosCumplidos: number): number {
+  if (aniosCumplidos < 1) return 0;
+  if (aniosCumplidos === 1) return 12;
+  if (aniosCumplidos === 2) return 14;
+  if (aniosCumplidos === 3) return 16;
+  if (aniosCumplidos === 4) return 18;
+  if (aniosCumplidos === 5) return 20;
+  if (aniosCumplidos <= 10) return 22;
+  if (aniosCumplidos <= 15) return 24;
+  if (aniosCumplidos <= 20) return 26;
+  if (aniosCumplidos <= 25) return 28;
+  if (aniosCumplidos <= 30) return 30;
+  if (aniosCumplidos <= 35) return 32;
+  return 34;
+}
+
+// ─── Cálculo principal ──────────────────────────────────────────────────────
+
+export function calcularFiniquito(input: FiniquitoInput): FiniquitoCalculado {
+  const start = parseDate(input.fechaIngreso);
+  const end = parseDate(input.fechaBaja);
+
+  // Antigüedad en años, meses, días cumplidos.
+  const antig = diffYearsMonthsDays(start, end);
+  const totalDias = daysBetween(start, end);
+
+  const sueldoDiario = input.sueldoDiario;
+  // SDI sólo si es > sueldo diario (no tiene sentido que sea menor);
+  // si no se proveyó, usar sueldoDiario como fallback.
+  const sdi = input.sdi && input.sdi > 0 ? input.sdi : sueldoDiario;
+
+  const diasAguinaldoPorAnio = input.diasAguinaldoPorAnio ?? 15;
+
+  const conceptos: FiniquitoConcepto[] = [];
+  const notas: string[] = [];
+
+  // 1) Días trabajados no pagados
+  const diasPend = input.diasPendientesPago ?? 0;
+  if (diasPend > 0) {
+    conceptos.push({
+      concepto: 'Días trabajados pendientes de pago',
+      dias: diasPend,
+      tasa: sueldoDiario,
+      monto: redondear(diasPend * sueldoDiario),
+    });
+  }
+
+  // 2) Aguinaldo proporcional (Art. 87). Proporción sobre el año en curso:
+  //    (días trabajados en el año / 365) × diasAguinaldoPorAnio × sueldoDiario.
+  const diasTrabajadosAnio = diasTrabajadosEnAnio(start, end);
+  const aguinaldoDias = (diasTrabajadosAnio / 365) * diasAguinaldoPorAnio;
+  const aguinaldoMonto = aguinaldoDias * sueldoDiario;
+  conceptos.push({
+    concepto: 'Aguinaldo proporcional (Art. 87 LFT)',
+    dias: round2(aguinaldoDias),
+    tasa: sueldoDiario,
+    monto: redondear(aguinaldoMonto),
+    nota: `${diasAguinaldoPorAnio} días/año · ${diasTrabajadosAnio} días del año corriente`,
+  });
+
+  // 3) Vacaciones pendientes del último periodo (no históricas — se asume que
+  //    ejercicios anteriores ya fueron tomadas o prescritas; Art. 81: prescribe
+  //    al año). Aplica proporción sobre el año en curso también.
+  const aniosCumplidos = antig.anios;
+  const vacsAnuales = diasVacacionesPorAntiguedad(Math.max(aniosCumplidos, 1));
+  const vacsProp = (diasTrabajadosAnio / 365) * vacsAnuales;
+  const vacsTomadas = input.diasVacacionesTomadasAnioActual ?? 0;
+  const vacsPendientes = Math.max(0, vacsProp - vacsTomadas);
+  const vacsMonto = vacsPendientes * sueldoDiario;
+  conceptos.push({
+    concepto: 'Vacaciones pendientes (Art. 76 LFT)',
+    dias: round2(vacsPendientes),
+    tasa: sueldoDiario,
+    monto: redondear(vacsMonto),
+    nota: `${vacsAnuales} días/año · proporcional al último periodo`,
+  });
+
+  // 4) Prima vacacional 25% (Art. 80).
+  const primaVacMonto = vacsMonto * 0.25;
+  conceptos.push({
+    concepto: 'Prima vacacional 25% (Art. 80 LFT)',
+    tasa: 0.25,
+    monto: redondear(primaVacMonto),
+    nota: `25% sobre vacaciones pendientes`,
+  });
+
+  // 5) Prima de antigüedad (Art. 162). Aplica según causa.
+  const aplicaPrimaAntiguedad = evaluarPrimaAntiguedad(input.causa, antig.anios);
+  if (aplicaPrimaAntiguedad) {
+    // 12 días por año, tope del salario diario igual a 2× salario mínimo.
+    const sueldoTope = Math.min(sueldoDiario, 2 * input.salarioMinimoDiario);
+    const primaAntigDias = 12 * (antig.anios + antig.meses / 12 + antig.dias / 365);
+    const primaAntigMonto = primaAntigDias * sueldoTope;
+    conceptos.push({
+      concepto: 'Prima de antigüedad (Art. 162 LFT)',
+      dias: round2(primaAntigDias),
+      tasa: sueldoTope,
+      monto: redondear(primaAntigMonto),
+      nota:
+        sueldoTope < sueldoDiario
+          ? `Tope 2× salario mínimo = ${sueldoTope.toFixed(2)}`
+          : '12 días × año antigüedad',
+    });
+  } else if (input.causa === 'renuncia' && antig.anios < 15) {
+    notas.push(
+      'Prima de antigüedad NO aplica: el Art. 162 LFT solo la otorga por renuncia con 15+ años.'
+    );
+  }
+
+  // 6) Indemnización Constitucional — solo en despido injustificado (Art. 50).
+  //    3 meses de salario (90 días) + 20 días por cada año de servicio.
+  //    Esto es INDEPENDIENTE del finiquito — conceptualmente va aparte.
+  const indemnizacionConceptos: FiniquitoConcepto[] = [];
+  if (input.causa === 'despido_injustificado') {
+    const tresMeses = 90 * sueldoDiario;
+    indemnizacionConceptos.push({
+      concepto: 'Indemnización 3 meses (Art. 50-III LFT)',
+      dias: 90,
+      tasa: sueldoDiario,
+      monto: redondear(tresMeses),
+    });
+    const veinteDiasAno = antig.anios + antig.meses / 12 + antig.dias / 365;
+    const veinteDiasTotal = 20 * veinteDiasAno;
+    indemnizacionConceptos.push({
+      concepto: '20 días por año de servicio (Art. 50-II LFT)',
+      dias: round2(veinteDiasTotal),
+      tasa: sueldoDiario,
+      monto: redondear(veinteDiasTotal * sueldoDiario),
+    });
+    notas.push(
+      'Indemnización constitucional se paga solo si el despido es declarado INJUSTIFICADO. Los salarios caídos (Art. 48) no se calculan aquí.'
+    );
+  }
+
+  const totalFiniquito = conceptos.reduce((s, c) => s + c.monto, 0);
+  const totalIndemnizacion = indemnizacionConceptos.reduce((s, c) => s + c.monto, 0);
+
+  return {
+    fechaIngreso: input.fechaIngreso,
+    fechaBaja: input.fechaBaja,
+    antiguedad: {
+      ...antig,
+      totalDias,
+    },
+    sueldoDiario,
+    sdi,
+    causa: input.causa,
+    conceptos: [...conceptos, ...indemnizacionConceptos],
+    totalFiniquito: redondear(totalFiniquito),
+    totalIndemnizacion: redondear(totalIndemnizacion),
+    totalGeneral: redondear(totalFiniquito + totalIndemnizacion),
+    notas,
+  };
+}
+
+// ─── Helpers internos ───────────────────────────────────────────────────────
+
+function evaluarPrimaAntiguedad(causa: CausaTerminacion, anios: number): boolean {
+  switch (causa) {
+    case 'renuncia':
+      return anios >= 15;
+    case 'despido_justificado':
+      return false; // No aplica
+    case 'despido_injustificado':
+    case 'mutuo_consentimiento':
+    case 'termino_contrato':
+    case 'incapacidad':
+    case 'muerte':
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Días trabajados durante el año calendario en curso (1-ene hasta fecha_baja
+ * O desde fecha_ingreso si ingresó este año, lo que sea más reciente).
+ */
+function diasTrabajadosEnAnio(start: Date, end: Date): number {
+  const anioBaja = end.getFullYear();
+  const inicioAnio = new Date(anioBaja, 0, 1);
+  const desde = start > inicioAnio ? start : inicioAnio;
+  return Math.max(0, daysBetween(desde, end) + 1); // +1 para incluir el día de baja
+}
+
+function redondear(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ─── Labels humanos ─────────────────────────────────────────────────────────
+
+export const CAUSA_LABELS: Record<CausaTerminacion, string> = {
+  renuncia: 'Renuncia voluntaria del trabajador',
+  mutuo_consentimiento: 'Mutuo consentimiento de las partes',
+  termino_contrato: 'Terminación por vencimiento de contrato',
+  despido_justificado: 'Rescisión sin responsabilidad para el patrón (Art. 47)',
+  despido_injustificado: 'Despido injustificado (Art. 47/50)',
+  muerte: 'Muerte del trabajador',
+  incapacidad: 'Incapacidad física/mental permanente',
+};
+
+export function formatMoneda(n: number): string {
+  return new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+    minimumFractionDigits: 2,
+  }).format(n);
+}


### PR DESCRIPTION
## Summary
Implementa el flujo completo de generación de documentos laborales para DILESA basados en la Ley Federal del Trabajo vigente en 2026.

### Contrato de trabajo
- **Plantilla imprimible** (\`components/rh/contrato-printable.tsx\`) basada en Art. 24/25/35 LFT. Incluye:
  - Declaraciones del trabajador (datos personales LFT) y del patrón
  - Cláusulas numeradas: objeto, duración, fecha inicio, lugar, jornada, salario, prestaciones, capacitación, confidencialidad, reglamento interior, causales de rescisión, designación de beneficiarios (Art. 501), jurisdicción
  - Manejo especial del tipo \"prueba\": cláusula Art. 39-A con periodo (default 30 días) y número (1 de 3, política DILESA)
  - Líneas de firma para patrón, trabajador y 2 testigos
- **Ruta** \`/dilesa/rh/empleados/[id]/contrato\` con botón Imprimir + Volver. CSS \`@media print\` oculta el app-shell.
- **Botón \"Contrato\"** en el header del detalle del empleado.

### Finiquito / convenio de terminación
- **Cálculo puro** en \`lib/hr/calcular-finiquito.ts\`:
  - Aguinaldo proporcional (Art. 87 LFT)
  - Vacaciones pendientes con tabla Art. 76 post-reforma 2023 (12/14/16/18/20 y luego +2 cada 5 años)
  - Prima vacacional 25% (Art. 80)
  - Prima de antigüedad 12 días/año con tope 2× salario mínimo (Art. 162) — se evalúa según causa (renuncia requiere 15+ años)
  - Indemnización constitucional 90 días + 20 días/año (Art. 50-II/III) solo para despido injustificado
- **Plantilla** (\`components/rh/finiquito-printable.tsx\`) con desglose tabulado (concepto, días, base, monto) + cláusulas de descargo amplio, confidencialidad, entrega de equipo, ratificación ante Centro Federal de Conciliación (Art. 33 LFT).
- **Ruta** \`/dilesa/rh/empleados/[id]/finiquito\` con panel de parámetros en vivo: fecha de baja, causa, salario mínimo (default ZLFN 2026 = \$374.89), vacaciones ya tomadas, días pendientes. Sueldo diario se precarga de \`empleados_compensacion\` vigente.
- **Dialog de baja** con 2 botones:
  - \"Solo dar de baja\"
  - \"Baja + generar finiquito\" — marca baja Y navega directo al finiquito

## Disclaimer legal
- Plantillas son **borrador** basado en LFT vigente. Deben ser revisadas por abogado laboral antes de usar.
- \`PATRON_DILESA\` tiene placeholders para RFC, domicilio y representante — reemplazar con datos reales antes de imprimir.
- Salario mínimo ZLFN 2026 hardcoded — ajustar anualmente.
- El convenio requiere **ratificación ante Centro Federal de Conciliación** (Art. 33 LFT) para ser cosa juzgada.

## Test plan
- [ ] Entrar a un empleado → click \"Contrato\" → abre la plantilla con datos llenados
- [ ] Click \"Imprimir\" → diálogo de impresión del browser con layout limpio
- [ ] Completar beneficiarios y volver a generar — se muestran en la cláusula 12
- [ ] Dar de baja un empleado → \"Baja + generar finiquito\" → navega al finiquito
- [ ] Cambiar causa a despido injustificado → aparece sección de indemnización
- [ ] Cambiar causa a renuncia con <15 años → no aparece prima de antigüedad
- [ ] Verificar que el total general es coherente con el desglose

## Próximo
El contrato requiere que DILESA capture: RFC de la empresa, domicilio fiscal, representante legal y su cargo. Ahora están como placeholders. Dime cuando los tengas y los reemplazo en \`PATRON_DILESA\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)