### PR TITLE
fix(rdb): proveedores muestra nombre completo (persona física)

### DIFF
--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -638,7 +638,7 @@ export default function OrdenesCompraPage() {
         .schema('erp')
         .from('ordenes_compra')
         .select(
-          'id, codigo, requisicion_id, proveedor_id, total, autorizada_at, created_at, proveedor:proveedores!proveedor_id(id, persona:personas!persona_id(nombre, email, telefono, rfc)), requisicion:requisiciones!requisicion_id(codigo)'
+          'id, codigo, requisicion_id, proveedor_id, total, autorizada_at, created_at, proveedor:proveedores!proveedor_id(id, persona:personas!persona_id(nombre, apellido_paterno, apellido_materno, email, telefono, rfc)), requisicion:requisiciones!requisicion_id(codigo)'
         )
         .eq('empresa_id', RDB_EMPRESA_ID)
         .order('created_at', { ascending: false });
@@ -660,11 +660,27 @@ export default function OrdenesCompraPage() {
         proveedor: unknown;
         requisicion: unknown;
       };
+      const buildNombre = (
+        p: {
+          nombre: string;
+          apellido_paterno: string | null;
+          apellido_materno: string | null;
+        } | null
+      ) => {
+        if (!p) return null;
+        const full = [p.nombre, p.apellido_paterno, p.apellido_materno]
+          .filter((s) => s && s.trim())
+          .join(' ')
+          .trim();
+        return full || null;
+      };
       const ordenesMapped: OrdenCompra[] = ((data ?? []) as unknown as RawOrden[]).map((o) => {
         const prov = o.proveedor as {
           id: string;
           persona: {
             nombre: string;
+            apellido_paterno: string | null;
+            apellido_materno: string | null;
             email: string | null;
             telefono: string | null;
             rfc: string | null;
@@ -674,7 +690,7 @@ export default function OrdenesCompraPage() {
         const proveedor: Proveedor | null = prov
           ? {
               id: prov.id,
-              nombre: persona?.nombre ?? null,
+              nombre: buildNombre(persona),
               email: persona?.email ?? null,
               telefono: persona?.telefono ?? null,
               rfc: persona?.rfc ?? null,
@@ -700,13 +716,17 @@ export default function OrdenesCompraPage() {
       const { data: provRaw } = await supabase
         .schema('erp')
         .from('proveedores')
-        .select('id, activo, persona:personas!persona_id(nombre, email, telefono, rfc)')
+        .select(
+          'id, activo, persona:personas!persona_id(nombre, apellido_paterno, apellido_materno, email, telefono, rfc)'
+        )
         .eq('empresa_id', RDB_EMPRESA_ID)
         .eq('activo', true);
       type RawProv = {
         id: string;
         persona: {
           nombre: string;
+          apellido_paterno: string | null;
+          apellido_materno: string | null;
           email: string | null;
           telefono: string | null;
           rfc: string | null;
@@ -717,7 +737,7 @@ export default function OrdenesCompraPage() {
           const persona = p.persona ?? null;
           return {
             id: p.id,
-            nombre: persona?.nombre ?? null,
+            nombre: buildNombre(persona),
             email: persona?.email ?? null,
             telefono: persona?.telefono ?? null,
             rfc: persona?.rfc ?? null,

--- a/app/rdb/proveedores/page.tsx
+++ b/app/rdb/proveedores/page.tsx
@@ -42,6 +42,9 @@ type Proveedor = {
   id: string;
   persona_id: string | null;
   nombre: string;
+  nombre_raw: string | null;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
   contacto: string | null;
   telefono: string | null;
   email: string | null;
@@ -183,6 +186,8 @@ export default function ProveedoresPage() {
   const [creating, setCreating] = useState(false);
   const [savingEdit, setSavingEdit] = useState(false);
   const [newNombre, setNewNombre] = useState('');
+  const [newApellidoPaterno, setNewApellidoPaterno] = useState('');
+  const [newApellidoMaterno, setNewApellidoMaterno] = useState('');
   const [newContacto, setNewContacto] = useState('');
   const [newTelefono, setNewTelefono] = useState('');
   const [newEmail, setNewEmail] = useState('');
@@ -190,6 +195,8 @@ export default function ProveedoresPage() {
   const [newDireccion, setNewDireccion] = useState('');
   const [newNotas, setNewNotas] = useState('');
   const [editNombre, setEditNombre] = useState('');
+  const [editApellidoPaterno, setEditApellidoPaterno] = useState('');
+  const [editApellidoMaterno, setEditApellidoMaterno] = useState('');
   const [editTelefono, setEditTelefono] = useState('');
   const [editEmail, setEditEmail] = useState('');
   const [editRFC, setEditRFC] = useState('');
@@ -208,6 +215,8 @@ export default function ProveedoresPage() {
         .insert({
           empresa_id: RDB_EMPRESA_ID,
           nombre: newNombre.trim(),
+          apellido_paterno: newApellidoPaterno.trim() || null,
+          apellido_materno: newApellidoMaterno.trim() || null,
           email: newEmail.trim() || null,
           telefono: newTelefono.trim() || null,
           rfc: newRFC.trim() || null,
@@ -228,6 +237,8 @@ export default function ProveedoresPage() {
 
       setCreateDrawerOpen(false);
       setNewNombre('');
+      setNewApellidoPaterno('');
+      setNewApellidoMaterno('');
       setNewContacto('');
       setNewTelefono('');
       setNewEmail('');
@@ -252,7 +263,7 @@ export default function ProveedoresPage() {
         .schema('erp')
         .from('proveedores')
         .select(
-          'id, persona_id, activo, created_at, updated_at, personas!persona_id(nombre, email, telefono, rfc)'
+          'id, persona_id, activo, created_at, updated_at, personas!persona_id(nombre, apellido_paterno, apellido_materno, email, telefono, rfc)'
         )
         .eq('empresa_id', RDB_EMPRESA_ID);
       if (err) throw err;
@@ -268,14 +279,25 @@ export default function ProveedoresPage() {
         .map((p) => {
           const persona = p.personas as {
             nombre: string;
+            apellido_paterno: string | null;
+            apellido_materno: string | null;
             email: string | null;
             telefono: string | null;
             rfc: string | null;
           } | null;
+          const nombreCompleto = persona
+            ? [persona.nombre, persona.apellido_paterno, persona.apellido_materno]
+                .filter((s) => s && s.trim())
+                .join(' ')
+                .trim()
+            : '';
           return {
             id: p.id,
             persona_id: p.persona_id,
-            nombre: persona?.nombre ?? '—',
+            nombre: nombreCompleto || '—',
+            nombre_raw: persona?.nombre ?? null,
+            apellido_paterno: persona?.apellido_paterno ?? null,
+            apellido_materno: persona?.apellido_materno ?? null,
             contacto: null,
             telefono: persona?.telefono ?? null,
             email: persona?.email ?? null,
@@ -315,7 +337,9 @@ export default function ProveedoresPage() {
   const activos = proveedores.filter((p) => p.activo).length;
 
   const openEdit = (p: Proveedor) => {
-    setEditNombre(p.nombre ?? '');
+    setEditNombre(p.nombre_raw ?? '');
+    setEditApellidoPaterno(p.apellido_paterno ?? '');
+    setEditApellidoMaterno(p.apellido_materno ?? '');
     setEditTelefono(p.telefono ?? '');
     setEditEmail(p.email ?? '');
     setEditRFC(p.rfc ?? '');
@@ -336,6 +360,8 @@ export default function ProveedoresPage() {
         .from('personas')
         .update({
           nombre: editNombre.trim(),
+          apellido_paterno: editApellidoPaterno.trim() || null,
+          apellido_materno: editApellidoMaterno.trim() || null,
           telefono: editTelefono.trim() || null,
           email: editEmail.trim() || null,
           rfc: editRFC.trim() || null,
@@ -557,9 +583,29 @@ export default function ProveedoresPage() {
               <div className="space-y-4">
                 <div className="space-y-2">
                   <label className="text-sm font-medium leading-none">
-                    Razón Social / Nombre Comercial <span className="text-destructive">*</span>
+                    Nombre / Razón Social <span className="text-destructive">*</span>
                   </label>
                   <Input value={editNombre} onChange={(e) => setEditNombre(e.target.value)} />
+                  <p className="text-xs text-muted-foreground">
+                    Persona física: sólo el nombre de pila. Persona moral: razón social completa
+                    (apellidos vacíos).
+                  </p>
+                </div>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium leading-none">Apellido paterno</label>
+                    <Input
+                      value={editApellidoPaterno}
+                      onChange={(e) => setEditApellidoPaterno(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium leading-none">Apellido materno</label>
+                    <Input
+                      value={editApellidoMaterno}
+                      onChange={(e) => setEditApellidoMaterno(e.target.value)}
+                    />
+                  </div>
                 </div>
                 <div className="grid gap-4 sm:grid-cols-2">
                   <div className="space-y-2">
@@ -605,13 +651,32 @@ export default function ProveedoresPage() {
               <div className="space-y-4">
                 <div className="space-y-2">
                   <label className="text-sm font-medium leading-none">
-                    Razón Social / Nombre Comercial <span className="text-destructive">*</span>
+                    Nombre / Razón Social <span className="text-destructive">*</span>
                   </label>
                   <Input
                     value={newNombre}
                     onChange={(e) => setNewNombre(e.target.value)}
-                    placeholder="Ej. Comercializadora La Estrella"
+                    placeholder="Persona física: nombre de pila. Moral: razón social."
                   />
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium leading-none">Apellido paterno</label>
+                    <Input
+                      value={newApellidoPaterno}
+                      onChange={(e) => setNewApellidoPaterno(e.target.value)}
+                      placeholder="Sólo personas físicas"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium leading-none">Apellido materno</label>
+                    <Input
+                      value={newApellidoMaterno}
+                      onChange={(e) => setNewApellidoMaterno(e.target.value)}
+                      placeholder="Sólo personas físicas"
+                    />
+                  </div>
                 </div>
 
                 <div className="grid gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- `erp.personas` guarda el nombre en 3 columnas (`nombre`, `apellido_paterno`, `apellido_materno`). Las vistas de RDB sólo pedían `nombre`, así que proveedores-persona física aparecían truncados.
- Listado de Proveedores y combobox/impresión de Órdenes de Compra ahora componen el nombre completo en el mapper.
- Sheet de Editar/Crear proveedor: nuevos campos **Apellido paterno** y **Apellido materno** con hint (persona física = nombre de pila + apellidos; persona moral = razón social en `nombre`, apellidos vacíos).

## Test plan
- [ ] Abrir **RDB → Proveedores**: los proveedores con persona física muestran nombre+apellidos en la tabla.
- [ ] Editar un proveedor existente: los 3 campos se pre-llenan con lo guardado.
- [ ] Crear un proveedor persona física: se guarda y aparece con nombre completo.
- [ ] Crear un proveedor persona moral (sólo `nombre`, apellidos vacíos): sigue funcionando.
- [ ] **RDB → Órdenes de Compra**: el nombre del proveedor en la lista y en la impresión sale completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)