### PR TITLE
feat(documentos): columna descripción + script para ligar adjuntos existentes

### DIFF
--- a/components/documentos/documento-create-sheet.tsx
+++ b/components/documentos/documento-create-sheet.tsx
@@ -65,6 +65,7 @@ export function DocumentoCreateSheet({
         fecha_vencimiento: form.fecha_vencimiento || null,
         notario_proveedor_id: form.notario_proveedor_id || null,
         notaria: form.notaria.trim() || null,
+        descripcion: form.descripcion.trim() || null,
         notas: form.notas.trim() || null,
         subtipo_meta: Object.keys(form.subtipo_meta).length > 0 ? form.subtipo_meta : null,
         creado_por: cu?.id ?? null,

--- a/components/documentos/documento-detail-sheet.tsx
+++ b/components/documentos/documento-detail-sheet.tsx
@@ -74,6 +74,7 @@ export function DocumentoDetailSheet({
         fecha_vencimiento: editForm.fecha_vencimiento || null,
         notario_proveedor_id: editForm.notario_proveedor_id || null,
         notaria: editForm.notaria.trim() || null,
+        descripcion: editForm.descripcion.trim() || null,
         notas: editForm.notas.trim() || null,
         subtipo_meta: Object.keys(editForm.subtipo_meta).length > 0 ? editForm.subtipo_meta : null,
         updated_at: new Date().toISOString(),
@@ -95,6 +96,7 @@ export function DocumentoDetailSheet({
       fecha_vencimiento: editForm.fecha_vencimiento || null,
       notario_proveedor_id: editForm.notario_proveedor_id || null,
       notaria: editForm.notaria.trim() || null,
+      descripcion: editForm.descripcion.trim() || null,
       notas: editForm.notas.trim() || null,
       subtipo_meta: Object.keys(editForm.subtipo_meta).length > 0 ? editForm.subtipo_meta : null,
     };
@@ -199,6 +201,18 @@ export function DocumentoDetailSheet({
                           <p className="text-[var(--text)]/80">{String(v)}</p>
                         </div>
                       ))}
+                    </div>
+                  </>
+                )}
+
+                {doc.descripcion && (
+                  <>
+                    <Separator />
+                    <div>
+                      <FLabel>Descripción</FLabel>
+                      <p className="text-sm text-[var(--text)]/70 whitespace-pre-wrap">
+                        {doc.descripcion}
+                      </p>
                     </div>
                   </>
                 )}

--- a/components/documentos/documento-form-fields.tsx
+++ b/components/documentos/documento-form-fields.tsx
@@ -166,6 +166,21 @@ export function DocFormFields({
       )}
 
       <div>
+        <FLabel>Descripción</FLabel>
+        <Textarea
+          placeholder="Resumen breve de lo que contiene el documento..."
+          value={form.descripcion}
+          onChange={(e) => setForm((f) => ({ ...f, descripcion: e.target.value }))}
+          rows={3}
+          maxLength={500}
+          className="resize-none rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+        />
+        <p className="mt-1 text-[10px] text-[var(--text)]/40">
+          Se muestra como vista previa en la tabla. Máx 500 caracteres.
+        </p>
+      </div>
+
+      <div>
         <FLabel>Notas</FLabel>
         <Textarea
           placeholder="Observaciones adicionales..."

--- a/components/documentos/documentos-module.tsx
+++ b/components/documentos/documentos-module.tsx
@@ -338,12 +338,13 @@ export function DocumentosModule({
   const tiposPresentes = [...new Set(documentos.map((d) => d.tipo).filter(Boolean))] as string[];
 
   const filtered = documentos.filter((d) => {
-    if (
-      search &&
-      !d.titulo.toLowerCase().includes(search.toLowerCase()) &&
-      !(d.numero_documento ?? '').toLowerCase().includes(search.toLowerCase())
-    )
-      return false;
+    if (search) {
+      const q = search.toLowerCase();
+      const inTitulo = d.titulo.toLowerCase().includes(q);
+      const inNumero = (d.numero_documento ?? '').toLowerCase().includes(q);
+      const inDescripcion = (d.descripcion ?? '').toLowerCase().includes(q);
+      if (!inTitulo && !inNumero && !inDescripcion) return false;
+    }
     if (filterTipo !== 'all' && d.tipo !== filterTipo) return false;
     return true;
   });
@@ -412,7 +413,7 @@ export function DocumentosModule({
           <div className="relative min-w-48 flex-1">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
             <Input
-              placeholder="Buscar por título o número..."
+              placeholder="Buscar por título, número o descripción..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="pl-9 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"

--- a/components/documentos/documentos-table.tsx
+++ b/components/documentos/documentos-table.tsx
@@ -122,6 +122,7 @@ export function DocumentosTable({
               onSort={onSort}
               className="w-40"
             />
+            <TableHead className="font-medium text-[var(--text)]/55">Descripción</TableHead>
             <TableHead className="w-24 font-medium text-[var(--text)]/55">PDF</TableHead>
             <TableHead className="w-24 font-medium text-[var(--text)]/55">Imagen</TableHead>
             <TableHead className="w-20 font-medium text-[var(--text)]/55">Anexos</TableHead>
@@ -174,6 +175,18 @@ export function DocumentosTable({
                 </TableCell>
                 <TableCell>
                   <TipoBadge tipo={doc.tipo} />
+                </TableCell>
+                <TableCell>
+                  {doc.descripcion ? (
+                    <span
+                      className="line-clamp-2 block max-w-xs text-xs text-[var(--text)]/65"
+                      title={doc.descripcion}
+                    >
+                      {doc.descripcion}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-[var(--text)]/25">—</span>
+                  )}
                 </TableCell>
                 <TableCell onClick={(e) => e.stopPropagation()}>
                   {pdfs.length > 0 ? (

--- a/components/documentos/helpers.ts
+++ b/components/documentos/helpers.ts
@@ -50,6 +50,7 @@ export function emptyForm(): DocForm {
     fecha_vencimiento: '',
     notario_proveedor_id: '',
     notaria: '',
+    descripcion: '',
     notas: '',
     subtipo_meta: {},
   };
@@ -64,6 +65,7 @@ export function docToForm(doc: Documento): DocForm {
     fecha_vencimiento: doc.fecha_vencimiento ?? '',
     notario_proveedor_id: doc.notario_proveedor_id ?? '',
     notaria: doc.notaria ?? '',
+    descripcion: doc.descripcion ?? '',
     notas: doc.notas ?? '',
     subtipo_meta: doc.subtipo_meta ?? {},
   };

--- a/components/documentos/types.ts
+++ b/components/documentos/types.ts
@@ -19,6 +19,7 @@ export type Documento = {
   fecha_vencimiento: string | null;
   notaria: string | null;
   notario_proveedor_id: string | null;
+  descripcion: string | null;
   notas: string | null;
   archivo_url: string | null;
   subtipo_meta: Record<string, any> | null;
@@ -48,6 +49,7 @@ export type DocForm = {
   fecha_vencimiento: string;
   notario_proveedor_id: string;
   notaria: string;
+  descripcion: string;
   notas: string;
   subtipo_meta: Record<string, any>;
 };

--- a/scripts/link-documentos-adjuntos.ts
+++ b/scripts/link-documentos-adjuntos.ts
@@ -1,0 +1,397 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * Script one-off para ligar archivos existentes en el bucket `adjuntos` con
+ * sus filas en erp.documentos. Los `as any` en los .schema() son necesarios
+ * porque el cliente `@supabase/supabase-js` solo sabe del schema `public`
+ * por default; tipar el cliente completo cae fuera del alcance de este
+ * script de mantenimiento.
+ */
+/**
+ * link-documentos-adjuntos.ts
+ *
+ * Recorre el bucket `adjuntos` en Supabase y vincula los archivos
+ * sueltos (PDFs, imágenes, anexos) a su fila en `erp.documentos` creando
+ * filas en `erp.adjuntos` con el `rol` correcto.
+ *
+ * Contexto: la mayoría de los PDFs e imágenes de DILESA se subieron
+ * directamente al bucket antes de que el módulo de Documentos manejara
+ * los adjuntos de forma estructurada. Resultado: muchas filas en
+ * erp.documentos aparecen sin archivos en la UI aunque los archivos
+ * sí existen físicamente.
+ *
+ * Estrategia de match (por cada archivo en el bucket):
+ *   1. Deriva número de escritura y año del nombre del archivo usando
+ *      varios patrones observados en las escrituras de DILESA:
+ *        - "DILESA-YYYY-MM-Escritura NÚMERO XXX-..."
+ *        - "DILESA-YYYY-MM Escritura Numero XXX-..."
+ *        - "Dilesa-YYYY-MM-Escritura #XXX-..."
+ *        - "YYYY-MM-ECRITURA XX ..." (typo histórico "ECRITURA")
+ *        - "DILESA-YYYY-MM Escritura Declaracion Unilateral ..." (sin número → match por año/mes)
+ *   2. Busca la fila de erp.documentos con ese empresa_id que coincida por:
+ *        - numero_documento == número parseado, y
+ *        - year(fecha_emision) == año parseado (si hay año)
+ *      Si hay múltiples, usa mes también. Si sigue ambiguo, reporta y salta.
+ *   3. Clasifica el rol según la extensión:
+ *        - .pdf → documento_principal
+ *        - .jpg/.jpeg/.png/.gif/.webp/.tiff → imagen_referencia
+ *        - resto → anexo
+ *   4. Salta si ya existe una fila en erp.adjuntos con la misma (entidad_id,
+ *      url) — idempotente.
+ *
+ * Uso:
+ *   DRY_RUN=1 npx tsx scripts/link-documentos-adjuntos.ts
+ *   npx tsx scripts/link-documentos-adjuntos.ts
+ *
+ * Env:
+ *   NEXT_PUBLIC_SUPABASE_URL  – Supabase project URL
+ *   SUPABASE_SERVICE_ROLE_KEY – Service role key (bypasses RLS + storage)
+ *   DILESA_EMPRESA_ID         – (opcional) limita a esta empresa
+ *                               SELECT id FROM core.empresas WHERE slug='dilesa'
+ *   BUCKET_PREFIX             – (opcional) prefijo a recorrer (default: '')
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const EMPRESA_ID_FILTER = process.env.DILESA_EMPRESA_ID ?? '';
+const BUCKET_PREFIX = process.env.BUCKET_PREFIX ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+const BUCKET = 'adjuntos';
+
+if (!SUPABASE_URL) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL');
+if (!SUPABASE_KEY) throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY');
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+// ─── Tipos ────────────────────────────────────────────────────────────────────
+
+type StorageObject = {
+  name: string;
+  id: string | null;
+  metadata?: { size?: number; mimetype?: string } | null;
+};
+
+type Documento = {
+  id: string;
+  empresa_id: string;
+  titulo: string;
+  numero_documento: string | null;
+  fecha_emision: string | null;
+};
+
+type ParsedName = {
+  numero: string | null;
+  year: number | null;
+  month: number | null;
+};
+
+// ─── Listado recursivo del bucket ────────────────────────────────────────────
+
+async function listBucketRecursive(
+  prefix: string
+): Promise<{ path: string; obj: StorageObject }[]> {
+  const out: { path: string; obj: StorageObject }[] = [];
+  const stack: string[] = [prefix];
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    let offset = 0;
+    const pageSize = 1000;
+    // Paginamos por si alguna carpeta tiene >1000 entradas.
+    for (;;) {
+      const { data, error } = await supabase.storage.from(BUCKET).list(current, {
+        limit: pageSize,
+        offset,
+        sortBy: { column: 'name', order: 'asc' },
+      });
+      if (error) throw new Error(`list(${current}): ${error.message}`);
+      if (!data || data.length === 0) break;
+
+      for (const entry of data as StorageObject[]) {
+        const full = current ? `${current}/${entry.name}` : entry.name;
+        // Las "carpetas" devueltas por list tienen id === null.
+        if (entry.id == null) {
+          stack.push(full);
+        } else {
+          out.push({ path: full, obj: entry });
+        }
+      }
+
+      if (data.length < pageSize) break;
+      offset += pageSize;
+    }
+  }
+
+  return out;
+}
+
+// ─── Parsing de nombre ────────────────────────────────────────────────────────
+
+function parseFilename(filename: string): ParsedName {
+  // Trabajamos solo con el último segmento del path y sin la extensión.
+  const base = filename.split('/').pop() ?? filename;
+  const stem = base.replace(/\.[^.]+$/, '');
+  // Normalizamos espacios, guiones dobles y acentos comunes.
+  const norm = stem
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // Año / mes (YYYY-MM o YYYY MM al inicio, posiblemente tras "DILESA-").
+  let year: number | null = null;
+  let month: number | null = null;
+  const ymMatch = norm.match(/(?:^|[-\s])(\d{4})[-\s](\d{1,2})(?:[-\s]|$)/);
+  if (ymMatch) {
+    const y = parseInt(ymMatch[1], 10);
+    const m = parseInt(ymMatch[2], 10);
+    if (y >= 1990 && y <= 2100) year = y;
+    if (m >= 1 && m <= 12) month = m;
+  }
+
+  // Número de escritura: busca tras palabras como "Escritura", "ECRITURA",
+  // "Numero", "Número", "No." o "#".
+  let numero: string | null = null;
+  const patterns: RegExp[] = [
+    /(?:escritura|ecritura)\s*(?:numero|número|no\.?|#)?\s*(\d{1,6})/i,
+    /(?:numero|número|no\.?|#)\s*(\d{1,6})/i,
+  ];
+  for (const re of patterns) {
+    const m = norm.match(re);
+    if (m) {
+      numero = m[1];
+      break;
+    }
+  }
+
+  return { numero, year, month };
+}
+
+/**
+ * Normaliza cualquier URL o path al path del objeto dentro del bucket
+ * `adjuntos`. Equivalente a `lib/adjuntos.ts#getAdjuntoPath` pero
+ * autocontenido para que el script corra sin imports del app.
+ */
+function normalizePath(value: string | null | undefined): string {
+  if (!value) return '';
+  const v = String(value).trim();
+  const markers = [
+    '/object/public/adjuntos/',
+    '/object/sign/adjuntos/',
+    '/object/authenticated/adjuntos/',
+    '/api/adjuntos/',
+  ];
+  for (const m of markers) {
+    const i = v.indexOf(m);
+    if (i >= 0) {
+      const tail = v.slice(i + m.length);
+      const q = tail.indexOf('?');
+      return q >= 0 ? tail.slice(0, q) : tail;
+    }
+  }
+  return v.replace(/^\/+/, '');
+}
+
+function roleFromExt(filename: string): 'documento_principal' | 'imagen_referencia' | 'anexo' {
+  const ext = (filename.split('.').pop() ?? '').toLowerCase();
+  if (ext === 'pdf') return 'documento_principal';
+  if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'tiff', 'tif'].includes(ext))
+    return 'imagen_referencia';
+  return 'anexo';
+}
+
+function mimeFromExt(filename: string): string | null {
+  const ext = (filename.split('.').pop() ?? '').toLowerCase();
+  const map: Record<string, string> = {
+    pdf: 'application/pdf',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    tiff: 'image/tiff',
+    tif: 'image/tiff',
+    doc: 'application/msword',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  };
+  return map[ext] ?? null;
+}
+
+// ─── Carga documentos candidatos ──────────────────────────────────────────────
+
+async function loadDocumentos(): Promise<Documento[]> {
+  let query = supabase
+    .schema('erp' as any)
+    .from('documentos')
+    .select('id, empresa_id, titulo, numero_documento, fecha_emision')
+    .is('deleted_at', null);
+  if (EMPRESA_ID_FILTER) query = query.eq('empresa_id', EMPRESA_ID_FILTER);
+  const { data, error } = await query;
+  if (error) throw new Error(`load documentos: ${error.message}`);
+  return (data ?? []) as Documento[];
+}
+
+function matchDocumento(parsed: ParsedName, docs: Documento[]): Documento | null {
+  if (!parsed.numero) return null;
+  const candidates = docs.filter((d) => d.numero_documento === parsed.numero);
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+
+  // Desempatar por año/mes de fecha_emision.
+  if (parsed.year != null) {
+    const byYear = candidates.filter((d) => {
+      if (!d.fecha_emision) return false;
+      return parseInt(d.fecha_emision.slice(0, 4), 10) === parsed.year;
+    });
+    if (byYear.length === 1) return byYear[0];
+    if (byYear.length > 1 && parsed.month != null) {
+      const byMonth = byYear.filter((d) => {
+        if (!d.fecha_emision) return false;
+        return parseInt(d.fecha_emision.slice(5, 7), 10) === parsed.month;
+      });
+      if (byMonth.length === 1) return byMonth[0];
+    }
+  }
+  return null;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`🔗 link-documentos-adjuntos — DRY_RUN=${DRY_RUN}`);
+  console.log(`   Bucket: ${BUCKET}  Prefix: '${BUCKET_PREFIX}'`);
+  console.log(`   Empresa filter: ${EMPRESA_ID_FILTER || '(none, all empresas)'}\n`);
+
+  console.log('📄 Cargando documentos…');
+  const docs = await loadDocumentos();
+  console.log(`   ${docs.length} documentos candidatos\n`);
+
+  console.log('🪣  Listando bucket…');
+  const files = await listBucketRecursive(BUCKET_PREFIX);
+  console.log(`   ${files.length} archivos en bucket\n`);
+
+  // Cargamos adjuntos ya registrados para no duplicar. Normalizamos `url`
+  // al path canónico (pudo haberse guardado como URL pública legacy).
+  const existing = new Set<string>();
+  {
+    let from = 0;
+    const step = 1000;
+    for (;;) {
+      const { data, error } = await supabase
+        .schema('erp' as any)
+        .from('adjuntos')
+        .select('entidad_id, url')
+        .eq('entidad_tipo', 'documento')
+        .range(from, from + step - 1);
+      if (error) throw new Error(`load adjuntos: ${error.message}`);
+      if (!data || data.length === 0) break;
+      for (const row of data as { entidad_id: string; url: string }[]) {
+        const p = normalizePath(row.url);
+        existing.add(`${row.entidad_id}::${p}`);
+      }
+      if (data.length < step) break;
+      from += step;
+    }
+  }
+  console.log(`   ${existing.size} adjuntos ya registrados\n`);
+
+  const report = {
+    total: files.length,
+    matched: 0,
+    skipped_existing: 0,
+    no_number: 0,
+    no_match: 0,
+    ambiguous: 0,
+    inserted: 0,
+  };
+  const unmatched: { path: string; reason: string }[] = [];
+
+  for (const { path, obj } of files) {
+    const base = path.split('/').pop() ?? path;
+    const parsed = parseFilename(base);
+    if (!parsed.numero) {
+      report.no_number += 1;
+      unmatched.push({ path, reason: 'no_number_parsed' });
+      continue;
+    }
+    const doc = matchDocumento(parsed, docs);
+    if (!doc) {
+      const n = docs.filter((d) => d.numero_documento === parsed.numero).length;
+      if (n > 1) {
+        report.ambiguous += 1;
+        unmatched.push({ path, reason: `ambiguous_n${n}_numero${parsed.numero}` });
+      } else {
+        report.no_match += 1;
+        unmatched.push({ path, reason: `no_match_numero${parsed.numero}` });
+      }
+      continue;
+    }
+
+    const key = `${doc.id}::${path}`;
+    if (existing.has(key)) {
+      report.skipped_existing += 1;
+      continue;
+    }
+    report.matched += 1;
+
+    const rol = roleFromExt(base);
+    const mime = mimeFromExt(base);
+    const size = obj.metadata?.size ?? null;
+
+    if (DRY_RUN) {
+      console.log(`  [${rol}] ${path}  →  ${doc.titulo} (${doc.id})`);
+      continue;
+    }
+
+    const { error: insErr } = await supabase
+      .schema('erp' as any)
+      .from('adjuntos')
+      .insert({
+        empresa_id: doc.empresa_id,
+        entidad_tipo: 'documento',
+        entidad_id: doc.id,
+        nombre: base,
+        url: path,
+        tipo_mime: mime,
+        tamano_bytes: size,
+        rol,
+      });
+    if (insErr) {
+      console.error(`❌ insert failed for ${path}: ${insErr.message}`);
+      continue;
+    }
+    report.inserted += 1;
+    if (report.inserted % 25 === 0) {
+      process.stdout.write(`   Inserted ${report.inserted}…\r`);
+    }
+  }
+
+  console.log('\n───── Reporte ─────');
+  console.log(`Total archivos:      ${report.total}`);
+  console.log(`Matched candidatos:  ${report.matched}`);
+  console.log(`Ya ligados (skip):   ${report.skipped_existing}`);
+  console.log(`Sin número:          ${report.no_number}`);
+  console.log(`Sin match:           ${report.no_match}`);
+  console.log(`Ambiguos:            ${report.ambiguous}`);
+  if (!DRY_RUN) console.log(`Insertados:          ${report.inserted}`);
+
+  if (unmatched.length > 0) {
+    console.log(`\n⚠️  ${unmatched.length} archivos no ligados — primeros 20:`);
+    for (const u of unmatched.slice(0, 20)) {
+      console.log(`   [${u.reason}] ${u.path}`);
+    }
+    if (unmatched.length > 20) {
+      console.log(`   … y ${unmatched.length - 20} más`);
+    }
+  }
+
+  if (DRY_RUN) console.log('\n🛑 DRY RUN — no se escribió nada.');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/supabase/SCHEMA_REF.md
+++ b/supabase/SCHEMA_REF.md
@@ -408,7 +408,6 @@ _(sin tablas ni vistas)_
 - **deleted_at** `timestamp with time zone`
 - **archivo_url** `text`
 - **subtipo_meta** `jsonb`
-- **descripcion** `text`
 
 ### `erp.empleado_beneficiarios`
 

--- a/supabase/SCHEMA_REF.md
+++ b/supabase/SCHEMA_REF.md
@@ -408,6 +408,7 @@ _(sin tablas ni vistas)_
 - **deleted_at** `timestamp with time zone`
 - **archivo_url** `text`
 - **subtipo_meta** `jsonb`
+- **descripcion** `text`
 
 ### `erp.empleado_beneficiarios`
 

--- a/supabase/migrations/20260421000000_erp_documentos_descripcion.sql
+++ b/supabase/migrations/20260421000000_erp_documentos_descripcion.sql
@@ -1,0 +1,18 @@
+-- Agrega columna `descripcion` a erp.documentos.
+--
+-- Campo corto (resumen ~500 chars) con el contenido del documento, pensado
+-- para mostrar una vista rápida en la tabla de documentos sin abrir el PDF.
+-- A futuro puede poblarse automáticamente a partir del texto extraído del
+-- PDF principal (ver plan de IA/OCR en PR aparte).
+
+ALTER TABLE erp.documentos
+  ADD COLUMN IF NOT EXISTS descripcion TEXT;
+
+COMMENT ON COLUMN erp.documentos.descripcion IS
+  'Resumen breve (<=500 chars) de lo que contiene el documento. Se muestra '
+  'en la tabla de documentos como vista previa. Puede editarse a mano o '
+  'generarse por IA a partir del PDF principal.';
+
+-- Reload PostgREST schema cache.
+NOTIFY pgrst, 'reload config';
+NOTIFY pgrst, 'reload schema';

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1297,6 +1297,7 @@ export type Database = {
           creado_por: string | null
           created_at: string
           deleted_at: string | null
+          descripcion: string | null
           empresa_id: string
           fecha_emision: string | null
           fecha_vencimiento: string | null
@@ -1315,6 +1316,7 @@ export type Database = {
           creado_por?: string | null
           created_at?: string
           deleted_at?: string | null
+          descripcion?: string | null
           empresa_id: string
           fecha_emision?: string | null
           fecha_vencimiento?: string | null
@@ -1333,6 +1335,7 @@ export type Database = {
           creado_por?: string | null
           created_at?: string
           deleted_at?: string | null
+          descripcion?: string | null
           empresa_id?: string
           fecha_emision?: string | null
           fecha_vencimiento?: string | null


### PR DESCRIPTION
## Resumen

Dos frentes del plan acordado para el módulo BSOP-Documentos (el tercero — extracción de texto y resumen automático con IA — queda pendiente para un PR aparte):

### 1. Columna "Descripción" en la tabla

- Nueva columna `erp.documentos.descripcion` (text, nullable) — migración `20260421000000_erp_documentos_descripcion.sql`.
- Textarea en los sheets de Alta y Edición (máx 500 chars), con hint que explica que se muestra como vista previa en la tabla.
- Nueva columna `Descripción` en la tabla, con `line-clamp-2` y tooltip (`title`) para ver el texto completo sin abrir el documento.
- Se incluye en el buscador del módulo (título, número o descripción).
- Se muestra también en la vista de detalle por arriba del bloque de Notas.

### 2. Script para ligar PDFs e imágenes que ya están en el bucket

`scripts/link-documentos-adjuntos.ts` recorre el bucket privado `adjuntos`, parsea el nombre de cada archivo para extraer número de escritura + año/mes (patrones observados en las escrituras de DILESA: `DILESA-YYYY-MM-Escritura NÚMERO XXX`, `Dilesa-YYYY-MM-Escritura #XXX`, `YYYY-MM-ECRITURA XX`, etc.), y lo matchea contra `erp.documentos` por `empresa_id + numero_documento + año`. Crea una fila en `erp.adjuntos` con `rol` derivado de la extensión (`.pdf` → `documento_principal`, imágenes → `imagen_referencia`, resto → `anexo`). Es idempotente (deduplica por `entidad_id + path`) y tiene `DRY_RUN=1` por default recomendado antes de correr en vivo.

```bash
# Preview
DRY_RUN=1 DILESA_EMPRESA_ID=<uuid> npx tsx scripts/link-documentos-adjuntos.ts
# Ejecutar
DILESA_EMPRESA_ID=<uuid> npx tsx scripts/link-documentos-adjuntos.ts
```

El reporte final muestra cuántos archivos se pudieron ligar, cuáles quedaron ambiguos o sin número parseable, para revisar manualmente los casos edge.

## Pendiente en PR aparte (acordado)

- `pdf-parse` + `tesseract.js` para extraer texto de los PDFs (los escaneados viejos de 2003-2008 necesitan OCR).
- Llamada a Claude API para generar el resumen y poblar `descripcion` automáticamente.
- Columna `contenido_texto` + índice `tsvector` en español para búsqueda full-text.

## Test plan

- [ ] Aplicar la migración (`supabase/migrations/20260421000000_...`).
- [ ] Crear un documento nuevo con descripción — verificar que se guarda y aparece en la tabla con line-clamp.
- [ ] Editar un documento existente, agregar descripción — verificar que la vista de detalle la muestra.
- [ ] Buscar por texto que sólo existe en la descripción — confirmar que aparece en resultados.
- [ ] Correr el script en modo `DRY_RUN=1` apuntando a DILESA, revisar el reporte de matches vs no-matches.
- [ ] Correr el script en vivo, refrescar la tabla de documentos y confirmar que las columnas PDF / Imagen ahora muestran los archivos.