### PR TITLE
feat(cron): resumen diario de tareas pendientes por mail

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -38,6 +38,19 @@ SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 
 
+# ─── Vercel Cron ────────────────────────────────────────────────────────────
+# Secret compartido entre Vercel Cron y los endpoints en `/api/cron/*`.
+# Vercel lo envía como `Authorization: Bearer $CRON_SECRET` al invocar el cron.
+# Genéralo con `openssl rand -hex 32` y guárdalo también en Vercel Dashboard
+# → Settings → Environment Variables (scope Production).
+CRON_SECRET=
+
+# Override opcional para probar `/api/cron/daily-task-summary`: si está set,
+# todos los correos del resumen diario se redirigen a esta dirección (con el
+# nombre del destinatario original en el subject). Vacío en prod.
+# TASK_SUMMARY_TEST_TO=beto@anorte.com
+
+
 # ─── Admin bypass (opcional, transitorio) ──────────────────────────────────
 # Email que puede entrar aunque no tenga row en core.usuarios. Usado por
 # `proxy.ts` como fallback de emergencia. Dejar vacío en prod una vez que

--- a/app/api/cron/daily-task-summary/route.ts
+++ b/app/api/cron/daily-task-summary/route.ts
@@ -107,9 +107,12 @@ export async function GET(req: NextRequest) {
     'empresa:empresa_id(nombre,slug),' +
     'empleado:asignado_a(id,email_empresa,activo,persona:persona_id(nombre,apellido_paterno,email))';
 
+  // Whitelist de estados activos (mismo criterio que components/inicio/mis-tareas-widget,
+  // arreglado en #119 — el enum real es 'completado', no 'completada'). Whitelist > blacklist:
+  // si mañana aparece 'archivado', 'pausado', etc. no se cuelan silenciosamente.
   const query = new URLSearchParams({
     select,
-    estado: 'not.in.(completada,cancelada)',
+    estado: 'in.(pendiente,en_progreso,bloqueado)',
     fecha_completado: 'is.null',
     asignado_a: 'not.is.null',
   });

--- a/app/api/cron/daily-task-summary/route.ts
+++ b/app/api/cron/daily-task-summary/route.ts
@@ -1,0 +1,243 @@
+/**
+ * Daily task summary cron — sends each employee their pending tasks by email.
+ *
+ * Schedule: every day at 13:00 UTC = 07:00 CST (see vercel.json).
+ *
+ * Delivery rules:
+ *   - Primary destination: erp.empleados.email_empresa
+ *   - Fallback: erp.personas.email
+ *   - If both null → skip employee (logged)
+ *   - If employee has zero pending tasks → no email sent
+ *   - If TASK_SUMMARY_TEST_TO env is set → all emails are redirected to that address
+ *     (subject is prefixed with the original recipient name for clarity during testing)
+ *
+ * Security:
+ *   - Requires `Authorization: Bearer ${CRON_SECRET}` header (Vercel Cron supplies this)
+ *   - Rejects everything else with 401
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  generateTaskSummaryHtml,
+  groupTasksByUrgency,
+  type TaskSummaryItem,
+} from '@/lib/task-summary-email';
+
+// Types matching the PostgREST response shape for our embedded select
+type EmbeddedTaskRow = {
+  id: string;
+  titulo: string;
+  fecha_vence: string | null;
+  fecha_compromiso: string | null;
+  porcentaje_avance: number | null;
+  empresa: { nombre: string; slug: string } | null;
+  empleado: {
+    id: string;
+    email_empresa: string | null;
+    activo: boolean;
+    persona: {
+      nombre: string;
+      apellido_paterno: string | null;
+      email: string | null;
+    } | null;
+  } | null;
+};
+
+type PerEmployeeBucket = {
+  empleadoId: string;
+  firstName: string;
+  email: string;
+  emailSource: 'empresa' | 'personal';
+  tasks: TaskSummaryItem[];
+};
+
+/** Today (YYYY-MM-DD) in CST (UTC-6, no DST in Mexico since 2022). */
+function getTodayCst(): string {
+  const now = new Date();
+  const cst = new Date(now.getTime() - 6 * 60 * 60 * 1000);
+  return cst.toISOString().slice(0, 10);
+}
+
+/** Short Spanish date label for subject: "20 abr". */
+function formatSubjectDate(todayCst: string): string {
+  const months = [
+    'ene',
+    'feb',
+    'mar',
+    'abr',
+    'may',
+    'jun',
+    'jul',
+    'ago',
+    'sep',
+    'oct',
+    'nov',
+    'dic',
+  ];
+  const [, m, d] = todayCst.split('-');
+  return `${parseInt(d, 10)} ${months[parseInt(m, 10) - 1]}`;
+}
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  const authHeader = req.headers.get('authorization');
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const resendKey = process.env.RESEND_API_KEY;
+  const testTo = process.env.TASK_SUMMARY_TEST_TO?.toLowerCase() || null;
+
+  if (!supabaseUrl || !serviceKey) {
+    return NextResponse.json({ error: 'Supabase env missing' }, { status: 500 });
+  }
+  if (!resendKey) {
+    return NextResponse.json({ error: 'RESEND_API_KEY missing' }, { status: 500 });
+  }
+
+  const todayCst = getTodayCst();
+  const subjectDate = formatSubjectDate(todayCst);
+
+  // Fetch all open tasks with employee + company + person embedded.
+  // Filters: estado not in completada/cancelada, fecha_completado IS NULL, has assignee.
+  const select =
+    'id,titulo,fecha_vence,fecha_compromiso,porcentaje_avance,' +
+    'empresa:empresa_id(nombre,slug),' +
+    'empleado:asignado_a(id,email_empresa,activo,persona:persona_id(nombre,apellido_paterno,email))';
+
+  const query = new URLSearchParams({
+    select,
+    estado: 'not.in.(completada,cancelada)',
+    fecha_completado: 'is.null',
+    asignado_a: 'not.is.null',
+  });
+
+  const tasksRes = await fetch(`${supabaseUrl}/rest/v1/tasks?${query}`, {
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Profile': 'erp',
+    },
+  });
+
+  if (!tasksRes.ok) {
+    const detail = await tasksRes.text();
+    console.error('[daily-task-summary] Tasks query failed:', tasksRes.status, detail);
+    return NextResponse.json({ error: 'Tasks query failed', detail }, { status: 500 });
+  }
+
+  const rows = (await tasksRes.json()) as EmbeddedTaskRow[];
+
+  // Group by empleado_id, resolving email (empresa → personal fallback).
+  const buckets = new Map<string, PerEmployeeBucket>();
+  let skippedNoEmail = 0;
+  let skippedInactive = 0;
+
+  for (const row of rows) {
+    const empleado = row.empleado;
+    if (!empleado) continue;
+    if (!empleado.activo) {
+      skippedInactive++;
+      continue;
+    }
+
+    const email = (empleado.email_empresa ?? empleado.persona?.email ?? '').trim();
+    if (!email) {
+      skippedNoEmail++;
+      continue;
+    }
+    const emailSource: 'empresa' | 'personal' = empleado.email_empresa ? 'empresa' : 'personal';
+    const firstName = empleado.persona?.nombre?.trim() || 'colega';
+
+    const task: TaskSummaryItem = {
+      id: row.id,
+      titulo: row.titulo,
+      empresaNombre: row.empresa?.nombre ?? 'Sin empresa',
+      fechaVence: row.fecha_vence,
+      fechaCompromiso: row.fecha_compromiso,
+      porcentajeAvance: row.porcentaje_avance ?? 0,
+    };
+
+    const existing = buckets.get(empleado.id);
+    if (existing) {
+      existing.tasks.push(task);
+    } else {
+      buckets.set(empleado.id, {
+        empleadoId: empleado.id,
+        firstName,
+        email,
+        emailSource,
+        tasks: [task],
+      });
+    }
+  }
+
+  // Send emails (serialized — Resend doesn't need parallel, keeps rate limit calm).
+  let sent = 0;
+  let failed = 0;
+  const failures: Array<{ empleadoId: string; email: string; error: string }> = [];
+  const previews: Array<{ empleadoId: string; to: string; total: number; subject: string }> = [];
+
+  for (const bucket of buckets.values()) {
+    if (bucket.tasks.length === 0) continue;
+
+    const groups = groupTasksByUrgency(bucket.tasks, todayCst);
+    const html = generateTaskSummaryHtml(bucket.firstName, groups, todayCst);
+
+    // Test mode: redirect all sends to TASK_SUMMARY_TEST_TO, prefix subject with original name.
+    const destination = testTo ?? bucket.email;
+    const subject = testTo
+      ? `[TEST → ${bucket.firstName}] Tareas de hoy — ${subjectDate}`
+      : `Tareas de hoy — ${subjectDate}`;
+
+    const resendRes = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${resendKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: 'BSOP <noreply@bsop.io>',
+        to: [destination],
+        subject,
+        html,
+      }),
+    });
+
+    if (!resendRes.ok) {
+      const err = await resendRes.text();
+      console.error('[daily-task-summary] Resend failed:', bucket.email, err);
+      failed++;
+      failures.push({ empleadoId: bucket.empleadoId, email: bucket.email, error: err });
+      continue;
+    }
+
+    sent++;
+    previews.push({
+      empleadoId: bucket.empleadoId,
+      to: destination,
+      total: bucket.tasks.length,
+      subject,
+    });
+  }
+
+  const summary = {
+    ok: true,
+    todayCst,
+    totalTasks: rows.length,
+    employeesWithTasks: buckets.size,
+    sent,
+    failed,
+    skippedNoEmail,
+    skippedInactive,
+    testMode: Boolean(testTo),
+    testTo,
+    failures: failures.length > 0 ? failures : undefined,
+    previews: testTo ? previews : undefined, // only surface previews in test mode
+  };
+
+  console.log('[daily-task-summary]', JSON.stringify(summary));
+  return NextResponse.json(summary);
+}

--- a/lib/task-summary-email.ts
+++ b/lib/task-summary-email.ts
@@ -1,0 +1,237 @@
+// ── Daily task summary email HTML generator for BSOP ───────────────────────
+//
+// Generates the morning summary with pending tasks grouped by urgency:
+//   🔴 Vencidas  ·  🟡 Hoy  ·  🟢 Esta semana  ·  ⚪ Más adelante  ·  ⬜ Sin fecha
+//
+// Empty sections are not rendered. If there are zero total tasks, the caller
+// should NOT invoke this function and skip the email entirely.
+
+const MONTHS_ES = [
+  'ene',
+  'feb',
+  'mar',
+  'abr',
+  'may',
+  'jun',
+  'jul',
+  'ago',
+  'sep',
+  'oct',
+  'nov',
+  'dic',
+];
+
+export type TaskSummaryItem = {
+  id: string;
+  titulo: string;
+  empresaNombre: string;
+  fechaVence: string | null; // ISO date (YYYY-MM-DD) or null
+  fechaCompromiso: string | null;
+  porcentajeAvance: number;
+};
+
+export type TaskSummaryGroups = {
+  vencidas: TaskSummaryItem[];
+  hoy: TaskSummaryItem[];
+  estaSemana: TaskSummaryItem[];
+  masAdelante: TaskSummaryItem[];
+  sinFecha: TaskSummaryItem[];
+};
+
+/**
+ * Split task rows into urgency buckets relative to `todayCst` (ISO date).
+ * Uses `fecha_vence` first, falls back to `fecha_compromiso`, null → sinFecha.
+ *
+ * Sorting inside each bucket:
+ *   vencidas / hoy / estaSemana / masAdelante → by date ASC
+ *   sinFecha → by titulo ASC
+ */
+export function groupTasksByUrgency(tasks: TaskSummaryItem[], todayCst: string): TaskSummaryGroups {
+  const todayMs = Date.parse(`${todayCst}T00:00:00Z`);
+  const weekAheadMs = todayMs + 7 * 24 * 60 * 60 * 1000;
+
+  const groups: TaskSummaryGroups = {
+    vencidas: [],
+    hoy: [],
+    estaSemana: [],
+    masAdelante: [],
+    sinFecha: [],
+  };
+
+  for (const task of tasks) {
+    const dueDate = task.fechaVence ?? task.fechaCompromiso;
+    if (!dueDate) {
+      groups.sinFecha.push(task);
+      continue;
+    }
+    const dueMs = Date.parse(`${dueDate}T00:00:00Z`);
+    if (dueMs < todayMs) groups.vencidas.push(task);
+    else if (dueMs === todayMs) groups.hoy.push(task);
+    else if (dueMs <= weekAheadMs) groups.estaSemana.push(task);
+    else groups.masAdelante.push(task);
+  }
+
+  const sortByDate = (a: TaskSummaryItem, b: TaskSummaryItem) => {
+    const aDate = a.fechaVence ?? a.fechaCompromiso ?? '';
+    const bDate = b.fechaVence ?? b.fechaCompromiso ?? '';
+    return aDate.localeCompare(bDate);
+  };
+  groups.vencidas.sort(sortByDate);
+  groups.hoy.sort(sortByDate);
+  groups.estaSemana.sort(sortByDate);
+  groups.masAdelante.sort(sortByDate);
+  groups.sinFecha.sort((a, b) => a.titulo.localeCompare(b.titulo));
+
+  return groups;
+}
+
+export function formatShortDateEs(isoDate: string): string {
+  const [y, m, d] = isoDate.split('-');
+  return `${parseInt(d, 10)} ${MONTHS_ES[parseInt(m, 10) - 1]} ${y}`;
+}
+
+/** Human-friendly description of how far in the past a vencidas task is. */
+function formatOverdue(dueDate: string, todayCst: string): string {
+  const dueMs = Date.parse(`${dueDate}T00:00:00Z`);
+  const todayMs = Date.parse(`${todayCst}T00:00:00Z`);
+  const days = Math.floor((todayMs - dueMs) / (24 * 60 * 60 * 1000));
+  if (days === 1) return 'Venció ayer';
+  return `Venció hace ${days} días`;
+}
+
+function renderTaskRow(
+  task: TaskSummaryItem,
+  todayCst: string,
+  urgency: keyof TaskSummaryGroups
+): string {
+  const dueDate = task.fechaVence ?? task.fechaCompromiso;
+  let dueLabel = '';
+  if (urgency === 'vencidas' && dueDate) {
+    dueLabel = formatOverdue(dueDate, todayCst);
+  } else if (urgency === 'hoy') {
+    dueLabel = 'Vence hoy';
+  } else if (dueDate) {
+    dueLabel = `Vence ${formatShortDateEs(dueDate)}`;
+  }
+
+  const avanceLabel =
+    task.porcentajeAvance > 0 && task.porcentajeAvance < 100
+      ? ` · ${task.porcentajeAvance}% avance`
+      : '';
+
+  const metaLine = [task.empresaNombre, dueLabel].filter(Boolean).join(' · ');
+
+  return `
+    <tr>
+      <td style="padding:10px 0;border-bottom:1px solid #eee">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+          <tr><td style="font-size:14px;font-weight:500;color:#1a1a1a;line-height:1.4">${escapeHtml(task.titulo)}</td></tr>
+          <tr><td style="font-size:12px;color:#888;padding-top:2px">${escapeHtml(metaLine)}${avanceLabel}</td></tr>
+        </table>
+      </td>
+    </tr>`;
+}
+
+function renderSection(
+  title: string,
+  icon: string,
+  tasks: TaskSummaryItem[],
+  todayCst: string,
+  urgency: keyof TaskSummaryGroups
+): string {
+  if (tasks.length === 0) return '';
+  const rows = tasks.map((t) => renderTaskRow(t, todayCst, urgency)).join('');
+  return `
+    <table cellpadding="0" cellspacing="0" border="0" width="100%" style="padding-top:20px">
+      <tr>
+        <td style="font-size:13px;font-weight:600;color:#666;text-transform:uppercase;letter-spacing:0.5px;padding-bottom:6px">
+          ${icon} ${title} (${tasks.length})
+        </td>
+      </tr>
+      ${rows}
+    </table>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function generateTaskSummaryHtml(
+  firstName: string,
+  groups: TaskSummaryGroups,
+  todayCst: string
+): string {
+  const total =
+    groups.vencidas.length +
+    groups.hoy.length +
+    groups.estaSemana.length +
+    groups.masAdelante.length +
+    groups.sinFecha.length;
+
+  const sections = [
+    renderSection('Vencidas', '🔴', groups.vencidas, todayCst, 'vencidas'),
+    renderSection('Hoy', '🟡', groups.hoy, todayCst, 'hoy'),
+    renderSection('Esta semana', '🟢', groups.estaSemana, todayCst, 'estaSemana'),
+    renderSection('Más adelante', '⚪', groups.masAdelante, todayCst, 'masAdelante'),
+    renderSection('Sin fecha', '⬜', groups.sinFecha, todayCst, 'sinFecha'),
+  ].join('');
+
+  return `
+<!DOCTYPE html>
+<html lang="es">
+<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/></head>
+<body style="margin:0;padding:0;background:#f0f0f0;font-family:system-ui,-apple-system,'Segoe UI',sans-serif">
+<table cellpadding="0" cellspacing="0" border="0" width="100%" style="background:#f0f0f0">
+<tr><td align="center" style="padding:24px 16px">
+
+  <table cellpadding="0" cellspacing="0" border="0" width="520" style="max-width:520px;background:#ffffff;border-radius:12px;border:1px solid #e5e5e5">
+
+    <tr>
+      <td style="background:#f8f8f8;padding:24px 32px;text-align:center;border-bottom:1px solid #e5e5e5;border-radius:12px 12px 0 0">
+        <img src="https://bsop.io/logo-bsop.jpg" alt="BSOP" width="140" style="display:block;margin:0 auto"/>
+      </td>
+    </tr>
+
+    <tr>
+      <td style="padding:28px 32px 24px">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+          <tr><td style="font-size:20px;font-weight:700;color:#1a1a1a;padding-bottom:4px">Buenos días, ${escapeHtml(firstName)} 👋</td></tr>
+          <tr><td style="font-size:15px;color:#555;line-height:1.5;padding-bottom:8px">Tienes <strong>${total}</strong> ${total === 1 ? 'tarea abierta' : 'tareas abiertas'} en BSOP.</td></tr>
+        </table>
+
+        ${sections}
+
+        <table cellpadding="0" cellspacing="0" border="0" width="100%" style="padding-top:28px">
+          <tr><td align="center">
+            <a href="https://bsop.io" style="display:inline-block;background:#F7941D;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.3px">Abrir BSOP</a>
+          </td></tr>
+        </table>
+
+        <table cellpadding="0" cellspacing="0" border="0" width="100%" style="padding-top:20px">
+          <tr><td style="font-size:12px;color:#888;line-height:1.5;text-align:center">
+            Si alguna tarea ya no aplica, responde este correo o márcala como completada en BSOP.
+          </td></tr>
+        </table>
+      </td>
+    </tr>
+
+    <tr>
+      <td style="background:#f8f8f8;padding:14px 32px;text-align:center;border-top:1px solid #e5e5e5;border-radius:0 0 12px 12px">
+        <table cellpadding="0" cellspacing="0" border="0" width="100%">
+          <tr><td align="center" style="font-size:11px;color:#999">BSOP · Sistema Operativo</td></tr>
+        </table>
+      </td>
+    </tr>
+
+  </table>
+
+</td></tr>
+</table>
+</body>
+</html>`;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,6 +9,7 @@ function isPublicPath(pathname: string) {
     pathname === '/auth/callback' ||
     pathname === '/api/auth/google' ||
     pathname.startsWith('/compartir/') ||
+    pathname.startsWith('/api/cron/') ||
     pathname === '/api/health/ingest' ||
     pathname.startsWith('/_next') ||
     pathname === '/favicon.ico' ||

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/daily-task-summary",
+      "schedule": "0 13 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Nuevo cron diario (**7 AM CST**) que envía a cada empleado un correo con sus tareas pendientes agrupadas por urgencia. Si no tiene tareas abiertas, no recibe nada.

## Cómo funciona

**Query:** `erp.tasks` donde `estado NOT IN ('completada','cancelada')` AND `fecha_completado IS NULL` AND `asignado_a IS NOT NULL`, embebiendo `empleado + persona + empresa`.

**Destinatario:** `empleado.email_empresa` primero, fallback `persona.email`. Si ambos null → skip con log.

**Secciones del correo (solo se muestran las que tengan contenido):**
- 🔴 Vencidas — "Venció hace N días"
- 🟡 Hoy
- 🟢 Esta semana
- ⚪ Más adelante
- ⬜ Sin fecha

**Test mode:** env `TASK_SUMMARY_TEST_TO=beto@anorte.com` redirige TODOS los correos a esa dirección, prefijando el subject con `[TEST → Nombre]`. Así itera el contenido sin molestar a los empleados.

## Archivos

- `lib/task-summary-email.ts` — HTML generator + `groupTasksByUrgency` (pura, testeable)
- `app/api/cron/daily-task-summary/route.ts` — endpoint cron, valida `Authorization: Bearer $CRON_SECRET`
- `vercel.json` — schedule `0 13 * * *` (13:00 UTC = 7:00 CST, MX sin DST desde 2022)
- `proxy.ts` — `/api/cron/*` agregado a `isPublicPath`
- `.env.local.example` — documenta `CRON_SECRET` y `TASK_SUMMARY_TEST_TO`

## Env vars a configurar en Vercel Dashboard (Production)

| Variable | Uso |
|---|---|
| `CRON_SECRET` | Secret que valida el header del cron. Generar con `openssl rand -hex 32` |
| `TASK_SUMMARY_TEST_TO` | (temporal) forzar todos los correos a ti — déjalo `beto@anorte.com` la primera semana, luego borra |

`RESEND_API_KEY` y las de Supabase ya están configuradas.

## Test plan

- [ ] Configurar `CRON_SECRET` y `TASK_SUMMARY_TEST_TO=beto@anorte.com` en Vercel
- [ ] Disparar manualmente el cron desde el preview o main: `curl -H "Authorization: Bearer $CRON_SECRET" https://bsop.io/api/cron/daily-task-summary`
- [ ] Verificar que te llega UN correo por cada empleado con tareas abiertas (todos a tu buzón, por test mode)
- [ ] Revisar formato, ortografía, secciones, CTA
- [ ] Cuando estés happy con el template, borrar `TASK_SUMMARY_TEST_TO` → primera corrida real mañana 7am

## Follow-ups (fuera de scope)
- Unit tests para `groupTasksByUrgency` (lógica de fechas)
- Link clicable a cada tarea específica (requiere UI de tarea con URL por id)
- Prioridad visual — joinar con `erp.prioridades` y ordenar alta > media > baja dentro de cada sección
- Migrar a la infra de plantillas cuando aterrice S2

🤖 Generated with [Claude Code](https://claude.com/claude-code)