### PR TITLE
feat(cortes): fase 6 — cierre del marbete impreso

### DIFF
--- a/components/cortes/corte-detail.tsx
+++ b/components/cortes/corte-detail.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { conciliarEfectivo, conciliarTarjeta } from './conciliacion';
 import { CorteConciliacion } from './corte-conciliacion';
 import { estadoVariant, formatCurrency, formatDate, formatDateTime } from './helpers';
+import { MarbeteConciliacion } from './marbete-conciliacion';
 import { RegistrarMovimientoDialog } from './registrar-movimiento-dialog';
 import type { Banco, Corte, CorteTotales, Movimiento, Voucher } from './types';
 import { VoucherLightbox } from './voucher-lightbox';
@@ -65,6 +66,14 @@ export function CorteDetail({
 
   const tarjeta = conciliarTarjeta(totales, vouchers);
   const efectivo = conciliarEfectivo(corte, totales);
+
+  const vouchersTarjeta = vouchers.filter(
+    (v) => (v.categoria ?? 'voucher_tarjeta') === 'voucher_tarjeta'
+  );
+  const bancoNombrePor = (id: string | null) => {
+    if (!id) return null;
+    return bancos.find((b) => b.id === id)?.nombre ?? null;
+  };
 
   return (
     <Sheet
@@ -156,12 +165,26 @@ export function CorteDetail({
             )}
 
             {!loadingDetail && (
-              <CorteConciliacion
-                tarjeta={tarjeta}
-                efectivo={efectivo}
-                ingresosStripe={totales?.ingresos_stripe ?? 0}
-                ingresosTransferencias={totales?.ingresos_transferencias ?? 0}
-              />
+              <>
+                <div className="print:hidden">
+                  <CorteConciliacion
+                    tarjeta={tarjeta}
+                    efectivo={efectivo}
+                    ingresosStripe={totales?.ingresos_stripe ?? 0}
+                    ingresosTransferencias={totales?.ingresos_transferencias ?? 0}
+                  />
+                </div>
+                <div className="hidden print:block">
+                  <MarbeteConciliacion
+                    tarjeta={tarjeta}
+                    efectivo={efectivo}
+                    ingresosStripe={totales?.ingresos_stripe ?? 0}
+                    ingresosTransferencias={totales?.ingresos_transferencias ?? 0}
+                    vouchersTarjeta={vouchersTarjeta}
+                    bancoNombrePor={bancoNombrePor}
+                  />
+                </div>
+              </>
             )}
 
             <Separator className="print:my-1" />
@@ -284,6 +307,9 @@ export function CorteDetail({
                           <span className="block text-xs text-muted-foreground print:text-[9px]">
                             {formatDate(m.fecha_hora)}
                             {m.registrado_por ? ` · ${m.registrado_por}` : ''}
+                            {comprobantes.length > 0 ? (
+                              <span className="hidden print:inline"> · 📎 c/comprobante</span>
+                            ) : null}
                           </span>
                           {comprobantes.length > 0 && (
                             <div className="mt-1.5 flex flex-wrap gap-1 print:hidden">

--- a/components/cortes/marbete-conciliacion.tsx
+++ b/components/cortes/marbete-conciliacion.tsx
@@ -1,0 +1,177 @@
+import type { ConciliacionEfectivo, ConciliacionEstado, ConciliacionTarjeta } from './conciliacion';
+import { formatCurrency } from './helpers';
+import type { Voucher } from './types';
+
+const SIMBOLO: Record<ConciliacionEstado, string> = {
+  cuadra: '✓',
+  cuadra_aprox: '~',
+  diferencia: '✗',
+  sin_voucher: '✗',
+  pendiente_captura: '•',
+  pendiente_cierre: '○',
+  sin_actividad: '—',
+};
+
+const ETIQUETA: Record<ConciliacionEstado, string> = {
+  cuadra: 'Cuadra',
+  cuadra_aprox: 'Cuadra ±',
+  diferencia: 'Diferencia',
+  sin_voucher: 'Sin voucher',
+  pendiente_captura: 'Pendiente captura',
+  pendiente_cierre: 'Pendiente cierre',
+  sin_actividad: 'Sin actividad',
+};
+
+type Props = {
+  tarjeta: ConciliacionTarjeta;
+  efectivo: ConciliacionEfectivo;
+  ingresosStripe: number;
+  ingresosTransferencias: number;
+  vouchersTarjeta: Voucher[];
+  bancoNombrePor: (id: string | null) => string | null;
+};
+
+// Versión print-only de la conciliación. Usa símbolos en lugar de color porque
+// el marbete suele imprimirse en B&W — los iconos sobreviven, los tonos no.
+export function MarbeteConciliacion({
+  tarjeta,
+  efectivo,
+  ingresosStripe,
+  ingresosTransferencias,
+  vouchersTarjeta,
+  bancoNombrePor,
+}: Props) {
+  const criticas = [tarjeta.estado, efectivo.estado].filter(
+    (e) => e === 'diferencia' || e === 'sin_voucher'
+  ).length;
+  const pendientes = [tarjeta.estado, efectivo.estado].filter(
+    (e) => e === 'pendiente_captura' || e === 'pendiente_cierre'
+  ).length;
+
+  let bannerSimbolo: string;
+  let bannerTexto: string;
+  if (criticas > 0) {
+    bannerSimbolo = '⚠';
+    bannerTexto = `${criticas} alerta${criticas > 1 ? 's' : ''} crítica${criticas > 1 ? 's' : ''}${
+      pendientes > 0 ? ` · ${pendientes} pendiente${pendientes > 1 ? 's' : ''}` : ''
+    }`;
+  } else if (pendientes > 0) {
+    bannerSimbolo = '•';
+    bannerTexto = `${pendientes} pendiente${pendientes > 1 ? 's' : ''} de captura`;
+  } else {
+    bannerSimbolo = '✓';
+    bannerTexto = 'Corte cuadra';
+  }
+
+  const totalVouchers = vouchersTarjeta.reduce((s, v) => s + (v.monto_reportado ?? 0), 0);
+
+  return (
+    <div className="text-[10px]" style={{ pageBreakInside: 'avoid' }}>
+      <div className="mb-1 border-y border-gray-400 py-0.5 font-semibold">
+        {bannerSimbolo} {bannerTexto}
+      </div>
+
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="text-[9px] uppercase tracking-wide text-gray-500">
+            <th className="text-left">Método</th>
+            <th className="text-right">Pedidos</th>
+            <th className="text-right">Evidencia</th>
+            <th className="w-8 text-center">Est.</th>
+            <th className="text-right">Diferencia</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr className="border-t border-gray-300">
+            <td>Tarjeta</td>
+            <td className="text-right tabular-nums">{formatCurrency(tarjeta.ingresos_pedidos)}</td>
+            <td className="text-right tabular-nums">
+              {formatCurrency(tarjeta.total_evidencia)}
+              {tarjeta.evidencia_pendiente > 0 ? ` (+${tarjeta.evidencia_pendiente} s/cap)` : ''}
+            </td>
+            <td className="text-center font-bold" title={ETIQUETA[tarjeta.estado]}>
+              {SIMBOLO[tarjeta.estado]}
+            </td>
+            <td className="text-right tabular-nums">
+              {tarjeta.evidencia_pendiente > 0
+                ? '—'
+                : tarjeta.diferencia === 0
+                  ? '$0.00'
+                  : (tarjeta.diferencia > 0 ? '+' : '') + formatCurrency(tarjeta.diferencia)}
+            </td>
+          </tr>
+          <tr className="border-t border-gray-300">
+            <td>Efectivo</td>
+            <td className="text-right tabular-nums">{formatCurrency(efectivo.esperado)}</td>
+            <td className="text-right tabular-nums">
+              {efectivo.contado == null ? '—' : formatCurrency(efectivo.contado)}
+            </td>
+            <td className="text-center font-bold" title={ETIQUETA[efectivo.estado]}>
+              {SIMBOLO[efectivo.estado]}
+            </td>
+            <td className="text-right tabular-nums">
+              {efectivo.diferencia == null
+                ? '—'
+                : efectivo.diferencia === 0
+                  ? '$0.00'
+                  : (efectivo.diferencia > 0 ? '+' : '') + formatCurrency(efectivo.diferencia)}
+            </td>
+          </tr>
+          {ingresosStripe > 0 && (
+            <tr className="border-t border-gray-300 text-gray-600">
+              <td>Stripe</td>
+              <td className="text-right tabular-nums">{formatCurrency(ingresosStripe)}</td>
+              <td className="text-right text-gray-400">—</td>
+              <td className="text-center text-gray-400">—</td>
+              <td className="text-right text-[9px] text-gray-500">sin conciliar</td>
+            </tr>
+          )}
+          {ingresosTransferencias > 0 && (
+            <tr className="border-t border-gray-300 text-gray-600">
+              <td>Transferencia</td>
+              <td className="text-right tabular-nums">{formatCurrency(ingresosTransferencias)}</td>
+              <td className="text-right text-gray-400">—</td>
+              <td className="text-center text-gray-400">—</td>
+              <td className="text-right text-[9px] text-gray-500">sin conciliar</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+
+      {vouchersTarjeta.length > 0 && (
+        <div className="mt-2" style={{ pageBreakInside: 'avoid' }}>
+          <div className="mb-0.5 text-[9px] uppercase tracking-wide text-gray-500">
+            Vouchers de tarjeta ({vouchersTarjeta.length})
+          </div>
+          <table className="w-full border-collapse">
+            <tbody>
+              {vouchersTarjeta.map((v) => {
+                const capturado = v.monto_reportado != null;
+                const banco = bancoNombrePor(v.banco_id ?? null);
+                return (
+                  <tr key={v.id} className="border-t border-gray-300">
+                    <td className="py-0.5">
+                      {banco ?? '—'}
+                      {v.afiliacion ? (
+                        <span className="text-gray-500"> · afil {v.afiliacion}</span>
+                      ) : null}
+                    </td>
+                    <td className="text-right tabular-nums">
+                      {capturado ? formatCurrency(v.monto_reportado) : '—'}
+                    </td>
+                    <td className="w-8 text-center font-bold">{capturado ? '✓' : '•'}</td>
+                  </tr>
+                );
+              })}
+              <tr className="border-t border-gray-400 font-semibold">
+                <td className="py-0.5">Total vouchers</td>
+                <td className="text-right tabular-nums">{formatCurrency(totalVouchers)}</td>
+                <td />
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Sexta y última fase del plan (`docs/plans/cortes-detail-conciliacion.md` §16). Cierra la versión impresa del marbete.

## Cambios

- Nuevo `marbete-conciliacion.tsx`: componente print-only B&W con banner de salud + tabla de conciliación + lista textual de vouchers de tarjeta. Símbolos `✓ ~ ✗ • ○` para estado.
- `corte-detail.tsx`:
  - `CorteConciliacion` (pantalla, con cards y colores) envuelto en `print:hidden`.
  - `MarbeteConciliacion` en `hidden print:block` en el mismo lugar.
  - Texto inline '· 📎 c/comprobante' en movimientos con comprobantes ligados, `hidden print:inline` — reemplaza el chip clickable.

## Verificación

- typecheck verde
- lint verde (solo warnings pre-existentes en otros archivos)
- test:run verde (161/161)
- build verde (compile + prerender 59/59)
- **Smoke test impresión (Cmd+P preview): pendiente de validar en preview.** Local dev server requiere OAuth con Google y no pude completarlo automáticamente; el render print depende sólo de clases tailwind \`print:*\`, sin lógica condicional adicional.

## Lo que NO toca esta fase
- Pantalla intacta — todos los componentes existentes se renderizan igual.
- Sin cambios en server actions, DB, OCR, captura.

## Plan completo cerrado

Con esto quedan completas las 6 fases del plan de conciliación de cortes. El módulo de detalle de corte está fully-featured:
- Conciliación visible (tarjeta vs vouchers, efectivo esperado vs contado)
- OCR pre-llena banco/monto al subir voucher
- Captura manual + reclasificación de categoría desde el lightbox
- Refinamientos (chip de comprobante, sección 'Otras evidencias')
- Marbete impreso completo en una hoja