### PR TITLE
feat(inicio): panel personal — tareas + fechas importantes

### DIFF
--- a/app/inicio/page.tsx
+++ b/app/inicio/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * /inicio — Dashboard personal del usuario.
+ *
+ * Arranque del panel por usuario: tareas arriba + próximas fechas importantes
+ * (cumpleaños + festivos) al lado. Los widgets irán creciendo:
+ * calendario semanal, mi vehículo, KPIs por rol, trámites, etc.
+ *
+ * Cada widget es independiente: carga su propio dato, falla solo, no tumba al resto.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { ContentShell } from '@/components/ui/content-shell';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { MisTareasWidget } from '@/components/inicio/mis-tareas-widget';
+import { FechasImportantesWidget } from '@/components/inicio/fechas-importantes-widget';
+
+function getGreeting() {
+  const hour = new Date().getHours();
+  if (hour < 12) return 'Buenos días';
+  if (hour < 19) return 'Buenas tardes';
+  return 'Buenas noches';
+}
+
+function formatToday(): string {
+  return new Date().toLocaleDateString('es-MX', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+export default function InicioPage() {
+  const [userName, setUserName] = useState<string>('');
+
+  useEffect(() => {
+    const supabase = createSupabaseBrowserClient();
+    supabase.auth.getUser().then(({ data }) => {
+      const meta = data?.user?.user_metadata as
+        | { first_name?: string; full_name?: string }
+        | undefined;
+      if (meta?.first_name) {
+        setUserName(meta.first_name);
+      } else if (meta?.full_name) {
+        setUserName(meta.full_name.split(' ')[0]);
+      } else if (data?.user?.email) {
+        setUserName(data.user.email.split('@')[0]);
+      }
+    });
+  }, []);
+
+  return (
+    <ContentShell>
+      <header className="mb-6">
+        <p className="text-xs uppercase tracking-wider text-[var(--text)]/40">{formatToday()}</p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--text)] sm:text-4xl">
+          {getGreeting()}
+          {userName ? `, ${userName}` : ''}
+        </h1>
+        <p className="mt-2 text-sm text-[var(--text)]/55">
+          Este es tu panel personal. Aquí vas a encontrar tus pendientes y las fechas que te
+          importan.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Tareas toman 2/3 del ancho en desktop */}
+        <div className="lg:col-span-2">
+          <MisTareasWidget />
+        </div>
+        <div>
+          <FechasImportantesWidget />
+        </div>
+      </div>
+    </ContentShell>
+  );
+}

--- a/components/inicio/fechas-importantes-widget.tsx
+++ b/components/inicio/fechas-importantes-widget.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+/**
+ * FechasImportantesWidget — bloque del dashboard `/inicio`.
+ * Próximos 30 días: cumpleaños de compañeros + días festivos.
+ *
+ * Cumpleaños: `erp.v_empleados_full` filtrado por empresas del usuario.
+ * Festivos: constante estática `DIAS_FESTIVOS_MX` (MVP). Mover a DB cuando se
+ * quieran festivos por empresa.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { CalendarHeart, Cake, PartyPopper, Flag } from 'lucide-react';
+
+import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { Surface } from '@/components/ui/surface';
+import { Skeleton } from '@/components/ui/skeleton';
+import { festivosEnRango, type DiaFestivo } from '@/lib/inicio/dias-festivos';
+
+type Cumpleanero = {
+  empleado_id: string;
+  empresa_id: string;
+  nombre_completo: string;
+  fecha_nacimiento: string; // YYYY-MM-DD
+};
+
+type EventoItem =
+  | {
+      kind: 'cumple';
+      fecha: Date;
+      diasFaltan: number;
+      label: string;
+      subLabel: string;
+    }
+  | {
+      kind: 'festivo';
+      fecha: Date;
+      diasFaltan: number;
+      label: string;
+      subLabel: string;
+      tipo: DiaFestivo['tipo'];
+    };
+
+const VENTANA_DIAS = 30;
+
+function startOfDay(d: Date): Date {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+}
+
+/**
+ * Calcula el próximo cumpleaños (Date, a las 00:00 local) a partir de la fecha
+ * de nacimiento, dado un "hoy". Si el cumpleaños de este año ya pasó, devuelve
+ * el del año siguiente.
+ */
+function proximoCumple(fechaNacIso: string, today: Date): Date {
+  const [, m, d] = fechaNacIso.split('-').map((x) => parseInt(x, 10));
+  let year = today.getFullYear();
+  const candidate = new Date(year, m - 1, d);
+  if (startOfDay(candidate) < startOfDay(today)) {
+    year += 1;
+    return new Date(year, m - 1, d);
+  }
+  return candidate;
+}
+
+function diasDiferencia(a: Date, b: Date): number {
+  return Math.round((startOfDay(a).getTime() - startOfDay(b).getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function formatDiasFaltan(dias: number): string {
+  if (dias === 0) return '¡Hoy!';
+  if (dias === 1) return 'Mañana';
+  if (dias <= 7) return `En ${dias} días`;
+  return `En ${dias} días`;
+}
+
+function formatFechaCorta(d: Date): string {
+  return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', weekday: 'short' });
+}
+
+export function FechasImportantesWidget() {
+  const supabase = useMemo(() => createSupabaseERPClient(), []);
+  const [cumples, setCumples] = useState<Cumpleanero[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user?.email) {
+          if (!cancelled) {
+            setCumples([]);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const { data: coreUser } = await supabase
+          .schema('core')
+          .from('usuarios')
+          .select('id')
+          .eq('email', user.email.toLowerCase())
+          .maybeSingle();
+
+        if (!coreUser) {
+          if (!cancelled) {
+            setCumples([]);
+            setLoading(false);
+          }
+          return;
+        }
+
+        const { data: ue } = await supabase
+          .schema('core')
+          .from('usuarios_empresas')
+          .select('empresa_id')
+          .eq('usuario_id', coreUser.id)
+          .eq('activo', true);
+
+        const empresaIds = (ue ?? []).map((r: { empresa_id: string }) => r.empresa_id);
+        if (empresaIds.length === 0) {
+          if (!cancelled) {
+            setCumples([]);
+            setLoading(false);
+          }
+          return;
+        }
+
+        // Empleados activos con fecha de nacimiento en esas empresas.
+        const { data: emp, error: empErr } = await supabase
+          .schema('erp')
+          .from('v_empleados_full')
+          .select('empleado_id, empresa_id, nombre_completo, fecha_nacimiento, empleado_activo')
+          .in('empresa_id', empresaIds)
+          .not('fecha_nacimiento', 'is', null)
+          .eq('empleado_activo', true);
+
+        if (empErr) throw empErr;
+
+        if (!cancelled) {
+          const rows = (emp ?? []) as Array<{
+            empleado_id: string | null;
+            empresa_id: string | null;
+            nombre_completo: string | null;
+            fecha_nacimiento: string | null;
+          }>;
+          const mapped: Cumpleanero[] = rows
+            .filter(
+              (
+                r
+              ): r is {
+                empleado_id: string;
+                empresa_id: string;
+                nombre_completo: string | null;
+                fecha_nacimiento: string;
+              } => Boolean(r.empleado_id && r.empresa_id && r.fecha_nacimiento)
+            )
+            .map((r) => ({
+              empleado_id: r.empleado_id,
+              empresa_id: r.empresa_id,
+              nombre_completo: r.nombre_completo ?? '—',
+              fecha_nacimiento: r.fecha_nacimiento,
+            }));
+          setCumples(mapped);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Error cargando fechas');
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase]);
+
+  const eventos = useMemo<EventoItem[]>(() => {
+    const today = startOfDay(new Date());
+    const limite = new Date(today);
+    limite.setDate(today.getDate() + VENTANA_DIAS);
+
+    const items: EventoItem[] = [];
+
+    // cumpleaños
+    for (const c of cumples) {
+      const prox = proximoCumple(c.fecha_nacimiento, today);
+      if (prox > limite) continue;
+      const dias = diasDiferencia(prox, today);
+      items.push({
+        kind: 'cumple',
+        fecha: prox,
+        diasFaltan: dias,
+        label: c.nombre_completo,
+        subLabel: 'Cumpleaños',
+      });
+    }
+
+    // festivos
+    for (const f of festivosEnRango(today, limite)) {
+      const fDate = new Date(f.fecha + 'T00:00:00');
+      const dias = diasDiferencia(fDate, today);
+      items.push({
+        kind: 'festivo',
+        fecha: fDate,
+        diasFaltan: dias,
+        label: f.nombre,
+        subLabel: f.descansoObligatorio ? 'Día festivo (descanso obligatorio)' : 'Día festivo',
+        tipo: f.tipo,
+      });
+    }
+
+    items.sort((a, b) => a.fecha.getTime() - b.fecha.getTime());
+    return items;
+  }, [cumples]);
+
+  return (
+    <Surface className="p-6">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-pink-500/10">
+          <CalendarHeart className="h-5 w-5 text-pink-300" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--text)]">Próximas fechas importantes</h2>
+          <p className="text-xs text-[var(--text)]/55">Cumpleaños y días festivos (30 días)</p>
+        </div>
+      </div>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mt-4 rounded-xl border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-400"
+        >
+          {error}
+        </div>
+      ) : loading ? (
+        <div className="mt-4 space-y-2" aria-busy="true">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : eventos.length === 0 ? (
+        <div className="mt-6 flex flex-col items-center justify-center rounded-2xl border border-dashed border-[var(--border)] py-10 text-center">
+          <CalendarHeart className="h-8 w-8 text-[var(--text)]/20" />
+          <p className="mt-3 text-sm text-[var(--text)]/60">
+            No hay fechas relevantes en los próximos {VENTANA_DIAS} días
+          </p>
+        </div>
+      ) : (
+        <ul className="mt-4 space-y-1.5">
+          {eventos.map((e, idx) => {
+            const Icon =
+              e.kind === 'cumple'
+                ? Cake
+                : e.kind === 'festivo' && e.tipo === 'oficial'
+                  ? Flag
+                  : PartyPopper;
+            const iconTone =
+              e.kind === 'cumple'
+                ? 'text-pink-300 bg-pink-500/10'
+                : e.tipo === 'oficial'
+                  ? 'text-emerald-300 bg-emerald-500/10'
+                  : 'text-amber-300 bg-amber-500/10';
+            const esHoy = e.diasFaltan === 0;
+            return (
+              <li key={`${e.kind}-${idx}-${e.fecha.toISOString()}`}>
+                <div
+                  className={`flex items-center gap-3 rounded-xl border px-3 py-2.5 ${
+                    esHoy
+                      ? 'border-[var(--accent)]/30 bg-[var(--accent)]/5'
+                      : 'border-transparent bg-white/[0.02] hover:border-[var(--border)]'
+                  }`}
+                >
+                  <div
+                    className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${iconTone}`}
+                  >
+                    <Icon className="h-4 w-4" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="line-clamp-1 text-sm font-medium text-[var(--text)]">{e.label}</p>
+                    <p className="line-clamp-1 text-xs text-[var(--text)]/50">{e.subLabel}</p>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <p className="text-xs font-medium text-[var(--text)]/80">
+                      {formatDiasFaltan(e.diasFaltan)}
+                    </p>
+                    <p className="text-[11px] text-[var(--text)]/40">{formatFechaCorta(e.fecha)}</p>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Surface>
+  );
+}

--- a/components/inicio/mis-tareas-widget.tsx
+++ b/components/inicio/mis-tareas-widget.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+/**
+ * MisTareasWidget — bloque del dashboard `/inicio` con las tareas del usuario
+ * agrupadas por urgencia (vencidas / hoy / esta semana / después).
+ *
+ * Estrategia:
+ *  - Resuelve `core.usuarios.id` a partir del email del auth user.
+ *  - Resuelve las empresas del usuario (`core.usuarios_empresas`) → empresa_ids.
+ *  - Resuelve los `erp.empleados.id` del usuario en esas empresas (1 por empresa).
+ *  - Query a `erp.tasks` donde `asignado_a IN (empleado_ids)` y `estado != 'completada'`.
+ *
+ * Agrupa por fecha_vence (o fecha_compromiso si fecha_vence es null).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { AlertCircle, Calendar, CheckCircle2, ChevronRight, Clock, ListTodo } from 'lucide-react';
+
+import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { Surface } from '@/components/ui/surface';
+import { Skeleton } from '@/components/ui/skeleton';
+
+type TaskRow = {
+  id: string;
+  empresa_id: string;
+  titulo: string;
+  estado: string;
+  fecha_vence: string | null;
+  fecha_compromiso: string | null;
+  prioridad: string | null;
+};
+
+type Bucket = 'vencidas' | 'hoy' | 'semana' | 'despues' | 'sin_fecha';
+
+const BUCKET_CONFIG: Record<Bucket, { label: string; tone: string; icon: typeof AlertCircle }> = {
+  vencidas: {
+    label: 'Vencidas',
+    tone: 'text-red-400 bg-red-500/10 border-red-500/20',
+    icon: AlertCircle,
+  },
+  hoy: { label: 'Hoy', tone: 'text-amber-300 bg-amber-500/10 border-amber-500/20', icon: Clock },
+  semana: {
+    label: 'Esta semana',
+    tone: 'text-sky-300 bg-sky-500/10 border-sky-500/20',
+    icon: Calendar,
+  },
+  despues: {
+    label: 'Después',
+    tone: 'text-white/60 bg-white/5 border-white/10',
+    icon: ListTodo,
+  },
+  sin_fecha: {
+    label: 'Sin fecha',
+    tone: 'text-white/50 bg-white/5 border-white/10',
+    icon: ListTodo,
+  },
+};
+
+function bucketFor(task: TaskRow, todayIso: string, endOfWeekIso: string): Bucket {
+  const due = task.fecha_vence ?? task.fecha_compromiso;
+  if (!due) return 'sin_fecha';
+  if (due < todayIso) return 'vencidas';
+  if (due === todayIso) return 'hoy';
+  if (due <= endOfWeekIso) return 'semana';
+  return 'despues';
+}
+
+function toIsoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function formatRelative(iso: string | null, todayIso: string): string {
+  if (!iso) return 'Sin fecha';
+  if (iso === todayIso) return 'Hoy';
+  const d = new Date(iso + 'T00:00:00');
+  const today = new Date(todayIso + 'T00:00:00');
+  const diffDays = Math.round((d.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays === 1) return 'Mañana';
+  if (diffDays === -1) return 'Ayer';
+  if (diffDays > 1 && diffDays <= 7) return d.toLocaleDateString('es-MX', { weekday: 'long' });
+  if (diffDays < 0) return `Hace ${Math.abs(diffDays)} días`;
+  return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short' });
+}
+
+export function MisTareasWidget() {
+  const supabase = useMemo(() => createSupabaseERPClient(), []);
+  const [tasks, setTasks] = useState<TaskRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user?.email) {
+          if (!cancelled) {
+            setTasks([]);
+            setLoading(false);
+          }
+          return;
+        }
+
+        // core.usuarios por email
+        const { data: coreUser } = await supabase
+          .schema('core')
+          .from('usuarios')
+          .select('id')
+          .eq('email', user.email.toLowerCase())
+          .maybeSingle();
+
+        if (!coreUser) {
+          if (!cancelled) {
+            setTasks([]);
+            setLoading(false);
+          }
+          return;
+        }
+
+        // empresas del usuario
+        const { data: ue } = await supabase
+          .schema('core')
+          .from('usuarios_empresas')
+          .select('empresa_id')
+          .eq('usuario_id', coreUser.id)
+          .eq('activo', true);
+
+        const empresaIds = (ue ?? []).map((r: { empresa_id: string }) => r.empresa_id);
+        if (empresaIds.length === 0) {
+          if (!cancelled) {
+            setTasks([]);
+            setLoading(false);
+          }
+          return;
+        }
+
+        // empleados del usuario en esas empresas (match por email empresa o personal)
+        const emailLower = user.email.toLowerCase();
+        const { data: empleados } = await supabase
+          .schema('erp')
+          .from('v_empleados_full')
+          .select('empleado_id, empresa_id, email_empresa, email_personal')
+          .in('empresa_id', empresaIds)
+          .or(`email_empresa.eq.${emailLower},email_personal.eq.${emailLower}`);
+
+        const empleadoIds = (empleados ?? [])
+          .map((e: { empleado_id: string | null }) => e.empleado_id)
+          .filter((id: string | null): id is string => Boolean(id));
+
+        if (empleadoIds.length === 0) {
+          // Usuario no tiene ficha de empleado en ninguna empresa: no tareas personales.
+          if (!cancelled) {
+            setTasks([]);
+            setLoading(false);
+          }
+          return;
+        }
+
+        // tareas asignadas a este usuario, no completadas
+        const { data: taskRows, error: taskErr } = await supabase
+          .schema('erp')
+          .from('tasks')
+          .select('id, empresa_id, titulo, estado, fecha_vence, fecha_compromiso, prioridad')
+          .in('asignado_a', empleadoIds)
+          .neq('estado', 'completada')
+          .order('fecha_vence', { ascending: true, nullsFirst: false })
+          .limit(50);
+
+        if (taskErr) throw taskErr;
+        if (!cancelled) {
+          setTasks((taskRows ?? []) as TaskRow[]);
+          setLoading(false);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Error cargando tareas');
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase]);
+
+  const { grouped, todayIso } = useMemo(() => {
+    const today = new Date();
+    const endOfWeek = new Date(today);
+    const daysUntilSunday = (7 - today.getDay()) % 7 || 7; // lunes=1..domingo=0
+    endOfWeek.setDate(today.getDate() + daysUntilSunday);
+
+    const todayIso = toIsoDate(today);
+    const endIso = toIsoDate(endOfWeek);
+
+    const grouped: Record<Bucket, TaskRow[]> = {
+      vencidas: [],
+      hoy: [],
+      semana: [],
+      despues: [],
+      sin_fecha: [],
+    };
+    for (const t of tasks) {
+      grouped[bucketFor(t, todayIso, endIso)].push(t);
+    }
+    return { grouped, todayIso };
+  }, [tasks]);
+
+  const totalPendientes = tasks.length;
+
+  return (
+    <Surface className="p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[var(--accent)]/10">
+            <ListTodo className="h-5 w-5 text-[var(--accent-soft)]" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--text)]">Mis tareas</h2>
+            <p className="text-xs text-[var(--text)]/55">
+              {loading
+                ? 'Cargando…'
+                : totalPendientes === 0
+                  ? 'No tienes tareas pendientes'
+                  : `${totalPendientes} pendiente${totalPendientes === 1 ? '' : 's'}`}
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/inicio/tasks"
+          className="inline-flex items-center gap-1 rounded-xl px-3 py-1.5 text-xs font-medium text-[var(--text)]/60 transition hover:bg-white/5 hover:text-[var(--text)]"
+        >
+          Ver todas
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mt-4 rounded-xl border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-400"
+        >
+          {error}
+        </div>
+      ) : loading ? (
+        <div className="mt-4 space-y-2" aria-busy="true">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : totalPendientes === 0 ? (
+        <div className="mt-6 flex flex-col items-center justify-center rounded-2xl border border-dashed border-[var(--border)] py-10 text-center">
+          <CheckCircle2 className="h-8 w-8 text-emerald-400/60" />
+          <p className="mt-3 text-sm text-[var(--text)]/60">Estás al corriente 👌</p>
+        </div>
+      ) : (
+        <div className="mt-4 space-y-4">
+          {(['vencidas', 'hoy', 'semana', 'despues', 'sin_fecha'] as Bucket[])
+            .filter((b) => grouped[b].length > 0)
+            .map((bucket) => {
+              const cfg = BUCKET_CONFIG[bucket];
+              const Icon = cfg.icon;
+              return (
+                <section key={bucket}>
+                  <div className="mb-2 flex items-center gap-2">
+                    <span
+                      className={`inline-flex items-center gap-1.5 rounded-lg border px-2 py-0.5 text-xs font-medium ${cfg.tone}`}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                      {cfg.label}
+                    </span>
+                    <span className="text-xs text-[var(--text)]/40">{grouped[bucket].length}</span>
+                  </div>
+                  <ul className="space-y-1.5">
+                    {grouped[bucket].slice(0, 5).map((t) => (
+                      <li key={t.id}>
+                        <Link
+                          href="/inicio/tasks"
+                          className="flex items-center justify-between gap-3 rounded-xl border border-transparent bg-white/[0.02] px-3 py-2.5 transition hover:border-[var(--border)] hover:bg-white/[0.04]"
+                        >
+                          <span className="line-clamp-1 flex-1 text-sm text-[var(--text)]">
+                            {t.titulo}
+                          </span>
+                          <span className="shrink-0 text-xs text-[var(--text)]/45">
+                            {formatRelative(t.fecha_vence ?? t.fecha_compromiso, todayIso)}
+                          </span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                  {grouped[bucket].length > 5 && (
+                    <p className="mt-1.5 text-right text-xs text-[var(--text)]/40">
+                      + {grouped[bucket].length - 5} más
+                    </p>
+                  )}
+                </section>
+              );
+            })}
+        </div>
+      )}
+    </Surface>
+  );
+}

--- a/lib/inicio/dias-festivos.ts
+++ b/lib/inicio/dias-festivos.ts
@@ -1,0 +1,119 @@
+/**
+ * Días festivos oficiales de México.
+ *
+ * MVP: constante estática. Cuando el producto lo justifique, mover a
+ * `core.dias_festivos` (con `empresa_id` opcional para festivos de empresa).
+ *
+ * Fechas según la LFT (Ley Federal del Trabajo) Art. 74 + festivos nacionales
+ * comunes en la operación. Algunos se mueven al lunes siguiente (art. 74 fr. II/III/V).
+ */
+
+export type DiaFestivo = {
+  fecha: string; // ISO: YYYY-MM-DD
+  nombre: string;
+  tipo: 'oficial' | 'nacional' | 'religioso';
+  /** Si aplica como descanso obligatorio por LFT Art. 74. */
+  descansoObligatorio: boolean;
+};
+
+export const DIAS_FESTIVOS_MX: DiaFestivo[] = [
+  // 2026
+  { fecha: '2026-01-01', nombre: 'Año Nuevo', tipo: 'oficial', descansoObligatorio: true },
+  {
+    fecha: '2026-02-02',
+    nombre: 'Día de la Constitución',
+    tipo: 'oficial',
+    descansoObligatorio: true,
+  },
+  {
+    fecha: '2026-03-16',
+    nombre: 'Natalicio de Benito Juárez',
+    tipo: 'oficial',
+    descansoObligatorio: true,
+  },
+  { fecha: '2026-04-02', nombre: 'Jueves Santo', tipo: 'religioso', descansoObligatorio: false },
+  { fecha: '2026-04-03', nombre: 'Viernes Santo', tipo: 'religioso', descansoObligatorio: false },
+  { fecha: '2026-05-01', nombre: 'Día del Trabajo', tipo: 'oficial', descansoObligatorio: true },
+  {
+    fecha: '2026-05-05',
+    nombre: 'Batalla de Puebla',
+    tipo: 'nacional',
+    descansoObligatorio: false,
+  },
+  {
+    fecha: '2026-05-10',
+    nombre: 'Día de las Madres',
+    tipo: 'nacional',
+    descansoObligatorio: false,
+  },
+  {
+    fecha: '2026-09-16',
+    nombre: 'Día de la Independencia',
+    tipo: 'oficial',
+    descansoObligatorio: true,
+  },
+  { fecha: '2026-11-02', nombre: 'Día de Muertos', tipo: 'nacional', descansoObligatorio: false },
+  {
+    fecha: '2026-11-16',
+    nombre: 'Revolución Mexicana',
+    tipo: 'oficial',
+    descansoObligatorio: true,
+  },
+  {
+    fecha: '2026-12-12',
+    nombre: 'Virgen de Guadalupe',
+    tipo: 'religioso',
+    descansoObligatorio: false,
+  },
+  { fecha: '2026-12-25', nombre: 'Navidad', tipo: 'oficial', descansoObligatorio: true },
+
+  // 2027
+  { fecha: '2027-01-01', nombre: 'Año Nuevo', tipo: 'oficial', descansoObligatorio: true },
+  {
+    fecha: '2027-02-01',
+    nombre: 'Día de la Constitución',
+    tipo: 'oficial',
+    descansoObligatorio: true,
+  },
+  {
+    fecha: '2027-03-15',
+    nombre: 'Natalicio de Benito Juárez',
+    tipo: 'oficial',
+    descansoObligatorio: true,
+  },
+  { fecha: '2027-03-25', nombre: 'Jueves Santo', tipo: 'religioso', descansoObligatorio: false },
+  { fecha: '2027-03-26', nombre: 'Viernes Santo', tipo: 'religioso', descansoObligatorio: false },
+  { fecha: '2027-05-01', nombre: 'Día del Trabajo', tipo: 'oficial', descansoObligatorio: true },
+  {
+    fecha: '2027-09-16',
+    nombre: 'Día de la Independencia',
+    tipo: 'oficial',
+    descansoObligatorio: true,
+  },
+  {
+    fecha: '2027-11-15',
+    nombre: 'Revolución Mexicana',
+    tipo: 'oficial',
+    descansoObligatorio: true,
+  },
+  { fecha: '2027-12-25', nombre: 'Navidad', tipo: 'oficial', descansoObligatorio: true },
+];
+
+/**
+ * Devuelve los festivos entre `desde` y `hasta` (inclusive), ordenados ascendente.
+ * Fechas comparadas por string ISO (YYYY-MM-DD) para evitar problemas de TZ.
+ */
+export function festivosEnRango(desde: Date, hasta: Date): DiaFestivo[] {
+  const desdeIso = toIsoDate(desde);
+  const hastaIso = toIsoDate(hasta);
+  return DIAS_FESTIVOS_MX.filter((f) => f.fecha >= desdeIso && f.fecha <= hastaIso).sort((a, b) =>
+    a.fecha.localeCompare(b.fecha)
+  );
+}
+
+function toIsoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}


### PR DESCRIPTION
## Summary

Primer arranque del **dashboard personal por usuario** en `/inicio`. Se agregan dos widgets independientes:

- **Mis tareas** — pendientes del usuario agrupadas por urgencia: Vencidas · Hoy · Esta semana · Después · Sin fecha. Muestra 5 por bucket con "+N más".
- **Próximas fechas importantes** — cumpleaños de compañeros (todas las empresas a las que pertenece el usuario) + días festivos, próximos 30 días, ordenados cronológicamente. "¡Hoy!" resaltado.

### Decisiones

- **Sin migración.** Festivos MX 2026–2027 como constante en `lib/inicio/dias-festivos.ts`. Migrables a `core.dias_festivos` cuando se justifique (festivos por empresa, locales, religiosos, etc.).
- **Patrón client-side** consistente con `/inicio/juntas` existente (`createSupabaseERPClient` + `useEffect`). Candidato a migrar a RSC cuando se haga la refactor global del módulo.
- **Cada widget falla solo** — si un fetch rompe, el otro sigue funcionando.
- **Resolución de empleado_id** por match de email (empresa o personal) en `v_empleados_full`. Si el usuario no tiene ficha de empleado en ninguna empresa, el widget muestra estado vacío apropiado ("Estás al corriente").

### Próximos pasos

Widgets pendientes del diseño discutido con @beto-sudo:
- Calendario semanal (juntas + tasks + cumples + festivos)
- Hero "Próximo / Hoy"
- Trámites (solicitudes de vacaciones, permisos, gastos)
- Mi vehículo (cuando exista schema de bitácora + mantenimiento programa)
- KPIs por rol

## Test plan

- [ ] `/inicio` carga sin errores en preview deploy
- [ ] Widget de tareas muestra pendientes agrupados correctamente (o estado vacío si no hay)
- [ ] Widget de fechas muestra cumpleaños + festivos próximos
- [ ] Responsive: se apila correctamente en móvil
- [ ] Usuario sin ficha de empleado ve estado vacío sin errores de consola
- [ ] `npx tsc --noEmit` pasa (verificado local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)