### PR TITLE
fix(empresas): lint errors in branding generate + page setState

### DIFF
--- a/app/settings/empresas/[slug]/page.tsx
+++ b/app/settings/empresas/[slug]/page.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Pre-existing data-sync pattern (loading guards around async fetch).
+ */
+
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';

--- a/app/settings/empresas/_components/empresa-detail.tsx
+++ b/app/settings/empresas/_components/empresa-detail.tsx
@@ -1,9 +1,5 @@
 'use client';
 
-/* eslint-disable react-hooks/set-state-in-effect --
- * Same hydration pattern as before — out of scope for this refactor.
- */
-
 import { useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';

--- a/app/settings/empresas/page.tsx
+++ b/app/settings/empresas/page.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Pre-existing data-sync pattern inherited from prior page version.
+ */
+
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';


### PR DESCRIPTION
## Summary
Fix CI lint errors that snuck through after #116 merge.

- `scripts/branding/generate.ts`: replace `require()` with import, `let → const`, remove unused `svgBox`, `renderIsotipo`, `_paleta`
- `app/settings/empresas/page.tsx` + `[slug]/page.tsx`: add disable directive for `react-hooks/set-state-in-effect` (same pre-existing data-sync pattern as the original page)
- `empresa-detail.tsx`: remove now-unused disable directive after extraction

## Test plan
- [x] `npm run lint` clean (0 errors, only pre-existing warnings)
- [x] `npx tsx scripts/branding/generate.ts ... --only logo_vertical` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)