### PR TITLE
fix(documentos): sube límite descripcion 500 → 1500 chars

### DIFF
--- a/components/documentos/documento-form-fields.tsx
+++ b/components/documentos/documento-form-fields.tsx
@@ -213,12 +213,13 @@ export function DocFormFields({
             placeholder="Resumen breve de lo que contiene el documento..."
             value={form.descripcion}
             onChange={(e) => setForm((f) => ({ ...f, descripcion: e.target.value }))}
-            rows={3}
-            maxLength={500}
+            rows={4}
+            maxLength={1500}
             className="resize-none rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
           />
           <p className="mt-1 text-[10px] text-[var(--text-subtle)]">
-            Se muestra como vista previa en la tabla. Máx 500 caracteres.
+            Se muestra como vista previa en la tabla. Hasta 1500 caracteres para escrituras
+            complejas que contienen varios actos jurídicos.
           </p>
         </div>
       )}

--- a/lib/documentos/extraction-core.ts
+++ b/lib/documentos/extraction-core.ts
@@ -62,10 +62,13 @@ export const ParteSchema = z.object({
 export const ExtraccionSchema = z.object({
   descripcion: z
     .string()
-    .max(500)
+    .max(1500)
     .describe(
-      'Resumen humano de 2-3 oraciones (máximo 500 caracteres) de qué contiene el documento. ' +
-        'Debe incluir tipo de operación, partes principales y objeto en lenguaje natural.'
+      'Resumen humano del documento (máximo ~1500 caracteres). Para escrituras simples ' +
+        '(una sola operación), 2-3 oraciones bastan (~300-500 chars). Para escrituras ' +
+        'complejas que contienen varios actos jurídicos en un mismo instrumento ' +
+        '(ej. compraventa + declaración unilateral + liberación de reserva), incluye ' +
+        'cada acto brevemente. Siempre menciona partes principales, objeto y montos clave.'
     ),
   contenido_texto: z
     .string()


### PR DESCRIPTION
## Resumen

Fix puntual: el doc 2009-12 #659 (escritura compleja con 3 actos jurídicos en un solo instrumento) fallaba en "Procesar con IA" con \`Type validation failed\`. Causa: la descripción legítima generada por Claude tenía ~600 chars, excediendo el \`max(500)\` del Zod schema.

## Cambios

- Schema: \`descripcion.max(500)\` → \`max(1500)\`. Descripción del field actualizada para guiar al modelo según complejidad del doc.
- Textarea del form de edición: \`maxLength\` también a 1500. La tabla sigue usando \`line-clamp-2\` (visualmente compacto).

## Por qué 1500

Cubre escrituras con hasta ~5 actos descritos brevemente. El contenido completo del doc vive en \`contenido_texto\` (sin límite). El campo \`descripcion\` sigue siendo "vista previa rápida", no "transcripción".

🤖 Generated with [Claude Code](https://claude.com/claude-code)