### PR TITLE
feat(cortes): botón registrar movimiento en corte abierto

### DIFF
--- a/app/rdb/cortes/actions.ts
+++ b/app/rdb/cortes/actions.ts
@@ -137,7 +137,6 @@ export type RegistrarMovimientoInput = {
   tipo_detalle: string;
   monto: number;
   concepto: string;
-  realizado_por_nombre: string;
 };
 
 export async function registrarMovimiento(
@@ -149,6 +148,11 @@ export async function registrarMovimiento(
     data: { session },
   } = await supabase.auth.getSession();
   if (!session?.user) throw new Error('No autenticado');
+
+  // Audit trail: quien capturó = user logueado. No confiamos en input del cliente.
+  const userMeta = session.user.user_metadata as { full_name?: string } | undefined;
+  const realizadoPorNombre = (userMeta?.full_name || session.user.email || '').trim();
+  if (!realizadoPorNombre) throw new Error('Usuario sin nombre ni email registrado');
 
   if (!input.corte_id) throw new Error('corte_id requerido');
   if (!input.monto || input.monto <= 0) throw new Error('Monto debe ser mayor a 0');
@@ -187,7 +191,7 @@ export async function registrarMovimiento(
       tipo_detalle: input.tipo_detalle,
       monto: input.monto,
       concepto: input.concepto.trim(),
-      realizado_por_nombre: input.realizado_por_nombre.trim(),
+      realizado_por_nombre: realizadoPorNombre,
       // `referencia` se reserva para marca histórica de Coda (i-xxxxx).
     })
     .select('id')

--- a/app/rdb/cortes/actions.ts
+++ b/app/rdb/cortes/actions.ts
@@ -130,3 +130,72 @@ export async function cerrarCaja(input: CerrarCajaInput): Promise<void> {
 
   revalidatePath('/rdb/cortes');
 }
+
+export type RegistrarMovimientoInput = {
+  corte_id: string;
+  tipo: 'entrada' | 'salida';
+  tipo_detalle: string;
+  monto: number;
+  concepto: string;
+  realizado_por_nombre: string;
+};
+
+export async function registrarMovimiento(
+  input: RegistrarMovimientoInput
+): Promise<{ id: string }> {
+  const supabase = await createSupabaseServerClient();
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.user) throw new Error('No autenticado');
+
+  if (!input.corte_id) throw new Error('corte_id requerido');
+  if (!input.monto || input.monto <= 0) throw new Error('Monto debe ser mayor a 0');
+  if (!input.concepto?.trim()) throw new Error('Concepto requerido');
+  if (!['entrada', 'salida'].includes(input.tipo)) {
+    throw new Error(`tipo inválido: ${input.tipo}`);
+  }
+
+  // Solo cortes abiertos aceptan movimientos; cierres son inmutables.
+  const { data: corte, error: fetchErr } = await supabase
+    .schema('erp')
+    .from('cortes_caja')
+    .select('id, estado')
+    .eq('empresa_id', RDB_EMPRESA_ID)
+    .eq('id', input.corte_id)
+    .maybeSingle();
+
+  if (fetchErr) throw new Error(fetchErr.message);
+  if (!corte) throw new Error('Corte no encontrado');
+  if (corte.estado !== 'abierto') {
+    throw new Error(
+      `No se puede registrar movimiento: el corte está "${corte.estado}". Solo cortes abiertos aceptan movimientos.`
+    );
+  }
+
+  // Escribimos directo a erp.movimientos_caja. NO llamar rdb.upsert_movimiento:
+  // está DEPRECATED desde PR #172 y lanza RAISE WARNING — ese shim es solo
+  // para callers tardíos de Coda.
+  const { data: mov, error: insertErr } = await supabase
+    .schema('erp')
+    .from('movimientos_caja')
+    .insert({
+      empresa_id: RDB_EMPRESA_ID,
+      corte_id: input.corte_id,
+      tipo: input.tipo,
+      tipo_detalle: input.tipo_detalle,
+      monto: input.monto,
+      concepto: input.concepto.trim(),
+      realizado_por_nombre: input.realizado_por_nombre.trim(),
+      // `referencia` se reserva para marca histórica de Coda (i-xxxxx).
+    })
+    .select('id')
+    .single();
+
+  if (insertErr) throw new Error(insertErr.message);
+  if (!mov) throw new Error('Error al registrar movimiento');
+
+  revalidatePath('/rdb/cortes');
+  return mov as { id: string };
+}

--- a/components/cortes/corte-detail.tsx
+++ b/components/cortes/corte-detail.tsx
@@ -1,4 +1,5 @@
-import { Printer, XCircle } from 'lucide-react';
+import { Plus, Printer, XCircle } from 'lucide-react';
+import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -13,6 +14,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { CortePrintMarbete } from './corte-print-marbete';
 import { estadoVariant, formatCurrency, formatDate, formatDateTime } from './helpers';
+import { RegistrarMovimientoDialog } from './registrar-movimiento-dialog';
 import type { Corte, CorteTotales, Movimiento } from './types';
 
 function DetailSkeleton() {
@@ -36,6 +38,7 @@ export function CorteDetail({
   open,
   onClose,
   onCerrar,
+  onMovimientoRegistered,
 }: {
   corte: Corte | null;
   totales: CorteTotales | null;
@@ -44,7 +47,9 @@ export function CorteDetail({
   open: boolean;
   onClose: () => void;
   onCerrar: (corte: Corte) => void;
+  onMovimientoRegistered: () => void;
 }) {
+  const [registrarOpen, setRegistrarOpen] = useState(false);
   if (!corte) return null;
   const estaAbierto = corte.estado?.toLowerCase() === 'abierto';
   const efectivoEsperado = totales?.efectivo_esperado ?? corte.efectivo_esperado ?? 0;
@@ -205,10 +210,23 @@ export function CorteDetail({
 
             <Separator />
 
-            {/* Movimientos — placeholder */}
+            {/* Movimientos */}
             <div>
-              <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                Movimientos
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Movimientos
+                </span>
+                {estaAbierto && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setRegistrarOpen(true)}
+                    aria-label="Registrar movimiento de caja"
+                  >
+                    <Plus className="mr-1.5 h-3.5 w-3.5" />
+                    Registrar
+                  </Button>
+                )}
               </div>
               {loadingDetail ? (
                 <DetailSkeleton />
@@ -238,6 +256,16 @@ export function CorteDetail({
             </div>
           </div>
         </ScrollArea>
+
+        {estaAbierto && (
+          <RegistrarMovimientoDialog
+            corteId={corte.id}
+            defaultRealizadoPor={corte.responsable_apertura ?? ''}
+            open={registrarOpen}
+            onOpenChange={setRegistrarOpen}
+            onSuccess={onMovimientoRegistered}
+          />
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/components/cortes/corte-detail.tsx
+++ b/components/cortes/corte-detail.tsx
@@ -260,7 +260,6 @@ export function CorteDetail({
         {estaAbierto && (
           <RegistrarMovimientoDialog
             corteId={corte.id}
-            defaultRealizadoPor={corte.responsable_apertura ?? ''}
             open={registrarOpen}
             onOpenChange={setRegistrarOpen}
             onSuccess={onMovimientoRegistered}

--- a/components/cortes/cortes-view.tsx
+++ b/components/cortes/cortes-view.tsx
@@ -103,24 +103,33 @@ export function CortesView() {
     void fetchCortes();
   }, [fetchCortes]);
 
-  const openDetail = async (corte: Corte) => {
-    setSelected(corte);
-    setSelectedTotales(null);
-    setSelectedMovimientos([]);
-    setDrawerOpen(true);
-    setLoadingDetail(true);
-
+  const loadDetail = useCallback(async (corteId: string, withSpinner: boolean) => {
+    if (withSpinner) setLoadingDetail(true);
     try {
-      const { totales, movimientos, productos } = await fetchCorteDetail(corte.id);
+      const { totales, movimientos, productos } = await fetchCorteDetail(corteId);
       setSelectedTotales(totales);
       setSelectedMovimientos(movimientos);
       setSelectedProductos(productos);
     } catch {
       // non-fatal — drawer still shows corte base info
     } finally {
-      setLoadingDetail(false);
+      if (withSpinner) setLoadingDetail(false);
     }
+  }, []);
+
+  const openDetail = async (corte: Corte) => {
+    setSelected(corte);
+    setSelectedTotales(null);
+    setSelectedMovimientos([]);
+    setDrawerOpen(true);
+    await loadDetail(corte.id, true);
   };
+
+  const refreshSelectedDetail = useCallback(() => {
+    if (!selected) return;
+    void loadDetail(selected.id, false);
+    void fetchCortes();
+  }, [selected, loadDetail, fetchCortes]);
 
   const filtered = cortes.filter((c) => {
     if (estadoFilter !== 'all' && c.estado?.toLowerCase() !== estadoFilter) return false;
@@ -196,6 +205,7 @@ export function CortesView() {
           open={drawerOpen}
           onClose={() => setDrawerOpen(false)}
           onCerrar={openCerrarDialog}
+          onMovimientoRegistered={refreshSelectedDetail}
         />
 
         {/* Cerrar Corte dialog */}

--- a/components/cortes/data.ts
+++ b/components/cortes/data.ts
@@ -58,7 +58,7 @@ export async function fetchCorteDetail(corteId: string): Promise<{
       .schema('erp')
       .from('movimientos_caja')
       .select(
-        'id,corte_id,fecha_hora:created_at,tipo,monto,nota:concepto,registrado_por:referencia'
+        'id,corte_id,fecha_hora:created_at,tipo,tipo_detalle,monto,nota:concepto,registrado_por:realizado_por_nombre'
       )
       .eq('empresa_id', RDB_EMPRESA_ID)
       .eq('corte_id', corteId)

--- a/components/cortes/registrar-movimiento-dialog.tsx
+++ b/components/cortes/registrar-movimiento-dialog.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { Loader2, Plus } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { registrarMovimiento } from '@/app/rdb/cortes/actions';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/toast';
+import { TIPO_MOVIMIENTO_OPTIONS } from './types';
+
+type Props = {
+  corteId: string;
+  defaultRealizadoPor: string;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onSuccess: () => void;
+};
+
+export function RegistrarMovimientoDialog({
+  corteId,
+  defaultRealizadoPor,
+  open,
+  onOpenChange,
+  onSuccess,
+}: Props) {
+  const toast = useToast();
+  const [tipoDetalle, setTipoDetalle] = useState<string>('');
+  const [monto, setMonto] = useState<string>('');
+  const [concepto, setConcepto] = useState<string>('');
+  const [realizadoPor, setRealizadoPor] = useState<string>(defaultRealizadoPor);
+  const [submitting, setSubmitting] = useState(false);
+  const prevConceptoDefaultRef = useRef<string | undefined>(undefined);
+  const tipoInputRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setTipoDetalle('');
+      setMonto('');
+      setConcepto('');
+      setRealizadoPor(defaultRealizadoPor);
+      prevConceptoDefaultRef.current = undefined;
+      queueMicrotask(() => tipoInputRef.current?.focus());
+    }
+  }, [open, defaultRealizadoPor]);
+
+  const selected = TIPO_MOVIMIENTO_OPTIONS.find((o) => o.tipo_detalle === tipoDetalle);
+  const direccion = selected?.tipo;
+
+  function handleTipoChange(next: string | null) {
+    const value = next ?? '';
+    setTipoDetalle(value);
+    const nextOpt = TIPO_MOVIMIENTO_OPTIONS.find((o) => o.tipo_detalle === value);
+    const prevDefault = prevConceptoDefaultRef.current;
+    const conceptoIsEmpty = !concepto.trim();
+    const conceptoMatchesPrevDefault = prevDefault ? concepto === prevDefault : false;
+    if (nextOpt?.conceptoDefault && (conceptoIsEmpty || conceptoMatchesPrevDefault)) {
+      setConcepto(nextOpt.conceptoDefault);
+    }
+    prevConceptoDefaultRef.current = nextOpt?.conceptoDefault;
+  }
+
+  const montoNum = Number(monto);
+  const canSubmit =
+    !!selected &&
+    Number.isFinite(montoNum) &&
+    montoNum > 0 &&
+    concepto.trim().length > 0 &&
+    realizadoPor.trim().length > 0 &&
+    !submitting;
+
+  async function handleSubmit() {
+    if (!selected || !canSubmit) return;
+    setSubmitting(true);
+    try {
+      await registrarMovimiento({
+        corte_id: corteId,
+        tipo: selected.tipo,
+        tipo_detalle: selected.tipo_detalle,
+        monto: montoNum,
+        concepto: concepto.trim(),
+        realizado_por_nombre: realizadoPor.trim(),
+      });
+      toast.add({ title: 'Movimiento registrado', type: 'success' });
+      onSuccess();
+      onOpenChange(false);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Error al registrar';
+      toast.add({ title: 'Error al registrar movimiento', description: msg, type: 'error' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const conceptoPlaceholder = selected
+    ? (selected.conceptoDefault ?? `Detalle del ${selected.label.toLowerCase()}`)
+    : 'Describe el movimiento…';
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v && !submitting) onOpenChange(false);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Registrar movimiento</DialogTitle>
+          <DialogDescription>
+            Entrada o salida manual de caja durante el turno abierto.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="space-y-4 py-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void handleSubmit();
+          }}
+        >
+          <div className="space-y-1.5">
+            <label
+              htmlFor="mov-tipo"
+              className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+            >
+              Tipo de movimiento
+            </label>
+            <Select value={tipoDetalle} onValueChange={handleTipoChange}>
+              <SelectTrigger
+                id="mov-tipo"
+                ref={tipoInputRef}
+                aria-describedby="mov-tipo-help"
+                className="w-full"
+              >
+                <SelectValue placeholder="Seleccionar tipo…" />
+              </SelectTrigger>
+              <SelectContent>
+                {TIPO_MOVIMIENTO_OPTIONS.map((o) => (
+                  <SelectItem key={o.tipo_detalle} value={o.tipo_detalle}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p id="mov-tipo-help" className="min-h-4 text-xs text-muted-foreground">
+              {selected?.descripcion ?? ' '}
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <label
+                htmlFor="mov-monto"
+                className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+              >
+                Monto
+              </label>
+              {direccion && (
+                <span
+                  className={
+                    'text-xs font-medium tabular-nums ' +
+                    (direccion === 'salida' ? 'text-destructive' : 'text-emerald-500')
+                  }
+                >
+                  {direccion === 'salida' ? '– salida' : '+ entrada'}
+                </span>
+              )}
+            </div>
+            <div className="relative">
+              <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                $
+              </span>
+              <Input
+                id="mov-monto"
+                type="number"
+                inputMode="decimal"
+                min="0.01"
+                step="0.01"
+                value={monto}
+                onChange={(e) => setMonto(e.target.value)}
+                placeholder="0.00"
+                className="pl-7 text-lg font-medium"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label
+              htmlFor="mov-concepto"
+              className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+            >
+              Concepto
+            </label>
+            <Textarea
+              id="mov-concepto"
+              rows={2}
+              value={concepto}
+              onChange={(e) => setConcepto(e.target.value)}
+              placeholder={conceptoPlaceholder}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label
+              htmlFor="mov-realizado-por"
+              className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+            >
+              Realizado por
+            </label>
+            <Input
+              id="mov-realizado-por"
+              value={realizadoPor}
+              onChange={(e) => setRealizadoPor(e.target.value)}
+              placeholder="Nombre del cajero"
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={!canSubmit}>
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Registrando…
+                </>
+              ) : (
+                <>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Registrar
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/cortes/registrar-movimiento-dialog.tsx
+++ b/components/cortes/registrar-movimiento-dialog.tsx
@@ -26,24 +26,16 @@ import { TIPO_MOVIMIENTO_OPTIONS } from './types';
 
 type Props = {
   corteId: string;
-  defaultRealizadoPor: string;
   open: boolean;
   onOpenChange: (v: boolean) => void;
   onSuccess: () => void;
 };
 
-export function RegistrarMovimientoDialog({
-  corteId,
-  defaultRealizadoPor,
-  open,
-  onOpenChange,
-  onSuccess,
-}: Props) {
+export function RegistrarMovimientoDialog({ corteId, open, onOpenChange, onSuccess }: Props) {
   const toast = useToast();
   const [tipoDetalle, setTipoDetalle] = useState<string>('');
   const [monto, setMonto] = useState<string>('');
   const [concepto, setConcepto] = useState<string>('');
-  const [realizadoPor, setRealizadoPor] = useState<string>(defaultRealizadoPor);
   const [submitting, setSubmitting] = useState(false);
   const prevConceptoDefaultRef = useRef<string | undefined>(undefined);
   const tipoInputRef = useRef<HTMLButtonElement | null>(null);
@@ -53,11 +45,10 @@ export function RegistrarMovimientoDialog({
       setTipoDetalle('');
       setMonto('');
       setConcepto('');
-      setRealizadoPor(defaultRealizadoPor);
       prevConceptoDefaultRef.current = undefined;
       queueMicrotask(() => tipoInputRef.current?.focus());
     }
-  }, [open, defaultRealizadoPor]);
+  }, [open]);
 
   const selected = TIPO_MOVIMIENTO_OPTIONS.find((o) => o.tipo_detalle === tipoDetalle);
   const direccion = selected?.tipo;
@@ -81,7 +72,6 @@ export function RegistrarMovimientoDialog({
     Number.isFinite(montoNum) &&
     montoNum > 0 &&
     concepto.trim().length > 0 &&
-    realizadoPor.trim().length > 0 &&
     !submitting;
 
   async function handleSubmit() {
@@ -94,7 +84,6 @@ export function RegistrarMovimientoDialog({
         tipo_detalle: selected.tipo_detalle,
         monto: montoNum,
         concepto: concepto.trim(),
-        realizado_por_nombre: realizadoPor.trim(),
       });
       toast.add({ title: 'Movimiento registrado', type: 'success' });
       onSuccess();
@@ -212,21 +201,6 @@ export function RegistrarMovimientoDialog({
               value={concepto}
               onChange={(e) => setConcepto(e.target.value)}
               placeholder={conceptoPlaceholder}
-            />
-          </div>
-
-          <div className="space-y-1.5">
-            <label
-              htmlFor="mov-realizado-por"
-              className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
-            >
-              Realizado por
-            </label>
-            <Input
-              id="mov-realizado-por"
-              value={realizadoPor}
-              onChange={(e) => setRealizadoPor(e.target.value)}
-              placeholder="Nombre del cajero"
             />
           </div>
 

--- a/components/cortes/types.ts
+++ b/components/cortes/types.ts
@@ -60,6 +60,7 @@ export type Movimiento = {
   corte_id: string;
   fecha_hora: string | null;
   tipo: string | null;
+  tipo_detalle: string | null;
   monto: number | null;
   nota: string | null;
   registrado_por: string | null;
@@ -97,4 +98,60 @@ export const DENOMINACIONES_DEFAULT: Denominacion[] = [
   { denominacion: 2, tipo: 'moneda', cantidad: 0 },
   { denominacion: 1, tipo: 'moneda', cantidad: 0 },
   { denominacion: 0.5, tipo: 'moneda', cantidad: 0 },
+];
+
+// ─── Catálogo de movimientos manuales de caja ─────────────────────────────────
+// Hardcoded: 6 valores fijos que replican lo que RDB usaba en Coda antes de la
+// migración (2026-04-23). Si el catálogo crece, mover a tabla seed en erp.
+
+export type TipoMovimientoDireccion = 'entrada' | 'salida';
+
+export type TipoMovimientoOption = {
+  tipo_detalle: string;
+  tipo: TipoMovimientoDireccion;
+  label: string;
+  descripcion: string;
+  conceptoDefault?: string;
+};
+
+export const TIPO_MOVIMIENTO_OPTIONS: TipoMovimientoOption[] = [
+  {
+    tipo_detalle: 'caja_negra',
+    tipo: 'salida',
+    label: 'Caja negra',
+    descripcion: 'Efectivo guardado al cierre (no es gasto).',
+    conceptoDefault: 'Caja negra',
+  },
+  {
+    tipo_detalle: 'retiro_efectivo',
+    tipo: 'salida',
+    label: 'Retiro de efectivo',
+    descripcion: 'Gasto o compra pagada en efectivo desde la caja.',
+  },
+  {
+    tipo_detalle: 'propina',
+    tipo: 'salida',
+    label: 'Propina a staff',
+    descripcion: 'Pago de propinas al personal al cierre del turno.',
+    conceptoDefault: 'Propinas staff',
+  },
+  {
+    tipo_detalle: 'deposito_inicial',
+    tipo: 'entrada',
+    label: 'Depósito inicial',
+    descripcion: 'Fondo extra que se agrega a la caja durante el turno (cambio).',
+    conceptoDefault: 'Depósito para cambio',
+  },
+  {
+    tipo_detalle: 'pago_proveedor',
+    tipo: 'salida',
+    label: 'Pago a proveedor',
+    descripcion: 'Pago en efectivo a un proveedor.',
+  },
+  {
+    tipo_detalle: 'gasto_operativo',
+    tipo: 'salida',
+    label: 'Gasto operativo',
+    descripcion: 'Gasto general del negocio pagado de caja.',
+  },
 ];


### PR DESCRIPTION
## Summary

RDB migró el 2026-04-23 de Coda a BSOP nativo para cortes de caja, pero la UI mostraba la lista de movimientos sin un botón para capturarlos — el comentario literal `{/* Movimientos — placeholder */}` vivía en `components/cortes/corte-detail.tsx:208`. Evidencia del problema: primer corte nativo (Caja Laisha 23-abr, id `ea80b7ba-3d44-4fab-bcfa-c7fca6d72f69`) se cerró con 0 filas en `erp.movimientos_caja`, cuando en Coda siempre había al menos una de caja_negra.

- **Botón "+ Registrar"** visible solo cuando el corte está abierto, dentro del side sheet de detalle.
- **Dialog nuevo** (`registrar-movimiento-dialog.tsx`) con catálogo de 6 tipos: `caja_negra`, `retiro_efectivo`, `propina`, `deposito_inicial`, `pago_proveedor`, `gasto_operativo`. La dirección (`entrada`/`salida`) se deriva del tipo seleccionado.
- **Server action `registrarMovimiento`** escribe directo a `erp.movimientos_caja`. NO usa el shim deprecado `rdb.upsert_movimiento` (ver [#172](https://github.com/beto-sudo/BSOP/pull/172)). Valida que el corte exista y esté abierto antes de insertar.
- **Fix menor** en `components/cortes/data.ts`: el select mapeaba `registrado_por:referencia`, que en datos de Coda traía el `coda_id` en vez del nombre. Cambiado a `realizado_por_nombre`.
- **Refresh callback** (`onMovimientoRegistered`) en `cortes-view.tsx` recarga totales/movimientos del corte seleccionado + la lista de cortes tras cada inserción.

## Archivos tocados

- `components/cortes/types.ts` — catálogo `TIPO_MOVIMIENTO_OPTIONS` + `Movimiento.tipo_detalle`
- `app/rdb/cortes/actions.ts` — server action `registrarMovimiento`
- `components/cortes/registrar-movimiento-dialog.tsx` — nuevo, Dialog con validación
- `components/cortes/corte-detail.tsx` — botón + montaje del Dialog
- `components/cortes/data.ts` — fix del select
- `components/cortes/cortes-view.tsx` — wire del callback de refresh

## Verificación automática (pasó en esta rama)

- ✅ `npm run lint` — 0 errores (58 warnings preexistentes sin relación)
- ✅ `npm run typecheck` — clean
- ✅ `npm run build` — clean (compiló todas las rutas, incluyendo `/rdb/cortes`)

## Test plan (manual E2E — pendiente ejecutar en dev local)

- [ ] `npm run dev`, login con usuario con acceso a RDB.
- [ ] Abrir caja de prueba → abrir su detail → botón "+ Registrar" visible.
- [ ] Registrar 3 movimientos: `caja_negra $1000`, `retiro_efectivo $250` (concepto "prueba gasolina"), `deposito_inicial $500`.
- [ ] Los 3 aparecen en la lista con `tipo_detalle` correcto y el nombre del user logueado.
- [ ] Resumen Financiero actualiza tras cada inserción: esperado `retiros = 1250`, `depositos = 500`.
- [ ] Cerrar corte → botón "+ Registrar" desaparece.
- [ ] Llamar server action con `corte_id` de corte cerrado vía devtools → falla con mensaje claro.

**SQL post-test** (confirmar escritura correcta):

```sql
SELECT tipo, tipo_detalle, monto, concepto, realizado_por_nombre, referencia
FROM erp.movimientos_caja
WHERE corte_id = '<corte de prueba>'
ORDER BY created_at DESC;
-- Esperado: referencia IS NULL, tipo_detalle llenado, realizado_por_nombre = nombre del user.
```

**Logs check** (probar que NO pasamos por el shim):

```
-- Vía mcp__supabase__get_logs(service='postgres') buscar regex:
--   'DEPRECATED.*upsert_movimiento'
-- Filtrar por timestamp > momento-de-las-pruebas.
-- Esperado: 0 hits.
```

**Cleanup post-test**:

```sql
DELETE FROM erp.movimientos_caja WHERE corte_id = '<corte de prueba>';
DELETE FROM erp.cortes_caja WHERE id = '<corte de prueba>';
```

Cierra #5 del backlog post-migración Coda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)