### PR TITLE
fix(health): acepta source vacío en ingest y cae al fallback

### DIFF
--- a/app/api/health/ingest/route.ts
+++ b/app/api/health/ingest/route.ts
@@ -188,12 +188,9 @@ function normalizeMetricRecords(metrics: unknown[]) {
       const row = sample as Record<string, unknown>;
       const date = parseDate(row.date ?? row.startDate ?? row.sleepStart ?? row.start);
       if (!date) return;
-      const sampleSource =
-        typeof row.source === 'string'
-          ? row.source
-          : typeof entry.source === 'string'
-            ? entry.source
-            : 'Health Auto Export';
+      const rowSource = typeof row.source === 'string' ? row.source.trim() : '';
+      const entrySource = typeof entry.source === 'string' ? entry.source.trim() : '';
+      const sampleSource = rowSource || entrySource || 'Health Auto Export';
 
       if (isSleepAnalysis) {
         const stage = typeof row.value === 'string' ? row.value.trim() : null;


### PR DESCRIPTION
## Summary

- El handler `/api/health/ingest` validaba el source solo con `typeof === 'string'`, dejando pasar strings vacíos.
- El trigger `health.fn_reject_noisy_ingest` (BEFORE INSERT) rechaza `source IS NULL OR source = ''`, tirando 500 `P0001` en cada ciclo.
- Ahora se trimean ambos niveles (sample y entry) y se cae al fallback `'Health Auto Export'` cuando quedan vacíos.

## Context

Detectado en producción hoy: Health Auto Export envió un batch válido (587 KB, 3,137 métricas) y falló con:
```
error: health_metrics: source cannot be null/empty | code=P0001
```

## Test plan

- [ ] Preview deploy compila sin errores de TypeScript
- [ ] Re-enviar un export desde Health Auto Export al preview URL y verificar `health_ingest_log.status = 'ok'`
- [ ] Verificar que las nuevas filas en `health.health_metrics` tienen `source` no vacío

🤖 Generated with [Claude Code](https://claude.com/claude-code)