### PR TITLE
feat(juntas): reenviar minuta en dilesa/rdb + conteo correcto de avances en lista

### DIFF
--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -57,6 +57,7 @@ import {
   ImagePlus,
   MessageSquarePlus,
   Clock,
+  Send,
 } from 'lucide-react';
 
 type Junta = {
@@ -335,6 +336,8 @@ function JuntaDetailInner() {
 
   const [terminating, setTerminating] = useState(false);
   const [showTerminarDialog, setShowTerminarDialog] = useState(false);
+  const [reenviando, setReenviando] = useState(false);
+  const [showReenviarDialog, setShowReenviarDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [isDireccion, setIsDireccion] = useState(false);
@@ -1086,6 +1089,31 @@ function JuntaDetailInner() {
     }
   };
 
+  const handleReenviar = async () => {
+    if (!junta) return;
+    setReenviando(true);
+    try {
+      const res = await fetch('/api/juntas/reenviar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ juntaId: junta.id }),
+      });
+      const result = await res.json();
+      if (!res.ok) {
+        alert(`Error al reenviar minuta: ${result.error ?? 'Error desconocido'}`);
+        return;
+      }
+      setShowReenviarDialog(false);
+      const emailMsg =
+        result.emailsSent > 0
+          ? `Minuta reenviada a ${result.emailsSent} participante(s).`
+          : (result.warning ?? 'No se envió el correo.');
+      alert(emailMsg);
+    } finally {
+      setReenviando(false);
+    }
+  };
+
   const handleDelete = async () => {
     if (!junta) return;
     setDeleting(true);
@@ -1215,6 +1243,21 @@ function JuntaDetailInner() {
             >
               <CheckCircle2 className="h-4 w-4" />
               Terminar junta
+            </Button>
+          )}
+          {estado === 'completada' && (
+            <Button
+              variant="outline"
+              onClick={() => setShowReenviarDialog(true)}
+              disabled={reenviando}
+              className="gap-1.5 rounded-xl border-[var(--accent)]/40 text-[var(--accent)] hover:bg-[var(--accent)]/10 hover:border-[var(--accent)]/60"
+            >
+              {reenviando ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+              Reenviar minuta
             </Button>
           )}
           <Button
@@ -1876,6 +1919,40 @@ function JuntaDetailInner() {
           </div>
         </SheetContent>
       </Sheet>
+
+      <Dialog open={showReenviarDialog} onOpenChange={setShowReenviarDialog}>
+        <DialogContent className="max-w-sm rounded-3xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]">
+          <DialogHeader>
+            <DialogTitle className="text-[var(--text)]">Reenviar minuta</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-[var(--text)]/70 pb-2">
+            Se enviará nuevamente la minuta por correo a los participantes con email registrado, con
+            el contenido actual de las notas, tareas y avances.
+          </p>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowReenviarDialog(false)}
+              disabled={reenviando}
+              className="rounded-xl border-[var(--border)] text-[var(--text)]"
+            >
+              Cancelar
+            </Button>
+            <Button
+              onClick={handleReenviar}
+              disabled={reenviando}
+              className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90 disabled:opacity-60"
+            >
+              {reenviando ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+              Sí, reenviar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={showTerminarDialog} onOpenChange={setShowTerminarDialog}>
         <DialogContent className="max-w-sm rounded-3xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]">

--- a/app/dilesa/admin/juntas/page.tsx
+++ b/app/dilesa/admin/juntas/page.tsx
@@ -43,6 +43,7 @@ type Junta = {
   titulo: string;
   descripcion: string | null;
   fecha_hora: string;
+  fecha_terminada: string | null;
   duracion_minutos: number | null;
   lugar: string | null;
   estado: JuntaEstado;
@@ -223,16 +224,15 @@ function JuntasInner() {
         .eq('empresa_id', EMPRESA_ID)
         .eq('entidad_tipo', 'junta')
         .limit(50000),
-      // task_updates para todas las tareas de junta de la empresa. Se hace un
-      // !inner join con tasks para poder filtrar por entidad_tipo='junta' y
-      // obtener la junta_id sin un segundo round-trip. Límite alto para que
-      // no se corte con el default de 1000 filas de PostgREST.
+      // task_updates de toda la empresa con su timestamp. Agrupamos por
+      // ventana de junta en cliente (misma lógica que el detalle): un update
+      // cuenta si su created_at cae entre fecha_hora y fecha_terminada de la
+      // junta, sin importar de qué tarea provenga.
       supabase
         .schema('erp')
         .from('task_updates')
-        .select('task_id, tasks!inner(entidad_id, entidad_tipo)')
+        .select('task_id, created_at')
         .eq('empresa_id', EMPRESA_ID)
-        .eq('tasks.entidad_tipo', 'junta')
         .limit(50000),
     ]);
     if (jRes.error) {
@@ -247,15 +247,13 @@ function JuntasInner() {
     });
     setAsistenciaCounts(aCounts);
 
-    // Map task_id → junta_id + total de tareas por junta + tally de
-    // terminadas (estado='completado') directamente desde erp.tasks.
-    const taskToJunta = new Map<string, string>();
+    // Total de tareas por junta + tally de terminadas (estado='completado')
+    // directamente desde erp.tasks.
     const tCounts = new Map<string, number>();
     const teCounts = new Map<string, number>();
     (tRes.data ?? []).forEach(
       (t: { id: string; entidad_id: string | null; estado: string | null }) => {
         if (!t.entidad_id) return;
-        taskToJunta.set(t.id, t.entidad_id);
         tCounts.set(t.entidad_id, (tCounts.get(t.entidad_id) ?? 0) + 1);
         if (t.estado === 'completado') {
           teCounts.set(t.entidad_id, (teCounts.get(t.entidad_id) ?? 0) + 1);
@@ -265,22 +263,24 @@ function JuntasInner() {
     setTaskCounts(tCounts);
     setTaskTerminadasCounts(teCounts);
 
-    // Avanzadas = # tareas distintas con ≥1 task_update durante la junta
-    // (cruzan en la sección "Actualizaciones de tareas" del detalle). Uso
-    // Set<task_id> para no duplicar cuando una tarea tiene varios updates.
-    const avanzadasPerJunta = new Map<string, Set<string>>();
-    (uRes.data ?? []).forEach((u: { task_id: string }) => {
-      const juntaId = taskToJunta.get(u.task_id);
-      if (!juntaId) return;
-      let aSet = avanzadasPerJunta.get(juntaId);
-      if (!aSet) {
-        aSet = new Set<string>();
-        avanzadasPerJunta.set(juntaId, aSet);
-      }
-      aSet.add(u.task_id);
-    });
+    // Avanzadas = # tareas distintas con ≥1 task_update dentro de la ventana
+    // de la junta [fecha_hora, fecha_terminada]. Misma definición que la
+    // sección "Actualizaciones de tareas" del detalle: cualquier tarea de la
+    // empresa actualizada en esa ventana — no tiene que pertenecer a esta
+    // junta. Para juntas sin fecha_terminada (en curso) la ventana es
+    // abierta hacia el futuro.
+    const updatesData = (uRes.data ?? []) as { task_id: string; created_at: string }[];
     const avCounts = new Map<string, number>();
-    for (const [j, s] of avanzadasPerJunta) avCounts.set(j, s.size);
+    for (const j of (jRes.data ?? []) as Junta[]) {
+      const startTs = new Date(j.fecha_hora).getTime();
+      const endTs = j.fecha_terminada ? new Date(j.fecha_terminada).getTime() : Infinity;
+      const taskSet = new Set<string>();
+      for (const u of updatesData) {
+        const ts = new Date(u.created_at).getTime();
+        if (ts >= startTs && ts <= endTs) taskSet.add(u.task_id);
+      }
+      if (taskSet.size > 0) avCounts.set(j.id, taskSet.size);
+    }
     setTaskAvanzadasCounts(avCounts);
   }, [supabase]);
 

--- a/app/rdb/admin/documentos/page.tsx
+++ b/app/rdb/admin/documentos/page.tsx
@@ -3,7 +3,7 @@
 import { RequireAccess } from '@/components/require-access';
 import { DocumentosModule } from '@/components/documentos/documentos-module';
 
-const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
+const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
 export default function RdbAdminDocumentosPage() {
   return (

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -59,7 +59,7 @@ import {
   Send,
 } from 'lucide-react';
 
-const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
+const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
 type Junta = {
   id: string;

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -56,6 +56,7 @@ import {
   CheckCircle2,
   MessageSquarePlus,
   Clock,
+  Send,
 } from 'lucide-react';
 
 const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
@@ -280,6 +281,8 @@ function JuntaDetailInner() {
 
   const [terminating, setTerminating] = useState(false);
   const [showTerminarDialog, setShowTerminarDialog] = useState(false);
+  const [reenviando, setReenviando] = useState(false);
+  const [showReenviarDialog, setShowReenviarDialog] = useState(false);
 
   const editor = useEditor({
     // TipTap v3 exige `immediatelyRender: false` para Next.js SSR/RSC; evita
@@ -830,6 +833,31 @@ function JuntaDetailInner() {
     }
   };
 
+  const handleReenviar = async () => {
+    if (!junta) return;
+    setReenviando(true);
+    try {
+      const res = await fetch('/api/juntas/reenviar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ juntaId: junta.id }),
+      });
+      const result = await res.json();
+      if (!res.ok) {
+        alert(`Error al reenviar minuta: ${result.error ?? 'Error desconocido'}`);
+        return;
+      }
+      setShowReenviarDialog(false);
+      const emailMsg =
+        result.emailsSent > 0
+          ? `Minuta reenviada a ${result.emailsSent} participante(s).`
+          : (result.warning ?? 'No se envió el correo.');
+      alert(emailMsg);
+    } finally {
+      setReenviando(false);
+    }
+  };
+
   const handleSaveUpdate = async () => {
     const taskId = showAddUpdate;
     if (!taskId || !updateForm.contenido.trim() || !junta) return;
@@ -989,6 +1017,21 @@ function JuntaDetailInner() {
             >
               <CheckCircle2 className="h-4 w-4" />
               Terminar junta
+            </Button>
+          )}
+          {estado === 'completada' && (
+            <Button
+              variant="outline"
+              onClick={() => setShowReenviarDialog(true)}
+              disabled={reenviando}
+              className="gap-1.5 rounded-xl border-[var(--accent)]/40 text-[var(--accent)] hover:bg-[var(--accent)]/10 hover:border-[var(--accent)]/60"
+            >
+              {reenviando ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+              Reenviar minuta
             </Button>
           )}
           <Button
@@ -1644,6 +1687,40 @@ function JuntaDetailInner() {
                 <Plus className="h-4 w-4" />
               )}
               Crear tarea
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showReenviarDialog} onOpenChange={setShowReenviarDialog}>
+        <DialogContent className="max-w-sm rounded-3xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]">
+          <DialogHeader>
+            <DialogTitle className="text-[var(--text)]">Reenviar minuta</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-[var(--text)]/70 pb-2">
+            Se enviará nuevamente la minuta por correo a los participantes con email registrado, con
+            el contenido actual de las notas, tareas y avances.
+          </p>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowReenviarDialog(false)}
+              disabled={reenviando}
+              className="rounded-xl border-[var(--border)] text-[var(--text)]"
+            >
+              Cancelar
+            </Button>
+            <Button
+              onClick={handleReenviar}
+              disabled={reenviando}
+              className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90 disabled:opacity-60"
+            >
+              {reenviando ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+              Sí, reenviar
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/rdb/admin/juntas/page.tsx
+++ b/app/rdb/admin/juntas/page.tsx
@@ -29,7 +29,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Plus, Search, RefreshCw, Loader2, CalendarDays, ChevronRight } from 'lucide-react';
 import { JUNTA_ESTADO_CONFIG as ESTADO_CONFIG, type JuntaEstado } from '@/lib/status-tokens';
 
-const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
+const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
 type Junta = {
   id: string;

--- a/app/rdb/admin/tasks/page.tsx
+++ b/app/rdb/admin/tasks/page.tsx
@@ -3,7 +3,7 @@
 import { RequireAccess } from '@/components/require-access';
 import { TasksModule } from '@/components/tasks/tasks-module';
 
-const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
+const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
 export default function Page() {
   return (

--- a/app/rdb/rh/departamentos/page.tsx
+++ b/app/rdb/rh/departamentos/page.tsx
@@ -3,7 +3,7 @@
 import { RequireAccess } from '@/components/require-access';
 import { DepartamentosModule } from '@/components/rh/departamentos-module';
 
-const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
+const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
 export default function Page() {
   return (

--- a/app/rdb/rh/empleados/[id]/page.tsx
+++ b/app/rdb/rh/empleados/[id]/page.tsx
@@ -26,7 +26,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Separator } from '@/components/ui/separator';
 import { ArrowLeft, Save, Loader2, UserX, Pencil, X } from 'lucide-react';
 
-const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
+const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 const EMPRESA_SLUG = 'rdb';
 
 type Persona = {

--- a/app/rdb/rh/empleados/page.tsx
+++ b/app/rdb/rh/empleados/page.tsx
@@ -3,7 +3,7 @@
 import { RequireAccess } from '@/components/require-access';
 import { EmpleadosModule } from '@/components/rh/empleados-module';
 
-const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
+const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
 export default function Page() {
   return (

--- a/app/rdb/rh/puestos/page.tsx
+++ b/app/rdb/rh/puestos/page.tsx
@@ -3,7 +3,7 @@
 import { RequireAccess } from '@/components/require-access';
 import { PuestosModule } from '@/components/rh/puestos-module';
 
-const EMPRESA_ID = '41c0b58f-5483-439b-aaa6-17b9d995697f';
+const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
 export default function Page() {
   return (


### PR DESCRIPTION
## Summary
Dos cosas en juntas que quedaron fuera del alcance de PRs anteriores:

1. **Botón "Reenviar minuta"**: [#108](https://github.com/beto-sudo/BSOP/pull/108) solo lo agregó en \`/inicio/juntas/[id]\`. En \`/dilesa/admin/juntas/[id]\` y \`/rdb/admin/juntas/[id]\` no aparece. Lo propago con los mismos state + handler + botón + Dialog.
2. **Columna "Avanz." en la lista de juntas de dilesa**: contaba \`task_updates\` de tareas cuyo \`entidad_id\` era esa junta (y tenían algún update histórico). Eso dejaba el conteo en 0/1 aunque durante la junta se hubieran registrado muchos avances. Misma causa raíz que [#109](https://github.com/beto-sudo/BSOP/pull/109): el criterio correcto es **ventana de tiempo + empresa**, no \`task_id\`.

## Cambios

### Botón "Reenviar minuta" (paridad con [#108](https://github.com/beto-sudo/BSOP/pull/108))
- \`app/dilesa/admin/juntas/[id]/page.tsx\`
- \`app/rdb/admin/juntas/[id]/page.tsx\`

En ambas: import \`Send\` de lucide, dos state vars (\`reenviando\`, \`showReenviarDialog\`), handler \`handleReenviar\` que hace \`POST /api/juntas/reenviar\`, botón condicional a \`estado === 'completada'\` entre "Terminar junta" y "Guardar cambios", Dialog de confirmación. Es copia textual del patrón de \`/inicio\`.

### Conteo de avances en lista
- \`app/dilesa/admin/juntas/page.tsx\`

**Antes**: query pedía \`task_updates\` con \`tasks!inner(entidad_id, entidad_tipo='junta')\`, luego agrupaba por \`entidad_id\` (junta_id de la tarea).

**Después**: query simple \`task_updates\` filtrado por \`empresa_id\`. Cómputo: para cada junta, contar \`task_id\` distintos con \`created_at\` en \`[fecha_hora, fecha_terminada]\` (ventana abierta si la junta sigue en curso). Misma definición que la sección "Actualizaciones de tareas" del detalle — los conteos ahora concilian.

Type \`Junta\` local gana \`fecha_terminada: string \\| null\`.

## Test plan
- [ ] Abrir una junta completada en \`/dilesa/admin/juntas/[id]\` → botón "Reenviar minuta" visible → click → dialog → "Sí, reenviar" → llega el correo.
- [ ] Mismo flujo en \`/rdb/admin/juntas/[id]\`.
- [ ] En \`/dilesa/admin/juntas\` (lista): columna "Avanz." refleja el mismo número de tareas con movimiento que se ven en la sección "Actualizaciones de tareas" al abrir el detalle de cada fila.
- [ ] Junta en curso (sin \`fecha_terminada\`): columna cuenta avances desde \`fecha_hora\` hasta ahora.
- [ ] Junta sin avances en su ventana: columna queda en 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)