### PR TITLE
fix(ui): bundle de quick wins de UX/UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,6 +13,9 @@
   --card: oklch(1 0 0);
   --border: oklch(0.922 0 0);
   --text: #1a1d27;
+  /* Texto secundario con contraste AA sobre --bg (#f8f9fc). */
+  --text-muted: #4b5563; /* ~7:1 */
+  --text-subtle: #6b7280; /* ~4.8:1 */
   --muted: oklch(0.97 0 0);
   --accent: #6c63ff;
   --accent-soft: #5a52e0;
@@ -53,6 +56,8 @@
   --card: oklch(0.205 0 0);
   --border: oklch(1 0 0 / 10%);
   --text: #f5f7fb;
+  --text-muted: rgba(245, 247, 251, 0.75);
+  --text-subtle: rgba(245, 247, 251, 0.55);
   --muted: oklch(0.269 0 0);
   --accent: #6c63ff;
   --accent-soft: #9d97ff;

--- a/app/inicio/page.tsx
+++ b/app/inicio/page.tsx
@@ -16,24 +16,11 @@ import { ContentShell } from '@/components/ui/content-shell';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { MisTareasWidget } from '@/components/inicio/mis-tareas-widget';
 import { FechasImportantesWidget } from '@/components/inicio/fechas-importantes-widget';
-
-function getGreeting() {
-  const hour = new Date().getHours();
-  if (hour < 12) return 'Buenos días';
-  if (hour < 19) return 'Buenas tardes';
-  return 'Buenas noches';
-}
-
-function formatToday(): string {
-  return new Date().toLocaleDateString('es-MX', {
-    weekday: 'long',
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
-}
+import { useLocale } from '@/lib/i18n';
+import { getGreeting, formatLongDate } from '@/lib/datetime/greeting';
 
 export default function InicioPage() {
+  const { t, locale } = useLocale();
   const [userName, setUserName] = useState<string>('');
 
   useEffect(() => {
@@ -55,12 +42,14 @@ export default function InicioPage() {
   return (
     <ContentShell>
       <header className="mb-6">
-        <p className="text-xs uppercase tracking-wider text-[var(--text)]/40">{formatToday()}</p>
+        <p className="text-xs uppercase tracking-wider text-[var(--text-subtle)]">
+          {formatLongDate(new Date(), locale)}
+        </p>
         <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--text)] sm:text-4xl">
-          {getGreeting()}
+          {getGreeting(new Date(), t)}
           {userName ? `, ${userName}` : ''}
         </h1>
-        <p className="mt-2 text-sm text-[var(--text)]/55">
+        <p className="mt-2 text-sm text-[var(--text-muted)]">
           Este es tu panel personal. Aquí vas a encontrar tus pendientes y las fechas que te
           importan.
         </p>

--- a/app/login/login-card.tsx
+++ b/app/login/login-card.tsx
@@ -20,10 +20,10 @@ export function LoginCard({ unauthorized }: { unauthorized: boolean }) {
             Acceso privado
           </div>
 
-          <h1 className="mt-5 text-3xl font-semibold tracking-tight text-white">
+          <h1 className="mt-5 text-3xl font-semibold tracking-tight text-[var(--text)]">
             Bienvenido de vuelta
           </h1>
-          <p className="mt-3 max-w-sm text-sm leading-6 text-white/60">
+          <p className="mt-3 max-w-sm text-sm leading-6 text-[var(--text-muted)]">
             Entra con tu cuenta de Google para acceder a BSOP y a tu panel privado de operaciones.
           </p>
 
@@ -62,7 +62,7 @@ export function LoginCard({ unauthorized }: { unauthorized: boolean }) {
             Entrar con Google
           </a>
 
-          <p className="mt-4 text-xs text-white/40">
+          <p className="mt-4 text-xs text-[var(--text-subtle)]">
             Solo las cuentas autorizadas pueden acceder a este espacio.
           </p>
         </div>

--- a/components/app-shell/account-menu.tsx
+++ b/components/app-shell/account-menu.tsx
@@ -70,7 +70,7 @@ export function AccountMenu({ user }: { user: AuthUser | null }) {
           <div className="max-w-56 truncate text-xs dark:text-white/90 text-[var(--text)]/90">
             {displayName}
           </div>
-          <div className="max-w-56 truncate text-[10px] dark:text-white/45 text-[var(--text)]/55">
+          <div className="max-w-56 truncate text-[10px] dark:text-white/45 text-[var(--text-muted)]">
             {displayEmail}
           </div>
         </div>
@@ -83,7 +83,7 @@ export function AccountMenu({ user }: { user: AuthUser | null }) {
             <div className="truncate text-xs font-medium dark:text-white text-[var(--text)]">
               {displayName}
             </div>
-            <div className="mt-1 text-xs dark:text-white/45 text-[var(--text)]/55">
+            <div className="mt-1 text-xs dark:text-white/45 text-[var(--text-muted)]">
               {displayEmail}
             </div>
           </div>

--- a/components/app-shell/app-shell.tsx
+++ b/components/app-shell/app-shell.tsx
@@ -4,6 +4,7 @@ import { Menu } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 import { usePathname } from 'next/navigation';
 import { useLocale } from '@/lib/i18n';
+import { getGreeting } from '@/lib/datetime/greeting';
 import { usePermissions } from '@/components/providers';
 import { Header } from './header';
 import { ImpersonationBanner } from './impersonation-banner';
@@ -42,13 +43,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   const displayName = user?.name ?? '';
 
-  const greeting = useMemo(() => {
-    const date = now ?? new Date();
-    const hour = date.getHours();
-    if (hour < 12) return t('greeting.morning');
-    if (hour < 19) return t('greeting.afternoon');
-    return t('greeting.evening');
-  }, [now, t]);
+  const greeting = useMemo(() => getGreeting(now ?? new Date(), t), [now, t]);
 
   const formattedDate = now
     ? now.toLocaleString(locale === 'es' ? 'es-MX' : 'en-US', {

--- a/components/app-shell/header.tsx
+++ b/components/app-shell/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bell, Moon, Sun } from 'lucide-react';
+import { Bell, ChevronDown, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useLocale } from '@/lib/i18n';
 import { AccountMenu } from './account-menu';
@@ -96,26 +96,43 @@ export function Header({
             <button
               type="button"
               onClick={() => setLocale(locale === 'es' ? 'en' : 'es')}
-              className="flex h-7 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--card)] px-2 text-[10px] font-semibold dark:text-white/70 text-[var(--text)]/70 transition hover:border-[var(--accent)] dark:hover:text-white hover:text-[var(--text)]"
+              className="flex h-7 items-center justify-center gap-1 rounded-xl border border-[var(--border)] bg-[var(--card)] px-2 text-[10px] font-semibold dark:text-white/70 text-[var(--text)]/70 transition hover:border-[var(--accent)] dark:hover:text-white hover:text-[var(--text)]"
               aria-label={t('header.toggle_locale')}
+              title={locale === 'es' ? 'Cambiar a English' : 'Change to Español'}
             >
               {locale === 'es' ? 'ES' : 'EN'}
-              <span className="mx-1 dark:text-white/25 text-[var(--text)]/25">|</span>
-              {locale === 'es' ? 'EN' : 'ES'}
+              <ChevronDown className="h-3 w-3" />
             </button>
 
             {/* Notifications bell */}
-            <div className="relative">
-              <Bell className="h-4 w-4 dark:text-white/70 text-[var(--text)]/70" />
-              <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--accent)] px-1 text-[10px] font-semibold text-white">
-                0
-              </span>
-            </div>
+            <NotificationsBell />
 
             <AccountMenu user={user} />
           </div>
         </div>
       </div>
     </header>
+  );
+}
+
+function NotificationsBell() {
+  const count = 0;
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        // TODO: abrir panel de notificaciones (pendiente de implementación)
+      }}
+      aria-label="Notificaciones"
+      title="Próximamente"
+      className="relative flex h-7 w-7 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--card)] dark:text-white/70 text-[var(--text)]/70 transition hover:border-[var(--accent)] dark:hover:text-white hover:text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
+    >
+      <Bell className="h-3.5 w-3.5" />
+      {count > 0 ? (
+        <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--accent)] px-1 text-[10px] font-semibold text-white">
+          {count}
+        </span>
+      ) : null}
+    </button>
   );
 }

--- a/components/app-shell/sidebar.tsx
+++ b/components/app-shell/sidebar.tsx
@@ -217,7 +217,7 @@ export function Sidebar({
                           return (
                             <div
                               key={child.label}
-                              className="px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-[0.16em] dark:text-white/35 text-[var(--text)]/40"
+                              className="px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-[0.16em] dark:text-white/35 text-[var(--text-subtle)]"
                             >
                               {child.label}
                             </div>
@@ -232,7 +232,7 @@ export function Sidebar({
                               'block rounded-xl border-l-2 px-3 py-2 text-xs transition',
                               childActive
                                 ? 'border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--accent)]'
-                                : 'border-transparent dark:text-white/48 text-[var(--text)]/55 hover:bg-[var(--card)] dark:hover:text-white/80 hover:text-[var(--text)]',
+                                : 'border-transparent dark:text-white/48 text-[var(--text-muted)] hover:bg-[var(--card)] dark:hover:text-white/80 hover:text-[var(--text)]',
                             ].join(' ')}
                           >
                             {child.label}
@@ -245,7 +245,7 @@ export function Sidebar({
 
                 {collapsed && hasChildren ? (
                   <div className="pointer-events-none absolute left-full top-0 z-50 ml-2 hidden min-w-48 rounded-2xl border border-[var(--border)] bg-[var(--panel)] p-2 opacity-0 shadow-2xl transition duration-200 group-hover/item:pointer-events-auto group-hover/item:block group-hover/item:opacity-100 md:block">
-                    <div className="px-2 pb-2 text-xs font-semibold uppercase tracking-[0.16em] dark:text-white/40 text-[var(--text)]/40">
+                    <div className="px-2 pb-2 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--text-subtle)]">
                       {label}
                     </div>
                     <div className="space-y-1">
@@ -254,7 +254,7 @@ export function Sidebar({
                           return (
                             <div
                               key={child.label}
-                              className="px-2 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-[0.16em] dark:text-white/35 text-[var(--text)]/40"
+                              className="px-2 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-[0.16em] dark:text-white/35 text-[var(--text-subtle)]"
                             >
                               {child.label}
                             </div>

--- a/components/inicio/fechas-importantes-widget.tsx
+++ b/components/inicio/fechas-importantes-widget.tsx
@@ -232,7 +232,7 @@ export function FechasImportantesWidget() {
         </div>
         <div>
           <h2 className="text-lg font-semibold text-[var(--text)]">Próximas fechas importantes</h2>
-          <p className="text-xs text-[var(--text)]/55">Cumpleaños y días festivos (30 días)</p>
+          <p className="text-xs text-[var(--text-muted)]">Cumpleaños y días festivos (30 días)</p>
         </div>
       </div>
 
@@ -294,7 +294,9 @@ export function FechasImportantesWidget() {
                     <p className="text-xs font-medium text-[var(--text)]/80">
                       {formatDiasFaltan(e.diasFaltan)}
                     </p>
-                    <p className="text-[11px] text-[var(--text)]/40">{formatFechaCorta(e.fecha)}</p>
+                    <p className="text-[11px] text-[var(--text-subtle)]">
+                      {formatFechaCorta(e.fecha)}
+                    </p>
                   </div>
                 </div>
               </li>

--- a/components/inicio/mis-tareas-widget.tsx
+++ b/components/inicio/mis-tareas-widget.tsx
@@ -13,9 +13,17 @@
  * Agrupa por fecha_vence (o fecha_compromiso si fecha_vence es null).
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { AlertCircle, Calendar, CheckCircle2, ChevronRight, Clock, ListTodo } from 'lucide-react';
+import {
+  AlertCircle,
+  Calendar,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  ListTodo,
+  RefreshCw,
+} from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import { Surface } from '@/components/ui/surface';
@@ -92,108 +100,96 @@ export function MisTareasWidget() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        if (!user?.email) {
-          if (!cancelled) {
-            setTasks([]);
-            setLoading(false);
-          }
-          return;
-        }
-
-        // core.usuarios por email
-        const { data: coreUser } = await supabase
-          .schema('core')
-          .from('usuarios')
-          .select('id')
-          .eq('email', user.email.toLowerCase())
-          .maybeSingle();
-
-        if (!coreUser) {
-          if (!cancelled) {
-            setTasks([]);
-            setLoading(false);
-          }
-          return;
-        }
-
-        // empresas del usuario
-        const { data: ue } = await supabase
-          .schema('core')
-          .from('usuarios_empresas')
-          .select('empresa_id')
-          .eq('usuario_id', coreUser.id)
-          .eq('activo', true);
-
-        const empresaIds = (ue ?? []).map((r: { empresa_id: string }) => r.empresa_id);
-        if (empresaIds.length === 0) {
-          if (!cancelled) {
-            setTasks([]);
-            setLoading(false);
-          }
-          return;
-        }
-
-        // empleados del usuario en esas empresas (match por email empresa o personal)
-        const emailLower = user.email.toLowerCase();
-        const { data: empleados } = await supabase
-          .schema('erp')
-          .from('v_empleados_full')
-          .select('empleado_id, empresa_id, email_empresa, email_personal')
-          .in('empresa_id', empresaIds)
-          .or(`email_empresa.eq.${emailLower},email_personal.eq.${emailLower}`);
-
-        const empleadoIds = (empleados ?? [])
-          .map((e: { empleado_id: string | null }) => e.empleado_id)
-          .filter((id: string | null): id is string => Boolean(id));
-
-        if (empleadoIds.length === 0) {
-          // Usuario no tiene ficha de empleado en ninguna empresa: no tareas personales.
-          if (!cancelled) {
-            setTasks([]);
-            setLoading(false);
-          }
-          return;
-        }
-
-        // tareas asignadas a este usuario en estado activo.
-        // Whitelist en vez de blacklist: si aparece un estado nuevo ('archivado',
-        // etc.) no queremos que se cuele. Estados actuales:
-        // pendiente · en_progreso · bloqueado · completado · cancelado.
-        const { data: taskRows, error: taskErr } = await supabase
-          .schema('erp')
-          .from('tasks')
-          .select('id, empresa_id, titulo, estado, fecha_vence, fecha_compromiso, prioridad')
-          .in('asignado_a', empleadoIds)
-          .in('estado', ['pendiente', 'en_progreso', 'bloqueado'])
-          .order('fecha_vence', { ascending: true, nullsFirst: false })
-          .limit(100);
-
-        if (taskErr) throw taskErr;
-        if (!cancelled) {
-          setTasks((taskRows ?? []) as TaskRow[]);
-          setLoading(false);
-        }
-      } catch (e) {
-        if (!cancelled) {
-          setError(e instanceof Error ? e.message : 'Error cargando tareas');
-          setLoading(false);
-        }
+  const loadTasks = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user?.email) {
+        setTasks([]);
+        setLoading(false);
+        return;
       }
-    })();
 
-    return () => {
-      cancelled = true;
-    };
+      // core.usuarios por email
+      const { data: coreUser } = await supabase
+        .schema('core')
+        .from('usuarios')
+        .select('id')
+        .eq('email', user.email.toLowerCase())
+        .maybeSingle();
+
+      if (!coreUser) {
+        setTasks([]);
+        setLoading(false);
+        return;
+      }
+
+      // empresas del usuario
+      const { data: ue } = await supabase
+        .schema('core')
+        .from('usuarios_empresas')
+        .select('empresa_id')
+        .eq('usuario_id', coreUser.id)
+        .eq('activo', true);
+
+      const empresaIds = (ue ?? []).map((r: { empresa_id: string }) => r.empresa_id);
+      if (empresaIds.length === 0) {
+        setTasks([]);
+        setLoading(false);
+        return;
+      }
+
+      // empleados del usuario en esas empresas (match por email empresa o personal)
+      const emailLower = user.email.toLowerCase();
+      const { data: empleados } = await supabase
+        .schema('erp')
+        .from('v_empleados_full')
+        .select('empleado_id, empresa_id, email_empresa, email_personal')
+        .in('empresa_id', empresaIds)
+        .or(`email_empresa.eq.${emailLower},email_personal.eq.${emailLower}`);
+
+      const empleadoIds = (empleados ?? [])
+        .map((e: { empleado_id: string | null }) => e.empleado_id)
+        .filter((id: string | null): id is string => Boolean(id));
+
+      if (empleadoIds.length === 0) {
+        // Usuario no tiene ficha de empleado en ninguna empresa: no tareas personales.
+        setTasks([]);
+        setLoading(false);
+        return;
+      }
+
+      // tareas asignadas a este usuario en estado activo.
+      // Whitelist en vez de blacklist: si aparece un estado nuevo ('archivado',
+      // etc.) no queremos que se cuele. Estados actuales:
+      // pendiente · en_progreso · bloqueado · completado · cancelado.
+      const { data: taskRows, error: taskErr } = await supabase
+        .schema('erp')
+        .from('tasks')
+        .select('id, empresa_id, titulo, estado, fecha_vence, fecha_compromiso, prioridad')
+        .in('asignado_a', empleadoIds)
+        .in('estado', ['pendiente', 'en_progreso', 'bloqueado'])
+        .order('fecha_vence', { ascending: true, nullsFirst: false })
+        .limit(100);
+
+      if (taskErr) throw taskErr;
+      setTasks((taskRows ?? []) as TaskRow[]);
+      setLoading(false);
+    } catch (e) {
+      // El detalle técnico (ej. "permission denied for schema core") va a consola
+      // para debugging; al usuario le mostramos un mensaje accionable.
+      console.error('[MisTareasWidget]', e);
+      setError('No pudimos cargar tus tareas. Intenta recargar la página.');
+      setLoading(false);
+    }
   }, [supabase]);
+
+  useEffect(() => {
+    void loadTasks();
+  }, [loadTasks]);
 
   const { grouped, todayIso } = useMemo(() => {
     const today = new Date();
@@ -249,9 +245,17 @@ export function MisTareasWidget() {
       {error ? (
         <div
           role="alert"
-          className="mt-4 rounded-xl border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-400"
+          className="mt-4 flex items-center justify-between gap-3 rounded-xl border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-400"
         >
-          {error}
+          <span className="min-w-0 flex-1">{error}</span>
+          <button
+            type="button"
+            onClick={() => void loadTasks()}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-red-500/30 bg-red-500/10 px-2.5 py-1 text-xs font-medium text-red-300 transition hover:border-red-500/50 hover:bg-red-500/20 focus:outline-none focus:ring-2 focus:ring-red-500/40"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            Reintentar
+          </button>
         </div>
       ) : loading ? (
         <div className="mt-4 space-y-2" aria-busy="true">

--- a/components/inicio/mis-tareas-widget.tsx
+++ b/components/inicio/mis-tareas-widget.tsx
@@ -228,7 +228,7 @@ export function MisTareasWidget() {
           </div>
           <div>
             <h2 className="text-lg font-semibold text-[var(--text)]">Mis tareas</h2>
-            <p className="text-xs text-[var(--text)]/55">
+            <p className="text-xs text-[var(--text-muted)]">
               {loading
                 ? 'Cargando…'
                 : totalPendientes === 0
@@ -280,7 +280,9 @@ export function MisTareasWidget() {
                       <Icon className="h-3.5 w-3.5" />
                       {cfg.label}
                     </span>
-                    <span className="text-xs text-[var(--text)]/40">{grouped[bucket].length}</span>
+                    <span className="text-xs text-[var(--text-subtle)]">
+                      {grouped[bucket].length}
+                    </span>
                   </div>
                   <ul className="space-y-1.5">
                     {grouped[bucket].slice(0, 10).map((t) => (
@@ -300,7 +302,7 @@ export function MisTareasWidget() {
                     ))}
                   </ul>
                   {grouped[bucket].length > 10 && (
-                    <p className="mt-1.5 text-right text-xs text-[var(--text)]/40">
+                    <p className="mt-1.5 text-right text-xs text-[var(--text-subtle)]">
                       + {grouped[bucket].length - 10} más
                     </p>
                   )}

--- a/lib/datetime/greeting.test.ts
+++ b/lib/datetime/greeting.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+import { getGreeting, formatLongDate } from './greeting';
+
+/**
+ * Los tests de getGreeting usan un mock de `t` que devuelve la clave que recibe.
+ * Así no dependemos del diccionario real de i18n y aislamos la lógica de franja
+ * horaria. La franja corta:
+ *   hora < 12   → morning
+ *   12 <= hora < 19 → afternoon
+ *   hora >= 19  → evening
+ */
+const identityT = (key: string) => key;
+
+describe('getGreeting', () => {
+  it('devuelve greeting.morning antes de mediodía', () => {
+    expect(getGreeting(new Date('2026-04-22T08:15:00'), identityT)).toBe('greeting.morning');
+  });
+
+  it('devuelve greeting.afternoon entre 12 y 19', () => {
+    expect(getGreeting(new Date('2026-04-22T14:30:00'), identityT)).toBe('greeting.afternoon');
+  });
+
+  it('devuelve greeting.evening desde las 19 en adelante', () => {
+    expect(getGreeting(new Date('2026-04-22T21:05:00'), identityT)).toBe('greeting.evening');
+  });
+});
+
+describe('formatLongDate', () => {
+  it('incluye el año en ambos locales', () => {
+    const d = new Date('2026-04-22T12:00:00');
+    expect(formatLongDate(d, 'es')).toMatch(/2026/);
+    expect(formatLongDate(d, 'en')).toMatch(/2026/);
+  });
+});

--- a/lib/datetime/greeting.ts
+++ b/lib/datetime/greeting.ts
@@ -1,0 +1,21 @@
+/**
+ * Helpers de saludo + fecha localizada para el shell y el dashboard.
+ * Se mantienen en un solo lugar para que ninguna vista diverja si el reloj
+ * cambia de franja a las 11:59/18:59 mientras se está renderizando.
+ */
+
+export function getGreeting(date: Date, t: (key: string) => string): string {
+  const hour = date.getHours();
+  if (hour < 12) return t('greeting.morning');
+  if (hour < 19) return t('greeting.afternoon');
+  return t('greeting.evening');
+}
+
+export function formatLongDate(date: Date, locale: 'es' | 'en'): string {
+  return date.toLocaleDateString(locale === 'es' ? 'es-MX' : 'en-US', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}


### PR DESCRIPTION
## Resumen

Bundle de 6 quick wins de UX/UI identificados en una auditoría previa. Cambios chicos, de bajo riesgo, agrupados en un PR porque comparten revisión visual.

## Fixes

- **FIX 1 — Bell de notificaciones es ahora un botón real.** Antes era un `<div>` no focusable con el badge "0" siempre visible. Ahora: `<button>` con `aria-label`, `title=\"Próximamente\"`, focus ring, y el badge solo se renderiza cuando `count > 0`. `onClick` tiene un TODO hasta que implementemos el panel.
- **FIX 2 — Toggle de idioma deja de verse ambiguo.** Antes mostraba \"ES | EN\" simultáneo (parecía que ambos estaban activos). Ahora solo el idioma activo + `ChevronDown`, con `title` explicando la acción (\"Cambiar a English\" / \"Change to Español\").
- **FIX 3 — Greeting y fecha deduplicados en `lib/datetime/greeting.ts`.** AppShell y `/inicio` calculaban el saludo por separado; en la frontera de franjas (11:59 → 12:00) podían diverger. Ahora ambos llaman `getGreeting(date, t)` / `formatLongDate(date, locale)`. `/inicio` también respeta el locale activo. Tests: 4 casos (mañana/tarde/noche + locale).
- **FIX 4 — Contraste de textos secundarios a WCAG AA.** `text-[var(--text)]/40` sobre `#f8f9fc` daba ~3.1:1 (falla AA). Creamos `--text-muted` (#4b5563, ~7:1) y `--text-subtle` (#6b7280, ~4.8:1), con variantes dark (rgba 0.75 / 0.55). Scope: app-shell (header, sidebar, account-menu) + widgets de `/inicio`. Módulos de negocio quedan fuera.
- **FIX 5 — Login respeta tokens de theme.** `LoginCard` tenía `text-white`, `text-white/60` y `text-white/40` hardcoded — en light quedaba ilegible sobre el card blanco. Reemplazado por `--text` / `--text-muted` / `--text-subtle`.
- **FIX 6 — Mensaje de error amigable + retry en MisTareasWidget.** El catch serializaba `e.message` crudo, exponiendo detalles tipo \"permission denied for schema core\". Ahora: `console.error('[MisTareasWidget]', e)` para debugging y en pantalla solo \"No pudimos cargar tus tareas. Intenta recargar la página.\". El banner incluye botón \"Reintentar\" que reusa `loadTasks` (extraído del IIFE a `useCallback`).

## Desviaciones del plan

- **FIX 1 y FIX 2 en un solo commit** (`fix(ui): convertir Bell en botón y simplificar toggle de idioma`). Ambos cambios viven en el mismo cluster de controles del header y su diff está entrelazado en el mismo hunk — separarlos requería split manual sin valor. El PR sigue describiendo cada fix individualmente.
- **Los tokens `--text-subtle` / `--text-muted` en `app/inicio/page.tsx`** aplican implícitamente dentro del commit de FIX 3 (al reescribir las líneas que invocaban `formatToday()` / `getGreeting()` locales).
- **Solo toco `dark:text-white/40` y `dark:text-white/55` cuando acompañan a un reemplazo de token.** Variantes sueltas como `/35`, `/45`, `/48`, `/50` las dejé intactas — entraban en la zona gris del spec y cambiarlas sin un token específico era ampliar scope.

## Verificación

- `npm run lint` — 0 errores (65 warnings pre-existentes, ninguno nuevo en archivos tocados).
- `npm run test:run` — 136/136 pasan, incluidos los 4 nuevos de `lib/datetime/greeting.test.ts`.
- `npm run build` — compila y typecheck OK.
- `/login` verificado visualmente en light + dark con preview local. Título legible en ambos themes, subtítulos con contraste adecuado.
- Tokens computados confirmados vía `getComputedStyle`: light `--text-muted=#4b5563`, `--text-subtle=#6b7280`; dark `rgba(245,247,251,0.75|0.55)`.

## Test plan

- [ ] Abrir el preview deploy, hacer login con Google.
- [ ] `/inicio` en light: confirmar que el saludo, la fecha y \"Este es tu panel personal...\" son legibles (contraste AA).
- [ ] `/inicio` en dark: mismo check. Sidebar + header con textos atenuados legibles.
- [ ] Header: tabular por el Bell — debe ser focusable con keyboard y no mostrar badge. Toggle de idioma: click alterna ES ↔ EN, hover muestra título.
- [ ] Gatillar un error en MisTareasWidget (dropear temporalmente el schema `core` en la consola del browser o cambiar `asignado_a` a una columna inexistente) y verificar: mensaje amigable + botón Reintentar funcional. El error técnico aparece en `console.error`.
- [ ] `/login` en light: título \"Bienvenido de vuelta\" y subtítulo legibles sobre el card blanco.
- [ ] Módulos (`/rdb`, `/dilesa`, etc.) — sanity check visual; NO se tocaron, no deberían cambiar.

## Follow-ups identificados (fuera de scope)

- `app/inicio/juntas/**` y `app/inicio/juntas/[id]/page.tsx` tienen ~8 ocurrencias de `text-[var(--text)]/40` que también fallan AA. Scope de FIX 4 excluyó módulos; separar en su propio PR cuando se revise el módulo de juntas.
- Varios archivos del shell tienen `text-[var(--text)]/50` y `dark:text-white/45` sueltos (header.tsx, account-menu.tsx, sidebar.tsx). Contraste marginal (~3.5:1) pero el spec de FIX 4 los puso fuera de alcance. Candidato a una segunda tanda de tokens (`--text-faint`) si el tema vuelve.
- El toggle de idioma en el header alterna directo sin menú. El `ChevronDown` sugiere dropdown — cuando tengamos más de 2 idiomas o queramos mostrar el nombre completo, vale agregar el menú real.
- InfoPill del header (🕐 / 📅) sigue con `/85`. Cumple AA pero la mezcla con emojis nativos puede verse inconsistente cross-platform — revisión de design system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)