### PR TITLE
feat(rdb-inventario): UI levantamientos — sub-PR B2 (detalle, captura, diferencias, reporte)

### DIFF
--- a/app/rdb/inventario/levantamientos/[id]/capturar/page.tsx
+++ b/app/rdb/inventario/levantamientos/[id]/capturar/page.tsx
@@ -1,0 +1,618 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de /rdb/inventario/levantamientos.
+ */
+
+/**
+ * Captura a ciegas — pantalla mobile para conteo físico.
+ *
+ * Diseño:
+ *   - El usuario busca un producto (input + scanner USB-HID friendly), tap
+ *     para seleccionarlo, ingresa cantidad con NumPad, y "Guardar y siguiente"
+ *     persiste el conteo y limpia para el próximo producto.
+ *   - "A ciegas": NO se muestra `stock_inicial` — la RPC `fn_get_lineas_para_capturar`
+ *     no lo devuelve. La diferencia se calcula al cerrar la captura.
+ *   - Offline-tolerant: usa `useCapturaQueue` que encola en IndexedDB y reenvía
+ *     en background. La UI no espera la red para resolver "Guardar".
+ *   - Sticky header con folio + progreso y botón cerrar (vuelve al detail,
+ *     NO cierra la captura).
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Loader2,
+  RotateCcw,
+  Search,
+  Wifi,
+  WifiOff,
+} from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
+import { NumPad } from '@/components/ui/num-pad';
+import { useCapturaQueue } from '@/hooks/use-captura-queue';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { formatNumber } from '@/lib/inventario/format';
+import { cn } from '@/lib/utils';
+import { getLineasParaCapturar } from '../../actions';
+import type { LineaParaCapturar } from '../../types';
+
+type LevantamientoMeta = {
+  id: string;
+  folio: string | null;
+  estado: string;
+  almacen_nombre: string | null;
+};
+
+export default function CapturarPage() {
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.inventario" write>
+      <CapturarInner />
+    </RequireAccess>
+  );
+}
+
+function CapturarInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const toast = useToast();
+  const queue = useCapturaQueue();
+
+  const [meta, setMeta] = useState<LevantamientoMeta | null>(null);
+  const [lineas, setLineas] = useState<LineaParaCapturar[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const [search, setSearch] = useState('');
+  const [activoId, setActivoId] = useState<string | null>(null);
+  const [valor, setValor] = useState('0');
+  const [showPendientes, setShowPendientes] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    const supabase = createSupabaseBrowserClient();
+
+    const [{ data: lev, error: levErr }, lineasRes] = await Promise.all([
+      supabase
+        .schema('erp')
+        .from('inventario_levantamientos')
+        .select('id, folio, estado, almacenes(nombre)')
+        .eq('id', id)
+        .is('deleted_at', null)
+        .maybeSingle(),
+      getLineasParaCapturar(id),
+    ]);
+
+    if (levErr) {
+      setLoadError(levErr.message);
+      setLoading(false);
+      return;
+    }
+    if (!lev) {
+      setLoadError('Levantamiento no encontrado.');
+      setLoading(false);
+      return;
+    }
+
+    type LevQuery = {
+      id: string;
+      folio: string | null;
+      estado: string;
+      almacenes: { nombre: string } | null;
+    };
+    const levRow = lev as unknown as LevQuery;
+    setMeta({
+      id: levRow.id,
+      folio: levRow.folio,
+      estado: levRow.estado,
+      almacen_nombre: levRow.almacenes?.nombre ?? null,
+    });
+
+    if (!lineasRes.ok) {
+      setLoadError(lineasRes.error);
+      setLoading(false);
+      return;
+    }
+    setLineas(lineasRes.data);
+    setLoading(false);
+    setRefreshing(false);
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!loading) searchInputRef.current?.focus();
+  }, [loading]);
+
+  // Filtrado fuzzy client-side (case-insensitive sobre nombre + código).
+  const resultados = useMemo(() => {
+    if (!search.trim()) return [] as LineaParaCapturar[];
+    const q = search.toLowerCase();
+    return lineas
+      .filter(
+        (l) =>
+          l.producto_nombre.toLowerCase().includes(q) || l.producto_codigo.toLowerCase().includes(q)
+      )
+      .slice(0, 25);
+  }, [lineas, search]);
+
+  const pendientes = useMemo(() => lineas.filter((l) => l.contado_at == null), [lineas]);
+  const total = lineas.length;
+  const contadas = total - pendientes.length;
+  const pct = total === 0 ? 0 : Math.round((contadas / total) * 100);
+
+  const activa = useMemo(
+    () => (activoId ? (lineas.find((l) => l.producto_id === activoId) ?? null) : null),
+    [activoId, lineas]
+  );
+
+  const seleccionar = (productoId: string) => {
+    setActivoId(productoId);
+    setSearch('');
+    setValor('0');
+  };
+
+  // Scanner USB-HID: typing rápido + Enter en el buscador. Si hay un match
+  // exacto por código, lo seleccionamos directo; si hay uno solo de nombre,
+  // también; en otro caso, el usuario selecciona manualmente.
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    const q = search.trim().toLowerCase();
+    if (!q) return;
+    const exactCode = lineas.find((l) => l.producto_codigo.toLowerCase() === q);
+    if (exactCode) {
+      seleccionar(exactCode.producto_id);
+      return;
+    }
+    if (resultados.length === 1) seleccionar(resultados[0].producto_id);
+  };
+
+  const guardarYSiguiente = async () => {
+    if (!activa || !id) return;
+    const cantidad = Number(valor);
+    if (!Number.isFinite(cantidad) || cantidad < 0) {
+      toast.add({ title: 'Cantidad inválida', type: 'error' });
+      return;
+    }
+    setSaving(true);
+    try {
+      await queue.guardar({
+        lev_id: id,
+        producto_id: activa.producto_id,
+        cantidad,
+        ts: Date.now(),
+      });
+    } catch (err) {
+      setSaving(false);
+      toast.add({
+        title: 'Error al guardar',
+        description: err instanceof Error ? err.message : 'Intenta de nuevo.',
+        type: 'error',
+      });
+      return;
+    }
+    setSaving(false);
+
+    // Optimistic local update — el sync real puede tardar; el UI ya refleja el conteo.
+    setLineas((prev) =>
+      prev.map((l) =>
+        l.producto_id === activa.producto_id
+          ? {
+              ...l,
+              cantidad_contada: cantidad,
+              contado_at: l.contado_at ?? new Date().toISOString(),
+              recontada: l.contado_at != null,
+            }
+          : l
+      )
+    );
+
+    setActivoId(null);
+    setValor('0');
+    setSearch('');
+    searchInputRef.current?.focus();
+  };
+
+  const saltar = () => {
+    setActivoId(null);
+    setValor('0');
+    setSearch('');
+    searchInputRef.current?.focus();
+  };
+
+  const refresh = async () => {
+    setRefreshing(true);
+    await load();
+  };
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-xl space-y-4 px-4 py-6">
+        <Skeleton className="h-12 w-full rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-lg" />
+        <Skeleton className="h-72 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (loadError || !meta) {
+    return (
+      <div className="container mx-auto max-w-xl space-y-4 px-4 py-6">
+        <Link
+          href={`/rdb/inventario/levantamientos/${id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" /> Volver al levantamiento
+        </Link>
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {loadError ?? 'Levantamiento no encontrado.'}
+        </div>
+      </div>
+    );
+  }
+
+  if (meta.estado !== 'capturando') {
+    return (
+      <div className="container mx-auto max-w-xl space-y-4 px-4 py-6">
+        <Link
+          href={`/rdb/inventario/levantamientos/${id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" /> Volver al levantamiento
+        </Link>
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-4 text-sm">
+          Captura solo permitida en estado <strong>capturando</strong>. Estado actual:{' '}
+          <strong>{meta.estado}</strong>.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-xl">
+      {/* ─── Header sticky ─────────────────────────────────────────────── */}
+      <header className="sticky top-0 z-10 border-b bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="flex items-center justify-between gap-2">
+          <Link
+            href={`/rdb/inventario/levantamientos/${id}`}
+            aria-label="Salir de la captura"
+            className="inline-flex h-9 items-center gap-1 rounded-md px-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" /> Salir
+          </Link>
+          <div className="flex flex-col items-end text-xs">
+            <span className="font-medium tabular-nums">{meta.folio ?? '—'}</span>
+            <span className="text-muted-foreground">{meta.almacen_nombre ?? 'Sin almacén'}</span>
+          </div>
+        </div>
+        <div className="mt-2">
+          <div className="flex items-center justify-between text-xs">
+            <span className="tabular-nums">
+              {contadas} / {total} · {pct}%
+            </span>
+            <SyncIndicator
+              pendientes={queue.pendientes}
+              syncing={queue.syncing}
+              fallback={queue.fallbackMode}
+            />
+          </div>
+          <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div className="h-full bg-sky-500 transition-[width]" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
+      </header>
+
+      <main className="space-y-4 px-4 py-4">
+        {/* ─── Buscador ────────────────────────────────────────────────── */}
+        <div className="space-y-2">
+          <label
+            htmlFor="capturar-search"
+            className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+          >
+            Buscar producto
+          </label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              ref={searchInputRef}
+              id="capturar-search"
+              autoFocus
+              autoComplete="off"
+              inputMode="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              placeholder="Nombre o código (incluye scanner)"
+              className="h-12 pl-10 text-base"
+            />
+          </div>
+
+          {search.trim() && (
+            <ul className="rounded-md border bg-card text-sm">
+              {resultados.length === 0 ? (
+                <li className="px-3 py-2 text-muted-foreground">Sin coincidencias.</li>
+              ) : (
+                resultados.map((l) => {
+                  const yaContada = l.contado_at != null;
+                  return (
+                    <li key={l.linea_id}>
+                      <button
+                        type="button"
+                        onClick={() => seleccionar(l.producto_id)}
+                        className="flex w-full items-center justify-between gap-2 px-3 py-2.5 text-left hover:bg-muted/40"
+                      >
+                        <div className="min-w-0">
+                          <div className="font-medium">{l.producto_nombre}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {l.producto_codigo}
+                            {l.categoria ? ` · ${l.categoria}` : ''}
+                          </div>
+                        </div>
+                        {yaContada && (
+                          <CheckCircle2
+                            className="size-4 shrink-0 text-emerald-600 dark:text-emerald-400"
+                            aria-label="Ya contada"
+                          />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })
+              )}
+            </ul>
+          )}
+        </div>
+
+        {/* ─── Producto activo + NumPad ────────────────────────────────── */}
+        {activa ? (
+          <section className="rounded-xl border bg-card p-4">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
+                  Capturando
+                </div>
+                <div className="mt-0.5 truncate text-base font-semibold">
+                  {activa.producto_nombre}
+                </div>
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  {activa.producto_codigo}
+                  {activa.categoria ? ` · ${activa.categoria}` : ''} · {activa.unidad}
+                </div>
+                {activa.contado_at && (
+                  <div className="mt-1 inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-400">
+                    <RotateCcw className="size-3" /> Recontando — el último valor reemplaza al
+                    anterior
+                  </div>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => setActivoId(null)}
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                Cancelar
+              </button>
+            </div>
+
+            <div className="my-4 flex h-20 items-center justify-center rounded-lg bg-muted/40 px-4 text-4xl font-bold tabular-nums">
+              {valor}{' '}
+              <span className="ml-2 text-base font-medium text-muted-foreground">
+                {activa.unidad}
+              </span>
+            </div>
+
+            <NumPad value={valor} onChange={setValor} quickValues={[0, 1, 6, 12, 24]} />
+
+            <div className="mt-3 flex flex-col gap-2">
+              <Button
+                type="button"
+                onClick={guardarYSiguiente}
+                disabled={saving}
+                className="h-14 text-base"
+              >
+                {saving ? <Loader2 className="size-5 animate-spin" /> : null}
+                Guardar y siguiente
+              </Button>
+              <Button type="button" variant="outline" onClick={saltar} disabled={saving}>
+                Saltar
+              </Button>
+            </div>
+          </section>
+        ) : (
+          <section className="rounded-xl border border-dashed bg-muted/20 p-8 text-center text-sm text-muted-foreground">
+            Selecciona un producto para capturar su cantidad.
+          </section>
+        )}
+
+        {/* ─── Pendientes (colapsable) ─────────────────────────────────── */}
+        <section className="rounded-lg border bg-card">
+          <button
+            type="button"
+            onClick={() => setShowPendientes((v) => !v)}
+            className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium"
+          >
+            <span>Pendientes ({pendientes.length})</span>
+            <span className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void refresh();
+                }}
+                disabled={refreshing}
+                className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-muted/40"
+                aria-label="Actualizar"
+              >
+                {refreshing ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <RotateCcw className="size-3" />
+                )}
+                Refrescar
+              </button>
+              {showPendientes ? (
+                <ChevronUp className="size-4" />
+              ) : (
+                <ChevronDown className="size-4" />
+              )}
+            </span>
+          </button>
+          {showPendientes && (
+            <ul className="border-t">
+              {pendientes.length === 0 ? (
+                <li className="px-4 py-3 text-sm text-emerald-600 dark:text-emerald-400">
+                  <CheckCircle2 className="mr-1 inline size-3.5" /> Todos los productos están
+                  contados.
+                </li>
+              ) : (
+                pendientes.map((l) => (
+                  <li key={l.linea_id} className="border-b last:border-b-0">
+                    <button
+                      type="button"
+                      onClick={() => seleccionar(l.producto_id)}
+                      className="flex w-full items-center justify-between gap-2 px-4 py-2 text-left hover:bg-muted/40"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{l.producto_nombre}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {l.producto_codigo}
+                          {l.categoria ? ` · ${l.categoria}` : ''}
+                        </div>
+                      </div>
+                      <span className="text-xs text-muted-foreground">{l.unidad}</span>
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          )}
+        </section>
+
+        <ResumenContadas
+          contadas={lineas.filter((l) => l.contado_at != null)}
+          onReabrir={(productoId) => seleccionar(productoId)}
+        />
+      </main>
+    </div>
+  );
+}
+
+function SyncIndicator({
+  pendientes,
+  syncing,
+  fallback,
+}: {
+  pendientes: number;
+  syncing: boolean;
+  fallback: boolean;
+}) {
+  const [online, setOnline] = useState(true);
+  useEffect(() => {
+    const update = () => setOnline(typeof navigator !== 'undefined' ? navigator.onLine : true);
+    update();
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium',
+        !online && 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+        online && pendientes > 0 && 'bg-sky-500/10 text-sky-700 dark:text-sky-400',
+        online && pendientes === 0 && 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+      )}
+      title={
+        fallback
+          ? 'IndexedDB no disponible — usando localStorage como respaldo'
+          : online
+            ? 'Conectado'
+            : 'Sin conexión — los conteos se sincronizan cuando vuelva la red'
+      }
+    >
+      {!online ? (
+        <>
+          <WifiOff className="size-3" />
+          Sin red · {pendientes} pendiente{pendientes === 1 ? '' : 's'}
+        </>
+      ) : pendientes > 0 ? (
+        <>
+          {syncing ? <Loader2 className="size-3 animate-spin" /> : <Wifi className="size-3" />}
+          {pendientes} sync
+        </>
+      ) : (
+        <>
+          <Wifi className="size-3" />
+          Sincronizado
+        </>
+      )}
+    </span>
+  );
+}
+
+function ResumenContadas({
+  contadas,
+  onReabrir,
+}: {
+  contadas: LineaParaCapturar[];
+  onReabrir: (productoId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  if (contadas.length === 0) return null;
+  return (
+    <section className="rounded-lg border bg-card">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium"
+      >
+        <span>Ya contados ({contadas.length})</span>
+        {open ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
+      </button>
+      {open && (
+        <ul className="max-h-72 overflow-auto border-t">
+          {contadas.map((l) => (
+            <li key={l.linea_id} className="border-b last:border-b-0">
+              <button
+                type="button"
+                onClick={() => onReabrir(l.producto_id)}
+                className="flex w-full items-center justify-between gap-2 px-4 py-2 text-left hover:bg-muted/40"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium">{l.producto_nombre}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {l.producto_codigo}
+                    {l.recontada ? ' · recontado' : ''}
+                  </div>
+                </div>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {formatNumber(l.cantidad_contada)} {l.unidad}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/app/rdb/inventario/levantamientos/[id]/diferencias/page.tsx
+++ b/app/rdb/inventario/levantamientos/[id]/diferencias/page.tsx
@@ -1,0 +1,589 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de /rdb/inventario/levantamientos.
+ */
+
+/**
+ * Diferencias detalladas — tabla de revisión post-captura.
+ *
+ * Carga vía `getLineasParaRevisar` (RPC) — la SELECT directa a la tabla está
+ * bloqueada por RLS para no-admins.
+ *
+ * Filtros y acciones:
+ *   - Solo con diferencia / Solo fuera de tolerancia / por categoría.
+ *   - Edición inline de `notas_diferencia` (server action `actualizarNotaDiferencia`)
+ *     habilitada solo para el contador y mientras estado === 'capturado'.
+ *   - Imprimir: link a `/reporte`.
+ *   - Exportar CSV: client-side, sin roundtrip.
+ *
+ * NO renderiza <InventarioTabs>.
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  Download,
+  Loader2,
+  Pencil,
+  Printer,
+  Save,
+  X,
+} from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import { Combobox } from '@/components/ui/combobox';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useToast } from '@/components/ui/toast';
+import { LevantamientoStatusBadge } from '@/components/inventario/levantamiento-status-badge';
+import { VarianceCell } from '@/components/inventario/variance-cell';
+import { formatCurrency, formatDateTime, formatNumber } from '@/lib/inventario/format';
+import { cn } from '@/lib/utils';
+import { actualizarNotaDiferencia, getLineasParaRevisar } from '../../actions';
+import type { LineaParaRevisar } from '../../types';
+
+type LevHeader = {
+  id: string;
+  folio: string | null;
+  estado: string;
+  fecha_cierre: string | null;
+  almacen_nombre: string | null;
+  contador_id: string | null;
+  contador_nombre: string | null;
+};
+
+export default function DiferenciasPage() {
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.inventario">
+      <DiferenciasInner />
+    </RequireAccess>
+  );
+}
+
+function DiferenciasInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [lev, setLev] = useState<LevHeader | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [lineas, setLineas] = useState<LineaParaRevisar[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [soloConDiff, setSoloConDiff] = useState(false);
+  const [soloFuera, setSoloFuera] = useState(false);
+  const [categoriaFiltro, setCategoriaFiltro] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    const supabase = createSupabaseBrowserClient();
+
+    const [
+      { data: levRow, error: levErr },
+      {
+        data: { user },
+      },
+      lineasRes,
+    ] = await Promise.all([
+      supabase
+        .schema('erp')
+        .from('inventario_levantamientos')
+        .select('id, folio, estado, fecha_cierre, contador_id, almacenes(nombre)')
+        .eq('id', id)
+        .is('deleted_at', null)
+        .maybeSingle(),
+      supabase.auth.getUser(),
+      getLineasParaRevisar(id),
+    ]);
+
+    if (levErr) {
+      setError(levErr.message);
+      setLoading(false);
+      return;
+    }
+    if (!levRow) {
+      setError('Levantamiento no encontrado.');
+      setLoading(false);
+      return;
+    }
+    if (!lineasRes.ok) {
+      setError(lineasRes.error);
+      setLoading(false);
+      return;
+    }
+
+    type LevQuery = {
+      id: string;
+      folio: string | null;
+      estado: string;
+      fecha_cierre: string | null;
+      contador_id: string | null;
+      almacenes: { nombre: string } | null;
+    };
+    const lr = levRow as unknown as LevQuery;
+
+    let contador_nombre: string | null = null;
+    if (lr.contador_id) {
+      const { data: ucRow } = await supabase
+        .schema('core')
+        .from('usuarios')
+        .select('first_name, email')
+        .eq('id', lr.contador_id)
+        .maybeSingle();
+      if (ucRow) {
+        contador_nombre = ucRow.first_name?.trim() || ucRow.email || null;
+      }
+    }
+
+    setLev({
+      id: lr.id,
+      folio: lr.folio,
+      estado: lr.estado,
+      fecha_cierre: lr.fecha_cierre,
+      almacen_nombre: lr.almacenes?.nombre ?? null,
+      contador_id: lr.contador_id,
+      contador_nombre,
+    });
+    setUserId(user?.id ?? null);
+    setLineas(lineasRes.data);
+    setLoading(false);
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const categorias = useMemo(() => {
+    const set = new Set<string>();
+    for (const l of lineas) {
+      if (l.categoria) set.add(l.categoria);
+    }
+    return Array.from(set).sort();
+  }, [lineas]);
+
+  const filtered = useMemo(() => {
+    return lineas.filter((l) => {
+      if (soloConDiff && (l.diferencia ?? 0) === 0) return false;
+      if (soloFuera && !l.fuera_de_tolerancia) return false;
+      if (categoriaFiltro && l.categoria !== categoriaFiltro) return false;
+      return true;
+    });
+  }, [lineas, soloConDiff, soloFuera, categoriaFiltro]);
+
+  const editable =
+    lev != null && lev.estado === 'capturado' && userId != null && lev.contador_id === userId;
+
+  const handleNotaUpdated = (linea_id: string, nota: string) => {
+    setLineas((prev) =>
+      prev.map((l) =>
+        l.linea_id === linea_id ? { ...l, notas_diferencia: nota.trim() || null } : l
+      )
+    );
+  };
+
+  const exportCSV = () => {
+    if (!lev) return;
+    const header = [
+      'Producto',
+      'Codigo',
+      'Categoria',
+      'Unidad',
+      'Stock inicial',
+      'Salidas durante captura',
+      'Stock efectivo',
+      'Contado',
+      'Diferencia',
+      'Diferencia $',
+      'Fuera de tolerancia',
+      'Notas',
+      'Contado at',
+    ];
+    const rows = filtered.map((l) => [
+      l.producto_nombre,
+      l.producto_codigo,
+      l.categoria ?? '',
+      l.unidad,
+      String(l.stock_inicial),
+      String(l.salidas_durante_captura),
+      String(l.stock_efectivo),
+      l.cantidad_contada == null ? '' : String(l.cantidad_contada),
+      l.diferencia == null ? '' : String(l.diferencia),
+      l.diferencia_valor == null ? '' : String(l.diferencia_valor),
+      l.fuera_de_tolerancia ? 'sí' : 'no',
+      (l.notas_diferencia ?? '').replaceAll('\n', ' '),
+      l.contado_at ?? '',
+    ]);
+    const csv = [header, ...rows]
+      .map((r) =>
+        r
+          .map((cell) => {
+            const s = String(cell ?? '');
+            return /[",\n]/.test(s) ? `"${s.replaceAll('"', '""')}"` : s;
+          })
+          .join(',')
+      )
+      .join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `levantamiento-${lev.folio ?? lev.id}-diferencias.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-7xl space-y-4 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-96 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !lev) {
+    return (
+      <div className="container mx-auto max-w-7xl space-y-4 px-4 py-6">
+        <BackLink id={id} />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Levantamiento no encontrado.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-7xl space-y-5 px-4 py-6">
+      <BackLink id={id} />
+
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Diferencias — {lev.folio ?? '—'}
+            </h1>
+            <LevantamientoStatusBadge estado={lev.estado} />
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {lev.almacen_nombre ?? 'Sin almacén'}
+            {lev.fecha_cierre ? ` · Cerrado ${formatDateTime(lev.fecha_cierre)}` : ''}
+            {lev.contador_nombre ? ` · Contador: ${lev.contador_nombre}` : ''}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Link href={`/rdb/inventario/levantamientos/${lev.id}/reporte`}>
+            <Button variant="outline" size="sm">
+              <Printer className="size-4" />
+              Imprimir
+            </Button>
+          </Link>
+          <Button variant="outline" size="sm" onClick={exportCSV}>
+            <Download className="size-4" />
+            Exportar CSV
+          </Button>
+        </div>
+      </header>
+
+      {/* ─── Filtros ──────────────────────────────────────────────── */}
+      <section className="flex flex-wrap items-center gap-4 rounded-lg border bg-card px-4 py-3 text-sm">
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={soloConDiff}
+            onChange={(e) => setSoloConDiff(e.target.checked)}
+            className="size-4 rounded border-input"
+          />
+          Solo con diferencia
+        </label>
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={soloFuera}
+            onChange={(e) => setSoloFuera(e.target.checked)}
+            className="size-4 rounded border-input"
+          />
+          Solo fuera de tolerancia
+        </label>
+        <div className="ml-auto flex items-center gap-2">
+          <span className="text-muted-foreground">Categoría:</span>
+          <Combobox
+            value={categoriaFiltro ?? ''}
+            onChange={(v) => setCategoriaFiltro(v || null)}
+            options={[
+              { value: '', label: 'Todas' },
+              ...categorias.map((c) => ({ value: c, label: c })),
+            ]}
+            className="min-w-[12rem]"
+            placeholder="Todas"
+          />
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {filtered.length} de {lineas.length} líneas
+        </span>
+      </section>
+
+      {/* ─── Tabla ───────────────────────────────────────────────── */}
+      <div className="overflow-x-auto rounded-lg border bg-card">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Producto</TableHead>
+              <TableHead>Categoría</TableHead>
+              <TableHead className="text-right">Stock inicial</TableHead>
+              <TableHead className="text-right">Salidas</TableHead>
+              <TableHead className="text-right">Efectivo</TableHead>
+              <TableHead className="text-right">Δ vs Sistema</TableHead>
+              <TableHead className="text-right">Δ $</TableHead>
+              <TableHead>Tolerancia</TableHead>
+              <TableHead>Notas</TableHead>
+              <TableHead>Contado</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={10} className="py-10 text-center text-sm text-muted-foreground">
+                  Sin líneas que coincidan con los filtros.
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((l) => (
+                <DiferenciaRow
+                  key={l.linea_id}
+                  linea={l}
+                  editable={editable}
+                  onUpdated={handleNotaUpdated}
+                />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+function BackLink({ id }: { id: string }) {
+  return (
+    <Link
+      href={`/rdb/inventario/levantamientos/${id}`}
+      className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="size-4" /> Volver al levantamiento
+    </Link>
+  );
+}
+
+function DiferenciaRow({
+  linea,
+  editable,
+  onUpdated,
+}: {
+  linea: LineaParaRevisar;
+  editable: boolean;
+  onUpdated: (linea_id: string, nota: string) => void;
+}) {
+  const sinContar = linea.cantidad_contada == null;
+  const conDiff = (linea.diferencia ?? 0) !== 0;
+
+  return (
+    <TableRow className={cn(linea.fuera_de_tolerancia && 'bg-destructive/5')}>
+      <TableCell>
+        <div className="font-medium">{linea.producto_nombre}</div>
+        <div className="text-xs text-muted-foreground">
+          {linea.producto_codigo} · {linea.unidad}
+        </div>
+      </TableCell>
+      <TableCell className="text-sm text-muted-foreground">{linea.categoria ?? '—'}</TableCell>
+      <TableCell className="text-right tabular-nums">{formatNumber(linea.stock_inicial)}</TableCell>
+      <TableCell className="text-right tabular-nums">
+        {linea.salidas_durante_captura > 0 ? (
+          <span className="text-amber-600 dark:text-amber-400">
+            -{formatNumber(linea.salidas_durante_captura)}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">0</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right tabular-nums font-medium">
+        {formatNumber(linea.stock_efectivo)}
+      </TableCell>
+      <TableCell className="text-right">
+        {sinContar ? (
+          <span className="text-xs italic text-muted-foreground">Sin contar</span>
+        ) : (
+          <VarianceCell
+            sistema={linea.stock_efectivo}
+            contado={Number(linea.cantidad_contada)}
+            unidad={linea.unidad}
+            fueraDeTolerancia={linea.fuera_de_tolerancia}
+            className="grid-cols-1 text-right"
+          />
+        )}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {linea.diferencia_valor == null ? (
+          <span className="text-muted-foreground">—</span>
+        ) : (
+          <span
+            className={cn(
+              linea.fuera_de_tolerancia && 'font-semibold text-destructive',
+              !linea.fuera_de_tolerancia && conDiff && 'text-amber-600 dark:text-amber-400'
+            )}
+          >
+            {formatCurrency(linea.diferencia_valor)}
+          </span>
+        )}
+      </TableCell>
+      <TableCell>
+        <ToleranceLabel
+          fuera={linea.fuera_de_tolerancia}
+          conDiferencia={conDiff}
+          sinContar={sinContar}
+        />
+      </TableCell>
+      <TableCell className="min-w-[16rem] max-w-sm">
+        <NotaCell linea={linea} editable={editable} onUpdated={onUpdated} />
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">
+        {linea.contado_at ? formatDateTime(linea.contado_at) : '—'}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function ToleranceLabel({
+  fuera,
+  conDiferencia,
+  sinContar,
+}: {
+  fuera: boolean;
+  conDiferencia: boolean;
+  sinContar: boolean;
+}) {
+  if (sinContar) {
+    return <span className="text-xs italic text-muted-foreground">Sin contar</span>;
+  }
+  if (fuera) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+        <AlertTriangle className="size-3" /> Fuera
+      </span>
+    );
+  }
+  if (conDiferencia) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+        Dentro
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+      <CheckCircle2 className="size-3" /> OK
+    </span>
+  );
+}
+
+function NotaCell({
+  linea,
+  editable,
+  onUpdated,
+}: {
+  linea: LineaParaRevisar;
+  editable: boolean;
+  onUpdated: (linea_id: string, nota: string) => void;
+}) {
+  const toast = useToast();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(linea.notas_diferencia ?? '');
+  const [saving, setSaving] = useState(false);
+
+  if (!editing) {
+    const empty = !linea.notas_diferencia;
+    return (
+      <div className="flex items-start gap-2">
+        <p
+          className={cn(
+            'min-h-[1.25rem] flex-1 whitespace-pre-wrap text-sm',
+            empty && 'italic text-muted-foreground'
+          )}
+        >
+          {empty ? (editable ? 'Sin nota — agregar' : 'Sin nota') : linea.notas_diferencia}
+        </p>
+        {editable && (
+          <button
+            type="button"
+            onClick={() => {
+              setDraft(linea.notas_diferencia ?? '');
+              setEditing(true);
+            }}
+            className="text-xs text-muted-foreground hover:text-foreground"
+            aria-label="Editar nota"
+          >
+            <Pencil className="size-3.5" />
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  const guardar = async () => {
+    setSaving(true);
+    const res = await actualizarNotaDiferencia(linea.linea_id, draft);
+    setSaving(false);
+    if (!res.ok) {
+      toast.add({ title: 'No se pudo guardar', description: res.error, type: 'error' });
+      return;
+    }
+    onUpdated(linea.linea_id, draft);
+    setEditing(false);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Textarea
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        rows={2}
+        className="text-sm"
+        autoFocus
+        disabled={saving}
+      />
+      <div className="flex items-center justify-end gap-1">
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => setEditing(false)}
+          disabled={saving}
+          aria-label="Cancelar"
+        >
+          <X className="size-3.5" />
+        </Button>
+        <Button size="sm" onClick={guardar} disabled={saving}>
+          {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
+          Guardar
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/rdb/inventario/levantamientos/[id]/page.tsx
+++ b/app/rdb/inventario/levantamientos/[id]/page.tsx
@@ -1,0 +1,905 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de /rdb/inventario/levantamientos.
+ */
+
+/**
+ * Detalle de un levantamiento físico.
+ *
+ * La UI cambia según `estado`:
+ *   borrador   → ficha + acciones de iniciar/editar
+ *   capturando → progreso + continuar/cerrar captura
+ *   capturado  → KPIs + líneas fuera de tolerancia + firma (placeholder B3)
+ *   aplicado   → firmas + reporte + link a movimientos generados
+ *   cancelado  → motivo + sólo lectura
+ *
+ * NO renderiza <InventarioTabs> — flujo focalizado.
+ */
+
+import Link from 'next/link';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Calculator,
+  CheckCircle2,
+  ClipboardList,
+  FileSignature,
+  FileText,
+  Info,
+  Loader2,
+  Pencil,
+  Play,
+  PlayCircle,
+  Printer,
+  Save,
+  XCircle,
+} from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { useToast } from '@/components/ui/toast';
+import {
+  LevantamientoStatusBadge,
+  type LevantamientoEstado,
+} from '@/components/inventario/levantamiento-status-badge';
+import { LevantamientoProgressGauge } from '@/components/inventario/levantamiento-progress-gauge';
+import { KpiCard } from '@/components/ui/kpi-card';
+import { TolerancePanel, type ToleranciaConfig } from '@/components/inventario/tolerance-panel';
+import {
+  formatCurrency,
+  formatDateShort,
+  formatDateTime,
+  formatNumber,
+} from '@/lib/inventario/format';
+import {
+  actualizarNotaDiferencia,
+  cerrarCaptura,
+  getLineasParaCapturar,
+  getLineasParaRevisar,
+  guardarConteo,
+  iniciarCaptura,
+} from '../actions';
+import type { LineaParaCapturar, LineaParaRevisar } from '../types';
+
+const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
+
+type LevantamientoFull = {
+  id: string;
+  empresa_id: string;
+  folio: string | null;
+  estado: string;
+  tipo: string;
+  fecha_programada: string;
+  fecha_inicio: string | null;
+  fecha_cierre: string | null;
+  fecha_aplicado: string | null;
+  fecha_cancelado: string | null;
+  contador_id: string | null;
+  almacen_id: string;
+  notas: string | null;
+  motivo_cancelacion: string | null;
+  tolerancia_pct_override: number | null;
+  tolerancia_monto_override: number | null;
+  almacenes: { nombre: string } | null;
+};
+
+type FirmaRow = {
+  id: string;
+  paso: number;
+  rol: string;
+  firmante_nombre: string;
+  firmado_at: string;
+  comentario: string | null;
+};
+
+export default function LevantamientoDetailPage() {
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.inventario">
+      <DetailInner />
+    </RequireAccess>
+  );
+}
+
+function DetailInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const router = useRouter();
+  const toast = useToast();
+
+  const [lev, setLev] = useState<LevantamientoFull | null>(null);
+  const [tolerancia, setTolerancia] = useState<ToleranciaConfig | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // estado-specific data
+  const [capturarLineas, setCapturarLineas] = useState<LineaParaCapturar[] | null>(null);
+  const [revisarLineas, setRevisarLineas] = useState<LineaParaRevisar[] | null>(null);
+  const [firmas, setFirmas] = useState<FirmaRow[] | null>(null);
+
+  const [working, setWorking] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    const supabase = createSupabaseBrowserClient();
+
+    const [
+      { data: levRow, error: levErr },
+      {
+        data: { user },
+      },
+      tolRes,
+    ] = await Promise.all([
+      supabase
+        .schema('erp')
+        .from('inventario_levantamientos')
+        .select(
+          `id, empresa_id, folio, estado, tipo, fecha_programada, fecha_inicio, fecha_cierre,
+           fecha_aplicado, fecha_cancelado, contador_id, almacen_id, notas, motivo_cancelacion,
+           tolerancia_pct_override, tolerancia_monto_override, almacenes(nombre)`
+        )
+        .eq('id', id)
+        .is('deleted_at', null)
+        .maybeSingle(),
+      supabase.auth.getUser(),
+      supabase.schema('erp').rpc('fn_get_empresa_tolerancia', { p_empresa_id: RDB_EMPRESA_ID }),
+    ]);
+
+    if (levErr) {
+      setError(levErr.message);
+      setLoading(false);
+      return;
+    }
+    if (!levRow) {
+      setError('Levantamiento no encontrado.');
+      setLoading(false);
+      return;
+    }
+
+    const levantamiento = levRow as unknown as LevantamientoFull;
+    setLev(levantamiento);
+    setUserId(user?.id ?? null);
+
+    if (!tolRes.error && tolRes.data?.[0]) {
+      const tol = tolRes.data[0];
+      setTolerancia({
+        tolerancia_pct: Number(tol.tolerancia_pct),
+        tolerancia_monto: Number(tol.tolerancia_monto),
+        firmas_requeridas: Number(tol.firmas_requeridas),
+      });
+    }
+
+    // Datos por estado
+    if (levantamiento.estado === 'capturando') {
+      const r = await getLineasParaCapturar(id);
+      if (r.ok) setCapturarLineas(r.data);
+    } else if (
+      levantamiento.estado === 'capturado' ||
+      levantamiento.estado === 'aplicado' ||
+      levantamiento.estado === 'cancelado'
+    ) {
+      const r = await getLineasParaRevisar(id);
+      if (r.ok) setRevisarLineas(r.data);
+    }
+
+    if (levantamiento.estado === 'aplicado') {
+      const fRes = await supabase
+        .schema('erp')
+        .from('inventario_levantamiento_firmas')
+        .select('id, paso, rol, firmante_nombre, firmado_at, comentario')
+        .eq('levantamiento_id', id)
+        .order('paso', { ascending: true });
+      if (!fRes.error) setFirmas((fRes.data ?? []) as FirmaRow[]);
+    }
+
+    setLoading(false);
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleIniciar = async () => {
+    if (!lev) return;
+    setWorking(true);
+    const res = await iniciarCaptura(lev.id);
+    setWorking(false);
+    if (!res.ok) {
+      toast.add({ title: 'No se pudo iniciar la captura', description: res.error, type: 'error' });
+      return;
+    }
+    toast.add({
+      title: 'Captura iniciada',
+      description: `${res.data.lineasSembradas} producto${res.data.lineasSembradas === 1 ? '' : 's'} sembrado${res.data.lineasSembradas === 1 ? '' : 's'}.`,
+      type: 'success',
+    });
+    router.push(`/rdb/inventario/levantamientos/${lev.id}/capturar`);
+  };
+
+  const handleCerrar = async (forcePendientesACero: boolean) => {
+    if (!lev) return;
+    setWorking(true);
+
+    // Si quedan pendientes y el usuario eligió forzar 0, primero los marcamos.
+    if (forcePendientesACero && capturarLineas) {
+      const pendientes = capturarLineas.filter((l) => l.contado_at == null);
+      // En serie: evita writes concurrentes contra el RPC y deja el orden auditable.
+      for (const p of pendientes) {
+        const r = await guardarConteo(lev.id, p.producto_id, 0);
+        if (!r.ok) {
+          setWorking(false);
+          toast.add({
+            title: 'Error marcando pendientes en 0',
+            description: r.error,
+            type: 'error',
+          });
+          return;
+        }
+      }
+    }
+
+    const res = await cerrarCaptura(lev.id);
+    setWorking(false);
+    if (!res.ok) {
+      toast.add({ title: 'No se pudo cerrar la captura', description: res.error, type: 'error' });
+      return;
+    }
+    toast.add({ title: 'Captura cerrada — pendiente de firma', type: 'success' });
+    void load();
+  };
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-4xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !lev) {
+    return (
+      <div className="container mx-auto max-w-4xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Levantamiento no encontrado.'}
+        </div>
+      </div>
+    );
+  }
+
+  const esContador = userId != null && lev.contador_id === userId;
+  const estado = lev.estado as LevantamientoEstado;
+
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Levantamiento {lev.folio ?? '—'}
+            </h1>
+            <LevantamientoStatusBadge estado={lev.estado} />
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {lev.almacenes?.nombre ?? 'Sin almacén'} · Programado{' '}
+            {formatDateShort(lev.fecha_programada)}
+          </p>
+        </div>
+      </header>
+
+      <MetadataCard lev={lev} />
+
+      {/* Bloques de acciones según estado */}
+      {estado === 'borrador' && (
+        <section className="rounded-lg border bg-card p-5">
+          <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Acciones
+          </h2>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Link href={`/rdb/inventario/levantamientos/nuevo?id=${lev.id}`}>
+              <Button variant="outline" disabled={working}>
+                <Pencil className="size-4" />
+                Editar
+              </Button>
+            </Link>
+            <Button onClick={handleIniciar} disabled={working}>
+              {working ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <PlayCircle className="size-4" />
+              )}
+              Iniciar captura
+            </Button>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Al iniciar la captura, el sistema siembra una línea por producto inventariable activo y
+            queda registrado el contador.
+          </p>
+        </section>
+      )}
+
+      {estado === 'capturando' && (
+        <CapturandoSection
+          lev={lev}
+          esContador={esContador}
+          working={working}
+          lineas={capturarLineas}
+          onCerrar={handleCerrar}
+        />
+      )}
+
+      {estado === 'capturado' && (
+        <CapturadoSection
+          lev={lev}
+          esContador={esContador}
+          tolerancia={tolerancia}
+          lineas={revisarLineas}
+          onLineasChange={setRevisarLineas}
+        />
+      )}
+
+      {estado === 'aplicado' && (
+        <AplicadoSection lev={lev} firmas={firmas} lineas={revisarLineas} />
+      )}
+
+      {estado === 'cancelado' && <CanceladoSection lev={lev} />}
+
+      {/* Tolerancia siempre visible (excepto en cancelado) si tenemos config. */}
+      {tolerancia && estado !== 'cancelado' && (
+        <TolerancePanel
+          config={tolerancia}
+          overridePct={lev.tolerancia_pct_override}
+          overrideMonto={lev.tolerancia_monto_override}
+          lineasFueraDeTolerancia={revisarLineas?.filter((l) => l.fuera_de_tolerancia).length ?? 0}
+        />
+      )}
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/rdb/inventario/levantamientos"
+      className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="size-4" /> Volver a levantamientos
+    </Link>
+  );
+}
+
+function MetadataCard({ lev }: { lev: LevantamientoFull }) {
+  return (
+    <div className="rounded-lg border bg-card p-5">
+      <dl className="grid gap-4 text-sm sm:grid-cols-3">
+        <Field label="Folio" value={lev.folio ?? '—'} mono />
+        <Field label="Almacén" value={lev.almacenes?.nombre ?? '—'} />
+        <Field label="Tipo" value={lev.tipo} />
+        <Field label="Programado" value={formatDateShort(lev.fecha_programada)} />
+        <Field label="Inicio" value={formatDateTime(lev.fecha_inicio)} />
+        <Field
+          label={
+            lev.estado === 'cancelado'
+              ? 'Cancelado'
+              : lev.estado === 'aplicado'
+                ? 'Aplicado'
+                : 'Cierre'
+          }
+          value={formatDateTime(
+            lev.fecha_cancelado ?? lev.fecha_aplicado ?? lev.fecha_cierre ?? null
+          )}
+        />
+      </dl>
+      {lev.notas && (
+        <div className="mt-4 border-t pt-4">
+          <div className="text-xs uppercase tracking-wider text-muted-foreground">Notas</div>
+          <p className="mt-1 text-sm whitespace-pre-wrap">{lev.notas}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wider text-muted-foreground">{label}</dt>
+      <dd className={mono ? 'mt-0.5 font-medium tabular-nums' : 'mt-0.5 font-medium'}>{value}</dd>
+    </div>
+  );
+}
+
+// ─── Estado: capturando ────────────────────────────────────────────────────────
+
+function CapturandoSection({
+  lev,
+  esContador,
+  working,
+  lineas,
+  onCerrar,
+}: {
+  lev: LevantamientoFull;
+  esContador: boolean;
+  working: boolean;
+  lineas: LineaParaCapturar[] | null;
+  onCerrar: (forcePendientesACero: boolean) => void;
+}) {
+  const total = lineas?.length ?? 0;
+  const contadas = lineas?.filter((l) => l.contado_at != null).length ?? 0;
+  const completo = total > 0 && contadas === total;
+  const tienePendientes = total > 0 && contadas < total;
+
+  return (
+    <section className="rounded-lg border bg-card p-5">
+      <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+        Captura en proceso
+      </h2>
+
+      <div className="mt-4 flex flex-wrap items-center gap-6">
+        <LevantamientoProgressGauge contadas={contadas} totales={total} size={128} />
+        <div className="min-w-0 flex-1">
+          <div className="text-2xl font-semibold tabular-nums">
+            {contadas} / {total}{' '}
+            <span className="text-base font-medium text-muted-foreground">productos contados</span>
+          </div>
+          {lineas == null ? (
+            <p className="mt-1 text-sm text-muted-foreground">
+              <Loader2 className="mr-1 inline size-3 animate-spin" /> Cargando líneas…
+            </p>
+          ) : tienePendientes ? (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {total - contadas} producto{total - contadas === 1 ? '' : 's'} pendiente
+              {total - contadas === 1 ? '' : 's'} de capturar.
+            </p>
+          ) : (
+            <p className="mt-1 text-sm text-emerald-600 dark:text-emerald-400">
+              <CheckCircle2 className="mr-1 inline size-3.5" /> Todos los productos están contados.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-2">
+        {esContador ? (
+          <Link href={`/rdb/inventario/levantamientos/${lev.id}/capturar`}>
+            <Button>
+              <Play className="size-4" />
+              Continuar capturando
+            </Button>
+          </Link>
+        ) : (
+          <Button disabled title="Solo el contador asignado puede continuar la captura.">
+            <Play className="size-4" />
+            Continuar capturando
+          </Button>
+        )}
+
+        {completo ? (
+          <Button variant="outline" onClick={() => onCerrar(false)} disabled={working}>
+            {working ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <CheckCircle2 className="size-4" />
+            )}
+            Cerrar captura
+          </Button>
+        ) : (
+          <AlertDialog>
+            <AlertDialogTrigger
+              render={
+                <Button variant="outline" disabled={total === 0 || working}>
+                  <CheckCircle2 className="size-4" />
+                  Cerrar captura
+                </Button>
+              }
+            />
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Cerrar con productos pendientes</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Quedan {total - contadas} producto{total - contadas === 1 ? '' : 's'} sin contar.
+                  Si cierras ahora, se marcarán como <strong>cantidad contada = 0</strong> y
+                  generarán diferencia contra el sistema. Esta acción es reversible solo cancelando
+                  el levantamiento.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Volver</AlertDialogCancel>
+                <AlertDialogAction onClick={() => onCerrar(true)} disabled={working}>
+                  Marcar pendientes en 0 y cerrar
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ─── Estado: capturado ────────────────────────────────────────────────────────
+
+function CapturadoSection({
+  lev,
+  esContador,
+  tolerancia,
+  lineas,
+  onLineasChange,
+}: {
+  lev: LevantamientoFull;
+  esContador: boolean;
+  tolerancia: ToleranciaConfig | null;
+  lineas: LineaParaRevisar[] | null;
+  onLineasChange: (next: LineaParaRevisar[]) => void;
+}) {
+  const kpis = useMemo(() => {
+    const all = lineas ?? [];
+    const conDiff = all.filter((l) => (l.diferencia ?? 0) !== 0);
+    const fuera = all.filter((l) => l.fuera_de_tolerancia);
+    const ajusteNeto = all.reduce((s, l) => s + (Number(l.diferencia_valor) || 0), 0);
+    return {
+      total: all.length,
+      conDiff: conDiff.length,
+      fuera: fuera.length,
+      ajusteNeto,
+    };
+  }, [lineas]);
+
+  const fuera = useMemo(() => (lineas ?? []).filter((l) => l.fuera_de_tolerancia), [lineas]);
+
+  return (
+    <>
+      <section className="grid gap-3 sm:grid-cols-2">
+        <KpiCard
+          icon={<ClipboardList className="size-3.5" />}
+          label="Productos contados"
+          value={formatNumber(kpis.total)}
+        />
+        <KpiCard
+          icon={<Calculator className="size-3.5" />}
+          label="Líneas con diferencia"
+          value={formatNumber(kpis.conDiff)}
+          tone={kpis.conDiff > 0 ? 'warning' : 'default'}
+        />
+        <KpiCard
+          icon={<AlertTriangle className="size-3.5" />}
+          label="Fuera de tolerancia"
+          value={formatNumber(kpis.fuera)}
+          tone={kpis.fuera > 0 ? 'destructive' : 'default'}
+        />
+        <KpiCard
+          icon={<Calculator className="size-3.5" />}
+          label="Ajuste neto"
+          value={formatCurrency(kpis.ajusteNeto)}
+          tone={kpis.ajusteNeto < 0 ? 'destructive' : kpis.ajusteNeto > 0 ? 'success' : 'default'}
+        />
+      </section>
+
+      {fuera.length > 0 && (
+        <FueraDeToleranciaList
+          lineas={fuera}
+          esContador={esContador}
+          tolerancia={tolerancia}
+          onLineaUpdated={(updated) => {
+            if (!lineas) return;
+            onLineasChange(lineas.map((l) => (l.linea_id === updated.linea_id ? updated : l)));
+          }}
+        />
+      )}
+
+      <section className="rounded-lg border bg-card p-5">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Acciones
+        </h2>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <Link href={`/rdb/inventario/levantamientos/${lev.id}/diferencias`}>
+            <Button variant="outline">
+              <FileText className="size-4" />
+              Ver diferencias detalladas
+            </Button>
+          </Link>
+          <FirmarPlaceholderButton />
+        </div>
+      </section>
+    </>
+  );
+}
+
+function FueraDeToleranciaList({
+  lineas,
+  esContador,
+  tolerancia,
+  onLineaUpdated,
+}: {
+  lineas: LineaParaRevisar[];
+  esContador: boolean;
+  tolerancia: ToleranciaConfig | null;
+  onLineaUpdated: (l: LineaParaRevisar) => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <section className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-5">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center justify-between text-left"
+      >
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="size-4 text-amber-700 dark:text-amber-400" />
+          <h2 className="text-sm font-medium uppercase tracking-wider text-amber-800 dark:text-amber-300">
+            Fuera de tolerancia ({lineas.length})
+          </h2>
+        </div>
+        {tolerancia && (
+          <span className="text-xs text-muted-foreground">
+            Tolerancia: {tolerancia.tolerancia_pct.toFixed(2)}% /{' '}
+            {formatCurrency(tolerancia.tolerancia_monto)}
+          </span>
+        )}
+      </button>
+      {expanded && (
+        <ul className="mt-4 space-y-3">
+          {lineas.map((l) => (
+            <FueraLineaRow
+              key={l.linea_id}
+              linea={l}
+              esContador={esContador}
+              onUpdated={onLineaUpdated}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function FueraLineaRow({
+  linea,
+  esContador,
+  onUpdated,
+}: {
+  linea: LineaParaRevisar;
+  esContador: boolean;
+  onUpdated: (l: LineaParaRevisar) => void;
+}) {
+  const toast = useToast();
+  const [nota, setNota] = useState(linea.notas_diferencia ?? '');
+  const [saving, setSaving] = useState(false);
+  const dirty = nota !== (linea.notas_diferencia ?? '');
+
+  const guardar = async () => {
+    setSaving(true);
+    const res = await actualizarNotaDiferencia(linea.linea_id, nota);
+    setSaving(false);
+    if (!res.ok) {
+      toast.add({ title: 'No se pudo guardar la nota', description: res.error, type: 'error' });
+      return;
+    }
+    toast.add({ title: 'Nota guardada', type: 'success' });
+    onUpdated({ ...linea, notas_diferencia: nota.trim() || null });
+  };
+
+  return (
+    <li className="rounded-md bg-card p-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <div className="min-w-0">
+          <div className="font-medium">{linea.producto_nombre}</div>
+          <div className="text-xs text-muted-foreground">
+            {linea.producto_codigo}
+            {linea.categoria ? ` · ${linea.categoria}` : ''}
+          </div>
+        </div>
+        <div className="text-right text-sm tabular-nums">
+          <div>
+            <span className="text-muted-foreground">Sistema:</span>{' '}
+            {formatNumber(linea.stock_efectivo)} {linea.unidad}
+          </div>
+          <div>
+            <span className="text-muted-foreground">Contado:</span>{' '}
+            {formatNumber(linea.cantidad_contada)} {linea.unidad}
+          </div>
+          <div className="font-semibold text-destructive">
+            Δ {formatNumber(linea.diferencia)} {linea.unidad} (
+            {formatCurrency(linea.diferencia_valor)})
+          </div>
+        </div>
+      </div>
+      <div className="mt-3">
+        <Textarea
+          value={nota}
+          onChange={(e) => setNota(e.target.value)}
+          placeholder={
+            esContador
+              ? 'Justificación: dónde estaba el producto, motivo de la diferencia, etc.'
+              : 'Solo el contador puede editar esta nota.'
+          }
+          rows={2}
+          disabled={!esContador || saving}
+          className="text-sm"
+        />
+        {esContador && (
+          <div className="mt-2 flex justify-end">
+            <Button size="sm" variant="outline" onClick={guardar} disabled={!dirty || saving}>
+              {saving ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Save className="size-3.5" />
+              )}
+              Guardar nota
+            </Button>
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function FirmarPlaceholderButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <FileSignature className="size-4" />
+        Firmar
+      </Button>
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Firma electrónica — próximamente</AlertDialogTitle>
+            <AlertDialogDescription>
+              La firma del levantamiento se implementa en el sub-PR B3. Mientras tanto, el
+              levantamiento puede seguir consultándose y editando notas. Si necesitas firmar antes
+              de B3, escribe a soporte para hacerlo manualmente.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Entendido</AlertDialogCancel>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+// ─── Estado: aplicado ─────────────────────────────────────────────────────────
+
+function AplicadoSection({
+  lev,
+  firmas,
+  lineas,
+}: {
+  lev: LevantamientoFull;
+  firmas: FirmaRow[] | null;
+  lineas: LineaParaRevisar[] | null;
+}) {
+  const movimientos = lineas?.filter((l) => (l.diferencia ?? 0) !== 0).length ?? 0;
+
+  return (
+    <>
+      <section className="rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-5">
+        <div className="flex items-center gap-2">
+          <CheckCircle2 className="size-4 text-emerald-700 dark:text-emerald-400" />
+          <h2 className="text-sm font-medium uppercase tracking-wider text-emerald-800 dark:text-emerald-300">
+            Aplicado
+          </h2>
+        </div>
+        <p className="mt-2 text-sm">
+          Aplicado el <strong>{formatDateTime(lev.fecha_aplicado)}</strong>. Se generaron{' '}
+          <strong>{formatNumber(movimientos)}</strong> movimiento
+          {movimientos === 1 ? '' : 's'} de ajuste contra el inventario.
+        </p>
+      </section>
+
+      <section className="rounded-lg border bg-card p-5">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Firmas recibidas ({firmas?.length ?? 0})
+        </h2>
+        {firmas == null ? (
+          <Skeleton className="mt-3 h-16 w-full rounded-md" />
+        ) : firmas.length === 0 ? (
+          <p className="mt-3 text-sm text-muted-foreground">
+            Sin firmas registradas. (Levantamientos antiguos pre-flujo de firma).
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {firmas.map((f) => (
+              <li
+                key={f.id}
+                className="flex flex-wrap items-baseline justify-between gap-2 rounded-md border bg-muted/20 px-3 py-2 text-sm"
+              >
+                <div>
+                  <Badge variant="outline" className="mr-2 capitalize">
+                    {f.rol}
+                  </Badge>
+                  <span className="font-medium">{f.firmante_nombre}</span>
+                  {f.comentario && (
+                    <span className="ml-2 text-muted-foreground">— {f.comentario}</span>
+                  )}
+                </div>
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  Paso {f.paso} · {formatDateTime(f.firmado_at)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="rounded-lg border bg-card p-5">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Acciones
+        </h2>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <Link href={`/rdb/inventario/levantamientos/${lev.id}/reporte`}>
+            <Button variant="outline">
+              <Printer className="size-4" />
+              Ver reporte
+            </Button>
+          </Link>
+          <Link href={`/rdb/inventario/levantamientos/${lev.id}/diferencias`}>
+            <Button variant="outline">
+              <FileText className="size-4" />
+              Ver diferencias
+            </Button>
+          </Link>
+          <Link href={`/rdb/inventario?ref=lev:${lev.id}`}>
+            <Button variant="outline">
+              <Calculator className="size-4" />
+              Ver ajustes generados
+            </Button>
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}
+
+// ─── Estado: cancelado ────────────────────────────────────────────────────────
+
+function CanceladoSection({ lev }: { lev: LevantamientoFull }) {
+  return (
+    <section className="rounded-lg border border-destructive/40 bg-destructive/5 p-5">
+      <div className="flex items-center gap-2">
+        <XCircle className="size-4 text-destructive" />
+        <h2 className="text-sm font-medium uppercase tracking-wider text-destructive">Cancelado</h2>
+      </div>
+      <p className="mt-2 text-sm">
+        Cancelado el <strong>{formatDateTime(lev.fecha_cancelado)}</strong>.
+      </p>
+      {lev.motivo_cancelacion && (
+        <div className="mt-3 rounded-md border border-destructive/20 bg-card p-3 text-sm">
+          <div className="text-xs uppercase tracking-wider text-muted-foreground">Motivo</div>
+          <p className="mt-1 whitespace-pre-wrap">{lev.motivo_cancelacion}</p>
+        </div>
+      )}
+      <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+        <Info className="size-3.5" />
+        Este levantamiento no generó movimientos en el inventario.
+      </div>
+    </section>
+  );
+}

--- a/app/rdb/inventario/levantamientos/[id]/reporte/page.tsx
+++ b/app/rdb/inventario/levantamientos/[id]/reporte/page.tsx
@@ -1,0 +1,504 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de /rdb/inventario/levantamientos.
+ */
+
+/**
+ * Reporte de levantamiento — vista print-friendly.
+ *
+ * Estructura (orden vertical):
+ *   1. Membrete RDB (full-width)
+ *   2. Encabezado: folio, almacén, contador, fechas
+ *   3. KPIs (4 tarjetas)
+ *   4. Tabla de líneas con diferencia ≠ 0
+ *   5. Sección de líneas fuera de tolerancia con notas
+ *   6. Pie con N bloques de firma (si aplicado)
+ *
+ * Render strategy: el contenido vive en la misma página; `@media print` oculta
+ * la navegación de pantalla y deja sólo el documento. Auto-`window.print()`
+ * 400 ms después del mount, replicando el patrón de `handlePrintLista` en
+ * `/rdb/inventario/page.tsx`.
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, Printer } from 'lucide-react';
+import Image from 'next/image';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { LevantamientoStatusBadge } from '@/components/inventario/levantamiento-status-badge';
+import {
+  formatCurrency,
+  formatDateShort,
+  formatDateTime,
+  formatNumber,
+} from '@/lib/inventario/format';
+import { getLineasParaRevisar } from '../../actions';
+import type { LineaParaRevisar } from '../../types';
+
+type LevReporte = {
+  id: string;
+  folio: string | null;
+  estado: string;
+  fecha_programada: string;
+  fecha_inicio: string | null;
+  fecha_cierre: string | null;
+  fecha_aplicado: string | null;
+  almacen_nombre: string | null;
+  contador_nombre: string | null;
+  notas: string | null;
+};
+
+type FirmaRow = {
+  id: string;
+  paso: number;
+  rol: string;
+  firmante_nombre: string;
+  firmado_at: string;
+  comentario: string | null;
+};
+
+export default function ReportePage() {
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.inventario">
+      <ReporteInner />
+    </RequireAccess>
+  );
+}
+
+const REPORTE_STYLES = `
+@media print {
+  .reporte-screen-only { display: none !important; }
+  .reporte-doc { margin: 0; padding: 0; background: white; }
+  .reporte-doc table { page-break-inside: auto; }
+  .reporte-doc tr { page-break-inside: avoid; page-break-after: auto; }
+  .reporte-firmas { page-break-inside: avoid; }
+}
+.reporte-doc {
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+  color: #111;
+}
+.reporte-doc table { width: 100%; border-collapse: collapse; }
+.reporte-doc th {
+  font-weight: 700; text-align: left; padding: 6px 8px;
+  border-bottom: 2px solid #1a1a2e; font-size: 9.5px;
+  text-transform: uppercase; letter-spacing: 0.04em;
+  color: #1a1a2e; background: #f5f5f8;
+}
+.reporte-doc td {
+  padding: 5px 8px; border-bottom: 1px solid #eee;
+  vertical-align: middle; font-size: 11px;
+}
+.reporte-doc tr:nth-child(even) td { background: #fafafa; }
+.reporte-doc .num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.reporte-doc .rojo { color: #dc2626; font-weight: 600; }
+.reporte-doc .ambar { color: #d97706; font-weight: 600; }
+.reporte-doc .verde { color: #16a34a; }
+.reporte-doc .gris { color: #777; }
+`;
+
+function ReporteInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [lev, setLev] = useState<LevReporte | null>(null);
+  const [lineas, setLineas] = useState<LineaParaRevisar[]>([]);
+  const [firmas, setFirmas] = useState<FirmaRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    const supabase = createSupabaseBrowserClient();
+
+    const [{ data: levRow, error: levErr }, lineasRes, { data: firmasRows }] = await Promise.all([
+      supabase
+        .schema('erp')
+        .from('inventario_levantamientos')
+        .select(
+          `id, folio, estado, fecha_programada, fecha_inicio, fecha_cierre, fecha_aplicado,
+           contador_id, notas, almacenes(nombre)`
+        )
+        .eq('id', id)
+        .is('deleted_at', null)
+        .maybeSingle(),
+      getLineasParaRevisar(id),
+      supabase
+        .schema('erp')
+        .from('inventario_levantamiento_firmas')
+        .select('id, paso, rol, firmante_nombre, firmado_at, comentario')
+        .eq('levantamiento_id', id)
+        .order('paso', { ascending: true }),
+    ]);
+
+    if (levErr) {
+      setError(levErr.message);
+      setLoading(false);
+      return;
+    }
+    if (!levRow) {
+      setError('Levantamiento no encontrado.');
+      setLoading(false);
+      return;
+    }
+    if (!lineasRes.ok) {
+      setError(lineasRes.error);
+      setLoading(false);
+      return;
+    }
+
+    type LevQuery = {
+      id: string;
+      folio: string | null;
+      estado: string;
+      fecha_programada: string;
+      fecha_inicio: string | null;
+      fecha_cierre: string | null;
+      fecha_aplicado: string | null;
+      contador_id: string | null;
+      notas: string | null;
+      almacenes: { nombre: string } | null;
+    };
+    const lr = levRow as unknown as LevQuery;
+
+    let contador_nombre: string | null = null;
+    if (lr.contador_id) {
+      const { data: u } = await supabase
+        .schema('core')
+        .from('usuarios')
+        .select('first_name, email')
+        .eq('id', lr.contador_id)
+        .maybeSingle();
+      if (u) contador_nombre = u.first_name?.trim() || u.email || null;
+    }
+
+    setLev({
+      id: lr.id,
+      folio: lr.folio,
+      estado: lr.estado,
+      fecha_programada: lr.fecha_programada,
+      fecha_inicio: lr.fecha_inicio,
+      fecha_cierre: lr.fecha_cierre,
+      fecha_aplicado: lr.fecha_aplicado,
+      almacen_nombre: lr.almacenes?.nombre ?? null,
+      contador_nombre,
+      notas: lr.notas,
+    });
+    setLineas(lineasRes.data);
+    setFirmas((firmasRows ?? []) as FirmaRow[]);
+    setLoading(false);
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Auto-print 400ms después de cargar (replica el patrón de handlePrintLista).
+  useEffect(() => {
+    if (loading || error || !lev) return;
+    const t = window.setTimeout(() => window.print(), 400);
+    return () => window.clearTimeout(t);
+  }, [loading, error, lev]);
+
+  const kpis = useMemo(() => {
+    const conDiff = lineas.filter((l) => (l.diferencia ?? 0) !== 0);
+    const fuera = lineas.filter((l) => l.fuera_de_tolerancia);
+    const ajusteNeto = lineas.reduce((s, l) => s + (Number(l.diferencia_valor) || 0), 0);
+    return {
+      total: lineas.length,
+      conDiff: conDiff.length,
+      fuera: fuera.length,
+      ajusteNeto,
+    };
+  }, [lineas]);
+
+  const conDiff = useMemo(() => lineas.filter((l) => (l.diferencia ?? 0) !== 0), [lineas]);
+  const fueraDeTolerancia = useMemo(() => lineas.filter((l) => l.fuera_de_tolerancia), [lineas]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-5xl space-y-4 px-4 py-6 print:hidden">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-96 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !lev) {
+    return (
+      <div className="container mx-auto max-w-5xl space-y-4 px-4 py-6">
+        <Link
+          href={`/rdb/inventario/levantamientos/${id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" /> Volver al levantamiento
+        </Link>
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Levantamiento no encontrado.'}
+        </div>
+      </div>
+    );
+  }
+
+  const fechaImpresion = formatDateTime(new Date().toISOString());
+
+  return (
+    <div className="reporte-root">
+      {/* Estilos print + screen específicos del reporte. Inyectados como
+          <style> simple — no usamos styled-jsx en el resto del repo. */}
+      <style
+        dangerouslySetInnerHTML={{
+          __html: REPORTE_STYLES,
+        }}
+      />
+
+      {/* ─── Encabezado de pantalla (oculto al imprimir) ─────────────── */}
+      <div className="reporte-screen-only border-b bg-background/95 px-4 py-3 backdrop-blur">
+        <div className="container mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-2">
+          <Link
+            href={`/rdb/inventario/levantamientos/${lev.id}`}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" /> Volver al levantamiento
+          </Link>
+          <div className="flex items-center gap-2">
+            <LevantamientoStatusBadge estado={lev.estado} />
+            <Button size="sm" onClick={() => window.print()}>
+              <Printer className="size-4" />
+              Imprimir
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* ─── Documento ────────────────────────────────────────────────── */}
+      <div className="reporte-doc container mx-auto max-w-5xl px-6 py-6">
+        {/* Membrete */}
+        <div className="mb-1">
+          <Image
+            src="/membrete-rdb.jpg"
+            alt="Rincón del Bosque"
+            width={1240}
+            height={300}
+            className="h-auto w-full"
+            priority
+          />
+        </div>
+
+        {/* Encabezado del reporte */}
+        <div className="mt-3 flex items-baseline justify-between border-b pb-3 text-xs">
+          <div>
+            <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+              Reporte de levantamiento físico
+            </span>
+            <h1 className="mt-1 text-xl font-bold tracking-tight">Folio {lev.folio ?? '—'}</h1>
+          </div>
+          <div className="text-right text-[11px] text-muted-foreground">
+            <div>Impreso: {fechaImpresion}</div>
+            {lev.fecha_aplicado && <div>Aplicado: {formatDateTime(lev.fecha_aplicado)}</div>}
+          </div>
+        </div>
+
+        {/* Metadata principal */}
+        <dl className="mt-4 grid grid-cols-2 gap-y-1.5 text-[11px] sm:grid-cols-4">
+          <Meta label="Almacén" value={lev.almacen_nombre ?? '—'} />
+          <Meta label="Programado" value={formatDateShort(lev.fecha_programada)} />
+          <Meta label="Inicio" value={formatDateTime(lev.fecha_inicio)} />
+          <Meta label="Cierre" value={formatDateTime(lev.fecha_aplicado ?? lev.fecha_cierre)} />
+          {lev.contador_nombre && <Meta label="Contador" value={lev.contador_nombre} colSpan={2} />}
+          {lev.notas && <Meta label="Notas" value={lev.notas} colSpan={4} />}
+        </dl>
+
+        {/* KPIs ejecutivos */}
+        <section className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <ReportKpi label="Productos" value={formatNumber(kpis.total)} />
+          <ReportKpi label="Con diferencia" value={formatNumber(kpis.conDiff)} />
+          <ReportKpi
+            label="Fuera de tolerancia"
+            value={formatNumber(kpis.fuera)}
+            highlight={kpis.fuera > 0 ? 'rojo' : undefined}
+          />
+          <ReportKpi
+            label="Ajuste neto"
+            value={formatCurrency(kpis.ajusteNeto)}
+            highlight={kpis.ajusteNeto < 0 ? 'rojo' : kpis.ajusteNeto > 0 ? 'verde' : undefined}
+          />
+        </section>
+
+        {/* Tabla de líneas con diferencia */}
+        <section className="mt-6">
+          <h2 className="mb-2 text-[11px] font-bold uppercase tracking-wider">
+            Líneas con diferencia ({conDiff.length})
+          </h2>
+          {conDiff.length === 0 ? (
+            <p className="rounded border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+              Sin diferencias — el conteo físico coincide con el sistema en todas las líneas.
+            </p>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Producto</th>
+                  <th>Categoría</th>
+                  <th className="num">Sistema</th>
+                  <th className="num">Contado</th>
+                  <th className="num">Δ</th>
+                  <th className="num">Δ $</th>
+                  <th>Tol.</th>
+                </tr>
+              </thead>
+              <tbody>
+                {conDiff.map((l) => (
+                  <tr key={l.linea_id}>
+                    <td>
+                      <div style={{ fontWeight: 600 }}>{l.producto_nombre}</div>
+                      <div className="gris" style={{ fontSize: '9.5px' }}>
+                        {l.producto_codigo}
+                      </div>
+                    </td>
+                    <td className="gris">{l.categoria ?? '—'}</td>
+                    <td className="num">
+                      {formatNumber(l.stock_efectivo)} {l.unidad}
+                    </td>
+                    <td className="num">
+                      {formatNumber(l.cantidad_contada)} {l.unidad}
+                    </td>
+                    <td
+                      className={`num ${l.fuera_de_tolerancia ? 'rojo' : (l.diferencia ?? 0) < 0 ? 'ambar' : 'verde'}`}
+                    >
+                      {(l.diferencia ?? 0) > 0 ? '+' : ''}
+                      {formatNumber(l.diferencia)} {l.unidad}
+                    </td>
+                    <td
+                      className={`num ${l.fuera_de_tolerancia ? 'rojo' : (l.diferencia_valor ?? 0) < 0 ? 'ambar' : ''}`}
+                    >
+                      {formatCurrency(l.diferencia_valor)}
+                    </td>
+                    <td>
+                      {l.fuera_de_tolerancia ? (
+                        <span className="rojo">Fuera</span>
+                      ) : (
+                        <span className="ambar">Dentro</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        {/* Sección de líneas fuera de tolerancia con notas */}
+        {fueraDeTolerancia.length > 0 && (
+          <section className="mt-6">
+            <h2 className="mb-2 text-[11px] font-bold uppercase tracking-wider">
+              Fuera de tolerancia — justificaciones ({fueraDeTolerancia.length})
+            </h2>
+            <ul className="space-y-2">
+              {fueraDeTolerancia.map((l) => (
+                <li
+                  key={l.linea_id}
+                  className="rounded border border-destructive/30 bg-destructive/5 p-2 text-[11px]"
+                >
+                  <div className="flex justify-between gap-2">
+                    <div>
+                      <strong>{l.producto_nombre}</strong>{' '}
+                      <span className="gris">({l.producto_codigo})</span>
+                    </div>
+                    <div className="rojo">
+                      Δ {formatNumber(l.diferencia)} {l.unidad} (
+                      {formatCurrency(l.diferencia_valor)})
+                    </div>
+                  </div>
+                  <div className="mt-1">
+                    {l.notas_diferencia ? (
+                      <span style={{ whiteSpace: 'pre-wrap' }}>{l.notas_diferencia}</span>
+                    ) : (
+                      <span className="gris" style={{ fontStyle: 'italic' }}>
+                        Sin nota registrada.
+                      </span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {/* Pie con firmas */}
+        <section className="reporte-firmas mt-8">
+          <h2 className="mb-3 text-[11px] font-bold uppercase tracking-wider">
+            Firmas {firmas.length > 0 ? `(${firmas.length})` : ''}
+          </h2>
+          {firmas.length === 0 ? (
+            <p className="rounded border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+              Sin firmas registradas para este levantamiento.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
+              {firmas.map((f) => (
+                <div key={f.id} className="text-[11px]">
+                  <div className="border-b border-foreground pb-12" />
+                  <div className="mt-1 font-semibold">{f.firmante_nombre}</div>
+                  <div className="text-muted-foreground capitalize">
+                    {f.rol} · paso {f.paso}
+                  </div>
+                  <div className="text-muted-foreground">{formatDateTime(f.firmado_at)}</div>
+                  {f.comentario && <div className="mt-1 italic">&ldquo;{f.comentario}&rdquo;</div>}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Nota de movimientos generados */}
+        {lev.estado === 'aplicado' && (
+          <section className="mt-6 rounded border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+            Ajustes contables generados — referencia <strong>{lev.folio ?? '—'}</strong> ·{' '}
+            {kpis.conDiff} movimiento{kpis.conDiff === 1 ? '' : 's'} de inventario.
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Meta({ label, value, colSpan }: { label: string; value: string; colSpan?: 2 | 4 }) {
+  const span = colSpan === 4 ? 'sm:col-span-4' : colSpan === 2 ? 'sm:col-span-2' : '';
+  return (
+    <div className={span}>
+      <dt className="text-[9.5px] uppercase tracking-wider text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{value}</dd>
+    </div>
+  );
+}
+
+function ReportKpi({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: string;
+  highlight?: 'rojo' | 'verde';
+}) {
+  const tone =
+    highlight === 'rojo'
+      ? 'text-destructive'
+      : highlight === 'verde'
+        ? 'text-emerald-700'
+        : 'text-foreground';
+  return (
+    <div className="rounded border bg-card px-3 py-2">
+      <div className="text-[9.5px] uppercase tracking-wider text-muted-foreground">{label}</div>
+      <div className={`mt-0.5 text-base font-bold tabular-nums ${tone}`}>{value}</div>
+    </div>
+  );
+}

--- a/app/rdb/inventario/levantamientos/actions.ts
+++ b/app/rdb/inventario/levantamientos/actions.ts
@@ -6,6 +6,7 @@
 import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import type { Json } from '@/types/supabase';
 import {
   RDB_EMPRESA_ID,
@@ -197,4 +198,82 @@ export async function getLineasParaRevisar(
 
   if (error) return { ok: false, error: error.message };
   return { ok: true, data: (data ?? []) as LineaParaRevisar[] };
+}
+
+// ─── Notas de diferencia ──────────────────────────────────────────────────────
+//
+// El UPDATE directo a `inventario_levantamiento_lineas.notas_diferencia` está
+// bloqueado por la RLS de la tabla (solo el trigger de `fn_guardar_conteo` tiene
+// permiso de escritura). Para que el contador pueda anotar la justificación
+// post-captura, esta acción usa el cliente service-role tras validar:
+//   1. Hay sesión.
+//   2. El levantamiento existe, está en estado `capturado` y la línea le
+//      pertenece.
+//   3. El usuario es el contador del levantamiento.
+//
+// Migrar a una RPC dedicada queda como follow-up (sub-PR de DB) si el patrón
+// se repite — por ahora B2 lo absorbe acá para no bloquear la UI de revisión.
+export async function actualizarNotaDiferencia(
+  linea_id: string,
+  nota: string
+): Promise<ActionResult> {
+  const supabase = await createSupabaseServerClient();
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.user) {
+    return { ok: false, error: 'No autenticado. Vuelve a iniciar sesión.' };
+  }
+
+  // 1) Lookup de la línea + levantamiento (RLS de levantamientos permite SELECT
+  //    por miembros de la empresa; lineas no — por eso buscamos vía join al
+  //    levantamiento usando service-role).
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return { ok: false, error: 'Cliente service-role no disponible en este entorno.' };
+  }
+
+  const { data: linea, error: lineaErr } = await admin
+    .schema('erp')
+    .from('inventario_levantamiento_lineas')
+    .select('id, levantamiento_id')
+    .eq('id', linea_id)
+    .maybeSingle();
+
+  if (lineaErr) return { ok: false, error: lineaErr.message };
+  if (!linea) return { ok: false, error: 'Línea no encontrada.' };
+
+  const { data: lev, error: levErr } = await admin
+    .schema('erp')
+    .from('inventario_levantamientos')
+    .select('id, estado, contador_id')
+    .eq('id', linea.levantamiento_id)
+    .maybeSingle();
+
+  if (levErr) return { ok: false, error: levErr.message };
+  if (!lev) return { ok: false, error: 'Levantamiento no encontrado.' };
+
+  if (lev.estado !== 'capturado') {
+    return {
+      ok: false,
+      error: `Solo se pueden editar notas mientras el levantamiento está en revisión (estado actual: ${lev.estado}).`,
+    };
+  }
+  if (lev.contador_id !== session.user.id) {
+    return { ok: false, error: 'Solo el contador puede editar las notas de diferencia.' };
+  }
+
+  const trimmed = nota.trim();
+  const { error: updErr } = await admin
+    .schema('erp')
+    .from('inventario_levantamiento_lineas')
+    .update({ notas_diferencia: trimmed.length > 0 ? trimmed : null })
+    .eq('id', linea_id);
+
+  if (updErr) return { ok: false, error: updErr.message };
+
+  revalidatePath(`/rdb/inventario/levantamientos/${linea.levantamiento_id}`);
+  revalidatePath(`/rdb/inventario/levantamientos/${linea.levantamiento_id}/diferencias`);
+  return { ok: true };
 }

--- a/app/rdb/inventario/levantamientos/types.ts
+++ b/app/rdb/inventario/levantamientos/types.ts
@@ -34,8 +34,9 @@ export type LineaParaCapturar = {
   producto_codigo: string;
   producto_nombre: string;
   unidad: string;
-  categoria: string;
-  cantidad_contada: number;
+  categoria: string | null;
+  /** NULL hasta que el contador la captura. Use `contado_at` como fuente de verdad de "ya contada". */
+  cantidad_contada: number | null;
   contado_at: string | null;
   recontada: boolean;
 };
@@ -46,14 +47,15 @@ export type LineaParaRevisar = {
   producto_codigo: string;
   producto_nombre: string;
   unidad: string;
-  categoria: string;
-  costo_unitario: number;
+  categoria: string | null;
+  costo_unitario: number | null;
   stock_inicial: number;
   salidas_durante_captura: number;
   stock_efectivo: number;
-  cantidad_contada: number;
-  diferencia: number;
-  diferencia_valor: number;
+  /** Puede ser NULL si la línea quedó sin contar al cerrar la captura. */
+  cantidad_contada: number | null;
+  diferencia: number | null;
+  diferencia_valor: number | null;
   fuera_de_tolerancia: boolean;
   notas_diferencia: string | null;
   contado_at: string | null;

--- a/hooks/use-captura-queue.ts
+++ b/hooks/use-captura-queue.ts
@@ -1,0 +1,243 @@
+'use client';
+
+/**
+ * useCapturaQueue — cola offline-tolerant para conteos de levantamiento.
+ *
+ * Envuelve `guardarConteo` (server action) con una cola persistente:
+ *   1. `guardar(c)` encola en IndexedDB y dispara un sync inmediato.
+ *   2. Si la red falla, el conteo queda en cola; un listener `online` y un
+ *      poll de 30s lo reintentan.
+ *   3. Si IndexedDB no está disponible (Safari ITP, modo privado), degrada
+ *      a `localStorage` con el mismo contrato.
+ *
+ * El hook NO bloquea la captura: `guardar()` resuelve apenas el conteo queda
+ * persistido localmente. La UI muestra `pendientes` para informar al usuario
+ * que hay sync en vuelo.
+ *
+ * Diseño deliberado:
+ *   - Sin dependencias externas (no idb/dexie). Wrapper minimalista contra
+ *     la API nativa, suficiente para un solo object store.
+ *   - FIFO estricto: id auto-incremental garantiza que se reenvían en el
+ *     orden en que se capturaron (importante si el contador edita un mismo
+ *     producto dos veces — solo el último valor debe quedar).
+ *   - Si una llamada al server action falla, la sincronización se detiene
+ *     y deja el resto de la cola para el próximo intento. Evita rafagas
+ *     contra el endpoint cuando el problema es transitorio.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { guardarConteo } from '@/app/rdb/inventario/levantamientos/actions';
+
+export type Conteo = {
+  lev_id: string;
+  producto_id: string;
+  cantidad: number;
+  /** Unix ms — útil para auditar latencia entre captura y sync. */
+  ts: number;
+};
+
+export type UseCapturaQueueResult = {
+  /** Encola un conteo y dispara sync inmediato; nunca lanza. */
+  guardar: (c: Conteo) => Promise<void>;
+  /** Conteos que aún no han sincronizado al servidor. */
+  pendientes: number;
+  /** True mientras hay un drain de la cola en vuelo. */
+  syncing: boolean;
+  /** True cuando IndexedDB no está disponible y se usa localStorage. */
+  fallbackMode: boolean;
+};
+
+const DB_NAME = 'bsop-captura-queue';
+const STORE_NAME = 'pending_conteos';
+const DB_VERSION = 1;
+const LS_KEY = 'bsop-captura-queue-fallback';
+const SYNC_INTERVAL_MS = 30_000;
+
+type Stored = Conteo & { id: number };
+
+// ─── IndexedDB wrapper minimalista ────────────────────────────────────────────
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function dbAdd(db: IDBDatabase, c: Conteo): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).add(c);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function dbGetAll(db: IDBDatabase): Promise<Stored[]> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).getAll();
+    req.onsuccess = () => resolve((req.result as Stored[]) ?? []);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function dbDelete(db: IDBDatabase, id: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+function dbCount(db: IDBDatabase): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).count();
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+// ─── localStorage fallback (Safari ITP, modo privado) ─────────────────────────
+
+function lsRead(): Stored[] {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    return raw ? (JSON.parse(raw) as Stored[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function lsWrite(items: Stored[]): void {
+  try {
+    localStorage.setItem(LS_KEY, JSON.stringify(items));
+  } catch {
+    // Cuota excedida — el sync periódico drenará en cuanto la red responda.
+  }
+}
+
+// ─── hook ─────────────────────────────────────────────────────────────────────
+
+export function useCapturaQueue(): UseCapturaQueueResult {
+  const [pendientes, setPendientes] = useState(0);
+  const [syncing, setSyncing] = useState(false);
+  const [fallbackMode, setFallbackMode] = useState(false);
+
+  const dbRef = useRef<IDBDatabase | null>(null);
+  const fallbackIdRef = useRef(1);
+  const syncingRef = useRef(false);
+  const initializedRef = useRef(false);
+
+  const refreshCount = useCallback(async (): Promise<number> => {
+    if (dbRef.current) return dbCount(dbRef.current);
+    return lsRead().length;
+  }, []);
+
+  const sync = useCallback(async (): Promise<void> => {
+    if (syncingRef.current || !initializedRef.current) return;
+    syncingRef.current = true;
+    setSyncing(true);
+    try {
+      let items: Stored[];
+      if (dbRef.current) {
+        items = await dbGetAll(dbRef.current);
+      } else {
+        items = lsRead();
+      }
+      items.sort((a, b) => a.id - b.id);
+
+      for (const it of items) {
+        const res = await guardarConteo(it.lev_id, it.producto_id, it.cantidad);
+        if (!res.ok) break;
+        if (dbRef.current) {
+          await dbDelete(dbRef.current, it.id);
+        } else {
+          lsWrite(lsRead().filter((x) => x.id !== it.id));
+        }
+      }
+
+      setPendientes(await refreshCount());
+    } catch {
+      // No re-lanzar — el próximo tick de 30s reintenta.
+    } finally {
+      syncingRef.current = false;
+      setSyncing(false);
+    }
+  }, [refreshCount]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        if (typeof indexedDB === 'undefined') throw new Error('IndexedDB no disponible');
+        const db = await openDb();
+        if (cancelled) {
+          db.close();
+          return;
+        }
+        dbRef.current = db;
+        setPendientes(await dbCount(db));
+      } catch {
+        if (cancelled) return;
+        setFallbackMode(true);
+        const items = lsRead();
+        fallbackIdRef.current = items.reduce((m, it) => Math.max(m, it.id), 0) + 1;
+        setPendientes(items.length);
+      } finally {
+        if (!cancelled) {
+          initializedRef.current = true;
+          // Drain inicial — si quedó cola de una sesión anterior, vacía ahora.
+          void sync();
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sync]);
+
+  useEffect(() => {
+    const onOnline = () => void sync();
+    window.addEventListener('online', onOnline);
+    const tick = window.setInterval(() => {
+      if (pendientes > 0) void sync();
+    }, SYNC_INTERVAL_MS);
+    return () => {
+      window.removeEventListener('online', onOnline);
+      window.clearInterval(tick);
+    };
+  }, [sync, pendientes]);
+
+  const guardar = useCallback(
+    async (c: Conteo): Promise<void> => {
+      if (dbRef.current) {
+        await dbAdd(dbRef.current, c);
+      } else if (fallbackMode) {
+        const id = fallbackIdRef.current++;
+        const items = lsRead();
+        items.push({ ...c, id });
+        lsWrite(items);
+      } else {
+        // Init aún en vuelo (raro). Llamar directo y degradar silenciosamente.
+        const res = await guardarConteo(c.lev_id, c.producto_id, c.cantidad);
+        if (!res.ok) throw new Error(res.error);
+        return;
+      }
+      setPendientes(await refreshCount());
+      void sync();
+    },
+    [fallbackMode, refreshCount, sync]
+  );
+
+  return { guardar, pendientes, syncing, fallbackMode };
+}


### PR DESCRIPTION
## Summary

Sub-PR B2 del módulo de levantamientos físicos de inventario. PR #192 entregó schema y RPCs; PR #195 entregó componentes compartidos + lista + alta. Este PR conecta las pantallas operativas a las RPCs y suma el hook offline.

- **Detalle** [\`/rdb/inventario/levantamientos/[id]\`](app/rdb/inventario/levantamientos/[id]/page.tsx) — UI distinta por estado (borrador → capturando → capturado → aplicado → cancelado). KPIs cuando hay revisión, lista de líneas fuera de tolerancia con notas inline, breadcrumb. Placeholder de firma con dialog \"B3 próximamente\".
- **Captura mobile a ciegas** [\`/[id]/capturar\`](app/rdb/inventario/levantamientos/[id]/capturar/page.tsx) — buscador con autofocus + scanner USB-HID (Enter), NumPad full-width, recontado, lista de pendientes y de ya contados, indicador de sync, sin \`stock_inicial\` (verificar en network tab que \`fn_get_lineas_para_capturar\` no lo devuelve).
- **Diferencias** [\`/[id]/diferencias\`](app/rdb/inventario/levantamientos/[id]/diferencias/page.tsx) — tabla con filtros, edición inline de \`notas_diferencia\` (solo contador en estado \`capturado\`), exportar CSV.
- **Reporte print-friendly** [\`/[id]/reporte\`](app/rdb/inventario/levantamientos/[id]/reporte/page.tsx) — membrete RDB, KPIs, líneas con diferencia, sección de fuera de tolerancia con notas, bloques de firma. Auto-\`window.print()\` a 400 ms (mismo patrón que \`handlePrintLista\`).
- **Hook offline** [\`hooks/use-captura-queue.ts\`](hooks/use-captura-queue.ts) — cola IndexedDB con fallback a localStorage, listener \`online\`, reintento cada 30s. Cero dependencias nuevas.
- **Server action** \`actualizarNotaDiferencia\` — usa cliente service-role porque la RLS de \`inventario_levantamiento_lineas\` bloquea UPDATE directo. Valida \`estado='capturado'\` + \`user.id === contador_id\` antes de escribir.
- **Types** — \`cantidad_contada\`, \`diferencia\`, \`diferencia_valor\`, \`categoria\` y \`costo_unitario\` ahora nullable; refleja la realidad del SQL (las RPCs no hacen \`COALESCE\`).

### Notas de diseño

- **service-role para notas:** documentado en el comment de la action. Migrar a una RPC dedicada (\`fn_actualizar_nota_diferencia\`) queda como follow-up de DB si el patrón se repite.
- **Cierre con pendientes:** dialog que llama \`guardarConteo(producto, 0)\` por cada pendiente antes de \`cerrarCaptura\`. La RPC de cierre no auto-zerea NULLs (solo deja \`diferencia=NULL\`), así que la UI lo hace explícito.
- **Link \`?ref=lev:{id}\`:** la página \`/rdb/inventario\` aún no filtra movimientos por \`referencia_id\` desde URL. El query param queda para wireup futuro (no rompe nada hoy).

## Test plan

- [ ] \`/rdb/inventario/levantamientos/[id]\` carga para los 5 estados sin error
- [ ] Captura mobile no muestra \`stock_inicial\` (HTML + network tab)
- [ ] Capturar 3 productos vía UI persiste (SELECT como admin)
- [ ] Cerrar la red, capturar 2 más → indicador de pendientes; reabrir red → sync automático
- [ ] Cerrar captura con pendientes → dialog → todos los \`cantidad_contada IS NULL\` quedan en 0
- [ ] Diferencias muestra \`<VarianceCell>\` con tonos correctos; fuera de tolerancia con highlight rojo
- [ ] Reporte imprime con membrete y firmas (validar contra un levantamiento aplicado o con bloques vacíos)
- [ ] Edición de \`notas_diferencia\` solo habilitada para el contador
- [ ] Lint, typecheck, vitest y build de producción ✓ (validados en este worktree)

## Pendiente para B3

- Dialog de firma electrónica (\`firmarPaso\` action ya existe desde B1)
- Suite e2e Playwright cubriendo el ciclo completo borrador → aplicado
- Opcional: RPC \`fn_actualizar_nota_diferencia\` para reemplazar el service-role de \`actualizarNotaDiferencia\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)