### PR TITLE
fix(juntas): actualizaciones solo dentro de ventana de la junta

### DIFF
--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -76,6 +76,7 @@ type Junta = {
   creado_por: string | null;
   created_at: string;
   updated_at: string | null;
+  fecha_terminada: string | null;
 };
 
 type Asistencia = {
@@ -387,12 +388,17 @@ function JuntaDetailInner() {
 
     const taskIds = (tasksData ?? []).map((t: any) => t.id);
     if (taskIds.length > 0) {
-      const { data: updatesData } = await supabase
+      let updatesQuery = supabase
         .schema('erp')
         .from('task_updates')
         .select('*')
         .in('task_id', taskIds)
+        .gte('created_at', juntaData.fecha_hora)
         .order('created_at', { ascending: false });
+      if (juntaData.fecha_terminada) {
+        updatesQuery = updatesQuery.lte('created_at', juntaData.fecha_terminada);
+      }
+      const { data: updatesData } = await updatesQuery;
       if (updatesData && updatesData.length > 0) {
         const userIds = [...new Set(updatesData.map((u: any) => u.creado_por).filter(Boolean))];
         const { data: usersData } =
@@ -634,12 +640,17 @@ function JuntaDetailInner() {
           setTasks(tasksData as JuntaTask[]);
           const tIds = tasksData.map((t: any) => t.id);
           if (tIds.length > 0) {
-            const { data: updData } = await supabase
+            let updQuery = supabase
               .schema('erp')
               .from('task_updates')
               .select('*')
               .in('task_id', tIds)
+              .gte('created_at', junta.fecha_hora)
               .order('created_at', { ascending: false });
+            if (junta.fecha_terminada) {
+              updQuery = updQuery.lte('created_at', junta.fecha_terminada);
+            }
+            const { data: updData } = await updQuery;
             if (updData) {
               const uIds = [...new Set(updData.map((u: any) => u.creado_por).filter(Boolean))];
               const { data: uData } =


### PR DESCRIPTION
## Summary
- La sección "Actualizaciones de Tareas" en el detalle de la junta traía todo el historial de cada tarea vinculada, confundiendo qué avances se reportaron durante la sesión.
- Ahora filtra `erp.task_updates` por `created_at >= junta.fecha_hora` y, si la junta ya está completada, `<= junta.fecha_terminada`.
- Aplica igual en la carga inicial y en el polling cada 10s.

## Test plan
- [ ] Abrir una junta `en_curso`: la sección muestra solo avances generados desde el inicio de la junta.
- [ ] Abrir una junta `completada`: muestra solo avances registrados entre `fecha_hora` y `fecha_terminada`.
- [ ] Generar un avance nuevo durante una junta en curso y confirmar que aparece dentro de ~10s por el polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)