### PR TITLE
feat(documentos): script de extracción con Claude + OpenAI (PR B)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "bsop",
       "version": "2.0.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.71",
+        "@ai-sdk/openai": "^3.0.53",
         "@base-ui/react": "^1.3.0",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.100.0",
@@ -20,6 +22,7 @@
         "@tiptap/starter-kit": "^3.22.3",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
+        "ai": "^6.0.168",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -54,6 +57,84 @@
         "tailwindcss": "latest",
         "typescript": "latest",
         "vitest": "^3.2.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2559,6 +2640,15 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3407,6 +3497,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.0",
@@ -4993,6 +5089,15 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
@@ -5185,6 +5290,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -9286,6 +9409,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.71",
+    "@ai-sdk/openai": "^3.0.53",
     "@base-ui/react": "^1.3.0",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.100.0",
@@ -40,6 +42,7 @@
     "@tiptap/starter-kit": "^3.22.3",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
+    "ai": "^6.0.168",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/scripts/extract-documento-contents.ts
+++ b/scripts/extract-documento-contents.ts
@@ -1,0 +1,496 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * Script one-off (y re-ejecutable) para poblar los campos de extracción IA
+ * en erp.documentos. Los `as any` en los .schema() son necesarios porque
+ * el cliente @supabase/supabase-js solo sabe del schema `public` por default.
+ */
+/**
+ * extract-documento-contents.ts
+ *
+ * Procesa cada fila de erp.documentos cuyo extraccion_status sea
+ * 'pendiente' o 'error' y que tenga un adjunto con rol='documento_principal'.
+ * Por cada documento:
+ *   1. Descarga el PDF desde el bucket privado `adjuntos`.
+ *   2. Llama a Claude (claude-opus-4-7, multimodal) con el PDF y un
+ *      Zod schema para extraer:
+ *        - contenido_texto completo (con OCR si es escaneado)
+ *        - descripcion humana (resumen <=500 chars)
+ *        - campos legales estructurados (tipo_operacion, monto, moneda,
+ *          superficie_m2, ubicacion_predio, municipio, estado, folio_real,
+ *          libro_tomo, partes[])
+ *   3. Genera embedding con OpenAI text-embedding-3-large truncado a 1536
+ *      dims (Matryoshka) sobre el contenido_texto.
+ *   4. Actualiza la fila marcando extraccion_status='completado'.
+ *
+ * Es idempotente: una segunda corrida salta los 'completado'. Los 'error'
+ * sí se reintentan (útil después de arreglar un bug).
+ *
+ * Uso:
+ *   # Preview (NO toca la DB, solo imprime lo que haría)
+ *   DRY_RUN=1 npx tsx scripts/extract-documento-contents.ts
+ *
+ *   # Procesar solo los primeros 3 documentos
+ *   LIMIT=3 npx tsx scripts/extract-documento-contents.ts
+ *
+ *   # Procesar un documento específico (debug)
+ *   ONLY_ID=<uuid> npx tsx scripts/extract-documento-contents.ts
+ *
+ *   # Producción
+ *   npx tsx scripts/extract-documento-contents.ts
+ *
+ * Env:
+ *   NEXT_PUBLIC_SUPABASE_URL     Supabase project URL
+ *   SUPABASE_SERVICE_ROLE_KEY    Service role key (bypassa RLS + storage)
+ *   ANTHROPIC_API_KEY            API key de Anthropic (claude-opus-4-7)
+ *   OPENAI_API_KEY               API key de OpenAI (text-embedding-3-large)
+ *   DRY_RUN=1                    No escribe en DB, solo imprime
+ *   LIMIT=<n>                    Procesa máximo n docs (default: todos)
+ *   ONLY_ID=<uuid>               Procesa solo ese documento (ignora LIMIT)
+ *   CONCURRENCY=<n>              Docs en paralelo (default 2)
+ *   EMPRESA_ID=<uuid>            Filtra por empresa
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { openai } from '@ai-sdk/openai';
+import { generateText, embed, Output } from 'ai';
+import { z } from 'zod';
+
+// baseURL explícito para evitar que una ANTHROPIC_BASE_URL seteada en el
+// shell (ej. cuando este script corre dentro de Claude Code) rompa las
+// llamadas apuntándolas a un proxy. El default oficial es el mismo.
+const anthropic = createAnthropic({ baseURL: 'https://api.anthropic.com/v1' });
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+const LIMIT = process.env.LIMIT ? Number(process.env.LIMIT) : null;
+const ONLY_ID = process.env.ONLY_ID ?? null;
+const CONCURRENCY = process.env.CONCURRENCY ? Number(process.env.CONCURRENCY) : 2;
+const EMPRESA_ID = process.env.EMPRESA_ID ?? null;
+const BUCKET = 'adjuntos';
+
+if (!SUPABASE_URL) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL');
+if (!SUPABASE_KEY) throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY');
+if (!process.env.ANTHROPIC_API_KEY) throw new Error('Missing ANTHROPIC_API_KEY');
+if (!process.env.OPENAI_API_KEY) throw new Error('Missing OPENAI_API_KEY');
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const MODELO_CLAUDE = 'claude-opus-4-7';
+const MODELO_EMBEDDING = 'text-embedding-3-large';
+const EMBEDDING_DIMS = 1536;
+
+// ─── Schema de extracción ────────────────────────────────────────────────────
+
+const ParteSchema = z.object({
+  rol: z
+    .string()
+    .describe(
+      'Rol de esta parte en el documento: vendedor, comprador, poderdante, ' +
+        'apoderado, fideicomitente, fiduciaria, fideicomisario, arrendador, ' +
+        'arrendatario, otorgante, beneficiario, donante, donatario, etc. Usar minúsculas.'
+    ),
+  nombre: z.string().describe('Nombre completo de la persona física o moral.'),
+  rfc: z.string().nullable().describe('RFC si aparece en el documento, si no null.'),
+  representante: z
+    .string()
+    .nullable()
+    .describe('Nombre del representante legal si la parte es una persona moral, si no null.'),
+});
+
+const ExtraccionSchema = z.object({
+  descripcion: z
+    .string()
+    .max(500)
+    .describe(
+      'Resumen humano de 2-3 oraciones (máximo 500 caracteres) de qué contiene el documento. ' +
+        'Debe incluir tipo de operación, partes principales y objeto en lenguaje natural. ' +
+        'Ejemplo: "Compraventa por $1,500,000 MXN del predio urbano en Calle X #123 de Juan Pérez ' +
+        'a DILESA S.A. de C.V. ante notario 42 de Piedras Negras."'
+    ),
+  contenido_texto: z
+    .string()
+    .describe(
+      'Transcripción completa del documento, incluyendo encabezados, cláusulas, firmas y ' +
+        'anexos. Preservar saltos de línea entre secciones. Si es escaneado ilegible, ' +
+        'hacer tu mejor esfuerzo y marcar [ilegible] donde no se pueda leer.'
+    ),
+  tipo_operacion: z
+    .string()
+    .nullable()
+    .describe(
+      'Naturaleza legal del documento, en minúsculas y sin acentos: compraventa, donacion, ' +
+        'hipoteca, poder, fideicomiso, permuta, arrendamiento, constitutiva, acta, ' +
+        'testamento, convenio, etc. null si no se puede determinar.'
+    ),
+  monto: z
+    .number()
+    .nullable()
+    .describe('Valor económico de la operación si aplica y está explícito. null si no aplica.'),
+  moneda: z
+    .string()
+    .describe(
+      'Moneda de la operación: MXN, USD, EUR. Default MXN si hay monto pero no se especifica moneda.'
+    ),
+  superficie_m2: z
+    .number()
+    .nullable()
+    .describe(
+      'Superficie en metros cuadrados si es un inmueble. Convertir hectáreas a m² (1 ha = 10,000 m²). ' +
+        'null si no aplica.'
+    ),
+  ubicacion_predio: z
+    .string()
+    .nullable()
+    .describe(
+      'Dirección o descripción del objeto del documento (inmueble, predio, negocio). ' +
+        'null si no aplica.'
+    ),
+  municipio: z
+    .string()
+    .nullable()
+    .describe('Municipio donde está el objeto del documento. null si no se menciona.'),
+  estado: z
+    .string()
+    .nullable()
+    .describe(
+      'Entidad federativa donde está el objeto (Coahuila, Nuevo León, Texas, etc.). ' +
+        'null si no se menciona.'
+    ),
+  folio_real: z
+    .string()
+    .nullable()
+    .describe('Folio real del Registro Público de la Propiedad si aparece. null si no.'),
+  libro_tomo: z
+    .string()
+    .nullable()
+    .describe(
+      'Referencia al protocolo notarial (libro, tomo, foja, folio) si aparece. ' +
+        'Ejemplo: "Libro 5, Tomo II, Folio 123". null si no.'
+    ),
+  partes: z
+    .array(ParteSchema)
+    .describe(
+      'Todas las personas físicas o morales que intervienen en el documento con su rol. ' +
+        'Incluir otorgantes, beneficiarios, testigos si son relevantes (no incluir al notario).'
+    ),
+});
+
+type Extraccion = z.infer<typeof ExtraccionSchema>;
+
+// ─── Tipos de datos ──────────────────────────────────────────────────────────
+
+type DocRow = {
+  id: string;
+  empresa_id: string;
+  titulo: string;
+  numero_documento: string | null;
+  extraccion_status: string;
+  pdf_url: string; // path en el bucket `adjuntos`
+};
+
+// ─── Helpers DB ──────────────────────────────────────────────────────────────
+
+async function fetchPendingDocs(): Promise<DocRow[]> {
+  // Traemos documentos con status pendiente/error que tengan adjunto PDF principal.
+  // Hacemos join manual porque supabase-js no soporta inner joins arbitrarios
+  // con condiciones sobre la tabla unida de forma limpia entre schemas.
+
+  let q = (supabase.schema('erp') as any)
+    .from('documentos')
+    .select('id, empresa_id, titulo, numero_documento, extraccion_status')
+    .in('extraccion_status', ['pendiente', 'error'])
+    .is('deleted_at', null)
+    .order('created_at', { ascending: true });
+
+  if (ONLY_ID) q = q.eq('id', ONLY_ID);
+  if (EMPRESA_ID) q = q.eq('empresa_id', EMPRESA_ID);
+  if (LIMIT && !ONLY_ID) q = q.limit(LIMIT * 3); // margen por si algunos no tienen PDF
+
+  const { data: docs, error } = await q;
+  if (error) throw new Error(`fetch documentos: ${error.message}`);
+  if (!docs || docs.length === 0) return [];
+
+  // Traemos los adjuntos 'documento_principal' para todos esos docs en un batch.
+  const docIds = docs.map((d: any) => d.id);
+  const { data: adjuntos, error: errAdj } = await (supabase.schema('erp') as any)
+    .from('adjuntos')
+    .select('entidad_id, url, rol')
+    .eq('entidad_tipo', 'documento')
+    .eq('rol', 'documento_principal')
+    .in('entidad_id', docIds);
+
+  if (errAdj) throw new Error(`fetch adjuntos: ${errAdj.message}`);
+
+  const pdfByDocId = new Map<string, string>();
+  for (const a of adjuntos ?? []) {
+    if (!pdfByDocId.has(a.entidad_id)) pdfByDocId.set(a.entidad_id, a.url);
+  }
+
+  const rows: DocRow[] = [];
+  for (const d of docs) {
+    const pdf = pdfByDocId.get(d.id);
+    if (!pdf) continue;
+    rows.push({
+      id: d.id,
+      empresa_id: d.empresa_id,
+      titulo: d.titulo,
+      numero_documento: d.numero_documento,
+      extraccion_status: d.extraccion_status,
+      pdf_url: pdf,
+    });
+    if (LIMIT && rows.length >= LIMIT) break;
+  }
+
+  return rows;
+}
+
+async function downloadPdf(path: string): Promise<Uint8Array> {
+  // Algunos paths guardados en erp.adjuntos traen el nombre del bucket como prefijo
+  // (p.ej. "adjuntos/DILESA-..."); hay que quitárselo antes de llamar al storage.
+  const clean = path.replace(/^adjuntos\//, '').replace(/^\//, '');
+  const { data, error } = await supabase.storage.from(BUCKET).download(clean);
+  if (error) throw new Error(`download(${clean}): ${error.message}`);
+  if (!data) throw new Error(`download(${clean}): no data`);
+  const buf = await data.arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+async function markProcessing(id: string): Promise<boolean> {
+  // Lock optimistic: solo si sigue pendiente/error — evita double processing.
+  const { data, error } = await (supabase.schema('erp') as any)
+    .from('documentos')
+    .update({ extraccion_status: 'procesando', extraccion_error: null })
+    .eq('id', id)
+    .in('extraccion_status', ['pendiente', 'error'])
+    .select('id');
+  if (error) throw new Error(`markProcessing(${id}): ${error.message}`);
+  return (data?.length ?? 0) > 0;
+}
+
+async function writeResult(id: string, extraccion: Extraccion, embedding: number[]): Promise<void> {
+  const { error } = await (supabase.schema('erp') as any)
+    .from('documentos')
+    .update({
+      descripcion: extraccion.descripcion,
+      contenido_texto: extraccion.contenido_texto,
+      contenido_embedding: embedding as any,
+      tipo_operacion: extraccion.tipo_operacion,
+      monto: extraccion.monto,
+      moneda: extraccion.moneda,
+      superficie_m2: extraccion.superficie_m2,
+      ubicacion_predio: extraccion.ubicacion_predio,
+      municipio: extraccion.municipio,
+      estado: extraccion.estado,
+      folio_real: extraccion.folio_real,
+      libro_tomo: extraccion.libro_tomo,
+      partes: extraccion.partes,
+      extraccion_status: 'completado',
+      extraccion_fecha: new Date().toISOString(),
+      extraccion_modelo: MODELO_CLAUDE,
+      extraccion_error: null,
+    })
+    .eq('id', id);
+  if (error) throw new Error(`writeResult(${id}): ${error.message}`);
+}
+
+async function writeError(id: string, err: unknown): Promise<void> {
+  const msg = err instanceof Error ? err.message : String(err);
+  const { error } = await (supabase.schema('erp') as any)
+    .from('documentos')
+    .update({
+      extraccion_status: 'error',
+      extraccion_error: msg.slice(0, 2000),
+      extraccion_fecha: new Date().toISOString(),
+    })
+    .eq('id', id);
+  if (error) console.error(`writeError(${id}) falló: ${error.message}`);
+}
+
+// ─── Llamada a Claude con PDF ────────────────────────────────────────────────
+
+async function extractWithClaude(pdfBytes: Uint8Array, titulo: string): Promise<Extraccion> {
+  const { experimental_output: output } = await generateText({
+    model: anthropic(MODELO_CLAUDE),
+    experimental_output: Output.object({ schema: ExtraccionSchema }),
+    maxRetries: 2,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text:
+              `Eres un asistente legal especializado en documentos notariales mexicanos. ` +
+              `Analiza el siguiente PDF y extrae la información solicitada en el schema. ` +
+              `El título del documento en nuestro sistema es: "${titulo}". ` +
+              `Si el PDF es un escaneado, transcribe el texto lo mejor posible. ` +
+              `Responde únicamente con los datos del schema, sin texto adicional.`,
+          },
+          {
+            type: 'file',
+            data: pdfBytes,
+            mediaType: 'application/pdf',
+          },
+        ],
+      },
+    ],
+  });
+
+  return output as Extraccion;
+}
+
+// ─── Embedding ───────────────────────────────────────────────────────────────
+
+async function embedContent(contenido: string): Promise<number[]> {
+  // text-embedding-3-large max input = 8191 tokens. Truncamos por chars como aproximación
+  // conservadora (~4 chars por token). No vale la pena meter tiktoken solo para esto.
+  const MAX_CHARS = 28000;
+  const truncated = contenido.length > MAX_CHARS ? contenido.slice(0, MAX_CHARS) : contenido;
+
+  const { embedding } = await embed({
+    model: openai.embedding(MODELO_EMBEDDING),
+    value: truncated,
+    providerOptions: {
+      openai: {
+        dimensions: EMBEDDING_DIMS,
+      },
+    },
+    maxRetries: 2,
+  });
+
+  if (embedding.length !== EMBEDDING_DIMS) {
+    throw new Error(`Embedding tiene ${embedding.length} dims, esperaba ${EMBEDDING_DIMS}`);
+  }
+  return embedding;
+}
+
+// ─── Procesamiento por documento ─────────────────────────────────────────────
+
+type Result =
+  | { ok: true; id: string; titulo: string; charsTexto: number; tipoOperacion: string | null }
+  | { ok: false; id: string; titulo: string; error: string };
+
+async function processDoc(doc: DocRow): Promise<Result> {
+  const startedAt = Date.now();
+  try {
+    if (!DRY_RUN) {
+      const locked = await markProcessing(doc.id);
+      if (!locked) {
+        return {
+          ok: false,
+          id: doc.id,
+          titulo: doc.titulo,
+          error: 'no se pudo lockear (otro proceso lo tomó?)',
+        };
+      }
+    }
+
+    const pdf = await downloadPdf(doc.pdf_url);
+    const extraccion = await extractWithClaude(pdf, doc.titulo);
+    const embedding = await embedContent(extraccion.contenido_texto);
+
+    if (!DRY_RUN) {
+      await writeResult(doc.id, extraccion, embedding);
+    }
+
+    const ms = Date.now() - startedAt;
+    console.log(
+      `✓ ${doc.titulo} [${doc.id.slice(0, 8)}] — ` +
+        `${extraccion.contenido_texto.length} chars, ` +
+        `tipo=${extraccion.tipo_operacion ?? '-'}, ` +
+        `partes=${extraccion.partes.length}, ${ms}ms`
+    );
+
+    return {
+      ok: true,
+      id: doc.id,
+      titulo: doc.titulo,
+      charsTexto: extraccion.contenido_texto.length,
+      tipoOperacion: extraccion.tipo_operacion,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!DRY_RUN) await writeError(doc.id, err);
+    console.error(`✗ ${doc.titulo} [${doc.id.slice(0, 8)}] — ${msg}`);
+    return { ok: false, id: doc.id, titulo: doc.titulo, error: msg };
+  }
+}
+
+// ─── Runner con pool de concurrencia ─────────────────────────────────────────
+
+async function runPool(docs: DocRow[]): Promise<Result[]> {
+  const results: Result[] = [];
+  let index = 0;
+
+  async function worker() {
+    for (;;) {
+      const i = index++;
+      if (i >= docs.length) return;
+      const r = await processDoc(docs[i]);
+      results.push(r);
+    }
+  }
+
+  const workers = Array.from({ length: Math.max(1, CONCURRENCY) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('─────────────────────────────────────────────────────');
+  console.log(' extract-documento-contents');
+  console.log('─────────────────────────────────────────────────────');
+  console.log(` DRY_RUN      = ${DRY_RUN}`);
+  console.log(` LIMIT        = ${LIMIT ?? '(todos)'}`);
+  console.log(` ONLY_ID      = ${ONLY_ID ?? '-'}`);
+  console.log(` EMPRESA_ID   = ${EMPRESA_ID ?? '(todas)'}`);
+  console.log(` CONCURRENCY  = ${CONCURRENCY}`);
+  console.log(` MODELO       = ${MODELO_CLAUDE}`);
+  console.log(` EMBEDDING    = ${MODELO_EMBEDDING} @ ${EMBEDDING_DIMS} dims`);
+  console.log('');
+
+  const docs = await fetchPendingDocs();
+  console.log(`Documentos a procesar: ${docs.length}`);
+  if (docs.length === 0) {
+    console.log('Nada que hacer. Salgo.');
+    return;
+  }
+
+  const t0 = Date.now();
+  const results = await runPool(docs);
+  const ms = Date.now() - t0;
+
+  const ok = results.filter((r): r is Extract<Result, { ok: true }> => r.ok);
+  const bad = results.filter((r): r is Extract<Result, { ok: false }> => !r.ok);
+
+  console.log('');
+  console.log('─── Reporte ─────────────────────────────────────────');
+  console.log(`Total:         ${results.length}`);
+  console.log(`Completados:   ${ok.length}`);
+  console.log(`Errores:       ${bad.length}`);
+  console.log(`Tiempo total:  ${(ms / 1000).toFixed(1)}s`);
+  console.log(`Promedio:      ${(ms / Math.max(1, results.length) / 1000).toFixed(1)}s/doc`);
+
+  if (bad.length > 0) {
+    console.log('');
+    console.log('Errores:');
+    for (const b of bad) {
+      console.log(`  - ${b.titulo} [${b.id.slice(0, 8)}]: ${b.error}`);
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log('');
+    console.log('⚠️  DRY_RUN=1 — no se escribió nada en la DB.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Resumen

Segundo PR del plan. Procesa los PDFs adjuntos a \`erp.documentos\`, extrae texto + metadatos legales estructurados con Claude, genera embedding con OpenAI, y puebla las columnas creadas en el PR A.

**⚠️ Depende del PR A (#129) — mergear ese primero.** Branch base de este PR es \`feat/documentos-extraccion-schema\`; se rebasea a \`main\` automático cuando #129 mergee.

## Qué hace el script

\`scripts/extract-documento-contents.ts\` itera cada documento con \`extraccion_status IN ('pendiente','error')\` que tenga un adjunto con \`rol='documento_principal'\`:

1. Descarga el PDF del bucket privado \`adjuntos\`.
2. Llama a \`claude-opus-4-7\` (multimodal, OCR incluido para escaneados) con un Zod schema. Extrae:
   - \`descripcion\` humana (≤500 chars)
   - \`contenido_texto\` completo (con \`[ilegible]\` donde no se pueda leer)
   - Campos legales: \`tipo_operacion\`, \`monto\`, \`moneda\`, \`superficie_m2\`, \`ubicacion_predio\`, \`municipio\`, \`estado\`, \`folio_real\`, \`libro_tomo\`
   - \`partes[]\` con rol, nombre, RFC, representante
3. Genera embedding con \`text-embedding-3-large\` truncado a 1536 dims (Matryoshka).
4. UPDATE \`erp.documentos\` con todo + \`extraccion_status='completado'\`.

## Invariantes

- **Idempotente:** la segunda corrida salta los \`completado\`.
- **Reintenta errores:** \`extraccion_status='error'\` sí se re-procesa (útil tras bug fixes).
- **Lock optimistic:** \`markProcessing\` solo pasa si sigue pendiente/error → previene double-processing si alguien corre dos instancias.
- **Errores capturan stack** en \`extraccion_error\` (truncado a 2000 chars) para debug.
- **Respeta los status nuevos** definidos en el PR A (pendiente/procesando/completado/error/omitido).

## Config vía env

| Variable | Propósito |
|---|---|
| \`ANTHROPIC_API_KEY\` | Claude Opus 4.7 |
| \`OPENAI_API_KEY\` | text-embedding-3-large |
| \`NEXT_PUBLIC_SUPABASE_URL\` + \`SUPABASE_SERVICE_ROLE_KEY\` | Supabase (bypassa RLS + storage) |
| \`DRY_RUN=1\` | No escribe en DB, solo imprime |
| \`LIMIT=<n>\` | Procesa máximo n docs |
| \`ONLY_ID=<uuid>\` | Debug: un doc específico |
| \`CONCURRENCY=<n>\` | Paralelos (default 2) |
| \`EMPRESA_ID=<uuid>\` | Filtra por empresa |

## Uso

\`\`\`bash
# Preview de qué haría (no escribe)
DRY_RUN=1 LIMIT=3 npx tsx scripts/extract-documento-contents.ts

# Procesar 10 docs para evaluar calidad
LIMIT=10 npx tsx scripts/extract-documento-contents.ts

# Producción (todos los pendientes)
CONCURRENCY=3 npx tsx scripts/extract-documento-contents.ts
\`\`\`

## Validación con 1 documento real

Escritura #574 de DILESA (cancelación de reserva de dominio, 8.8 MB, Dic 2025) — extracción completa en 65 s:

| Campo | Valor |
|---|---|
| descripcion | "Escritura Pública No. 574 de fecha 4 de diciembre de 2025 ante el Notario 25 de Piedras Negras, que contiene la cancelación de reserva de dominio otorgada por Marco Antonio Perales Domínguez y Silvia..." |
| tipo_operacion | cancelacion de reserva de dominio |
| superficie_m2 | 529,349.23 (≈52.9 ha) |
| municipio / estado | Piedras Negras / Coahuila |
| folio_real | 48930 |
| libro_tomo | Volumen Octavo, Libro XI |
| partes | 3 (vendedor, consentimiento conyugal, comprador con representante) — todas con RFC |
| contenido_texto | 4,525 chars |
| embedding | 1536 dims |

## Quirk a tener en cuenta

\`\`\`ts
const anthropic = createAnthropic({ baseURL: 'https://api.anthropic.com/v1' });
\`\`\`

Tenemos que setear \`baseURL\` explícito porque el SDK respeta \`ANTHROPIC_BASE_URL\` del env si está presente (rompe cuando el script corre dentro de Claude Code, que exporta esa variable con un proxy interno). El valor explícito coincide con el default oficial.

## Costo estimado

- Claude Opus 4.7 con PDF de ~10 pág + output estructurado: ~\$0.05/doc
- OpenAI embedding (1 llamada con ~1k-4k tokens): ~\$0.0005/doc
- Para los ~500 documentos de DILESA: **~\$25 USD total**

## Test plan

- [ ] \`DRY_RUN=1 LIMIT=3\` y revisar output
- [ ] \`LIMIT=10\` y revisar calidad en DB vs PDFs originales
- [ ] Query de sanidad: \`SELECT COUNT(*) FROM erp.documentos WHERE extraccion_status='completado'\`
- [ ] Probar full-text: \`SELECT titulo FROM erp.documentos WHERE contenido_texto_tsv @@ plainto_tsquery('spanish', 'reserva de dominio')\`
- [ ] Probar búsqueda semántica con embedding de referencia

## Siguiente

**PR C:** UI — mostrar los campos extraídos en la tabla y vista de detalle, buscador híbrido (texto + filtros estructurados), búsqueda semántica.

Una vez que el PR A esté mergeado, correr el batch sobre DILESA (~4.5 hrs @ concurrency 2, ~1.5 hrs @ concurrency 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)