### PR TITLE
refactor(ui): unify shell iconography to lucide

### DIFF
--- a/components/app-shell/header.tsx
+++ b/components/app-shell/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bell, ChevronDown, Moon, Sun } from 'lucide-react';
+import { Bell, Calendar, ChevronDown, Clock, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useLocale } from '@/lib/i18n';
 import { AccountMenu } from './account-menu';
@@ -75,8 +75,8 @@ export function Header({
         </div>
 
         <div className="flex flex-wrap items-center gap-3 text-sm dark:text-white/70 text-[var(--text)]/70">
-          <InfoPill label="🕐" value={formattedDate} />
-          <InfoPill label="📅" value={t('header.no_events')} />
+          <InfoPill icon={Clock} value={formattedDate} />
+          <InfoPill icon={Calendar} value={t('header.no_events')} />
           <div className="flex items-center gap-2 rounded-2xl border border-[var(--border)] bg-[var(--panel)] px-3 py-2">
             {/* Theme toggle */}
             <button

--- a/components/app-shell/info-pill.tsx
+++ b/components/app-shell/info-pill.tsx
@@ -1,10 +1,12 @@
+import type { LucideIcon } from 'lucide-react';
+
 /**
- * Small label+value capsule used in the AppShell header (clock, events, etc).
+ * Small icon+value capsule used in the AppShell header (clock, events, etc).
  */
-export function InfoPill({ label, value }: { label: string; value: string }) {
+export function InfoPill({ icon: Icon, value }: { icon: LucideIcon; value: string }) {
   return (
     <div className="flex items-center gap-2 rounded-2xl border border-[var(--border)] bg-[var(--panel)] px-3 py-2">
-      <span>{label}</span>
+      <Icon className="h-3.5 w-3.5 text-[var(--text-muted)]" aria-hidden="true" />
       <span className="dark:text-white/85 text-[var(--text)]/85">{value}</span>
     </div>
   );

--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -11,20 +11,28 @@ export type NavChild = {
   divider?: boolean;
 };
 
+export type NavIconKey =
+  | 'home'
+  | 'id-card'
+  | 'settings'
+  | 'dilesa-logo'
+  | 'rdb-logo'
+  | 'sanren-logo';
+
 export type NavItem = {
   href: string;
   labelKey: string;
-  icon: string;
+  icon: NavIconKey;
   matchPaths?: string[];
   children?: NavChild[];
 };
 
 export const NAV_ITEMS: NavItem[] = [
-  { href: '/', labelKey: 'nav.overview', icon: '🏠' },
+  { href: '/', labelKey: 'nav.overview', icon: 'home' },
   {
     href: '/dilesa',
     labelKey: 'DILESA',
-    icon: 'DILESA_LOGO',
+    icon: 'dilesa-logo',
     children: [
       { label: 'Administración', href: '#', divider: true },
       { label: 'Tareas', href: '/dilesa/admin/tasks' },
@@ -39,7 +47,7 @@ export const NAV_ITEMS: NavItem[] = [
   {
     href: '/rdb',
     labelKey: 'Rincón del Bosque',
-    icon: 'RDB_LOGO',
+    icon: 'rdb-logo',
     children: [
       { label: 'Administración', href: '#', divider: true },
       { label: 'Tareas', href: '/rdb/admin/tasks' },
@@ -63,12 +71,12 @@ export const NAV_ITEMS: NavItem[] = [
   {
     href: '/personas-fisicas',
     labelKey: 'Personas Físicas',
-    icon: '🪪',
+    icon: 'id-card',
   },
   {
     href: '/family',
     labelKey: 'SANREN',
-    icon: 'SANREN_LOGO',
+    icon: 'sanren-logo',
     matchPaths: ['/family', '/travel', '/health'],
     children: [
       { label: 'Viajes', href: '/travel' },
@@ -79,7 +87,7 @@ export const NAV_ITEMS: NavItem[] = [
   {
     href: '/settings',
     labelKey: 'nav.settings',
-    icon: '⚙️',
+    icon: 'settings',
     children: [
       { label: 'Acceso', href: '/settings/acceso' },
       { label: 'Empresas', href: '/settings/empresas' },

--- a/components/app-shell/sidebar.tsx
+++ b/components/app-shell/sidebar.tsx
@@ -4,18 +4,53 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
-import { ChevronDown, ChevronRight, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Home,
+  IdCard,
+  type LucideIcon,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Settings as SettingsIcon,
+} from 'lucide-react';
 import { useLocale } from '@/lib/i18n';
 import { usePermissions } from '@/components/providers';
 import { canAccessEmpresa, canAccessModulo, ROUTE_TO_MODULE } from '@/lib/permissions';
 import {
   NAV_ITEMS,
   NAV_TO_EMPRESA,
+  type NavIconKey,
   type NavItem,
   getActiveSection,
   isItemActive,
   matchesPath,
 } from './nav-config';
+
+const LUCIDE_BY_KEY: Record<'home' | 'id-card' | 'settings', LucideIcon> = {
+  home: Home,
+  'id-card': IdCard,
+  settings: SettingsIcon,
+};
+
+const LOGO_BY_KEY: Record<
+  'dilesa-logo' | 'rdb-logo' | 'sanren-logo',
+  { src: string; alt: string }
+> = {
+  'dilesa-logo': { src: '/logos/dilesa.jpg', alt: 'DILESA' },
+  'rdb-logo': { src: '/logos/rdb.jpg', alt: 'RDB' },
+  'sanren-logo': { src: '/logos/sanren.png', alt: 'SANREN' },
+};
+
+function NavIcon({ icon }: { icon: NavIconKey }) {
+  if (icon in LOGO_BY_KEY) {
+    const { src, alt } = LOGO_BY_KEY[icon as keyof typeof LOGO_BY_KEY];
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt={alt} className="h-5 w-5 object-contain rounded-sm" />;
+  }
+  const Icon = LUCIDE_BY_KEY[icon as keyof typeof LUCIDE_BY_KEY];
+  return <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />;
+}
 
 /**
  * Left sidebar: logo header, collapsible nav tree, footer credit.
@@ -169,29 +204,7 @@ export function Sidebar({
                     ].join(' ')}
                     title={collapsed ? label : undefined}
                   >
-                    <span className="text-lg leading-none">
-                      {item.icon === 'DILESA_LOGO' ? (
-                        <img
-                          src="/logos/dilesa.jpg"
-                          alt="DILESA"
-                          className="h-5 w-5 object-contain rounded-sm"
-                        />
-                      ) : item.icon === 'RDB_LOGO' ? (
-                        <img
-                          src="/logos/rdb.jpg"
-                          alt="RDB"
-                          className="h-5 w-5 object-contain rounded-sm"
-                        />
-                      ) : item.icon === 'SANREN_LOGO' ? (
-                        <img
-                          src="/logos/sanren.png"
-                          alt="SANREN"
-                          className="h-5 w-5 object-contain rounded-sm"
-                        />
-                      ) : (
-                        item.icon
-                      )}
-                    </span>
+                    <NavIcon icon={item.icon} />
                     {!collapsed ? <span className="min-w-0 flex-1 truncate">{label}</span> : null}
                   </Link>
                   {!collapsed && hasChildren ? (


### PR DESCRIPTION
## Por qué

Los emojis en el shell tenían tres problemas:

- **Cross-platform inconsistency**: 🏠 🪪 ⚙️ 🕐 📅 se renderizan distinto en Apple vs Windows vs Android (diferentes paletas y grados de detalle).
- **No heredan `currentColor`**: los emojis tienen color hardcoded por el OS, por lo que no respetan dark mode ni el token `--accent` al hacer hover/active.
- **Inconsistencia interna**: el resto del shell (chevrons, panel-collapse, bell, sun/moon) ya usa Lucide. Los emojis rompían el sistema visual.

## Qué cambió

Sustitución puntual de 5 emojis de iconografía de UI por componentes Lucide:

| Antes | Después |
|---|---|
| 🏠 (overview) | `<Home />` |
| 🪪 (personas físicas) | `<IdCard />` |
| ⚙️ (settings) | `<Settings />` (importado como `SettingsIcon` para no colisionar con el label del item) |
| 🕐 (clock pill) | `<Clock />` |
| 📅 (events pill) | `<Calendar />` |

Los logos de empresa (DILESA/RDB/SANREN) no cambian visualmente — solo se renombraron los sentinels internos de `SNAKE_CASE` a `kebab-case` para consistencia con el resto de `NavIconKey`.

## Arquitectura

`nav-config.ts` mantiene su contrato de **módulo puro** (sin React, sin side effects) para que tests y storybooks puedan importarlo sin arrastrar el árbol de UI. Los iconos se declaran como `NavIconKey` (union de strings literales) y el mapping a componentes Lucide vive en `sidebar.tsx`:

```ts
// nav-config.ts — puro
export type NavIconKey =
  | 'home' | 'id-card' | 'settings'
  | 'dilesa-logo' | 'rdb-logo' | 'sanren-logo';
```

```tsx
// sidebar.tsx — resuelve el mapping
const LUCIDE_BY_KEY: Record<'home' | 'id-card' | 'settings', LucideIcon> = {
  home: Home, 'id-card': IdCard, settings: SettingsIcon,
};

function NavIcon({ icon }: { icon: NavIconKey }) {
  if (icon in LOGO_BY_KEY) { /* <img /> con src del logo */ }
  const Icon = LUCIDE_BY_KEY[icon];
  return <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />;
}
```

`InfoPill` cambió de `label: string` a `icon: LucideIcon` — API más tipada, imposible pasar un string arbitrario.

## Beneficios concretos

- **Dark mode**: los iconos heredan `currentColor` vía el `text-*` del contenedor, por lo que se aclaran/oscurecen con el tema sin CSS extra.
- **Accesibilidad**: `aria-hidden="true"` en todos los iconos decorativos (el texto del label ya los describe).
- **Bundle**: Lucide es tree-shakeable — solo pagamos los 5 iconos nuevos (Home, IdCard, Settings, Clock, Calendar); no inflamos el bundle.
- **Type safety**: `NavIconKey` como union literal permite que TypeScript verifique en compile-time que no se usen claves inválidas.

## Fuera de scope (explícito)

Estos emojis NO se tocaron porque son decorativos-de-copy (parte del texto), no iconografía de UI:
- Labels tipo "Estás al corriente 👌", "⏳ Guardando notas...", "📷 2"
- Footer del sidebar colapsado: `🦞` (mascota-placeholder cuando no hay espacio para "built_by") — se queda como parte de la identidad visual del footer.

## Checks

- [x] `npm run lint` — 0 errors, solo warnings pre-existentes
- [x] `npm run typecheck` — pasa
- [x] `npm run test:run` — 136/136 tests pass
- [x] `npm run build` — compila limpio
- [x] `InfoPill` solo se consume en `header.tsx` (grep verificado antes de cambiar la API)
- [x] Sidebar colapsado/expandido, logos de empresa sin cambios visuales

## QA visual (pendiente de verificar en preview)

- [ ] Light mode: iconos Home/IdCard/Settings nítidos, heredan color del texto
- [ ] Dark mode: iconos claros, sin color hardcoded de emoji
- [ ] Sidebar colapsado: iconos centrados, flyout de submenús intacto
- [ ] Header: Clock + Calendar alineados con el resto del cluster
- [ ] Logos DILESA/RDB/SANREN sin cambios visuales