### PR TITLE
fix(a11y): sweep contrast AA tokens across modules

### DIFF
--- a/app/dilesa/admin/juntas/[id]/page.tsx
+++ b/app/dilesa/admin/juntas/[id]/page.tsx
@@ -129,7 +129,7 @@ const ESTADO_TASK: Record<string, { label: string; cls: string }> = {
   completado: { label: 'Completado', cls: 'bg-green-500/15 text-green-400 border-green-500/20' },
   cancelado: {
     label: 'Cancelado',
-    cls: 'bg-[var(--border)]/60 text-[var(--text)]/40 border-[var(--border)]',
+    cls: 'bg-[var(--border)]/60 text-[var(--text-subtle)] border-[var(--border)]',
   },
 };
 
@@ -1274,7 +1274,7 @@ function JuntaDetailInner() {
                           ? 'border-green-500/50 bg-green-500/15 text-green-400'
                           : a.asistio === false
                             ? 'border-red-500/50 bg-red-500/15 text-red-400'
-                            : 'border-[var(--border)] bg-[var(--card)] text-[var(--text)]/40',
+                            : 'border-[var(--border)] bg-[var(--card)] text-[var(--text-subtle)]',
                       ].join(' ')}
                     >
                       {a.asistio === true ? (
@@ -1333,7 +1333,7 @@ function JuntaDetailInner() {
           </div>
         </div>
         <div className="flex items-center gap-2 mt-2">
-          <p className="text-[10px] text-[var(--text)]/40 flex-1">
+          <p className="text-[10px] text-[var(--text-subtle)] flex-1">
             {estado !== 'completada' && estado !== 'cancelada'
               ? autoSaveStatus === 'saving'
                 ? '⏳ Guardando notas...'
@@ -1481,7 +1481,7 @@ function JuntaDetailInner() {
           <SectionTitle>
             Tareas de esta junta{' '}
             {tasks.length > 0 && (
-              <span className="text-[var(--text)]/40 font-normal">({tasks.length})</span>
+              <span className="text-[var(--text-subtle)] font-normal">({tasks.length})</span>
             )}
           </SectionTitle>
           <Button
@@ -1549,7 +1549,7 @@ function JuntaDetailInner() {
                   )}
                   <div className="flex-1 min-w-0">
                     <span
-                      className={`text-sm font-medium line-clamp-1 ${task.estado === 'completado' ? 'text-[var(--text)]/40 line-through' : 'text-[var(--text)]'}`}
+                      className={`text-sm font-medium line-clamp-1 ${task.estado === 'completado' ? 'text-[var(--text-subtle)] line-through' : 'text-[var(--text)]'}`}
                     >
                       {task.titulo}
                     </span>
@@ -1563,7 +1563,7 @@ function JuntaDetailInner() {
                     {cfg.label}
                   </span>
                   {task.fecha_vence && (
-                    <span className="text-xs text-[var(--text)]/40 shrink-0">
+                    <span className="text-xs text-[var(--text-subtle)] shrink-0">
                       {formatDate(task.fecha_vence)}
                     </span>
                   )}

--- a/app/dilesa/admin/juntas/page.tsx
+++ b/app/dilesa/admin/juntas/page.tsx
@@ -138,7 +138,7 @@ function generateTitulo(fechaHora: string, tipo: string) {
  */
 function JuntaContentPreview({ descripcion }: { descripcion: string | null }) {
   if (!descripcion) {
-    return <span className="text-xs text-[var(--text)]/40">(vacía)</span>;
+    return <span className="text-xs text-[var(--text-subtle)]">(vacía)</span>;
   }
   // Plain text excerpt — strip HTML tags + collapse whitespace
   const plain = descripcion
@@ -158,7 +158,7 @@ function JuntaContentPreview({ descripcion }: { descripcion: string | null }) {
           className={`inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 font-mono ${
             imgCount > 0
               ? 'bg-emerald-500/15 text-emerald-400'
-              : 'bg-[var(--border)]/40 text-[var(--text)]/40'
+              : 'bg-[var(--border)]/40 text-[var(--text-subtle)]'
           }`}
         >
           {imgCount > 0 ? `📷 ${imgCount}` : '📷 0'}
@@ -388,7 +388,7 @@ function JuntasInner() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">Juntas — DILESA</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">Agenda y minutas de juntas</p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">Agenda y minutas de juntas</p>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -418,7 +418,7 @@ function JuntasInner() {
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
         <div className="flex flex-wrap gap-3">
           <div className="relative min-w-48 flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-subtle)]" />
             <Input
               placeholder="Buscar juntas..."
               value={search}
@@ -486,7 +486,7 @@ function JuntasInner() {
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-16 text-center">
             <CalendarDays className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text)]/55">
+            <p className="text-sm text-[var(--text-muted)]">
               {juntas.length === 0
                 ? 'No hay juntas registradas aún'
                 : 'No hay juntas que coincidan con los filtros'}
@@ -602,7 +602,7 @@ function JuntasInner() {
                         {TIPO_CONFIG[junta.tipo]?.label ?? junta.tipo}
                       </span>
                     ) : (
-                      <span className="text-[var(--text)]/40">—</span>
+                      <span className="text-[var(--text-subtle)]">—</span>
                     )}
                   </TableCell>
                   <TableCell>
@@ -661,7 +661,7 @@ function JuntasInner() {
       </div>
 
       {!loading && juntas.length > 0 && (
-        <p className="text-right text-xs text-[var(--text)]/40">
+        <p className="text-right text-xs text-[var(--text-subtle)]">
           {filtered.length} de {juntas.length} {juntas.length === 1 ? 'junta' : 'juntas'}
         </p>
       )}
@@ -719,7 +719,7 @@ function JuntasInner() {
                 }}
                 className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
               />
-              <p className="mt-1 text-[10px] text-[var(--text)]/40">
+              <p className="mt-1 text-[10px] text-[var(--text-subtle)]">
                 Se genera como &quot;fecha, hora - tipo&quot;. Puedes editarlo si quieres.
               </p>
             </div>

--- a/app/dilesa/rh/empleados/[id]/finiquito/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/finiquito/page.tsx
@@ -276,7 +276,7 @@ function Inner() {
               onChange={(e) => setSalarioMinimo(Number(e.target.value) || 0)}
               className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
             />
-            <p className="mt-1 text-[10px] text-[var(--text)]/40">
+            <p className="mt-1 text-[10px] text-[var(--text-subtle)]">
               Zona libre frontera norte 2026: $374.89. Ajustar si cambia vigencia.
             </p>
           </div>

--- a/app/dilesa/rh/empleados/[id]/page.tsx
+++ b/app/dilesa/rh/empleados/[id]/page.tsx
@@ -268,7 +268,7 @@ function BeneficiariosSection({
         )}
       </div>
       {beneficiarios.length === 0 && !adding ? (
-        <p className="text-xs text-[var(--text)]/40">
+        <p className="text-xs text-[var(--text-subtle)]">
           Sin beneficiarios registrados. El Art. 501 LFT permite designar a quién pagarle salarios y
           prestaciones devengadas en caso de fallecimiento del trabajador.
         </p>
@@ -366,7 +366,7 @@ function InfoRow({
     <div>
       <FieldLabel>{label}</FieldLabel>
       <p className="text-sm text-[var(--text)]">{value || '—'}</p>
-      {sub && <p className="text-xs text-[var(--text)]/40 mt-0.5">{sub}</p>}
+      {sub && <p className="text-xs text-[var(--text-subtle)] mt-0.5">{sub}</p>}
     </div>
   );
 }
@@ -1024,7 +1024,7 @@ function EmpleadoDetailInner() {
               />
             </div>
             <div className="pt-3 border-t border-[var(--border)] sm:col-span-2 lg:col-span-3">
-              <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/40 mb-2">
+              <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-subtle)] mb-2">
                 Contacto de emergencia
               </p>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
@@ -1066,7 +1066,7 @@ function EmpleadoDetailInner() {
             <InfoRow label="Teléfono celular" value={persona?.telefono ?? null} />
             <InfoRow label="Teléfono de casa" value={persona?.telefono_casa ?? null} />
             <div className="sm:col-span-2 lg:col-span-3 pt-3 border-t border-[var(--border)]">
-              <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/40 mb-2">
+              <p className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-subtle)] mb-2">
                 Contacto de emergencia
               </p>
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
@@ -1362,7 +1362,7 @@ function EmpleadoDetailInner() {
             dangerouslySetInnerHTML={{ __html: empleado.notas }}
           />
         ) : (
-          <p className="text-xs text-[var(--text)]/40">Sin notas registradas.</p>
+          <p className="text-xs text-[var(--text-subtle)]">Sin notas registradas.</p>
         )}
       </div>
 

--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -127,7 +127,7 @@ const ESTADO_TASK: Record<string, { label: string; cls: string }> = {
   completado: { label: 'Completado', cls: 'bg-green-500/15 text-green-400 border-green-500/20' },
   cancelado: {
     label: 'Cancelado',
-    cls: 'bg-[var(--border)]/60 text-[var(--text)]/40 border-[var(--border)]',
+    cls: 'bg-[var(--border)]/60 text-[var(--text-subtle)] border-[var(--border)]',
   },
 };
 
@@ -1031,7 +1031,7 @@ function JuntaDetailInner() {
             <EditorContent editor={editor} />
           </div>
         </div>
-        <p className="mt-2 text-[10px] text-[var(--text)]/40">
+        <p className="mt-2 text-[10px] text-[var(--text-subtle)]">
           {estado !== 'completada' && estado !== 'cancelada'
             ? autoSaveStatus === 'saving'
               ? '⏳ Guardando notas...'
@@ -1108,7 +1108,7 @@ function JuntaDetailInner() {
                               >
                                 {tc.label}
                               </span>
-                              <span className="text-[10px] text-[var(--text)]/40">
+                              <span className="text-[10px] text-[var(--text-subtle)]">
                                 {u.usuario?.nombre ?? 'Sistema'}
                               </span>
                               <span className="text-[10px] text-[var(--text)]/30 ml-auto">
@@ -1209,7 +1209,7 @@ function JuntaDetailInner() {
                         ? 'border-green-500/50 bg-green-500/15 text-green-400'
                         : a.asistio === false
                           ? 'border-red-500/50 bg-red-500/15 text-red-400'
-                          : 'border-[var(--border)] bg-[var(--card)] text-[var(--text)]/40',
+                          : 'border-[var(--border)] bg-[var(--card)] text-[var(--text-subtle)]',
                     ].join(' ')}
                   >
                     {a.asistio === true ? (
@@ -1278,7 +1278,7 @@ function JuntaDetailInner() {
           <SectionTitle>
             Tareas de esta junta{' '}
             {tasks.length > 0 && (
-              <span className="text-[var(--text)]/40 font-normal">({tasks.length})</span>
+              <span className="text-[var(--text-subtle)] font-normal">({tasks.length})</span>
             )}
           </SectionTitle>
           <Button
@@ -1347,7 +1347,7 @@ function JuntaDetailInner() {
                   )}
                   <div className="flex-1 min-w-0">
                     <span
-                      className={`text-sm font-medium line-clamp-1 ${task.estado === 'completado' ? 'text-[var(--text)]/40 line-through' : 'text-[var(--text)]'}`}
+                      className={`text-sm font-medium line-clamp-1 ${task.estado === 'completado' ? 'text-[var(--text-subtle)] line-through' : 'text-[var(--text)]'}`}
                     >
                       {task.titulo}
                     </span>
@@ -1361,7 +1361,7 @@ function JuntaDetailInner() {
                     {cfg.label}
                   </span>
                   {task.fecha_vence && (
-                    <span className="text-xs text-[var(--text)]/40 shrink-0">
+                    <span className="text-xs text-[var(--text-subtle)] shrink-0">
                       {formatDate(task.fecha_vence)}
                     </span>
                   )}

--- a/app/inicio/juntas/page.tsx
+++ b/app/inicio/juntas/page.tsx
@@ -255,7 +255,7 @@ function JuntasInner() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">Juntas</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">
+          <p className="mt-1 text-sm text-[var(--text-muted)]">
             Agenda y minutas de juntas operativas
           </p>
         </div>
@@ -289,7 +289,7 @@ function JuntasInner() {
         <div className="flex flex-wrap gap-3">
           <div className="relative min-w-48 flex-1">
             <Search
-              className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40"
+              className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-subtle)]"
               aria-hidden="true"
             />
             <Input
@@ -341,7 +341,7 @@ function JuntasInner() {
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-16 text-center">
             <CalendarDays className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text)]/55">
+            <p className="text-sm text-[var(--text-muted)]">
               {juntas.length === 0
                 ? 'No hay juntas registradas aún'
                 : 'No hay juntas que coincidan con los filtros'}
@@ -421,7 +421,7 @@ function JuntasInner() {
                         {TIPO_CONFIG[junta.tipo]?.icon} {TIPO_CONFIG[junta.tipo]?.label}
                       </span>
                     ) : (
-                      <span className="text-[var(--text)]/40">—</span>
+                      <span className="text-[var(--text-subtle)]">—</span>
                     )}
                   </TableCell>
                   <TableCell>
@@ -448,7 +448,7 @@ function JuntasInner() {
       </div>
 
       {!loading && juntas.length > 0 && (
-        <p className="text-right text-xs text-[var(--text)]/40">
+        <p className="text-right text-xs text-[var(--text-subtle)]">
           {filtered.length} de {juntas.length} {juntas.length === 1 ? 'junta' : 'juntas'}
         </p>
       )}

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -128,7 +128,7 @@ const ESTADO_TASK: Record<string, { label: string; cls: string }> = {
   completado: { label: 'Completado', cls: 'bg-green-500/15 text-green-400 border-green-500/20' },
   cancelado: {
     label: 'Cancelado',
-    cls: 'bg-[var(--border)]/60 text-[var(--text)]/40 border-[var(--border)]',
+    cls: 'bg-[var(--border)]/60 text-[var(--text-subtle)] border-[var(--border)]',
   },
 };
 
@@ -1029,7 +1029,7 @@ function JuntaDetailInner() {
             <EditorContent editor={editor} />
           </div>
         </div>
-        <p className="mt-2 text-[10px] text-[var(--text)]/40">
+        <p className="mt-2 text-[10px] text-[var(--text-subtle)]">
           {estado !== 'completada' && estado !== 'cancelada'
             ? autoSaveStatus === 'saving'
               ? '⏳ Guardando notas...'
@@ -1105,7 +1105,7 @@ function JuntaDetailInner() {
                                 >
                                   {tc.label}
                                 </span>
-                                <span className="text-[10px] text-[var(--text)]/40">
+                                <span className="text-[10px] text-[var(--text-subtle)]">
                                   {u.usuario?.nombre ?? 'Sistema'}
                                 </span>
                                 <span className="text-[10px] text-[var(--text)]/30 ml-auto">
@@ -1202,7 +1202,7 @@ function JuntaDetailInner() {
                         ? 'border-green-500/50 bg-green-500/15 text-green-400'
                         : a.asistio === false
                           ? 'border-red-500/50 bg-red-500/15 text-red-400'
-                          : 'border-[var(--border)] bg-[var(--card)] text-[var(--text)]/40',
+                          : 'border-[var(--border)] bg-[var(--card)] text-[var(--text-subtle)]',
                     ].join(' ')}
                   >
                     {a.asistio === true ? (
@@ -1268,7 +1268,7 @@ function JuntaDetailInner() {
           <SectionTitle>
             Tareas de esta junta{' '}
             {tasks.length > 0 && (
-              <span className="text-[var(--text)]/40 font-normal">({tasks.length})</span>
+              <span className="text-[var(--text-subtle)] font-normal">({tasks.length})</span>
             )}
           </SectionTitle>
           <Button
@@ -1337,7 +1337,7 @@ function JuntaDetailInner() {
                   )}
                   <div className="flex-1 min-w-0">
                     <span
-                      className={`text-sm font-medium line-clamp-1 ${task.estado === 'completado' ? 'text-[var(--text)]/40 line-through' : 'text-[var(--text)]'}`}
+                      className={`text-sm font-medium line-clamp-1 ${task.estado === 'completado' ? 'text-[var(--text-subtle)] line-through' : 'text-[var(--text)]'}`}
                     >
                       {task.titulo}
                     </span>
@@ -1351,7 +1351,7 @@ function JuntaDetailInner() {
                     {cfg.label}
                   </span>
                   {task.fecha_vence && (
-                    <span className="text-xs text-[var(--text)]/40 shrink-0">
+                    <span className="text-xs text-[var(--text-subtle)] shrink-0">
                       {formatDate(task.fecha_vence)}
                     </span>
                   )}

--- a/app/rdb/admin/juntas/page.tsx
+++ b/app/rdb/admin/juntas/page.tsx
@@ -234,7 +234,7 @@ function JuntasInner() {
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">
             Juntas — Rincón del Bosque
           </h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">
+          <p className="mt-1 text-sm text-[var(--text-muted)]">
             Agenda y minutas de juntas operativas
           </p>
         </div>
@@ -266,7 +266,7 @@ function JuntasInner() {
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
         <div className="flex flex-wrap gap-3">
           <div className="relative min-w-48 flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-subtle)]" />
             <Input
               placeholder="Buscar juntas..."
               value={search}
@@ -318,7 +318,7 @@ function JuntasInner() {
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-16 text-center">
             <CalendarDays className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text)]/55">
+            <p className="text-sm text-[var(--text-muted)]">
               {juntas.length === 0
                 ? 'No hay juntas registradas aún'
                 : 'No hay juntas que coincidan con los filtros'}
@@ -412,7 +412,7 @@ function JuntasInner() {
                         {TIPO_CONFIG[junta.tipo]?.icon} {TIPO_CONFIG[junta.tipo]?.label}
                       </span>
                     ) : (
-                      <span className="text-[var(--text)]/40">—</span>
+                      <span className="text-[var(--text-subtle)]">—</span>
                     )}
                   </TableCell>
                   <TableCell>
@@ -444,7 +444,7 @@ function JuntasInner() {
       </div>
 
       {!loading && juntas.length > 0 && (
-        <p className="text-right text-xs text-[var(--text)]/40">
+        <p className="text-right text-xs text-[var(--text-subtle)]">
           {filtered.length} de {juntas.length} {juntas.length === 1 ? 'junta' : 'juntas'}
         </p>
       )}

--- a/app/rdb/page.tsx
+++ b/app/rdb/page.tsx
@@ -328,7 +328,7 @@ function KpiCard({
         {label}
       </div>
       <div className="mt-2 text-2xl font-semibold tracking-tight text-[var(--text)]">{value}</div>
-      {hint ? <div className="mt-1 text-sm text-[var(--text)]/55">{hint}</div> : null}
+      {hint ? <div className="mt-1 text-sm text-[var(--text-muted)]">{hint}</div> : null}
     </div>
   );
 }
@@ -667,7 +667,7 @@ export default function RdbHomePage() {
             <section className="space-y-3">
               <div>
                 <h2 className="text-lg font-semibold text-[var(--text)]">Requiere atención</h2>
-                <p className="text-sm text-[var(--text)]/55">
+                <p className="text-sm text-[var(--text-muted)]">
                   Alertas cortas, derivadas de pedidos y cortes que ya existen en RDB.
                 </p>
               </div>
@@ -723,7 +723,7 @@ export default function RdbHomePage() {
               <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
                 <div>
                   <h2 className="text-lg font-semibold text-[var(--text)]">Ventas</h2>
-                  <p className="text-sm text-[var(--text)]/55">
+                  <p className="text-sm text-[var(--text-muted)]">
                     Serie principal del periodo seleccionado. El default es mes actual.
                   </p>
                 </div>
@@ -762,7 +762,7 @@ export default function RdbHomePage() {
                     <div className="mt-2 text-xl font-semibold text-[var(--text)]">
                       {vsPrev == null ? '—' : `${vsPrev >= 0 ? '+' : ''}${vsPrev.toFixed(1)}%`}
                     </div>
-                    <div className="mt-1 text-sm text-[var(--text)]/55">
+                    <div className="mt-1 text-sm text-[var(--text-muted)]">
                       Base: {formatMoney(previousTotal)}
                     </div>
                   </div>
@@ -775,7 +775,7 @@ export default function RdbHomePage() {
                         ? '—'
                         : `${vsLastYear >= 0 ? '+' : ''}${vsLastYear.toFixed(1)}%`}
                     </div>
-                    <div className="mt-1 text-sm text-[var(--text)]/55">
+                    <div className="mt-1 text-sm text-[var(--text-muted)]">
                       Base: {formatMoney(lastYearTotal)}
                     </div>
                   </div>

--- a/app/rdb/rh/empleados/[id]/page.tsx
+++ b/app/rdb/rh/empleados/[id]/page.tsx
@@ -145,7 +145,7 @@ function InfoRow({
     <div>
       <FieldLabel>{label}</FieldLabel>
       <p className="text-sm text-[var(--text)]">{value || '—'}</p>
-      {sub && <p className="text-xs text-[var(--text)]/40 mt-0.5">{sub}</p>}
+      {sub && <p className="text-xs text-[var(--text-subtle)] mt-0.5">{sub}</p>}
     </div>
   );
 }

--- a/app/rdb/tasks/[id]/page.tsx
+++ b/app/rdb/tasks/[id]/page.tsx
@@ -378,8 +378,10 @@ function TaskDetailInner() {
           Tareas
         </Button>
         <span className="text-[var(--text)]/30">/</span>
-        <span className="text-sm text-[var(--text)]/55 line-clamp-1 max-w-xs">{task.titulo}</span>
-        {saving && <Loader2 className="h-3.5 w-3.5 animate-spin text-[var(--text)]/40 ml-1" />}
+        <span className="text-sm text-[var(--text-muted)] line-clamp-1 max-w-xs">
+          {task.titulo}
+        </span>
+        {saving && <Loader2 className="h-3.5 w-3.5 animate-spin text-[var(--text-subtle)] ml-1" />}
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
@@ -504,7 +506,7 @@ function TaskDetailInner() {
                   setDescVal('');
                   setEditingDesc(true);
                 }}
-                className="text-sm italic text-[var(--text)]/35 hover:text-[var(--text)]/55 transition-colors"
+                className="text-sm italic text-[var(--text)]/35 hover:text-[var(--text-muted)] transition-colors"
               >
                 Sin descripción. Haz clic para agregar.
               </button>
@@ -548,7 +550,7 @@ function TaskDetailInner() {
                         >
                           {tc.label}
                         </span>
-                        <span className="text-[10px] text-[var(--text)]/40">
+                        <span className="text-[10px] text-[var(--text-subtle)]">
                           {u.usuario?.nombre ?? 'Sistema'}
                         </span>
                         <span className="text-[10px] text-[var(--text)]/30 ml-auto">

--- a/app/rdb/tasks/page.tsx
+++ b/app/rdb/tasks/page.tsx
@@ -123,7 +123,7 @@ function EstadoBadge({ estado }: { estado: ErpTask['estado'] }) {
 }
 
 function PrioridadBadge({ prioridad }: { prioridad: string | null }) {
-  if (!prioridad) return <span className="text-[var(--text)]/40">—</span>;
+  if (!prioridad) return <span className="text-[var(--text-subtle)]">—</span>;
   const cfg = PRIORIDAD_CONFIG[prioridad] ?? { label: prioridad, cls: '' };
   return (
     <span
@@ -375,7 +375,7 @@ function TasksInner() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">Tareas</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">Gestión de tareas operativas</p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">Gestión de tareas operativas</p>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -402,7 +402,7 @@ function TasksInner() {
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
         <div className="flex flex-wrap gap-3">
           <div className="relative min-w-48 flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-subtle)]" />
             <Input
               placeholder="Buscar tareas..."
               value={search}
@@ -461,7 +461,7 @@ function TasksInner() {
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-16 text-center">
             <TicketCheck className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text)]/55">
+            <p className="text-sm text-[var(--text-muted)]">
               {tasks.length === 0
                 ? 'No hay tareas creadas aún'
                 : 'No hay tareas que coincidan con los filtros'}
@@ -546,7 +546,7 @@ function TasksInner() {
                         {task.titulo}
                       </span>
                       {task.entidad_tipo && (
-                        <span className="mt-0.5 block text-xs text-[var(--text)]/40">
+                        <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">
                           {task.entidad_tipo}
                         </span>
                       )}
@@ -590,7 +590,7 @@ function TasksInner() {
 
       {/* Summary */}
       {!loading && tasks.length > 0 && (
-        <p className="text-right text-xs text-[var(--text)]/40">
+        <p className="text-right text-xs text-[var(--text-subtle)]">
           {filtered.length} de {tasks.length} {tasks.length === 1 ? 'tarea' : 'tareas'}
         </p>
       )}

--- a/app/settings/acceso/acceso-client.tsx
+++ b/app/settings/acceso/acceso-client.tsx
@@ -238,7 +238,7 @@ export function AccesoClient({
         <h1 className="text-2xl font-semibold dark:text-white text-[var(--text)]">
           Configuración de Accesos
         </h1>
-        <p className="mt-1 text-sm dark:text-white/55 text-[var(--text)]/55">
+        <p className="mt-1 text-sm dark:text-white/55 text-[var(--text-muted)]">
           Gestiona empresas, roles, permisos y accesos de usuarios en BSOP.
         </p>
       </div>
@@ -254,7 +254,7 @@ export function AccesoClient({
               'flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors',
               tab === id
                 ? 'bg-[var(--accent)] text-white shadow-sm'
-                : 'dark:text-white/55 text-[var(--text)]/55 dark:hover:text-white hover:text-[var(--text)] dark:hover:bg-white/5 hover:bg-black/3'
+                : 'dark:text-white/55 text-[var(--text-muted)] dark:hover:text-white hover:text-[var(--text)] dark:hover:bg-white/5 hover:bg-black/3'
             )}
           >
             {icon}
@@ -267,7 +267,7 @@ export function AccesoClient({
       {tab === 'empresas' && (
         <>
           <div className="flex items-center justify-between">
-            <p className="text-sm dark:text-white/40 text-[var(--text)]/40">
+            <p className="text-sm dark:text-white/40 text-[var(--text-subtle)]">
               {empresas.length} empresa{empresas.length !== 1 ? 's' : ''} registrada
               {empresas.length !== 1 ? 's' : ''}
             </p>
@@ -337,7 +337,7 @@ export function AccesoClient({
         <div className="space-y-4">
           {/* Company selector + new rol button */}
           <div className="flex items-center gap-3">
-            <span className="text-sm dark:text-white/55 text-[var(--text)]/55">Empresa:</span>
+            <span className="text-sm dark:text-white/55 text-[var(--text-muted)]">Empresa:</span>
             <Combobox
               value={filterEmpresaId}
               onChange={(v) => {
@@ -365,7 +365,7 @@ export function AccesoClient({
             {/* Roles list */}
             <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)]">
               <div className="border-b border-[var(--border)] px-4 py-3">
-                <p className="text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text)]/40">
+                <p className="text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text-subtle)]">
                   Roles
                 </p>
               </div>
@@ -436,7 +436,7 @@ export function AccesoClient({
                     <p className="text-sm font-semibold dark:text-white/85 text-[var(--text)]/85">
                       {selectedRol.nombre}
                     </p>
-                    <p className="mt-0.5 text-xs dark:text-white/40 text-[var(--text)]/40">
+                    <p className="mt-0.5 text-xs dark:text-white/40 text-[var(--text-subtle)]">
                       Permisos por módulo — haz clic para cambiar
                     </p>
                   </div>
@@ -528,7 +528,7 @@ export function AccesoClient({
       {tab === 'usuarios' && (
         <>
           <div className="flex items-center justify-between">
-            <p className="text-sm dark:text-white/40 text-[var(--text)]/40">
+            <p className="text-sm dark:text-white/40 text-[var(--text-subtle)]">
               {usuarios.length} usuario{usuarios.length !== 1 ? 's' : ''} registrado
               {usuarios.length !== 1 ? 's' : ''}
             </p>
@@ -650,7 +650,7 @@ export function AccesoClient({
                 <div className="space-y-8 px-6 py-5">
                   {/* ── Empresas section ── */}
                   <section>
-                    <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text)]/40">
+                    <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text-subtle)]">
                       Acceso a empresas
                     </h3>
                     <div className="space-y-3">
@@ -729,7 +729,7 @@ export function AccesoClient({
                   {/* ── Excepciones section ── */}
                   <section>
                     <div className="mb-3 flex items-center justify-between">
-                      <h3 className="text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text)]/40">
+                      <h3 className="text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text-subtle)]">
                         Excepciones de módulo
                       </h3>
                       <Button
@@ -759,7 +759,7 @@ export function AccesoClient({
                     {/* Add exception form */}
                     {addingExcepcion && (
                       <div className="mb-4 space-y-3 rounded-xl border border-dashed border-[var(--accent)]/40 bg-[var(--accent)]/5 p-4">
-                        <p className="text-xs dark:text-white/55 text-[var(--text)]/55">
+                        <p className="text-xs dark:text-white/55 text-[var(--text-muted)]">
                           Sobrescribe un permiso específico para este usuario.
                         </p>
                         <div className="grid grid-cols-2 gap-2">
@@ -870,7 +870,7 @@ export function AccesoClient({
                                 <span className="font-medium dark:text-white/80 text-[var(--text)]/80">
                                   {getModuloNombre(ex.modulo_id)}
                                 </span>
-                                <span className="ml-1.5 dark:text-white/40 text-[var(--text)]/40">
+                                <span className="ml-1.5 dark:text-white/40 text-[var(--text-subtle)]">
                                   en {getEmpresaNombre(ex.empresa_id)}
                                 </span>
                               </div>

--- a/app/settings/acceso/page.tsx
+++ b/app/settings/acceso/page.tsx
@@ -41,7 +41,7 @@ export default async function AccesoPage() {
         <h2 className="text-xl font-semibold dark:text-white text-[var(--text)]">
           Error de configuración
         </h2>
-        <p className="mt-2 text-sm dark:text-white/55 text-[var(--text)]/55">
+        <p className="mt-2 text-sm dark:text-white/55 text-[var(--text-muted)]">
           SUPABASE_SERVICE_ROLE_KEY no está configurada.
         </p>
       </div>
@@ -67,7 +67,7 @@ export default async function AccesoPage() {
         <h2 className="mt-4 text-xl font-semibold dark:text-white text-[var(--text)]">
           Acceso restringido
         </h2>
-        <p className="mt-2 text-sm dark:text-white/55 text-[var(--text)]/55">
+        <p className="mt-2 text-sm dark:text-white/55 text-[var(--text-muted)]">
           Solo los administradores pueden gestionar el acceso de usuarios.
         </p>
       </div>

--- a/app/settings/empresas/[slug]/page.tsx
+++ b/app/settings/empresas/[slug]/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-/* eslint-disable react-hooks/set-state-in-effect --
- * Pre-existing data-sync pattern (loading guards around async fetch).
- */
+ 
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
@@ -128,7 +126,7 @@ function EmpresaPageInner() {
             <h1 className="text-2xl font-bold tracking-tight text-[var(--text)] truncate">
               {empresa.nombre}
             </h1>
-            <p className="mt-1 text-sm text-[var(--text)]/55">
+            <p className="mt-1 text-sm text-[var(--text-muted)]">
               {empresa.razon_social ?? empresa.nombre_comercial ?? '—'}
               {empresa.rfc && (
                 <>
@@ -165,7 +163,7 @@ function EmpresaPageInner() {
             className={`px-4 py-2.5 text-sm font-medium transition border-b-2 -mb-px cursor-pointer ${
               tab === t.key
                 ? 'border-[var(--accent)] text-[var(--text)]'
-                : 'border-transparent text-[var(--text)]/55 hover:text-[var(--text)]/80'
+                : 'border-transparent text-[var(--text-muted)] hover:text-[var(--text)]/80'
             }`}
           >
             {t.label}

--- a/app/settings/empresas/[slug]/page.tsx
+++ b/app/settings/empresas/[slug]/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
- 
-
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';

--- a/app/settings/empresas/_components/empresa-branding.tsx
+++ b/app/settings/empresas/_components/empresa-branding.tsx
@@ -124,7 +124,7 @@ function LogoCard({ variant, url }: { variant: LogoVariant; url: string | null }
           <img src={url} alt={variant.label} className={`${sizing} object-contain`} />
         ) : (
           <div
-            className={`${sizing} flex items-center justify-center text-xs text-[var(--text)]/40`}
+            className={`${sizing} flex items-center justify-center text-xs text-[var(--text-subtle)]`}
           >
             <FileImage className="h-6 w-6" />
           </div>
@@ -165,7 +165,7 @@ export function EmpresaBranding({ branding, slug }: { branding: Branding; slug: 
         <p className="text-sm text-[var(--text)]/60">
           Esta empresa todavía no tiene branding configurado.
         </p>
-        <p className="mt-2 text-xs text-[var(--text)]/40">
+        <p className="mt-2 text-xs text-[var(--text-subtle)]">
           Corre el script:{' '}
           <code className="font-mono bg-[var(--card)] px-1.5 py-0.5 rounded text-[var(--text)]/70">
             npx tsx scripts/branding/generate.ts --empresa {slug} --svg path/to/master.svg

--- a/app/settings/empresas/_components/empresa-detail.tsx
+++ b/app/settings/empresas/_components/empresa-detail.tsx
@@ -374,7 +374,7 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
           )}
         </div>
         {empresa.csf_fecha_emision && (
-          <p className="text-xs text-[var(--text)]/40">
+          <p className="text-xs text-[var(--text-subtle)]">
             Emitida el {formatDate(empresa.csf_fecha_emision)}
           </p>
         )}

--- a/app/settings/empresas/_components/image-uploader.tsx
+++ b/app/settings/empresas/_components/image-uploader.tsx
@@ -65,7 +65,7 @@ export function ImageUploader({
           />
         </div>
       ) : (
-        <div className="flex h-20 items-center justify-center rounded-xl border border-dashed border-[var(--border)] bg-[var(--panel)] text-xs text-[var(--text)]/40">
+        <div className="flex h-20 items-center justify-center rounded-xl border border-dashed border-[var(--border)] bg-[var(--panel)] text-xs text-[var(--text-subtle)]">
           Sin imagen
         </div>
       )}

--- a/app/settings/empresas/page.tsx
+++ b/app/settings/empresas/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
- 
-
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';

--- a/app/settings/empresas/page.tsx
+++ b/app/settings/empresas/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-/* eslint-disable react-hooks/set-state-in-effect --
- * Pre-existing data-sync pattern inherited from prior page version.
- */
+ 
 
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useState } from 'react';
@@ -81,7 +79,7 @@ function EmpresasSettingsInner() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">Empresas</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">
+          <p className="mt-1 text-sm text-[var(--text-muted)]">
             Selecciona una empresa para ver y editar sus datos fiscales y branding
           </p>
         </div>
@@ -124,7 +122,7 @@ function EmpresasSettingsInner() {
       ) : empresas.length === 0 ? (
         <div className="flex flex-col items-center justify-center p-16 text-center rounded-2xl border border-[var(--border)] bg-[var(--card)]">
           <Building2 className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-          <p className="text-sm text-[var(--text)]/55">No hay empresas registradas.</p>
+          <p className="text-sm text-[var(--text-muted)]">No hay empresas registradas.</p>
         </div>
       ) : (
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">

--- a/components/documentos/documento-adjuntos.tsx
+++ b/components/documentos/documento-adjuntos.tsx
@@ -198,7 +198,7 @@ export function AdjuntosSection({
       )}
       {renderGroup(
         'Anexos / Antecedentes',
-        <Paperclip className="h-3.5 w-3.5 text-[var(--text)]/40" />,
+        <Paperclip className="h-3.5 w-3.5 text-[var(--text-subtle)]" />,
         anexos
       )}
       {!readOnly && (

--- a/components/documentos/documento-detail-sheet.tsx
+++ b/components/documentos/documento-detail-sheet.tsx
@@ -340,7 +340,7 @@ export function DocumentoDetailSheet({
                           Datos extraídos
                         </h3>
                         {doc.extraccion_fecha && (
-                          <span className="ml-auto text-[10px] text-[var(--text)]/40">
+                          <span className="ml-auto text-[10px] text-[var(--text-subtle)]">
                             {formatDate(doc.extraccion_fecha.slice(0, 10))}
                           </span>
                         )}
@@ -425,7 +425,7 @@ export function DocumentoDetailSheet({
                                     {p.rol}
                                   </span>
                                 </div>
-                                <div className="mt-1 flex flex-wrap gap-x-3 text-xs text-[var(--text)]/55">
+                                <div className="mt-1 flex flex-wrap gap-x-3 text-xs text-[var(--text-muted)]">
                                   {p.rfc && <span>RFC: {p.rfc}</span>}
                                   {p.representante && <span>Rep: {p.representante}</span>}
                                 </div>

--- a/components/documentos/documento-form-fields.tsx
+++ b/components/documentos/documento-form-fields.tsx
@@ -130,7 +130,7 @@ export function DocFormFields({
             readOnly={form.tipo === 'Escritura'}
           />
           {form.tipo === 'Escritura' && (
-            <p className="mt-1 text-[10px] text-[var(--text)]/40">
+            <p className="mt-1 text-[10px] text-[var(--text-subtle)]">
               Se genera a partir de los datos de la escritura.
             </p>
           )}
@@ -217,7 +217,7 @@ export function DocFormFields({
             maxLength={500}
             className="resize-none rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
           />
-          <p className="mt-1 text-[10px] text-[var(--text)]/40">
+          <p className="mt-1 text-[10px] text-[var(--text-subtle)]">
             Se muestra como vista previa en la tabla. Máx 500 caracteres.
           </p>
         </div>

--- a/components/documentos/documento-semantic-search.tsx
+++ b/components/documentos/documento-semantic-search.tsx
@@ -96,7 +96,7 @@ export function DocumentoSemanticSearch({
             <Sparkles className="h-5 w-5 text-[var(--accent)]" />
             Búsqueda IA
           </DialogTitle>
-          <DialogDescription className="text-[var(--text)]/55">
+          <DialogDescription className="text-[var(--text-muted)]">
             Describe lo que buscas en lenguaje natural. La IA encontrará documentos relacionados por
             significado, no solo por palabras exactas.
           </DialogDescription>
@@ -117,7 +117,7 @@ export function DocumentoSemanticSearch({
               }
             }}
           />
-          <div className="flex items-center justify-between text-[10px] text-[var(--text)]/40">
+          <div className="flex items-center justify-between text-[10px] text-[var(--text-subtle)]">
             <span>⌘/Ctrl + Enter para buscar</span>
             <span>{query.length}/400</span>
           </div>
@@ -129,7 +129,7 @@ export function DocumentoSemanticSearch({
           )}
 
           <div>
-            <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--text)]/40">
+            <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-subtle)]">
               Ejemplos
             </p>
             <div className="flex flex-wrap gap-1.5">

--- a/components/documentos/documentos-module.tsx
+++ b/components/documentos/documentos-module.tsx
@@ -430,7 +430,7 @@ export function DocumentosModule({
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">{title}</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">{subtitle}</p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">{subtitle}</p>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -475,7 +475,7 @@ export function DocumentosModule({
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
         <div className="flex flex-wrap gap-3">
           <div className="relative min-w-48 flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-subtle)]" />
             <Input
               placeholder="Buscar en título, número, contenido, ubicación o partes..."
               value={search}
@@ -549,7 +549,7 @@ export function DocumentosModule({
       />
 
       {!loading && documentos.length > 0 && (
-        <p className="text-right text-xs text-[var(--text)]/40">
+        <p className="text-right text-xs text-[var(--text-subtle)]">
           {filtered.length} de {documentos.length} documentos
         </p>
       )}

--- a/components/documentos/documentos-table.tsx
+++ b/components/documentos/documentos-table.tsx
@@ -92,7 +92,7 @@ export function DocumentosTable({
       <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)]">
         <div className="flex flex-col items-center justify-center p-16 text-center">
           <FileText className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-          <p className="text-sm text-[var(--text)]/55">
+          <p className="text-sm text-[var(--text-muted)]">
             {documentos.length === 0 ? 'No hay documentos capturados aún' : 'Sin resultados'}
           </p>
           {documentos.length === 0 && (
@@ -170,10 +170,10 @@ export function DocumentosTable({
                 className="w-28 text-right"
               />
             )}
-            <TableHead className="font-medium text-[var(--text)]/55">Descripción</TableHead>
-            <TableHead className="w-24 font-medium text-[var(--text)]/55">PDF</TableHead>
-            <TableHead className="w-24 font-medium text-[var(--text)]/55">Imagen</TableHead>
-            <TableHead className="w-20 font-medium text-[var(--text)]/55">Anexos</TableHead>
+            <TableHead className="font-medium text-[var(--text-muted)]">Descripción</TableHead>
+            <TableHead className="w-24 font-medium text-[var(--text-muted)]">PDF</TableHead>
+            <TableHead className="w-24 font-medium text-[var(--text-muted)]">Imagen</TableHead>
+            <TableHead className="w-20 font-medium text-[var(--text-muted)]">Anexos</TableHead>
             <SortableHead
               sortKey="fecha_emision"
               label="Emisión"
@@ -216,7 +216,7 @@ export function DocumentosTable({
                     )}
                   </div>
                   {doc.notaria && (
-                    <span className="mt-0.5 block text-xs text-[var(--text)]/40">
+                    <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">
                       {doc.notaria}
                     </span>
                   )}

--- a/components/documentos/ui.tsx
+++ b/components/documentos/ui.tsx
@@ -10,7 +10,7 @@ import { formatDate, getVencStatus } from './helpers';
 import { TIPOS_DOCUMENTO } from './types';
 
 export function VencBadge({ d }: { d: string | null }) {
-  if (!d) return <span className="text-[var(--text)]/40">—</span>;
+  if (!d) return <span className="text-[var(--text-subtle)]">—</span>;
   const st = getVencStatus(d);
   const txt = formatDate(d);
   if (st === 'expired')
@@ -31,7 +31,7 @@ export function VencBadge({ d }: { d: string | null }) {
 }
 
 export function TipoBadge({ tipo }: { tipo: string | null }) {
-  if (!tipo) return <span className="text-[var(--text)]/40">—</span>;
+  if (!tipo) return <span className="text-[var(--text-subtle)]">—</span>;
   const f = TIPOS_DOCUMENTO.find((t) => t.value === tipo);
   return (
     <span className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--panel)] px-2 py-0.5 text-xs font-medium text-[var(--text)]/70">

--- a/components/playtomic/cancellation-charts.tsx
+++ b/components/playtomic/cancellation-charts.tsx
@@ -10,7 +10,7 @@ export function CancellationWeekdayChart({ data }: { data: { label: string; valu
     <div className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-5">
       <div>
         <h3 className="text-base font-semibold text-[var(--text)]">Cancelaciones por día</h3>
-        <p className="text-sm text-[var(--text)]/55">
+        <p className="text-sm text-[var(--text-muted)]">
           Distribución semanal de reservas canceladas.
         </p>
       </div>
@@ -81,7 +81,7 @@ export function CancellationHourChart({ data }: { data: { label: string; value: 
     <div className="rounded-3xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-5">
       <div>
         <h3 className="text-base font-semibold text-[var(--text)]">Cancelaciones por hora</h3>
-        <p className="text-sm text-[var(--text)]/55">Horas del día con más cancelaciones.</p>
+        <p className="text-sm text-[var(--text-muted)]">Horas del día con más cancelaciones.</p>
       </div>
       <div className="mt-4 overflow-x-auto">
         <svg viewBox={`0 0 ${width} ${height}`} className="min-w-[760px] text-[var(--text)]">

--- a/components/playtomic/cancellation-section.tsx
+++ b/components/playtomic/cancellation-section.tsx
@@ -12,7 +12,7 @@ export function CancellationSection({
     <section className="space-y-6">
       <div>
         <h2 className="text-lg font-semibold text-[var(--text)]">Análisis de Cancelaciones</h2>
-        <p className="text-sm text-[var(--text)]/55">
+        <p className="text-sm text-[var(--text-muted)]">
           Patrones y tendencias en reservas canceladas dentro del periodo seleccionado.
         </p>
       </div>
@@ -25,7 +25,7 @@ export function CancellationSection({
           <div className="mt-2 text-3xl font-semibold text-[var(--text)]">
             {analysis.canceledCount}
           </div>
-          <div className="mt-1 text-sm text-[var(--text)]/55">
+          <div className="mt-1 text-sm text-[var(--text-muted)]">
             Reservas marcadas como canceladas.
           </div>
         </div>
@@ -36,7 +36,7 @@ export function CancellationSection({
           <div className="mt-2 text-3xl font-semibold text-[var(--text)]">
             {analysis.cancellationRate.toFixed(1)}%
           </div>
-          <div className="mt-1 text-sm text-[var(--text)]/55">
+          <div className="mt-1 text-sm text-[var(--text-muted)]">
             Sobre {totalBookings} reservas del periodo.
           </div>
         </div>
@@ -79,7 +79,7 @@ export function CancellationSection({
           <div className="mt-2 text-3xl font-semibold text-[var(--text)]">
             {analysis.avgCanceledDuration.toFixed(0)} min
           </div>
-          <div className="mt-1 text-sm text-[var(--text)]/55">
+          <div className="mt-1 text-sm text-[var(--text-muted)]">
             Promedio de minutos en reservas canceladas.
           </div>
         </div>

--- a/components/playtomic/kpi-card.tsx
+++ b/components/playtomic/kpi-card.tsx
@@ -18,7 +18,7 @@ export function KpiCard({
         {label}
       </div>
       <div className="mt-2 text-2xl font-semibold tracking-tight text-[var(--text)]">{value}</div>
-      {hint ? <div className="mt-1 text-sm text-[var(--text)]/55">{hint}</div> : null}
+      {hint ? <div className="mt-1 text-sm text-[var(--text-muted)]">{hint}</div> : null}
     </div>
   );
 }

--- a/components/playtomic/occupancy-heatmap.tsx
+++ b/components/playtomic/occupancy-heatmap.tsx
@@ -68,7 +68,7 @@ export function OccupancyHeatmap({
       <div className="mb-4 flex items-center justify-between gap-3">
         <div>
           <div className="text-lg font-semibold text-[var(--text)]">Mapa de ocupación</div>
-          <div className="text-sm text-[var(--text)]/55">
+          <div className="text-sm text-[var(--text-muted)]">
             Intensidad por hora y cancha. Más oscuro = más reservas.
           </div>
         </div>

--- a/components/playtomic/occupancy-section.tsx
+++ b/components/playtomic/occupancy-section.tsx
@@ -18,7 +18,7 @@ export function OccupancySection({
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <h2 className="text-lg font-semibold text-[var(--text)]">Ocupación</h2>
-          <p className="text-sm text-[var(--text)]/55">
+          <p className="text-sm text-[var(--text-muted)]">
             Vista cruzada de canchas por hora dentro del rango seleccionado.
           </p>
         </div>

--- a/components/playtomic/pending-payments-section.tsx
+++ b/components/playtomic/pending-payments-section.tsx
@@ -36,7 +36,7 @@ export function PendingPaymentsSection({
       <div className="space-y-3">
         <div>
           <h3 className="text-base font-semibold text-[var(--text)]">Resumen por Jugador</h3>
-          <p className="text-sm text-[var(--text)]/55">
+          <p className="text-sm text-[var(--text-muted)]">
             Top 20 jugadores con saldo pendiente acumulado.
           </p>
         </div>
@@ -96,7 +96,7 @@ export function PendingPaymentsSection({
             <h3 className="text-base font-semibold text-[var(--text)]">
               Detalle de Reservas Pendientes
             </h3>
-            <p className="text-sm text-[var(--text)]/55">
+            <p className="text-sm text-[var(--text-muted)]">
               Listado individual de reservas pendientes.
             </p>
           </div>
@@ -195,7 +195,7 @@ export function PendingPaymentsSection({
               </div>
             </div>
             {pendingPayments.detailTruncated ? (
-              <p className="text-sm text-[var(--text)]/55">
+              <p className="text-sm text-[var(--text-muted)]">
                 Mostrando 200 de {pendingPayments.totalReservas} reservas pendientes.
               </p>
             ) : null}

--- a/components/playtomic/players-section.tsx
+++ b/components/playtomic/players-section.tsx
@@ -34,7 +34,9 @@ export function PlayersSection({
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <h2 className="text-lg font-semibold text-[var(--text)]">Top jugadores</h2>
-            <p className="text-sm text-[var(--text)]/55">Ranking operable con búsqueda y orden.</p>
+            <p className="text-sm text-[var(--text-muted)]">
+              Ranking operable con búsqueda y orden.
+            </p>
           </div>
           <div className="flex flex-col gap-2 sm:flex-row">
             <Input
@@ -99,7 +101,7 @@ export function PlayersSection({
       <div className="overflow-hidden rounded-3xl border border-[var(--border)] bg-[var(--card)] self-start">
         <div className="border-b border-[var(--border)] px-4 py-4 sm:px-5">
           <h3 className="text-base font-semibold text-[var(--text)]">Top canceladores</h3>
-          <p className="text-sm text-[var(--text)]/55">
+          <p className="text-sm text-[var(--text-muted)]">
             Jugadores con al menos 2 cancelaciones dentro del periodo.
           </p>
         </div>

--- a/components/playtomic/reconciliation-section.tsx
+++ b/components/playtomic/reconciliation-section.tsx
@@ -36,7 +36,7 @@ export function ReconciliationSection({
       <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <h2 className="text-lg font-semibold text-[var(--text)]">Conciliación de Ingresos</h2>
-          <p className="text-sm text-[var(--text)]/55">
+          <p className="text-sm text-[var(--text-muted)]">
             Desglose diario de reservas por estado de pago y origen para cuadrar contra depósitos.
           </p>
         </div>

--- a/components/playtomic/reconciliation-table.tsx
+++ b/components/playtomic/reconciliation-table.tsx
@@ -76,7 +76,7 @@ export function ReconciliationTable({ reconciliation }: { reconciliation: Reconc
         </div>
       </div>
       {reconciliation.truncated ? (
-        <p className="text-sm text-[var(--text)]/55">
+        <p className="text-sm text-[var(--text-muted)]">
           Mostrando 60 de {reconciliation.totalDays} días. Los totales reflejan el periodo completo.
         </p>
       ) : null}

--- a/components/playtomic/revenue-section.tsx
+++ b/components/playtomic/revenue-section.tsx
@@ -8,7 +8,7 @@ export function RevenueSection({ revenueSeries }: { revenueSeries: ChartBucket[]
       <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <h2 className="text-lg font-semibold text-[var(--text)]">Ingresos diarios</h2>
-          <p className="text-sm text-[var(--text)]/55">
+          <p className="text-sm text-[var(--text-muted)]">
             Barras apiladas por deporte, sin librerías externas.
           </p>
         </div>

--- a/components/require-access.tsx
+++ b/components/require-access.tsx
@@ -29,7 +29,7 @@ function AccessDenied() {
       <h2 className="mt-4 text-xl font-semibold dark:text-white text-[var(--text)]">
         Acceso restringido
       </h2>
-      <p className="mt-2 text-sm dark:text-white/55 text-[var(--text)]/55">
+      <p className="mt-2 text-sm dark:text-white/55 text-[var(--text-muted)]">
         No tienes permisos para acceder a esta sección. Contacta al administrador si necesitas
         acceso.
       </p>

--- a/components/rh/departamentos-module.tsx
+++ b/components/rh/departamentos-module.tsx
@@ -385,7 +385,7 @@ export function DepartamentosModule({
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">{title}</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">{subtitle}</p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">{subtitle}</p>
         </div>
         <div className="flex gap-2">
           <Button
@@ -427,7 +427,7 @@ export function DepartamentosModule({
         ) : departamentos.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-16">
             <Network className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text)]/55">No hay departamentos registrados</p>
+            <p className="text-sm text-[var(--text-muted)]">No hay departamentos registrados</p>
           </div>
         ) : (
           <Table>
@@ -513,7 +513,7 @@ export function DepartamentosModule({
                         'inline-flex items-center rounded-lg border px-2 py-0.5 text-xs font-medium',
                         d.activo
                           ? 'border-green-500/20 bg-green-500/10 text-green-400'
-                          : 'border-[var(--border)] bg-[var(--panel)] text-[var(--text)]/40',
+                          : 'border-[var(--border)] bg-[var(--panel)] text-[var(--text-subtle)]',
                       ].join(' ')}
                     >
                       {d.activo ? 'Activo' : 'Inactivo'}

--- a/components/rh/empleado-adjuntos.tsx
+++ b/components/rh/empleado-adjuntos.tsx
@@ -173,13 +173,13 @@ export function EmpleadoAdjuntos({
   ];
 
   if (loading) {
-    return <p className="text-xs text-[var(--text)]/40">Cargando documentos…</p>;
+    return <p className="text-xs text-[var(--text-subtle)]">Cargando documentos…</p>;
   }
 
   return (
     <div className="space-y-3">
       {orderedRoles.length === 0 ? (
-        <p className="text-xs text-[var(--text)]/40">Sin documentos registrados todavía.</p>
+        <p className="text-xs text-[var(--text-subtle)]">Sin documentos registrados todavía.</p>
       ) : (
         // Lista vertical: cada documento ocupa una fila completa con el nombre
         // del archivo visible sin truncar. Ocupa más espacio pero es mucho más
@@ -235,7 +235,7 @@ export function EmpleadoAdjuntos({
                       className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-[var(--border)] ${
                         pdf
                           ? 'bg-red-500/10 text-red-400'
-                          : 'bg-[var(--card)] text-[var(--text)]/40'
+                          : 'bg-[var(--card)] text-[var(--text-subtle)]'
                       }`}
                     >
                       {pdf ? <FileText className="h-5 w-5" /> : <Paperclip className="h-4 w-4" />}
@@ -254,7 +254,7 @@ export function EmpleadoAdjuntos({
                     <div className="text-sm text-[var(--text)] break-words leading-snug">
                       {a.nombre}
                     </div>
-                    <div className="mt-0.5 flex items-center gap-2 text-[10px] text-[var(--text)]/40">
+                    <div className="mt-0.5 flex items-center gap-2 text-[10px] text-[var(--text-subtle)]">
                       {a.tamano_bytes != null && <span>{formatSize(a.tamano_bytes)}</span>}
                       <span>
                         ·{' '}

--- a/components/rh/empleado-alta-wizard.tsx
+++ b/components/rh/empleado-alta-wizard.tsx
@@ -624,7 +624,7 @@ export function EmpleadoAltaWizard({
   // ─── Step 1 render ──────────────────────────────────────────────────────────
   const Step1 = (
     <div className="space-y-4 py-2">
-      <p className="text-xs text-[var(--text)]/55">
+      <p className="text-xs text-[var(--text-muted)]">
         Datos del trabajador y su contacto de emergencia. Obligatorios para el contrato individual y
         el expediente.
       </p>
@@ -667,7 +667,7 @@ export function EmpleadoAltaWizard({
       </div>
 
       {persona.nombre && (
-        <p className="text-[10px] text-[var(--text)]/40">
+        <p className="text-[10px] text-[var(--text-subtle)]">
           Nombre completo:{' '}
           <span className="text-[var(--text)]/70">
             {composeFullName(persona.nombre, persona.apellido_paterno, persona.apellido_materno)}
@@ -884,7 +884,7 @@ export function EmpleadoAltaWizard({
 
   const Step2 = (
     <div className="space-y-4 py-2">
-      <p className="text-xs text-[var(--text)]/55">
+      <p className="text-xs text-[var(--text-muted)]">
         Puesto, cláusulas de contrato (Art. 25 LFT) y compensación. El SDI se calcula
         automáticamente a partir del sueldo mensual.
       </p>
@@ -1065,7 +1065,7 @@ export function EmpleadoAltaWizard({
               onChange={(e) => setEmpleado((s) => ({ ...s, sueldo_diario: e.target.value }))}
               className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)] font-mono"
             />
-            <p className="mt-1 text-[10px] text-[var(--text)]/40">Auto = mensual / 30.4167</p>
+            <p className="mt-1 text-[10px] text-[var(--text-subtle)]">Auto = mensual / 30.4167</p>
           </div>
           <div>
             <FieldLabel>SDI</FieldLabel>
@@ -1077,13 +1077,13 @@ export function EmpleadoAltaWizard({
               onChange={(e) => setEmpleado((s) => ({ ...s, sdi: e.target.value }))}
               className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)] font-mono"
             />
-            <p className="mt-1 text-[10px] text-[var(--text)]/40">
+            <p className="mt-1 text-[10px] text-[var(--text-subtle)]">
               Auto = diario × 1.0452 (1er año)
             </p>
           </div>
         </div>
         {empleado.sueldo_mensual && Number(empleado.sueldo_mensual) > 0 && (
-          <p className="text-[11px] text-[var(--text)]/55">
+          <p className="text-[11px] text-[var(--text-muted)]">
             Mensual {formatCurrency(Number(empleado.sueldo_mensual))} · diario{' '}
             {empleado.sueldo_diario ? formatCurrency(Number(empleado.sueldo_diario)) : '—'} · SDI{' '}
             {empleado.sdi ? formatCurrency(Number(empleado.sdi)) : '—'}
@@ -1117,7 +1117,7 @@ export function EmpleadoAltaWizard({
               ? 'bg-green-500/10 text-green-400'
               : required && !exento
                 ? 'bg-red-500/10 text-red-400'
-                : 'bg-[var(--card)] text-[var(--text)]/40'
+                : 'bg-[var(--card)] text-[var(--text-subtle)]'
           }`}
         >
           {file && isImageFile(file) ? (
@@ -1131,7 +1131,9 @@ export function EmpleadoAltaWizard({
             {r.label}
             {required && !exento && <span className="text-red-400">*</span>}
             {exento && (
-              <span className="text-[10px] text-[var(--text)]/40">(exento · primer empleo)</span>
+              <span className="text-[10px] text-[var(--text-subtle)]">
+                (exento · primer empleo)
+              </span>
             )}
           </p>
           {file && (
@@ -1183,7 +1185,7 @@ export function EmpleadoAltaWizard({
 
   const Step3 = (
     <div className="space-y-5 py-2">
-      <p className="text-xs text-[var(--text)]/55">
+      <p className="text-xs text-[var(--text-muted)]">
         Expediente legal: archivos obligatorios (INE, CURP, acta, comprobante de domicilio, CSF y
         constancia IMSS) + foto y beneficiarios (Art. 501 LFT). Sin estos archivos no se puede
         generar contrato.
@@ -1254,7 +1256,7 @@ export function EmpleadoAltaWizard({
                     <button
                       type="button"
                       onClick={() => removeBeneficiario(idx)}
-                      className="rounded-lg p-1.5 text-[var(--text)]/40 hover:bg-red-500/10 hover:text-red-400"
+                      className="rounded-lg p-1.5 text-[var(--text-subtle)] hover:bg-red-500/10 hover:text-red-400"
                       title="Quitar beneficiario"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -1283,7 +1285,7 @@ export function EmpleadoAltaWizard({
             <Check className="h-4 w-4" />
             Expediente completo — listo para generar contrato
           </p>
-          <p className="mt-1 text-[11px] text-[var(--text)]/55">
+          <p className="mt-1 text-[11px] text-[var(--text-muted)]">
             Al crear el empleado se guardan los datos, se suben los archivos y se redirige a la
             ficha. Desde ahí se puede imprimir el contrato individual de trabajo.
           </p>

--- a/components/rh/empleados-module.tsx
+++ b/components/rh/empleados-module.tsx
@@ -330,7 +330,7 @@ export function EmpleadosModule({
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">{title}</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">{subtitle}</p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">{subtitle}</p>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -378,7 +378,7 @@ export function EmpleadosModule({
             ))}
           </div>
           <div className="relative min-w-48 flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-subtle)]" />
             <Input
               placeholder="Buscar por nombre..."
               value={search}
@@ -418,7 +418,7 @@ export function EmpleadosModule({
         ) : visible.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-16 text-center">
             <Users className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text)]/55">
+            <p className="text-sm text-[var(--text-muted)]">
               {empleados.length === 0
                 ? 'No hay empleados registrados'
                 : 'Sin resultados para los filtros actuales'}
@@ -528,7 +528,7 @@ export function EmpleadosModule({
                         className={`inline-flex items-center rounded-lg border px-2 py-0.5 text-xs font-medium ${
                           emp.activo
                             ? 'border-green-500/20 bg-green-500/10 text-green-400'
-                            : 'border-[var(--border)] bg-[var(--panel)] text-[var(--text)]/40'
+                            : 'border-[var(--border)] bg-[var(--panel)] text-[var(--text-subtle)]'
                         }`}
                       >
                         {emp.activo ? 'Activo' : 'Inactivo'}
@@ -560,7 +560,7 @@ export function EmpleadosModule({
       </div>
 
       {!loading && empleados.length > 0 && (
-        <p className="text-right text-xs text-[var(--text)]/40">
+        <p className="text-right text-xs text-[var(--text-subtle)]">
           {visible.length} de {empleados.length} empleado
           {empleados.length !== 1 ? 's' : ''}
         </p>

--- a/components/rh/puestos-module.tsx
+++ b/components/rh/puestos-module.tsx
@@ -495,7 +495,7 @@ export function PuestosModule({
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">{title}</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">{subtitle}</p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">{subtitle}</p>
         </div>
         <div className="flex gap-2">
           <Button
@@ -554,7 +554,7 @@ export function PuestosModule({
         ) : visible.length === 0 ? (
           <div className="flex flex-col items-center justify-center p-16">
             <Briefcase className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text)]/55">No hay puestos registrados</p>
+            <p className="text-sm text-[var(--text-muted)]">No hay puestos registrados</p>
           </div>
         ) : (
           <Table>
@@ -670,7 +670,7 @@ export function PuestosModule({
                           'inline-flex items-center rounded-lg border px-2 py-0.5 text-xs font-medium',
                           p.activo
                             ? 'border-green-500/20 bg-green-500/10 text-green-400'
-                            : 'border-[var(--border)] bg-[var(--panel)] text-[var(--text)]/40',
+                            : 'border-[var(--border)] bg-[var(--panel)] text-[var(--text-subtle)]',
                         ].join(' ')}
                       >
                         {p.activo ? 'Activo' : 'Inactivo'}

--- a/components/tasks/tasks-edit-form.tsx
+++ b/components/tasks/tasks-edit-form.tsx
@@ -252,7 +252,7 @@ function RichEditSheet({
                 className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
               />
               {!canCompleteTask && (
-                <p className="mt-1 text-[10px] text-[var(--text)]/40">
+                <p className="mt-1 text-[10px] text-[var(--text-subtle)]">
                   Solo dirección o el creador pueden cambiar el estado
                 </p>
               )}
@@ -328,31 +328,35 @@ function RichEditSheet({
               <div className="grid grid-cols-2 gap-x-4 gap-y-3 rounded-2xl bg-[var(--panel)] p-3 border border-[var(--border)] text-[11px]">
                 {selectedTask.iniciativa && (
                   <div>
-                    <span className="font-semibold text-[var(--text)]/40 block">Iniciativa</span>
+                    <span className="font-semibold text-[var(--text-subtle)] block">
+                      Iniciativa
+                    </span>
                     {selectedTask.iniciativa}
                   </div>
                 )}
                 {selectedTask.tipo && (
                   <div>
-                    <span className="font-semibold text-[var(--text)]/40 block">Tipo</span>
+                    <span className="font-semibold text-[var(--text-subtle)] block">Tipo</span>
                     {selectedTask.tipo}
                   </div>
                 )}
                 {selectedTask.fecha_vence && (
                   <div>
-                    <span className="font-semibold text-[var(--text)]/40 block">Fecha Vence</span>
+                    <span className="font-semibold text-[var(--text-subtle)] block">
+                      Fecha Vence
+                    </span>
                     {formatDate(selectedTask.fecha_vence)}
                   </div>
                 )}
                 {selectedTask.motivo_bloqueo && (
                   <div className="col-span-2">
-                    <span className="font-semibold text-[var(--text)]/40 block">Bloqueo</span>
+                    <span className="font-semibold text-[var(--text-subtle)] block">Bloqueo</span>
                     {selectedTask.motivo_bloqueo}
                   </div>
                 )}
                 {selectedTask.siguiente_accion && (
                   <div className="col-span-2">
-                    <span className="font-semibold text-[var(--text)]/40 block">
+                    <span className="font-semibold text-[var(--text-subtle)] block">
                       Siguiente Acción
                     </span>
                     {selectedTask.siguiente_accion}
@@ -362,7 +366,7 @@ function RichEditSheet({
             )}
 
           {selectedTask?.asignado_por && (
-            <div className="text-xs text-[var(--text)]/40">
+            <div className="text-xs text-[var(--text-subtle)]">
               Asignada por: {empleadoMap.get(selectedTask.asignado_por)?.nombre ?? 'Desconocido'}
               {selectedTask.fecha_completado && (
                 <> · Completada: {formatDate(selectedTask.fecha_completado)}</>

--- a/components/tasks/tasks-filters-bar.tsx
+++ b/components/tasks/tasks-filters-bar.tsx
@@ -101,7 +101,7 @@ export function TasksFiltersBar({
     <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
       <div className="flex flex-wrap gap-3">
         <div className="relative min-w-48 flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-subtle)]" />
           <Input
             placeholder={
               isRich ? 'Buscar por título, descripción o responsable...' : 'Buscar tareas...'

--- a/components/tasks/tasks-module.tsx
+++ b/components/tasks/tasks-module.tsx
@@ -785,7 +785,7 @@ export function TasksModule({
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-[var(--text)]">{title}</h1>
-          <p className="mt-1 text-sm text-[var(--text)]/55">{subtitle}</p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">{subtitle}</p>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -841,7 +841,7 @@ export function TasksModule({
             {hideCompleted ? 'Mostrar completadas' : 'Ocultar completadas'}
           </button>
           {!loading && (
-            <span className="text-xs text-[var(--text)]/40">
+            <span className="text-xs text-[var(--text-subtle)]">
               {filtered.length} de {visibleTasks.length} tareas
               {hideCompleted ? ' (sin completadas)' : ''}
             </span>
@@ -880,7 +880,7 @@ export function TasksModule({
 
       {/* Footer counter (simple only — rich and simple+toggle show their own) */}
       {!isRich && !showHideCompletedToggle && !loading && tasks.length > 0 && (
-        <p className="text-right text-xs text-[var(--text)]/40">
+        <p className="text-right text-xs text-[var(--text-subtle)]">
           {filtered.length} de {tasks.length} {tasks.length === 1 ? 'tarea' : 'tareas'}
         </p>
       )}

--- a/components/tasks/tasks-shared.tsx
+++ b/components/tasks/tasks-shared.tsx
@@ -96,7 +96,7 @@ export const ESTADO_CONFIG: Record<TaskEstado, { label: string; cls: string }> =
   completado: { label: 'Completado', cls: 'bg-green-500/15 text-green-400 border-green-500/20' },
   cancelado: {
     label: 'Cancelado',
-    cls: 'bg-[var(--border)]/60 text-[var(--text)]/40 border-[var(--border)]',
+    cls: 'bg-[var(--border)]/60 text-[var(--text-subtle)] border-[var(--border)]',
   },
 };
 
@@ -168,7 +168,7 @@ export function EstadoBadge({ estado }: { estado: TaskEstado }) {
  * exact prioridad value (e.g. "Urgente", "Alta").
  */
 export function PrioridadBadge({ prioridad }: { prioridad: string | null }) {
-  if (!prioridad) return <span className="text-[var(--text)]/40">—</span>;
+  if (!prioridad) return <span className="text-[var(--text-subtle)]">—</span>;
   const cfg = PRIORIDAD_CONFIG[prioridad] ?? { label: prioridad, cls: '' };
   return (
     <span
@@ -184,7 +184,7 @@ export function PrioridadBadge({ prioridad }: { prioridad: string | null }) {
  * text (case-insensitive matching for "alta"/"urgente"/"media"/"baja").
  */
 export function PrioridadTextBadge({ text }: { text: string | null }) {
-  if (!text) return <span className="text-[var(--text)]/40">—</span>;
+  if (!text) return <span className="text-[var(--text-subtle)]">—</span>;
   const lower = text.toLowerCase();
   const dotColor =
     lower === 'alta' || lower === 'urgente'

--- a/components/tasks/tasks-table.tsx
+++ b/components/tasks/tasks-table.tsx
@@ -102,7 +102,7 @@ export function TasksTable(props: TasksTableProps) {
     return (
       <div className="flex flex-col items-center justify-center p-16 text-center">
         <TicketCheck className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-        <p className="text-sm text-[var(--text)]/55">
+        <p className="text-sm text-[var(--text-muted)]">
           {totalCount === 0
             ? 'No hay tareas creadas aún'
             : 'No hay tareas que coincidan con los filtros'}
@@ -202,7 +202,7 @@ function SimpleTable({
               <TableCell>
                 <span className="line-clamp-1 font-medium text-[var(--text)]">{task.titulo}</span>
                 {task.entidad_tipo && (
-                  <span className="mt-0.5 block text-xs text-[var(--text)]/40">
+                  <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">
                     {task.entidad_tipo}
                   </span>
                 )}
@@ -363,7 +363,7 @@ function RichTable({
 
               <TableCell className="whitespace-normal">
                 <span className="line-clamp-1 font-medium text-[var(--text)]">{task.titulo}</span>
-                <span className="mt-0.5 block text-xs text-[var(--text)]/40 line-clamp-1">
+                <span className="mt-0.5 block text-xs text-[var(--text-subtle)] line-clamp-1">
                   {[task.departamento_nombre, task.descripcion].filter(Boolean).join(' · ') || ' '}
                 </span>
               </TableCell>

--- a/components/tasks/tasks-updates.tsx
+++ b/components/tasks/tasks-updates.tsx
@@ -46,7 +46,9 @@ export function UpdatesList({
 
   if (updates.length === 0) {
     if (variant === 'embedded') {
-      return <p className="text-xs text-[var(--text)]/40 text-center py-3">Sin actualizaciones</p>;
+      return (
+        <p className="text-xs text-[var(--text-subtle)] text-center py-3">Sin actualizaciones</p>
+      );
     }
     return (
       <div className="flex flex-col items-center justify-center py-6 text-center">
@@ -74,7 +76,7 @@ export function UpdatesList({
               >
                 {tc.label}
               </span>
-              <span className="text-[10px] text-[var(--text)]/40">
+              <span className="text-[10px] text-[var(--text-subtle)]">
                 {u.usuario?.nombre ?? 'Sistema'}
               </span>
               <span className="text-[10px] text-[var(--text)]/30 ml-auto">

--- a/components/ui/sortable-head.tsx
+++ b/components/ui/sortable-head.tsx
@@ -24,7 +24,7 @@ export function SortableHead({
   return (
     <TableHead
       className={`cursor-pointer select-none font-medium transition-colors hover:text-[var(--text)]/80 ${
-        active ? 'text-[var(--text)]' : 'text-[var(--text)]/55'
+        active ? 'text-[var(--text)]' : 'text-[var(--text-muted)]'
       } ${className}`}
       onClick={() => onSort(sortKey)}
     >


### PR DESCRIPTION
## Por qué
Follow-up de [#145](https://github.com/beto-sudo/BSOP/pull/145). Los tokens `--text-muted` / `--text-subtle` ya están probados; solo los propago al resto del repo para cerrar la deuda de contraste AA.

## Qué cambió
Codemod determinista: dos sustituciones 1-a-1, 49 archivos afectados.
- `text-[var(--text)]/40` → `text-[var(--text-subtle)]`
- `text-[var(--text)]/55` → `text-[var(--text-muted)]`

Cero cambios de comportamiento, cero decisiones de diseño caso por caso.

## Verificación cuantitativa
- **Antes**: 99 ocurrencias de `/40` + 65 de `/55` = **164 total** (en 49 archivos únicos)
- **Después**: 0 de `/40`, 0 de `/55`
- **Tokens nuevos sumados**: `text-subtle` = 107, `text-muted` = 72 = **179 total**
- Diff (179 − 164 = 15) corresponde a los usos pre-existentes del token desde PR 145 (app-shell + widgets de /inicio). ✅ Consistente.

> Nota: el estimado inicial del spec era ~76, pero la realidad fueron 164. La causa es que los módulos están duplicados por empresa (rdb, dilesa) y los wizards/modales acumularon más usos desde PR 145. El codemod es determinista, así que la divergencia de volumen no cambia el resultado.

## Archivos afectados (49)
- `app/inicio/juntas/**` (2 archivos)
- `app/rdb/**`, `app/dilesa/**` (juntas + tasks + rh + page raíz, 12 archivos)
- `app/settings/**` (empresas + acceso, 7 archivos)
- `components/playtomic/**` (10 archivos)
- `components/rh/**` (5 archivos)
- `components/documentos/**` (7 archivos)
- `components/tasks/**` (6 archivos)
- `components/ui/sortable-head.tsx`, `components/require-access.tsx`

## Checks técnicos
- [x] `npm run lint` (0 errors, 65 warnings pre-existentes)
- [x] `npm run test:run` (136/136 ✅)
- [x] `npm run build` (TypeScript + prerender OK)

## QA visual
Spot check pendiente en preview:
- `/inicio/juntas` (lista) — light + dark
- `/inicio/juntas/[id]` (detalle) — light + dark
- `/rdb/playtomic` (KPIs) — light + dark
- `/rdb/rh/empleados` (lista) — light + dark
- `/rdb/rh/empleados` → alta wizard — light + dark

## Fuera de scope (follow-ups candidatos)
- `dark:text-white/X` cleanup (override explícito, puede haber sido intencional)
- Otras opacidades sobre `--text`: `/20`, `/45`, `/48`, `/50`, `/60`, `/65`, `/68`, `/70`, `/80`, `/85`, `/90`
- Clases `text-muted` / `text-subtle` sin `var()` (si existen en el repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)