### PR TITLE
sprint dilesa-1 UI: módulo Anteproyectos + convertir-a-proyecto

### DIFF
--- a/app/api/dilesa/anteproyectos/[id]/convertir/route.ts
+++ b/app/api/dilesa/anteproyectos/[id]/convertir/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { DILESA_EMPRESA_ID } from '@/lib/dilesa-constants';
+
+/**
+ * POST /api/dilesa/anteproyectos/[id]/convertir
+ *
+ * Convierte un anteproyecto a proyecto formal:
+ *   1. Valida precondiciones (no borrado, no convertido, terreno + área +
+ *      lotes completos).
+ *   2. Inserta `dilesa.proyectos` con snapshot del anteproyecto.
+ *   3. Actualiza `dilesa.anteproyectos` a estado `convertido_a_proyecto`
+ *      con `proyecto_id`, timestamp y el empleado que convirtió.
+ *      El UPDATE incluye `estado != 'convertido_a_proyecto'` en el WHERE
+ *      para que doble-click retorne 0 rows y hagamos rollback del insert.
+ *
+ * No es una transacción de PostgreSQL — es un best-effort en dos pasos con
+ * compensación. Si aparece una race en prod, migrar a un RPC con BEGIN/
+ * COMMIT explícito queda como follow-up documentado en el PR.
+ */
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id: anteproyectoId } = await params;
+
+  const sessionClient = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await sessionClient.auth.getUser();
+  if (!user?.email) {
+    return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+  }
+
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error' }, { status: 500 });
+  }
+
+  let body: { nombre?: string } = {};
+  try {
+    body = (await req.json()) as { nombre?: string };
+  } catch {
+    // body opcional — si no llega, usamos el nombre del anteproyecto.
+  }
+
+  // 1. Leer anteproyecto + validar precondiciones.
+  const { data: ap, error: apErr } = await admin
+    .schema('dilesa')
+    .from('anteproyectos')
+    .select(
+      'id, empresa_id, nombre, terreno_id, tipo_proyecto_id, area_vendible_m2, areas_verdes_m2, cantidad_lotes, infraestructura_cabecera_inversion, estado, deleted_at, proyecto_id'
+    )
+    .eq('id', anteproyectoId)
+    .maybeSingle();
+
+  if (apErr) {
+    return NextResponse.json({ error: apErr.message }, { status: 500 });
+  }
+  if (!ap) {
+    return NextResponse.json({ error: 'Anteproyecto no encontrado' }, { status: 404 });
+  }
+  if (ap.deleted_at) {
+    return NextResponse.json({ error: 'Anteproyecto archivado' }, { status: 400 });
+  }
+  if (ap.estado === 'convertido_a_proyecto') {
+    return NextResponse.json(
+      {
+        error: 'Este anteproyecto ya fue convertido',
+        proyecto_id: ap.proyecto_id,
+      },
+      { status: 409 }
+    );
+  }
+  if (!ap.terreno_id) {
+    return NextResponse.json(
+      { error: 'El anteproyecto no tiene terreno asignado' },
+      { status: 400 }
+    );
+  }
+  if (!ap.area_vendible_m2 || ap.area_vendible_m2 <= 0) {
+    return NextResponse.json(
+      { error: 'El anteproyecto requiere área vendible > 0' },
+      { status: 400 }
+    );
+  }
+  if (!ap.cantidad_lotes || ap.cantidad_lotes <= 0) {
+    return NextResponse.json(
+      { error: 'El anteproyecto requiere cantidad de lotes > 0' },
+      { status: 400 }
+    );
+  }
+
+  // 2. Resolver empleado que convierte (best-effort; FK SET NULL permite null).
+  const emailLower = user.email.toLowerCase();
+  let convertidoPor: string | null = null;
+  const { data: empleadoRow } = await admin
+    .schema('erp')
+    .from('v_empleados_full')
+    .select('empleado_id')
+    .eq('empresa_id', ap.empresa_id)
+    .or(`email_empresa.eq.${emailLower},email_personal.eq.${emailLower}`)
+    .maybeSingle();
+  if (empleadoRow?.empleado_id) {
+    convertidoPor = empleadoRow.empleado_id;
+  }
+
+  // 3. Insertar proyecto (snapshot del anteproyecto).
+  const nombreProyecto = body.nombre?.trim() || ap.nombre;
+  const { data: nuevoProyecto, error: insErr } = await admin
+    .schema('dilesa')
+    .from('proyectos')
+    .insert({
+      empresa_id: ap.empresa_id ?? DILESA_EMPRESA_ID,
+      nombre: nombreProyecto,
+      terreno_id: ap.terreno_id,
+      anteproyecto_id: ap.id,
+      tipo_proyecto_id: ap.tipo_proyecto_id,
+      area_vendible_m2: ap.area_vendible_m2,
+      areas_verdes_m2: ap.areas_verdes_m2,
+      cantidad_lotes_total: ap.cantidad_lotes,
+      etapa: 'planeacion',
+      decision_actual: 'desarrollar',
+    })
+    .select('id')
+    .single();
+
+  if (insErr || !nuevoProyecto) {
+    return NextResponse.json(
+      { error: insErr?.message ?? 'No se pudo crear el proyecto' },
+      { status: 500 }
+    );
+  }
+
+  // 4. Marcar anteproyecto como convertido (idempotente: si doble-click,
+  //    el WHERE estado != 'convertido_a_proyecto' retorna 0 rows y
+  //    hacemos rollback del insert).
+  const { data: updated, error: updErr } = await admin
+    .schema('dilesa')
+    .from('anteproyectos')
+    .update({
+      estado: 'convertido_a_proyecto',
+      proyecto_id: nuevoProyecto.id,
+      convertido_a_proyecto_en: new Date().toISOString(),
+      convertido_a_proyecto_por: convertidoPor,
+    })
+    .eq('id', ap.id)
+    .neq('estado', 'convertido_a_proyecto')
+    .select('id');
+
+  if (updErr || !updated || updated.length === 0) {
+    // Rollback best-effort.
+    await admin.schema('dilesa').from('proyectos').delete().eq('id', nuevoProyecto.id);
+    if (updErr) {
+      return NextResponse.json({ error: updErr.message }, { status: 500 });
+    }
+    return NextResponse.json(
+      { error: 'El anteproyecto fue convertido por otra sesión. Recarga la página.' },
+      { status: 409 }
+    );
+  }
+
+  return NextResponse.json({ proyecto_id: nuevoProyecto.id });
+}

--- a/app/dilesa/anteproyectos/[id]/page.tsx
+++ b/app/dilesa/anteproyectos/[id]/page.tsx
@@ -1,0 +1,417 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Data-sync pattern consistente con juntas/[id] y tasks detail.
+ */
+
+/**
+ * Detalle de un anteproyecto.
+ *
+ * Layout en 3 columnas (desktop):
+ *   IZQ (4/12): captura — Identidad / Inputs físicos / Gestión / Notas
+ *   CENTRO (5/12): panel financiero en vivo (v_anteproyectos_analisis)
+ *   DER (3/12): prototipos de referencia editables (M:N)
+ *
+ * Header:
+ *   - Badge de estado grande + botón "Convertir a Proyecto"
+ *   - Si estado = convertido_a_proyecto → link "Ver proyecto →" en lugar del
+ *     botón de conversión.
+ *
+ * La conversión llama a POST /api/dilesa/anteproyectos/[id]/convertir.
+ * El botón se deshabilita (con tooltip explicativo) si faltan precondiciones:
+ *   - terreno_id null
+ *   - area_vendible_m2 <= 0
+ *   - cantidad_lotes <= 0
+ */
+
+import { RequireAccess } from '@/components/require-access';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+import {
+  DILESA_EMPRESA_ID,
+  formatCurrency,
+  formatDateShort,
+  formatM2,
+} from '@/lib/dilesa-constants';
+import {
+  ANTEPROYECTO_ESTADO_CONFIG,
+  PRIORIDAD_CONFIG,
+  type AnteproyectoEstado,
+  type PrioridadNivel,
+} from '@/lib/status-tokens';
+import {
+  AnteproyectoPanelFinanciero,
+  type PanelFinancieroData,
+} from '@/components/dilesa/anteproyecto-panel-financiero';
+import { PrototipoMultiselect } from '@/components/dilesa/prototipo-multiselect';
+import { ConvertirAProyectoModal } from '@/components/dilesa/convertir-a-proyecto-modal';
+
+type AnteproyectoFull = {
+  id: string;
+  empresa_id: string;
+  nombre: string;
+  clave_interna: string | null;
+  terreno_id: string;
+  tipo_proyecto_id: string | null;
+  fecha_inicio: string | null;
+  plano_lotificacion_url: string | null;
+  area_vendible_m2: number | null;
+  areas_verdes_m2: number | null;
+  cantidad_lotes: number | null;
+  infraestructura_cabecera_inversion: number | null;
+  estado: string;
+  convertido_a_proyecto_en: string | null;
+  convertido_a_proyecto_por: string | null;
+  proyecto_id: string | null;
+  etapa: string | null;
+  decision_actual: string | null;
+  prioridad: string | null;
+  responsable_id: string | null;
+  fecha_ultima_revision: string | null;
+  siguiente_accion: string | null;
+  motivo_no_viable: string | null;
+  notas: string | null;
+  lote_promedio_m2: number | null;
+  created_at: string;
+  updated_at: string;
+  terreno: { id: string; nombre: string; municipio: string | null } | null;
+  tipo_proyecto: { id: string; nombre: string } | null;
+};
+
+function AnteproyectoDetailInner() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
+  const supabase = useMemo(() => createSupabaseBrowserClient(), []);
+
+  const [ap, setAp] = useState<AnteproyectoFull | null>(null);
+  const [analisis, setAnalisis] = useState<PanelFinancieroData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showConvertir, setShowConvertir] = useState(false);
+
+  const loadAp = useCallback(async () => {
+    if (!id) return;
+    const { data, error: err } = await supabase
+      .schema('dilesa')
+      .from('anteproyectos')
+      .select(
+        '*, terreno:terreno_id(id, nombre, municipio), tipo_proyecto:tipo_proyecto_id(id, nombre)'
+      )
+      .eq('id', id)
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .is('deleted_at', null)
+      .maybeSingle();
+    if (err) {
+      setError(err.message);
+      setAp(null);
+      return;
+    }
+    setAp((data as unknown as AnteproyectoFull | null) ?? null);
+  }, [supabase, id]);
+
+  const loadAnalisis = useCallback(async () => {
+    if (!id) return;
+    const { data } = await supabase
+      .schema('dilesa')
+      .from('v_anteproyectos_analisis')
+      .select(
+        'aprovechamiento_pct, porcentaje_areas_verdes, lote_promedio_m2, precio_m2_aprovechable, prototipos_referenciados, valor_comercial_proyecto, costo_total_proyecto, utilidad_proyecto, margen_pct'
+      )
+      .eq('id', id)
+      .maybeSingle();
+    setAnalisis((data as PanelFinancieroData | null) ?? null);
+  }, [supabase, id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const init = async () => {
+      await Promise.all([loadAp(), loadAnalisis()]);
+      if (!cancelled) setLoading(false);
+    };
+    void init();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadAp, loadAnalisis]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-2/3" />
+        <div className="grid gap-4 lg:grid-cols-12">
+          <Skeleton className="h-80 lg:col-span-4" />
+          <Skeleton className="h-80 lg:col-span-5" />
+          <Skeleton className="h-80 lg:col-span-3" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !ap) {
+    return (
+      <div className="space-y-4">
+        <Button variant="outline" size="sm" onClick={() => router.push('/dilesa/anteproyectos')}>
+          <ArrowLeft className="size-4" />
+          Volver a Anteproyectos
+        </Button>
+        <div
+          role="alert"
+          className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-400"
+        >
+          {error ?? 'No se encontró el anteproyecto o fue archivado.'}
+        </div>
+      </div>
+    );
+  }
+
+  const yaConvertido = ap.estado === 'convertido_a_proyecto';
+  const missing: string[] = [];
+  if (!ap.terreno_id) missing.push('terreno');
+  if (!ap.area_vendible_m2 || ap.area_vendible_m2 <= 0) missing.push('área vendible > 0');
+  if (!ap.cantidad_lotes || ap.cantidad_lotes <= 0) missing.push('cantidad de lotes > 0');
+  const canConvert = !yaConvertido && missing.length === 0;
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-2">
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => router.push('/dilesa/anteproyectos')}
+            aria-label="Volver a Anteproyectos"
+          >
+            <ArrowLeft className="size-4" />
+          </Button>
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">
+              DILESA · Anteproyecto
+            </div>
+            <h1 className="mt-0.5 text-2xl font-semibold tracking-tight text-[var(--text)]">
+              {ap.nombre}
+            </h1>
+            {ap.clave_interna ? (
+              <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-[var(--text)]/45">
+                {ap.clave_interna}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <EstadoBadgeLarge estado={ap.estado} />
+
+          {yaConvertido && ap.proyecto_id ? (
+            <Link
+              href={`/dilesa/proyectos/${ap.proyecto_id}`}
+              className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-1.5 text-sm font-medium text-emerald-400 hover:bg-emerald-500/20"
+            >
+              Ver proyecto
+              <ArrowRight className="size-4" />
+            </Link>
+          ) : (
+            <Button
+              type="button"
+              onClick={() => setShowConvertir(true)}
+              disabled={!canConvert}
+              title={
+                !canConvert && missing.length > 0
+                  ? `Faltan datos: ${missing.join(', ')}`
+                  : yaConvertido
+                    ? 'Este anteproyecto ya fue convertido'
+                    : undefined
+              }
+              size="sm"
+            >
+              <ArrowRight className="size-4" />
+              Convertir a Proyecto
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-12">
+        <div className="space-y-4 lg:col-span-4">
+          <Section title="Identidad">
+            <Field label="Nombre">{ap.nombre}</Field>
+            <Field label="Clave interna">{ap.clave_interna ?? '—'}</Field>
+            <Field label="Terreno">
+              {ap.terreno ? (
+                <Link
+                  href={`/dilesa/terrenos/${ap.terreno_id}`}
+                  className="text-[var(--accent)] hover:underline"
+                >
+                  {ap.terreno.nombre}
+                </Link>
+              ) : (
+                '—'
+              )}
+              {ap.terreno?.municipio ? (
+                <span className="block text-[11px] text-[var(--text)]/45">
+                  {ap.terreno.municipio}
+                </span>
+              ) : null}
+            </Field>
+            <Field label="Tipo de proyecto">{ap.tipo_proyecto?.nombre ?? '—'}</Field>
+            <Field label="Fecha inicio">{formatDateShort(ap.fecha_inicio)}</Field>
+            <Field label="Plano lotificación" wide>
+              {ap.plano_lotificacion_url ? (
+                <a
+                  href={ap.plano_lotificacion_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-[var(--accent)] hover:underline"
+                >
+                  Abrir plano
+                </a>
+              ) : (
+                <span className="text-[var(--text)]/40">—</span>
+              )}
+            </Field>
+          </Section>
+
+          <Section title="Inputs físicos">
+            <Field label="Área vendible">{formatM2(ap.area_vendible_m2)}</Field>
+            <Field label="Áreas verdes">{formatM2(ap.areas_verdes_m2)}</Field>
+            <Field label="Cantidad de lotes">
+              {ap.cantidad_lotes ?? <span className="text-[var(--text)]/40">—</span>}
+            </Field>
+            <Field label="Infraestructura cabecera">
+              {formatCurrency(ap.infraestructura_cabecera_inversion)}
+            </Field>
+          </Section>
+
+          <Section title="Gestión">
+            <Field label="Estado" wide>
+              <EstadoBadgeLarge estado={ap.estado} />
+            </Field>
+            <Field label="Etapa">{ap.etapa ?? '—'}</Field>
+            <Field label="Decisión actual">{ap.decision_actual ?? '—'}</Field>
+            <Field label="Prioridad">
+              {ap.prioridad
+                ? (PRIORIDAD_CONFIG[ap.prioridad as PrioridadNivel]?.label ?? ap.prioridad)
+                : '—'}
+            </Field>
+            <Field label="Responsable">
+              {ap.responsable_id ? (
+                <span className="font-mono text-xs text-[var(--text)]/60">
+                  {ap.responsable_id.slice(0, 8)}…
+                </span>
+              ) : (
+                '—'
+              )}
+            </Field>
+            <Field label="Última revisión">{formatDateShort(ap.fecha_ultima_revision)}</Field>
+            <Field label="Siguiente acción" wide>
+              {ap.siguiente_accion ?? '—'}
+            </Field>
+            {ap.estado === 'no_viable' ? (
+              <Field label="Motivo no viable" wide>
+                <span className="text-red-400">{ap.motivo_no_viable ?? '—'}</span>
+              </Field>
+            ) : null}
+          </Section>
+
+          {ap.notas ? (
+            <Section title="Notas">
+              <div className="col-span-full whitespace-pre-wrap text-sm text-[var(--text)]/80">
+                {ap.notas}
+              </div>
+            </Section>
+          ) : null}
+        </div>
+
+        <div className="space-y-4 lg:col-span-5">
+          <AnteproyectoPanelFinanciero data={analisis} />
+          {yaConvertido ? (
+            <section className="rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-4">
+              <h3 className="text-xs font-semibold uppercase tracking-widest text-emerald-400">
+                Convertido a proyecto
+              </h3>
+              <p className="mt-1 text-sm text-[var(--text)]/75">
+                {formatDateShort(ap.convertido_a_proyecto_en)} — el análisis financiero actual es
+                referencia histórica; los números vivos están en el proyecto.
+              </p>
+            </section>
+          ) : null}
+        </div>
+
+        <div className="space-y-4 lg:col-span-3">
+          <PrototipoMultiselect anteproyectoId={ap.id} onChange={() => void loadAnalisis()} />
+        </div>
+      </div>
+
+      <ConvertirAProyectoModal
+        open={showConvertir}
+        onOpenChange={setShowConvertir}
+        anteproyectoId={ap.id}
+        defaultNombre={ap.nombre}
+      />
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+      <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+        {title}
+      </h2>
+      <dl className="mt-3 grid gap-x-4 gap-y-2 sm:grid-cols-2">{children}</dl>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  children,
+  wide,
+}: {
+  label: string;
+  children: React.ReactNode;
+  wide?: boolean;
+}) {
+  return (
+    <div className={wide ? 'col-span-full' : undefined}>
+      <dt className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/45">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-sm text-[var(--text)]/85">{children}</dd>
+    </div>
+  );
+}
+
+function EstadoBadgeLarge({ estado }: { estado: string | null }) {
+  if (!estado) return null;
+  const cfg = ANTEPROYECTO_ESTADO_CONFIG[estado as AnteproyectoEstado];
+  if (!cfg) {
+    return (
+      <span className="inline-flex items-center rounded-lg border border-[var(--border)] px-3 py-1 text-xs text-[var(--text)]/65">
+        {estado}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`inline-flex items-center rounded-lg border px-3 py-1 text-xs font-medium ${cfg.cls}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+export default function AnteproyectoDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa">
+      <AnteproyectoDetailInner />
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/anteproyectos/page.tsx
+++ b/app/dilesa/anteproyectos/page.tsx
@@ -1,13 +1,926 @@
 'use client';
 
-import { ComingSoonModule } from '@/components/shared/coming-soon-module';
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Data-sync pattern: el effect siembra loading antes de disparar los fetch.
+ * Mismo patrón que juntas, tasks y empleados (y /dilesa/terrenos). Mover a
+ * Suspense-driven data exige refactor mayor — fuera del scope del sprint.
+ */
+
+/**
+ * Módulo Anteproyectos — master page.
+ *
+ * Sprint dilesa-1 UI (branch feat/dilesa-ui-anteproyectos). Tercer módulo
+ * del backbone inmobiliario. Expone tabs Consulta / Resumen / Timeline /
+ * Chart siguiendo la convención de flujo-maestro §6.
+ *
+ * Alcance:
+ *   - Consulta: tabla master con identidad, terreno, tipo, KPIs físicos
+ *     y cálculos derivados de v_anteproyectos_analisis.
+ *   - Alta: Sheet lateral con campos mínimos. El expediente se completa
+ *     desde /dilesa/anteproyectos/[id].
+ *   - Resumen: totales por estado, utilidad proyectada, margen promedio,
+ *     top 5 por utilidad, alertas de anteproyectos sin prototipos ref.
+ *   - Timeline / Chart: placeholders para iteración futura.
+ */
+
+import { RequireAccess } from '@/components/require-access';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { SortableHead } from '@/components/ui/sortable-head';
+import { useSortableTable } from '@/hooks/use-sortable-table';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { FieldLabel } from '@/components/ui/field-label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
+import { Plus, Search, RefreshCw, Loader2, AlertTriangle } from 'lucide-react';
+import {
+  ANTEPROYECTO_ESTADO_CONFIG,
+  PRIORIDAD_CONFIG,
+  type AnteproyectoEstado,
+  type PrioridadNivel,
+} from '@/lib/status-tokens';
+import {
+  DILESA_EMPRESA_ID,
+  formatCurrency,
+  formatDateShort,
+  formatM2,
+  formatPercent,
+} from '@/lib/dilesa-constants';
+import { ModuleTabs, TabPanel, useActiveTab } from '@/components/shared/module-tabs';
+import { EmptyStateImported } from '@/components/shared/empty-state-imported';
+
+type TerrenoOption = {
+  id: string;
+  nombre: string;
+  municipio: string | null;
+};
+
+type TipoProyectoOption = {
+  id: string;
+  nombre: string;
+};
+
+type Anteproyecto = {
+  id: string;
+  nombre: string;
+  clave_interna: string | null;
+  terreno_id: string;
+  tipo_proyecto_id: string | null;
+  fecha_inicio: string | null;
+  area_vendible_m2: number | null;
+  areas_verdes_m2: number | null;
+  cantidad_lotes: number | null;
+  infraestructura_cabecera_inversion: number | null;
+  estado: string;
+  etapa: string | null;
+  decision_actual: string | null;
+  prioridad: string | null;
+  responsable_id: string | null;
+  fecha_ultima_revision: string | null;
+  siguiente_accion: string | null;
+  proyecto_id: string | null;
+  created_at: string;
+  updated_at: string;
+  terreno: { nombre: string; municipio: string | null } | null;
+  tipo_proyecto: { nombre: string } | null;
+};
+
+type Analisis = {
+  id: string;
+  aprovechamiento_pct: number | null;
+  prototipos_referenciados: number | null;
+  valor_comercial_proyecto: number | null;
+  costo_total_proyecto: number | null;
+  utilidad_proyecto: number | null;
+  margen_pct: number | null;
+};
+
+type Row = Anteproyecto & {
+  aprovechamiento_pct: number | null;
+  prototipos_referenciados: number | null;
+  valor_comercial_proyecto: number | null;
+  costo_total_proyecto: number | null;
+  utilidad_proyecto: number | null;
+  margen_pct: number | null;
+};
+
+const ESTADO_KEYS = Object.keys(ANTEPROYECTO_ESTADO_CONFIG) as AnteproyectoEstado[];
+
+function EstadoBadge({ estado }: { estado: string | null }) {
+  if (!estado) return <span className="text-[var(--text)]/35">—</span>;
+  const cfg = ANTEPROYECTO_ESTADO_CONFIG[estado as AnteproyectoEstado];
+  if (!cfg) {
+    return (
+      <span className="inline-flex items-center rounded-lg border border-[var(--border)] px-2 py-0.5 text-xs text-[var(--text)]/55">
+        {estado}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`inline-flex items-center rounded-lg border px-2 py-0.5 text-xs font-medium ${cfg.cls}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+function PrioridadDot({ prioridad }: { prioridad: string | null }) {
+  if (!prioridad) return <span className="text-[var(--text)]/35">—</span>;
+  const cfg = PRIORIDAD_CONFIG[prioridad as PrioridadNivel];
+  if (!cfg) return <span className="text-[var(--text)]/55">{prioridad}</span>;
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-[var(--text)]/75">
+      <span className={`inline-block size-2 rounded-full ${cfg.dot}`} aria-hidden="true" />
+      {cfg.label}
+    </span>
+  );
+}
+
+function AnteproyectosInner() {
+  const router = useRouter();
+  const supabase = useMemo(() => createSupabaseBrowserClient(), []);
+  const active = useActiveTab();
+
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [terrenos, setTerrenos] = useState<TerrenoOption[]>([]);
+  const [tiposProyecto, setTiposProyecto] = useState<TipoProyectoOption[]>([]);
+
+  const [search, setSearch] = useState('');
+  const [filterEstado, setFilterEstado] = useState<string>('all');
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createNombre, setCreateNombre] = useState('');
+  const [createTerrenoId, setCreateTerrenoId] = useState('');
+  const [createTipoProyectoId, setCreateTipoProyectoId] = useState('');
+  const [createFechaInicio, setCreateFechaInicio] = useState('');
+  const [createAreaVendible, setCreateAreaVendible] = useState('');
+  const [createAreasVerdes, setCreateAreasVerdes] = useState('');
+  const [createCantidadLotes, setCreateCantidadLotes] = useState('');
+  const [createInfraestructura, setCreateInfraestructura] = useState('');
+
+  const fetchAll = useCallback(async () => {
+    const [apRes, vRes, tRes, tpRes] = await Promise.all([
+      supabase
+        .schema('dilesa')
+        .from('anteproyectos')
+        .select('*, terreno:terreno_id(nombre, municipio), tipo_proyecto:tipo_proyecto_id(nombre)')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null)
+        .order('created_at', { ascending: false }),
+      supabase
+        .schema('dilesa')
+        .from('v_anteproyectos_analisis')
+        .select(
+          'id, aprovechamiento_pct, prototipos_referenciados, valor_comercial_proyecto, costo_total_proyecto, utilidad_proyecto, margen_pct'
+        )
+        .eq('empresa_id', DILESA_EMPRESA_ID),
+      supabase
+        .schema('dilesa')
+        .from('terrenos')
+        .select('id, nombre, municipio')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null)
+        .order('nombre', { ascending: true }),
+      supabase
+        .schema('dilesa')
+        .from('tipo_proyecto')
+        .select('id, nombre')
+        .is('deleted_at', null)
+        .eq('activo', true)
+        .order('orden', { ascending: true }),
+    ]);
+
+    if (apRes.error) {
+      setError(apRes.error.message);
+      return;
+    }
+
+    const analisisById = new Map<string, Analisis>();
+    for (const r of (vRes.data ?? []) as Analisis[]) {
+      analisisById.set(r.id, r);
+    }
+
+    const merged: Row[] = ((apRes.data ?? []) as unknown as Anteproyecto[]).map((ap) => {
+      const a = analisisById.get(ap.id);
+      return {
+        ...ap,
+        aprovechamiento_pct: a?.aprovechamiento_pct ?? null,
+        prototipos_referenciados: a?.prototipos_referenciados ?? null,
+        valor_comercial_proyecto: a?.valor_comercial_proyecto ?? null,
+        costo_total_proyecto: a?.costo_total_proyecto ?? null,
+        utilidad_proyecto: a?.utilidad_proyecto ?? null,
+        margen_pct: a?.margen_pct ?? null,
+      };
+    });
+
+    setRows(merged);
+    setTerrenos((tRes.data ?? []) as TerrenoOption[]);
+    setTiposProyecto((tpRes.data ?? []) as TipoProyectoOption[]);
+  }, [supabase]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const init = async () => {
+      await fetchAll();
+      if (!cancelled) setLoading(false);
+    };
+    void init();
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchAll]);
+
+  const openCreate = () => {
+    setCreateNombre('');
+    setCreateTerrenoId('');
+    setCreateTipoProyectoId('');
+    setCreateFechaInicio('');
+    setCreateAreaVendible('');
+    setCreateAreasVerdes('');
+    setCreateCantidadLotes('');
+    setCreateInfraestructura('');
+    setShowCreate(true);
+  };
+
+  const handleCreate = async () => {
+    if (!createNombre.trim() || !createTerrenoId) return;
+    setCreating(true);
+    const { data: newRow, error: err } = await supabase
+      .schema('dilesa')
+      .from('anteproyectos')
+      .insert({
+        empresa_id: DILESA_EMPRESA_ID,
+        nombre: createNombre.trim(),
+        terreno_id: createTerrenoId,
+        tipo_proyecto_id: createTipoProyectoId || null,
+        fecha_inicio: createFechaInicio || null,
+        area_vendible_m2: createAreaVendible ? Number(createAreaVendible) : null,
+        areas_verdes_m2: createAreasVerdes ? Number(createAreasVerdes) : null,
+        cantidad_lotes: createCantidadLotes ? Number(createCantidadLotes) : null,
+        infraestructura_cabecera_inversion: createInfraestructura
+          ? Number(createInfraestructura)
+          : null,
+        estado: 'en_analisis',
+      })
+      .select('id')
+      .single();
+    setCreating(false);
+    if (err) {
+      alert(`Error al crear anteproyecto: ${err.message}`);
+      return;
+    }
+    setShowCreate(false);
+    await fetchAll();
+    if (newRow?.id) {
+      router.push(`/dilesa/anteproyectos/${newRow.id}`);
+    }
+  };
+
+  const filtered = useMemo(() => {
+    const s = search.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (filterEstado !== 'all' && r.estado !== filterEstado) return false;
+      if (!s) return true;
+      return (
+        r.nombre.toLowerCase().includes(s) ||
+        (r.clave_interna ?? '').toLowerCase().includes(s) ||
+        (r.terreno?.nombre ?? '').toLowerCase().includes(s) ||
+        (r.tipo_proyecto?.nombre ?? '').toLowerCase().includes(s)
+      );
+    });
+  }, [rows, search, filterEstado]);
+
+  const { sortKey, sortDir, onSort, sortData } = useSortableTable<Row>('created_at', 'desc');
+  const sorted = useMemo(
+    () => sortData(filtered as unknown as Record<string, unknown>[]) as unknown as Row[],
+    [filtered, sortData]
+  );
+
+  const terrenoOptions: ComboboxOption[] = useMemo(
+    () =>
+      terrenos.map((t) => ({
+        value: t.id,
+        label: t.nombre,
+        sub: t.municipio ?? undefined,
+        searchLabel: `${t.nombre} ${t.municipio ?? ''}`.trim(),
+      })),
+    [terrenos]
+  );
+
+  const tipoProyectoOptions: ComboboxOption[] = useMemo(
+    () => tiposProyecto.map((t) => ({ value: t.id, label: t.nombre, searchLabel: t.nombre })),
+    [tiposProyecto]
+  );
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">
+            DILESA · Inmobiliario
+          </div>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight text-[var(--text)]">
+            Anteproyectos
+          </h1>
+          <p className="mt-1 text-sm text-[var(--text)]/55">
+            Evaluación y análisis financiero pre-proyecto. De aquí nacen los proyectos formales vía
+            &ldquo;Convertir a Proyecto&rdquo;.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="outline" onClick={() => fetchAll()} size="sm">
+            <RefreshCw className="size-4" />
+            Actualizar
+          </Button>
+          <Button type="button" onClick={openCreate} size="sm">
+            <Plus className="size-4" />
+            Nuevo anteproyecto
+          </Button>
+        </div>
+      </header>
+
+      <ModuleTabs
+        tabs={[
+          { key: 'consulta', label: 'Consulta', badge: rows.length },
+          { key: 'resumen', label: 'Resumen' },
+          { key: 'timeline', label: 'Timeline' },
+          { key: 'chart', label: 'Chart' },
+        ]}
+      />
+
+      <TabPanel tabKey="consulta" active={active}>
+        <ConsultaPanel
+          rows={sorted}
+          loading={loading}
+          error={error}
+          search={search}
+          setSearch={setSearch}
+          filterEstado={filterEstado}
+          setFilterEstado={setFilterEstado}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          onOpenCreate={openCreate}
+          onOpenDetail={(id) => router.push(`/dilesa/anteproyectos/${id}`)}
+        />
+      </TabPanel>
+
+      <TabPanel tabKey="resumen" active={active}>
+        <ResumenPanel rows={rows} loading={loading} />
+      </TabPanel>
+
+      <TabPanel tabKey="timeline" active={active}>
+        <PlaceholderPanel
+          title="Timeline"
+          description="Cronología de cambios por anteproyecto: transiciones de estado, decisiones, referencias agregadas. Próximo sprint."
+        />
+      </TabPanel>
+
+      <TabPanel tabKey="chart" active={active}>
+        <PlaceholderPanel
+          title="Chart"
+          description="Distribución por estado, utilidad proyectada comparada, margen vs. tamaño. Próximo sprint."
+        />
+      </TabPanel>
+
+      <Sheet open={showCreate} onOpenChange={setShowCreate}>
+        <SheetContent side="right" className="w-full max-w-xl">
+          <SheetHeader>
+            <SheetTitle>Nuevo anteproyecto</SheetTitle>
+            <SheetDescription>
+              Solo campos esenciales — el expediente y los prototipos de referencia se capturan
+              desde el detalle.
+            </SheetDescription>
+          </SheetHeader>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleCreate();
+            }}
+            className="mt-6 space-y-5"
+          >
+            <div>
+              <FieldLabel htmlFor="ap-nombre" required>
+                Nombre del anteproyecto
+              </FieldLabel>
+              <Input
+                id="ap-nombre"
+                value={createNombre}
+                onChange={(e) => setCreateNombre(e.target.value)}
+                placeholder="Ej. Los Nogales Etapa 1"
+                required
+              />
+            </div>
+
+            <div>
+              <FieldLabel htmlFor="ap-terreno" required>
+                Terreno
+              </FieldLabel>
+              <Combobox
+                id="ap-terreno"
+                value={createTerrenoId}
+                onChange={setCreateTerrenoId}
+                options={terrenoOptions}
+                placeholder="Seleccionar terreno…"
+                searchPlaceholder="Buscar por nombre o municipio…"
+                emptyText="Sin terrenos disponibles"
+                allowClear
+              />
+              {terrenoOptions.length === 0 ? (
+                <p className="mt-1 text-xs text-[var(--text)]/55">
+                  Aún no hay terrenos capturados. Crea uno en{' '}
+                  <Link href="/dilesa/terrenos" className="text-[var(--accent)] hover:underline">
+                    Terrenos
+                  </Link>
+                  .
+                </p>
+              ) : null}
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <FieldLabel htmlFor="ap-tipo">Tipo de proyecto</FieldLabel>
+                <Combobox
+                  id="ap-tipo"
+                  value={createTipoProyectoId}
+                  onChange={setCreateTipoProyectoId}
+                  options={tipoProyectoOptions}
+                  placeholder={tipoProyectoOptions.length === 0 ? '(sin definir)' : 'Seleccionar…'}
+                  emptyText="Catálogo vacío"
+                  allowClear
+                />
+              </div>
+              <div>
+                <FieldLabel htmlFor="ap-fecha">Fecha inicio</FieldLabel>
+                <Input
+                  id="ap-fecha"
+                  type="date"
+                  value={createFechaInicio}
+                  onChange={(e) => setCreateFechaInicio(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <FieldLabel htmlFor="ap-area-v">Área vendible (m²)</FieldLabel>
+                <Input
+                  id="ap-area-v"
+                  type="number"
+                  step="0.01"
+                  inputMode="decimal"
+                  value={createAreaVendible}
+                  onChange={(e) => setCreateAreaVendible(e.target.value)}
+                  placeholder="0"
+                />
+              </div>
+              <div>
+                <FieldLabel htmlFor="ap-area-verdes">Áreas verdes (m²)</FieldLabel>
+                <Input
+                  id="ap-area-verdes"
+                  type="number"
+                  step="0.01"
+                  inputMode="decimal"
+                  value={createAreasVerdes}
+                  onChange={(e) => setCreateAreasVerdes(e.target.value)}
+                  placeholder="0"
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <FieldLabel htmlFor="ap-lotes">Cantidad de lotes</FieldLabel>
+                <Input
+                  id="ap-lotes"
+                  type="number"
+                  inputMode="numeric"
+                  value={createCantidadLotes}
+                  onChange={(e) => setCreateCantidadLotes(e.target.value)}
+                  placeholder="0"
+                />
+              </div>
+              <div>
+                <FieldLabel htmlFor="ap-infra">Inversión cabecera</FieldLabel>
+                <Input
+                  id="ap-infra"
+                  type="number"
+                  step="0.01"
+                  inputMode="decimal"
+                  value={createInfraestructura}
+                  onChange={(e) => setCreateInfraestructura(e.target.value)}
+                  placeholder="0"
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-end gap-2 pt-2">
+              <Button type="button" variant="outline" onClick={() => setShowCreate(false)}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={creating || !createNombre.trim() || !createTerrenoId}>
+                {creating ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Plus className="size-4" />
+                )}
+                Crear anteproyecto
+              </Button>
+            </div>
+          </form>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}
+
+function ConsultaPanel(props: {
+  rows: Row[];
+  loading: boolean;
+  error: string | null;
+  search: string;
+  setSearch: (v: string) => void;
+  filterEstado: string;
+  setFilterEstado: (v: string) => void;
+  sortKey: string;
+  sortDir: 'asc' | 'desc';
+  onSort: (key: string) => void;
+  onOpenCreate: () => void;
+  onOpenDetail: (id: string) => void;
+}) {
+  const {
+    rows,
+    loading,
+    error,
+    search,
+    setSearch,
+    filterEstado,
+    setFilterEstado,
+    sortKey,
+    sortDir,
+    onSort,
+    onOpenCreate,
+    onOpenDetail,
+  } = props;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-[220px] flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar nombre, clave, terreno, tipo…"
+            className="pl-8"
+          />
+        </div>
+        <select
+          value={filterEstado}
+          onChange={(e) => setFilterEstado(e.target.value)}
+          className="h-8 rounded-lg border border-[var(--border)] bg-[var(--card)] px-2 text-sm"
+          aria-label="Filtrar por estado"
+        >
+          <option value="all">Todos los estados</option>
+          {ESTADO_KEYS.map((k) => (
+            <option key={k} value={k}>
+              {ANTEPROYECTO_ESTADO_CONFIG[k].label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : error ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-400"
+        >
+          No se pudieron cargar los anteproyectos: {error}
+        </div>
+      ) : rows.length === 0 ? (
+        <EmptyStateImported
+          entityLabel="Anteproyectos"
+          description="Crea el primer anteproyecto para evaluar un terreno. Necesitarás al menos un terreno capturado."
+          onCreate={onOpenCreate}
+        />
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-[var(--card)]">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <SortableHead
+                  sortKey="nombre"
+                  label="Nombre"
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+                <TableHead>Terreno</TableHead>
+                <TableHead>Tipo</TableHead>
+                <SortableHead
+                  sortKey="cantidad_lotes"
+                  label="Lotes"
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+                <SortableHead
+                  sortKey="area_vendible_m2"
+                  label="Área vendible"
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+                <SortableHead
+                  sortKey="aprovechamiento_pct"
+                  label="Aprov. %"
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+                <SortableHead
+                  sortKey="utilidad_proyecto"
+                  label="Utilidad"
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+                <SortableHead
+                  sortKey="margen_pct"
+                  label="Margen %"
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+                <TableHead>Estado</TableHead>
+                <TableHead>Prioridad</TableHead>
+                <SortableHead
+                  sortKey="fecha_ultima_revision"
+                  label="Última revisión"
+                  currentSort={sortKey}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((r) => (
+                <TableRow key={r.id} onClick={() => onOpenDetail(r.id)} className="cursor-pointer">
+                  <TableCell>
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate font-medium text-[var(--text)]">{r.nombre}</span>
+                      {r.clave_interna ? (
+                        <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/45">
+                          {r.clave_interna}
+                        </span>
+                      ) : null}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex min-w-0 flex-col text-xs">
+                      <span className="truncate text-[var(--text)]/80">
+                        {r.terreno?.nombre ?? '—'}
+                      </span>
+                      {r.terreno?.municipio ? (
+                        <span className="truncate text-[var(--text)]/45">
+                          {r.terreno.municipio}
+                        </span>
+                      ) : null}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-xs text-[var(--text)]/70">
+                    {r.tipo_proyecto?.nombre ?? <span className="text-[var(--text)]/35">—</span>}
+                  </TableCell>
+                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
+                    {r.cantidad_lotes ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
+                    {formatM2(r.area_vendible_m2)}
+                  </TableCell>
+                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
+                    {formatPercent(r.aprovechamiento_pct)}
+                  </TableCell>
+                  <TableCell
+                    className={`text-xs tabular-nums ${
+                      r.utilidad_proyecto != null && r.utilidad_proyecto < 0
+                        ? 'text-red-400'
+                        : 'text-[var(--text)]/75'
+                    }`}
+                  >
+                    {formatCurrency(r.utilidad_proyecto, { compact: true })}
+                  </TableCell>
+                  <TableCell
+                    className={`text-xs tabular-nums ${
+                      r.margen_pct != null && r.margen_pct < 0
+                        ? 'text-red-400'
+                        : 'text-[var(--text)]/75'
+                    }`}
+                  >
+                    {formatPercent(r.margen_pct)}
+                  </TableCell>
+                  <TableCell>
+                    <EstadoBadge estado={r.estado} />
+                  </TableCell>
+                  <TableCell>
+                    <PrioridadDot prioridad={r.prioridad} />
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-xs text-[var(--text)]/60">
+                    {formatDateShort(r.fecha_ultima_revision)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ResumenPanel({ rows, loading }: { rows: Row[]; loading: boolean }) {
+  const kpis = useMemo(() => {
+    const activos = rows.filter(
+      (r) => r.estado !== 'convertido_a_proyecto' && r.estado !== 'no_viable'
+    );
+    const utilidadTotal = activos.reduce((acc, r) => acc + (r.utilidad_proyecto ?? 0), 0);
+    const margenes = activos.map((r) => r.margen_pct).filter((m): m is number => m != null);
+    const margenPromedio =
+      margenes.length > 0 ? margenes.reduce((a, b) => a + b, 0) / margenes.length : null;
+
+    const porEstado = new Map<string, number>();
+    rows.forEach((r) => {
+      porEstado.set(r.estado, (porEstado.get(r.estado) ?? 0) + 1);
+    });
+
+    const top5 = [...activos]
+      .filter((r) => r.utilidad_proyecto != null)
+      .sort((a, b) => (b.utilidad_proyecto ?? 0) - (a.utilidad_proyecto ?? 0))
+      .slice(0, 5);
+
+    const sinPrototipos = activos.filter((r) => (r.prototipos_referenciados ?? 0) === 0);
+
+    return {
+      total: rows.length,
+      activos: activos.length,
+      utilidadTotal,
+      margenPromedio,
+      porEstado: Array.from(porEstado.entries()),
+      top5,
+      sinPrototipos,
+    };
+  }, [rows]);
+
+  if (loading) {
+    return (
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard label="Anteproyectos totales" value={kpis.total.toLocaleString('es-MX')} />
+        <KpiCard label="Activos" value={kpis.activos.toLocaleString('es-MX')} />
+        <KpiCard
+          label="Utilidad proyectada (activos)"
+          value={formatCurrency(kpis.utilidadTotal, { compact: true })}
+        />
+        <KpiCard label="Margen promedio (activos)" value={formatPercent(kpis.margenPromedio)} />
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+          <h3 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+            Distribución por estado
+          </h3>
+          <ul className="mt-3 space-y-2">
+            {kpis.porEstado.length === 0 ? (
+              <li className="text-sm text-[var(--text)]/50">(sin datos)</li>
+            ) : (
+              kpis.porEstado.map(([estado, count]) => (
+                <li key={estado} className="flex items-center justify-between gap-3">
+                  <EstadoBadge estado={estado} />
+                  <span className="text-sm tabular-nums text-[var(--text)]/70">{count}</span>
+                </li>
+              ))
+            )}
+          </ul>
+        </section>
+
+        <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+          <h3 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+            Top 5 por utilidad proyectada
+          </h3>
+          <ul className="mt-3 space-y-2">
+            {kpis.top5.length === 0 ? (
+              <li className="text-sm text-[var(--text)]/50">
+                Agrega prototipos de referencia a los anteproyectos para ver proyecciones.
+              </li>
+            ) : (
+              kpis.top5.map((r) => (
+                <li key={r.id} className="flex items-center justify-between gap-3">
+                  <span className="min-w-0 truncate text-sm text-[var(--text)]/80">{r.nombre}</span>
+                  <span
+                    className={`text-sm tabular-nums ${
+                      (r.utilidad_proyecto ?? 0) < 0 ? 'text-red-400' : 'text-[var(--text)]/70'
+                    }`}
+                  >
+                    {formatCurrency(r.utilidad_proyecto, { compact: true })}
+                  </span>
+                </li>
+              ))
+            )}
+          </ul>
+        </section>
+      </div>
+
+      {kpis.sinPrototipos.length > 0 ? (
+        <section className="rounded-2xl border border-amber-500/30 bg-amber-500/5 p-4">
+          <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-amber-400">
+            <AlertTriangle className="size-3.5" />
+            Sin prototipos de referencia ({kpis.sinPrototipos.length})
+          </h3>
+          <p className="mt-1 text-xs text-[var(--text)]/55">
+            Los anteproyectos sin prototipos referenciados no muestran utilidad proyectada ni
+            margen. Agrega al menos uno desde el detalle.
+          </p>
+          <ul className="mt-3 space-y-1 text-sm">
+            {kpis.sinPrototipos.slice(0, 8).map((r) => (
+              <li key={r.id} className="text-[var(--text)]/75">
+                · {r.nombre}
+              </li>
+            ))}
+            {kpis.sinPrototipos.length > 8 ? (
+              <li className="text-[var(--text)]/45">…y {kpis.sinPrototipos.length - 8} más.</li>
+            ) : null}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function KpiCard({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+      <div className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-semibold tracking-tight text-[var(--text)]">{value}</div>
+    </div>
+  );
+}
+
+function PlaceholderPanel({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-[var(--border)] bg-[var(--card)]/40 p-8 text-center">
+      <h3 className="text-base font-semibold text-[var(--text)]">{title}</h3>
+      <p className="mt-2 text-sm text-[var(--text)]/55">{description}</p>
+    </div>
+  );
+}
 
 export default function AnteproyectosPage() {
   return (
-    <ComingSoonModule
-      title="Anteproyectos"
-      description="Evaluación financiera y decisión de convertir a proyecto. Incluirá panel financiero en vivo contra v_anteproyectos_analisis, multi-select de prototipos de referencia y el botón Convertir-a-Proyecto."
-      branchName="feat/dilesa-ui-anteproyectos"
-    />
+    <RequireAccess empresa="dilesa">
+      <Suspense fallback={<div className="p-6 text-sm text-[var(--text)]/55">Cargando…</div>}>
+        <AnteproyectosInner />
+      </Suspense>
+    </RequireAccess>
   );
 }

--- a/app/dilesa/proyectos/[id]/page.tsx
+++ b/app/dilesa/proyectos/[id]/page.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Data-sync pattern consistente con el resto del sprint dilesa-1.
+ */
+
+/**
+ * Scaffold temporal del detail de Proyecto.
+ *
+ * Este archivo existe para que el redirect post-"Convertir a Proyecto"
+ * tenga un destino visible y coherente. El módulo Proyectos completo
+ * (tabs Info / Lotes / Prototipos / Presupuesto / Documentos, edición,
+ * archivar, lotificación, progreso de obra) llega en el siguiente PR:
+ * feat/dilesa-ui-proyectos.
+ *
+ * Scope actual (read-only):
+ *   - Secciones Identidad / Económica / Gestión / Notas
+ *   - Header con badge de fase y link "← Anteproyectos" cuando aplique
+ */
+
+import { RequireAccess } from '@/components/require-access';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ArrowLeft } from 'lucide-react';
+import {
+  DILESA_EMPRESA_ID,
+  formatCurrency,
+  formatDateShort,
+  formatM2,
+} from '@/lib/dilesa-constants';
+import { PRIORIDAD_CONFIG, type PrioridadNivel } from '@/lib/status-tokens';
+
+type ProyectoFull = {
+  id: string;
+  empresa_id: string;
+  nombre: string;
+  codigo: string | null;
+  terreno_id: string;
+  anteproyecto_id: string | null;
+  tipo_proyecto_id: string | null;
+  fase: string | null;
+  fecha_inicio: string | null;
+  fecha_estimada_cierre: string | null;
+  area_vendible_m2: number | null;
+  areas_verdes_m2: number | null;
+  cantidad_lotes_total: number | null;
+  presupuesto_total: number | null;
+  inversion_total: number | null;
+  notas: string | null;
+  etapa: string | null;
+  decision_actual: string | null;
+  prioridad: string | null;
+  responsable_id: string | null;
+  fecha_ultima_revision: string | null;
+  siguiente_accion: string | null;
+  terreno: { id: string; nombre: string; municipio: string | null } | null;
+  anteproyecto: { id: string; nombre: string; clave_interna: string | null } | null;
+  tipo_proyecto: { id: string; nombre: string } | null;
+};
+
+function ProyectoDetailInner() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
+  const supabase = useMemo(() => createSupabaseBrowserClient(), []);
+
+  const [proyecto, setProyecto] = useState<ProyectoFull | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    const { data, error: err } = await supabase
+      .schema('dilesa')
+      .from('proyectos')
+      .select(
+        '*, terreno:terreno_id(id, nombre, municipio), anteproyecto:anteproyecto_id(id, nombre, clave_interna), tipo_proyecto:tipo_proyecto_id(id, nombre)'
+      )
+      .eq('id', id)
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .is('deleted_at', null)
+      .maybeSingle();
+    if (err) {
+      setError(err.message);
+      setProyecto(null);
+      return;
+    }
+    setProyecto((data as unknown as ProyectoFull | null) ?? null);
+  }, [supabase, id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const init = async () => {
+      await load();
+      if (!cancelled) setLoading(false);
+    };
+    void init();
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-2/3" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !proyecto) {
+    return (
+      <div className="space-y-4">
+        <Button variant="outline" size="sm" onClick={() => router.push('/dilesa')}>
+          <ArrowLeft className="size-4" />
+          Volver a DILESA
+        </Button>
+        <div
+          role="alert"
+          className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-400"
+        >
+          {error ?? 'No se encontró el proyecto o fue archivado.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-2">
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() =>
+              proyecto.anteproyecto_id
+                ? router.push(`/dilesa/anteproyectos/${proyecto.anteproyecto_id}`)
+                : router.push('/dilesa')
+            }
+            aria-label={proyecto.anteproyecto_id ? 'Volver al anteproyecto' : 'Volver a DILESA'}
+          >
+            <ArrowLeft className="size-4" />
+          </Button>
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">
+              DILESA · Proyecto
+            </div>
+            <h1 className="mt-0.5 text-2xl font-semibold tracking-tight text-[var(--text)]">
+              {proyecto.nombre}
+            </h1>
+            {proyecto.codigo ? (
+              <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-[var(--text)]/45">
+                {proyecto.codigo}
+              </p>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <FaseBadge fase={proyecto.fase} />
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-dashed border-amber-500/30 bg-amber-500/5 p-3 text-xs text-amber-300">
+        Scaffold temporal del detail de proyecto. El módulo completo (tabs Info / Lotes / Prototipos
+        / Presupuesto / Documentos, edición y progreso de obra) llega con{' '}
+        <span className="font-mono">feat/dilesa-ui-proyectos</span>.
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Section title="A. Identidad">
+          <Field label="Nombre">{proyecto.nombre}</Field>
+          <Field label="Código">{proyecto.codigo ?? '—'}</Field>
+          <Field label="Terreno">
+            {proyecto.terreno ? (
+              <Link
+                href={`/dilesa/terrenos/${proyecto.terreno_id}`}
+                className="text-[var(--accent)] hover:underline"
+              >
+                {proyecto.terreno.nombre}
+              </Link>
+            ) : (
+              '—'
+            )}
+            {proyecto.terreno?.municipio ? (
+              <span className="block text-[11px] text-[var(--text)]/45">
+                {proyecto.terreno.municipio}
+              </span>
+            ) : null}
+          </Field>
+          <Field label="Anteproyecto origen">
+            {proyecto.anteproyecto ? (
+              <Link
+                href={`/dilesa/anteproyectos/${proyecto.anteproyecto.id}`}
+                className="text-[var(--accent)] hover:underline"
+              >
+                {proyecto.anteproyecto.nombre}
+              </Link>
+            ) : (
+              <span className="text-[var(--text)]/40">(sin anteproyecto origen)</span>
+            )}
+          </Field>
+          <Field label="Tipo de proyecto">{proyecto.tipo_proyecto?.nombre ?? '—'}</Field>
+        </Section>
+
+        <Section title="D. Económica">
+          <Field label="Presupuesto total">{formatCurrency(proyecto.presupuesto_total)}</Field>
+          <Field label="Inversión total">{formatCurrency(proyecto.inversion_total)}</Field>
+          <Field label="Área vendible">{formatM2(proyecto.area_vendible_m2)}</Field>
+          <Field label="Áreas verdes">{formatM2(proyecto.areas_verdes_m2)}</Field>
+          <Field label="Cantidad lotes total">
+            {proyecto.cantidad_lotes_total ?? <span className="text-[var(--text)]/40">—</span>}
+          </Field>
+        </Section>
+
+        <Section title="E. Gestión">
+          <Field label="Fase">{proyecto.fase ?? '—'}</Field>
+          <Field label="Etapa">{proyecto.etapa ?? '—'}</Field>
+          <Field label="Decisión actual">{proyecto.decision_actual ?? '—'}</Field>
+          <Field label="Prioridad">
+            {proyecto.prioridad
+              ? (PRIORIDAD_CONFIG[proyecto.prioridad as PrioridadNivel]?.label ??
+                proyecto.prioridad)
+              : '—'}
+          </Field>
+          <Field label="Responsable">
+            {proyecto.responsable_id ? (
+              <span className="font-mono text-xs text-[var(--text)]/60">
+                {proyecto.responsable_id.slice(0, 8)}…
+              </span>
+            ) : (
+              '—'
+            )}
+          </Field>
+          <Field label="Fecha inicio">{formatDateShort(proyecto.fecha_inicio)}</Field>
+          <Field label="Cierre estimado">{formatDateShort(proyecto.fecha_estimada_cierre)}</Field>
+          <Field label="Última revisión">{formatDateShort(proyecto.fecha_ultima_revision)}</Field>
+          <Field label="Siguiente acción" wide>
+            {proyecto.siguiente_accion ?? '—'}
+          </Field>
+        </Section>
+
+        {proyecto.notas ? (
+          <Section title="Notas">
+            <div className="col-span-full whitespace-pre-wrap text-sm text-[var(--text)]/80">
+              {proyecto.notas}
+            </div>
+          </Section>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+      <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+        {title}
+      </h2>
+      <dl className="mt-3 grid gap-x-4 gap-y-2 sm:grid-cols-2">{children}</dl>
+    </section>
+  );
+}
+
+function Field({
+  label,
+  children,
+  wide,
+}: {
+  label: string;
+  children: React.ReactNode;
+  wide?: boolean;
+}) {
+  return (
+    <div className={wide ? 'col-span-full' : undefined}>
+      <dt className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/45">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-sm text-[var(--text)]/85">{children}</dd>
+    </div>
+  );
+}
+
+function FaseBadge({ fase }: { fase: string | null }) {
+  if (!fase) {
+    return (
+      <span className="inline-flex items-center rounded-lg border border-[var(--border)] px-3 py-1 text-xs text-[var(--text)]/55">
+        Sin fase
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-400">
+      {fase}
+    </span>
+  );
+}
+
+export default function ProyectoDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa">
+      <ProyectoDetailInner />
+    </RequireAccess>
+  );
+}

--- a/components/dilesa/anteproyecto-panel-financiero.tsx
+++ b/components/dilesa/anteproyecto-panel-financiero.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+/**
+ * Panel financiero del anteproyecto.
+ *
+ * Renderiza 9 KPI cards en grid 3x3 a partir de una fila de
+ * `dilesa.v_anteproyectos_analisis`. Las métricas que dependen de
+ * prototipos de referencia (valor_comercial_proyecto, costo_total_proyecto,
+ * utilidad_proyecto, margen_pct) se muestran con placeholder "—" y un
+ * hint cuando `prototipos_referenciados === 0`.
+ *
+ * El fetch lo hace el detail page y pasa los datos ya resueltos — este
+ * componente es puro presentation. Así separamos testing (snapshot visual)
+ * del lifecycle de datos y permite reuso eventual en Proyectos.
+ */
+
+import { AlertTriangle } from 'lucide-react';
+import { formatCurrency, formatM2, formatPercent } from '@/lib/dilesa-constants';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export type PanelFinancieroData = {
+  aprovechamiento_pct: number | null;
+  porcentaje_areas_verdes: number | null;
+  lote_promedio_m2: number | null;
+  precio_m2_aprovechable: number | null;
+  prototipos_referenciados: number | null;
+  valor_comercial_proyecto: number | null;
+  costo_total_proyecto: number | null;
+  utilidad_proyecto: number | null;
+  margen_pct: number | null;
+};
+
+export function AnteproyectoPanelFinanciero({
+  data,
+  loading,
+}: {
+  data: PanelFinancieroData | null;
+  loading?: boolean;
+}) {
+  if (loading) {
+    return (
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+          Panel financiero
+        </h2>
+        <div className="mt-4 grid gap-3 sm:grid-cols-3">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <Skeleton key={i} className="h-20 w-full" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (!data) {
+    return (
+      <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+          Panel financiero
+        </h2>
+        <p className="mt-4 text-sm text-[var(--text)]/55">
+          No se pudo cargar el análisis financiero de este anteproyecto.
+        </p>
+      </section>
+    );
+  }
+
+  const sinPrototipos = (data.prototipos_referenciados ?? 0) === 0;
+  const utilidad = data.utilidad_proyecto;
+  const margen = data.margen_pct;
+
+  return (
+    <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+          Panel financiero
+        </h2>
+        <span className="text-[10px] text-[var(--text)]/40">
+          Calculado en vivo desde v_anteproyectos_analisis
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <Kpi label="Aprovechamiento" value={formatPercent(data.aprovechamiento_pct)} />
+        <Kpi label="Áreas verdes" value={formatPercent(data.porcentaje_areas_verdes)} />
+        <Kpi label="Lote promedio" value={formatM2(data.lote_promedio_m2)} />
+
+        <Kpi label="Precio / m² aprovechable" value={formatCurrency(data.precio_m2_aprovechable)} />
+        <Kpi
+          label="Prototipos referenciados"
+          value={(data.prototipos_referenciados ?? 0).toLocaleString('es-MX')}
+        />
+        <Kpi
+          label="Valor comercial"
+          value={
+            sinPrototipos ? '—' : formatCurrency(data.valor_comercial_proyecto, { compact: true })
+          }
+          muted={sinPrototipos}
+        />
+
+        <Kpi
+          label="Costo total proyecto"
+          value={sinPrototipos ? '—' : formatCurrency(data.costo_total_proyecto, { compact: true })}
+          muted={sinPrototipos}
+        />
+        <Kpi
+          label="Utilidad proyecto"
+          value={sinPrototipos ? '—' : formatCurrency(utilidad, { compact: true })}
+          tone={!sinPrototipos && utilidad != null && utilidad < 0 ? 'negative' : 'default'}
+          muted={sinPrototipos}
+        />
+        <Kpi
+          label="Margen"
+          value={sinPrototipos ? '—' : formatPercent(margen)}
+          tone={!sinPrototipos && margen != null && margen < 0 ? 'negative' : 'default'}
+          muted={sinPrototipos}
+        />
+      </div>
+
+      {sinPrototipos ? (
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-amber-300">
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+          <span>
+            Agrega prototipos de referencia para ver valor comercial, costo total, utilidad y margen
+            proyectados.
+          </span>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  tone = 'default',
+  muted = false,
+}: {
+  label: string;
+  value: React.ReactNode;
+  tone?: 'default' | 'negative';
+  muted?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-xl border border-[var(--border)] bg-[var(--card)] p-3 ${
+        muted ? 'opacity-60' : ''
+      }`}
+    >
+      <div className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/45">
+        {label}
+      </div>
+      <div
+        className={`mt-1 text-lg font-semibold tracking-tight tabular-nums ${
+          tone === 'negative' ? 'text-red-400' : 'text-[var(--text)]'
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/components/dilesa/convertir-a-proyecto-modal.tsx
+++ b/components/dilesa/convertir-a-proyecto-modal.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+/**
+ * Modal de confirmación para "Convertir Anteproyecto a Proyecto".
+ *
+ * Llama `POST /api/dilesa/anteproyectos/[id]/convertir` y redirige al
+ * detail del proyecto recién creado. Si la API responde con error, lo
+ * muestra inline sin cerrar el modal (para que el usuario pueda
+ * corregir y re-intentar sin perder el nombre editado).
+ */
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { FieldLabel } from '@/components/ui/field-label';
+import { Button } from '@/components/ui/button';
+import { Loader2, ArrowRight } from 'lucide-react';
+
+export function ConvertirAProyectoModal({
+  open,
+  onOpenChange,
+  anteproyectoId,
+  defaultNombre,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  anteproyectoId: string;
+  defaultNombre: string;
+}) {
+  const router = useRouter();
+  const [nombre, setNombre] = useState(defaultNombre);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setNombre(defaultNombre);
+      setError(null);
+    }
+  }, [open, defaultNombre]);
+
+  const handleConfirm = async () => {
+    if (!nombre.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/dilesa/anteproyectos/${anteproyectoId}/convertir`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ nombre: nombre.trim() }),
+      });
+      const payload = (await res.json()) as { proyecto_id?: string; error?: string };
+      if (!res.ok || !payload.proyecto_id) {
+        setError(payload.error ?? `Error ${res.status} al convertir.`);
+        return;
+      }
+      onOpenChange(false);
+      router.push(`/dilesa/proyectos/${payload.proyecto_id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error de red.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Convertir a Proyecto</DialogTitle>
+          <DialogDescription>
+            Esto crea un proyecto formal ligado a este anteproyecto y marca el anteproyecto como
+            <strong> convertido</strong>. El anteproyecto queda como referencia histórica.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <FieldLabel htmlFor="conv-nombre" required>
+              Nombre del proyecto
+            </FieldLabel>
+            <Input
+              id="conv-nombre"
+              value={nombre}
+              onChange={(e) => setNombre(e.target.value)}
+              autoFocus
+            />
+            <p className="mt-1 text-[11px] text-[var(--text)]/55">
+              Por default tomamos el nombre del anteproyecto. Edítalo si quieres un código diferente
+              para el proyecto.
+            </p>
+          </div>
+
+          <label className="flex items-start gap-2 rounded-lg border border-[var(--border)] bg-[var(--card)] p-3">
+            <input
+              type="checkbox"
+              checked
+              readOnly
+              className="mt-0.5 size-4 accent-[var(--accent)]"
+            />
+            <span className="text-sm text-[var(--text)]/80">
+              Usar el snapshot del anteproyecto como datos iniciales (terreno, área vendible, áreas
+              verdes, cantidad de lotes, tipo de proyecto).
+              <span className="mt-0.5 block text-[11px] text-[var(--text)]/45">
+                Siempre activo en v1; en iteración futura permitiremos override manual.
+              </span>
+            </span>
+          </label>
+
+          {error ? (
+            <div
+              role="alert"
+              className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400"
+            >
+              {error}
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancelar
+          </Button>
+          <Button onClick={() => void handleConfirm()} disabled={submitting || !nombre.trim()}>
+            {submitting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <ArrowRight className="size-4" />
+            )}
+            Convertir
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dilesa/prototipo-multiselect.tsx
+++ b/components/dilesa/prototipo-multiselect.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Data-sync pattern consistente con el resto del sprint dilesa-1.
+ */
+
+/**
+ * Lista editable de prototipos de referencia para un anteproyecto.
+ *
+ * Muestra los prototipos ya ligados al anteproyecto vía
+ * `dilesa.anteproyectos_prototipos_referencia` como cards pequeñas y
+ * permite agregar/quitar por el cliente directo (sin endpoint API —
+ * la RLS de la tabla M:N ya gobierna).
+ *
+ * Cada cambio dispara `onChange()` para que el contenedor refresque el
+ * panel financiero (la vista `v_anteproyectos_analisis` recalcula al
+ * vuelo a partir de esta tabla).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Plus, Trash2, Loader2 } from 'lucide-react';
+import { DILESA_EMPRESA_ID, formatCurrency } from '@/lib/dilesa-constants';
+
+type Prototipo = {
+  id: string;
+  nombre: string;
+  codigo: string | null;
+  valor_comercial: number | null;
+  costo_total_unitario: number | null;
+};
+
+type Referencia = {
+  id: string;
+  prototipo_id: string;
+  prototipo: Prototipo | null;
+};
+
+export function PrototipoMultiselect({
+  anteproyectoId,
+  onChange,
+}: {
+  anteproyectoId: string;
+  onChange?: () => void;
+}) {
+  const supabase = useMemo(() => createSupabaseBrowserClient(), []);
+
+  const [referencias, setReferencias] = useState<Referencia[]>([]);
+  const [catalogo, setCatalogo] = useState<Prototipo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const refsIds = useMemo(() => new Set(referencias.map((r) => r.prototipo_id)), [referencias]);
+
+  const load = useCallback(async () => {
+    const [refRes, protoRes] = await Promise.all([
+      supabase
+        .schema('dilesa')
+        .from('anteproyectos_prototipos_referencia')
+        .select(
+          'id, prototipo_id, prototipo:prototipo_id(id, nombre, codigo, valor_comercial, costo_total_unitario)'
+        )
+        .eq('anteproyecto_id', anteproyectoId),
+      supabase
+        .schema('dilesa')
+        .from('prototipos')
+        .select('id, nombre, codigo, valor_comercial, costo_total_unitario')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null)
+        .order('nombre', { ascending: true }),
+    ]);
+    setReferencias(((refRes.data ?? []) as unknown as Referencia[]) ?? []);
+    setCatalogo((protoRes.data ?? []) as Prototipo[]);
+  }, [supabase, anteproyectoId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    const init = async () => {
+      await load();
+      if (!cancelled) setLoading(false);
+    };
+    void init();
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  const addReferencia = async (prototipoId: string) => {
+    setBusy(prototipoId);
+    const { error } = await supabase
+      .schema('dilesa')
+      .from('anteproyectos_prototipos_referencia')
+      .insert({
+        empresa_id: DILESA_EMPRESA_ID,
+        anteproyecto_id: anteproyectoId,
+        prototipo_id: prototipoId,
+      });
+    setBusy(null);
+    setOpen(false);
+    if (error) {
+      // UK violation → ya estaba; igual recargamos para sincronizar.
+      if (!error.message.includes('duplicate') && !error.message.includes('23505')) {
+        alert(`Error al agregar prototipo: ${error.message}`);
+      }
+    }
+    await load();
+    onChange?.();
+  };
+
+  const removeReferencia = async (id: string) => {
+    setBusy(id);
+    const { error } = await supabase
+      .schema('dilesa')
+      .from('anteproyectos_prototipos_referencia')
+      .delete()
+      .eq('id', id);
+    setBusy(null);
+    if (error) {
+      alert(`Error al quitar prototipo: ${error.message}`);
+      return;
+    }
+    await load();
+    onChange?.();
+  };
+
+  const disponibles = useMemo(
+    () => catalogo.filter((p) => !refsIds.has(p.id)),
+    [catalogo, refsIds]
+  );
+
+  return (
+    <section className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
+          Prototipos de referencia
+        </h2>
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger
+            render={(props) => (
+              <Button
+                {...props}
+                size="sm"
+                variant="outline"
+                type="button"
+                disabled={disponibles.length === 0}
+              >
+                <Plus className="size-3.5" />
+                Agregar
+              </Button>
+            )}
+          />
+          <PopoverContent align="end" className="w-80 p-0">
+            <Command>
+              <CommandInput placeholder="Buscar prototipo…" />
+              <CommandList>
+                <CommandEmpty>Sin prototipos disponibles</CommandEmpty>
+                <CommandGroup>
+                  {disponibles.map((p) => (
+                    <CommandItem
+                      key={p.id}
+                      value={p.id}
+                      keywords={[p.nombre, p.codigo ?? '']}
+                      onSelect={() => void addReferencia(p.id)}
+                    >
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate font-medium">{p.nombre}</span>
+                        <span className="truncate text-xs text-[var(--text)]/55">
+                          {p.codigo ? `${p.codigo} · ` : ''}
+                          {formatCurrency(p.valor_comercial, { compact: true })}
+                        </span>
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {loading ? (
+          Array.from({ length: 2 }).map((_, i) => <Skeleton key={i} className="h-16 w-full" />)
+        ) : referencias.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-[var(--border)] p-4 text-center text-sm text-[var(--text)]/55">
+            Sin prototipos ligados. Agrega al menos uno para calcular utilidad y margen proyectado.
+          </p>
+        ) : (
+          referencias.map((ref) => {
+            const p = ref.prototipo;
+            return (
+              <div
+                key={ref.id}
+                className="flex items-start gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-[var(--text)]">
+                    {p?.nombre ?? '(prototipo eliminado)'}
+                  </div>
+                  {p?.codigo ? (
+                    <div className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/45">
+                      {p.codigo}
+                    </div>
+                  ) : null}
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-[var(--text)]/60">
+                    <span>
+                      Valor: {formatCurrency(p?.valor_comercial ?? null, { compact: true })}
+                    </span>
+                    <span>
+                      Costo: {formatCurrency(p?.costo_total_unitario ?? null, { compact: true })}
+                    </span>
+                  </div>
+                </div>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  type="button"
+                  aria-label={`Quitar ${p?.nombre ?? 'prototipo'}`}
+                  onClick={() => void removeReferencia(ref.id)}
+                  disabled={busy === ref.id}
+                >
+                  {busy === ref.id ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <Trash2 className="size-3.5 text-red-400" />
+                  )}
+                </Button>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Tercer branch del sprint **dilesa-1 UI**. Expone el módulo **Anteproyectos** completo (master + detail con panel financiero en vivo y M:N con prototipos de referencia) más el flujo **Convertir a Proyecto** con rollback best-effort. Incluye scaffold mínimo read-only para `/dilesa/proyectos/[id]` como destino del redirect post-conversión.

## Qué expone

- **Master `/dilesa/anteproyectos`** — tabs Consulta / Resumen / Timeline / Chart.
  - Consulta: tabla con identidad + terreno embed + tipo + lotes + área + aprovechamiento % + utilidad + margen % + estado + prioridad + última revisión; filtros por estado y search client-side; cálculos mergeados desde `dilesa.v_anteproyectos_analisis`.
  - Alta: Sheet con `nombre*`, `terreno_id*` (Combobox), `tipo_proyecto_id`, `fecha_inicio`, `area_vendible_m2`, `areas_verdes_m2`, `cantidad_lotes`, `infraestructura_cabecera_inversion`. Estado default `en_analisis`.
  - Resumen: KPIs (totales, activos, utilidad proyectada, margen promedio), distribución por estado, top 5 por utilidad, alerta de anteproyectos sin prototipos referenciados.
- **Detail `/dilesa/anteproyectos/[id]`** — layout 3 columnas (4/5/3 en desktop):
  - IZQ: Identidad / Inputs físicos / Gestión (badge grande + motivo_no_viable condicional) / Notas.
  - CENTRO: panel financiero en vivo con 9 KPIs desde `v_anteproyectos_analisis`. Utilidad y margen se pintan en rojo si son negativos; sin prototipos referenciados → "—" + hint.
  - DER: lista editable de prototipos referenciados (M:N con `dilesa.anteproyectos_prototipos_referencia`) — agregar vía Popover con búsqueda, quitar inline. Cada cambio dispara refetch del panel central.
  - Header: botón **Convertir a Proyecto** (disabled con tooltip si faltan precondiciones: terreno, área vendible > 0, cantidad lotes > 0) o link **Ver proyecto →** si `estado = convertido_a_proyecto`.
- **Endpoint `POST /api/dilesa/anteproyectos/[id]/convertir`** — valida precondiciones, inserta `dilesa.proyectos` con snapshot del anteproyecto (terreno, área vendible/verdes, cantidad lotes, tipo, `anteproyecto_id`, `etapa=planeacion`, `decision=desarrollar`), actualiza el anteproyecto con `estado=convertido_a_proyecto`, `proyecto_id`, timestamp y empleado que convirtió (resuelto via `erp.v_empleados_full` por email; null si no tiene ficha). El UPDATE filtra `estado != 'convertido_a_proyecto'` en el WHERE → si doble-click retorna 0 rows, hacemos **rollback best-effort** borrando el proyecto recién insertado y devolvemos 409.
- **Scaffold `/dilesa/proyectos/[id]`** — read-only con secciones Identidad / Económica / Gestión / Notas, link "← Anteproyectos" cuando aplica, banner amarillo "scaffold temporal".

## Decisión arquitectónica

- **Endpoint API (Next route handler) en lugar de RPC de Postgres** para la conversión. Razones: el query admin ya bypasea RLS con service_role, y el flujo tiene dos pasos (insert proyecto → update anteproyecto) con compensación explícita. **Upgrade a RPC con `BEGIN/COMMIT` queda como follow-up** si aparece una race genuina en producción.
- M:N de prototipos se hace con **cliente directo** (no endpoint) — la RLS de la tabla M:N ya gobierna y evita un round-trip extra. Endpoint solo para convertir.

## Archivos

**Nuevos (7):**
- `app/api/dilesa/anteproyectos/[id]/convertir/route.ts`
- `app/dilesa/anteproyectos/[id]/page.tsx`
- `app/dilesa/proyectos/[id]/page.tsx`
- `components/dilesa/anteproyecto-panel-financiero.tsx`
- `components/dilesa/convertir-a-proyecto-modal.tsx`
- `components/dilesa/prototipo-multiselect.tsx`

**Modificados (1):**
- `app/dilesa/anteproyectos/page.tsx` (reemplaza el stub `ComingSoonModule`)

## Reuso 100%

`ModuleTabs` / `useActiveTab` / `TabPanel`, `EmptyStateImported`, `ANTEPROYECTO_ESTADO_CONFIG` + `PRIORIDAD_CONFIG` de `lib/status-tokens`, `DILESA_EMPRESA_ID` + formatters de `lib/dilesa-constants`, `SortableHead` + `useSortableTable`, `RequireAccess empresa="dilesa"`, `Combobox`, `Dialog/AlertDialog`, `Popover`. Sin duplicar componentes shared.

## Test plan

- [ ] Master `/dilesa/anteproyectos` carga — tabla render con al menos 1 anteproyecto migrado, badges de estado correctos.
- [ ] Filtro por estado y search en master funcionan client-side.
- [ ] Sheet de Alta abre, Combobox de terreno lista los disponibles, creación exitosa redirige al detail.
- [ ] Detail carga en 3 columnas desktop; panel financiero renderiza 9 KPIs (con "—" si aún no hay prototipos ref).
- [ ] Agregar prototipo desde popover → panel central recalcula valor comercial / costo total / utilidad / margen.
- [ ] Quitar prototipo → panel vuelve a placeholders cuando llega a 0.
- [ ] Botón Convertir disabled con tooltip si falta terreno / área / lotes; habilitado con datos completos.
- [ ] Convertir → redirige a `/dilesa/proyectos/[nuevo-id]` con banner "scaffold temporal" visible y anteproyecto marcado "convertido_a_proyecto" con link "Ver proyecto →".
- [ ] Re-intento de convertir con el mismo anteproyecto responde **409** (idempotencia defensiva).
- [ ] Resumen muestra totales, top 5, alerta de anteproyectos sin prototipos ref.
- [ ] `npm run typecheck` — 0 errores.
- [ ] `npm run lint` — 0 errores (warnings pre-existentes no relacionados).

## Follow-ups explícitos

- Módulo Proyectos completo (`feat/dilesa-ui-proyectos`) — reemplaza el scaffold con tabs Info / Lotes / Prototipos / Presupuesto / Documentos.
- Upgrade a RPC transaccional para la conversión si aparece race en prod.
- Edición inline del expediente en el detail del anteproyecto (v1 es read-only salvo M:N y convertir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)