### PR TITLE
feat(cron): correo por empresa con branding propio + fix rate limit

### DIFF
--- a/app/api/cron/daily-task-summary/route.ts
+++ b/app/api/cron/daily-task-summary/route.ts
@@ -1,19 +1,23 @@
 /**
- * Daily task summary cron — sends each employee their pending tasks by email.
+ * Daily task summary cron — un correo por (empleado, empresa).
  *
  * Schedule: every day at 13:00 UTC = 07:00 CST (see vercel.json).
  *
  * Delivery rules:
+ *   - Un correo por empresa donde el empleado tiene tareas abiertas.
+ *     El empleado con tareas en 2 empresas recibe 2 correos, cada uno branded
+ *     con el header/logo/colores de esa empresa.
  *   - Primary destination: erp.empleados.email_empresa
  *   - Fallback: erp.personas.email
  *   - If both null → skip employee (logged)
- *   - If employee has zero pending tasks → no email sent
- *   - If TASK_SUMMARY_TEST_TO env is set → all emails are redirected to that address
- *     (subject is prefixed with the original recipient name for clarity during testing)
+ *   - Si el empleado tiene 0 tareas en alguna empresa → no se le manda correo de esa.
+ *   - TASK_SUMMARY_TEST_TO env redirige TODOS los envíos a esa dirección,
+ *     prefijando el subject con [TEST → Nombre] para iteración de plantilla.
  *
- * Security:
- *   - Requires `Authorization: Bearer ${CRON_SECRET}` header (Vercel Cron supplies this)
- *   - Rejects everything else with 401
+ * Rate limit: Resend free tier = 5 req/s. Metemos sleep(220ms) entre envíos
+ * para quedar holgados bajo ese cap.
+ *
+ * Security: requiere `Authorization: Bearer ${CRON_SECRET}`. Vercel Cron lo envía.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -21,12 +25,16 @@ import { createClient } from '@supabase/supabase-js';
 import {
   generateTaskSummaryHtml,
   groupTasksByUrgency,
+  type EmpresaBranding,
   type TaskSummaryItem,
 } from '@/lib/task-summary-email';
 
-// Types matching the PostgREST response shape for our embedded select.
-// NOTA: empresa se resuelve en TS (no como embed) porque PostgREST no
-// puede hacer joins cross-schema (erp.tasks.empresa_id → core.empresas).
+// 300s cap for cron — tolera crecimiento hasta ~1000 buckets con sleep(220ms)
+// entre envíos y fetch a Resend. Si llegamos cerca del cap, migrar a Workflow
+// con step-based execution.
+export const maxDuration = 300;
+
+/** PostgREST embedded select — empleado + persona viven en erp, OK embed. */
 type EmbeddedTaskRow = {
   id: string;
   titulo: string;
@@ -46,15 +54,42 @@ type EmbeddedTaskRow = {
   } | null;
 };
 
-type EmpresaLite = { id: string; nombre: string; slug: string };
+/** core.empresas row — branding para el correo. */
+type EmpresaRow = {
+  id: string;
+  nombre: string;
+  slug: string;
+  header_email_url: string | null;
+  logo_horizontal_light_url: string | null;
+  logo_url: string | null;
+  color_primario: string | null;
+  color_primario_dark: string | null;
+};
 
-type PerEmployeeBucket = {
+/** Un bucket por (empleado, empresa) → un correo. */
+type Bucket = {
+  key: string;
   empleadoId: string;
+  empresaId: string;
   firstName: string;
   email: string;
-  emailSource: 'empresa' | 'personal';
   tasks: TaskSummaryItem[];
 };
+
+const MONTHS_ES = [
+  'ene',
+  'feb',
+  'mar',
+  'abr',
+  'may',
+  'jun',
+  'jul',
+  'ago',
+  'sep',
+  'oct',
+  'nov',
+  'dic',
+];
 
 /** Today (YYYY-MM-DD) in CST (UTC-6, no DST in Mexico since 2022). */
 function getTodayCst(): string {
@@ -63,28 +98,27 @@ function getTodayCst(): string {
   return cst.toISOString().slice(0, 10);
 }
 
-/** Short Spanish date label for subject: "20 abr". */
+/** Short Spanish date label: "22 abr". */
 function formatSubjectDate(todayCst: string): string {
-  const months = [
-    'ene',
-    'feb',
-    'mar',
-    'abr',
-    'may',
-    'jun',
-    'jul',
-    'ago',
-    'sep',
-    'oct',
-    'nov',
-    'dic',
-  ];
   const [, m, d] = todayCst.split('-');
-  return `${parseInt(d, 10)} ${months[parseInt(m, 10) - 1]}`;
+  return `${parseInt(d, 10)} ${MONTHS_ES[parseInt(m, 10) - 1]}`;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function toBranding(row: EmpresaRow): EmpresaBranding {
+  return {
+    nombre: row.nombre,
+    headerEmailUrl: row.header_email_url,
+    logoHorizontalUrl: row.logo_horizontal_light_url,
+    logoUrl: row.logo_url,
+    colorPrimario: row.color_primario,
+    colorPrimarioDark: row.color_primario_dark,
+  };
 }
 
 export async function GET(req: NextRequest) {
-  const cronSecret = process.env.CRON_SECRET;
+  const cronSecret = process.env.CRON_SECRET?.trim();
   const authHeader = req.headers.get('authorization');
   if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -93,7 +127,8 @@ export async function GET(req: NextRequest) {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   const resendKey = process.env.RESEND_API_KEY;
-  const testTo = process.env.TASK_SUMMARY_TEST_TO?.toLowerCase() || null;
+  const testToRaw = process.env.TASK_SUMMARY_TEST_TO?.trim().toLowerCase();
+  const testTo = testToRaw && testToRaw.length > 0 ? testToRaw : null;
 
   if (!supabaseUrl || !serviceKey) {
     return NextResponse.json({ error: 'Supabase env missing' }, { status: 500 });
@@ -105,20 +140,13 @@ export async function GET(req: NextRequest) {
   const todayCst = getTodayCst();
   const subjectDate = formatSubjectDate(todayCst);
 
-  // Supabase JS client con service role — bypasea RLS y maneja el Accept-Profile
-  // automáticamente cuando haces .schema('erp'). Patrón idiomático del repo
-  // (ver proxy.ts y app/settings/acceso/actions.ts).
   const supabase = createClient(supabaseUrl, serviceKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
-  // Whitelist de estados activos (mismo criterio que components/inicio/mis-tareas-widget,
-  // arreglado en #119 — el enum real es 'completado', no 'completada'). Whitelist > blacklist:
-  // si mañana aparece 'archivado', 'pausado', etc. no se cuelan silenciosamente.
-  //
-  // empleado y persona están en erp → se pueden embedear. empresa vive en core
-  // y PostgREST no hace joins cross-schema, así que la resolvemos abajo con un
-  // Map en memoria.
+  // Whitelist de estados activos (ver fix #119). Fetch en paralelo de tasks y
+  // empresas (cross-schema: empresa_id → core.empresas; PostgREST no hace joins
+  // cross-schema en embeds, así que resolvemos con Map en memoria).
   const select =
     'id,titulo,fecha_vence,fecha_compromiso,porcentaje_avance,empresa_id,' +
     'empleado:asignado_a(id,email_empresa,activo,persona:persona_id(nombre,apellido_paterno,email))';
@@ -132,7 +160,13 @@ export async function GET(req: NextRequest) {
       .is('fecha_completado', null)
       .not('asignado_a', 'is', null)
       .returns<EmbeddedTaskRow[]>(),
-    supabase.schema('core').from('empresas').select('id,nombre,slug').returns<EmpresaLite[]>(),
+    supabase
+      .schema('core')
+      .from('empresas')
+      .select(
+        'id,nombre,slug,header_email_url,logo_horizontal_light_url,logo_url,color_primario,color_primario_dark'
+      )
+      .returns<EmpresaRow[]>(),
   ]);
 
   if (tasksRes.error || !tasksRes.data) {
@@ -151,12 +185,13 @@ export async function GET(req: NextRequest) {
   }
 
   const rows = tasksRes.data;
-  const empresaMap = new Map<string, EmpresaLite>(empresasRes.data.map((e) => [e.id, e]));
+  const empresaMap = new Map<string, EmpresaRow>(empresasRes.data.map((e) => [e.id, e]));
 
-  // Group by empleado_id, resolving email (empresa → personal fallback).
-  const buckets = new Map<string, PerEmployeeBucket>();
+  // Bucket por (empleado, empresa): un correo por pareja.
+  const buckets = new Map<string, Bucket>();
   let skippedNoEmail = 0;
   let skippedInactive = 0;
+  let skippedNoEmpresa = 0;
 
   for (const row of rows) {
     const empleado = row.empleado;
@@ -165,55 +200,77 @@ export async function GET(req: NextRequest) {
       skippedInactive++;
       continue;
     }
+    if (!empresaMap.has(row.empresa_id)) {
+      skippedNoEmpresa++;
+      continue;
+    }
 
     const email = (empleado.email_empresa ?? empleado.persona?.email ?? '').trim();
     if (!email) {
       skippedNoEmail++;
       continue;
     }
-    const emailSource: 'empresa' | 'personal' = empleado.email_empresa ? 'empresa' : 'personal';
     const firstName = empleado.persona?.nombre?.trim() || 'colega';
 
     const task: TaskSummaryItem = {
       id: row.id,
       titulo: row.titulo,
-      empresaNombre: empresaMap.get(row.empresa_id)?.nombre ?? 'Sin empresa',
       fechaVence: row.fecha_vence,
       fechaCompromiso: row.fecha_compromiso,
       porcentajeAvance: row.porcentaje_avance ?? 0,
     };
 
-    const existing = buckets.get(empleado.id);
+    const key = `${empleado.id}:${row.empresa_id}`;
+    const existing = buckets.get(key);
     if (existing) {
       existing.tasks.push(task);
     } else {
-      buckets.set(empleado.id, {
+      buckets.set(key, {
+        key,
         empleadoId: empleado.id,
+        empresaId: row.empresa_id,
         firstName,
         email,
-        emailSource,
         tasks: [task],
       });
     }
   }
 
-  // Send emails (serialized — Resend doesn't need parallel, keeps rate limit calm).
+  // Envío serializado con sleep 220ms → ≤5 req/s. Resend free = 5/s.
   let sent = 0;
   let failed = 0;
-  const failures: Array<{ empleadoId: string; email: string; error: string }> = [];
-  const previews: Array<{ empleadoId: string; to: string; total: number; subject: string }> = [];
+  const failures: Array<{ empleadoId: string; empresaId: string; email: string; error: string }> =
+    [];
+  const previews: Array<{
+    empleadoId: string;
+    empresaSlug: string;
+    to: string;
+    total: number;
+    subject: string;
+    fromName: string;
+  }> = [];
 
+  let firstSend = true;
   for (const bucket of buckets.values()) {
     if (bucket.tasks.length === 0) continue;
 
-    const groups = groupTasksByUrgency(bucket.tasks, todayCst);
-    const html = generateTaskSummaryHtml(bucket.firstName, groups, todayCst);
+    const empresaRow = empresaMap.get(bucket.empresaId);
+    if (!empresaRow) continue; // already filtered above, defensive
+    const branding = toBranding(empresaRow);
 
-    // Test mode: redirect all sends to TASK_SUMMARY_TEST_TO, prefix subject with original name.
+    const groups = groupTasksByUrgency(bucket.tasks, todayCst);
+    const html = generateTaskSummaryHtml(bucket.firstName, groups, todayCst, branding);
+
+    const fromName = empresaRow.nombre;
     const destination = testTo ?? bucket.email;
     const subject = testTo
-      ? `[TEST → ${bucket.firstName}] Tareas de hoy — ${subjectDate}`
-      : `Tareas de hoy — ${subjectDate}`;
+      ? `[TEST → ${bucket.firstName}] Tareas de hoy en ${empresaRow.nombre} — ${subjectDate}`
+      : `Tareas de hoy en ${empresaRow.nombre} — ${subjectDate}`;
+
+    if (!firstSend) {
+      await sleep(220);
+    }
+    firstSend = false;
 
     const resendRes = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -222,7 +279,7 @@ export async function GET(req: NextRequest) {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        from: 'BSOP <noreply@bsop.io>',
+        from: `${fromName} <noreply@bsop.io>`,
         to: [destination],
         subject,
         html,
@@ -233,16 +290,23 @@ export async function GET(req: NextRequest) {
       const err = await resendRes.text();
       console.error('[daily-task-summary] Resend failed:', bucket.email, err);
       failed++;
-      failures.push({ empleadoId: bucket.empleadoId, email: bucket.email, error: err });
+      failures.push({
+        empleadoId: bucket.empleadoId,
+        empresaId: bucket.empresaId,
+        email: bucket.email,
+        error: err,
+      });
       continue;
     }
 
     sent++;
     previews.push({
       empleadoId: bucket.empleadoId,
+      empresaSlug: empresaRow.slug,
       to: destination,
       total: bucket.tasks.length,
       subject,
+      fromName,
     });
   }
 
@@ -250,15 +314,16 @@ export async function GET(req: NextRequest) {
     ok: true,
     todayCst,
     totalTasks: rows.length,
-    employeesWithTasks: buckets.size,
+    bucketsWithTasks: buckets.size,
     sent,
     failed,
     skippedNoEmail,
     skippedInactive,
+    skippedNoEmpresa,
     testMode: Boolean(testTo),
     testTo,
     failures: failures.length > 0 ? failures : undefined,
-    previews: testTo ? previews : undefined, // only surface previews in test mode
+    previews: testTo ? previews : undefined,
   };
 
   console.log('[daily-task-summary]', JSON.stringify(summary));

--- a/lib/task-summary-email.ts
+++ b/lib/task-summary-email.ts
@@ -1,10 +1,12 @@
 // ── Daily task summary email HTML generator for BSOP ───────────────────────
 //
-// Generates the morning summary with pending tasks grouped by urgency:
-//   🔴 Vencidas  ·  🟡 Hoy  ·  🟢 Esta semana  ·  ⚪ Más adelante  ·  ⬜ Sin fecha
+// Un correo por (empleado, empresa). El branding refleja la empresa dueña
+// de las tareas — banner, logo y colores salen de core.empresas. BSOP queda
+// visible solo en el footer chico y en el texto del botón "Abrir en BSOP".
 //
-// Empty sections are not rendered. If there are zero total tasks, the caller
-// should NOT invoke this function and skip the email entirely.
+// Secciones por urgencia: 🔴 Vencidas · 🟡 Hoy · 🟢 Esta semana · ⚪ Más adelante · ⬜ Sin fecha
+// Las secciones vacías no se renderizan. Si el empleado tiene cero tareas
+// en la empresa, el caller NO debe invocar esta función (no mandes correo vacío).
 
 const MONTHS_ES = [
   'ene',
@@ -21,10 +23,13 @@ const MONTHS_ES = [
   'dic',
 ];
 
+/** BSOP orange — fallback cuando la empresa no tiene color_primario. */
+const DEFAULT_ACCENT = '#F7941D';
+const DEFAULT_ACCENT_DARK = '#D97E0C';
+
 export type TaskSummaryItem = {
   id: string;
   titulo: string;
-  empresaNombre: string;
   fechaVence: string | null; // ISO date (YYYY-MM-DD) or null
   fechaCompromiso: string | null;
   porcentajeAvance: number;
@@ -38,13 +43,23 @@ export type TaskSummaryGroups = {
   sinFecha: TaskSummaryItem[];
 };
 
+export type EmpresaBranding = {
+  nombre: string;
+  /** Banner ancho para tope del correo (preferido). */
+  headerEmailUrl: string | null;
+  /** Logo horizontal como fallback si no hay header. */
+  logoHorizontalUrl: string | null;
+  /** Logo vertical como último recurso. */
+  logoUrl: string | null;
+  /** Color del botón CTA y acentos. */
+  colorPrimario: string | null;
+  /** Variante oscura para hover/edges — usada aquí como fondo de banner si no hay imagen. */
+  colorPrimarioDark: string | null;
+};
+
 /**
  * Split task rows into urgency buckets relative to `todayCst` (ISO date).
  * Uses `fecha_vence` first, falls back to `fecha_compromiso`, null → sinFecha.
- *
- * Sorting inside each bucket:
- *   vencidas / hoy / estaSemana / masAdelante → by date ASC
- *   sinFecha → by titulo ASC
  */
 export function groupTasksByUrgency(tasks: TaskSummaryItem[], todayCst: string): TaskSummaryGroups {
   const todayMs = Date.parse(`${todayCst}T00:00:00Z`);
@@ -116,17 +131,17 @@ function renderTaskRow(
 
   const avanceLabel =
     task.porcentajeAvance > 0 && task.porcentajeAvance < 100
-      ? ` · ${task.porcentajeAvance}% avance`
+      ? `${dueLabel ? ' · ' : ''}${task.porcentajeAvance}% avance`
       : '';
 
-  const metaLine = [task.empresaNombre, dueLabel].filter(Boolean).join(' · ');
+  const metaLine = `${dueLabel}${avanceLabel}`;
 
   return `
     <tr>
       <td style="padding:10px 0;border-bottom:1px solid #eee">
         <table cellpadding="0" cellspacing="0" border="0" width="100%">
           <tr><td style="font-size:14px;font-weight:500;color:#1a1a1a;line-height:1.4">${escapeHtml(task.titulo)}</td></tr>
-          <tr><td style="font-size:12px;color:#888;padding-top:2px">${escapeHtml(metaLine)}${avanceLabel}</td></tr>
+          ${metaLine ? `<tr><td style="font-size:12px;color:#888;padding-top:2px">${escapeHtml(metaLine)}</td></tr>` : ''}
         </table>
       </td>
     </tr>`;
@@ -161,10 +176,43 @@ function escapeHtml(s: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/** Header/banner block: usa header_email_url si existe; si no, logo sobre color de marca. */
+function renderBanner(empresa: EmpresaBranding): string {
+  const bgColor = empresa.colorPrimarioDark || empresa.colorPrimario || '#f8f8f8';
+  const fallbackLogo = empresa.logoHorizontalUrl || empresa.logoUrl;
+
+  if (empresa.headerEmailUrl) {
+    return `
+      <tr>
+        <td style="padding:0;border-radius:12px 12px 0 0;overflow:hidden">
+          <img src="${escapeHtml(empresa.headerEmailUrl)}" alt="${escapeHtml(empresa.nombre)}" width="520" style="display:block;width:100%;max-width:520px;height:auto;border-radius:12px 12px 0 0"/>
+        </td>
+      </tr>`;
+  }
+
+  if (fallbackLogo) {
+    return `
+      <tr>
+        <td style="background:${bgColor};padding:28px 32px;text-align:center;border-radius:12px 12px 0 0">
+          <img src="${escapeHtml(fallbackLogo)}" alt="${escapeHtml(empresa.nombre)}" height="48" style="display:block;margin:0 auto;max-height:48px;width:auto"/>
+        </td>
+      </tr>`;
+  }
+
+  // Último fallback: texto sobre color de marca.
+  return `
+    <tr>
+      <td style="background:${bgColor};padding:32px;text-align:center;border-radius:12px 12px 0 0">
+        <div style="font-size:22px;font-weight:700;color:#ffffff;letter-spacing:0.3px">${escapeHtml(empresa.nombre)}</div>
+      </td>
+    </tr>`;
+}
+
 export function generateTaskSummaryHtml(
   firstName: string,
   groups: TaskSummaryGroups,
-  todayCst: string
+  todayCst: string,
+  empresa: EmpresaBranding
 ): string {
   const total =
     groups.vencidas.length +
@@ -172,6 +220,9 @@ export function generateTaskSummaryHtml(
     groups.estaSemana.length +
     groups.masAdelante.length +
     groups.sinFecha.length;
+
+  const accent = empresa.colorPrimario || DEFAULT_ACCENT;
+  const accentHover = empresa.colorPrimarioDark || DEFAULT_ACCENT_DARK;
 
   const sections = [
     renderSection('Vencidas', '🔴', groups.vencidas, todayCst, 'vencidas'),
@@ -191,30 +242,26 @@ export function generateTaskSummaryHtml(
 
   <table cellpadding="0" cellspacing="0" border="0" width="520" style="max-width:520px;background:#ffffff;border-radius:12px;border:1px solid #e5e5e5">
 
-    <tr>
-      <td style="background:#f8f8f8;padding:24px 32px;text-align:center;border-bottom:1px solid #e5e5e5;border-radius:12px 12px 0 0">
-        <img src="https://bsop.io/logo-bsop.jpg" alt="BSOP" width="140" style="display:block;margin:0 auto"/>
-      </td>
-    </tr>
+    ${renderBanner(empresa)}
 
     <tr>
       <td style="padding:28px 32px 24px">
         <table cellpadding="0" cellspacing="0" border="0" width="100%">
           <tr><td style="font-size:20px;font-weight:700;color:#1a1a1a;padding-bottom:4px">Buenos días, ${escapeHtml(firstName)} 👋</td></tr>
-          <tr><td style="font-size:15px;color:#555;line-height:1.5;padding-bottom:8px">Tienes <strong>${total}</strong> ${total === 1 ? 'tarea abierta' : 'tareas abiertas'} en BSOP.</td></tr>
+          <tr><td style="font-size:15px;color:#555;line-height:1.5;padding-bottom:8px">Tienes <strong>${total}</strong> ${total === 1 ? 'tarea abierta' : 'tareas abiertas'} en <strong>${escapeHtml(empresa.nombre)}</strong>.</td></tr>
         </table>
 
         ${sections}
 
         <table cellpadding="0" cellspacing="0" border="0" width="100%" style="padding-top:28px">
           <tr><td align="center">
-            <a href="https://bsop.io" style="display:inline-block;background:#F7941D;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.3px">Abrir BSOP</a>
+            <a href="https://bsop.io" style="display:inline-block;background:${accent};color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.3px;border-bottom:2px solid ${accentHover}">Abrir en BSOP</a>
           </td></tr>
         </table>
 
         <table cellpadding="0" cellspacing="0" border="0" width="100%" style="padding-top:20px">
           <tr><td style="font-size:12px;color:#888;line-height:1.5;text-align:center">
-            Si alguna tarea ya no aplica, responde este correo o márcala como completada en BSOP.
+            Si alguna tarea ya no aplica, responde este correo.
           </td></tr>
         </table>
       </td>
@@ -223,7 +270,7 @@ export function generateTaskSummaryHtml(
     <tr>
       <td style="background:#f8f8f8;padding:14px 32px;text-align:center;border-top:1px solid #e5e5e5;border-radius:0 0 12px 12px">
         <table cellpadding="0" cellspacing="0" border="0" width="100%">
-          <tr><td align="center" style="font-size:11px;color:#999">BSOP · Sistema Operativo</td></tr>
+          <tr><td align="center" style="font-size:11px;color:#999">Enviado por BSOP · Sistema Operativo</td></tr>
         </table>
       </td>
     </tr>


### PR DESCRIPTION
## Feedback post-primera-prueba

Del disparo manual del cron (22 abr, 8 correos entregados):
- Formato aceptado, pero el correo se veía muy "BSOP" — el usuario quería que luciera de la empresa dueña de las tareas
- 6 correos fallaron con Resend 429 (rate limit tier free = 5/s)
- `testTo` tenía `\n` al final (artefacto del `echo`) — Resend lo aceptó pero feo

## Cambios

### 1. Un correo por (empleado, empresa)
Antes: un correo por empleado con todas sus tareas mezcladas. Ahora: admin con tareas en DILESA y RDB recibe 2 correos, cada uno branded para esa empresa. El caso típico (empleado con 1 empresa) sigue siendo 1 correo.

### 2. Branding del correo viene de `core.empresas`
| Elemento | Campo DB | Fallback |
|---|---|---|
| Banner tope | `header_email_url` | `logo_horizontal_light_url` sobre `color_primario_dark` |
| Botón CTA | `color_primario` | BSOP orange `#F7941D` |
| From name | `nombre` | — |
| Subject | — | "Tareas de hoy en {nombre} — {fecha}" |

BSOP solo queda visible en el footer chico y en el texto del botón "Abrir en BSOP".

### 3. Rate limit fix
`sleep(220ms)` entre envíos → ≤5 req/s. La prueba con 14 buckets dio 6 fallos sin esto.

### 4. Trim de env vars
`.trim()` en `CRON_SECRET` y `TASK_SUMMARY_TEST_TO` para tolerar newlines.

### 5. CTA copy más limpio
Quité "márcala como completada en BSOP" — el asignado no siempre puede cerrar la tarea (el que la asignó sí). Queda "Si alguna tarea ya no aplica, responde este correo".

### 6. `maxDuration = 300`
Headroom para cuando empleados × empresas suban.

## Test plan
- [x] Typecheck limpio
- [ ] Merge → redeploy → curl manual → vuelven a caer correos a beto@anorte.com, esta vez:
  - [ ] Banner de la empresa arriba
  - [ ] Color del CTA = color de la empresa
  - [ ] From: "DILESA <noreply@bsop.io>" / "RDB <noreply@bsop.io>" etc.
  - [ ] Subject: "[TEST → Adalberto] Tareas de hoy en DILESA — 22 abr"
  - [ ] 0 fallos por rate limit

## Follow-ups
- Verificar dominios por empresa en Resend (`noreply@dilesa.mx`, etc.) — requiere DNS
- Excluir tareas asignadas por el mismo usuario si quieres que la CTA "responde este correo" tenga sentido práctico
- Migrar a Vercel Workflow si buckets > 500 (hoy ~14, growth = 5x al año)

🤖 Generated with [Claude Code](https://claude.com/claude-code)