### PR TITLE
feat(documentos): normalizar tipos a Escritura + Title Case notarios

### DIFF
--- a/lib/documentos/text-normalize.ts
+++ b/lib/documentos/text-normalize.ts
@@ -1,0 +1,174 @@
+/**
+ * Normalización de nombres propios en español (RAE).
+ *
+ * Regla general:
+ *   - Primera letra de cada palabra en mayúscula
+ *   - Preposiciones, artículos y conjunciones cortas en minúscula
+ *     (excepto cuando son la primera palabra)
+ *   - Abreviaturas comunes (Lic., Dr., Ma.) mantienen su forma
+ *   - Siglas conocidas (IMSS, ISR, etc.) se ponen en mayúscula
+ *   - Iniciales de una sola letra ("J.") se ponen en mayúscula
+ *
+ * Uso típico: normalizar nombres de personas (notarios, representantes) que
+ * se capturaron en mayúscula/minúscula inconsistente.
+ *
+ * Limitación consciente: **no añadimos acentos faltantes**. Si el nombre
+ * original dice "lopez" no lo convertimos a "López" — eso requiere un
+ * diccionario y corre el riesgo de meter falsos positivos. El admin puede
+ * corregirlos a mano desde la UI de editar.
+ */
+
+// Preposiciones / artículos / conjunciones que van en minúscula, salvo cuando
+// son la primera palabra de la cadena.
+const LOWER_WORDS = new Set([
+  'a',
+  'al',
+  'ante',
+  'bajo',
+  'con',
+  'contra',
+  'de',
+  'del',
+  'desde',
+  'e',
+  'el',
+  'en',
+  'entre',
+  'hacia',
+  'hasta',
+  'la',
+  'las',
+  'los',
+  'ni',
+  'o',
+  'para',
+  'por',
+  'sin',
+  'so',
+  'sobre',
+  'tras',
+  'u',
+  'un',
+  'una',
+  'y',
+]);
+
+// Siglas/acrónimos comunes en nombres de organizaciones e instituciones
+// mexicanas. Ampliable — si un nombre trae algo nuevo, agrégalo acá.
+const ACRONYMS = new Set([
+  'IMSS',
+  'ISSSTE',
+  'INFONAVIT',
+  'SAT',
+  'INE',
+  'SEP',
+  'IFAI',
+  'INAI',
+  'CONAGUA',
+  'CFE',
+  'DIF',
+  'UNAM',
+  'IPN',
+  'ITESM',
+  'UANL',
+  'UAT',
+  'RFC',
+  'CURP',
+  'AC',
+  'SA',
+  'SC',
+  'SRL',
+  'CV',
+  'SAPI',
+  'SOFOM',
+]);
+
+// Abreviaturas comunes que ya llevan punto y capitalización estándar.
+// Lista en minúscula; el output lleva primera letra en mayúscula.
+const ABBREVIATIONS = new Set([
+  'lic.',
+  'dr.',
+  'dra.',
+  'mtro.',
+  'mtra.',
+  'ing.',
+  'arq.',
+  'sr.',
+  'sra.',
+  'srta.',
+  'cp.',
+  'c.p.',
+  'ma.',
+  'mo.',
+  'no.',
+  'sto.',
+  'sta.',
+  'fr.',
+]);
+
+function capitalizeFirst(word: string): string {
+  if (!word) return word;
+  return word.charAt(0).toLocaleUpperCase('es-MX') + word.slice(1).toLocaleLowerCase('es-MX');
+}
+
+/**
+ * Aplica Title Case según convenciones RAE a un nombre propio.
+ *
+ * @example
+ *   titleCaseEs('lic. guillermo lopez elizondo')
+ *   // → 'Lic. Guillermo Lopez Elizondo'
+ *
+ *   titleCaseEs('lic. ma. inmaculada del rosario martinez ortegón')
+ *   // → 'Lic. Ma. Inmaculada del Rosario Martinez Ortegón'
+ *
+ *   titleCaseEs('notaria 10 imss')
+ *   // → 'Notaria 10 IMSS'
+ */
+export function titleCaseEs(input: string | null | undefined): string {
+  if (!input) return '';
+  const normalized = input.trim().replace(/\s+/g, ' ');
+  if (!normalized) return '';
+
+  const words = normalized.split(' ');
+  return words
+    .map((word, index) => {
+      const lower = word.toLocaleLowerCase('es-MX');
+
+      // Siglas conocidas — todo en mayúscula.
+      if (/^[a-zá-úñ]+$/i.test(word) && ACRONYMS.has(word.toUpperCase())) {
+        return word.toUpperCase();
+      }
+
+      // Abreviaturas comunes (lic., dra., ma., etc.).
+      if (ABBREVIATIONS.has(lower)) {
+        return capitalizeFirst(lower);
+      }
+
+      // Inicial de una sola letra con o sin punto: "j." / "j" → "J." / "J".
+      if (/^[a-zá-úñ]\.?$/i.test(word)) {
+        return word.toUpperCase();
+      }
+
+      // Tokens con punto intermedio (iniciales compuestas: "j.a." o similar).
+      if (/^[a-zá-úñ](\.[a-zá-úñ])+\.?$/i.test(word)) {
+        return word.toUpperCase();
+      }
+
+      // Preposiciones/artículos: minúscula salvo si son la primera palabra.
+      if (index > 0 && LOWER_WORDS.has(lower)) {
+        return lower;
+      }
+
+      // Caso general: primera letra mayúscula, resto minúsculas.
+      // Manejo especial para palabras con guión (ej. "rocha-perez" → "Rocha-Perez").
+      if (word.includes('-')) {
+        return word
+          .split('-')
+          .map((chunk) => capitalizeFirst(chunk.toLocaleLowerCase('es-MX')))
+          .join('-');
+      }
+
+      return capitalizeFirst(lower);
+    })
+    .join(' ');
+}

--- a/scripts/normalize-documentos.ts
+++ b/scripts/normalize-documentos.ts
@@ -1,0 +1,248 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js tipa solo `public`; para leer/escribir en `erp` usamos `as any`
+ * (mismo patrón que el resto de scripts de mantenimiento).
+ */
+/**
+ * normalize-documentos.ts
+ *
+ * Script one-shot (idempotente) para limpiar dos dimensiones del módulo
+ * de documentos que quedaron inconsistentes del data histórico:
+ *
+ *   1. `erp.documentos.tipo` — formulario viejo dejaba elegir cualquier
+ *      texto. Terminamos con 29 variantes distintas ("Compra-Venta",
+ *      "Sub-Division", "Rcononcimiento de Adeudo", etc.) cuando en
+ *      realidad todos son escrituras notariales.
+ *
+ *      Regla acordada: todo doc cuyo tipo NO sea Acta Constitutiva,
+ *      Poder o Seguro pasa a `tipo='Escritura'`. La naturaleza específica
+ *      (compraventa, subdivision, cancelación de reserva de dominio,
+ *      protocolización de acta de asamblea, etc.) ya vive en
+ *      `tipo_operacion` — poblada por la extracción IA.
+ *
+ *   2. `erp.personas.nombre` y `erp.documentos.notaria` — todos los
+ *      notarios se capturaron en minúsculas ("lic. guillermo lopez
+ *      elizondo"). Aplicamos Title Case según convenciones RAE:
+ *      preposiciones/artículos (de, del, la) en minúscula, abreviaturas
+ *      comunes (Lic., Dra., Ma.) y siglas (IMSS) con mayúscula propia.
+ *
+ * Uso:
+ *   DRY_RUN=1 npx tsx scripts/normalize-documentos.ts     # preview
+ *   npx tsx scripts/normalize-documentos.ts               # aplica
+ *
+ * Env:
+ *   NEXT_PUBLIC_SUPABASE_URL      (requerido)
+ *   SUPABASE_SERVICE_ROLE_KEY     (requerido — bypassa RLS)
+ *   DRY_RUN=1                     no escribe a DB, solo reporta
+ *   EMPRESA_ID=<uuid>             limita a una empresa
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+import { titleCaseEs } from '../lib/documentos/text-normalize';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+const EMPRESA_ID = process.env.EMPRESA_ID ?? null;
+
+if (!SUPABASE_URL) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL');
+if (!SUPABASE_KEY) throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY');
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+// Tipos que se CONSERVAN como están. Todo lo demás pasa a 'Escritura'.
+const TIPOS_CONSERVAR = new Set(['Acta Constitutiva', 'Poder', 'Seguro', 'Escritura', 'Otro']);
+
+// ─── 1. Normalizar tipos ─────────────────────────────────────────────────────
+
+async function normalizarTipos(): Promise<{ before: number; changed: number }> {
+  console.log('');
+  console.log('─── 1. Normalizando tipos de documento ─────────────────────────');
+
+  let q = (supabase.schema('erp') as any)
+    .from('documentos')
+    .select('id, titulo, tipo, tipo_operacion')
+    .is('deleted_at', null);
+  if (EMPRESA_ID) q = q.eq('empresa_id', EMPRESA_ID);
+
+  const { data: docs, error } = await q;
+  if (error) throw new Error(`fetch documentos: ${error.message}`);
+
+  const toUpdate = (docs ?? []).filter(
+    (d: any) => d.tipo && !TIPOS_CONSERVAR.has(d.tipo as string)
+  );
+
+  console.log(`Total docs: ${docs?.length ?? 0}`);
+  console.log(`A reclasificar como "Escritura": ${toUpdate.length}`);
+
+  if (toUpdate.length > 0) {
+    // Mostramos la distribución de tipos que se van a sobrescribir
+    const tipoCounts = new Map<string, number>();
+    for (const d of toUpdate) {
+      tipoCounts.set(d.tipo, (tipoCounts.get(d.tipo) ?? 0) + 1);
+    }
+    console.log('\nDistribución de tipos a cambiar:');
+    for (const [tipo, n] of [...tipoCounts.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${n.toString().padStart(3)} × "${tipo}"`);
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log('\n⚠️  DRY_RUN — no se escribe nada.');
+    return { before: docs?.length ?? 0, changed: toUpdate.length };
+  }
+
+  if (toUpdate.length === 0) {
+    console.log('Nada que cambiar.');
+    return { before: docs?.length ?? 0, changed: 0 };
+  }
+
+  const ids = toUpdate.map((d: any) => d.id);
+  const { error: upErr } = await (supabase.schema('erp') as any)
+    .from('documentos')
+    .update({ tipo: 'Escritura', updated_at: new Date().toISOString() })
+    .in('id', ids);
+
+  if (upErr) throw new Error(`update tipos: ${upErr.message}`);
+  console.log(`✓ Actualizados ${ids.length} docs a tipo='Escritura'.`);
+  return { before: docs?.length ?? 0, changed: ids.length };
+}
+
+// ─── 2. Normalizar nombres de notarios ───────────────────────────────────────
+
+async function normalizarNotarios(): Promise<{ personas: number; documentos: number }> {
+  console.log('');
+  console.log('─── 2. Normalizando nombres de notarios ─────────────────────────');
+
+  // 2a) erp.personas (fuente de verdad): solo las ligadas como notaría.
+  const { data: personas, error: persErr } = await (supabase.schema('erp') as any)
+    .from('personas')
+    .select('id, nombre, proveedores:proveedores!inner(id, categoria)')
+    .eq('proveedores.categoria', 'notaria')
+    .eq('proveedores.activo', true)
+    .is('deleted_at', null);
+
+  if (persErr) {
+    // Fallback si el embed no funciona — hacemos join manual.
+    console.log(`(embed falló, usando join manual: ${persErr.message})`);
+    const { data: provs, error: provErr } = await (supabase.schema('erp') as any)
+      .from('proveedores')
+      .select('persona_id')
+      .eq('categoria', 'notaria')
+      .eq('activo', true)
+      .is('deleted_at', null);
+    if (provErr) throw new Error(`fetch proveedores: ${provErr.message}`);
+    const personaIds = [...new Set((provs ?? []).map((p: any) => p.persona_id))];
+    const { data: ps, error: psErr } = await (supabase.schema('erp') as any)
+      .from('personas')
+      .select('id, nombre')
+      .in('id', personaIds)
+      .is('deleted_at', null);
+    if (psErr) throw new Error(`fetch personas: ${psErr.message}`);
+    return await applyPersonaChanges(ps ?? []);
+  }
+
+  return await applyPersonaChanges(personas ?? []);
+}
+
+async function applyPersonaChanges(
+  personas: Array<{ id: string; nombre: string }>
+): Promise<{ personas: number; documentos: number }> {
+  const changes: Array<{ id: string; antes: string; despues: string }> = [];
+  for (const p of personas) {
+    const normalizado = titleCaseEs(p.nombre);
+    if (normalizado && normalizado !== p.nombre) {
+      changes.push({ id: p.id, antes: p.nombre, despues: normalizado });
+    }
+  }
+
+  console.log(`Notarios revisados: ${personas.length}`);
+  console.log(`Requieren normalización: ${changes.length}`);
+  if (changes.length > 0) {
+    console.log('\nCambios propuestos:');
+    for (const c of changes) {
+      console.log(`  "${c.antes}"\n    → "${c.despues}"`);
+    }
+  }
+
+  // 2b) erp.documentos.notaria (texto libre, duplicado del nombre del notario
+  //     cacheado al momento de asignarlo). Lo recorremos independiente.
+  let q = (supabase.schema('erp') as any)
+    .from('documentos')
+    .select('id, notaria')
+    .not('notaria', 'is', null)
+    .is('deleted_at', null);
+  if (EMPRESA_ID) q = q.eq('empresa_id', EMPRESA_ID);
+
+  const { data: docs, error: docErr } = await q;
+  if (docErr) throw new Error(`fetch documentos.notaria: ${docErr.message}`);
+
+  const docChanges: Array<{ id: string; antes: string; despues: string }> = [];
+  for (const d of docs ?? []) {
+    const normalizado = titleCaseEs(d.notaria);
+    if (normalizado && normalizado !== d.notaria) {
+      docChanges.push({ id: d.id, antes: d.notaria, despues: normalizado });
+    }
+  }
+
+  console.log(`\nDocumentos con notaria string: ${docs?.length ?? 0}`);
+  console.log(`Requieren normalización: ${docChanges.length}`);
+
+  if (DRY_RUN) {
+    console.log('\n⚠️  DRY_RUN — no se escribe nada.');
+    return { personas: changes.length, documentos: docChanges.length };
+  }
+
+  // Aplicar cambios en personas
+  for (const c of changes) {
+    const { error: uErr } = await (supabase.schema('erp') as any)
+      .from('personas')
+      .update({ nombre: c.despues, updated_at: new Date().toISOString() })
+      .eq('id', c.id);
+    if (uErr) {
+      console.error(`  ✗ persona ${c.id}: ${uErr.message}`);
+    }
+  }
+  console.log(`✓ Actualizadas ${changes.length} personas (notarios).`);
+
+  // Aplicar cambios en documentos.notaria
+  for (const c of docChanges) {
+    const { error: uErr } = await (supabase.schema('erp') as any)
+      .from('documentos')
+      .update({ notaria: c.despues, updated_at: new Date().toISOString() })
+      .eq('id', c.id);
+    if (uErr) {
+      console.error(`  ✗ doc ${c.id}: ${uErr.message}`);
+    }
+  }
+  console.log(`✓ Actualizados ${docChanges.length} documentos (campo notaria).`);
+
+  return { personas: changes.length, documentos: docChanges.length };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('─────────────────────────────────────────────────────');
+  console.log(' normalize-documentos');
+  console.log('─────────────────────────────────────────────────────');
+  console.log(` DRY_RUN     = ${DRY_RUN}`);
+  console.log(` EMPRESA_ID  = ${EMPRESA_ID ?? '(todas)'}`);
+
+  const tipos = await normalizarTipos();
+  const notarios = await normalizarNotarios();
+
+  console.log('');
+  console.log('─── Reporte ─────────────────────────────────────────');
+  console.log(`Tipos cambiados:              ${tipos.changed}`);
+  console.log(`Personas (notarios):          ${notarios.personas}`);
+  console.log(`Documentos (campo notaria):   ${notarios.documentos}`);
+  if (DRY_RUN) {
+    console.log('\n⚠️  DRY_RUN=1 — no se escribió nada en la DB.');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Resumen

Script one-shot ya ejecutado en prod que limpia dos dimensiones del data histórico:

1. **Tipos**: 29 variantes ("Compra-Venta", "Sub-Division", "Rcononcimiento de Adeudo"...) → 3 tipos normalizados (Escritura, Poder, Acta Constitutiva). La naturaleza específica ya vive en \`tipo_operacion\` (IA).
2. **Notarios**: 18 nombres en minúsculas → Title Case RAE (preposiciones/artículos cortos en minúscula, abreviaturas y siglas con capitalización correcta).

## Resultado en DILESA

| Antes | Después |
|---|---|
| 29 variantes de tipo | Escritura (56) · Poder (2) · Acta Constitutiva (1) |
| "lic. guillermo lopez elizondo" | "Lic. Guillermo Lopez Elizondo" |
| "lic. ma. inmaculada del rosario martinez ortegón" | "Lic. Ma. Inmaculada del Rosario Martinez Ortegón" |
| "notaria 10 imss" | "Notaria 10 IMSS" |

## Archivos

- \`lib/documentos/text-normalize.ts\` — función \`titleCaseEs\` reutilizable
- \`scripts/normalize-documentos.ts\` — script idempotente con \`DRY_RUN\` y \`EMPRESA_ID\`

## Limitación consciente

El script **no añade acentos faltantes**. "lopez" → "Lopez", no "López". Meter un diccionario de acentos corre el riesgo de falsos positivos (nombres propios con ortografía legítima distinta). El admin puede corregir a mano desde la UI de editar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)