### PR TITLE
fix(inicio): Mis tareas filtradas por usuario + toggle completadas

### DIFF
--- a/app/inicio/tasks/page.tsx
+++ b/app/inicio/tasks/page.tsx
@@ -1,12 +1,26 @@
 'use client';
 
-import { RequireAccess } from '@/components/require-access';
 import { TasksModule } from '@/components/tasks/tasks-module';
 
+/**
+ * /inicio/tasks — "Mis tareas" del usuario logueado.
+ *
+ * Expansión del widget del dashboard. Filtra a tareas donde
+ * `asignado_a` = empleado_id del usuario (en todas sus empresas),
+ * con toggle para ocultar/mostrar completadas.
+ *
+ * Sin RequireAccess de empresa: el dashboard personal es para todo
+ * usuario logueado; el proxy ya valida la sesión.
+ */
 export default function Page() {
   return (
-    <RequireAccess empresa="rdb">
-      <TasksModule scope="user-empresas" empresaSlug="" title="Tareas" />
-    </RequireAccess>
+    <TasksModule
+      scope="user-empresas"
+      empresaSlug=""
+      title="Mis tareas"
+      subtitle="Tareas donde eres responsable"
+      onlyMine
+      hideCompletedToggle
+    />
   );
 }

--- a/components/inicio/mis-tareas-widget.tsx
+++ b/components/inicio/mis-tareas-widget.tsx
@@ -175,7 +175,7 @@ export function MisTareasWidget() {
           .in('asignado_a', empleadoIds)
           .in('estado', ['pendiente', 'en_progreso', 'bloqueado'])
           .order('fecha_vence', { ascending: true, nullsFirst: false })
-          .limit(50);
+          .limit(100);
 
         if (taskErr) throw taskErr;
         if (!cancelled) {
@@ -283,7 +283,7 @@ export function MisTareasWidget() {
                     <span className="text-xs text-[var(--text)]/40">{grouped[bucket].length}</span>
                   </div>
                   <ul className="space-y-1.5">
-                    {grouped[bucket].slice(0, 5).map((t) => (
+                    {grouped[bucket].slice(0, 10).map((t) => (
                       <li key={t.id}>
                         <Link
                           href="/inicio/tasks"
@@ -299,9 +299,9 @@ export function MisTareasWidget() {
                       </li>
                     ))}
                   </ul>
-                  {grouped[bucket].length > 5 && (
+                  {grouped[bucket].length > 10 && (
                     <p className="mt-1.5 text-right text-xs text-[var(--text)]/40">
-                      + {grouped[bucket].length - 5} más
+                      + {grouped[bucket].length - 10} más
                     </p>
                   )}
                 </section>

--- a/components/tasks/tasks-module.tsx
+++ b/components/tasks/tasks-module.tsx
@@ -78,6 +78,18 @@ export type TasksModuleProps = {
 
   /** Rich-only: auto-link new tasks to an in-progress junta (default true). */
   autoLinkJunta?: boolean;
+
+  /**
+   * Personal view: filter to tasks where `asignado_a` matches the current
+   * user's empleado_id across all their empresas. Used by `/inicio/tasks`.
+   */
+  onlyMine?: boolean;
+
+  /**
+   * Show the "Ocultar/Mostrar completadas" toggle (always shown on rich).
+   * When true in simple variant, also applies the `hideCompleted` filter.
+   */
+  hideCompletedToggle?: boolean;
 };
 
 export function TasksModule({
@@ -88,6 +100,8 @@ export function TasksModule({
   subtitle = 'Gestión de tareas operativas',
   variant = 'simple',
   autoLinkJunta = true,
+  onlyMine = false,
+  hideCompletedToggle = false,
 }: TasksModuleProps) {
   // `_empresaSlug` is accepted for call-site parity with EmpleadosModule and
   // future detail-page links; silence unused-var lint until then.
@@ -106,6 +120,10 @@ export function TasksModule({
   const [isDireccion, setIsDireccion] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
 
+  // ── Personal view (onlyMine) ───────────────────────────────────────────────
+  // null = still loading, [] = user has no empleado rows, [...] = resolved.
+  const [myEmpleadoIds, setMyEmpleadoIds] = useState<string[] | null>(null);
+
   // ── Data ───────────────────────────────────────────────────────────────────
   const [empleados, setEmpleados] = useState<Empleado[]>([]);
   const [tasks, setTasks] = useState<ErpTask[]>([]);
@@ -118,7 +136,8 @@ export function TasksModule({
   const [filterPrioridad, setFilterPrioridad] = useState('all');
   const [filterAsignado, setFilterAsignado] = useState('all');
   const [filterDepto, setFilterDepto] = useState('all'); // rich only
-  const [hideCompleted, setHideCompleted] = useState(true); // rich only
+  // Used by rich variant and by simple+hideCompletedToggle.
+  const [hideCompleted, setHideCompleted] = useState(true);
 
   // ── Create / edit state ────────────────────────────────────────────────────
   const [showCreate, setShowCreate] = useState(false);
@@ -198,6 +217,24 @@ export function TasksModule({
       });
       setEmpleados(mapped);
 
+      // Personal view: resolve my empleado_ids across all empresas in scope.
+      if (onlyMine) {
+        if (!email) {
+          setMyEmpleadoIds([]);
+        } else {
+          const { data: mineRows } = await supabase
+            .schema('erp')
+            .from('v_empleados_full')
+            .select('empleado_id, empresa_id, email_empresa, email_personal')
+            .in('empresa_id', ids)
+            .or(`email_empresa.eq.${email},email_personal.eq.${email}`);
+          const mineIds = (mineRows ?? [])
+            .map((r: { empleado_id: string | null }) => r.empleado_id)
+            .filter((x: string | null): x is string => Boolean(x));
+          setMyEmpleadoIds(mineIds);
+        }
+      }
+
       if (!isRich || !email) return;
 
       // Role gating + currentEmpleadoId (DILESA / rich variant only)
@@ -258,7 +295,7 @@ export function TasksModule({
         }
       }
     },
-    [supabase, isRich]
+    [supabase, isRich, onlyMine]
   );
 
   const fetchTasks = useCallback(
@@ -677,6 +714,13 @@ export function TasksModule({
   const { sortKey, sortDir, onSort, sortData } = useSortableTable('created_at', 'desc');
 
   const visibleTasks = useMemo(() => {
+    if (onlyMine) {
+      // While resolving ids, hide everything (avoid flashing all tasks).
+      if (myEmpleadoIds === null) return [];
+      if (myEmpleadoIds.length === 0) return [];
+      const idSet = new Set(myEmpleadoIds);
+      return tasks.filter((t) => t.asignado_a && idSet.has(t.asignado_a));
+    }
     if (!isRich) return tasks;
     if (isAdmin || isDireccion) return tasks;
     return tasks.filter(
@@ -685,10 +729,16 @@ export function TasksModule({
         t.asignado_por === currentEmpleadoId ||
         t.creado_por === currentEmpleadoId
     );
-  }, [tasks, isRich, isAdmin, isDireccion, currentEmpleadoId]);
+  }, [tasks, isRich, isAdmin, isDireccion, currentEmpleadoId, onlyMine, myEmpleadoIds]);
+
+  const showHideCompletedToggle = isRich || hideCompletedToggle;
 
   const filtered = visibleTasks.filter((t) => {
-    if (isRich && hideCompleted && (t.estado === 'completado' || t.estado === 'cancelado'))
+    if (
+      showHideCompletedToggle &&
+      hideCompleted &&
+      (t.estado === 'completado' || t.estado === 'cancelado')
+    )
       return false;
 
     if (search) {
@@ -779,8 +829,8 @@ export function TasksModule({
         empleadoOptions={empleadoOptions}
       />
 
-      {/* Hide-completadas toggle (rich only) */}
-      {isRich && (
+      {/* Hide-completadas toggle (rich or when explicitly enabled) */}
+      {showHideCompletedToggle && (
         <div className="flex items-center justify-between">
           <button
             type="button"
@@ -828,8 +878,8 @@ export function TasksModule({
         />
       </div>
 
-      {/* Footer counter (simple only — rich shows its own) */}
-      {!isRich && !loading && tasks.length > 0 && (
+      {/* Footer counter (simple only — rich and simple+toggle show their own) */}
+      {!isRich && !showHideCompletedToggle && !loading && tasks.length > 0 && (
         <p className="text-right text-xs text-[var(--text)]/40">
           {filtered.length} de {tasks.length} {tasks.length === 1 ? 'tarea' : 'tareas'}
         </p>


### PR DESCRIPTION
## Summary

Reportado por @beto-sudo:

1. El widget cortaba a 5 tareas por bucket y no alcanzaba a ver todas
2. El botón **"Ver todas"** iba a `/inicio/tasks` pero mostraba tareas de **todos los usuarios**, no solo las del logueado
3. Faltaba el toggle **"Mostrar/Ocultar completadas"** que sí tiene DILESA

### Causa raíz

`TasksModule` en variant `simple` no filtraba por `asignado_a = yo` (eso solo pasa en variant `rich` para DILESA). Y el toggle de completadas vivía gateado a `isRich`.

### Fix

- Dos props nuevas opcionales en `TasksModule`:
  - `onlyMine`: resuelve los `empleado_id` del usuario (una query a `v_empleados_full` por email en todas sus empresas) y filtra `asignado_a ∈ misIds`.
  - `hideCompletedToggle`: muestra el toggle y aplica `hideCompleted` también en variant `simple`.
- `/inicio/tasks` las activa y renombra título a **"Mis tareas"**.
- Se elimina `<RequireAccess empresa="rdb">` — el dashboard personal debe ser para cualquier usuario logueado, no solo los de RDB.
- Widget de `/inicio`: 5 → 10 tareas por bucket; fetch 50 → 100.

No toca DILESA, RDB, ni los módulos `admin/tasks` — mantienen su comportamiento.

## Test plan

- [ ] En preview, `/inicio/tasks` muestra solo tareas donde el usuario es responsable
- [ ] Toggle "Mostrar/Ocultar completadas" funciona y persiste
- [ ] Widget muestra hasta 10 por bucket antes del "+N más"
- [ ] `/rdb/admin/tasks` y `/dilesa/admin/tasks` sin regresión (siguen mostrando todas)
- [ ] Un usuario que no es de RDB ahora puede ver `/inicio/tasks` sin 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)