### PR TITLE
feat(cortes): fase 1 — types + lógica pura de conciliación

### DIFF
--- a/components/cortes/__tests__/conciliacion.test.ts
+++ b/components/cortes/__tests__/conciliacion.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from 'vitest';
+
+import { TOLERANCIA_MXN, conciliarEfectivo, conciliarTarjeta } from '../conciliacion';
+import type { Corte, CorteTotales, Voucher } from '../types';
+
+/**
+ * Tests para components/cortes/conciliacion.ts.
+ *
+ * Cubre las reglas de §7 del plan (`docs/plans/cortes-detail-conciliacion.md`)
+ * y los edge cases de §9. Lógica 100% pura — sin DB, sin fetch.
+ */
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function v(overrides: Partial<Voucher> = {}): Voucher {
+  return {
+    id: 'v-default',
+    corte_id: 'corte-1',
+    storage_path: 'rdb/corte-1/v.jpg',
+    signed_url: null,
+    nombre_original: 'voucher.jpg',
+    tamano_bytes: 12345,
+    mime_type: 'image/jpeg',
+    afiliacion: null,
+    monto_reportado: null,
+    uploaded_by_nombre: null,
+    uploaded_at: null,
+    categoria: 'voucher_tarjeta',
+    banco_id: null,
+    banco_nombre: null,
+    movimiento_caja_id: null,
+    ocr_texto_crudo: null,
+    ocr_monto_sugerido: null,
+    ocr_banco_sugerido_id: null,
+    ocr_confianza: null,
+    ...overrides,
+  };
+}
+
+function totales(over: Partial<CorteTotales> = {}): CorteTotales {
+  return {
+    corte_id: 'corte-1',
+    caja_id: null,
+    caja_nombre: null,
+    estado: 'cerrado',
+    hora_inicio: null,
+    hora_fin: null,
+    efectivo_inicial: 0,
+    ingresos_efectivo: 0,
+    ingresos_tarjeta: 0,
+    ingresos_stripe: 0,
+    ingresos_transferencias: 0,
+    total_ingresos: 0,
+    depositos: 0,
+    retiros: 0,
+    efectivo_esperado: 0,
+    ...over,
+  };
+}
+
+function corte(over: Partial<Corte> = {}): Corte {
+  return {
+    id: 'corte-1',
+    corte_nombre: null,
+    caja_nombre: null,
+    caja_id: null,
+    fecha_operativa: null,
+    hora_inicio: null,
+    hora_fin: null,
+    estado: 'cerrado',
+    efectivo_inicial: null,
+    efectivo_contado: null,
+    responsable_apertura: null,
+    responsable_cierre: null,
+    turno: null,
+    tipo: null,
+    observaciones: null,
+    ...over,
+  };
+}
+
+// ── conciliarTarjeta ─────────────────────────────────────────────────────────
+
+describe('conciliarTarjeta', () => {
+  it('sin_actividad: ingresos=0 y sin vouchers', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 0 }), []);
+    expect(r.estado).toBe('sin_actividad');
+    expect(r.ingresos_pedidos).toBe(0);
+    expect(r.total_evidencia).toBe(0);
+    expect(r.evidencia_count).toBe(0);
+    expect(r.evidencia_pendiente).toBe(0);
+    expect(r.diferencia).toBe(0);
+  });
+
+  it('sin_voucher: ingresos>0 sin vouchers de tarjeta', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), []);
+    expect(r.estado).toBe('sin_voucher');
+    expect(r.ingresos_pedidos).toBe(5354);
+    expect(r.total_evidencia).toBe(0);
+    expect(r.evidencia_count).toBe(0);
+    expect(r.diferencia).toBe(-5354);
+  });
+
+  it('pendiente_captura: 1 voucher con monto, 1 sin monto', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
+      v({ id: 'v1', monto_reportado: 1200 }),
+      v({ id: 'v2', monto_reportado: null }),
+    ]);
+    expect(r.estado).toBe('pendiente_captura');
+    expect(r.evidencia_count).toBe(2);
+    expect(r.evidencia_pendiente).toBe(1);
+    expect(r.total_evidencia).toBe(1200);
+    expect(r.diferencia).toBe(1200 - 5354);
+  });
+
+  it('cuadra exacto: suma vouchers === ingresos', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
+      v({ id: 'v1', monto_reportado: 1200 }),
+      v({ id: 'v2', monto_reportado: 4154 }),
+    ]);
+    expect(r.estado).toBe('cuadra');
+    expect(r.diferencia).toBe(0);
+    expect(r.total_evidencia).toBe(5354);
+    expect(r.evidencia_count).toBe(2);
+    expect(r.evidencia_pendiente).toBe(0);
+  });
+
+  it('cuadra_aprox: diferencia exactamente $5 (tolerancia inclusiva)', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
+      v({ monto_reportado: 5359 }),
+    ]);
+    expect(r.estado).toBe('cuadra_aprox');
+    expect(r.diferencia).toBe(5);
+  });
+
+  it('cuadra_aprox: diferencia $4.99', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 100 }), [
+      v({ monto_reportado: 95.01 }),
+    ]);
+    expect(r.estado).toBe('cuadra_aprox');
+    expect(Math.abs(r.diferencia)).toBeLessThanOrEqual(TOLERANCIA_MXN);
+  });
+
+  it('diferencia: diferencia $5.01 (justo arriba de tolerancia)', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 100 }), [
+      v({ monto_reportado: 105.01 }),
+    ]);
+    expect(r.estado).toBe('diferencia');
+    expect(Math.abs(r.diferencia)).toBeGreaterThan(TOLERANCIA_MXN);
+  });
+
+  it('diferencia: vouchers menores que ingresos por mucho', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
+      v({ monto_reportado: 1200 }),
+    ]);
+    expect(r.estado).toBe('diferencia');
+    expect(r.diferencia).toBe(-4154);
+  });
+
+  it('diferencia: vouchers mayores que ingresos (positivo)', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
+      v({ monto_reportado: 5360 }),
+    ]);
+    expect(r.estado).toBe('diferencia');
+    expect(r.diferencia).toBe(6);
+  });
+
+  it('voucher monto=0 cuenta como capturado, no pendiente', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 0 }), [
+      v({ monto_reportado: 0 }),
+    ]);
+    // No es sin_actividad porque hay un voucher; no es pendiente_captura porque
+    // 0 cuenta como capturado; ingresos=0 y total=0 → cuadra exacto.
+    expect(r.estado).toBe('cuadra');
+    expect(r.evidencia_count).toBe(1);
+    expect(r.evidencia_pendiente).toBe(0);
+    expect(r.total_evidencia).toBe(0);
+    expect(r.diferencia).toBe(0);
+  });
+
+  it('ignora vouchers con categoria=comprobante_movimiento', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
+      v({ id: 'v1', monto_reportado: 5354 }),
+      v({ id: 'v2', monto_reportado: 999, categoria: 'comprobante_movimiento' }),
+    ]);
+    expect(r.estado).toBe('cuadra');
+    expect(r.evidencia_count).toBe(1);
+    expect(r.total_evidencia).toBe(5354);
+    expect(r.diferencia).toBe(0);
+  });
+
+  it('ignora vouchers con categoria=otro', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
+      v({ id: 'v1', monto_reportado: 5354 }),
+      v({ id: 'v2', monto_reportado: 999, categoria: 'otro' }),
+    ]);
+    expect(r.estado).toBe('cuadra');
+    expect(r.evidencia_count).toBe(1);
+    expect(r.total_evidencia).toBe(5354);
+  });
+
+  it('múltiples vouchers misma afiliación suman normal', () => {
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 9000 }), [
+      v({ id: 'v1', afiliacion: '7235801', monto_reportado: 3000 }),
+      v({ id: 'v2', afiliacion: '7235801', monto_reportado: 4000 }),
+      v({ id: 'v3', afiliacion: '7235801', monto_reportado: 2000 }),
+    ]);
+    expect(r.estado).toBe('cuadra');
+    expect(r.total_evidencia).toBe(9000);
+    expect(r.evidencia_count).toBe(3);
+  });
+
+  it('totales=null se trata como ingresos=0', () => {
+    const r = conciliarTarjeta(null, []);
+    expect(r.estado).toBe('sin_actividad');
+    expect(r.ingresos_pedidos).toBe(0);
+    expect(r.diferencia).toBe(0);
+  });
+
+  it('totales=null con vouchers da diferencia (ingresos=0, vouchers>0)', () => {
+    const r = conciliarTarjeta(null, [v({ monto_reportado: 100 })]);
+    expect(r.estado).toBe('diferencia');
+    expect(r.ingresos_pedidos).toBe(0);
+    expect(r.total_evidencia).toBe(100);
+    expect(r.diferencia).toBe(100);
+  });
+});
+
+// ── conciliarEfectivo ────────────────────────────────────────────────────────
+
+describe('conciliarEfectivo', () => {
+  it('pendiente_cierre: corte abierto', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'abierto', efectivo_contado: 3000 }),
+      totales({ efectivo_esperado: 3166.2 })
+    );
+    expect(r.estado).toBe('pendiente_cierre');
+    expect(r.contado).toBeNull();
+    expect(r.diferencia).toBeNull();
+    expect(r.esperado).toBe(3166.2);
+  });
+
+  it('pendiente_cierre: efectivo_contado null aunque corte cerrado', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'cerrado', efectivo_contado: null }),
+      totales({ efectivo_esperado: 3166.2 })
+    );
+    expect(r.estado).toBe('pendiente_cierre');
+    expect(r.contado).toBeNull();
+    expect(r.diferencia).toBeNull();
+  });
+
+  it('cuadra exacto: contado === esperado', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'cerrado', efectivo_contado: 3166.2 }),
+      totales({ efectivo_esperado: 3166.2 })
+    );
+    expect(r.estado).toBe('cuadra');
+    expect(r.diferencia).toBe(0);
+    expect(r.contado).toBe(3166.2);
+  });
+
+  it('cuadra_aprox: diferencia exactamente $5', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'cerrado', efectivo_contado: 3171 }),
+      totales({ efectivo_esperado: 3166 })
+    );
+    expect(r.estado).toBe('cuadra_aprox');
+    expect(r.diferencia).toBe(5);
+  });
+
+  it('diferencia: faltó efectivo (negativo) > tolerancia', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'cerrado', efectivo_contado: 3150 }),
+      totales({ efectivo_esperado: 3166.2 })
+    );
+    expect(r.estado).toBe('diferencia');
+    expect(r.diferencia).toBeCloseTo(-16.2, 2);
+  });
+
+  it('diferencia: sobró efectivo (positivo) > tolerancia', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'cerrado', efectivo_contado: 3200 }),
+      totales({ efectivo_esperado: 3166 })
+    );
+    expect(r.estado).toBe('diferencia');
+    expect(r.diferencia).toBe(34);
+  });
+
+  it('diferencia es null cuando estado=pendiente_cierre', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'abierto', efectivo_contado: null }),
+      totales({ efectivo_esperado: 100 })
+    );
+    expect(r.estado).toBe('pendiente_cierre');
+    expect(r.diferencia).toBeNull();
+  });
+
+  it('totales=null se trata como esperado=0', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'cerrado', efectivo_contado: 0 }),
+      null
+    );
+    expect(r.estado).toBe('cuadra');
+    expect(r.esperado).toBe(0);
+    expect(r.diferencia).toBe(0);
+  });
+
+  it('estado abierto en mayúsculas también dispara pendiente_cierre', () => {
+    const r = conciliarEfectivo(
+      corte({ estado: 'ABIERTO', efectivo_contado: 3166.2 }),
+      totales({ efectivo_esperado: 3166.2 })
+    );
+    expect(r.estado).toBe('pendiente_cierre');
+    expect(r.contado).toBeNull();
+    expect(r.diferencia).toBeNull();
+  });
+});
+
+// ── TOLERANCIA_MXN ──────────────────────────────────────────────────────────
+
+describe('TOLERANCIA_MXN', () => {
+  it('está exportada y vale 5', () => {
+    expect(TOLERANCIA_MXN).toBe(5);
+  });
+});

--- a/components/cortes/__tests__/conciliacion.test.ts
+++ b/components/cortes/__tests__/conciliacion.test.ts
@@ -126,17 +126,13 @@ describe('conciliarTarjeta', () => {
   });
 
   it('cuadra_aprox: diferencia exactamente $5 (tolerancia inclusiva)', () => {
-    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
-      v({ monto_reportado: 5359 }),
-    ]);
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [v({ monto_reportado: 5359 })]);
     expect(r.estado).toBe('cuadra_aprox');
     expect(r.diferencia).toBe(5);
   });
 
   it('cuadra_aprox: diferencia $4.99', () => {
-    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 100 }), [
-      v({ monto_reportado: 95.01 }),
-    ]);
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 100 }), [v({ monto_reportado: 95.01 })]);
     expect(r.estado).toBe('cuadra_aprox');
     expect(Math.abs(r.diferencia)).toBeLessThanOrEqual(TOLERANCIA_MXN);
   });
@@ -150,25 +146,19 @@ describe('conciliarTarjeta', () => {
   });
 
   it('diferencia: vouchers menores que ingresos por mucho', () => {
-    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
-      v({ monto_reportado: 1200 }),
-    ]);
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [v({ monto_reportado: 1200 })]);
     expect(r.estado).toBe('diferencia');
     expect(r.diferencia).toBe(-4154);
   });
 
   it('diferencia: vouchers mayores que ingresos (positivo)', () => {
-    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [
-      v({ monto_reportado: 5360 }),
-    ]);
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 5354 }), [v({ monto_reportado: 5360 })]);
     expect(r.estado).toBe('diferencia');
     expect(r.diferencia).toBe(6);
   });
 
   it('voucher monto=0 cuenta como capturado, no pendiente', () => {
-    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 0 }), [
-      v({ monto_reportado: 0 }),
-    ]);
+    const r = conciliarTarjeta(totales({ ingresos_tarjeta: 0 }), [v({ monto_reportado: 0 })]);
     // No es sin_actividad porque hay un voucher; no es pendiente_captura porque
     // 0 cuenta como capturado; ingresos=0 y total=0 → cuadra exacto.
     expect(r.estado).toBe('cuadra');
@@ -297,10 +287,7 @@ describe('conciliarEfectivo', () => {
   });
 
   it('totales=null se trata como esperado=0', () => {
-    const r = conciliarEfectivo(
-      corte({ estado: 'cerrado', efectivo_contado: 0 }),
-      null
-    );
+    const r = conciliarEfectivo(corte({ estado: 'cerrado', efectivo_contado: 0 }), null);
     expect(r.estado).toBe('cuadra');
     expect(r.esperado).toBe(0);
     expect(r.diferencia).toBe(0);

--- a/components/cortes/conciliacion.ts
+++ b/components/cortes/conciliacion.ts
@@ -5,29 +5,29 @@ import type { Corte, CorteTotales, Voucher } from './types';
 export const TOLERANCIA_MXN = 5;
 
 export type ConciliacionEstado =
-  | 'sin_actividad'        // ingresos = 0 y sin evidencia
-  | 'cuadra'               // diferencia exactamente 0
-  | 'cuadra_aprox'         // |diferencia| <= TOLERANCIA_MXN
-  | 'diferencia'           // |diferencia| > TOLERANCIA_MXN
-  | 'sin_voucher'          // ingresos > 0 pero sin vouchers de tarjeta
-  | 'pendiente_captura'    // hay vouchers sin monto_reportado todavía
-  | 'pendiente_cierre';    // efectivo: corte abierto o contado nulo
+  | 'sin_actividad' // ingresos = 0 y sin evidencia
+  | 'cuadra' // diferencia exactamente 0
+  | 'cuadra_aprox' // |diferencia| <= TOLERANCIA_MXN
+  | 'diferencia' // |diferencia| > TOLERANCIA_MXN
+  | 'sin_voucher' // ingresos > 0 pero sin vouchers de tarjeta
+  | 'pendiente_captura' // hay vouchers sin monto_reportado todavía
+  | 'pendiente_cierre'; // efectivo: corte abierto o contado nulo
 
 export type ConciliacionTarjeta = {
   metodo: 'tarjeta';
   ingresos_pedidos: number;
-  total_evidencia: number;        // suma de monto_reportado de vouchers de tarjeta confirmados
-  evidencia_count: number;        // # vouchers con categoria='voucher_tarjeta'
-  evidencia_pendiente: number;    // # vouchers tarjeta sin monto_reportado
-  diferencia: number;             // total_evidencia - ingresos_pedidos
+  total_evidencia: number; // suma de monto_reportado de vouchers de tarjeta confirmados
+  evidencia_count: number; // # vouchers con categoria='voucher_tarjeta'
+  evidencia_pendiente: number; // # vouchers tarjeta sin monto_reportado
+  diferencia: number; // total_evidencia - ingresos_pedidos
   estado: ConciliacionEstado;
 };
 
 export type ConciliacionEfectivo = {
   metodo: 'efectivo';
   esperado: number;
-  contado: number | null;         // null si corte abierto o efectivo_contado nulo
-  diferencia: number | null;      // null si contado es null
+  contado: number | null; // null si corte abierto o efectivo_contado nulo
+  diferencia: number | null; // null si contado es null
   estado: ConciliacionEstado;
 };
 

--- a/components/cortes/conciliacion.ts
+++ b/components/cortes/conciliacion.ts
@@ -1,0 +1,128 @@
+import type { Corte, CorteTotales, Voucher } from './types';
+
+// Tolerancia en pesos para el estado "cuadra_aprox" (centavos por redondeo, propinas
+// chicas, etc.). Configurable como constante exportada.
+export const TOLERANCIA_MXN = 5;
+
+export type ConciliacionEstado =
+  | 'sin_actividad'        // ingresos = 0 y sin evidencia
+  | 'cuadra'               // diferencia exactamente 0
+  | 'cuadra_aprox'         // |diferencia| <= TOLERANCIA_MXN
+  | 'diferencia'           // |diferencia| > TOLERANCIA_MXN
+  | 'sin_voucher'          // ingresos > 0 pero sin vouchers de tarjeta
+  | 'pendiente_captura'    // hay vouchers sin monto_reportado todavía
+  | 'pendiente_cierre';    // efectivo: corte abierto o contado nulo
+
+export type ConciliacionTarjeta = {
+  metodo: 'tarjeta';
+  ingresos_pedidos: number;
+  total_evidencia: number;        // suma de monto_reportado de vouchers de tarjeta confirmados
+  evidencia_count: number;        // # vouchers con categoria='voucher_tarjeta'
+  evidencia_pendiente: number;    // # vouchers tarjeta sin monto_reportado
+  diferencia: number;             // total_evidencia - ingresos_pedidos
+  estado: ConciliacionEstado;
+};
+
+export type ConciliacionEfectivo = {
+  metodo: 'efectivo';
+  esperado: number;
+  contado: number | null;         // null si corte abierto o efectivo_contado nulo
+  diferencia: number | null;      // null si contado es null
+  estado: ConciliacionEstado;
+};
+
+/**
+ * Concilia ingresos por tarjeta vs sumatoria de vouchers de tarjeta.
+ *
+ * Reglas:
+ * - Solo cuentan vouchers con categoria === 'voucher_tarjeta'.
+ * - Un voucher con monto_reportado === null se considera pendiente (no entra en la suma).
+ * - Un voucher con monto_reportado === 0 SÍ está capturado (cero válido).
+ * - Si hay vouchers pendientes, el estado es 'pendiente_captura' aunque la suma
+ *   parcial cuadre — no podemos confirmar el cuadre hasta que estén todos.
+ * - Tolerancia ±TOLERANCIA_MXN aplica con `<=` (cinco pesos exactos cuadran aprox,
+ *   no se marca como diferencia crítica).
+ */
+export function conciliarTarjeta(
+  totales: CorteTotales | null,
+  vouchers: Voucher[]
+): ConciliacionTarjeta {
+  const ingresos = totales?.ingresos_tarjeta ?? 0;
+  const vouchersTarjeta = vouchers.filter((v) => v.categoria === 'voucher_tarjeta');
+  const conMonto = vouchersTarjeta.filter((v) => v.monto_reportado != null);
+  const sumVouchers = conMonto.reduce((acc, v) => acc + (v.monto_reportado ?? 0), 0);
+  const pendientes = vouchersTarjeta.length - conMonto.length;
+  const diferencia = sumVouchers - ingresos;
+  const absDif = Math.abs(diferencia);
+
+  let estado: ConciliacionEstado;
+  if (ingresos === 0 && vouchersTarjeta.length === 0) {
+    estado = 'sin_actividad';
+  } else if (ingresos > 0 && vouchersTarjeta.length === 0) {
+    estado = 'sin_voucher';
+  } else if (pendientes > 0) {
+    estado = 'pendiente_captura';
+  } else if (absDif === 0) {
+    estado = 'cuadra';
+  } else if (absDif <= TOLERANCIA_MXN) {
+    estado = 'cuadra_aprox';
+  } else {
+    estado = 'diferencia';
+  }
+
+  return {
+    metodo: 'tarjeta',
+    ingresos_pedidos: ingresos,
+    total_evidencia: sumVouchers,
+    evidencia_count: vouchersTarjeta.length,
+    evidencia_pendiente: pendientes,
+    diferencia,
+    estado,
+  };
+}
+
+/**
+ * Concilia efectivo esperado vs efectivo contado al cierre.
+ *
+ * Reglas:
+ * - Si corte abierto o `efectivo_contado` es null → 'pendiente_cierre' con diferencia null.
+ * - Tolerancia ±TOLERANCIA_MXN aplica con `<=`.
+ */
+export function conciliarEfectivo(
+  corte: Corte,
+  totales: CorteTotales | null
+): ConciliacionEfectivo {
+  const esperado = totales?.efectivo_esperado ?? 0;
+  const contado = corte.efectivo_contado;
+  const abierto = corte.estado?.toLowerCase() === 'abierto';
+
+  if (abierto || contado == null) {
+    return {
+      metodo: 'efectivo',
+      esperado,
+      contado: null,
+      diferencia: null,
+      estado: 'pendiente_cierre',
+    };
+  }
+
+  const diferencia = contado - esperado;
+  const absDif = Math.abs(diferencia);
+
+  let estado: ConciliacionEstado;
+  if (absDif === 0) {
+    estado = 'cuadra';
+  } else if (absDif <= TOLERANCIA_MXN) {
+    estado = 'cuadra_aprox';
+  } else {
+    estado = 'diferencia';
+  }
+
+  return {
+    metodo: 'efectivo',
+    esperado,
+    contado,
+    diferencia,
+    estado,
+  };
+}

--- a/components/cortes/types.ts
+++ b/components/cortes/types.ts
@@ -9,8 +9,8 @@ export const TZ = 'America/Matamoros';
 // Catálogo de bancos (seed en core.bancos). Cargado al montar el panel.
 export type Banco = {
   id: string;
-  codigo: string;        // 'BBVA', 'BANORTE', etc.
-  nombre: string;        // 'BBVA México', 'Banorte', etc.
+  codigo: string; // 'BBVA', 'BANORTE', etc.
+  nombre: string; // 'BBVA México', 'Banorte', etc.
   patron_ocr: string | null;
   activo: boolean;
 };
@@ -110,7 +110,7 @@ export type Voucher = {
   // action sí los hidrata (la columna `categoria` es NOT NULL DEFAULT).
   categoria?: VoucherCategoria;
   banco_id?: string | null;
-  banco_nombre?: string | null;       // resuelto via JOIN en server action; opcional para UI
+  banco_nombre?: string | null; // resuelto via JOIN en server action; opcional para UI
   movimiento_caja_id?: string | null;
   ocr_texto_crudo?: string | null;
   ocr_monto_sugerido?: number | null;

--- a/components/cortes/types.ts
+++ b/components/cortes/types.ts
@@ -6,6 +6,21 @@ export const TZ = 'America/Matamoros';
 
 // ─── Data shapes ──────────────────────────────────────────────────────────────
 
+// Catálogo de bancos (seed en core.bancos). Cargado al montar el panel.
+export type Banco = {
+  id: string;
+  codigo: string;        // 'BBVA', 'BANORTE', etc.
+  nombre: string;        // 'BBVA México', 'Banorte', etc.
+  patron_ocr: string | null;
+  activo: boolean;
+};
+
+// Categoría de la foto subida.
+// - voucher_tarjeta: cierre de lote de terminal bancaria
+// - comprobante_movimiento: foto ligada a un movimiento_caja (ej. sobre de caja negra)
+// - otro: sin clasificar
+export type VoucherCategoria = 'voucher_tarjeta' | 'comprobante_movimiento' | 'otro';
+
 // rdb.cortes columns (plus v_cortes_totales columns via v_cortes_completo).
 export type Corte = {
   id: string;
@@ -89,6 +104,18 @@ export type Voucher = {
   monto_reportado: number | null;
   uploaded_by_nombre: string | null;
   uploaded_at: string | null;
+  // Nuevos en migración 20260425153136. Opcionales en el tipo (no en DB) para
+  // tolerar el mock optimista en voucher-uploader.tsx que se construye antes de
+  // que se actualicen sus consumidores en fases siguientes. El SELECT del server
+  // action sí los hidrata (la columna `categoria` es NOT NULL DEFAULT).
+  categoria?: VoucherCategoria;
+  banco_id?: string | null;
+  banco_nombre?: string | null;       // resuelto via JOIN en server action; opcional para UI
+  movimiento_caja_id?: string | null;
+  ocr_texto_crudo?: string | null;
+  ocr_monto_sugerido?: number | null;
+  ocr_banco_sugerido_id?: string | null;
+  ocr_confianza?: number | null;
 };
 
 // Validación client-side antes de llamar al server action.


### PR DESCRIPTION
Primera fase del plan de conciliación de cortes (`docs/plans/cortes-detail-conciliacion.md`).

## Cambios
- `components/cortes/types.ts`: agrega `Banco`, `VoucherCategoria`, extiende `Voucher` con campos de la migración #189
- `components/cortes/conciliacion.ts` (nuevo): funciones puras `conciliarTarjeta` y `conciliarEfectivo` + types
- `components/cortes/__tests__/conciliacion.test.ts` (nuevo): cobertura de los edge cases de §9 del plan (25 tests)

## Lo que NO toca esta fase
- UI (`corte-detail.tsx`, `voucher-uploader.tsx`, `voucher-lightbox.tsx`, marbete) — fases 2-6
- Server actions ni queries de DB — fase 3
- OCR — fase 4

## Verificación local
- `npm run typecheck`: 0 errores nuevos (los 2 errores de `heic2any`/`browser-image-compression` son preexistentes en main)
- `npm run lint`: 0 errores, solo warnings preexistentes
- `npm run test:run`: 161/161 pasando, 25 tests nuevos en `conciliacion.test.ts`

## Nota de implementación
Los campos nuevos en `Voucher` se declaran con `?:` (opcionales) en lugar de `required` como muestra el plan §3.3. Razón: el mock optimista en `voucher-uploader.tsx:110` construye un `Voucher` inline sin esos campos, y la fase 1 explícitamente no debe tocarlo. La columna `categoria` en DB es `NOT NULL DEFAULT 'voucher_tarjeta'`, así que cualquier fila que venga del SELECT del server action sí los tendrá hidratados — la opcionalidad es solo concesión al constructor optimista. Se puede tightenar a required en fase 3 cuando el uploader se actualice.

Bajo riesgo: solo tipos y funciones puras 100% testeables sin estado externo.