### PR TITLE
feat(ui): Combobox universal con search + migración módulo RH

### DIFF
--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -9,33 +9,14 @@ import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
-import {
-  getAdjuntoSignedUrl,
-  rewriteHtmlImagesToSigned,
-  normalizeHtmlImagesToPaths,
-} from '@/lib/adjuntos';
+import { rewriteHtmlImagesToSigned, normalizeHtmlImagesToPaths } from '@/lib/adjuntos';
 import { htmlHasCodaImages, importCodaImagesInHtml } from '@/lib/coda-paste-import';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Image from '@tiptap/extension-image';
 import { Table, TableRow, TableHeader, TableCell } from '@tiptap/extension-table';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import {
-  Command,
-  CommandInput,
-  CommandList,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-} from '@/components/ui/command';
+import { Combobox } from '@/components/ui/combobox';
 import {
   Sheet,
   SheetContent,
@@ -74,7 +55,6 @@ import {
   Heading3,
   CheckCircle2,
   ImagePlus,
-  ChevronsUpDown,
   MessageSquarePlus,
   Clock,
 } from 'lucide-react';
@@ -222,62 +202,7 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   );
 }
 
-function Combobox({
-  value,
-  onChange,
-  options,
-  placeholder,
-  searchPlaceholder,
-  emptyText,
-  className,
-}: {
-  value: string;
-  onChange: (v: string) => void;
-  options: { id: string; label: string }[];
-  placeholder?: string;
-  searchPlaceholder?: string;
-  emptyText?: string;
-  className?: string;
-}) {
-  const [open, setOpen] = useState(false);
-  const selected = options.find((o) => o.id === value);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        className={`flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--panel)] text-[var(--text)] px-3 h-9 text-sm hover:bg-[var(--panel)]/80 transition-colors ${className ?? 'w-full'}`}
-      >
-        <span className={`truncate ${selected ? '' : 'text-[var(--text)]/40'}`}>
-          {selected ? selected.label : (placeholder ?? 'Seleccionar...')}
-        </span>
-        <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-40" />
-      </PopoverTrigger>
-      <PopoverContent className="w-64 p-0" align="start">
-        <Command>
-          <CommandInput placeholder={searchPlaceholder ?? 'Buscar...'} />
-          <CommandList>
-            <CommandEmpty>{emptyText ?? 'Sin resultados'}</CommandEmpty>
-            <CommandGroup>
-              {options.map((o) => (
-                <CommandItem
-                  key={o.id}
-                  value={o.label}
-                  onSelect={() => {
-                    onChange(o.id);
-                    setOpen(false);
-                  }}
-                  data-checked={value === o.id}
-                >
-                  {o.label}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-}
+// Combobox local eliminado — ahora se usa el universal `@/components/ui/combobox`.
 
 function EditorToolbar({
   editor,
@@ -1119,7 +1044,7 @@ function JuntaDetailInner() {
 
   const empleadoMap = new Map(empleados.map((e) => [e.id, e]));
   const empleadoOptions = useMemo(
-    () => empleados.map((e) => ({ id: e.id, label: e.nombre })),
+    () => empleados.map((e) => ({ value: e.id, label: e.nombre })),
     [empleados]
   );
 
@@ -1128,7 +1053,7 @@ function JuntaDetailInner() {
     () =>
       personas
         .filter((p) => !addedPersonaIds.has(p.id))
-        .map((p) => ({ id: p.id, label: p.nombre })),
+        .map((p) => ({ value: p.id, label: p.nombre })),
     [personas, addedPersonaIds]
   );
 
@@ -1245,33 +1170,29 @@ function JuntaDetailInner() {
         <div className="grid grid-cols-2 gap-4">
           <div>
             <FieldLabel>Estado</FieldLabel>
-            <Select value={estado} onValueChange={(v) => setEstado(v as Junta['estado'])}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(ESTADO_JUNTA).map(([k, v]) => (
-                  <SelectItem key={k} value={k}>
-                    {v.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={estado}
+              onChange={(v) => setEstado(v as Junta['estado'])}
+              options={Object.entries(ESTADO_JUNTA).map(([k, v]) => ({
+                value: k,
+                label: v.label,
+              }))}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
           <div>
             <FieldLabel>Tipo</FieldLabel>
-            <Select value={tipo ?? ''} onValueChange={(v) => setTipo(v || '')}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Sin tipo" />
-              </SelectTrigger>
-              <SelectContent>
-                {TIPO_OPTIONS.map((t) => (
-                  <SelectItem key={t.value} value={t.value}>
-                    {t.icon} {t.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={tipo ?? ''}
+              onChange={(v) => setTipo(v)}
+              options={TIPO_OPTIONS.map((t) => ({
+                value: t.value,
+                label: `${t.icon} ${t.label}`,
+              }))}
+              placeholder="Sin tipo"
+              allowClear
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
         </div>
         <div>
@@ -1696,21 +1617,17 @@ function JuntaDetailInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Cambiar estado</FieldLabel>
-                <Select
+                <Combobox
                   value={updateForm.nuevoEstado}
-                  onValueChange={(v) => setUpdateForm((f) => ({ ...f, nuevoEstado: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin cambio" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_TASK).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setUpdateForm((f) => ({ ...f, nuevoEstado: v }))}
+                  options={Object.entries(ESTADO_TASK).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  placeholder="Sin cambio"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Cambiar fecha compromiso</FieldLabel>
@@ -1792,41 +1709,25 @@ function JuntaDetailInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel required>Prioridad</FieldLabel>
-                <Select
+                <Combobox
                   value={taskForm.prioridad}
-                  onValueChange={(v) => setTaskForm((f) => ({ ...f, prioridad: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Seleccionar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PRIORIDAD_OPTIONS.map((p) => (
-                      <SelectItem key={p} value={p}>
-                        {p}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setTaskForm((f) => ({ ...f, prioridad: v }))}
+                  options={PRIORIDAD_OPTIONS.map((p) => ({ value: p, label: p }))}
+                  placeholder="Seleccionar"
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Estado</FieldLabel>
-                <Select
+                <Combobox
                   value={taskForm.estado}
-                  onValueChange={(v) =>
-                    setTaskForm((f) => ({ ...f, estado: v as JuntaTask['estado'] }))
-                  }
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_TASK).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setTaskForm((f) => ({ ...f, estado: v as JuntaTask['estado'] }))}
+                  options={Object.entries(ESTADO_TASK).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
             </div>
 
@@ -1838,6 +1739,7 @@ function JuntaDetailInner() {
                 options={empleadoOptions}
                 placeholder="Buscar responsable..."
                 searchPlaceholder="Escriba un nombre..."
+                allowClear
               />
             </div>
 

--- a/app/dilesa/admin/juntas/page.tsx
+++ b/app/dilesa/admin/juntas/page.tsx
@@ -26,14 +26,8 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@/components/ui/sheet';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox, type FilterComboboxOption } from '@/components/ui/filter-combobox';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -694,18 +688,16 @@ function JuntasInner() {
           <div className="space-y-5 py-4">
             <div>
               <FieldLabel>Tipo de Junta *</FieldLabel>
-              <Select value={createTipo} onValueChange={(v) => setCreateTipo(v ?? '')}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Seleccionar tipo..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {TIPO_OPTIONS.map((t) => (
-                    <SelectItem key={t.value} value={t.value}>
-                      {t.icon} {t.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={createTipo}
+                onChange={setCreateTipo}
+                options={TIPO_OPTIONS.map((t) => ({
+                  value: t.value,
+                  label: `${t.icon} ${t.label}`,
+                }))}
+                placeholder="Seleccionar tipo..."
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
 
             <div>

--- a/app/dilesa/rh/empleados/[id]/finiquito/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/finiquito/page.tsx
@@ -12,13 +12,7 @@ import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { FieldLabel } from '@/components/ui/field-label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, Printer } from 'lucide-react';
 import {
@@ -263,18 +257,15 @@ function Inner() {
           </div>
           <div>
             <FieldLabel>Causa de terminación</FieldLabel>
-            <Select value={causa} onValueChange={(v) => setCausa(v as CausaTerminacion)}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(CAUSA_LABELS).map(([k, label]) => (
-                  <SelectItem key={k} value={k}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={causa}
+              onChange={(v) => setCausa(v as CausaTerminacion)}
+              options={Object.entries(CAUSA_LABELS).map(([k, label]) => ({
+                value: k,
+                label,
+              }))}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
           <div>
             <FieldLabel>Salario mínimo diario</FieldLabel>

--- a/app/dilesa/rh/empleados/[id]/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/page.tsx
@@ -8,7 +8,7 @@
 
 import { RequireAccess } from '@/components/require-access';
 import { usePermissions } from '@/components/providers';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import { composeFullName, titleCase } from '@/lib/name-case';
@@ -21,13 +21,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -444,6 +438,24 @@ function EmpleadoDetailInner() {
 
   // Beneficiarios (Art. 501 LFT)
   const [beneficiarios, setBeneficiarios] = useState<Beneficiario[]>([]);
+
+  const departamentoOptions = useMemo(() => {
+    const opts = departamentos.map((d) => ({ value: d.id, label: d.nombre }));
+    const current = empleado?.departamento;
+    if (current?.id && !opts.some((o) => o.value === current.id)) {
+      opts.unshift({ value: current.id, label: `${current.nombre} (inactivo)` });
+    }
+    return opts;
+  }, [departamentos, empleado?.departamento]);
+
+  const puestoOptions = useMemo(() => {
+    const opts = puestos.map((p) => ({ value: p.id, label: p.nombre }));
+    const current = empleado?.puesto;
+    if (current?.id && !opts.some((o) => o.value === current.id)) {
+      opts.unshift({ value: current.id, label: `${current.nombre} (inactivo)` });
+    }
+    return opts;
+  }, [puestos, empleado?.puesto]);
 
   const [showBajaDialog, setShowBajaDialog] = useState(false);
   const [motivoBaja, setMotivoBaja] = useState('');
@@ -893,33 +905,25 @@ function EmpleadoDetailInner() {
             </div>
             <div>
               <FieldLabel>Estado civil</FieldLabel>
-              <Select value={pEstadoCivil} onValueChange={(v) => setPEstadoCivil(v ?? '')}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Seleccionar…" />
-                </SelectTrigger>
-                <SelectContent>
-                  {ESTADO_CIVIL_OPTIONS.map((o) => (
-                    <SelectItem key={o} value={o}>
-                      {o}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={pEstadoCivil}
+                onChange={setPEstadoCivil}
+                options={ESTADO_CIVIL_OPTIONS.map((o) => ({ value: o, label: o }))}
+                placeholder="Seleccionar…"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Sexo</FieldLabel>
-              <Select value={pSexo} onValueChange={(v) => setPSexo(v ?? '')}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Seleccionar…" />
-                </SelectTrigger>
-                <SelectContent>
-                  {SEXO_OPTIONS.map((o) => (
-                    <SelectItem key={o.value} value={o.value}>
-                      {o.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={pSexo}
+                onChange={setPSexo}
+                options={SEXO_OPTIONS}
+                placeholder="Seleccionar…"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>RFC</FieldLabel>
@@ -1122,33 +1126,25 @@ function EmpleadoDetailInner() {
             </div>
             <div>
               <FieldLabel>Departamento</FieldLabel>
-              <Select value={departamentoId} onValueChange={(v) => setDepartamentoId(v ?? '')}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin departamento" />
-                </SelectTrigger>
-                <SelectContent>
-                  {departamentos.map((d) => (
-                    <SelectItem key={d.id} value={d.id}>
-                      {d.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={departamentoId}
+                onChange={setDepartamentoId}
+                options={departamentoOptions}
+                placeholder="Sin departamento"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Puesto</FieldLabel>
-              <Select value={puestoId} onValueChange={(v) => setPuestoId(v ?? '')}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin puesto" />
-                </SelectTrigger>
-                <SelectContent>
-                  {puestos.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={puestoId}
+                onChange={setPuestoId}
+                options={puestoOptions}
+                placeholder="Sin puesto"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Email empresa</FieldLabel>
@@ -1179,18 +1175,14 @@ function EmpleadoDetailInner() {
             </div>
             <div>
               <FieldLabel>Tipo de contrato</FieldLabel>
-              <Select value={tipoContrato} onValueChange={(v) => setTipoContrato(v ?? '')}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Seleccionar…" />
-                </SelectTrigger>
-                <SelectContent>
-                  {TIPO_CONTRATO_OPTIONS.map((o) => (
-                    <SelectItem key={o.value} value={o.value}>
-                      {o.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={tipoContrato}
+                onChange={setTipoContrato}
+                options={TIPO_CONTRATO_OPTIONS}
+                placeholder="Seleccionar…"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             {(tipoContrato === 'prueba' || tipoContrato === 'capacitacion_inicial') && (
               <>

--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -15,13 +15,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Image from '@tiptap/extension-image';
 import { Table, TableRow, TableHeader, TableCell } from '@tiptap/extension-table';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import {
   Sheet,
   SheetContent,
@@ -1011,33 +1005,29 @@ function JuntaDetailInner() {
         <div className="grid grid-cols-2 gap-4">
           <div>
             <FieldLabel>Estado</FieldLabel>
-            <Select value={estado} onValueChange={(v) => setEstado(v as Junta['estado'])}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(ESTADO_JUNTA).map(([k, v]) => (
-                  <SelectItem key={k} value={k}>
-                    {v.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={estado}
+              onChange={(v) => setEstado(v as Junta['estado'])}
+              options={Object.entries(ESTADO_JUNTA).map(([k, v]) => ({
+                value: k,
+                label: v.label,
+              }))}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
           <div>
             <FieldLabel>Tipo</FieldLabel>
-            <Select value={tipo ?? ''} onValueChange={(v) => setTipo(v || '')}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Sin tipo" />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(TIPO_CONFIG).map(([k, v]) => (
-                  <SelectItem key={k} value={k}>
-                    {v}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={tipo ?? ''}
+              onChange={(v) => setTipo(v)}
+              options={Object.entries(TIPO_CONFIG).map(([k, v]) => ({
+                value: k,
+                label: String(v),
+              }))}
+              placeholder="Sin tipo"
+              allowClear
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
         </div>
 
@@ -1270,18 +1260,13 @@ function JuntaDetailInner() {
         {/* Add participant inline */}
         {showAddPersona && (
           <div className="mt-3 flex items-center gap-2 rounded-xl border border-[var(--accent)]/30 bg-[var(--accent)]/5 p-3">
-            <Select value={selectedPersonaId} onValueChange={(v) => setSelectedPersonaId(v ?? '')}>
-              <SelectTrigger className="flex-1 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Seleccionar persona..." />
-              </SelectTrigger>
-              <SelectContent>
-                {availablePersonas.map((p) => (
-                  <SelectItem key={p.id} value={p.id}>
-                    {p.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={selectedPersonaId}
+              onChange={setSelectedPersonaId}
+              options={availablePersonas.map((p) => ({ value: p.id, label: p.nombre }))}
+              placeholder="Seleccionar persona..."
+              className="flex-1 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
             <Button
               size="sm"
               onClick={handleAddParticipant}
@@ -1475,21 +1460,17 @@ function JuntaDetailInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Cambiar estado</FieldLabel>
-                <Select
+                <Combobox
                   value={updateForm.nuevoEstado}
-                  onValueChange={(v) => setUpdateForm((f) => ({ ...f, nuevoEstado: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin cambio" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_TASK).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setUpdateForm((f) => ({ ...f, nuevoEstado: v }))}
+                  options={Object.entries(ESTADO_TASK).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  placeholder="Sin cambio"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Cambiar fecha compromiso</FieldLabel>
@@ -1550,62 +1531,40 @@ function JuntaDetailInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Estado</FieldLabel>
-                <Select
+                <Combobox
                   value={taskForm.estado}
-                  onValueChange={(v) =>
-                    setTaskForm((f) => ({ ...f, estado: v as JuntaTask['estado'] }))
-                  }
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_TASK).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setTaskForm((f) => ({ ...f, estado: v as JuntaTask['estado'] }))}
+                  options={Object.entries(ESTADO_TASK).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Prioridad</FieldLabel>
-                <Select
+                <Combobox
                   value={taskForm.prioridad}
-                  onValueChange={(v) => setTaskForm((f) => ({ ...f, prioridad: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin prioridad" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PRIORIDAD_OPTIONS.map((p) => (
-                      <SelectItem key={p} value={p}>
-                        {p}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setTaskForm((f) => ({ ...f, prioridad: v }))}
+                  options={PRIORIDAD_OPTIONS.map((p) => ({ value: p, label: p }))}
+                  placeholder="Sin prioridad"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Asignar a</FieldLabel>
-                <Select
+                <Combobox
                   value={taskForm.asignado_a}
-                  onValueChange={(v) => setTaskForm((f) => ({ ...f, asignado_a: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin asignar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {empleados.map((e) => (
-                      <SelectItem key={e.id} value={e.id}>
-                        {e.nombre}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setTaskForm((f) => ({ ...f, asignado_a: v }))}
+                  options={empleados.map((e) => ({ value: e.id, label: e.nombre }))}
+                  placeholder="Sin asignar"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Fecha límite</FieldLabel>

--- a/app/inicio/juntas/page.tsx
+++ b/app/inicio/juntas/page.tsx
@@ -27,14 +27,8 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -505,41 +499,29 @@ function JuntasInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Tipo</FieldLabel>
-                <Select
+                <Combobox
                   value={createForm.tipo ?? ''}
-                  onValueChange={(v) => setCreateForm((f) => ({ ...f, tipo: v || '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin tipo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(TIPO_CONFIG).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.icon} {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setCreateForm((f) => ({ ...f, tipo: v }))}
+                  options={Object.entries(TIPO_CONFIG).map(([k, v]) => ({
+                    value: k,
+                    label: `${v.icon} ${v.label}`,
+                  }))}
+                  placeholder="Sin tipo"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Estado</FieldLabel>
-                <Select
+                <Combobox
                   value={createForm.estado}
-                  onValueChange={(v) =>
-                    setCreateForm((f) => ({ ...f, estado: v as Junta['estado'] }))
-                  }
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setCreateForm((f) => ({ ...f, estado: v as Junta['estado'] }))}
+                  options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
             </div>
 

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -15,13 +15,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Image from '@tiptap/extension-image';
 import { Table, TableRow, TableHeader, TableCell } from '@tiptap/extension-table';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import {
   Sheet,
   SheetContent,
@@ -975,33 +969,29 @@ function JuntaDetailInner() {
         <div className="grid grid-cols-2 gap-4">
           <div>
             <FieldLabel>Estado</FieldLabel>
-            <Select value={estado} onValueChange={(v) => setEstado(v as Junta['estado'])}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(ESTADO_JUNTA).map(([k, v]) => (
-                  <SelectItem key={k} value={k}>
-                    {v.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={estado}
+              onChange={(v) => setEstado(v as Junta['estado'])}
+              options={Object.entries(ESTADO_JUNTA).map(([k, v]) => ({
+                value: k,
+                label: v.label,
+              }))}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
           <div>
             <FieldLabel>Tipo</FieldLabel>
-            <Select value={tipo ?? ''} onValueChange={(v) => setTipo(v || '')}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Sin tipo" />
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(TIPO_CONFIG).map(([k, v]) => (
-                  <SelectItem key={k} value={k}>
-                    {v}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={tipo ?? ''}
+              onChange={(v) => setTipo(v)}
+              options={Object.entries(TIPO_CONFIG).map(([k, v]) => ({
+                value: k,
+                label: String(v),
+              }))}
+              placeholder="Sin tipo"
+              allowClear
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
         </div>
 
@@ -1226,18 +1216,13 @@ function JuntaDetailInner() {
 
         {showAddPersona && (
           <div className="mt-3 flex items-center gap-2 rounded-xl border border-[var(--accent)]/30 bg-[var(--accent)]/5 p-3">
-            <Select value={selectedPersonaId} onValueChange={(v) => setSelectedPersonaId(v ?? '')}>
-              <SelectTrigger className="flex-1 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Seleccionar persona..." />
-              </SelectTrigger>
-              <SelectContent>
-                {availablePersonas.map((p) => (
-                  <SelectItem key={p.id} value={p.id}>
-                    {p.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={selectedPersonaId}
+              onChange={setSelectedPersonaId}
+              options={availablePersonas.map((p) => ({ value: p.id, label: p.nombre }))}
+              placeholder="Seleccionar persona..."
+              className="flex-1 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
             <Button
               size="sm"
               onClick={handleAddParticipant}
@@ -1430,21 +1415,17 @@ function JuntaDetailInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Cambiar estado</FieldLabel>
-                <Select
+                <Combobox
                   value={updateForm.nuevoEstado}
-                  onValueChange={(v) => setUpdateForm((f) => ({ ...f, nuevoEstado: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin cambio" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_TASK).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setUpdateForm((f) => ({ ...f, nuevoEstado: v }))}
+                  options={Object.entries(ESTADO_TASK).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  placeholder="Sin cambio"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Cambiar fecha compromiso</FieldLabel>
@@ -1504,62 +1485,43 @@ function JuntaDetailInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Estado</FieldLabel>
-                <Select
+                <Combobox
                   value={taskForm.estado}
-                  onValueChange={(v) =>
-                    setTaskForm((f) => ({ ...f, estado: v as JuntaTask['estado'] }))
-                  }
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_TASK).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setTaskForm((f) => ({ ...f, estado: v as JuntaTask['estado'] }))}
+                  options={Object.entries(ESTADO_TASK).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Prioridad</FieldLabel>
-                <Select
+                <Combobox
                   value={taskForm.prioridad}
-                  onValueChange={(v) => setTaskForm((f) => ({ ...f, prioridad: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin prioridad" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(['Urgente', 'Alta', 'Media', 'Baja'] as const).map((p) => (
-                      <SelectItem key={p} value={p}>
-                        {p}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setTaskForm((f) => ({ ...f, prioridad: v }))}
+                  options={(['Urgente', 'Alta', 'Media', 'Baja'] as const).map((p) => ({
+                    value: p,
+                    label: p,
+                  }))}
+                  placeholder="Sin prioridad"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Asignar a</FieldLabel>
-                <Select
+                <Combobox
                   value={taskForm.asignado_a}
-                  onValueChange={(v) => setTaskForm((f) => ({ ...f, asignado_a: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin asignar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {empleados.map((e) => (
-                      <SelectItem key={e.id} value={e.id}>
-                        {e.nombre}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setTaskForm((f) => ({ ...f, asignado_a: v }))}
+                  options={empleados.map((e) => ({ value: e.id, label: e.nombre }))}
+                  placeholder="Sin asignar"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Fecha límite</FieldLabel>

--- a/app/rdb/admin/juntas/page.tsx
+++ b/app/rdb/admin/juntas/page.tsx
@@ -20,14 +20,8 @@ import {
 import { SortableHead } from '@/components/ui/sortable-head';
 import { useSortableTable } from '@/hooks/use-sortable-table';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -503,41 +497,29 @@ function JuntasInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Tipo</FieldLabel>
-                <Select
+                <Combobox
                   value={createForm.tipo ?? ''}
-                  onValueChange={(v) => setCreateForm((f) => ({ ...f, tipo: v || '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin tipo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(TIPO_CONFIG).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.icon} {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setCreateForm((f) => ({ ...f, tipo: v }))}
+                  options={Object.entries(TIPO_CONFIG).map(([k, v]) => ({
+                    value: k,
+                    label: `${v.icon} ${v.label}`,
+                  }))}
+                  placeholder="Sin tipo"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Estado</FieldLabel>
-                <Select
+                <Combobox
                   value={createForm.estado}
-                  onValueChange={(v) =>
-                    setCreateForm((f) => ({ ...f, estado: v as Junta['estado'] }))
-                  }
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setCreateForm((f) => ({ ...f, estado: v as Junta['estado'] }))}
+                  options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
             </div>
 

--- a/app/rdb/inventario/page.tsx
+++ b/app/rdb/inventario/page.tsx
@@ -33,13 +33,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
@@ -557,18 +551,12 @@ function RegistrarMovimientoDialog({
           {/* Tipo */}
           <div className="space-y-1.5">
             <label className="text-sm font-medium">Tipo de movimiento</label>
-            <Select value={tipo} onValueChange={(v) => setTipo(v as TipoUI)}>
-              <SelectTrigger className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {TIPO_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={tipo}
+              onChange={(v) => setTipo(v as TipoUI)}
+              options={TIPO_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label }))}
+              className="w-full"
+            />
             {tipoSeleccionado && (
               <p className="text-xs text-muted-foreground">{tipoSeleccionado.desc}</p>
             )}
@@ -1088,46 +1076,38 @@ export default function InventarioPage() {
           )}
 
           {tab === 'stock' && (
-            <Select value={categoriaFiltro} onValueChange={(v) => setCategoriaFiltro(v ?? '')}>
-              <SelectTrigger className="w-40 h-8 text-sm">
-                <SelectValue placeholder="Categoría" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">Todas</SelectItem>
-                {[
-                  'Alimentos',
-                  'Bebidas',
-                  'Licores',
-                  'Artículos',
-                  'Deportes',
-                  'Consumibles',
-                  'Propinas',
-                ].map((c) => (
-                  <SelectItem key={c} value={c}>
-                    {c}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={categoriaFiltro}
+              onChange={setCategoriaFiltro}
+              options={[
+                'Alimentos',
+                'Bebidas',
+                'Licores',
+                'Artículos',
+                'Deportes',
+                'Consumibles',
+                'Propinas',
+              ].map((c) => ({ value: c, label: c }))}
+              placeholder="Categoría"
+              allowClear
+              size="sm"
+              className="w-40"
+            />
           )}
 
           {tab === 'stock' && (
-            <Select
+            <Combobox
               value={clasificacionFiltro}
-              onValueChange={(v) => setClasificacionFiltro(v ?? '')}
-            >
-              <SelectTrigger className="w-40 h-8 text-sm">
-                <SelectValue placeholder="Clasificación" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="">Todas</SelectItem>
-                {['inventariable', 'consumible', 'merchandising', 'activo_fijo'].map((c) => (
-                  <SelectItem key={c} value={c}>
-                    {c}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              onChange={setClasificacionFiltro}
+              options={['inventariable', 'consumible', 'merchandising', 'activo_fijo'].map((c) => ({
+                value: c,
+                label: c,
+              }))}
+              placeholder="Clasificación"
+              allowClear
+              size="sm"
+              className="w-40"
+            />
           )}
 
           {tab === 'stock' && (

--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -31,13 +31,7 @@ import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { AlertTriangle, CalendarDays, RefreshCw, Search, Send, Truck } from 'lucide-react';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -354,21 +348,14 @@ function OrdenDetail({
                   Asignación de proveedor
                 </div>
                 <div className="flex gap-2">
-                  <Select
+                  <Combobox
                     value={selectedProveedorId}
-                    onValueChange={(v) => setSelectedProveedorId(v ?? '')}
-                  >
-                    <SelectTrigger className="flex-1">
-                      <SelectValue placeholder="Seleccionar proveedor…" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {proveedores.map((p) => (
-                        <SelectItem key={p.id} value={p.id}>
-                          {p.nombre}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    onChange={setSelectedProveedorId}
+                    options={proveedores.map((p) => ({ value: p.id, label: p.nombre }))}
+                    placeholder="Seleccionar proveedor…"
+                    allowClear
+                    className="flex-1"
+                  />
                   <Button
                     size="sm"
                     disabled={!selectedProveedorId || selectedProveedorId === orden?.proveedor_id}
@@ -1006,23 +993,21 @@ export default function OrdenesCompraPage() {
             />
           </div>
 
-          <Select value={presetKey} onValueChange={handlePreset}>
-            <SelectTrigger className="w-[140px]">
-              <SelectValue placeholder="Rango..." />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="hoy">Hoy</SelectItem>
-              <SelectItem value="ayer">Ayer</SelectItem>
-              <SelectItem value="semana">Esta semana</SelectItem>
-              <SelectItem value="7dias">Últimos 7 días</SelectItem>
-              <SelectItem value="mes">Este mes</SelectItem>
-              <SelectItem value="30dias">Últimos 30 días</SelectItem>
-              <SelectItem value="ano">Este año</SelectItem>
-              <SelectItem value="custom" className="hidden">
-                Personalizado
-              </SelectItem>
-            </SelectContent>
-          </Select>
+          <Combobox
+            value={presetKey}
+            onChange={handlePreset}
+            options={[
+              { value: 'hoy', label: 'Hoy' },
+              { value: 'ayer', label: 'Ayer' },
+              { value: 'semana', label: 'Esta semana' },
+              { value: '7dias', label: 'Últimos 7 días' },
+              { value: 'mes', label: 'Este mes' },
+              { value: '30dias', label: 'Últimos 30 días' },
+              { value: 'ano', label: 'Este año' },
+            ]}
+            placeholder="Rango..."
+            className="w-[140px]"
+          />
 
           <Button
             variant="outline"

--- a/app/rdb/productos/page.tsx
+++ b/app/rdb/productos/page.tsx
@@ -17,14 +17,8 @@ import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
+import { Combobox } from '@/components/ui/combobox';
 import {
   Sheet,
   SheetContent,
@@ -482,20 +476,17 @@ export default function ProductosPage() {
                     <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
                       Tipo
                     </label>
-                    <Select
+                    <Combobox
                       value={formCategoria || 'producto'}
-                      onValueChange={(v) => setFormCategoria(v ?? 'producto')}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Seleccionar tipo..." />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="producto">Producto</SelectItem>
-                        <SelectItem value="servicio">Servicio</SelectItem>
-                        <SelectItem value="insumo">Insumo</SelectItem>
-                        <SelectItem value="refaccion">Refacción</SelectItem>
-                      </SelectContent>
-                    </Select>
+                      onChange={(v) => setFormCategoria(v || 'producto')}
+                      options={[
+                        { value: 'producto', label: 'Producto' },
+                        { value: 'servicio', label: 'Servicio' },
+                        { value: 'insumo', label: 'Insumo' },
+                        { value: 'refaccion', label: 'Refacción' },
+                      ]}
+                      placeholder="Seleccionar tipo..."
+                    />
                   </div>
                 </div>
 
@@ -548,20 +539,17 @@ export default function ProductosPage() {
 
                 <div className="space-y-2">
                   <label className="text-sm font-medium leading-none">Tipo</label>
-                  <Select
+                  <Combobox
                     value={newCategoria || 'producto'}
-                    onValueChange={(v) => setNewCategoria(v ?? 'producto')}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Seleccionar tipo..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="producto">Producto</SelectItem>
-                      <SelectItem value="servicio">Servicio</SelectItem>
-                      <SelectItem value="insumo">Insumo</SelectItem>
-                      <SelectItem value="refaccion">Refacción</SelectItem>
-                    </SelectContent>
-                  </Select>
+                    onChange={(v) => setNewCategoria(v || 'producto')}
+                    options={[
+                      { value: 'producto', label: 'Producto' },
+                      { value: 'servicio', label: 'Servicio' },
+                      { value: 'insumo', label: 'Insumo' },
+                      { value: 'refaccion', label: 'Refacción' },
+                    ]}
+                    placeholder="Seleccionar tipo..."
+                  />
                 </div>
 
                 {/* Inventariable Toggle */}

--- a/app/rdb/requisiciones/page.tsx
+++ b/app/rdb/requisiciones/page.tsx
@@ -27,13 +27,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -1238,18 +1232,15 @@ export default function RequisicionesPage() {
             />
           </div>
 
-          <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value ?? 'all')}>
-            <SelectTrigger className="w-48">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {STATUS_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Combobox
+            value={statusFilter}
+            onChange={(value) => setStatusFilter(value || 'all')}
+            options={STATUS_OPTIONS.map((option) => ({
+              value: option.value,
+              label: option.label,
+            }))}
+            className="w-48"
+          />
 
           <div className="flex items-center gap-2">
             <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -1275,23 +1266,21 @@ export default function RequisicionesPage() {
               aria-label="Fecha hasta"
             />
           </div>
-          <Select value={presetKey} onValueChange={handlePreset}>
-            <SelectTrigger className="w-[140px]">
-              <SelectValue placeholder="Rango..." />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="hoy">Hoy</SelectItem>
-              <SelectItem value="ayer">Ayer</SelectItem>
-              <SelectItem value="semana">Esta semana</SelectItem>
-              <SelectItem value="7dias">Últimos 7 días</SelectItem>
-              <SelectItem value="mes">Este mes</SelectItem>
-              <SelectItem value="30dias">Últimos 30 días</SelectItem>
-              <SelectItem value="ano">Este año</SelectItem>
-              <SelectItem value="custom" className="hidden">
-                Personalizado
-              </SelectItem>
-            </SelectContent>
-          </Select>
+          <Combobox
+            value={presetKey}
+            onChange={handlePreset}
+            options={[
+              { value: 'hoy', label: 'Hoy' },
+              { value: 'ayer', label: 'Ayer' },
+              { value: 'semana', label: 'Esta semana' },
+              { value: '7dias', label: 'Últimos 7 días' },
+              { value: 'mes', label: 'Este mes' },
+              { value: '30dias', label: 'Últimos 30 días' },
+              { value: 'ano', label: 'Este año' },
+            ]}
+            placeholder="Rango..."
+            className="w-[140px]"
+          />
 
           <Button
             variant="outline"

--- a/app/rdb/rh/empleados/[id]/page.tsx
+++ b/app/rdb/rh/empleados/[id]/page.tsx
@@ -8,7 +8,7 @@
 
 import { RequireAccess } from '@/components/require-access';
 import { usePermissions } from '@/components/providers';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import {
@@ -18,13 +18,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -189,6 +183,24 @@ function EmpleadoDetailInner() {
   const [telefonoEmpresa, setTelefonoEmpresa] = useState('');
   const [extensionVal, setExtensionVal] = useState('');
   const [emailEmpresa, setEmailEmpresa] = useState('');
+
+  const departamentoOptions = useMemo(() => {
+    const opts = departamentos.map((d) => ({ value: d.id, label: d.nombre }));
+    const current = empleado?.departamento;
+    if (current?.id && !opts.some((o) => o.value === current.id)) {
+      opts.unshift({ value: current.id, label: `${current.nombre} (inactivo)` });
+    }
+    return opts;
+  }, [departamentos, empleado?.departamento]);
+
+  const puestoOptions = useMemo(() => {
+    const opts = puestos.map((p) => ({ value: p.id, label: p.nombre }));
+    const current = empleado?.puesto;
+    if (current?.id && !opts.some((o) => o.value === current.id)) {
+      opts.unshift({ value: current.id, label: `${current.nombre} (inactivo)` });
+    }
+    return opts;
+  }, [puestos, empleado?.puesto]);
 
   const [showBajaDialog, setShowBajaDialog] = useState(false);
   const [motivoBaja, setMotivoBaja] = useState('');
@@ -473,33 +485,25 @@ function EmpleadoDetailInner() {
             </div>
             <div>
               <FieldLabel>Departamento</FieldLabel>
-              <Select value={departamentoId} onValueChange={(v) => setDepartamentoId(v ?? '')}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin departamento" />
-                </SelectTrigger>
-                <SelectContent>
-                  {departamentos.map((d) => (
-                    <SelectItem key={d.id} value={d.id}>
-                      {d.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={departamentoId}
+                onChange={setDepartamentoId}
+                options={departamentoOptions}
+                placeholder="Sin departamento"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Puesto</FieldLabel>
-              <Select value={puestoId} onValueChange={(v) => setPuestoId(v ?? '')}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin puesto" />
-                </SelectTrigger>
-                <SelectContent>
-                  {puestos.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={puestoId}
+                onChange={setPuestoId}
+                options={puestoOptions}
+                placeholder="Sin puesto"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Email empresa</FieldLabel>

--- a/app/rdb/tasks/[id]/page.tsx
+++ b/app/rdb/tasks/[id]/page.tsx
@@ -10,13 +10,7 @@ import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -586,87 +580,43 @@ function TaskDetailInner() {
           {/* Estado */}
           <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
             <FieldLabel>Estado</FieldLabel>
-            <Select
+            <Combobox
               value={task.estado}
-              onValueChange={(v) => void patchTask({ estado: v as ErpTask['estado'] })}
-            >
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue>
-                  <span
-                    className={`inline-flex items-center gap-1.5 ${estadoCfg.cls.includes('text-') ? estadoCfg.cls.split(' ').find((c: string) => c.startsWith('text-')) : ''}`}
-                  >
-                    {estadoCfg.label}
-                  </span>
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                  <SelectItem key={k} value={k}>
-                    {v.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              onChange={(v) => void patchTask({ estado: v as ErpTask['estado'] })}
+              options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                value: k,
+                label: v.label,
+              }))}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
 
           {/* Metadata */}
           <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 space-y-4">
             <div>
               <FieldLabel>Prioridad</FieldLabel>
-              <Select
+              <Combobox
                 value={task.prioridad ?? ''}
-                onValueChange={(v) => void patchTask({ prioridad: v || null } as any)}
-              >
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin prioridad">
-                    {task.prioridad ? (
-                      <span
-                        className={`inline-flex items-center gap-1.5 ${PRIORIDAD_CONFIG[task.prioridad]?.cls.split(' ').find((c: string) => c.startsWith('text-')) ?? ''}`}
-                      >
-                        {task.prioridad}
-                      </span>
-                    ) : (
-                      <span className="text-[var(--text)]/40">Sin prioridad</span>
-                    )}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">Sin prioridad</SelectItem>
-                  {PRIORIDAD_OPTIONS.map((p) => (
-                    <SelectItem key={p} value={p}>
-                      {p}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onChange={(v) => void patchTask({ prioridad: (v || null) as any })}
+                options={PRIORIDAD_OPTIONS.map((p) => ({ value: p, label: p }))}
+                placeholder="Sin prioridad"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
 
             <Separator className="bg-[var(--border)]" />
 
             <div>
               <FieldLabel>Asignado a</FieldLabel>
-              <Select
+              <Combobox
                 value={task.asignado_a ?? ''}
-                onValueChange={(v) => void patchTask({ asignado_a: v || null })}
-              >
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin asignar">
-                    {asignado ? (
-                      asignado.nombre
-                    ) : (
-                      <span className="text-[var(--text)]/40">Sin asignar</span>
-                    )}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">Sin asignar</SelectItem>
-                  {empleados.map((e) => (
-                    <SelectItem key={e.id} value={e.id}>
-                      {e.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onChange={(v) => void patchTask({ asignado_a: v || null })}
+                options={empleados.map((e) => ({ value: e.id, label: e.nombre }))}
+                placeholder="Sin asignar"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
 
             <Separator className="bg-[var(--border)]" />
@@ -739,22 +689,17 @@ function TaskDetailInner() {
 
             <div>
               <FieldLabel>Cambiar estado (opcional)</FieldLabel>
-              <Select
+              <Combobox
                 value={updateForm.nuevoEstado}
-                onValueChange={(v) => setUpdateForm((f) => ({ ...f, nuevoEstado: v ?? '' }))}
-              >
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin cambio" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">Sin cambio</SelectItem>
-                  {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                    <SelectItem key={k} value={k}>
-                      {v.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onChange={(v) => setUpdateForm((f) => ({ ...f, nuevoEstado: v }))}
+                options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                  value: k,
+                  label: v.label,
+                }))}
+                placeholder="Sin cambio"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
 
             <div>

--- a/app/rdb/tasks/page.tsx
+++ b/app/rdb/tasks/page.tsx
@@ -34,14 +34,8 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@/components/ui/sheet';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -630,61 +624,39 @@ function TasksInner() {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Estado</FieldLabel>
-                <Select
+                <Combobox
                   value={createForm.estado}
-                  onValueChange={(v) =>
-                    setCreateForm((f) => ({ ...f, estado: v as ErpTask['estado'] }))
-                  }
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                      <SelectItem key={k} value={k}>
-                        {v.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setCreateForm((f) => ({ ...f, estado: v as ErpTask['estado'] }))}
+                  options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                    value: k,
+                    label: v.label,
+                  }))}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Prioridad</FieldLabel>
-                <Select
+                <Combobox
                   value={createForm.prioridad}
-                  onValueChange={(v) => setCreateForm((f) => ({ ...f, prioridad: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin prioridad" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PRIORIDAD_OPTIONS.map((p) => (
-                      <SelectItem key={p} value={p}>
-                        {p}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setCreateForm((f) => ({ ...f, prioridad: v }))}
+                  options={PRIORIDAD_OPTIONS.map((p) => ({ value: p, label: p }))}
+                  placeholder="Sin prioridad"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <FieldLabel>Asignado a</FieldLabel>
-                <Select
+                <Combobox
                   value={createForm.asignado_a}
-                  onValueChange={(v) => setCreateForm((f) => ({ ...f, asignado_a: v ?? '' }))}
-                >
-                  <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                    <SelectValue placeholder="Sin asignar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {empleados.map((e) => (
-                      <SelectItem key={e.id} value={e.id}>
-                        {e.nombre}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => setCreateForm((f) => ({ ...f, asignado_a: v }))}
+                  options={empleados.map((e) => ({ value: e.id, label: e.nombre }))}
+                  placeholder="Sin asignar"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
               </div>
               <div>
                 <FieldLabel>Fecha límite</FieldLabel>

--- a/app/rh/empleados/[id]/page.tsx
+++ b/app/rh/empleados/[id]/page.tsx
@@ -7,7 +7,7 @@
  */
 
 import { RequireAccess } from '@/components/require-access';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import {
@@ -17,13 +17,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -122,6 +116,24 @@ function EmpleadoDetailInner() {
   const [fechaNacimiento, setFechaNacimiento] = useState('');
   const [telefonoEmpresa, setTelefonoEmpresa] = useState('');
   const [extension, setExtension] = useState('');
+
+  const departamentoOptions = useMemo(() => {
+    const opts = departamentos.map((d) => ({ value: d.id, label: d.nombre }));
+    const current = empleado?.departamento;
+    if (current?.id && !opts.some((o) => o.value === current.id)) {
+      opts.unshift({ value: current.id, label: `${current.nombre} (inactivo)` });
+    }
+    return opts;
+  }, [departamentos, empleado?.departamento]);
+
+  const puestoOptions = useMemo(() => {
+    const opts = puestos.map((p) => ({ value: p.id, label: p.nombre }));
+    const current = empleado?.puesto;
+    if (current?.id && !opts.some((o) => o.value === current.id)) {
+      opts.unshift({ value: current.id, label: `${current.nombre} (inactivo)` });
+    }
+    return opts;
+  }, [puestos, empleado?.puesto]);
 
   // Baja dialog
   const [showBajaDialog, setShowBajaDialog] = useState(false);
@@ -345,33 +357,25 @@ function EmpleadoDetailInner() {
           </div>
           <div>
             <FieldLabel>Departamento</FieldLabel>
-            <Select value={departamentoId} onValueChange={(v) => setDepartamentoId(v ?? '')}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Sin departamento" />
-              </SelectTrigger>
-              <SelectContent>
-                {departamentos.map((d) => (
-                  <SelectItem key={d.id} value={d.id}>
-                    {d.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={departamentoId}
+              onChange={setDepartamentoId}
+              options={departamentoOptions}
+              placeholder="Sin departamento"
+              allowClear
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
           <div>
             <FieldLabel>Puesto</FieldLabel>
-            <Select value={puestoId} onValueChange={(v) => setPuestoId(v ?? '')}>
-              <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                <SelectValue placeholder="Sin puesto" />
-              </SelectTrigger>
-              <SelectContent>
-                {puestos.map((p) => (
-                  <SelectItem key={p.id} value={p.id}>
-                    {p.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={puestoId}
+              onChange={setPuestoId}
+              options={puestoOptions}
+              placeholder="Sin puesto"
+              allowClear
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
           </div>
           <div>
             <FieldLabel>Teléfono empresa</FieldLabel>

--- a/app/settings/acceso/acceso-client.tsx
+++ b/app/settings/acceso/acceso-client.tsx
@@ -37,13 +37,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
@@ -344,26 +338,16 @@ export function AccesoClient({
           {/* Company selector + new rol button */}
           <div className="flex items-center gap-3">
             <span className="text-sm dark:text-white/55 text-[var(--text)]/55">Empresa:</span>
-            <Select
+            <Combobox
               value={filterEmpresaId}
-              onValueChange={(v) => {
+              onChange={(v) => {
                 if (v) setFilterEmpresaId(v);
                 setSelectedRolId(null);
               }}
-            >
-              <SelectTrigger className="w-52">
-                <SelectValue placeholder="Selecciona empresa">
-                  {empresas.find((e) => e.id === filterEmpresaId)?.nombre ?? 'Selecciona empresa'}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {empresas.map((emp) => (
-                  <SelectItem key={emp.id} value={emp.id}>
-                    {emp.nombre}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              options={empresas.map((emp) => ({ value: emp.id, label: emp.nombre }))}
+              placeholder="Selecciona empresa"
+              className="w-52"
+            />
             {filterEmpresaId && (
               <Button
                 size="sm"
@@ -712,36 +696,27 @@ export function AccesoClient({
                                   <span className="text-xs dark:text-white/50 text-[var(--text)]/50">
                                     Rol base:
                                   </span>
-                                  <Select
-                                    value={ue.rol_id ?? '__none__'}
+                                  <Combobox
+                                    value={ue.rol_id ?? ''}
                                     disabled={isPending}
-                                    onValueChange={(v) => {
+                                    onChange={(v) => {
                                       run(() =>
                                         updateUsuarioEmpresaRol(
                                           selectedUsuario.id,
                                           emp.id,
-                                          v === '__none__' ? null : v
+                                          v || null
                                         )
                                       );
                                     }}
-                                  >
-                                    <SelectTrigger className="h-7 w-48 text-xs">
-                                      <SelectValue placeholder="Sin rol">
-                                        {ue.rol_id
-                                          ? (roles.find((r) => r.id === ue.rol_id)?.nombre ??
-                                            'Sin rol')
-                                          : 'Sin rol'}
-                                      </SelectValue>
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                      <SelectItem value="__none__">Sin rol</SelectItem>
-                                      {empRoles.map((rol) => (
-                                        <SelectItem key={rol.id} value={rol.id}>
-                                          {rol.nombre}
-                                        </SelectItem>
-                                      ))}
-                                    </SelectContent>
-                                  </Select>
+                                    options={empRoles.map((rol) => ({
+                                      value: rol.id,
+                                      label: rol.nombre,
+                                    }))}
+                                    placeholder="Sin rol"
+                                    allowClear
+                                    size="sm"
+                                    className="w-48 text-xs"
+                                  />
                                 </div>
                               )}
                             </div>
@@ -792,45 +767,37 @@ export function AccesoClient({
                             <p className="text-xs dark:text-white/45 text-[var(--text)]/45">
                               Empresa
                             </p>
-                            <Select
+                            <Combobox
                               value={newExcEmpresaId}
-                              onValueChange={(v) => {
+                              onChange={(v) => {
                                 if (v) setNewExcEmpresaId(v);
                               }}
-                            >
-                              <SelectTrigger className="h-8 text-xs">
-                                <SelectValue placeholder="Empresa" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {empresas.map((emp) => (
-                                  <SelectItem key={emp.id} value={emp.id}>
-                                    {emp.nombre}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
+                              options={empresas.map((emp) => ({
+                                value: emp.id,
+                                label: emp.nombre,
+                              }))}
+                              placeholder="Empresa"
+                              size="sm"
+                              className="text-xs"
+                            />
                           </div>
                           <div className="space-y-1">
                             <p className="text-xs dark:text-white/45 text-[var(--text)]/45">
                               Módulo
                             </p>
-                            <Select
+                            <Combobox
                               value={newExcModuloId}
-                              onValueChange={(v) => {
+                              onChange={(v) => {
                                 if (v) setNewExcModuloId(v);
                               }}
-                            >
-                              <SelectTrigger className="h-8 text-xs">
-                                <SelectValue placeholder="Módulo" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {modulos.map((mod) => (
-                                  <SelectItem key={mod.id} value={mod.id}>
-                                    {mod.nombre}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
+                              options={modulos.map((mod) => ({
+                                value: mod.id,
+                                label: mod.nombre,
+                              }))}
+                              placeholder="Módulo"
+                              size="sm"
+                              className="text-xs"
+                            />
                           </div>
                         </div>
                         <div className="flex gap-4">

--- a/components/cortes/abrir-caja-dialog.tsx
+++ b/components/cortes/abrir-caja-dialog.tsx
@@ -9,13 +9,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import type { Caja } from './types';
 
 export type AbrirForm = {
@@ -84,21 +78,14 @@ export function AbrirCajaDialog({
                   {cajas.find((c) => c.id === form.caja_id)?.nombre || '—'}
                 </div>
               ) : (
-                <Select
+                <Combobox
                   value={form.caja_id}
-                  onValueChange={(v) => onFormChange((f) => ({ ...f, caja_id: v ?? '' }))}
-                >
-                  <SelectTrigger className="h-8 mt-1 border-muted-foreground/30 bg-background">
-                    <SelectValue placeholder="Selecciona tu caja…" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {cajas.map((caja) => (
-                      <SelectItem key={caja.id} value={caja.id}>
-                        {caja.nombre}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  onChange={(v) => onFormChange((f) => ({ ...f, caja_id: v }))}
+                  options={cajas.map((caja) => ({ value: caja.id, label: caja.nombre }))}
+                  placeholder="Selecciona tu caja…"
+                  allowClear
+                  className="mt-1 border-muted-foreground/30 bg-background"
+                />
               )}
             </div>
           </div>

--- a/components/cortes/cortes-filters.tsx
+++ b/components/cortes/cortes-filters.tsx
@@ -1,13 +1,7 @@
 import { CalendarDays, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { ESTADO_OPTIONS } from './types';
 
 export function CortesFilters({
@@ -37,18 +31,12 @@ export function CortesFilters({
 }) {
   return (
     <div className="flex flex-wrap items-end gap-3">
-      <Select value={estadoFilter} onValueChange={(v) => onEstadoChange(v ?? 'all')}>
-        <SelectTrigger className="w-44">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {ESTADO_OPTIONS.map((opt) => (
-            <SelectItem key={opt.value} value={opt.value}>
-              {opt.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <Combobox
+        value={estadoFilter}
+        onChange={(v) => onEstadoChange(v || 'all')}
+        options={ESTADO_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label }))}
+        className="w-44"
+      />
 
       <div className="flex items-center gap-2">
         <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -68,23 +56,21 @@ export function CortesFilters({
           aria-label="Fecha hasta"
         />
       </div>
-      <Select value={presetKey} onValueChange={onPresetChange}>
-        <SelectTrigger className="w-[140px]">
-          <SelectValue placeholder="Rango..." />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="hoy">Hoy</SelectItem>
-          <SelectItem value="ayer">Ayer</SelectItem>
-          <SelectItem value="semana">Esta semana</SelectItem>
-          <SelectItem value="7dias">Últimos 7 días</SelectItem>
-          <SelectItem value="mes">Este mes</SelectItem>
-          <SelectItem value="30dias">Últimos 30 días</SelectItem>
-          <SelectItem value="ano">Este año</SelectItem>
-          <SelectItem value="custom" className="hidden">
-            Personalizado
-          </SelectItem>
-        </SelectContent>
-      </Select>
+      <Combobox
+        value={presetKey}
+        onChange={onPresetChange}
+        options={[
+          { value: 'hoy', label: 'Hoy' },
+          { value: 'ayer', label: 'Ayer' },
+          { value: 'semana', label: 'Esta semana' },
+          { value: '7dias', label: 'Últimos 7 días' },
+          { value: 'mes', label: 'Este mes' },
+          { value: '30dias', label: 'Últimos 30 días' },
+          { value: 'ano', label: 'Este año' },
+        ]}
+        placeholder="Rango..."
+        className="w-[140px]"
+      />
 
       <Button variant="outline" size="icon" onClick={onRefresh} aria-label="Actualizar">
         <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />

--- a/components/documentos/documento-adjuntos.tsx
+++ b/components/documentos/documento-adjuntos.tsx
@@ -20,13 +20,7 @@ import { useState } from 'react';
 import { FileText, Image as ImageIcon, Loader2, Paperclip, Trash2, Upload } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 
 import type { Adjunto, AdjuntoRol } from './types';
@@ -210,16 +204,17 @@ export function AdjuntosSection({
       {!readOnly && (
         <div className="pt-2 border-t border-[var(--border)]">
           <div className="flex items-center gap-2 flex-wrap">
-            <Select value={uploadRole} onValueChange={(v) => setUploadRole(v as AdjuntoRol)}>
-              <SelectTrigger className="w-52 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)] text-xs h-8">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="documento_principal">📄 Documento principal</SelectItem>
-                <SelectItem value="imagen_referencia">🖼️ Imagen / Plano</SelectItem>
-                <SelectItem value="anexo">📎 Anexo</SelectItem>
-              </SelectContent>
-            </Select>
+            <Combobox
+              value={uploadRole}
+              onChange={(v) => setUploadRole(v as AdjuntoRol)}
+              options={[
+                { value: 'documento_principal', label: '📄 Documento principal' },
+                { value: 'imagen_referencia', label: '🖼️ Imagen / Plano' },
+                { value: 'anexo', label: '📎 Anexo' },
+              ]}
+              size="sm"
+              className="w-52 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)] text-xs"
+            />
             <label className="cursor-pointer">
               <input
                 type="file"

--- a/components/documentos/documento-form-fields.tsx
+++ b/components/documentos/documento-form-fields.tsx
@@ -15,13 +15,7 @@
 import type React from 'react';
 
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Textarea } from '@/components/ui/textarea';
 
 import type { DocForm, NotariaOption } from './types';
@@ -42,7 +36,7 @@ export function DocFormFields({
   onOpenCreateNotaria: () => void;
 }) {
   const handleNotariaChange = (value: string | null) => {
-    if (!value || value === '__none__') {
+    if (!value) {
       setForm((f) => ({ ...f, notario_proveedor_id: '', notaria: '' }));
       return;
     }
@@ -78,20 +72,16 @@ export function DocFormFields({
       {/* Tipo selector — first, drives everything */}
       <div>
         <FLabel req>Tipo de documento</FLabel>
-        <Select value={form.tipo || undefined} onValueChange={handleTipoChange}>
-          <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-            <SelectValue placeholder="Seleccionar tipo..." />
-          </SelectTrigger>
-          <SelectContent>
-            {TIPOS_DOCUMENTO.map((t) => (
-              <SelectItem key={t.value} value={t.value}>
-                <span className="flex items-center gap-2">
-                  {t.icon} {t.label}
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Combobox
+          value={form.tipo}
+          onChange={handleTipoChange}
+          options={TIPOS_DOCUMENTO.map((t) => ({
+            value: t.value,
+            label: `${t.icon} ${t.label}`,
+          }))}
+          placeholder="Seleccionar tipo..."
+          className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+        />
       </div>
 
       {/* Type-specific fields */}
@@ -164,22 +154,14 @@ export function DocFormFields({
               + Nueva notaría
             </button>
           </div>
-          <Select
-            value={form.notario_proveedor_id || '__none__'}
-            onValueChange={handleNotariaChange}
-          >
-            <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Seleccionar notaría" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__none__">Sin asignar</SelectItem>
-              {notarias.map((n) => (
-                <SelectItem key={n.id} value={n.id}>
-                  {n.nombre}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Combobox
+            value={form.notario_proveedor_id}
+            onChange={(v) => handleNotariaChange(v || null)}
+            options={notarias.map((n) => ({ value: n.id, label: n.nombre }))}
+            placeholder="Seleccionar notaría"
+            allowClear
+            className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+          />
         </div>
       )}
 

--- a/components/documentos/documento-subtipo-fields.tsx
+++ b/components/documentos/documento-subtipo-fields.tsx
@@ -10,13 +10,7 @@
  */
 
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 
 import { FLabel } from './ui';
 
@@ -225,21 +219,20 @@ function PoderFields({ meta, onChange }: { meta: Meta; onChange: MetaChange }) {
       <div className="grid grid-cols-2 gap-3">
         <div>
           <FLabel>Tipo de Poder</FLabel>
-          <Select
-            value={v(meta, 'tipo_poder') || undefined}
-            onValueChange={(val) => onChange({ ...meta, tipo_poder: val })}
-          >
-            <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Seleccionar..." />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="General">General</SelectItem>
-              <SelectItem value="Especial">Especial</SelectItem>
-              <SelectItem value="Pleitos y cobranzas">Pleitos y cobranzas</SelectItem>
-              <SelectItem value="Actos de administración">Actos de administración</SelectItem>
-              <SelectItem value="Actos de dominio">Actos de dominio</SelectItem>
-            </SelectContent>
-          </Select>
+          <Combobox
+            value={v(meta, 'tipo_poder')}
+            onChange={(val) => onChange({ ...meta, tipo_poder: val })}
+            options={[
+              { value: 'General', label: 'General' },
+              { value: 'Especial', label: 'Especial' },
+              { value: 'Pleitos y cobranzas', label: 'Pleitos y cobranzas' },
+              { value: 'Actos de administración', label: 'Actos de administración' },
+              { value: 'Actos de dominio', label: 'Actos de dominio' },
+            ]}
+            placeholder="Seleccionar..."
+            allowClear
+            className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+          />
         </div>
         <div>
           <FLabel>Fecha del Poder</FLabel>

--- a/components/documentos/documentos-module.tsx
+++ b/components/documentos/documentos-module.tsx
@@ -47,14 +47,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
+// Combobox queda disponible si se necesita en form fields (ver documento-form-fields.tsx).
 import { useSortableTable } from '@/hooks/use-sortable-table';
 
 import type { Adjunto, Documento, NotariaOption } from './types';

--- a/components/playtomic/players-section.tsx
+++ b/components/playtomic/players-section.tsx
@@ -1,12 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import {
   Table,
   TableBody,
@@ -49,20 +43,17 @@ export function PlayersSection({
               placeholder="Buscar jugador o correo…"
               className="sm:w-64"
             />
-            <Select
+            <Combobox
               value={playerSort}
-              onValueChange={(value) => onPlayerSortChange(value as PlayerSortKey)}
-            >
-              <SelectTrigger className="sm:w-48">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="gasto">Ordenar por gasto</SelectItem>
-                <SelectItem value="reservas">Ordenar por reservas</SelectItem>
-                <SelectItem value="name">Ordenar por nombre</SelectItem>
-                <SelectItem value="sport">Ordenar por deporte</SelectItem>
-              </SelectContent>
-            </Select>
+              onChange={(value) => onPlayerSortChange(value as PlayerSortKey)}
+              options={[
+                { value: 'gasto', label: 'Ordenar por gasto' },
+                { value: 'reservas', label: 'Ordenar por reservas' },
+                { value: 'name', label: 'Ordenar por nombre' },
+                { value: 'sport', label: 'Ordenar por deporte' },
+              ]}
+              className="sm:w-48"
+            />
           </div>
         </div>
         <div className="overflow-hidden rounded-2xl border border-[var(--border)]">

--- a/components/rh/departamentos-module.tsx
+++ b/components/rh/departamentos-module.tsx
@@ -48,13 +48,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -353,21 +347,14 @@ export function DepartamentosModule({
       </div>
       <div>
         <FieldLabel>Departamento padre</FieldLabel>
-        <Select
+        <Combobox
           value={form.padre_id}
-          onValueChange={(v) => setForm((f) => ({ ...f, padre_id: v ?? '' }))}
-        >
-          <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-            <SelectValue placeholder="Ninguno (nivel raíz)" />
-          </SelectTrigger>
-          <SelectContent>
-            {parentOptions.map((d) => (
-              <SelectItem key={d.id} value={d.id}>
-                {d.nombre}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          onChange={(v) => setForm((f) => ({ ...f, padre_id: v }))}
+          options={parentOptions.map((d) => ({ value: d.id, label: d.nombre }))}
+          placeholder="Ninguno (nivel raíz)"
+          allowClear
+          className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+        />
       </div>
     </div>
   );

--- a/components/rh/empleado-adjuntos.tsx
+++ b/components/rh/empleado-adjuntos.tsx
@@ -33,13 +33,7 @@ import {
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import { getAdjuntoProxyUrl } from '@/lib/adjuntos';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 
 type Adjunto = {
@@ -307,18 +301,15 @@ export function EmpleadoAdjuntos({
 
       {!readOnly && (
         <div className="flex flex-wrap items-center gap-2 pt-2 border-t border-[var(--border)]">
-          <Select value={uploadRole} onValueChange={(v) => setUploadRole(v ?? 'otro')}>
-            <SelectTrigger className="h-8 w-56 rounded-xl border-[var(--border)] bg-[var(--panel)] text-xs text-[var(--text)]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {EMPLEADO_ROLES.map((r) => (
-                <SelectItem key={r.id} value={r.id}>
-                  {r.icon} {r.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Combobox
+            value={uploadRole}
+            onChange={(v) => setUploadRole(v || 'otro')}
+            options={EMPLEADO_ROLES.map((r) => ({
+              value: r.id,
+              label: `${r.icon} ${r.label}`,
+            }))}
+            className="h-8 w-56 rounded-xl border-[var(--border)] bg-[var(--panel)] text-xs text-[var(--text)]"
+          />
           <label className="cursor-pointer">
             <input
               type="file"

--- a/components/rh/empleados-module.tsx
+++ b/components/rh/empleados-module.tsx
@@ -49,14 +49,8 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -621,37 +615,31 @@ export function EmpleadosModule({
         </div>
         <div>
           <FieldLabel>Estado civil</FieldLabel>
-          <Select
+          <Combobox
             value={createForm.estado_civil}
-            onValueChange={(v) => setCreateForm((f) => ({ ...f, estado_civil: v ?? '' }))}
-          >
-            <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Seleccionar…" />
-            </SelectTrigger>
-            <SelectContent>
-              {['Soltero/a', 'Casado/a', 'Unión libre', 'Divorciado/a', 'Viudo/a'].map((o) => (
-                <SelectItem key={o} value={o}>
-                  {o}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            onChange={(v) => setCreateForm((f) => ({ ...f, estado_civil: v }))}
+            options={['Soltero/a', 'Casado/a', 'Unión libre', 'Divorciado/a', 'Viudo/a'].map(
+              (o) => ({ value: o, label: o })
+            )}
+            placeholder="Seleccionar…"
+            allowClear
+            className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+          />
         </div>
         <div>
           <FieldLabel>Sexo</FieldLabel>
-          <Select
+          <Combobox
             value={createForm.sexo}
-            onValueChange={(v) => setCreateForm((f) => ({ ...f, sexo: v ?? '' }))}
-          >
-            <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Seleccionar…" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="M">Masculino</SelectItem>
-              <SelectItem value="F">Femenino</SelectItem>
-              <SelectItem value="X">Otro / No especifica</SelectItem>
-            </SelectContent>
-          </Select>
+            onChange={(v) => setCreateForm((f) => ({ ...f, sexo: v }))}
+            options={[
+              { value: 'M', label: 'Masculino' },
+              { value: 'F', label: 'Femenino' },
+              { value: 'X', label: 'Otro / No especifica' },
+            ]}
+            placeholder="Seleccionar…"
+            allowClear
+            className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+          />
         </div>
       </div>
 
@@ -760,39 +748,25 @@ export function EmpleadosModule({
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div>
           <FieldLabel>Departamento</FieldLabel>
-          <Select
+          <Combobox
             value={createForm.departamento_id}
-            onValueChange={(v) => setCreateForm((f) => ({ ...f, departamento_id: v ?? '' }))}
-          >
-            <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Sin departamento" />
-            </SelectTrigger>
-            <SelectContent>
-              {departamentos.map((d) => (
-                <SelectItem key={d.id} value={d.id}>
-                  {d.nombre}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            onChange={(v) => setCreateForm((f) => ({ ...f, departamento_id: v }))}
+            options={departamentos.map((d) => ({ value: d.id, label: d.nombre }))}
+            placeholder="Sin departamento"
+            allowClear
+            className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+          />
         </div>
         <div>
           <FieldLabel>Puesto</FieldLabel>
-          <Select
+          <Combobox
             value={createForm.puesto_id}
-            onValueChange={(v) => setCreateForm((f) => ({ ...f, puesto_id: v ?? '' }))}
-          >
-            <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Sin puesto" />
-            </SelectTrigger>
-            <SelectContent>
-              {puestos.map((p) => (
-                <SelectItem key={p.id} value={p.id}>
-                  {p.nombre}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            onChange={(v) => setCreateForm((f) => ({ ...f, puesto_id: v }))}
+            options={puestos.map((p) => ({ value: p.id, label: p.nombre }))}
+            placeholder="Sin puesto"
+            allowClear
+            className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+          />
         </div>
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -818,22 +792,20 @@ export function EmpleadosModule({
 
       <div>
         <FieldLabel>Tipo de contrato</FieldLabel>
-        <Select
+        <Combobox
           value={createForm.tipo_contrato}
-          onValueChange={(v) => setCreateForm((f) => ({ ...f, tipo_contrato: v ?? 'prueba' }))}
-        >
-          <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-            <SelectValue placeholder="Seleccionar…" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="prueba">Periodo de prueba (default DILESA)</SelectItem>
-            <SelectItem value="indefinido">Tiempo indefinido / Planta</SelectItem>
-            <SelectItem value="determinado">Tiempo determinado</SelectItem>
-            <SelectItem value="obra">Obra determinada</SelectItem>
-            <SelectItem value="temporada">Temporada</SelectItem>
-            <SelectItem value="capacitacion_inicial">Capacitación inicial</SelectItem>
-          </SelectContent>
-        </Select>
+          onChange={(v) => setCreateForm((f) => ({ ...f, tipo_contrato: v || 'prueba' }))}
+          options={[
+            { value: 'prueba', label: 'Periodo de prueba (default DILESA)' },
+            { value: 'indefinido', label: 'Tiempo indefinido / Planta' },
+            { value: 'determinado', label: 'Tiempo determinado' },
+            { value: 'obra', label: 'Obra determinada' },
+            { value: 'temporada', label: 'Temporada' },
+            { value: 'capacitacion_inicial', label: 'Capacitación inicial' },
+          ]}
+          placeholder="Seleccionar…"
+          className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+        />
         {createForm.tipo_contrato === 'prueba' && (
           <p className="mt-1 text-[10px] text-[var(--text)]/40">
             Por defecto 30 días, prueba 1 de 3. Ajusta después en la ficha si es necesario.

--- a/components/rh/puestos-module.tsx
+++ b/components/rh/puestos-module.tsx
@@ -47,14 +47,8 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
@@ -401,21 +395,14 @@ export function PuestosModule({
         </div>
         <div>
           <FieldLabel>Departamento</FieldLabel>
-          <Select
+          <Combobox
             value={form.departamento_id}
-            onValueChange={(v) => setForm((f) => ({ ...f, departamento_id: v ?? '' }))}
-          >
-            <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-              <SelectValue placeholder="Sin departamento" />
-            </SelectTrigger>
-            <SelectContent>
-              {departamentos.map((d) => (
-                <SelectItem key={d.id} value={d.id}>
-                  {d.nombre}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            onChange={(v) => setForm((f) => ({ ...f, departamento_id: v }))}
+            options={departamentos.map((d) => ({ value: d.id, label: d.nombre }))}
+            placeholder="Sin departamento"
+            allowClear
+            className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+          />
         </div>
       </div>
       <div className="grid grid-cols-2 gap-4">

--- a/components/tasks/tasks-create-form.tsx
+++ b/components/tasks/tasks-create-form.tsx
@@ -23,18 +23,11 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
-  Combobox,
   type ComboboxOption,
   type Empleado,
   ESTADO_CONFIG,
@@ -106,51 +99,40 @@ function SimpleCreateDialog({
           <div className="grid grid-cols-2 gap-4">
             <div>
               <FieldLabel>Estado</FieldLabel>
-              <Select value={value.estado} onValueChange={(v) => set({ estado: v as TaskEstado })}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                    <SelectItem key={k} value={k}>
-                      {v.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={value.estado}
+                onChange={(v) => set({ estado: v as TaskEstado })}
+                options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                  value: k,
+                  label: v.label,
+                }))}
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Prioridad</FieldLabel>
-              <Select value={value.prioridad} onValueChange={(v) => set({ prioridad: v ?? '' })}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin prioridad" />
-                </SelectTrigger>
-                <SelectContent>
-                  {PRIORIDAD_OPTIONS.map((p) => (
-                    <SelectItem key={p} value={p}>
-                      {p}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={value.prioridad}
+                onChange={(v) => set({ prioridad: v })}
+                options={PRIORIDAD_OPTIONS.map((p) => ({ value: p, label: p }))}
+                placeholder="Sin prioridad"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div>
               <FieldLabel>Asignado a</FieldLabel>
-              <Select value={value.asignado_a} onValueChange={(v) => set({ asignado_a: v ?? '' })}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin asignar" />
-                </SelectTrigger>
-                <SelectContent>
-                  {empleados.map((e) => (
-                    <SelectItem key={e.id} value={e.id}>
-                      {e.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={value.asignado_a}
+                onChange={(v) => set({ asignado_a: v })}
+                options={empleados.map((e) => ({ value: e.id, label: e.nombre }))}
+                placeholder="Sin asignar"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Fecha límite</FieldLabel>
@@ -237,18 +219,13 @@ function RichCreateSheet({
           <div className="grid grid-cols-2 gap-4">
             <div>
               <FieldLabel required>Prioridad</FieldLabel>
-              <Select value={value.prioridad} onValueChange={(v) => set({ prioridad: v ?? '' })}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Seleccionar" />
-                </SelectTrigger>
-                <SelectContent>
-                  {PRIORIDAD_OPTIONS.map((p) => (
-                    <SelectItem key={p} value={p}>
-                      {p}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={value.prioridad}
+                onChange={(v) => set({ prioridad: v })}
+                options={PRIORIDAD_OPTIONS.map((p) => ({ value: p, label: p }))}
+                placeholder="Seleccionar"
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             {/* Estado se asigna automáticamente como 'pendiente' */}
           </div>
@@ -270,10 +247,11 @@ function RichCreateSheet({
             <FieldLabel required>Responsable</FieldLabel>
             <Combobox
               value={value.asignado_a}
-              onChange={(v) => set({ asignado_a: v === 'all' ? '' : v })}
-              options={empleadoOptions}
+              onChange={(v) => set({ asignado_a: v })}
+              options={empleadoOptions.map((o) => ({ value: o.id, label: o.label }))}
               placeholder="Buscar responsable..."
               searchPlaceholder="Escriba un nombre..."
+              allowClear
             />
           </div>
 

--- a/components/tasks/tasks-edit-form.tsx
+++ b/components/tasks/tasks-edit-form.tsx
@@ -23,18 +23,11 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
-  Combobox,
   type ComboboxOption,
   type Empleado,
   type ErpTask,
@@ -119,50 +112,39 @@ function SimpleEditDialog({
           <div className="grid grid-cols-2 gap-4">
             <div>
               <FieldLabel>Estado</FieldLabel>
-              <Select value={value.estado} onValueChange={(v) => set({ estado: v as TaskEstado })}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                    <SelectItem key={k} value={k}>
-                      {v.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={value.estado}
+                onChange={(v) => set({ estado: v as TaskEstado })}
+                options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                  value: k,
+                  label: v.label,
+                }))}
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Prioridad</FieldLabel>
-              <Select value={value.prioridad} onValueChange={(v) => set({ prioridad: v ?? '' })}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin prioridad" />
-                </SelectTrigger>
-                <SelectContent>
-                  {PRIORIDAD_OPTIONS.map((p) => (
-                    <SelectItem key={p} value={p}>
-                      {p}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={value.prioridad}
+                onChange={(v) => set({ prioridad: v })}
+                options={PRIORIDAD_OPTIONS.map((p) => ({ value: p, label: p }))}
+                placeholder="Sin prioridad"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
               <FieldLabel>Asignado a</FieldLabel>
-              <Select value={value.asignado_a} onValueChange={(v) => set({ asignado_a: v ?? '' })}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin asignar" />
-                </SelectTrigger>
-                <SelectContent>
-                  {empleados.map((e) => (
-                    <SelectItem key={e.id} value={e.id}>
-                      {e.nombre}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={value.asignado_a}
+                onChange={(v) => set({ asignado_a: v })}
+                options={empleados.map((e) => ({ value: e.id, label: e.nombre }))}
+                placeholder="Sin asignar"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
             <div>
               <FieldLabel>Fecha límite</FieldLabel>
@@ -259,22 +241,16 @@ function RichEditSheet({
           <div className="grid grid-cols-2 gap-4">
             <div>
               <FieldLabel>Estado</FieldLabel>
-              <Select
+              <Combobox
                 value={value.estado}
-                onValueChange={(v) => set({ estado: v as TaskEstado })}
+                onChange={(v) => set({ estado: v as TaskEstado })}
+                options={Object.entries(ESTADO_CONFIG).map(([k, v]) => ({
+                  value: k,
+                  label: v.label,
+                }))}
                 disabled={!canCompleteTask}
-              >
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(ESTADO_CONFIG).map(([k, v]) => (
-                    <SelectItem key={k} value={k}>
-                      {v.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
               {!canCompleteTask && (
                 <p className="mt-1 text-[10px] text-[var(--text)]/40">
                   Solo dirección o el creador pueden cambiar el estado
@@ -283,18 +259,14 @@ function RichEditSheet({
             </div>
             <div>
               <FieldLabel>Prioridad</FieldLabel>
-              <Select value={value.prioridad} onValueChange={(v) => set({ prioridad: v ?? '' })}>
-                <SelectTrigger className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]">
-                  <SelectValue placeholder="Sin prioridad" />
-                </SelectTrigger>
-                <SelectContent>
-                  {PRIORIDAD_OPTIONS.map((p) => (
-                    <SelectItem key={p} value={p}>
-                      {p}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Combobox
+                value={value.prioridad}
+                onChange={(v) => set({ prioridad: v })}
+                options={PRIORIDAD_OPTIONS.map((p) => ({ value: p, label: p }))}
+                placeholder="Sin prioridad"
+                allowClear
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
             </div>
           </div>
 
@@ -315,10 +287,11 @@ function RichEditSheet({
             <FieldLabel>Responsable</FieldLabel>
             <Combobox
               value={value.asignado_a}
-              onChange={(v) => set({ asignado_a: v === 'all' ? '' : v })}
-              options={empleadoOptions}
+              onChange={(v) => set({ asignado_a: v })}
+              options={empleadoOptions.map((o) => ({ value: o.id, label: o.label }))}
               placeholder="Buscar responsable..."
               searchPlaceholder="Escriba un nombre..."
+              allowClear
             />
           </div>
 

--- a/components/tasks/tasks-filters-bar.tsx
+++ b/components/tasks/tasks-filters-bar.tsx
@@ -18,7 +18,6 @@ import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Input } from '@/components/ui/input';
 
 import {
-  Combobox,
   ESTADO_CONFIG,
   PRIORIDAD_OPTIONS,
   type ComboboxOption,
@@ -115,7 +114,7 @@ export function TasksFiltersBar({
 
         {isRich ? (
           <>
-            <Combobox
+            <FilterCombobox
               value={filterEstado}
               onChange={onFilterEstadoChange}
               options={estadoOptions}
@@ -125,7 +124,7 @@ export function TasksFiltersBar({
               clearLabel="Todos"
               className="w-40"
             />
-            <Combobox
+            <FilterCombobox
               value={filterPrioridad}
               onChange={onFilterPrioridadChange}
               options={prioridadOptions}
@@ -135,7 +134,7 @@ export function TasksFiltersBar({
               clearLabel="Todas"
               className="w-36"
             />
-            <Combobox
+            <FilterCombobox
               value={filterAsignado}
               onChange={onFilterAsignadoChange}
               options={empleadoOptions}
@@ -145,7 +144,7 @@ export function TasksFiltersBar({
               clearLabel="Todos"
               className="w-48"
             />
-            <Combobox
+            <FilterCombobox
               value={filterDepto}
               onChange={onFilterDeptoChange}
               options={deptoOptions}

--- a/components/tasks/tasks-shared.tsx
+++ b/components/tasks/tasks-shared.tsx
@@ -7,17 +7,8 @@
  * orchestration. Split further only if any section starts growing independently.
  */
 
-import { useState } from 'react';
-import { ChevronsUpDown } from 'lucide-react';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
+// (Combobox local eliminado — usar @/components/ui/combobox para form fields y
+// @/components/ui/filter-combobox para filtros de tabla).
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -239,78 +230,6 @@ export function ProgressBar({ value }: { value: number }) {
 
 export { FieldLabel } from '@/components/ui/field-label';
 
-// ─── Combobox — used by DILESA variant for filters and responsable picker ────
-
-export type ComboboxOption = { id: string; label: string };
-
-export function Combobox({
-  value,
-  onChange,
-  options,
-  placeholder = 'Seleccionar...',
-  searchPlaceholder = 'Buscar...',
-  emptyText = 'Sin resultados',
-  allowClear = false,
-  clearLabel = 'Todos',
-  className,
-}: {
-  value: string;
-  onChange: (v: string) => void;
-  options: ComboboxOption[];
-  placeholder?: string;
-  searchPlaceholder?: string;
-  emptyText?: string;
-  allowClear?: boolean;
-  clearLabel?: string;
-  className?: string;
-}) {
-  const [open, setOpen] = useState(false);
-  const selected = options.find((o) => o.id === value);
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        className={`flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--panel)] text-[var(--text)] px-3 h-9 text-sm hover:bg-[var(--panel)]/80 transition-colors ${className ?? 'w-full'}`}
-      >
-        <span className={`truncate ${selected ? '' : 'text-[var(--text)]/40'}`}>
-          {selected ? selected.label : placeholder}
-        </span>
-        <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-40" />
-      </PopoverTrigger>
-      <PopoverContent className="w-64 p-0" align="start">
-        <Command>
-          <CommandInput placeholder={searchPlaceholder} />
-          <CommandList>
-            <CommandEmpty>{emptyText}</CommandEmpty>
-            <CommandGroup>
-              {allowClear && (
-                <CommandItem
-                  value={`__clear__${clearLabel}`}
-                  onSelect={() => {
-                    onChange('all');
-                    setOpen(false);
-                  }}
-                  data-checked={value === 'all' || value === ''}
-                >
-                  {clearLabel}
-                </CommandItem>
-              )}
-              {options.map((o) => (
-                <CommandItem
-                  key={o.id}
-                  value={o.label}
-                  onSelect={() => {
-                    onChange(o.id);
-                    setOpen(false);
-                  }}
-                  data-checked={value === o.id}
-                >
-                  {o.label}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-}
+// Re-export del tipo de FilterCombobox para consumidores que importaban
+// `ComboboxOption` desde este módulo (eran filtros filter-style).
+export type { FilterComboboxOption as ComboboxOption } from '@/components/ui/filter-combobox';

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import * as React from 'react';
+import { ChevronDownIcon, XIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  sub?: string;
+  keywords?: string[];
+  disabled?: boolean;
+}
+
+export interface ComboboxProps {
+  value: string | null | undefined;
+  onChange: (value: string) => void;
+  options: ComboboxOption[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  className?: string;
+  allowClear?: boolean;
+  size?: 'sm' | 'default';
+  id?: string;
+  name?: string;
+  'aria-label'?: string;
+}
+
+export function Combobox({
+  value,
+  onChange,
+  options,
+  placeholder = 'Seleccionar…',
+  searchPlaceholder = 'Buscar…',
+  emptyText = 'Sin resultados',
+  disabled = false,
+  className,
+  allowClear = false,
+  size = 'default',
+  id,
+  name,
+  'aria-label': ariaLabel,
+}: ComboboxProps) {
+  const [open, setOpen] = React.useState(false);
+  const selected = React.useMemo(() => options.find((o) => o.value === value), [options, value]);
+  const displayLabel = selected?.label ?? (value ? '' : '');
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={(triggerProps) => (
+          <button
+            {...triggerProps}
+            type="button"
+            id={id}
+            name={name}
+            aria-label={ariaLabel}
+            disabled={disabled}
+            className={cn(
+              'flex w-full items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent pr-2 pl-2.5 text-left text-sm whitespace-nowrap outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 dark:hover:bg-input/50',
+              size === 'sm' ? 'h-7' : 'h-8',
+              className
+            )}
+          >
+            <span className={cn('min-w-0 flex-1 truncate', !selected && 'text-muted-foreground')}>
+              {selected ? displayLabel : placeholder}
+            </span>
+            <span className="flex shrink-0 items-center gap-0.5">
+              {allowClear && selected && !disabled && (
+                <span
+                  role="button"
+                  tabIndex={-1}
+                  aria-label="Limpiar selección"
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onChange('');
+                  }}
+                  className="flex size-4 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  <XIcon className="size-3" />
+                </span>
+              )}
+              <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground" />
+            </span>
+          </button>
+        )}
+      />
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="min-w-(--anchor-width) max-w-[min(calc(100vw-1rem),28rem)] w-auto p-0 gap-0"
+      >
+        <Command
+          filter={(itemValue, search, keywords) => {
+            const haystack = `${itemValue} ${(keywords ?? []).join(' ')}`.toLowerCase();
+            const needle = search.toLowerCase().trim();
+            if (!needle) return 1;
+            return haystack.includes(needle) ? 1 : 0;
+          }}
+        >
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {options.map((opt) => (
+                <CommandItem
+                  key={opt.value}
+                  value={opt.value}
+                  keywords={[opt.label, ...(opt.keywords ?? []), ...(opt.sub ? [opt.sub] : [])]}
+                  disabled={opt.disabled}
+                  data-checked={opt.value === value ? 'true' : 'false'}
+                  onSelect={() => {
+                    onChange(opt.value);
+                    setOpen(false);
+                  }}
+                >
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate">{opt.label}</span>
+                    {opt.sub && (
+                      <span className="truncate text-xs text-muted-foreground">{opt.sub}</span>
+                    )}
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -16,7 +16,9 @@ import {
 
 export interface ComboboxOption {
   value: string;
-  label: string;
+  label: React.ReactNode;
+  /** Texto puro del label — requerido si `label` es ReactNode, para search + trigger. */
+  searchLabel?: string;
   sub?: string;
   keywords?: string[];
   disabled?: boolean;
@@ -119,7 +121,11 @@ export function Combobox({
                 <CommandItem
                   key={opt.value}
                   value={opt.value}
-                  keywords={[opt.label, ...(opt.keywords ?? []), ...(opt.sub ? [opt.sub] : [])]}
+                  keywords={[
+                    opt.searchLabel ?? (typeof opt.label === 'string' ? opt.label : ''),
+                    ...(opt.keywords ?? []),
+                    ...(opt.sub ? [opt.sub] : []),
+                  ]}
                   disabled={opt.disabled}
                   data-checked={opt.value === value ? 'true' : 'false'}
                   onSelect={() => {

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -59,9 +59,9 @@ function SelectContent({
   children,
   side = 'bottom',
   sideOffset = 4,
-  align = 'center',
+  align = 'start',
   alignOffset = 0,
-  alignItemWithTrigger = true,
+  alignItemWithTrigger = false,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<
@@ -82,7 +82,7 @@ function SelectContent({
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            'relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            'relative isolate z-50 max-h-(--available-height) min-w-(--anchor-width) max-w-[min(calc(100vw-1rem),28rem)] origin-(--transform-origin) overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
             className
           )}
           {...props}

--- a/components/ventas/ventas-filters.tsx
+++ b/components/ventas/ventas-filters.tsx
@@ -1,13 +1,7 @@
 'use client';
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Search, RefreshCw, CalendarDays } from 'lucide-react';
@@ -64,18 +58,12 @@ export function VentasFilters({
         />
       </div>
 
-      <Select value={statusFilter} onValueChange={(v) => onStatusFilterChange(v ?? 'all')}>
-        <SelectTrigger className="w-44">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {STATUS_OPTIONS.map((opt) => (
-            <SelectItem key={opt.value} value={opt.value}>
-              {opt.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <Combobox
+        value={statusFilter}
+        onChange={(v) => onStatusFilterChange(v || 'all')}
+        options={STATUS_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label }))}
+        className="w-44"
+      />
 
       <FilterCombobox
         value={corteFilter}
@@ -111,23 +99,21 @@ export function VentasFilters({
           aria-label="Fecha hasta"
         />
       </div>
-      <Select value={presetKey} onValueChange={onPresetChange}>
-        <SelectTrigger className="w-[140px]">
-          <SelectValue placeholder="Rango..." />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="hoy">Hoy</SelectItem>
-          <SelectItem value="ayer">Ayer</SelectItem>
-          <SelectItem value="semana">Esta semana</SelectItem>
-          <SelectItem value="7dias">Últimos 7 días</SelectItem>
-          <SelectItem value="mes">Este mes</SelectItem>
-          <SelectItem value="30dias">Últimos 30 días</SelectItem>
-          <SelectItem value="ano">Este año</SelectItem>
-          <SelectItem value="custom" className="hidden">
-            Personalizado
-          </SelectItem>
-        </SelectContent>
-      </Select>
+      <Combobox
+        value={presetKey}
+        onChange={onPresetChange}
+        options={[
+          { value: 'hoy', label: 'Hoy' },
+          { value: 'ayer', label: 'Ayer' },
+          { value: 'semana', label: 'Esta semana' },
+          { value: '7dias', label: 'Últimos 7 días' },
+          { value: 'mes', label: 'Este mes' },
+          { value: '30dias', label: 'Últimos 30 días' },
+          { value: 'ano', label: 'Este año' },
+        ]}
+        placeholder="Rango..."
+        className="w-[140px]"
+      />
 
       <Button variant="outline" size="icon" onClick={onRefresh} aria-label="Actualizar">
         <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />


### PR DESCRIPTION
## Resumen

Estandarización completa de dropdowns en BSOP. Introduce `<Combobox>` universal (con search, nunca muestra UUIDs) y migra **TODOS los módulos**.

## Problema original

Dos issues en el screenshot que reportó Beto:
1. **Dropdown `TIPO DE CONTRATO` truncado** — el popup tenía `w-(--anchor-width)` forzando el ancho del trigger + `overflow-x-hidden` recortando labels largos.
2. **Departamento y Puesto mostraban UUIDs** — el empleado tenía un depto/puesto que quedó `activo=false` y el Select de base-ui muestra el value crudo cuando ningún `SelectItem` matchea.

## Solución

### Nuevo: `components/ui/combobox.tsx`

- Filter/search integrado con `cmdk` (busca por label, no por UUID)
- Popup crece al contenido, no recorta
- Siempre muestra el label; cuando el value no está en options pero aún existe en DB (como un depto inactivo), se incluye con `useMemo` + label `(inactivo)`
- `allowClear` — X en el trigger para limpiar sin abrir el popup
- `label: ReactNode` — soporta labels con colores/iconos

### Fix colateral: `components/ui/select.tsx`

- `min-w-(--anchor-width)` en lugar de `w-(--anchor-width)`
- `alignItemWithTrigger=false` + `align=start`
- Quita `overflow-x-hidden`

## Módulos migrados — commits por módulo

Los commits son atómicos por módulo (revisables individualmente o cherry-pick si se quieren PRs separados):

1. `7388628` **RH** — empleados (dilesa/rdb/inicio), empleados-module create form, puestos, departamentos, empleado-adjuntos, finiquito DILESA
2. `47e5fc9` **Tasks** — create form, edit form, filters-bar, rdb/tasks page + detail (incluye eliminación del `Combobox` local de tasks-shared)
3. `50c4358` **Juntas** — dilesa/rdb/inicio list + detail pages (incluye eliminación de un `Combobox` local duplicado en dilesa detail)
4. `cb1609c` **Documentos** — form fields, subtipo fields, adjuntos
5. `498fb6b` **RDB ops** — productos, inventario, requisiciones, ordenes-compra
6. `8cc6a06` **Filters + settings** — ventas-filters, cortes-filters, abrir-caja-dialog, settings/acceso (elimina hacks `__none__`), playtomic players

## Criterio final

- **`<Combobox>`**: TODOS los form fields (con search siempre, como pidió Beto — "asi lo puedes escribir o seleccionar con el mouse")
- **`<FilterCombobox>`**: filtros de tabla con opción "Todos"/`all` default
- **`<Select>`**: disponible pero ya no se usa en ningún archivo del repo (solo el componente base)

## Verificación

- `tsc --noEmit` limpio después de cada commit
- `eslint` solo warnings pre-existentes (no relacionados a Combobox)
- Pendiente: verificación visual en dev/preview (Beto se retiró mientras avanzaba)

## Test plan

- [ ] **Screenshot original** — abrir empleado DILESA en edit: `TIPO DE CONTRATO` ya no se trunca + `DEPARTAMENTO` y `PUESTO` muestran nombre en vez de UUID
- [ ] Tipear en dropdown grande → filtra por label
- [ ] Empleado con depto/puesto inactivo → aparece marcado `(inactivo)` en la lista
- [ ] X del `allowClear` limpia sin abrir popup
- [ ] Probar create form de empleado, task, junta, documento, orden-compra, requisición, cortes
- [ ] Filtros de tabla (tasks, ventas, cortes) siguen funcionando con `FilterCombobox`
- [ ] Settings › Acceso: asignar rol a usuario en empresa + crear excepción
- [ ] Playtomic ordenamiento de jugadores

🤖 Generated with [Claude Code](https://claude.com/claude-code)