### PR TITLE
chore(nav): Personas Físicas arriba de SANREN

### DIFF
--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -61,6 +61,11 @@ export const NAV_ITEMS: NavItem[] = [
     ],
   },
   {
+    href: '/personas-fisicas',
+    labelKey: 'Personas Físicas',
+    icon: '🪪',
+  },
+  {
     href: '/family',
     labelKey: 'SANREN',
     icon: 'SANREN_LOGO',
@@ -70,11 +75,6 @@ export const NAV_ITEMS: NavItem[] = [
       { label: 'Salud', href: '/health' },
       { label: 'Familia', href: '/family' },
     ],
-  },
-  {
-    href: '/personas-fisicas',
-    labelKey: 'Personas Físicas',
-    icon: '🪪',
   },
   {
     href: '/settings',


### PR DESCRIPTION
## Summary
Swap del orden en el sidebar — **Personas Físicas** sube antes de **SANREN**. Cambio cosmético de un solo archivo.

### Antes
```
DILESA → Rincón del Bosque → SANREN → Personas Físicas → Configuración
```

### Después
```
DILESA → Rincón del Bosque → Personas Físicas → SANREN → Configuración
```

## Test plan
- [ ] Preview: sidebar muestra Personas Físicas arriba de SANREN
- [ ] Rutas `/personas-fisicas` y `/family` siguen accesibles

🤖 Generated with [Claude Code](https://claude.com/claude-code)