### PR TITLE
feat(rdb-inventario): UI de levantamientos físicos — sub-PR B1 (componentes + lista + alta + tabs)

### DIFF
--- a/app/rdb/inventario/levantamientos/actions.ts
+++ b/app/rdb/inventario/levantamientos/actions.ts
@@ -1,27 +1,23 @@
 'use server';
 
+// Next.js requires `'use server'` modules to export only async functions —
+// constants, types and helpers live in ./types.ts.
+
 import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import type { Json } from '@/types/supabase';
-
-export const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
-
-export type ActionResult<T = void> =
-  | (T extends void ? { ok: true } : { ok: true; data: T })
-  | { ok: false; error: string };
+import {
+  RDB_EMPRESA_ID,
+  type ActionResult,
+  type CrearLevantamientoInput,
+  type FirmarPasoData,
+  type FirmarPasoInput,
+  type LineaParaCapturar,
+  type LineaParaRevisar,
+} from './types';
 
 // ─── Crear ────────────────────────────────────────────────────────────────────
-
-export type CrearLevantamientoInput = {
-  almacen_id: string;
-  fecha_programada: string; // YYYY-MM-DD
-  notas?: string;
-  tolerancia_pct_override?: number | null;
-  tolerancia_monto_override?: number | null;
-  /** 'fisico' (default) — el schema permite otros tipos a futuro. */
-  tipo?: string;
-};
 
 export async function crearLevantamiento(
   input: CrearLevantamientoInput
@@ -109,20 +105,6 @@ export async function cerrarCaptura(levantamiento_id: string): Promise<ActionRes
 
 // ─── Firma ────────────────────────────────────────────────────────────────────
 
-export type FirmarPasoInput = {
-  levantamiento_id: string;
-  paso: number;
-  rol: string;
-  comentario?: string;
-};
-
-export type FirmarPasoData = {
-  firmas_actuales: number;
-  firmas_requeridas: number;
-  aplicado: boolean;
-  movimientos_generados: number;
-};
-
 export async function firmarPaso(input: FirmarPasoInput): Promise<ActionResult<FirmarPasoData>> {
   const supabase = await createSupabaseServerClient();
   const hdrs = await headers();
@@ -191,18 +173,6 @@ export async function cancelarLevantamiento(
 
 // ─── Lecturas (RPC, RLS-safe) ─────────────────────────────────────────────────
 
-export type LineaParaCapturar = {
-  linea_id: string;
-  producto_id: string;
-  producto_codigo: string;
-  producto_nombre: string;
-  unidad: string;
-  categoria: string;
-  cantidad_contada: number;
-  contado_at: string | null;
-  recontada: boolean;
-};
-
 export async function getLineasParaCapturar(
   levantamiento_id: string
 ): Promise<ActionResult<LineaParaCapturar[]>> {
@@ -215,25 +185,6 @@ export async function getLineasParaCapturar(
   if (error) return { ok: false, error: error.message };
   return { ok: true, data: (data ?? []) as LineaParaCapturar[] };
 }
-
-export type LineaParaRevisar = {
-  linea_id: string;
-  producto_id: string;
-  producto_codigo: string;
-  producto_nombre: string;
-  unidad: string;
-  categoria: string;
-  costo_unitario: number;
-  stock_inicial: number;
-  salidas_durante_captura: number;
-  stock_efectivo: number;
-  cantidad_contada: number;
-  diferencia: number;
-  diferencia_valor: number;
-  fuera_de_tolerancia: boolean;
-  notas_diferencia: string | null;
-  contado_at: string | null;
-};
 
 export async function getLineasParaRevisar(
   levantamiento_id: string

--- a/app/rdb/inventario/levantamientos/actions.ts
+++ b/app/rdb/inventario/levantamientos/actions.ts
@@ -1,0 +1,249 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { headers } from 'next/headers';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import type { Json } from '@/types/supabase';
+
+export const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
+
+export type ActionResult<T = void> =
+  | (T extends void ? { ok: true } : { ok: true; data: T })
+  | { ok: false; error: string };
+
+// ─── Crear ────────────────────────────────────────────────────────────────────
+
+export type CrearLevantamientoInput = {
+  almacen_id: string;
+  fecha_programada: string; // YYYY-MM-DD
+  notas?: string;
+  tolerancia_pct_override?: number | null;
+  tolerancia_monto_override?: number | null;
+  /** 'fisico' (default) — el schema permite otros tipos a futuro. */
+  tipo?: string;
+};
+
+export async function crearLevantamiento(
+  input: CrearLevantamientoInput
+): Promise<ActionResult<{ id: string; folio: string | null }>> {
+  const supabase = await createSupabaseServerClient();
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.user) {
+    return { ok: false, error: 'No autenticado. Vuelve a iniciar sesión.' };
+  }
+
+  const { data, error } = await supabase
+    .schema('erp')
+    .from('inventario_levantamientos')
+    .insert({
+      empresa_id: RDB_EMPRESA_ID,
+      almacen_id: input.almacen_id,
+      fecha_programada: input.fecha_programada,
+      notas: input.notas?.trim() || null,
+      tolerancia_pct_override: input.tolerancia_pct_override ?? null,
+      tolerancia_monto_override: input.tolerancia_monto_override ?? null,
+      tipo: input.tipo ?? 'fisico',
+      created_by: session.user.id,
+    })
+    .select('id, folio')
+    .single();
+
+  if (error) return { ok: false, error: error.message };
+  if (!data) return { ok: false, error: 'Sin datos de respuesta al crear levantamiento.' };
+
+  revalidatePath('/rdb/inventario/levantamientos');
+  return { ok: true, data: { id: data.id, folio: data.folio } };
+}
+
+// ─── Captura: iniciar / guardar conteo / cerrar ───────────────────────────────
+
+export async function iniciarCaptura(
+  levantamiento_id: string
+): Promise<ActionResult<{ lineasSembradas: number }>> {
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .schema('erp')
+    .rpc('fn_iniciar_captura_levantamiento', { p_levantamiento_id: levantamiento_id });
+
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath('/rdb/inventario/levantamientos');
+  revalidatePath(`/rdb/inventario/levantamientos/${levantamiento_id}`);
+  return { ok: true, data: { lineasSembradas: data ?? 0 } };
+}
+
+export async function guardarConteo(
+  levantamiento_id: string,
+  producto_id: string,
+  cantidad: number
+): Promise<ActionResult> {
+  const supabase = await createSupabaseServerClient();
+
+  const { error } = await supabase.schema('erp').rpc('fn_guardar_conteo', {
+    p_levantamiento_id: levantamiento_id,
+    p_producto_id: producto_id,
+    p_cantidad: cantidad,
+  });
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}
+
+export async function cerrarCaptura(levantamiento_id: string): Promise<ActionResult> {
+  const supabase = await createSupabaseServerClient();
+
+  const { error } = await supabase
+    .schema('erp')
+    .rpc('fn_cerrar_captura_levantamiento', { p_levantamiento_id: levantamiento_id });
+
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath('/rdb/inventario/levantamientos');
+  revalidatePath(`/rdb/inventario/levantamientos/${levantamiento_id}`);
+  return { ok: true };
+}
+
+// ─── Firma ────────────────────────────────────────────────────────────────────
+
+export type FirmarPasoInput = {
+  levantamiento_id: string;
+  paso: number;
+  rol: string;
+  comentario?: string;
+};
+
+export type FirmarPasoData = {
+  firmas_actuales: number;
+  firmas_requeridas: number;
+  aplicado: boolean;
+  movimientos_generados: number;
+};
+
+export async function firmarPaso(input: FirmarPasoInput): Promise<ActionResult<FirmarPasoData>> {
+  const supabase = await createSupabaseServerClient();
+  const hdrs = await headers();
+  const ipHeader =
+    hdrs.get('x-forwarded-for')?.split(',')[0]?.trim() ?? hdrs.get('x-real-ip') ?? null;
+  const userAgent = hdrs.get('user-agent') ?? undefined;
+
+  const { data, error } = await supabase.schema('erp').rpc('fn_firmar_levantamiento', {
+    p_levantamiento_id: input.levantamiento_id,
+    p_paso: input.paso,
+    p_rol: input.rol,
+    p_comentario: input.comentario,
+    p_ip: ipHeader ?? undefined,
+    p_user_agent: userAgent,
+  });
+
+  if (error) return { ok: false, error: error.message };
+
+  const parsed = parseFirmarPasoResult(data);
+  if (!parsed) {
+    return { ok: false, error: 'Respuesta inesperada al firmar levantamiento.' };
+  }
+
+  revalidatePath('/rdb/inventario/levantamientos');
+  revalidatePath(`/rdb/inventario/levantamientos/${input.levantamiento_id}`);
+  return { ok: true, data: parsed };
+}
+
+function parseFirmarPasoResult(raw: Json | null): FirmarPasoData | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const obj = raw as Record<string, unknown>;
+  const firmas_actuales = Number(obj.firmas_actuales);
+  const firmas_requeridas = Number(obj.firmas_requeridas);
+  const aplicado = Boolean(obj.aplicado);
+  const movimientos_generados = Number(obj.movimientos_generados ?? 0);
+  if (!Number.isFinite(firmas_actuales) || !Number.isFinite(firmas_requeridas)) {
+    return null;
+  }
+  return { firmas_actuales, firmas_requeridas, aplicado, movimientos_generados };
+}
+
+// ─── Cancelar ─────────────────────────────────────────────────────────────────
+
+export async function cancelarLevantamiento(
+  levantamiento_id: string,
+  motivo: string
+): Promise<ActionResult> {
+  const motivoTrim = motivo.trim();
+  if (!motivoTrim) {
+    return { ok: false, error: 'El motivo de cancelación es requerido.' };
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  const { error } = await supabase.schema('erp').rpc('fn_cancelar_levantamiento', {
+    p_levantamiento_id: levantamiento_id,
+    p_motivo: motivoTrim,
+  });
+
+  if (error) return { ok: false, error: error.message };
+
+  revalidatePath('/rdb/inventario/levantamientos');
+  revalidatePath(`/rdb/inventario/levantamientos/${levantamiento_id}`);
+  return { ok: true };
+}
+
+// ─── Lecturas (RPC, RLS-safe) ─────────────────────────────────────────────────
+
+export type LineaParaCapturar = {
+  linea_id: string;
+  producto_id: string;
+  producto_codigo: string;
+  producto_nombre: string;
+  unidad: string;
+  categoria: string;
+  cantidad_contada: number;
+  contado_at: string | null;
+  recontada: boolean;
+};
+
+export async function getLineasParaCapturar(
+  levantamiento_id: string
+): Promise<ActionResult<LineaParaCapturar[]>> {
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .schema('erp')
+    .rpc('fn_get_lineas_para_capturar', { p_levantamiento_id: levantamiento_id });
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, data: (data ?? []) as LineaParaCapturar[] };
+}
+
+export type LineaParaRevisar = {
+  linea_id: string;
+  producto_id: string;
+  producto_codigo: string;
+  producto_nombre: string;
+  unidad: string;
+  categoria: string;
+  costo_unitario: number;
+  stock_inicial: number;
+  salidas_durante_captura: number;
+  stock_efectivo: number;
+  cantidad_contada: number;
+  diferencia: number;
+  diferencia_valor: number;
+  fuera_de_tolerancia: boolean;
+  notas_diferencia: string | null;
+  contado_at: string | null;
+};
+
+export async function getLineasParaRevisar(
+  levantamiento_id: string
+): Promise<ActionResult<LineaParaRevisar[]>> {
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .schema('erp')
+    .rpc('fn_get_lineas_para_revisar', { p_levantamiento_id: levantamiento_id });
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, data: (data ?? []) as LineaParaRevisar[] };
+}

--- a/app/rdb/inventario/levantamientos/nuevo/page.tsx
+++ b/app/rdb/inventario/levantamientos/nuevo/page.tsx
@@ -19,7 +19,8 @@ import { Combobox } from '@/components/ui/combobox';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/toast';
 import { TolerancePanel, type ToleranciaConfig } from '@/components/inventario/tolerance-panel';
-import { crearLevantamiento, iniciarCaptura, type CrearLevantamientoInput } from '../actions';
+import { crearLevantamiento, iniciarCaptura } from '../actions';
+import type { CrearLevantamientoInput } from '../types';
 
 const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 

--- a/app/rdb/inventario/levantamientos/nuevo/page.tsx
+++ b/app/rdb/inventario/levantamientos/nuevo/page.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Same data-sync pattern used elsewhere in /rdb/inventario (see page.tsx). The
+ * loadMeta() function flips loading flags around an awaited fetch — refactoring
+ * to avoid the rule changes render semantics without measurable benefit.
+ */
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { ArrowLeft, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Combobox } from '@/components/ui/combobox';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
+import { TolerancePanel, type ToleranciaConfig } from '@/components/inventario/tolerance-panel';
+import { crearLevantamiento, iniciarCaptura, type CrearLevantamientoInput } from '../actions';
+
+const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
+
+type Almacen = { id: string; nombre: string };
+
+export default function NuevoLevantamientoPage() {
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.inventario" write>
+      <NuevoLevantamientoForm />
+    </RequireAccess>
+  );
+}
+
+function todayISO(): string {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function NuevoLevantamientoForm() {
+  const router = useRouter();
+  const toast = useToast();
+
+  const [almacenes, setAlmacenes] = useState<Almacen[]>([]);
+  const [tolerancia, setTolerancia] = useState<ToleranciaConfig | null>(null);
+  const [loadingMeta, setLoadingMeta] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [almacenId, setAlmacenId] = useState<string>('');
+  const [fechaProgramada, setFechaProgramada] = useState<string>(todayISO);
+  const [notas, setNotas] = useState<string>('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [overridePctStr, setOverridePctStr] = useState<string>('');
+  const [overrideMontoStr, setOverrideMontoStr] = useState<string>('');
+
+  const [submitting, setSubmitting] = useState(false);
+
+  const loadMeta = useCallback(async () => {
+    setLoadingMeta(true);
+    setLoadError(null);
+    const supabase = createSupabaseBrowserClient();
+
+    const [almacenesRes, toleranciaRes] = await Promise.all([
+      supabase
+        .schema('erp')
+        .from('almacenes')
+        .select('id, nombre')
+        .eq('empresa_id', RDB_EMPRESA_ID)
+        .eq('activo', true)
+        .order('nombre'),
+      supabase.schema('erp').rpc('fn_get_empresa_tolerancia', { p_empresa_id: RDB_EMPRESA_ID }),
+    ]);
+
+    if (almacenesRes.error) {
+      setLoadError(almacenesRes.error.message);
+      setLoadingMeta(false);
+      return;
+    }
+    if (toleranciaRes.error) {
+      setLoadError(toleranciaRes.error.message);
+      setLoadingMeta(false);
+      return;
+    }
+
+    const list = almacenesRes.data ?? [];
+    setAlmacenes(list);
+    if (list.length === 1) setAlmacenId(list[0].id);
+
+    const tol = toleranciaRes.data?.[0];
+    if (tol) {
+      setTolerancia({
+        tolerancia_pct: Number(tol.tolerancia_pct),
+        tolerancia_monto: Number(tol.tolerancia_monto),
+        firmas_requeridas: Number(tol.firmas_requeridas),
+      });
+    }
+    setLoadingMeta(false);
+  }, []);
+
+  useEffect(() => {
+    loadMeta();
+  }, [loadMeta]);
+
+  const buildInput = (): CrearLevantamientoInput | string => {
+    if (!almacenId) return 'Selecciona un almacén.';
+    if (!fechaProgramada) return 'La fecha programada es requerida.';
+
+    const overridePct = overridePctStr.trim() === '' ? null : Number(overridePctStr);
+    const overrideMonto = overrideMontoStr.trim() === '' ? null : Number(overrideMontoStr);
+
+    if (overridePct != null && (Number.isNaN(overridePct) || overridePct < 0)) {
+      return 'Override de % de tolerancia inválido.';
+    }
+    if (overrideMonto != null && (Number.isNaN(overrideMonto) || overrideMonto < 0)) {
+      return 'Override de $ de tolerancia inválido.';
+    }
+
+    return {
+      almacen_id: almacenId,
+      fecha_programada: fechaProgramada,
+      notas: notas.trim() || undefined,
+      tolerancia_pct_override: overridePct,
+      tolerancia_monto_override: overrideMonto,
+    };
+  };
+
+  const handleSubmit = async (intent: 'borrador' | 'capturar') => {
+    const built = buildInput();
+    if (typeof built === 'string') {
+      toast.add({ title: built, type: 'error' });
+      return;
+    }
+
+    setSubmitting(true);
+    const result = await crearLevantamiento(built);
+    if (!result.ok) {
+      setSubmitting(false);
+      toast.add({
+        title: 'No se pudo crear el levantamiento',
+        description: result.error,
+        type: 'error',
+      });
+      return;
+    }
+
+    if (intent === 'borrador') {
+      toast.add({
+        title: 'Borrador creado',
+        description: result.data.folio ? `Folio ${result.data.folio}` : undefined,
+        type: 'success',
+      });
+      router.push('/rdb/inventario/levantamientos');
+      return;
+    }
+
+    const startRes = await iniciarCaptura(result.data.id);
+    setSubmitting(false);
+    if (!startRes.ok) {
+      toast.add({
+        title: 'Levantamiento creado, pero no se pudo iniciar la captura',
+        description: startRes.error,
+        type: 'error',
+      });
+      router.push('/rdb/inventario/levantamientos');
+      return;
+    }
+
+    toast.add({
+      title: 'Captura iniciada',
+      description: `${startRes.data.lineasSembradas} producto${
+        startRes.data.lineasSembradas === 1 ? '' : 's'
+      } sembrado${startRes.data.lineasSembradas === 1 ? '' : 's'}.`,
+      type: 'success',
+    });
+    router.push('/rdb/inventario/levantamientos');
+  };
+
+  return (
+    <div className="container mx-auto max-w-2xl space-y-6 px-4 py-6">
+      <Link
+        href="/rdb/inventario/levantamientos"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" /> Volver a levantamientos
+      </Link>
+
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Nuevo levantamiento</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          El folio se asigna automáticamente. El contador queda registrado al iniciar la captura.
+        </p>
+      </header>
+
+      {loadError && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          {loadError}
+        </div>
+      )}
+
+      {loadingMeta ? (
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-full rounded-lg" />
+          <Skeleton className="h-10 w-full rounded-lg" />
+          <Skeleton className="h-24 w-full rounded-lg" />
+        </div>
+      ) : (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void handleSubmit('borrador');
+          }}
+          className="space-y-5"
+        >
+          <Field
+            label="Almacén"
+            htmlFor="almacen"
+            help={
+              almacenes.length === 1 ? 'Pre-llenado: la empresa tiene un solo almacén.' : undefined
+            }
+          >
+            {almacenes.length === 1 ? (
+              <Input id="almacen" value={almacenes[0].nombre} readOnly className="bg-muted/40" />
+            ) : (
+              <Combobox
+                id="almacen"
+                value={almacenId || null}
+                onChange={setAlmacenId}
+                options={almacenes.map((a) => ({ value: a.id, label: a.nombre }))}
+                placeholder="Selecciona almacén…"
+              />
+            )}
+          </Field>
+
+          <Field label="Fecha programada" htmlFor="fecha">
+            <Input
+              id="fecha"
+              type="date"
+              value={fechaProgramada}
+              onChange={(e) => setFechaProgramada(e.target.value)}
+            />
+          </Field>
+
+          <Field label="Notas (opcional)" htmlFor="notas">
+            <Textarea
+              id="notas"
+              value={notas}
+              onChange={(e) => setNotas(e.target.value)}
+              placeholder="Contexto, motivo, observaciones…"
+              rows={3}
+            />
+          </Field>
+
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowAdvanced((v) => !v)}
+              className="inline-flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground"
+            >
+              {showAdvanced ? (
+                <ChevronDown className="size-4" />
+              ) : (
+                <ChevronRight className="size-4" />
+              )}
+              Opciones avanzadas
+            </button>
+
+            {showAdvanced && (
+              <div className="mt-3 space-y-4 rounded-lg border bg-muted/20 p-4">
+                {tolerancia && (
+                  <TolerancePanel
+                    config={tolerancia}
+                    overridePct={overridePctStr.trim() === '' ? null : Number(overridePctStr)}
+                    overrideMonto={overrideMontoStr.trim() === '' ? null : Number(overrideMontoStr)}
+                  />
+                )}
+                <div className="grid grid-cols-2 gap-3">
+                  <Field
+                    label="Override % tolerancia"
+                    htmlFor="override-pct"
+                    help="Vacío = usar default empresa."
+                  >
+                    <Input
+                      id="override-pct"
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={overridePctStr}
+                      onChange={(e) => setOverridePctStr(e.target.value)}
+                      placeholder={tolerancia?.tolerancia_pct.toFixed(2)}
+                    />
+                  </Field>
+                  <Field
+                    label="Override $ tolerancia"
+                    htmlFor="override-monto"
+                    help="Vacío = usar default empresa."
+                  >
+                    <Input
+                      id="override-monto"
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={overrideMontoStr}
+                      onChange={(e) => setOverrideMontoStr(e.target.value)}
+                      placeholder={tolerancia?.tolerancia_monto.toFixed(2)}
+                    />
+                  </Field>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={submitting}
+              onClick={() => router.push('/rdb/inventario/levantamientos')}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" variant="outline" disabled={submitting || !almacenId}>
+              {submitting && <Loader2 className="size-4 animate-spin" />}
+              Guardar borrador
+            </Button>
+            <Button
+              type="button"
+              disabled={submitting || !almacenId}
+              onClick={() => handleSubmit('capturar')}
+            >
+              {submitting && <Loader2 className="size-4 animate-spin" />}
+              Iniciar captura ahora
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  help,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  help?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={htmlFor} className="text-sm font-medium">
+        {label}
+      </label>
+      {children}
+      {help && <p className="text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/app/rdb/inventario/levantamientos/page.tsx
+++ b/app/rdb/inventario/levantamientos/page.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Same data-sync pattern used elsewhere in /rdb/inventario (see page.tsx). The
+ * load() function flips loading flags around an awaited fetch — refactoring to
+ * avoid the rule changes render semantics without measurable benefit.
+ */
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import { ClipboardList, Plus, RefreshCw } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { InventarioTabs } from '@/components/inventario/inventario-tabs';
+import {
+  LevantamientoStatusBadge,
+  type LevantamientoEstado,
+} from '@/components/inventario/levantamiento-status-badge';
+import { formatDateShort, formatDateTime } from '@/lib/inventario/format';
+
+const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
+
+type LevantamientoRow = {
+  id: string;
+  folio: string | null;
+  estado: string;
+  fecha_programada: string;
+  fecha_inicio: string | null;
+  fecha_cierre: string | null;
+  fecha_aplicado: string | null;
+  almacen_id: string;
+  notas: string | null;
+  created_at: string;
+  almacenes: { nombre: string } | null;
+};
+
+export default function LevantamientosListaPage() {
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.inventario">
+      <LevantamientosListaInner />
+    </RequireAccess>
+  );
+}
+
+function LevantamientosListaInner() {
+  const [items, setItems] = useState<LevantamientoRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const supabase = createSupabaseBrowserClient();
+    const { data, error: err } = await supabase
+      .schema('erp')
+      .from('inventario_levantamientos')
+      .select(
+        'id, folio, estado, fecha_programada, fecha_inicio, fecha_cierre, fecha_aplicado, almacen_id, notas, created_at, almacenes(nombre)'
+      )
+      .eq('empresa_id', RDB_EMPRESA_ID)
+      .is('deleted_at', null)
+      .order('created_at', { ascending: false })
+      .limit(200);
+
+    if (err) {
+      setError(err.message);
+      setLoading(false);
+      return;
+    }
+    setItems((data ?? []) as unknown as LevantamientoRow[]);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const activos = items.filter(
+    (i) => i.estado === 'borrador' || i.estado === 'capturando' || i.estado === 'capturado'
+  );
+  const cerrados = items.filter((i) => i.estado === 'aplicado' || i.estado === 'cancelado');
+
+  return (
+    <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+      <InventarioTabs activeKey="levantamientos" />
+
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Levantamientos físicos</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Conteo físico, conciliación y aplicación de movimientos al inventario.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => load()}
+            disabled={loading}
+            aria-label="Actualizar"
+          >
+            <RefreshCw className={loading ? 'size-4 animate-spin' : 'size-4'} />
+            Actualizar
+          </Button>
+          <Link href="/rdb/inventario/levantamientos/nuevo">
+            <Button size="sm">
+              <Plus className="size-4" />
+              Nuevo levantamiento
+            </Button>
+          </Link>
+        </div>
+      </header>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <section>
+        <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Activos
+        </h2>
+        {loading ? (
+          <ListSkeleton />
+        ) : activos.length === 0 ? (
+          <EmptyState
+            title="No hay levantamientos activos"
+            description="Inicia uno nuevo para comenzar el conteo."
+            cta={
+              <Link href="/rdb/inventario/levantamientos/nuevo">
+                <Button>
+                  <Plus className="size-4" />
+                  Nuevo levantamiento
+                </Button>
+              </Link>
+            }
+          />
+        ) : (
+          <LevantamientosTable rows={activos} />
+        )}
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Histórico reciente
+        </h2>
+        {loading ? (
+          <ListSkeleton rows={3} />
+        ) : cerrados.length === 0 ? (
+          <p className="rounded-lg border bg-muted/40 p-4 text-sm text-muted-foreground">
+            Sin levantamientos cerrados todavía.
+          </p>
+        ) : (
+          <LevantamientosTable rows={cerrados} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function LevantamientosTable({ rows }: { rows: LevantamientoRow[] }) {
+  return (
+    <div className="rounded-lg border bg-card">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Folio</TableHead>
+            <TableHead>Estado</TableHead>
+            <TableHead>Almacén</TableHead>
+            <TableHead>Programado</TableHead>
+            <TableHead>Última actividad</TableHead>
+            <TableHead className="text-right">Acción</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => {
+            const ultima =
+              row.fecha_aplicado ?? row.fecha_cierre ?? row.fecha_inicio ?? row.created_at;
+            return (
+              <TableRow key={row.id}>
+                <TableCell className="font-medium tabular-nums">{row.folio ?? '—'}</TableCell>
+                <TableCell>
+                  <LevantamientoStatusBadge estado={row.estado as LevantamientoEstado} />
+                </TableCell>
+                <TableCell>{row.almacenes?.nombre ?? '—'}</TableCell>
+                <TableCell className="tabular-nums">
+                  {formatDateShort(row.fecha_programada)}
+                </TableCell>
+                <TableCell className="tabular-nums text-muted-foreground">
+                  {formatDateTime(ultima)}
+                </TableCell>
+                <TableCell className="text-right">
+                  <Link href={`/rdb/inventario/levantamientos/${row.id}`}>
+                    <Button variant="outline" size="sm">
+                      Abrir
+                    </Button>
+                  </Link>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function ListSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-12 w-full rounded-lg" />
+      ))}
+    </div>
+  );
+}
+
+function EmptyState({
+  title,
+  description,
+  cta,
+}: {
+  title: string;
+  description: string;
+  cta?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-muted/30 p-10 text-center">
+      <ClipboardList className="size-10 text-muted-foreground/60" />
+      <div>
+        <div className="font-medium">{title}</div>
+        <div className="mt-1 text-sm text-muted-foreground">{description}</div>
+      </div>
+      {cta}
+    </div>
+  );
+}

--- a/app/rdb/inventario/levantamientos/types.ts
+++ b/app/rdb/inventario/levantamientos/types.ts
@@ -1,0 +1,60 @@
+export const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
+
+export type ActionResult<T = void> =
+  | (T extends void ? { ok: true } : { ok: true; data: T })
+  | { ok: false; error: string };
+
+export type CrearLevantamientoInput = {
+  almacen_id: string;
+  fecha_programada: string; // YYYY-MM-DD
+  notas?: string;
+  tolerancia_pct_override?: number | null;
+  tolerancia_monto_override?: number | null;
+  /** 'fisico' (default) — el schema permite otros tipos a futuro. */
+  tipo?: string;
+};
+
+export type FirmarPasoInput = {
+  levantamiento_id: string;
+  paso: number;
+  rol: string;
+  comentario?: string;
+};
+
+export type FirmarPasoData = {
+  firmas_actuales: number;
+  firmas_requeridas: number;
+  aplicado: boolean;
+  movimientos_generados: number;
+};
+
+export type LineaParaCapturar = {
+  linea_id: string;
+  producto_id: string;
+  producto_codigo: string;
+  producto_nombre: string;
+  unidad: string;
+  categoria: string;
+  cantidad_contada: number;
+  contado_at: string | null;
+  recontada: boolean;
+};
+
+export type LineaParaRevisar = {
+  linea_id: string;
+  producto_id: string;
+  producto_codigo: string;
+  producto_nombre: string;
+  unidad: string;
+  categoria: string;
+  costo_unitario: number;
+  stock_inicial: number;
+  salidas_durante_captura: number;
+  stock_efectivo: number;
+  cantidad_contada: number;
+  diferencia: number;
+  diferencia_valor: number;
+  fuera_de_tolerancia: boolean;
+  notas_diferencia: string | null;
+  contado_at: string | null;
+};

--- a/app/rdb/inventario/page.tsx
+++ b/app/rdb/inventario/page.tsx
@@ -6,6 +6,7 @@
  */
 
 import { RequireAccess } from '@/components/require-access';
+import { InventarioTabs } from '@/components/inventario/inventario-tabs';
 import { useCallback, useEffect, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import {
@@ -938,6 +939,8 @@ export default function InventarioPage() {
   return (
     <RequireAccess empresa="rdb" modulo="rdb.inventario">
       <div className="space-y-6">
+        <InventarioTabs activeKey="overview" />
+
         {/* Header */}
         <div className="flex items-start justify-between gap-4">
           <div>

--- a/components/inventario/inventario-tabs.tsx
+++ b/components/inventario/inventario-tabs.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+export type InventarioTabKey = 'overview' | 'levantamientos' | 'analisis';
+
+const TABS: { key: InventarioTabKey; label: string; href: string }[] = [
+  { key: 'overview', label: 'Stock & Movimientos', href: '/rdb/inventario' },
+  {
+    key: 'levantamientos',
+    label: 'Levantamientos',
+    href: '/rdb/inventario/levantamientos',
+  },
+  { key: 'analisis', label: 'Análisis', href: '/rdb/inventario/analisis' },
+];
+
+export interface InventarioTabsProps {
+  activeKey: InventarioTabKey;
+  className?: string;
+}
+
+export function InventarioTabs({ activeKey, className }: InventarioTabsProps) {
+  return (
+    <nav
+      aria-label="Secciones de inventario"
+      className={cn(
+        'inline-flex items-center gap-1 rounded-lg border bg-muted/40 p-1 text-sm',
+        className
+      )}
+    >
+      {TABS.map((tab) => {
+        const active = tab.key === activeKey;
+        return (
+          <Link
+            key={tab.key}
+            href={tab.href}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'inline-flex h-8 items-center rounded-md px-3 font-medium transition-colors',
+              active
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/inventario/levantamiento-progress-gauge.tsx
+++ b/components/inventario/levantamiento-progress-gauge.tsx
@@ -1,0 +1,67 @@
+import { cn } from '@/lib/utils';
+
+export interface LevantamientoProgressGaugeProps {
+  /** Lines already counted. */
+  contadas: number;
+  /** Total seeded lines. */
+  totales: number;
+  /** Diameter in px. Defaults to 96. */
+  size?: number;
+  className?: string;
+}
+
+export function LevantamientoProgressGauge({
+  contadas,
+  totales,
+  size = 96,
+  className,
+}: LevantamientoProgressGaugeProps) {
+  const safeTotales = Math.max(totales, 0);
+  const safeContadas = Math.max(0, Math.min(contadas, safeTotales));
+  const pct = safeTotales === 0 ? 0 : (safeContadas / safeTotales) * 100;
+  const strokeWidth = Math.max(6, Math.round(size / 12));
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - pct / 100);
+
+  let stroke = 'stroke-muted-foreground/40';
+  if (pct >= 100) stroke = 'stroke-emerald-500';
+  else if (pct > 0) stroke = 'stroke-sky-500';
+
+  return (
+    <div
+      className={cn('relative inline-flex items-center justify-center', className)}
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={`Progreso ${safeContadas} de ${safeTotales}`}
+    >
+      <svg width={size} height={size} className="-rotate-90" viewBox={`0 0 ${size} ${size}`}>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={strokeWidth}
+          className="stroke-muted/40"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          className={cn('transition-[stroke-dashoffset]', stroke)}
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center text-center">
+        <div className="text-lg font-semibold tabular-nums leading-none">{Math.round(pct)}%</div>
+        <div className="mt-0.5 text-[10px] uppercase tracking-wider text-muted-foreground tabular-nums">
+          {safeContadas}/{safeTotales}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/inventario/levantamiento-status-badge.tsx
+++ b/components/inventario/levantamiento-status-badge.tsx
@@ -1,0 +1,49 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+export type LevantamientoEstado =
+  | 'borrador'
+  | 'capturando'
+  | 'capturado'
+  | 'aplicado'
+  | 'cancelado';
+
+const META: Record<LevantamientoEstado, { label: string; className: string }> = {
+  borrador: {
+    label: 'Borrador',
+    className: 'border-border bg-muted text-muted-foreground',
+  },
+  capturando: {
+    label: 'Capturando',
+    className: 'border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-400',
+  },
+  capturado: {
+    label: 'Pendiente firma',
+    className: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+  },
+  aplicado: {
+    label: 'Aplicado',
+    className: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+  },
+  cancelado: {
+    label: 'Cancelado',
+    className: 'border-destructive/40 bg-destructive/5 text-destructive',
+  },
+};
+
+export interface LevantamientoStatusBadgeProps {
+  estado: string;
+  className?: string;
+}
+
+export function LevantamientoStatusBadge({ estado, className }: LevantamientoStatusBadgeProps) {
+  const meta = META[estado as LevantamientoEstado] ?? {
+    label: estado,
+    className: 'border-border bg-muted text-muted-foreground',
+  };
+  return (
+    <Badge variant="outline" className={cn('border', meta.className, className)}>
+      {meta.label}
+    </Badge>
+  );
+}

--- a/components/inventario/producto-search-input.tsx
+++ b/components/inventario/producto-search-input.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
+
+export interface ProductoOption {
+  id: string;
+  nombre: string;
+  codigo?: string | null;
+  unidad?: string | null;
+  categoria?: string | null;
+}
+
+export interface ProductoSearchInputProps {
+  productos: ProductoOption[];
+  value: string | null;
+  onChange: (productoId: string) => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Combobox de productos con búsqueda fuzzy por nombre + código.
+ * Scanner-USB friendly: el código de barras llega como typing rápido al
+ * CommandInput y se filtra por keywords (incluye `codigo`).
+ */
+export function ProductoSearchInput({
+  productos,
+  value,
+  onChange,
+  placeholder = 'Buscar producto…',
+  className,
+  disabled,
+}: ProductoSearchInputProps) {
+  const options = useMemo<ComboboxOption[]>(
+    () =>
+      productos.map((p) => ({
+        value: p.id,
+        label: p.nombre,
+        searchLabel: p.nombre,
+        sub: [p.codigo, p.unidad, p.categoria].filter(Boolean).join(' · ') || undefined,
+        keywords: [p.codigo, p.categoria, p.unidad].filter(
+          (v): v is string => typeof v === 'string' && v.length > 0
+        ),
+      })),
+    [productos]
+  );
+
+  return (
+    <Combobox
+      value={value ?? ''}
+      onChange={onChange}
+      options={options}
+      placeholder={placeholder}
+      searchPlaceholder="Nombre o código…"
+      emptyText="Sin productos"
+      className={className}
+      disabled={disabled}
+    />
+  );
+}

--- a/components/inventario/tolerance-panel.tsx
+++ b/components/inventario/tolerance-panel.tsx
@@ -1,0 +1,83 @@
+import { AlertTriangle } from 'lucide-react';
+import { formatCurrency } from '@/lib/inventario/format';
+import { cn } from '@/lib/utils';
+
+export interface ToleranciaConfig {
+  tolerancia_pct: number;
+  tolerancia_monto: number;
+  firmas_requeridas: number;
+}
+
+export interface TolerancePanelProps {
+  /** Empresa-level config (from `erp.fn_get_empresa_tolerancia`). */
+  config: ToleranciaConfig;
+  /** Per-levantamiento overrides (NULL when not set). */
+  overridePct?: number | null;
+  overrideMonto?: number | null;
+  /** Number of lines currently outside tolerance. */
+  lineasFueraDeTolerancia?: number;
+  className?: string;
+}
+
+export function TolerancePanel({
+  config,
+  overridePct,
+  overrideMonto,
+  lineasFueraDeTolerancia = 0,
+  className,
+}: TolerancePanelProps) {
+  const effectivePct = overridePct ?? config.tolerancia_pct;
+  const effectiveMonto = overrideMonto ?? config.tolerancia_monto;
+  const tieneOverride = overridePct != null || overrideMonto != null;
+  const hayFuera = lineasFueraDeTolerancia > 0;
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border bg-card p-4',
+        hayFuera && 'border-amber-500/40 bg-amber-500/5',
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Tolerancia
+          </div>
+          <div className="mt-2 grid grid-cols-3 gap-4 text-sm tabular-nums">
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                % por línea
+              </div>
+              <div className="font-semibold">{effectivePct.toFixed(2)}%</div>
+            </div>
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                $ por línea
+              </div>
+              <div className="font-semibold">{formatCurrency(effectiveMonto)}</div>
+            </div>
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                Firmas
+              </div>
+              <div className="font-semibold">{config.firmas_requeridas}</div>
+            </div>
+          </div>
+          {tieneOverride && (
+            <div className="mt-2 text-xs text-muted-foreground">
+              Override del levantamiento (default empresa: {config.tolerancia_pct.toFixed(2)}% /{' '}
+              {formatCurrency(config.tolerancia_monto)}).
+            </div>
+          )}
+        </div>
+        {hayFuera && (
+          <div className="flex shrink-0 items-center gap-2 rounded-md bg-amber-500/10 px-2.5 py-1.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+            <AlertTriangle className="size-3.5" />
+            {lineasFueraDeTolerancia} línea{lineasFueraDeTolerancia === 1 ? '' : 's'} fuera
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/inventario/variance-cell.tsx
+++ b/components/inventario/variance-cell.tsx
@@ -1,0 +1,64 @@
+import { formatNumber } from '@/lib/inventario/format';
+import { cn } from '@/lib/utils';
+
+export interface VarianceCellProps {
+  /** Stock theoretically expected (sistema). */
+  sistema: number;
+  /** Counted physically. */
+  contado: number;
+  /** Optional unit (e.g. 'kg', 'pza'). */
+  unidad?: string | null;
+  /** When true, highlight Δ in destructive tone. */
+  fueraDeTolerancia?: boolean;
+  className?: string;
+}
+
+export function VarianceCell({
+  sistema,
+  contado,
+  unidad,
+  fueraDeTolerancia,
+  className,
+}: VarianceCellProps) {
+  const diferencia = contado - sistema;
+  const sign = diferencia > 0 ? '+' : '';
+  let deltaTone = 'text-muted-foreground';
+  if (diferencia !== 0) {
+    if (fueraDeTolerancia) {
+      deltaTone = 'text-destructive';
+    } else if (diferencia > 0) {
+      deltaTone = 'text-emerald-600 dark:text-emerald-400';
+    } else {
+      deltaTone = 'text-amber-600 dark:text-amber-400';
+    }
+  }
+
+  const u = unidad ? ` ${unidad}` : '';
+
+  return (
+    <div className={cn('grid grid-cols-3 gap-3 text-sm tabular-nums', className)}>
+      <div className="text-right">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Sistema</div>
+        <div className="font-medium">
+          {formatNumber(sistema)}
+          {u}
+        </div>
+      </div>
+      <div className="text-right">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Contado</div>
+        <div className="font-medium">
+          {formatNumber(contado)}
+          {u}
+        </div>
+      </div>
+      <div className="text-right">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Δ</div>
+        <div className={cn('font-semibold', deltaTone)}>
+          {sign}
+          {formatNumber(diferencia)}
+          {u}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/kpi-card.tsx
+++ b/components/ui/kpi-card.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+type KpiTone = 'default' | 'success' | 'warning' | 'destructive' | 'muted';
+
+const TONE_CLASSES: Record<KpiTone, string> = {
+  default: 'text-foreground',
+  success: 'text-emerald-600 dark:text-emerald-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  destructive: 'text-destructive',
+  muted: 'text-muted-foreground',
+};
+
+export interface KpiCardProps {
+  label: string;
+  value: ReactNode;
+  hint?: ReactNode;
+  icon?: ReactNode;
+  tone?: KpiTone;
+  className?: string;
+}
+
+export function KpiCard({ label, value, hint, icon, tone = 'default', className }: KpiCardProps) {
+  return (
+    <div className={cn('rounded-xl border bg-card px-4 py-3', className)}>
+      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className={cn('mt-1 text-2xl font-semibold tabular-nums', TONE_CLASSES[tone])}>
+        {value}
+      </div>
+      {hint != null && <div className="mt-1 text-xs text-muted-foreground">{hint}</div>}
+    </div>
+  );
+}

--- a/components/ui/num-pad.tsx
+++ b/components/ui/num-pad.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Delete } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface NumPadProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit?: () => void;
+  /** Quick values that paste a whole number (e.g. [0, 0.25, 0.5, 1, 5, 10]). */
+  quickValues?: number[];
+  className?: string;
+}
+
+const KEYS = ['7', '8', '9', '4', '5', '6', '1', '2', '3', '.', '0'] as const;
+
+export function NumPad({ value, onChange, onSubmit, quickValues, className }: NumPadProps) {
+  const append = (k: string) => {
+    if (k === '.' && value.includes('.')) return;
+    if (value === '0' && k !== '.') {
+      onChange(k);
+      return;
+    }
+    onChange(value + k);
+  };
+
+  const backspace = () => {
+    if (value.length <= 1) {
+      onChange('0');
+      return;
+    }
+    onChange(value.slice(0, -1));
+  };
+
+  const setQuick = (n: number) => {
+    onChange(String(n));
+  };
+
+  return (
+    <div className={cn('w-full select-none', className)}>
+      {quickValues && quickValues.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-2">
+          {quickValues.map((n) => (
+            <Button
+              key={n}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="min-w-[3rem] tabular-nums"
+              onClick={() => setQuick(n)}
+            >
+              {n}
+            </Button>
+          ))}
+        </div>
+      )}
+      <div className="grid grid-cols-3 gap-2">
+        {KEYS.map((k) => (
+          <Button
+            key={k}
+            type="button"
+            variant="outline"
+            className="h-14 text-2xl tabular-nums"
+            onClick={() => append(k)}
+          >
+            {k}
+          </Button>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          className="h-14"
+          onClick={backspace}
+          aria-label="Borrar último dígito"
+        >
+          <Delete className="size-5" />
+        </Button>
+      </div>
+      {onSubmit && (
+        <Button type="button" className="mt-3 h-14 w-full text-base" onClick={onSubmit}>
+          Aceptar
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/lib/inventario/format.ts
+++ b/lib/inventario/format.ts
@@ -1,0 +1,41 @@
+const CURRENCY_FORMATTER = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+});
+
+const NUMBER_FORMATTER = new Intl.NumberFormat('es-MX', {
+  maximumFractionDigits: 2,
+});
+
+const DATE_SHORT_FORMATTER = new Intl.DateTimeFormat('es-MX', {
+  timeZone: 'America/Matamoros',
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+});
+
+const DATETIME_FORMATTER = new Intl.DateTimeFormat('es-MX', {
+  timeZone: 'America/Matamoros',
+  dateStyle: 'short',
+  timeStyle: 'short',
+});
+
+export function formatCurrency(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return CURRENCY_FORMATTER.format(value);
+}
+
+export function formatNumber(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return NUMBER_FORMATTER.format(value);
+}
+
+export function formatDateShort(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  return DATE_SHORT_FORMATTER.format(new Date(iso));
+}
+
+export function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  return DATETIME_FORMATTER.format(new Date(iso));
+}


### PR DESCRIPTION
Primer sub-PR del módulo de levantamientos físicos de inventario sobre el schema/RPCs ya mergeado en [#192](https://github.com/beto-sudo/BSOP/pull/192).

Construye la base reusable: componentes UI, segmented control compartido, server actions completas, lista con DB real y formulario de alta. Sin tocar `nav-config.ts` (sigue habiendo UNA sola entrada "Inventario") — la navegación entre secciones se hace con `<InventarioTabs />` que vive arriba de las vistas-hub.

## Summary

- **Componentes UI base**: `KpiCard`, `NumPad` (touch keypad con quick values).
- **Componentes inventario**: `InventarioTabs` (segmented control en 3 vistas-hub), `LevantamientoStatusBadge` (5 estados, "capturado" → "Pendiente firma"), `LevantamientoProgressGauge` (gauge SVG), `VarianceCell` (Sistema/Contado/Δ con tono según signo + tolerancia), `ProductoSearchInput` (combobox fuzzy scanner-friendly), `TolerancePanel` (readonly, muestra override).
- **Server actions** (`app/rdb/inventario/levantamientos/actions.ts`): las 8 funciones del plan — `crearLevantamiento`, `iniciarCaptura`, `guardarConteo`, `cerrarCaptura`, `firmarPaso` (con parsing del `Json` que devuelve el RPC + captura de IP/user-agent desde `headers()`), `cancelarLevantamiento`, `getLineasParaCapturar`, `getLineasParaRevisar`.
- **Lista** `/rdb/inventario/levantamientos`: query real a `erp.inventario_levantamientos` filtrando por `empresa_id` RDB y `deleted_at IS NULL`, dividida en Activos / Histórico, refresh manual, badges por estado.
- **Alta** `/rdb/inventario/levantamientos/nuevo`: form mínimo siguiendo §5 del plan — almacén pre-llenado si la empresa tiene 1 (caso RDB), fecha programada default = hoy, notas opcional, override de tolerancia colapsable. Acciones "Guardar borrador" / "Iniciar captura ahora" (esta última también dispara `fn_iniciar_captura_levantamiento`). NO se pide folio (trigger), contador (auto al iniciar), revisor/autorizador (se firman después).
- **`/rdb/inventario` modificada**: `<InventarioTabs activeKey="overview" />` insertado al inicio del shell — coexiste con el toggle interno Stock/Movimientos existente sin sustituirlo (criterio de §troubleshooting del plan).
- **Helper `lib/inventario/format`**: `formatCurrency`, `formatNumber`, `formatDateShort`, `formatDateTime` con timezone `America/Matamoros`, para no reinventar `Intl` en cada componente.

## Decisiones tomadas

- **`asChild` no existe en este `Button`**: el patrón del repo es `<Link><Button>…</Button></Link>` (visto en `app/rdb/productos/page.tsx`). Lo seguí.
- **`react-hooks/set-state-in-effect`**: misma regla que tiene `eslint-disable` consciente en `app/rdb/inventario/page.tsx`. Apliqué el mismo disable a las 2 páginas nuevas para mantener el patrón data-sync; refactor cambia render semantics sin beneficio medible (igual que el comentario original).
- **`<InventarioTabs />` NO se renderiza en `/nuevo`** — flujo focalizado, breadcrumb "← Volver" en su lugar (criterio de §navegación del plan).
- **Sub-PRs siguientes (no cubiertos aquí)**:
  - B2: detail page (estado-machine), captura mobile (`fn_get_lineas_para_capturar` + `fn_guardar_conteo`), hook offline IndexedDB, diferencias, reporte print-friendly.
  - B3: `SignatureDialog`, 3 pasos de firma, auto-aplicación al firmar la última, Playwright e2e.

## Test plan

- [ ] `npm run typecheck` — verde (verificado localmente)
- [ ] `npm run lint` — 0 errores (56 warnings pre-existentes sin cambio)
- [ ] `npm run format:check` — verde
- [ ] `npm run test:run` — 161/161 verde
- [ ] Visitar `/rdb/inventario` y confirmar que `<InventarioTabs />` aparece arriba con "Stock & Movimientos" activo y el toggle interno Stock/Movimientos sigue funcionando
- [ ] Visitar `/rdb/inventario/levantamientos` y confirmar que la lista carga (vacía o con datos), tabs muestran "Levantamientos" activo, botón "Nuevo levantamiento" navega
- [ ] En `/rdb/inventario/levantamientos/nuevo` confirmar: almacén pre-llenado para RDB (1 almacén), fecha = hoy, override colapsado por default
- [ ] Crear borrador → toast success + redirect → aparece en lista con estado "Borrador"
- [ ] Crear + "Iniciar captura ahora" → toast con N líneas sembradas + redirect → aparece con estado "Capturando"

🤖 Generated with [Claude Code](https://claude.com/claude-code)