### PR TITLE
fix(juntas): imágenes visibles en correo de minuta

### DIFF
--- a/app/api/juntas/terminar/route.ts
+++ b/app/api/juntas/terminar/route.ts
@@ -9,12 +9,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { validateBody } from '@/lib/validation';
+import { rewriteHtmlImagesWithSignedUrls } from '@/lib/adjuntos';
 
 const TerminarJuntaSchema = z.object({
   juntaId: z.string().uuid('juntaId must be a valid UUID'),
 });
 
 const CONSEJO_EMAIL = 'consejo@dilesa.mx';
+
+// 1 año — los correos pueden abrirse meses después (archivo, reenvíos). La
+// firma es server-side con service role, sin costo por TTLs largos.
+const EMAIL_IMAGE_TTL_SECONDS = 365 * 24 * 60 * 60;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -376,11 +381,20 @@ export async function POST(req: NextRequest) {
   }
 
   // ── Generate email ─────────────────────────────────────────────────────────
+  // Reescribir <img src="/api/adjuntos/…"> → signed URL pública antes de
+  // serializar el HTML. El cliente de correo no tiene cookies del mismo
+  // origen, así que el proxy same-origin del flujo web no funciona en
+  // Gmail/Outlook: las imágenes salen rotas. La firma dura 1 año.
+  const descripcionParaCorreo = await rewriteHtmlImagesWithSignedUrls(
+    supabase,
+    junta.descripcion as string | null,
+    EMAIL_IMAGE_TTL_SECONDS
+  );
   const html = generateMinutaHtml({
     titulo: junta.titulo as string,
     fechaTerminada: now.toISOString(),
     duracionMinutos,
-    descripcion: junta.descripcion as string | null,
+    descripcion: descripcionParaCorreo || null,
     asistentes,
     tareasCreadas,
     tareasCompletadas,

--- a/lib/adjuntos.ts
+++ b/lib/adjuntos.ts
@@ -236,6 +236,38 @@ export function rewriteHtmlImagesToProxy(html: string | null | undefined): strin
 }
 
 /**
+ * Reescribe cada `<img src="…">` a una signed URL pública de Supabase
+ * Storage. Pensada para contextos que se consumen fuera del navegador
+ * autenticado (ej. correo enviado por Resend): el cliente de mail no
+ * tiene cookies del mismo origen, así que el proxy `/api/adjuntos/<path>`
+ * no le sirve.
+ *
+ * Requiere un `SupabaseClient` con permisos para firmar objetos del
+ * bucket privado `adjuntos` (en server-side, service role). Si alguna
+ * firma falla, deja el `src` original (no rompe el HTML).
+ */
+export async function rewriteHtmlImagesWithSignedUrls(
+  supabase: SupabaseClient,
+  html: string | null | undefined,
+  expiresInSeconds = 3600
+): Promise<string> {
+  if (!html) return '';
+  const paths = new Set<string>();
+  replaceImgSrcs(html, (src) => {
+    const path = getAdjuntoPath(src);
+    if (path) paths.add(path);
+    return src;
+  });
+  if (paths.size === 0) return html;
+  const signedMap = await getAdjuntoSignedUrls(supabase, [...paths], expiresInSeconds);
+  return replaceImgSrcs(html, (src) => {
+    const path = getAdjuntoPath(src);
+    if (!path) return src;
+    return signedMap.get(path) ?? src;
+  });
+}
+
+/**
  * Normalize every `<img src="…">` in an HTML string to the canonical
  * `/api/adjuntos/<path>` form. Call this in the save path so the DB
  * always holds the same format (no signed URLs, no legacy public URLs).


### PR DESCRIPTION
## Summary
Desde el PR #76 las imágenes en \`erp.juntas.descripcion\` se guardan como \`/api/adjuntos/<path>\` (proxy same-origin con cookie). Eso funciona dentro de BSOP pero **no** en Gmail/Outlook — el correo llega con imágenes rotas (iconitos vacíos).

Fix:
- Nuevo helper \`rewriteHtmlImagesWithSignedUrls(supabase, html, ttl)\` en [lib/adjuntos.ts](lib/adjuntos.ts) que reescribe cada \`<img src>\` a una signed URL firmada server-side con service role, en un solo round-trip (batch).
- En [app/api/juntas/terminar/route.ts](app/api/juntas/terminar/route.ts) se aplica antes de pasar la descripción al template del correo. TTL = **1 año** (los correos pueden abrirse meses después).
- Los flujos del navegador no se tocan: siguen usando el proxy \`/api/adjuntos/<path>\`, así que dentro de BSOP las imágenes se siguen viendo igual.

## Test plan
- [ ] Terminar una junta con imágenes en las notas → el correo llega con las imágenes inline visibles.
- [ ] Abrir una junta dentro de BSOP (no afectada por este cambio) → imágenes se siguen viendo.
- [ ] Reabrir el correo 2-3 semanas después (test informal) → imágenes siguen cargando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)