### PR TITLE
fix(documentos): Ghostscript WASM para que "Procesar con IA" funcione en Vercel

### DIFF
--- a/lib/documentos/extraction-core.ts
+++ b/lib/documentos/extraction-core.ts
@@ -7,15 +7,23 @@
  * candidatos, bajar del bucket) vive en los call sites, no aquí.
  */
 
-import { spawn } from 'node:child_process';
-import { readFile, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { openai } from '@ai-sdk/openai';
 import { embed, generateObject } from 'ai';
 import { z } from 'zod';
+
+// Ghostscript via WebAssembly (~16 MB de bundle, pero funciona en cualquier
+// runtime: Mac local, Vercel Functions, Linux CI, etc. Antes usábamos spawn
+// del binary nativo de gs, lo cual rompía en serverless donde no hay gs).
+// Import dinámico para no cargar el wasm en módulos que no lo usan.
+type GsModuleFactory = (init?: unknown) => Promise<{
+  callMain: (args: string[]) => number;
+  FS: {
+    writeFile: (path: string, data: Uint8Array) => void;
+    readFile: (path: string) => Uint8Array;
+    unlink: (path: string) => void;
+  };
+}>;
 
 // ─── Configuración ───────────────────────────────────────────────────────────
 
@@ -104,43 +112,97 @@ export const ExtraccionSchema = z.object({
 
 export type Extraccion = z.infer<typeof ExtraccionSchema>;
 
-// ─── Compresión con Ghostscript ──────────────────────────────────────────────
+// ─── Compresión con Ghostscript (WASM) ───────────────────────────────────────
+
+// Cache singleton del módulo wasm — la inicialización (parse del .wasm,
+// compile, instanciate) es ~500ms y se reusa entre invocaciones de la
+// misma función serverless o del mismo proceso del script batch.
+let cachedGsModulePromise: ReturnType<GsModuleFactory> | null = null;
+
+async function loadGsModule(): ReturnType<GsModuleFactory> {
+  if (!cachedGsModulePromise) {
+    // Import dinámico para que el wasm solo se cargue cuando realmente
+    // hace falta comprimir (PDFs pequeños no lo necesitan).
+    //
+    // Pasamos `wasmBinary` precargado en lugar de dejar que el módulo de
+    // Emscripten haga `fetch(path)` — fetch en Node 18+ exige una URL válida
+    // (http://, https://, file://) y el resolver interno del módulo arma un
+    // path absoluto sin protocolo, lo cual rompe con ERR_INVALID_URL.
+    cachedGsModulePromise = (async () => {
+      const [factoryMod, fsMod, pathMod, moduleMod] = await Promise.all([
+        import('@jspawn/ghostscript-wasm'),
+        import('node:fs/promises'),
+        import('node:path'),
+        import('node:module'),
+      ]);
+      const factory = (factoryMod as unknown as { default: GsModuleFactory }).default;
+      // `require.resolve` desde el propio módulo de gs-wasm nos da el path
+      // absoluto de su `gs.js`; el `.wasm` vive junto a él. Funciona en dev
+      // (node_modules local) y en Vercel Functions (bundle de la function).
+      const require = moduleMod.createRequire(import.meta.url);
+      const gsJsPath = require.resolve('@jspawn/ghostscript-wasm');
+      const wasmPath = pathMod.join(pathMod.dirname(gsJsPath), 'gs.wasm');
+      const wasmBinary = await fsMod.readFile(wasmPath);
+
+      // El módulo ignora `wasmBinary` y prefiere fetch (que falla en Node con
+      // un path absoluto). Overridemos `instantiateWasm` para controlar la
+      // carga directamente desde el Buffer — funciona en cualquier runtime.
+      return factory({
+        wasmBinary,
+        instantiateWasm(
+          imports: WebAssembly.Imports,
+          done: (instance: WebAssembly.Instance) => void
+        ) {
+          WebAssembly.instantiate(wasmBinary, imports)
+            .then((result) => done(result.instance))
+            .catch((err) => {
+              console.error('[gs-wasm] instantiate failed:', err);
+              throw err;
+            });
+          return {};
+        },
+      });
+    })();
+  }
+  return cachedGsModulePromise;
+}
 
 export async function compressPdf(
   input: Uint8Array,
   preset: '/ebook' | '/screen' = '/ebook'
 ): Promise<Uint8Array> {
-  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-  const tmpIn = join(tmpdir(), `bsop-extract-${stamp}-in.pdf`);
-  const tmpOut = join(tmpdir(), `bsop-extract-${stamp}-out.pdf`);
+  const gs = await loadGsModule();
+  // El FS de Emscripten es una memoria virtual aislada — no toca disco real.
+  // Escribimos input.pdf, corremos gs, leemos out.pdf, limpiamos.
+  const inPath = `/in-${Date.now()}.pdf`;
+  const outPath = `/out-${Date.now()}.pdf`;
   try {
-    await writeFile(tmpIn, input);
-    await new Promise<void>((resolve, reject) => {
-      const proc = spawn('gs', [
-        '-sDEVICE=pdfwrite',
-        '-dCompatibilityLevel=1.4',
-        `-dPDFSETTINGS=${preset}`,
-        '-dNOPAUSE',
-        '-dQUIET',
-        '-dBATCH',
-        `-sOutputFile=${tmpOut}`,
-        tmpIn,
-      ]);
-      let stderr = '';
-      proc.stderr.on('data', (chunk) => {
-        stderr += String(chunk);
-      });
-      proc.on('error', reject);
-      proc.on('exit', (code) => {
-        if (code === 0) resolve();
-        else reject(new Error(`gs exit ${code}: ${stderr.slice(0, 500)}`));
-      });
-    });
-    const out = await readFile(tmpOut);
-    return new Uint8Array(out);
+    gs.FS.writeFile(inPath, input);
+    const exitCode = gs.callMain([
+      '-sDEVICE=pdfwrite',
+      '-dCompatibilityLevel=1.4',
+      `-dPDFSETTINGS=${preset}`,
+      '-dNOPAUSE',
+      '-dQUIET',
+      '-dBATCH',
+      `-sOutputFile=${outPath}`,
+      inPath,
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(`ghostscript-wasm exit ${exitCode}`);
+    }
+    return gs.FS.readFile(outPath);
   } finally {
-    await rm(tmpIn, { force: true }).catch(() => {});
-    await rm(tmpOut, { force: true }).catch(() => {});
+    try {
+      gs.FS.unlink(inPath);
+    } catch {
+      /* archivo puede no existir si writeFile falló */
+    }
+    try {
+      gs.FS.unlink(outPath);
+    } catch {
+      /* archivo puede no existir si gs falló */
+    }
   }
 }
 

--- a/lib/documentos/ghostscript-wasm.d.ts
+++ b/lib/documentos/ghostscript-wasm.d.ts
@@ -1,0 +1,16 @@
+// Declaración mínima para `@jspawn/ghostscript-wasm` — el package no
+// envía types. Solo necesitamos `callMain` y el FS de Emscripten para
+// escribir/leer/borrar archivos en la memoria virtual del módulo.
+declare module '@jspawn/ghostscript-wasm' {
+  type GsModule = {
+    callMain: (args: string[]) => number;
+    FS: {
+      writeFile: (path: string, data: Uint8Array) => void;
+      readFile: (path: string) => Uint8Array;
+      unlink: (path: string) => void;
+    };
+  };
+  type GsModuleFactory = (init?: unknown) => Promise<GsModule>;
+  const factory: GsModuleFactory;
+  export default factory;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -57,6 +57,14 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  // Vercel/Next.js hace "file tracing" para decidir qué archivos subir con
+  // cada Function serverless. Normalmente detecta imports JS automáticamente,
+  // pero los assets no-JS dentro de node_modules (como `.wasm`) no siempre
+  // los recoge. `outputFileTracingIncludes` fuerza la inclusión del wasm de
+  // Ghostscript en el bundle del route handler que lo usa.
+  outputFileTracingIncludes: {
+    '/api/documentos/[id]/extract': ['node_modules/@jspawn/ghostscript-wasm/gs.wasm'],
+  },
   async headers() {
     return [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ai-sdk/anthropic": "^3.0.71",
         "@ai-sdk/openai": "^3.0.53",
         "@base-ui/react": "^1.3.0",
+        "@jspawn/ghostscript-wasm": "^0.0.2",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.100.0",
         "@tiptap/extension-image": "^3.22.3",
@@ -2296,6 +2297,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@jspawn/ghostscript-wasm": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@jspawn/ghostscript-wasm/-/ghostscript-wasm-0.0.2.tgz",
+      "integrity": "sha512-IhGvfXNezc+V3jyJlmjz7oxrjWPqFPcz1gqRdo0Y7EkVyFuL1A+tCRnQXx/BHQZPRvBDA+Uf0EqkvXzfMzoDcw==",
+      "license": "AGPL-3.0"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@ai-sdk/anthropic": "^3.0.71",
     "@ai-sdk/openai": "^3.0.53",
     "@base-ui/react": "^1.3.0",
+    "@jspawn/ghostscript-wasm": "^0.0.2",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.100.0",
     "@tiptap/extension-image": "^3.22.3",


### PR DESCRIPTION
## Resumen

El \`POST /api/documentos/[id]/extract\` fallaba en producción con \`spawn gs ENOENT\` — Vercel Functions son Linux serverless sin gs instalado. Sustituyo el spawn nativo por **\`@jspawn/ghostscript-wasm\`** (Ghostscript compilado a WebAssembly, 16 MB).

## Cambios

- \`lib/documentos/extraction-core.ts\`:
  - Quito spawn + child_process + tmpdir + readFile/writeFile/rm (no más disco real)
  - Singleton \`loadGsModule()\` cacheado entre invocaciones (~500ms init)
  - \`compressPdf()\` usa el FS virtual de Emscripten (memoria)
  - Override de \`instantiateWasm\` pasando el Buffer precargado — el módulo internamente intenta \`fetch(path)\` que falla en Node con \`ERR_INVALID_URL\`
- \`lib/documentos/ghostscript-wasm.d.ts\`: types mínimos (el package no los envía)
- \`next.config.ts\`: \`outputFileTracingIncludes\` fuerza que el \`.wasm\` se copie al bundle de la Function (si no, Next detecta imports JS pero no el asset binario adyacente)
- \`package.json\`: +\`@jspawn/ghostscript-wasm@0.0.2\`

## Validación local

| PDF | Antes (gs nativo) | Después (wasm) |
|---|---|---|
| DILESA #574 (8.44 MB) | 2.65 MB en ~2s | 2.65 MB en 5.4s |

Mismo output funcional, ~2.5× más lento que nativo pero portable y funciona en Vercel.

## API pública sin cambios

\`compressPdf(input, preset)\` mantiene su firma. El script batch (\`scripts/extract-documento-contents.ts\`) hereda el fix automático — sigue corriendo en Mac local igual, ahora también funciona en cualquier Linux sin gs.

## Test plan

- [ ] Merge + deploy
- [ ] En https://bsop.io abrir un documento con PDF >20 MB (por ejemplo el que fallaba: "DILESA-2025-10-Escritura Numero 490-Compraventa", 29.6 MB)
- [ ] Click "Procesar con IA" → spinner 90-150s (wasm más lento que nativo, más el tiempo de Claude) → datos rellenos
- [ ] PDFs <20 MB deben seguir funcionando sin compresión

## Nota sobre licencia

\`@jspawn/ghostscript-wasm\` y Ghostscript original son AGPL-3.0. No cambia la situación de BSOP (ya usaba gs como dependencia del pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)