### PR TITLE
fix(documentos): bundlear @jspawn/ghostscript-wasm entero en la Function

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -57,13 +57,15 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  // Vercel/Next.js hace "file tracing" para decidir qué archivos subir con
-  // cada Function serverless. Normalmente detecta imports JS automáticamente,
-  // pero los assets no-JS dentro de node_modules (como `.wasm`) no siempre
-  // los recoge. `outputFileTracingIncludes` fuerza la inclusión del wasm de
-  // Ghostscript en el bundle del route handler que lo usa.
+  // `@jspawn/ghostscript-wasm` es un módulo de Emscripten con un gran
+  // `gs.js` (~10 MB) y su `gs.wasm` adyacente. Lo marcamos como external
+  // para que webpack no intente parsearlo/bundle'arlo (rompe el top-level
+  // `require()` que hace Emscripten para su FS de Node), y forzamos que
+  // el paquete completo — JS + WASM — viaje con la Function serverless
+  // vía outputFileTracingIncludes.
+  serverExternalPackages: ['@jspawn/ghostscript-wasm'],
   outputFileTracingIncludes: {
-    '/api/documentos/[id]/extract': ['node_modules/@jspawn/ghostscript-wasm/gs.wasm'],
+    '/api/documentos/[id]/extract': ['node_modules/@jspawn/ghostscript-wasm/**'],
   },
   async headers() {
     return [


### PR DESCRIPTION
## Resumen

Fix al fix anterior (#138). La compresión WASM volvía a fallar en producción con:

\`\`\`
Cannot find module '@jspawn/ghostscript-wasm'
Require stack: /var/task/lib/documentos/extraction-core.ts
\`\`\`

El \`.wasm\` se copiaba al bundle pero no el paquete JS. Dos configs en \`next.config.ts\`:

1. **\`serverExternalPackages\`** — webpack lo deja como external, Node hace \`require\` real al runtime (evita parsear el \`gs.js\` de Emscripten que tiene \`require\` condicional)
2. **\`outputFileTracingIncludes\` con \`**\`** — el paquete completo (JS + metadata + wasm) viaja con la Function serverless

## Test plan

- [ ] Merge + deploy (~90s)
- [ ] En bsop.io, "Procesar con IA" sobre el PDF de 29.6 MB debería arrancar correctamente
- [ ] Mira el banner rojo — si sigue dando error, dime el mensaje

🤖 Generated with [Claude Code](https://claude.com/claude-code)