### PR TITLE
chore(db): bootstrap schemas al inicio de la cadena para Preview Branches

### DIFF
--- a/supabase/migrations/20260101000000_bootstrap_schemas.sql
+++ b/supabase/migrations/20260101000000_bootstrap_schemas.sql
@@ -1,0 +1,40 @@
+-- ════════════════════════════════════════════════════════════════════════════
+-- SCHEMA BOOTSTRAP — corre antes que cualquier otra migración
+-- ════════════════════════════════════════════════════════════════════════════
+--
+-- Timestamp deliberadamente más antiguo que cualquier migración existente para
+-- que Supabase lo aplique PRIMERO al provisionar una DB fresca (Preview Branch,
+-- dev local, DR).
+--
+-- Problema que resuelve:
+--   Varios schemas de la aplicación (`erp`, `health`, `dilesa`, `maquinaria`,
+--   `waitry`, `caja`, `inventario`) fueron creados en prod vía dashboard antes
+--   de existir migration tracking. Migraciones que los referencian asumen que
+--   ya existen — rompen con "schema X does not exist" en branches frescas.
+--
+--   El bootstrap anterior (20260408000000_pre_migration_bootstrap.sql) sólo
+--   cubre `core`, `shared`, `rdb`, `playtomic`. Esta migración garantiza los
+--   11 schemas existan desde el primer tick de la cadena.
+--
+-- Convenciones:
+--   * `CREATE SCHEMA IF NOT EXISTS` — idempotente. En prod es no-op puro.
+--   * Sólo CREATE SCHEMA: tablas, GRANTs, índices, policies los hacen las
+--     migraciones originales sin cambios.
+--   * No se eliminan las líneas `CREATE SCHEMA IF NOT EXISTS` de migraciones
+--     posteriores: son defensivas, duplicadas y seguras.
+--
+-- Ver supabase/GOVERNANCE.md §1 — migraciones reproducibles desde cero.
+
+CREATE SCHEMA IF NOT EXISTS core;
+CREATE SCHEMA IF NOT EXISTS shared;
+CREATE SCHEMA IF NOT EXISTS rdb;
+CREATE SCHEMA IF NOT EXISTS playtomic;
+CREATE SCHEMA IF NOT EXISTS erp;
+CREATE SCHEMA IF NOT EXISTS health;
+CREATE SCHEMA IF NOT EXISTS dilesa;
+CREATE SCHEMA IF NOT EXISTS maquinaria;
+CREATE SCHEMA IF NOT EXISTS waitry;
+CREATE SCHEMA IF NOT EXISTS caja;
+CREATE SCHEMA IF NOT EXISTS inventario;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- Migración nueva `supabase/migrations/20260101000000_bootstrap_schemas.sql` con timestamp previo a cualquier otra, garantiza que los 11 schemas (`core, shared, rdb, playtomic, erp, health, dilesa, maquinaria, waitry, caja, inventario`) existan antes de que cualquier migración posterior los referencie.
- Resuelve el `ERROR: schema "X" does not exist` que rompía dev branches de Supabase al reaplicar la cadena completa contra una DB vacía.
- Idempotente: `CREATE SCHEMA IF NOT EXISTS` — no-op en prod donde ya viven. Complementa drift-1.5 sin tocar migraciones viejas.

## Context
El bootstrap anterior (`20260408000000_pre_migration_bootstrap.sql`) sólo cubría `core, shared, rdb, playtomic`. Los demás schemas se creaban recién en migraciones posteriores (`20260409300000` waitry/caja/inventario, `20260414000000` erp, `20260423005443` health, `20260423100000` dilesa/maquinaria). Las migraciones entre el primer tick y las de creación que tocaban esos schemas se apoyaban en `to_regclass()` guards para no explotar en Preview Branch — pero un bootstrap explícito es más defensivo y hace visible la intención.

## Test plan
- [ ] Supabase crea el preview branch sin `MIGRATIONS_FAILED`
- [ ] `supabase_migrations.schema_migrations` del branch incluye `20260101000000`
- [ ] `\dn` en la DB fresca muestra los 11 schemas después del primer tick
- [ ] Drift-check del PR pasa sin nuevos ALERT

🤖 Generated with [Claude Code](https://claude.com/claude-code)