### PR TITLE
feat(rh): foto empleado 128x128 en ficha DILESA

### DIFF
--- a/app/dilesa/rh/empleados/[id]/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/page.tsx
@@ -724,11 +724,11 @@ function EmpleadoDetailInner() {
               <img
                 src={photoUrl}
                 alt={fullName(empleado)}
-                className="h-20 w-20 rounded-2xl border border-[var(--border)] object-cover shadow-sm"
+                className="h-32 w-32 rounded-2xl border border-[var(--border)] object-cover shadow-sm"
               />
             </a>
           ) : (
-            <div className="flex h-20 w-20 shrink-0 items-center justify-center rounded-2xl bg-[var(--accent)]/15 text-3xl font-bold text-[var(--accent)]">
+            <div className="flex h-32 w-32 shrink-0 items-center justify-center rounded-2xl bg-[var(--accent)]/15 text-5xl font-bold text-[var(--accent)]">
               {(titleCase(persona?.nombre ?? '').charAt(0) || '?').toUpperCase()}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Foto del header en ficha DILESA sube de 80×80 a 128×128 (60% más grande)
- Inicial de fallback crece de text-3xl a text-5xl para quedar proporcionada

## Test plan
- [ ] Abrir `/dilesa/rh/empleados/[id]` con empleado que tenga foto subida (rol='foto')
- [ ] Verificar que la foto se ve notoriamente más grande en el header
- [ ] Click en la foto abre la imagen a tamaño completo
- [ ] Para empleado sin foto: la inicial también se ve más grande y proporcionada

🤖 Generated with [Claude Code](https://claude.com/claude-code)