### PR TITLE
fix(schema): schema:check ignore timestamp + auto-load .env.local

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "db:types": "supabase gen types typescript --project-id ybklderteyhuugzfmxbi --schema public --schema core --schema erp --schema rdb --schema dilesa --schema playtomic > types/supabase.ts",
     "db:check": "npm run db:types && git diff --exit-code types/supabase.ts",
     "schema:ref": "npx tsx scripts/gen-schema-ref.ts",
-    "schema:check": "npm run schema:ref && git diff --exit-code supabase/SCHEMA_REF.md",
+    "schema:check": "npm run schema:ref && git diff --exit-code -I '^  Last regenerated: ' supabase/SCHEMA_REF.md",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/gen-schema-ref.ts
+++ b/scripts/gen-schema-ref.ts
@@ -372,9 +372,37 @@ async function fetchSchemaData(client: Client, schemas: string[]): Promise<Schem
   return { tables, columns, pks, fks };
 }
 
+// ── .env.local loader ─────────────────────────────────────────────────────────
+//
+// Carga `.env.local` desde `process.cwd()` para que el script funcione con
+// `npm run schema:ref` sin que el usuario tenga que exportar SUPABASE_DB_URL
+// manualmente. Solo define variables que no estén ya en el entorno (el entorno
+// real gana — importante para CI, donde la var viene del GitHub secret).
+function loadEnvLocal(): void {
+  const envPath = path.join(process.cwd(), '.env.local');
+  if (!fs.existsSync(envPath)) return;
+  const content = fs.readFileSync(envPath, 'utf8');
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eqIndex = line.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = line.slice(0, eqIndex).trim();
+    let value = line.slice(eqIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
 // ── CLI entry ─────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
+  loadEnvLocal();
   const connectionString = process.env.SUPABASE_DB_URL;
   if (!connectionString) {
     console.error(


### PR DESCRIPTION
## Summary

Dos fixes al drift guard que mergeamos en #91, encontrados al habilitarlo en local:

1. **`schema:check` fallaba siempre** porque el timestamp `Last regenerated: ...` en SCHEMA_REF.md cambia en cada corrida. Ahora usa \`git diff --exit-code -I '^  Last regenerated: '\` para ignorar esa línea.
2. **`gen-schema-ref.ts` no leía \`.env.local\`** — el script requería exportar \`SUPABASE_DB_URL\` manualmente. Ahora auto-carga \`.env.local\` con el mismo patrón que \`scripts/seed-baja-expenses.ts\` (el env real sigue teniendo precedencia, importante para CI).

## Verificación

- \`npm run schema:check\` → exit 0 cuando DB y MD coinciden ✅
- Regeneración determinística: 57,874 bytes idénticos a la versión del MCP fallback de #91
- También verificado que el host pooler correcto es \`aws-1-us-east-1.pooler.supabase.com\` (no aws-0) — útil para futuras sesiones

## Test plan

- [x] \`npm run schema:ref\` termina OK sin exportar env manualmente
- [x] \`npm run schema:check\` exit 0 sin drift real
- [ ] Una vez mergeado, agregar \`SUPABASE_DB_URL\` como repo secret en GitHub Settings → el CI guard quedará duro

🤖 Generated with [Claude Code](https://claude.com/claude-code)