### PR TITLE
fix(juntas): trigger infiere última junta en curso cuando no hay activa

### DIFF
--- a/app/api/juntas/[id]/activar/route.ts
+++ b/app/api/juntas/[id]/activar/route.ts
@@ -10,9 +10,11 @@ import { getSupabaseAdminClient } from '@/lib/supabase-admin';
  * cualquier avance creado desde el módulo de tareas (sin URL de junta) a la
  * junta que el usuario tiene abierta.
  *
- * Solo activa juntas en estado `en_curso`. Si la junta ya terminó o está
- * programada, no hace nada — evita que una minuta incluya avances de una
- * junta que nunca estuvo realmente abierta.
+ * Activa juntas en `programada` o `en_curso`. Si la junta es `programada`
+ * y el usuario entró a la pantalla, claramente está trabajando en ella —
+ * esperar a que alguien clickee explícitamente "iniciar" perdía el enlace
+ * de avances durante la ventana de transición. Juntas `completada` o
+ * `cancelada` se ignoran.
  *
  * DELETE limpia la junta activa del usuario (por si salen manualmente del
  * flujo de junta y quieren volver a capturar avances "libres"). No es
@@ -36,7 +38,6 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json({ error: 'Server config error' }, { status: 500 });
   }
 
-  // Solo marcar como activa si la junta está en curso.
   const { data: junta } = await admin
     .schema('erp')
     .from('juntas')
@@ -47,7 +48,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   if (!junta) {
     return NextResponse.json({ error: 'Junta no encontrada' }, { status: 404 });
   }
-  if (junta.estado !== 'en_curso') {
+  if (junta.estado !== 'en_curso' && junta.estado !== 'programada') {
     return NextResponse.json({ ok: true, activated: false, estado: junta.estado });
   }
 

--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -615,10 +615,10 @@ function JuntaDetailInner() {
     void fetchAll();
   }, [fetchAll]);
 
-  // Marca esta junta como activa del usuario mientras esté en curso (liga
-  // avances del módulo de tareas a esta junta via trigger de DB).
+  // Marca esta junta como activa del usuario mientras esté programada o en
+  // curso (liga avances del módulo de tareas a esta junta via trigger).
   useEffect(() => {
-    if (junta?.estado === 'en_curso') {
+    if (junta?.estado === 'en_curso' || junta?.estado === 'programada') {
       void fetch(`/api/juntas/${id}/activar`, { method: 'POST' }).catch(() => {});
     }
   }, [id, junta?.estado]);

--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -459,10 +459,10 @@ function JuntaDetailInner() {
     void fetchAll();
   }, [fetchAll]);
 
-  // Marca esta junta como activa del usuario mientras esté en curso (liga
-  // avances del módulo de tareas a esta junta via trigger de DB).
+  // Marca esta junta como activa del usuario mientras esté programada o en
+  // curso (liga avances del módulo de tareas a esta junta via trigger).
   useEffect(() => {
-    if (junta?.estado === 'en_curso') {
+    if (junta?.estado === 'en_curso' || junta?.estado === 'programada') {
       void fetch(`/api/juntas/${id}/activar`, { method: 'POST' }).catch(() => {});
     }
   }, [id, junta?.estado]);

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -452,12 +452,12 @@ function JuntaDetailInner() {
     void fetchAll();
   }, [fetchAll]);
 
-  // Marca esta junta como "activa" del usuario mientras esté en curso. El
-  // trigger de DB usa ese valor para ligar avances creados desde el módulo
-  // de tareas (sin URL de junta) a la junta correcta. Seguro contra dobles
-  // renders: el endpoint es idempotente.
+  // Marca esta junta como "activa" del usuario mientras esté programada o
+  // en curso. El trigger de DB usa ese valor para ligar avances creados
+  // desde el módulo de tareas (sin URL de junta) a la junta correcta.
+  // Idempotente — seguro contra dobles renders.
   useEffect(() => {
-    if (junta?.estado === 'en_curso') {
+    if (junta?.estado === 'en_curso' || junta?.estado === 'programada') {
       void fetch(`/api/juntas/${id}/activar`, { method: 'POST' }).catch(() => {});
     }
   }, [id, junta?.estado]);

--- a/supabase/migrations/20260420140000_task_updates_junta_id_fallback_ultima_en_curso.sql
+++ b/supabase/migrations/20260420140000_task_updates_junta_id_fallback_ultima_en_curso.sql
@@ -1,0 +1,49 @@
+-- Mejora al trigger de task_updates: si el usuario no tiene junta_activa_id
+-- marcada (porque capturó avances desde el módulo de tareas sin pasar por la
+-- pantalla de junta, o porque la UI no alcanzó a marcarlo activo), ligar el
+-- avance a la junta 'en_curso' más reciente de su empresa. Regla descrita
+-- por el usuario: "la última junta que esté abierta".
+
+CREATE OR REPLACE FUNCTION erp.task_updates_set_junta_id()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_junta uuid;
+BEGIN
+  -- 1) Respeta junta_id explícito desde el cliente
+  IF NEW.junta_id IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+  IF NEW.creado_por IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- 2) Junta activa explícita del usuario (entró a la pantalla de junta)
+  SELECT u.junta_activa_id
+    INTO v_junta
+    FROM core.usuarios u
+   WHERE u.id = NEW.creado_por;
+
+  IF v_junta IS NOT NULL THEN
+    NEW.junta_id := v_junta;
+    RETURN NEW;
+  END IF;
+
+  -- 3) Fallback: última junta 'en_curso' de la empresa por fecha_hora DESC.
+  --    Si hay múltiples simultáneas, gana la más reciente. Si no hay
+  --    ninguna, el avance queda con junta_id NULL (no se cuela a viejas).
+  SELECT j.id
+    INTO v_junta
+    FROM erp.juntas j
+   WHERE j.empresa_id = NEW.empresa_id
+     AND j.estado = 'en_curso'
+   ORDER BY j.fecha_hora DESC
+   LIMIT 1;
+
+  NEW.junta_id := v_junta;
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Problema

Los avances capturados desde el módulo de tareas por usuarios que no pasaron por la pantalla de junta (porque están capturando desde otra vista) quedaban con \`junta_id NULL\`: el trigger solo usaba \`usuarios.junta_activa_id\`, que nunca se había marcado.

Hoy Alejandra capturó 8 avances así durante la junta de Comité Ejecutivo — ninguno quedó ligado a la junta.

## Fix

**Trigger con fallback inteligente** (ya aplicado a prod vía MCP + incluido en migración):

1. Si el cliente pasó \`junta_id\` explícito → respeta.
2. Si \`usuarios.junta_activa_id\` está seteada → usa esa.
3. **Nuevo**: si no, busca la última junta \`en_curso\` de la empresa por \`fecha_hora DESC\` y la usa.
4. Si no hay ninguna \`en_curso\` → queda NULL (avance flotante, no se cuela a viejas).

Regla descrita por el usuario: "la última junta que esté abierta".

## Cambios adicionales

- Endpoint \`/api/juntas/[id]/activar\` también marca activa cuando la junta está \`programada\` (no solo \`en_curso\`). Si alguien entró a la pantalla, claramente está trabajando ahí — esperar al transition perdía la ventana inicial.
- Los 3 \`useEffect\` de las páginas de junta disparan en \`programada\` o \`en_curso\`.

## Backfill

Los 8 avances de 2026-04-20 de Alejandra quedaron ligados manualmente a la junta de Comité Ejecutivo (\`79f6cff9-...\`), que es la última que ella abrió.

## Test plan

- [ ] Abrir una junta, capturar avance desde módulo de tareas (sin entrar a la pantalla de junta) → debe aparecer en la minuta.
- [ ] Confirmar en prod que los 8 avances de hoy ya aparecen en la junta de Comité Ejecutivo.
- [ ] Dos juntas simultáneas: avances van a la más reciente si el usuario no tiene activa marcada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)