### PR TITLE
fix(cortes): scroll interno del modal cerrar corte en viewports de poca altura

### DIFF
--- a/components/cortes/cerrar-corte-dialog.tsx
+++ b/components/cortes/cerrar-corte-dialog.tsx
@@ -98,7 +98,7 @@ export function CerrarCorteDialog({
         if (!v) onOpenChange(false);
       }}
     >
-      <DialogContent className="flex max-h-[90vh] flex-col sm:max-w-lg">
+      <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>{titulo}</DialogTitle>
           <DialogDescription>
@@ -111,7 +111,7 @@ export function CerrarCorteDialog({
           )}
         </DialogHeader>
 
-        <ScrollArea className="flex-1 pr-2">
+        <ScrollArea className="min-h-0 flex-1 pr-2">
           {(!isWizard || step === 1) && (
             <div className="space-y-4 py-2">
               {/* Referencia */}


### PR DESCRIPTION
## Summary
- Agrega `overflow-hidden` al `DialogContent` y `min-h-0` al `ScrollArea` del `CerrarCorteDialog` para que el modal respete su `max-h-[90vh]` y scrollee internamente en vez de desbordar.
- Fix reportado por usuarios de RDB con monitores ultrawide 2560×1080: los botones Cancelar/Confirmar quedaban fuera de viewport al abrir el modal.

## Por qué
Un flex child tiene `min-height: auto` por default, lo que le permite crecer más allá de su contenedor. Para que el `ScrollArea` realmente scrollee dentro de un `DialogContent` flex-col con altura máxima, ambas reglas son necesarias:
1. `overflow-hidden` en el padre (evita que desborde hacia afuera del viewport)
2. `min-h-0` en el hijo scrolleable (lo deja shrinkeable y activa el overflow interno)

## Cambio
Dos líneas en `components/cortes/cerrar-corte-dialog.tsx`:
- `DialogContent`: añade `overflow-hidden`
- `ScrollArea`: añade `min-h-0`

## Test plan
- [ ] Abrir corte en RDB y luego el modal de cerrar corte en viewport angosto de alto (ej. 1280×780 via devtools Responsive).
- [ ] Verificar que header y footer (Cancelar/Confirmar) quedan fijos y visibles.
- [ ] Verificar que la zona de billetes/monedas scrollea internamente cuando no cabe.
- [ ] En viewport alto normal (≥900px), verificar que no aparece scrollbar innecesario.
- [ ] Repetir en step 2 del wizard (vouchers) para confirmar que también se comporta bien.

## Notas
- Sin cambios de schema. No requiere regenerar `SCHEMA_REF.md`.
- Errores previos de typecheck en `voucher-uploader.tsx` (módulos `heic2any` y `browser-image-compression` faltantes) son pre-existentes de #176 y no bloquean este fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)