### PR TITLE
feat(cortes): fase 2 — UI de conciliación visible en panel

### DIFF
--- a/components/cortes/corte-conciliacion.tsx
+++ b/components/cortes/corte-conciliacion.tsx
@@ -1,0 +1,406 @@
+'use client';
+
+import {
+  AlertTriangle,
+  ArrowLeftRight,
+  Banknote,
+  CheckCircle2,
+  CreditCard,
+  Info,
+  Smartphone,
+  type LucideIcon,
+} from 'lucide-react';
+
+import type { ConciliacionEfectivo, ConciliacionEstado, ConciliacionTarjeta } from './conciliacion';
+import { formatCurrency } from './helpers';
+
+type Props = {
+  tarjeta: ConciliacionTarjeta;
+  efectivo: ConciliacionEfectivo;
+  ingresosStripe: number;
+  ingresosTransferencias: number;
+};
+
+export function CorteConciliacion({
+  tarjeta,
+  efectivo,
+  ingresosStripe,
+  ingresosTransferencias,
+}: Props) {
+  return (
+    <section className="space-y-4">
+      <HealthBanner tarjeta={tarjeta} efectivo={efectivo} />
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Conciliación
+          </h3>
+          <span className="text-[10px] text-muted-foreground/70">Ingresos vs evidencia</span>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <CardTarjeta tarjeta={tarjeta} />
+          <CardEfectivo efectivo={efectivo} />
+          <CardInformativa
+            metodo="Stripe"
+            monto={ingresosStripe}
+            icon={Smartphone}
+            descripcion="Conciliación contra liquidación Stripe — próximamente."
+          />
+          <CardInformativa
+            metodo="Transferencia"
+            monto={ingresosTransferencias}
+            icon={ArrowLeftRight}
+            descripcion="Conciliación contra estado de cuenta — próximamente."
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── HealthBanner ──────────────────────────────────────────────────────────────
+
+function HealthBanner({
+  tarjeta,
+  efectivo,
+}: {
+  tarjeta: ConciliacionTarjeta;
+  efectivo: ConciliacionEfectivo;
+}) {
+  const estados: ConciliacionEstado[] = [tarjeta.estado, efectivo.estado];
+  const criticas = estados.filter((e) => e === 'diferencia' || e === 'sin_voucher').length;
+  const pendientes = estados.filter(
+    (e) => e === 'pendiente_captura' || e === 'pendiente_cierre'
+  ).length;
+
+  if (criticas > 0) {
+    const titulo = criticas === 1 ? '1 alerta crítica' : `${criticas} alertas críticas`;
+    const sufijo =
+      pendientes > 0 ? ` · ${pendientes} ${pendientes === 1 ? 'pendiente' : 'pendientes'}` : '';
+    return (
+      <BannerShell
+        tone="destructive"
+        Icon={AlertTriangle}
+        titulo={`${titulo}${sufijo}`}
+        descripcion="Revisar la conciliación para entender las diferencias."
+      />
+    );
+  }
+
+  if (pendientes > 0) {
+    const titulo =
+      pendientes === 1 ? '1 pendiente de captura' : `${pendientes} pendientes de captura`;
+    return (
+      <BannerShell
+        tone="warning"
+        Icon={Info}
+        titulo={titulo}
+        descripcion="El sistema no puede confirmar el cuadre hasta que se completen."
+      />
+    );
+  }
+
+  return (
+    <BannerShell
+      tone="success"
+      Icon={CheckCircle2}
+      titulo="Corte cuadra"
+      descripcion="Tarjeta y efectivo conciliados sin discrepancias."
+    />
+  );
+}
+
+type BannerTone = 'destructive' | 'warning' | 'success';
+
+const BANNER_TONES: Record<
+  BannerTone,
+  { wrapper: string; bubble: string; icon: string; titulo: string; descripcion: string }
+> = {
+  destructive: {
+    wrapper: 'bg-destructive/10 border-destructive/20',
+    bubble: 'bg-destructive/15',
+    icon: 'text-destructive',
+    titulo: 'text-destructive',
+    descripcion: 'text-destructive/80',
+  },
+  warning: {
+    wrapper: 'bg-yellow-500/10 border-yellow-500/20',
+    bubble: 'bg-yellow-500/15',
+    icon: 'text-yellow-600 dark:text-yellow-400',
+    titulo: 'text-yellow-700 dark:text-yellow-300',
+    descripcion: 'text-yellow-700/80 dark:text-yellow-400/80',
+  },
+  success: {
+    wrapper: 'bg-emerald-500/10 border-emerald-500/20',
+    bubble: 'bg-emerald-500/15',
+    icon: 'text-emerald-600 dark:text-emerald-400',
+    titulo: 'text-emerald-700 dark:text-emerald-300',
+    descripcion: 'text-emerald-700/80 dark:text-emerald-400/80',
+  },
+};
+
+function BannerShell({
+  tone,
+  Icon,
+  titulo,
+  descripcion,
+}: {
+  tone: BannerTone;
+  Icon: LucideIcon;
+  titulo: string;
+  descripcion: string;
+}) {
+  const t = BANNER_TONES[tone];
+  return (
+    <div className={`rounded-lg border p-3.5 ${t.wrapper}`}>
+      <div className="flex items-start gap-3">
+        <div
+          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${t.bubble}`}
+        >
+          <Icon className={`h-4 w-4 ${t.icon}`} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className={`text-sm font-semibold ${t.titulo}`}>{titulo}</div>
+          <div className={`mt-0.5 text-xs ${t.descripcion}`}>{descripcion}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── EstadoBadge ───────────────────────────────────────────────────────────────
+
+const ESTADO_BADGE: Record<ConciliacionEstado, { label: string; className: string }> = {
+  cuadra: {
+    label: '✓ Cuadra',
+    className:
+      'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border border-emerald-500/20',
+  },
+  cuadra_aprox: {
+    label: '~ Cuadra ±',
+    className: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-400 border border-yellow-500/20',
+  },
+  diferencia: {
+    label: '✗ Diferencia',
+    className: 'bg-destructive/10 text-destructive border border-destructive/20',
+  },
+  sin_voucher: {
+    label: '✗ Sin voucher',
+    className: 'bg-destructive/10 text-destructive border border-destructive/20',
+  },
+  pendiente_captura: {
+    label: '• Pendiente captura',
+    className: 'bg-yellow-500/10 text-yellow-700 dark:text-yellow-400 border border-yellow-500/20',
+  },
+  pendiente_cierre: {
+    label: '○ Pendiente cierre',
+    className: 'bg-muted text-muted-foreground border border-border',
+  },
+  sin_actividad: {
+    label: '— Sin actividad',
+    className: 'bg-muted text-muted-foreground border border-border',
+  },
+};
+
+function EstadoBadge({ estado }: { estado: ConciliacionEstado }) {
+  const meta = ESTADO_BADGE[estado];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${meta.className}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+// ── Helpers de formato ────────────────────────────────────────────────────────
+
+function diferenciaColor(estado: ConciliacionEstado) {
+  if (estado === 'diferencia' || estado === 'sin_voucher') return 'text-destructive';
+  if (estado === 'cuadra_aprox') return 'text-yellow-600 dark:text-yellow-400';
+  return 'text-foreground';
+}
+
+function formatDiferencia(value: number) {
+  if (value === 0) return formatCurrency(0);
+  const prefix = value > 0 ? '+' : '−';
+  return `${prefix}${formatCurrency(Math.abs(value))}`;
+}
+
+// ── CardTarjeta ───────────────────────────────────────────────────────────────
+
+function CardTarjeta({ tarjeta }: { tarjeta: ConciliacionTarjeta }) {
+  const pendientes = tarjeta.evidencia_pendiente;
+  const sumaPendienteLabel = pendientes > 0 ? ` +${pendientes} s/cap` : '';
+  const difLabel = pendientes > 0 ? '—' : formatDiferencia(tarjeta.diferencia);
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-muted">
+            <CreditCard className="h-4 w-4 text-muted-foreground" />
+          </div>
+          <span className="text-xs font-semibold uppercase tracking-wider text-foreground">
+            Tarjeta
+          </span>
+        </div>
+        <EstadoBadge estado={tarjeta.estado} />
+      </div>
+
+      <dl className="space-y-1 text-sm">
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Pedidos</dt>
+          <dd className="font-medium tabular-nums">{formatCurrency(tarjeta.ingresos_pedidos)}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">
+            Σ Vouchers <span className="text-muted-foreground/70">({tarjeta.evidencia_count})</span>
+          </dt>
+          <dd
+            className={`font-medium tabular-nums ${
+              pendientes > 0 ? 'text-yellow-600 dark:text-yellow-400' : ''
+            }`}
+          >
+            {formatCurrency(tarjeta.total_evidencia)}
+            {sumaPendienteLabel}
+          </dd>
+        </div>
+        <hr className="my-1 border-muted" />
+        <div className="flex justify-between text-sm font-semibold">
+          <dt>Diferencia</dt>
+          <dd className={`tabular-nums ${diferenciaColor(tarjeta.estado)}`}>{difLabel}</dd>
+        </div>
+      </dl>
+
+      <CardTarjetaMensaje tarjeta={tarjeta} />
+    </div>
+  );
+}
+
+function CardTarjetaMensaje({ tarjeta }: { tarjeta: ConciliacionTarjeta }) {
+  if (tarjeta.estado === 'sin_voucher') {
+    return (
+      <p className="mt-3 rounded border border-destructive/20 bg-destructive/10 p-2 text-[11px] text-destructive">
+        ⚠ Hay ingresos por tarjeta sin voucher de respaldo.
+      </p>
+    );
+  }
+  if (tarjeta.estado === 'pendiente_captura') {
+    const n = tarjeta.evidencia_pendiente;
+    return (
+      <p className="mt-3 rounded border border-yellow-500/20 bg-yellow-500/10 p-2 text-[11px] text-yellow-700 dark:text-yellow-400">
+        • Faltan {n} {n === 1 ? 'monto' : 'montos'} por capturar para confirmar el cuadre.
+      </p>
+    );
+  }
+  if (tarjeta.estado === 'diferencia') {
+    const verbo = tarjeta.diferencia > 0 ? 'exceden' : 'son menores que';
+    return (
+      <p className="mt-3 rounded border border-destructive/20 bg-destructive/10 p-2 text-[11px] text-destructive">
+        ⚠ Vouchers {verbo} ingresos por {formatCurrency(Math.abs(tarjeta.diferencia))}.
+      </p>
+    );
+  }
+  return null;
+}
+
+// ── CardEfectivo ──────────────────────────────────────────────────────────────
+
+function CardEfectivo({ efectivo }: { efectivo: ConciliacionEfectivo }) {
+  const difLabel =
+    efectivo.estado === 'pendiente_cierre' || efectivo.diferencia == null
+      ? '—'
+      : formatDiferencia(efectivo.diferencia);
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-muted">
+            <Banknote className="h-4 w-4 text-muted-foreground" />
+          </div>
+          <span className="text-xs font-semibold uppercase tracking-wider text-foreground">
+            Efectivo
+          </span>
+        </div>
+        <EstadoBadge estado={efectivo.estado} />
+      </div>
+
+      <dl className="space-y-1 text-sm">
+        <div className="flex justify-between">
+          <dt
+            className="inline-flex items-center gap-1 text-muted-foreground"
+            title="Inicial + Ingresos efectivo − Salidas"
+          >
+            Esperado <Info className="h-3 w-3 text-muted-foreground/70" />
+          </dt>
+          <dd className="font-medium tabular-nums">{formatCurrency(efectivo.esperado)}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Contado</dt>
+          <dd className="font-medium tabular-nums">
+            {efectivo.contado == null ? '—' : formatCurrency(efectivo.contado)}
+          </dd>
+        </div>
+        <hr className="my-1 border-muted" />
+        <div className="flex justify-between text-sm font-semibold">
+          <dt>Diferencia</dt>
+          <dd className={`tabular-nums ${diferenciaColor(efectivo.estado)}`}>{difLabel}</dd>
+        </div>
+      </dl>
+
+      <CardEfectivoMensaje efectivo={efectivo} />
+    </div>
+  );
+}
+
+function CardEfectivoMensaje({ efectivo }: { efectivo: ConciliacionEfectivo }) {
+  if (efectivo.estado === 'pendiente_cierre') {
+    return (
+      <p className="mt-3 rounded border border-border bg-muted p-2 text-[11px] text-muted-foreground">
+        ○ Falta capturar el conteo de efectivo al cerrar el corte.
+      </p>
+    );
+  }
+  if (efectivo.estado === 'diferencia' && efectivo.diferencia != null) {
+    const verbo = efectivo.diferencia < 0 ? 'Falta' : 'Sobra';
+    return (
+      <p className="mt-3 rounded border border-destructive/20 bg-destructive/10 p-2 text-[11px] text-destructive">
+        ⚠ {verbo} efectivo en caja por {formatCurrency(Math.abs(efectivo.diferencia))}.
+      </p>
+    );
+  }
+  return null;
+}
+
+// ── CardInformativa (Stripe / Transferencia) ──────────────────────────────────
+
+function CardInformativa({
+  metodo,
+  monto,
+  icon: Icon,
+  descripcion,
+}: {
+  metodo: string;
+  monto: number;
+  icon: LucideIcon;
+  descripcion: string;
+}) {
+  return (
+    <div className="rounded-lg border bg-card p-4 opacity-90">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-muted">
+            <Icon className="h-4 w-4 text-muted-foreground" />
+          </div>
+          <span className="text-xs font-semibold uppercase tracking-wider text-foreground">
+            {metodo}
+          </span>
+        </div>
+        <span className="text-sm font-semibold tabular-nums">{formatCurrency(monto)}</span>
+      </div>
+      <p className="text-[11px] text-muted-foreground">{descripcion}</p>
+    </div>
+  );
+}

--- a/components/cortes/corte-detail.tsx
+++ b/components/cortes/corte-detail.tsx
@@ -12,6 +12,8 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
+import { conciliarEfectivo, conciliarTarjeta } from './conciliacion';
+import { CorteConciliacion } from './corte-conciliacion';
 import { CortePrintMarbete } from './corte-print-marbete';
 import { estadoVariant, formatCurrency, formatDate, formatDateTime } from './helpers';
 import { RegistrarMovimientoDialog } from './registrar-movimiento-dialog';
@@ -59,6 +61,9 @@ export function CorteDetail({
   const efectivoEsperado = totales?.efectivo_esperado ?? corte.efectivo_esperado ?? 0;
   const efectivoContado = corte.efectivo_contado ?? 0;
   const diferencia = efectivoContado - efectivoEsperado;
+
+  const tarjeta = conciliarTarjeta(totales, vouchers);
+  const efectivo = conciliarEfectivo(corte, totales);
 
   return (
     <Sheet
@@ -136,6 +141,15 @@ export function CorteDetail({
                 <span className="mb-1 block font-semibold">Observaciones</span>
                 {corte.observaciones}
               </div>
+            )}
+
+            {!loadingDetail && (
+              <CorteConciliacion
+                tarjeta={tarjeta}
+                efectivo={efectivo}
+                ingresosStripe={totales?.ingresos_stripe ?? 0}
+                ingresosTransferencias={totales?.ingresos_transferencias ?? 0}
+              />
             )}
 
             <Separator />


### PR DESCRIPTION
Segunda fase del plan (`docs/plans/cortes-detail-conciliacion.md`).

## Cambios
- `components/cortes/corte-conciliacion.tsx` (nuevo): `<CorteConciliacion>` con HealthBanner + 4 cards (Tarjeta y Efectivo conciliados, Stripe y Transferencia informativos).
- `components/cortes/corte-detail.tsx`: importa el componente y lo renderiza arriba del Resumen Financiero usando los outputs de `conciliarTarjeta`/`conciliarEfectivo` (Fase 1).

## Lo que NO toca esta fase
- Captura de monto del voucher — fase 3
- OCR — fase 4
- Chip 📎 en movimientos / sección 'Otras evidencias' colapsable — fase 5
- Marbete impreso — fase 6

## Comportamiento esperado en producción
Como los vouchers existentes en DB tienen `monto_reportado=null` (el uploader nunca lo capturó), todos los cortes existentes mostrarán **'Pendiente captura'** en la tarjeta de Tarjeta. Eso es UX correcta — el usuario verá la señal de que hay trabajo que hacer.

Una vez deployada Fase 3 (captura manual), los montos podrán capturarse y los estados evolucionarán a cuadra/cuadra_aprox/diferencia.

## Verificación
- `npm run typecheck`: solo los 2 errores preexistentes en `voucher-uploader.tsx` (módulos `heic2any`/`browser-image-compression` ausentes en main, no tocado en esta fase).
- `npm run lint`: 0 errores.
- `npm run test:run`: 161/161 verdes (incluye los 25 de conciliación de Fase 1).
- `npm run format:check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)