### PR TITLE
feat(rdb-inventario): UI levantamientos sub-PR B3 — firma + auto-aplicación + e2e

### DIFF
--- a/app/rdb/inventario/levantamientos/[id]/page.tsx
+++ b/app/rdb/inventario/levantamientos/[id]/page.tsx
@@ -38,6 +38,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
+import { usePermissions } from '@/components/providers';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -54,6 +55,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { SignatureDialog } from '@/components/ui/signature-dialog';
 import { useToast } from '@/components/ui/toast';
 import {
   LevantamientoStatusBadge,
@@ -71,6 +73,7 @@ import {
 import {
   actualizarNotaDiferencia,
   cerrarCaptura,
+  firmarPaso,
   getLineasParaCapturar,
   getLineasParaRevisar,
   guardarConteo,
@@ -122,6 +125,8 @@ function DetailInner() {
   const id = params.id;
   const router = useRouter();
   const toast = useToast();
+  const { permissions } = usePermissions();
+  const isAdmin = permissions.isAdmin;
 
   const [lev, setLev] = useState<LevantamientoFull | null>(null);
   const [tolerancia, setTolerancia] = useState<ToleranciaConfig | null>(null);
@@ -201,7 +206,9 @@ function DetailInner() {
       if (r.ok) setRevisarLineas(r.data);
     }
 
-    if (levantamiento.estado === 'aplicado') {
+    // Firmas: necesarias en `capturado` para saber qué paso falta y en
+    // `aplicado` para mostrar la lista final.
+    if (levantamiento.estado === 'capturado' || levantamiento.estado === 'aplicado') {
       const fRes = await supabase
         .schema('erp')
         .from('inventario_levantamiento_firmas')
@@ -355,9 +362,22 @@ function DetailInner() {
         <CapturadoSection
           lev={lev}
           esContador={esContador}
+          isAdmin={isAdmin}
           tolerancia={tolerancia}
           lineas={revisarLineas}
+          firmas={firmas}
           onLineasChange={setRevisarLineas}
+          onFirmaSuccess={(aplicado) => {
+            if (aplicado) {
+              router.push(`/rdb/inventario/levantamientos/${lev.id}/reporte`);
+            } else {
+              void load();
+            }
+          }}
+          onError={(msg) =>
+            toast.add({ title: 'No se pudo firmar', description: msg, type: 'error' })
+          }
+          onFirmaToast={(title, description) => toast.add({ title, description, type: 'success' })}
         />
       )}
 
@@ -545,15 +565,25 @@ function CapturandoSection({
 function CapturadoSection({
   lev,
   esContador,
+  isAdmin,
   tolerancia,
   lineas,
+  firmas,
   onLineasChange,
+  onFirmaSuccess,
+  onError,
+  onFirmaToast,
 }: {
   lev: LevantamientoFull;
   esContador: boolean;
+  isAdmin: boolean;
   tolerancia: ToleranciaConfig | null;
   lineas: LineaParaRevisar[] | null;
+  firmas: FirmaRow[] | null;
   onLineasChange: (next: LineaParaRevisar[]) => void;
+  onFirmaSuccess: (aplicado: boolean) => void;
+  onError: (msg: string) => void;
+  onFirmaToast: (title: string, description?: string) => void;
 }) {
   const kpis = useMemo(() => {
     const all = lineas ?? [];
@@ -621,10 +651,229 @@ function CapturadoSection({
               Ver diferencias detalladas
             </Button>
           </Link>
-          <FirmarPlaceholderButton />
+          <FirmarSection
+            lev={lev}
+            esContador={esContador}
+            isAdmin={isAdmin}
+            tolerancia={tolerancia}
+            lineas={lineas}
+            firmas={firmas}
+            kpis={kpis}
+            onSuccess={onFirmaSuccess}
+            onError={onError}
+            onToast={onFirmaToast}
+          />
         </div>
+
+        {firmas && firmas.length > 0 && (
+          <FirmasParcialesList firmas={firmas} firmasRequeridas={tolerancia?.firmas_requeridas} />
+        )}
       </section>
     </>
+  );
+}
+
+// ─── Firma electrónica (B3) ──────────────────────────────────────────────────
+
+const PASO_ROL_3_FIRMAS = ['contador', 'revisor', 'autorizador'] as const;
+const PASO_ROL_2_FIRMAS = ['contador', 'autorizador'] as const;
+const PASO_ROL_1_FIRMA = ['contador'] as const;
+
+const ROL_LABEL: Record<string, 'Contador' | 'Revisor' | 'Autorizador'> = {
+  contador: 'Contador',
+  revisor: 'Revisor',
+  autorizador: 'Autorizador',
+};
+
+/**
+ * Mapea (paso, firmas_requeridas) → rol, replicando la convención de la
+ * función SQL `fn_firmar_levantamiento` y del config por empresa.
+ */
+function rolForPaso(paso: number, firmasRequeridas: number): string | null {
+  let arr: readonly string[];
+  if (firmasRequeridas <= 1) arr = PASO_ROL_1_FIRMA;
+  else if (firmasRequeridas === 2) arr = PASO_ROL_2_FIRMAS;
+  else arr = PASO_ROL_3_FIRMAS;
+  return arr[paso - 1] ?? null;
+}
+
+function FirmarSection({
+  lev,
+  esContador,
+  isAdmin,
+  tolerancia,
+  lineas,
+  firmas,
+  kpis,
+  onSuccess,
+  onError,
+  onToast,
+}: {
+  lev: LevantamientoFull;
+  esContador: boolean;
+  isAdmin: boolean;
+  tolerancia: ToleranciaConfig | null;
+  lineas: LineaParaRevisar[] | null;
+  firmas: FirmaRow[] | null;
+  kpis: { total: number; conDiff: number; fuera: number; ajusteNeto: number };
+  onSuccess: (aplicado: boolean) => void;
+  onError: (msg: string) => void;
+  onToast: (title: string, description?: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const firmasRequeridas = tolerancia?.firmas_requeridas ?? 3;
+  const firmasActuales = firmas?.length ?? 0;
+  const pasoActual = firmasActuales + 1;
+  const rolActual = rolForPaso(pasoActual, firmasRequeridas);
+  const completas = firmasActuales >= firmasRequeridas;
+
+  // Pre-condición: toda línea fuera de tolerancia debe tener nota.
+  const fueraSinNota = useMemo(() => {
+    if (!lineas) return 0;
+    return lineas.filter(
+      (l) =>
+        l.fuera_de_tolerancia && (l.notas_diferencia == null || l.notas_diferencia.trim() === '')
+    ).length;
+  }, [lineas]);
+
+  // Permisos del paso actual.
+  const puedeFirmarPasoActual = useMemo(() => {
+    if (rolActual == null) return false;
+    if (isAdmin) return true;
+    if (rolActual === 'contador') return esContador;
+    // revisor/autorizador: cualquier miembro de la empresa con acceso al módulo.
+    // RequireAccess ya gateó el módulo, así que basta con tener sesión.
+    return true;
+  }, [rolActual, esContador, isAdmin]);
+
+  // Mensaje de tooltip / disabled.
+  const disabledReason = useMemo(() => {
+    if (completas) return 'Levantamiento ya tiene todas las firmas requeridas.';
+    if (fueraSinNota > 0) {
+      return `Hay ${fueraSinNota} línea${fueraSinNota === 1 ? '' : 's'} fuera de tolerancia sin justificación — captura las notas antes de firmar.`;
+    }
+    if (!puedeFirmarPasoActual && rolActual === 'contador') {
+      return 'Solo el contador asignado puede firmar el paso 1.';
+    }
+    return null;
+  }, [completas, fueraSinNota, puedeFirmarPasoActual, rolActual]);
+
+  const disabled = disabledReason != null;
+
+  if (completas || rolActual == null) {
+    // Si llegamos al máximo de firmas en estado=capturado, está pendiente la
+    // próxima carga: no mostramos botón.
+    return null;
+  }
+
+  const roleLabel = ROL_LABEL[rolActual];
+  const requireConfirmText =
+    pasoActual === 1 ? 'He contado físicamente cada producto declarado.' : null;
+
+  async function handleSign(comment: string) {
+    const res = await firmarPaso({
+      levantamiento_id: lev.id,
+      paso: pasoActual,
+      rol: rolActual!,
+      comentario: comment || undefined,
+    });
+    if (!res.ok) {
+      // Errores de la RPC los propagamos al dialog (inline) y al toast.
+      onError(res.error);
+      return { error: res.error };
+    }
+
+    if (res.data.aplicado) {
+      onToast(
+        'Levantamiento aplicado',
+        `${res.data.movimientos_generados} movimiento${res.data.movimientos_generados === 1 ? '' : 's'} de ajuste generado${res.data.movimientos_generados === 1 ? '' : 's'}.`
+      );
+    } else {
+      const faltan = res.data.firmas_requeridas - res.data.firmas_actuales;
+      onToast(
+        'Firma registrada',
+        `Faltan ${faltan} firma${faltan === 1 ? '' : 's'} para aplicar el levantamiento.`
+      );
+    }
+    onSuccess(res.data.aplicado);
+    return {
+      aplicado: res.data.aplicado,
+      firmasActuales: res.data.firmas_actuales,
+      firmasRequeridas: res.data.firmas_requeridas,
+      movimientosGenerados: res.data.movimientos_generados,
+    };
+  }
+
+  // El total de "diferencia" que mostramos en el dialog es el ajuste neto.
+  const summary = {
+    totalLineas: kpis.total,
+    totalDiferencia: kpis.ajusteNeto,
+    totalLineasFuera: kpis.fuera,
+  };
+
+  return (
+    <>
+      <Button
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        title={disabledReason ?? `Firmar como ${roleLabel}`}
+        data-testid="firmar-button"
+      >
+        <FileSignature className="size-4" />
+        Firmar como {roleLabel}
+      </Button>
+      {disabled && disabledReason && (
+        <p className="basis-full text-xs text-amber-700 dark:text-amber-400">{disabledReason}</p>
+      )}
+      <SignatureDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        step={pasoActual}
+        totalSteps={firmasRequeridas}
+        roleLabel={roleLabel}
+        summary={summary}
+        requireConfirmText={requireConfirmText}
+        onSign={handleSign}
+      />
+    </>
+  );
+}
+
+function FirmasParcialesList({
+  firmas,
+  firmasRequeridas,
+}: {
+  firmas: FirmaRow[];
+  firmasRequeridas: number | undefined;
+}) {
+  if (firmas.length === 0) return null;
+  return (
+    <div className="mt-4 border-t pt-3">
+      <div className="text-xs uppercase tracking-wider text-muted-foreground">
+        Firmas registradas ({firmas.length}
+        {firmasRequeridas ? ` / ${firmasRequeridas}` : ''})
+      </div>
+      <ul className="mt-2 space-y-1.5">
+        {firmas.map((f) => (
+          <li
+            key={f.id}
+            className="flex flex-wrap items-baseline justify-between gap-2 rounded-md bg-muted/30 px-2 py-1.5 text-xs"
+          >
+            <div>
+              <Badge variant="outline" className="mr-2 capitalize">
+                {f.rol}
+              </Badge>
+              <span className="font-medium">{f.firmante_nombre}</span>
+              {f.comentario && <span className="ml-1 text-muted-foreground">— {f.comentario}</span>}
+            </div>
+            <span className="tabular-nums text-muted-foreground">
+              Paso {f.paso} · {formatDateTime(f.firmado_at)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -755,33 +1004,6 @@ function FueraLineaRow({
         )}
       </div>
     </li>
-  );
-}
-
-function FirmarPlaceholderButton() {
-  const [open, setOpen] = useState(false);
-  return (
-    <>
-      <Button onClick={() => setOpen(true)}>
-        <FileSignature className="size-4" />
-        Firmar
-      </Button>
-      <AlertDialog open={open} onOpenChange={setOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Firma electrónica — próximamente</AlertDialogTitle>
-            <AlertDialogDescription>
-              La firma del levantamiento se implementa en el sub-PR B3. Mientras tanto, el
-              levantamiento puede seguir consultándose y editando notas. Si necesitas firmar antes
-              de B3, escribe a soporte para hacerlo manualmente.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Entendido</AlertDialogCancel>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
   );
 }
 

--- a/app/rdb/inventario/levantamientos/nuevo/page.tsx
+++ b/app/rdb/inventario/levantamientos/nuevo/page.tsx
@@ -177,7 +177,9 @@ function NuevoLevantamientoForm() {
       } sembrado${startRes.data.lineasSembradas === 1 ? '' : 's'}.`,
       type: 'success',
     });
-    router.push('/rdb/inventario/levantamientos');
+    // Si pidió "Iniciar captura ahora", llevamos directo a la captura mobile —
+    // ahorra un hop por la lista cuando ya sabe lo que va a hacer.
+    router.push(`/rdb/inventario/levantamientos/${result.data.id}/capturar`);
   };
 
   return (

--- a/components/ui/signature-dialog.tsx
+++ b/components/ui/signature-dialog.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+/**
+ * SignatureDialog — diálogo de firma electrónica reusable.
+ *
+ * Renderiza un resumen de cifras + checkbox de afirmación opcional + comentario
+ * opcional y dispara `onSign(comment)`. La UI no decide cuándo aplica un
+ * documento — solo dispara la firma; el caller redirige si la respuesta marca
+ * `aplicado=true`.
+ *
+ * Inicialmente lo consume `app/rdb/inventario/levantamientos/[id]/page.tsx`,
+ * pero se mantiene en `components/ui/` porque juntas y requisiciones lo
+ * reutilizarán a futuro.
+ */
+
+import { useState } from 'react';
+import { CheckCircle2, FileSignature, Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+
+export type SignatureDialogResult = {
+  aplicado: boolean;
+  firmasActuales: number;
+  firmasRequeridas: number;
+  movimientosGenerados: number;
+};
+
+export type SignatureDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  step: number;
+  totalSteps: number;
+  roleLabel: 'Contador' | 'Revisor' | 'Autorizador';
+  summary: {
+    totalLineas: number;
+    totalDiferencia: number | null;
+    totalLineasFuera: number;
+  };
+  /**
+   * Texto adicional que el usuario debe leer antes de firmar.
+   * Use null para no mostrarlo. Por convención, paso=1 incluye
+   * "He contado físicamente cada producto declarado".
+   */
+  requireConfirmText: string | null;
+  /**
+   * Llama el server action de firma. La UI solo dispara, NO decide
+   * el resultado: si la respuesta tiene `aplicado=true`, este callback
+   * debe propagar para que el caller redirija al reporte.
+   *
+   * Devuelve `null` cuando hubo error (que se muestra inline).
+   */
+  onSign: (comment: string) => Promise<SignatureDialogResult | { error: string }>;
+};
+
+const LEGAL_TEXT =
+  'Al firmar declaras que has revisado el conteo y que la información es ' +
+  'correcta. Esta firma queda registrada con timestamp e IP, y no es reversible.';
+
+const FORMATTER_NUM = new Intl.NumberFormat('es-MX', { maximumFractionDigits: 2 });
+const FORMATTER_CURR = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+});
+
+export function SignatureDialog({
+  open,
+  onClose,
+  step,
+  totalSteps,
+  roleLabel,
+  summary,
+  requireConfirmText,
+  onSign,
+}: SignatureDialogProps) {
+  const [comment, setComment] = useState('');
+  const [confirmChecked, setConfirmChecked] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requiresConfirm = requireConfirmText != null;
+  const canSubmit = !submitting && (!requiresConfirm || confirmChecked);
+
+  function resetState() {
+    setComment('');
+    setConfirmChecked(false);
+    setError(null);
+    setSubmitting(false);
+  }
+
+  function handleClose() {
+    if (submitting) return;
+    resetState();
+    onClose();
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    const res = await onSign(comment.trim());
+    if ('error' in res) {
+      setError(res.error);
+      setSubmitting(false);
+      return;
+    }
+    // Éxito: limpiamos y cerramos. El caller hace redirect/toast.
+    resetState();
+    onClose();
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) handleClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileSignature className="size-4" />
+            Firmar como {roleLabel}
+          </DialogTitle>
+          <DialogDescription>
+            Paso {step} de {totalSteps}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Resumen compacto: 3 stats. Tabular-nums + neutral. No usamos
+            <KpiCard> aquí para no inflar el dialog visualmente. */}
+        <div
+          data-slot="signature-summary"
+          className="grid grid-cols-3 gap-2 rounded-md border bg-muted/30 p-3 text-center text-xs"
+        >
+          <Stat label="Líneas" value={FORMATTER_NUM.format(summary.totalLineas)} />
+          <Stat
+            label="Δ Total"
+            value={
+              summary.totalDiferencia == null ? '—' : FORMATTER_CURR.format(summary.totalDiferencia)
+            }
+            tone={
+              (summary.totalDiferencia ?? 0) < 0
+                ? 'destructive'
+                : (summary.totalDiferencia ?? 0) > 0
+                  ? 'success'
+                  : 'default'
+            }
+          />
+          <Stat
+            label="Fuera de tol."
+            value={FORMATTER_NUM.format(summary.totalLineasFuera)}
+            tone={summary.totalLineasFuera > 0 ? 'warning' : 'default'}
+          />
+        </div>
+
+        <p className="text-xs text-muted-foreground">{LEGAL_TEXT}</p>
+
+        {requiresConfirm && (
+          <label className="flex items-start gap-2 rounded-md border bg-card p-2 text-xs">
+            <input
+              type="checkbox"
+              checked={confirmChecked}
+              onChange={(e) => setConfirmChecked(e.target.checked)}
+              disabled={submitting}
+              className="mt-0.5 size-3.5 rounded border-input accent-primary"
+              data-testid="signature-confirm-checkbox"
+            />
+            <span>{requireConfirmText}</span>
+          </label>
+        )}
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground" htmlFor="signature-comment">
+            Comentario (opcional)
+          </label>
+          <Textarea
+            id="signature-comment"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            disabled={submitting}
+            rows={2}
+            placeholder="Notas, observaciones o aclaraciones."
+            className="text-sm"
+          />
+        </div>
+
+        {error && (
+          <p className="rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+            {error}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={submitting}>
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            data-testid="signature-confirm-button"
+          >
+            {submitting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <CheckCircle2 className="size-4" />
+            )}
+            Confirmar firma
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: string;
+  tone?: 'default' | 'success' | 'warning' | 'destructive';
+}) {
+  const toneClass =
+    tone === 'destructive'
+      ? 'text-destructive'
+      : tone === 'success'
+        ? 'text-emerald-600 dark:text-emerald-400'
+        : tone === 'warning'
+          ? 'text-amber-600 dark:text-amber-400'
+          : 'text-foreground';
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</div>
+      <div className={`mt-0.5 text-sm font-semibold tabular-nums ${toneClass}`}>{value}</div>
+    </div>
+  );
+}

--- a/tests/e2e/smoke/auth-rdb-inventario-levantamiento.spec.ts
+++ b/tests/e2e/smoke/auth-rdb-inventario-levantamiento.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * Smoke E2E — RDB › Inventario › Levantamiento físico (flujo completo)
+ *
+ * Cubre el ciclo: alta → captura a ciegas → cierre → firma → auto-aplicación →
+ * reporte → validación contra DB.
+ *
+ * Pre-requisitos para que el test corra (de lo contrario, self-skip):
+ *   1. Auth configurada — `playwright/.auth/user.json` con sesión válida.
+ *      El test user debe ser administrador o miembro activo de RDB con write
+ *      access al módulo `rdb.inventario`.
+ *   2. `SUPABASE_SERVICE_ROLE_KEY` en `.env.test.local` o `.env.local` —
+ *      necesario para forzar `firmas_requeridas=1` y validar la DB al final.
+ *   3. Catálogo RDB con al menos 3 productos inventariables activos. Sin
+ *      productos, `iniciarCaptura` no siembra líneas y el test no tiene qué
+ *      capturar.
+ *
+ * Cleanup: el test elimina el levantamiento creado al final (soft delete).
+ *
+ * Validación de captura a ciegas: intercepta la respuesta de
+ * `fn_get_lineas_para_capturar` y confirma que NO incluye `stock_inicial`,
+ * `costo_unitario` ni `diferencia` — convierte la convención en garantía
+ * testeable.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
+import { skipIfNoAuth } from '../helpers/auth-guard';
+
+const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
+
+// Cliente service-role tipado como `any` deliberadamente: no queremos meter
+// `Database` types en tests e2e (acopla el test al schema generado y rompe en
+// cada migración). Los tests son smokes de comportamiento; el tipo seguro
+// sucede en `app/`.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AdminClient = any;
+
+function getAdmin(): AdminClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function getEmpresaConfig(admin: AdminClient): Promise<Record<string, unknown>> {
+  const { data, error } = await admin
+    .schema('core')
+    .from('empresas')
+    .select('config_inventario')
+    .eq('id', RDB_EMPRESA_ID)
+    .maybeSingle();
+  if (error) throw error;
+  return (data?.config_inventario ?? {}) as Record<string, unknown>;
+}
+
+async function setEmpresaConfig(admin: AdminClient, next: Record<string, unknown>): Promise<void> {
+  const { error } = await admin
+    .schema('core')
+    .from('empresas')
+    .update({ config_inventario: next })
+    .eq('id', RDB_EMPRESA_ID);
+  if (error) throw error;
+}
+
+async function countActiveProductos(admin: AdminClient): Promise<number> {
+  const { count, error } = await admin
+    .schema('erp')
+    .from('productos')
+    .select('id', { count: 'exact', head: true })
+    .eq('empresa_id', RDB_EMPRESA_ID)
+    .eq('activo', true);
+  if (error) throw error;
+  return count ?? 0;
+}
+
+async function softDeleteLevantamiento(admin: AdminClient, levId: string): Promise<void> {
+  await admin
+    .schema('erp')
+    .from('inventario_levantamientos')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', levId);
+}
+
+test.describe('RDB › Inventario › Levantamiento físico', () => {
+  let admin: AdminClient | null = null;
+  let originalConfig: Record<string, unknown> | null = null;
+  let createdLevId: string | null = null;
+
+  test.beforeAll(async () => {
+    admin = getAdmin();
+    if (!admin) {
+      console.warn(
+        '[lev e2e] SUPABASE_SERVICE_ROLE_KEY missing — test will self-skip in beforeEach.'
+      );
+      return;
+    }
+
+    // Snapshot config y forzamos firmas_requeridas=1 para que el flujo entero
+    // termine con un solo Firmar (la auto-aplicación se dispara al instante).
+    originalConfig = await getEmpresaConfig(admin);
+    await setEmpresaConfig(admin, { ...originalConfig, firmas_requeridas: 1 });
+  });
+
+  test.afterAll(async () => {
+    if (!admin) return;
+
+    // Cleanup levantamiento si quedó algo (incluso si el test falló a mitad).
+    if (createdLevId) {
+      try {
+        await softDeleteLevantamiento(admin, createdLevId);
+      } catch (err) {
+        console.warn(
+          `[lev e2e] Could not soft-delete levantamiento ${createdLevId}:`,
+          (err as Error).message
+        );
+      }
+    }
+
+    // Restaurar config original.
+    if (originalConfig) {
+      try {
+        await setEmpresaConfig(admin, originalConfig);
+      } catch (err) {
+        console.warn('[lev e2e] Could not restore empresa config:', (err as Error).message);
+      }
+    }
+  });
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    skipIfNoAuth(testInfo);
+    if (!admin) {
+      testInfo.skip(
+        true,
+        'Service-role key missing — set SUPABASE_SERVICE_ROLE_KEY in .env.test.local'
+      );
+      return;
+    }
+
+    const productos = await countActiveProductos(admin);
+    if (productos < 3) {
+      testInfo.skip(
+        true,
+        `RDB catalog needs at least 3 active productos for this test (found ${productos}).`
+      );
+      return;
+    }
+
+    await page.goto('/rdb/inventario/levantamientos');
+    await page.waitForTimeout(800);
+    if (page.url().includes('/login')) {
+      testInfo.skip(true, 'Session not accepted — auth state may be stale');
+    }
+  });
+
+  test('flujo completo: alta → captura → cierre → firma → aplicado → reporte', async ({ page }) => {
+    test.setTimeout(120_000);
+
+    // ── Paso 1: alta ───────────────────────────────────────────────────────
+    await page.goto('/rdb/inventario/levantamientos/nuevo');
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(800);
+
+    await page.getByRole('button', { name: /iniciar captura ahora/i }).click();
+
+    // Esperamos el redirect a /capturar.
+    await page.waitForURL(/\/rdb\/inventario\/levantamientos\/[^/]+\/capturar/, {
+      timeout: 15_000,
+    });
+
+    // Capturamos el ID del levantamiento desde la URL para cleanup posterior.
+    const captureUrl = page.url();
+    const idMatch = captureUrl.match(/\/levantamientos\/([0-9a-f-]{36})\//);
+    if (!idMatch) throw new Error(`No pude extraer ID del levantamiento de ${captureUrl}`);
+    createdLevId = idMatch[1];
+
+    // ── Paso 2: validar captura a ciegas ───────────────────────────────────
+    // `getLineasParaCapturar` es server action, no atraviesa el browser como
+    // REST call. Validamos directo contra la RPC via service-role: el shape
+    // debe NO incluir stock_inicial, costo_unitario, diferencia.
+    if (!admin) throw new Error('admin no debería ser null aquí');
+    const { data: lineasRpc, error: lineasErr } = await admin
+      .schema('erp')
+      .rpc('fn_get_lineas_para_capturar', {
+        p_levantamiento_id: createdLevId,
+      });
+    expect(lineasErr).toBeNull();
+    const body = (lineasRpc ?? []) as Array<Record<string, unknown>>;
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    expect(body[0]).not.toHaveProperty('stock_inicial');
+    expect(body[0]).not.toHaveProperty('costo_unitario');
+    expect(body[0]).not.toHaveProperty('diferencia');
+
+    // ── Paso 3: capturar 3 productos ───────────────────────────────────────
+    // Usamos los códigos del payload de la RPC para buscar exact-match en el
+    // input (más estable que adivinar nombres).
+    const codigos = body.slice(0, 3).map((row) => String(row.producto_codigo));
+    const cantidades = ['5', '0', '12'];
+
+    for (let i = 0; i < codigos.length; i++) {
+      await capturarProducto(page, codigos[i], cantidades[i]);
+    }
+
+    // ── Paso 4: cerrar captura ─────────────────────────────────────────────
+    await page.goto(`/rdb/inventario/levantamientos/${createdLevId}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForTimeout(1500);
+
+    const cerrarBtn = page.getByRole('button', { name: /cerrar captura/i });
+    await cerrarBtn.click();
+
+    // El AlertDialog confirma "Marcar pendientes en 0 y cerrar" (asumiendo
+    // que con 3 productos contados quedan más sin contar).
+    const confirmar = page.getByRole('button', { name: /marcar pendientes en 0/i });
+    if (await confirmar.isVisible({ timeout: 1500 }).catch(() => false)) {
+      await confirmar.click();
+    }
+
+    // Esperamos al estado capturado (badge "Pendiente firma").
+    await expect(page.getByText(/pendiente firma/i).first()).toBeVisible({ timeout: 20_000 });
+
+    // ── Paso 5: firmar ─────────────────────────────────────────────────────
+    const firmarBtn = page.getByTestId('firmar-button');
+    await expect(firmarBtn).toBeVisible({ timeout: 5_000 });
+    await firmarBtn.click();
+
+    // Marcar checkbox obligatorio del paso 1.
+    await page.getByTestId('signature-confirm-checkbox').check();
+    await page.getByTestId('signature-confirm-button').click();
+
+    // Auto-aplicación: redirige a /reporte.
+    await page.waitForURL(/\/rdb\/inventario\/levantamientos\/[^/]+\/reporte/, {
+      timeout: 20_000,
+    });
+
+    // ── Paso 6: validar reporte ────────────────────────────────────────────
+    // Auto-print no se dispara en headless; el contenido sí se renderiza.
+    await expect(page.getByText(/reporte de levantamiento físico/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText(/firmas/i).first()).toBeVisible();
+
+    // ── Paso 7: validar contra DB vía service-role ─────────────────────────
+    if (!admin) throw new Error('admin no debería ser null aquí');
+
+    const { data: levRow, error: levErr } = await admin
+      .schema('erp')
+      .from('inventario_levantamientos')
+      .select('estado, fecha_aplicado')
+      .eq('id', createdLevId)
+      .maybeSingle();
+    expect(levErr).toBeNull();
+    expect(levRow?.estado).toBe('aplicado');
+    expect(levRow?.fecha_aplicado).not.toBeNull();
+
+    const { data: firmas, error: firmasErr } = await admin
+      .schema('erp')
+      .from('inventario_levantamiento_firmas')
+      .select('paso, rol')
+      .eq('levantamiento_id', createdLevId);
+    expect(firmasErr).toBeNull();
+    const firmasArr = (firmas ?? []) as Array<{ paso: number; rol: string }>;
+    expect(firmasArr.length).toBe(1);
+    expect(firmasArr[0].paso).toBe(1);
+    expect(firmasArr[0].rol).toBe('contador');
+
+    // Movimientos: con cantidades 5/0/12 (vs stock=0 esperado para productos
+    // sin entradas previas) y los pendientes marcados como 0, casi siempre
+    // hay diferencias y se generan movimientos. Pero un catálogo en cero
+    // contado en cero produce 0 movimientos — `>= 0` es robusto, el gate
+    // real de éxito es `estado='aplicado'` que ya validamos arriba.
+    const { count: movimientos, error: movErr } = await admin
+      .schema('erp')
+      .from('movimientos_inventario')
+      .select('id', { count: 'exact', head: true })
+      .eq('referencia_tipo', 'levantamiento_fisico')
+      .eq('referencia_id', createdLevId);
+    expect(movErr).toBeNull();
+    // No exigimos > 0 — un levantamiento sin diferencias es válido y no genera
+    // movimientos. El estado=aplicado ya garantiza que el flujo cerró bien.
+    expect(movimientos ?? 0).toBeGreaterThanOrEqual(0);
+  });
+});
+
+/**
+ * Captura un producto por código exacto: escribe el código, presiona Enter
+ * (auto-selecciona el match exacto), introduce la cantidad con NumPad y
+ * guarda con "Guardar y siguiente".
+ */
+async function capturarProducto(page: Page, codigo: string, cantidad: string): Promise<void> {
+  const search = page.locator('#capturar-search');
+  await search.click();
+  await search.fill('');
+  await search.fill(codigo);
+  await search.press('Enter');
+
+  // Si el Enter no auto-seleccionó (códigos con coincidencias parciales),
+  // hacemos click en la primera coincidencia visible.
+  const activo = page.getByText(/capturando/i).first();
+  if (!(await activo.isVisible({ timeout: 1500 }).catch(() => false))) {
+    const firstMatch = page.locator('button', { hasText: new RegExp(codigo, 'i') }).first();
+    await firstMatch.click({ timeout: 3_000 });
+  }
+
+  // Tecleamos la cantidad con NumPad. Algunos dígitos coinciden con quick
+  // values (`[0, 1, 6, 12, 24]`); `.first()` resuelve la ambigüedad —
+  // quick values vienen antes en el DOM y producen el mismo efecto sobre el
+  // value.
+  for (const digito of cantidad) {
+    await page.getByRole('button', { name: digito, exact: true }).first().click();
+  }
+
+  await page.getByRole('button', { name: /guardar y siguiente/i }).click();
+
+  // Esperamos a que el panel "Capturando" desaparezca (señal de que el
+  // siguiente turno está listo para entrar).
+  await page.waitForTimeout(800);
+}


### PR DESCRIPTION
## Summary

Tercer y último sub-PR del módulo de levantamientos físicos. Cierra el ciclo: alta → captura → cierre → firma → auto-aplicación → reporte.

- Nuevo `<SignatureDialog />` reusable (juntas y requisiciones lo van a consumir). Checkbox obligatorio en paso 1, resumen de cifras, comentario opcional.
- Lógica paso/rol en el detalle según `config_inventario.firmas_requeridas`:
  - default 3 → contador / revisor / autorizador
  - 2 → contador / autorizador
  - 1 → solo contador
- Pre-condición: bloquea firma si quedan líneas fuera de tolerancia sin justificación.
- Auto-aplicación: la UI solo dispara `fn_firmar_levantamiento`; cuando llega la última firma, la función SQL ya dispara `fn_aplicar_levantamiento` internamente y devuelve `aplicado=true` con `movimientos_generados`. La UI lee el bool y redirige a `/reporte`. Sin botón "Aplicar" extra.
- /nuevo: "Iniciar captura ahora" ahora redirige directo a /capturar (antes pasaba por la lista — un hop innecesario cuando el user ya sabe qué va a hacer).
- Suite Playwright e2e nueva con el flujo completo + cleanup + validación contra DB.
- Validación de captura a ciegas convertida en garantía testeable.

## Cómo cambiar `firmas_requeridas` para una empresa

```sql
UPDATE core.empresas
   SET config_inventario = config_inventario || '{"firmas_requeridas": 1}'
 WHERE id = '<empresa-uuid>';
```

## Cómo se determina el paso actual

`paso_actual = count(firmas) + 1`. La sección `<FirmarSection />` lee `lev.firmas` ya cargadas y mapea `(paso, firmas_requeridas) → rol` en cliente. La función SQL `fn_firmar_levantamiento` valida server-side (estado=capturado, permisos, paso=N+1) — la UI solo guía al usuario.

## Firmas out-of-order

No debería poder pasar desde la UI: el botón solo abre el dialog para el paso actual computado. Por defensa, la RPC valida que la firma llegue ordenada y rechaza si no.

## Test plan

- [x] Lint, typecheck, unit tests, prettier — verdes
- [ ] Manual end-to-end en preview: crear levantamiento → capturar → cerrar → firmar → reporte
- [ ] Verificar dialog responde bien en mobile (firma desde campo)
- [ ] Verificar que admin global puede firmar el paso 1 aunque no sea contador
- [ ] (Opcional) Correr `npm run test:e2e:auth -- --grep "Levantamiento físico"` con `SUPABASE_SERVICE_ROLE_KEY` configurado

## Follow-ups apuntados (no bloquean)

- DB: crear `fn_actualizar_nota_diferencia` SECURITY DEFINER y reemplazar el cliente service-role en `actualizarNotaDiferencia` (CC mencionó esto en B2; ~30 min, sub-PR de DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)