### PR TITLE
fix(cortes): expose real error message when abrir caja duplicates an open turn

### DIFF
--- a/app/rdb/cortes/actions.ts
+++ b/app/rdb/cortes/actions.ts
@@ -23,9 +23,7 @@ export type AbrirCajaInput = {
   fecha_operativa: string; // YYYY-MM-DD
 };
 
-export type AbrirCajaResult =
-  | { ok: true; id: string }
-  | { ok: false; error: string };
+export type AbrirCajaResult = { ok: true; id: string } | { ok: false; error: string };
 
 export async function abrirCaja(input: AbrirCajaInput): Promise<AbrirCajaResult> {
   const supabase = await createSupabaseServerClient();

--- a/app/rdb/cortes/actions.ts
+++ b/app/rdb/cortes/actions.ts
@@ -23,13 +23,19 @@ export type AbrirCajaInput = {
   fecha_operativa: string; // YYYY-MM-DD
 };
 
-export async function abrirCaja(input: AbrirCajaInput): Promise<{ id: string }> {
+export type AbrirCajaResult =
+  | { ok: true; id: string }
+  | { ok: false; error: string };
+
+export async function abrirCaja(input: AbrirCajaInput): Promise<AbrirCajaResult> {
   const supabase = await createSupabaseServerClient();
 
   const {
     data: { session },
   } = await supabase.auth.getSession();
-  if (!session?.user) throw new Error('No autenticado');
+  if (!session?.user) {
+    return { ok: false, error: 'No autenticado. Vuelve a iniciar sesión.' };
+  }
 
   // Check for an existing open turn on this caja (case-insensitive)
   const { data: existing, error: checkErr } = await supabase
@@ -41,12 +47,15 @@ export async function abrirCaja(input: AbrirCajaInput): Promise<{ id: string }> 
     .eq('estado', 'abierto')
     .maybeSingle();
 
-  if (checkErr) throw new Error(checkErr.message);
+  if (checkErr) {
+    return { ok: false, error: `Error al verificar turno: ${checkErr.message}` };
+  }
 
   if (existing) {
-    throw new Error(
-      'Ya existe un turno abierto para esta caja. Ciérralo antes de abrir uno nuevo.'
-    );
+    return {
+      ok: false,
+      error: 'Ya existe un turno abierto para esta caja. Ciérralo antes de abrir uno nuevo.',
+    };
   }
 
   const now = new Date().toISOString();
@@ -66,11 +75,15 @@ export async function abrirCaja(input: AbrirCajaInput): Promise<{ id: string }> 
     .select('id')
     .single();
 
-  if (insertErr) throw new Error(insertErr.message);
-  if (!corte) throw new Error('Error al abrir el turno de caja');
+  if (insertErr) {
+    return { ok: false, error: `Error al abrir turno: ${insertErr.message}` };
+  }
+  if (!corte) {
+    return { ok: false, error: 'Error al abrir el turno de caja (sin datos de respuesta).' };
+  }
 
   revalidatePath('/rdb/cortes');
-  return corte as { id: string };
+  return { ok: true, id: corte.id };
 }
 
 export type Denominacion = {

--- a/components/cortes/use-abrir-caja.ts
+++ b/components/cortes/use-abrir-caja.ts
@@ -68,17 +68,25 @@ export function useAbrirCaja() {
 
     startTransition(async () => {
       try {
-        await abrirCaja({
+        const result = await abrirCaja({
           caja_id: form.caja_id,
           caja_nombre: selectedCaja?.nombre ?? form.caja_id,
           responsable_apertura: form.responsable_apertura.trim(),
           efectivo_inicial: parseFloat(form.efectivo_inicial) || 0,
           fecha_operativa: form.fecha_operativa || todayRange().from,
         });
+
+        if (!result.ok) {
+          setError(result.error);
+          return;
+        }
+
         setOpen(false);
         setForm(EMPTY_FORM);
         onSuccess();
       } catch (err) {
+        // Solo entra aquí por errores inesperados (red, parseo). Los errores
+        // de negocio (duplicado, no autenticado, etc.) llegan en result.error.
         setError(err instanceof Error ? err.message : 'Error al abrir la caja');
       }
     });


### PR DESCRIPTION
## Summary

- En Next.js 15, los errores lanzados desde Server Actions se sanitizan en producción: el cliente recibe el mensaje genérico de React (`"An error occurred in the Server Components render..."`) y nunca ve el mensaje real.
- Caso real (24-abr-2026): Laisha intentó abrir un turno en una caja que ya tenía uno abierto (`b9ee52f7-c5d2-4de4-a643-346510daaf1e`) y el UI mostró el digest genérico en lugar de `"Ya existe un turno abierto para esta caja. Ciérralo antes de abrir uno nuevo."`.
- Migra `abrirCaja` al patrón discriminated-union (`{ ok: true; id } | { ok: false; error }`) para que los errores esperables viajen como **valor de retorno**, no como excepción. El `catch` del hook queda solo para errores realmente inesperados (red, parseo).

## Alcance

- `app/rdb/cortes/actions.ts` — sólo `abrirCaja` (firma + cuerpo). `cerrarCaja`, `registrarMovimiento`, etc. tienen el mismo anti-pattern pero quedan para PRs separados.
- `components/cortes/use-abrir-caja.ts` — el `submit` lee `result.ok` antes de cerrar el modal.

## Nota sobre el caso real

El turno abierto `b9ee52f7-c5d2-4de4-a643-346510daaf1e` (Caja Laisha, 22:01 UTC) **no se toca** en este PR — es un dato válido que Laisha debe cerrar normalmente cuando termine su turno. Sirve como referencia del incidente que destapó el bug.

## Test plan

- [x] `npm run typecheck` — sin errores nuevos (los 2 errores en `voucher-uploader.tsx` son pre-existentes en main, módulos `heic2any` / `browser-image-compression` no instalados).
- [x] `npm run lint` — 0 errores; 58 warnings, todos pre-existentes.
- [ ] **Smoke test manual pendiente en preview** — al ser un cambio que depende del comportamiento de producción de Server Actions, verificar en preview/prod:
  - [ ] Caso duplicado: con el turno abierto `b9ee52f7-…` aún en pie, intentar abrir otro turno en Caja Laisha → debe mostrar `"Ya existe un turno abierto para esta caja. Ciérralo antes de abrir uno nuevo."` (no el digest genérico).
  - [ ] Caso feliz: abrir turno con caja libre → crea el corte y cierra el modal.