### PR TITLE
fix(inicio): labels de buckets 'Después' y 'Sin fecha' invisibles en tema claro

### DIFF
--- a/components/inicio/mis-tareas-widget.tsx
+++ b/components/inicio/mis-tareas-widget.tsx
@@ -47,12 +47,12 @@ const BUCKET_CONFIG: Record<Bucket, { label: string; tone: string; icon: typeof 
   },
   despues: {
     label: 'Después',
-    tone: 'text-white/60 bg-white/5 border-white/10',
+    tone: 'text-slate-500 bg-slate-500/10 border-slate-500/20',
     icon: ListTodo,
   },
   sin_fecha: {
     label: 'Sin fecha',
-    tone: 'text-white/50 bg-white/5 border-white/10',
+    tone: 'text-slate-500 bg-slate-500/10 border-slate-500/20',
     icon: ListTodo,
   },
 };


### PR DESCRIPTION
## Summary

Reportado por @beto-sudo vía screenshot: después del bucket "Esta semana" aparecía un "2" huérfano sin título del grupo.

**Causa:** los badges de "Después" y "Sin fecha" usaban `text-white/60 bg-white/5 border-white/10` — clases pensadas para fondo oscuro. En tema claro son prácticamente invisibles; solo se lee el contador.

**Fix:** mismo patrón que los otros buckets (`slate-500 bg-slate-500/10 border-slate-500/20`), visible en ambos temas.

## Test plan

- [ ] En preview, bucket "Después" muestra label + ícono
- [ ] Bucket "Sin fecha" igual
- [ ] No afecta rojo/amber/sky de Vencidas/Hoy/Semana

🤖 Generated with [Claude Code](https://claude.com/claude-code)