### PR TITLE
feat(ui): <ModulePage> component + Inventario migration (ADR-004 Fase 1)

### DIFF
--- a/app/rdb/inventario/page.tsx
+++ b/app/rdb/inventario/page.tsx
@@ -6,9 +6,17 @@
  */
 
 import { RequireAccess } from '@/components/require-access';
-import { InventarioTabs } from '@/components/inventario/inventario-tabs';
 import { useCallback, useEffect, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import {
+  ModulePage,
+  ModuleHeader,
+  ModuleTabs,
+  ModuleKpiStrip,
+  ModuleFilters,
+  ModuleContent,
+} from '@/components/module-page';
+import { CategoryFilterStrip } from '@/components/inventario/category-filter-strip';
 import {
   Table,
   TableBody,
@@ -54,7 +62,6 @@ import {
   Boxes,
   Check,
   ChevronsUpDown,
-  ClipboardList,
   Plus,
   Printer,
   RefreshCw,
@@ -156,55 +163,16 @@ function tipoColorClass(tipo: string, cantidad: number): string {
     : 'border-red-500/40 text-red-600 dark:text-red-400';
 }
 
-// ─── Summary Bar ──────────────────────────────────────────────────────────────
+// ─── Stock Stats Helper ───────────────────────────────────────────────────────
 
 const CLASIFICACION_INVENTARIO = ['inventariable', 'merchandising'];
 
-function SummaryBar({ items }: { items: StockItem[] }) {
+function computeStockStats(items: StockItem[]) {
   const valorables = items.filter((i) => CLASIFICACION_INVENTARIO.includes(i.clasificacion ?? ''));
   const bajosMinimo = valorables.filter((i) => i.bajo_minimo).length;
   const sinStock = valorables.filter((i) => i.stock_actual <= 0).length;
   const totalValue = valorables.reduce((acc, curr) => acc + (curr.valor_inventario || 0), 0);
-  return (
-    <div className="grid grid-cols-4 gap-3">
-      <div className="rounded-xl border bg-card px-4 py-3">
-        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          <Boxes className="h-3.5 w-3.5" />
-          Productos
-        </div>
-        <div className="mt-1 text-2xl font-semibold tabular-nums">{valorables.length}</div>
-      </div>
-      <div className="rounded-xl border bg-card px-4 py-3">
-        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
-          Bajo mínimo
-        </div>
-        <div
-          className={`mt-1 text-2xl font-semibold tabular-nums${bajosMinimo > 0 ? ' text-amber-500' : ''}`}
-        >
-          {bajosMinimo}
-        </div>
-      </div>
-      <div className="rounded-xl border bg-card px-4 py-3">
-        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          <TrendingDown className="h-3.5 w-3.5 text-destructive" />
-          Sin stock
-        </div>
-        <div
-          className={`mt-1 text-2xl font-semibold tabular-nums${sinStock > 0 ? ' text-destructive' : ''}`}
-        >
-          {sinStock}
-        </div>
-      </div>
-      <div className="rounded-xl border bg-card px-4 py-3">
-        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          <TrendingUp className="h-3.5 w-3.5" />
-          Valor Inventario
-        </div>
-        <div className="mt-1 text-2xl font-semibold tabular-nums">{formatCurrency(totalValue)}</div>
-      </div>
-    </div>
-  );
+  return { productos: valorables.length, bajosMinimo, sinStock, totalValue };
 }
 
 // ─── Stock Detail Drawer ──────────────────────────────────────────────────────
@@ -938,112 +906,96 @@ export default function InventarioPage() {
 
   return (
     <RequireAccess empresa="rdb" modulo="rdb.inventario">
-      <div className="space-y-6">
-        <InventarioTabs activeKey="overview" />
+      <ModulePage>
+        <ModuleHeader
+          title="Inventario"
+          subtitle="Control de stock y movimientos"
+          action={
+            <Button className="gap-2" onClick={() => setDialogOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Registrar Movimiento
+            </Button>
+          }
+        />
 
-        {/* Header */}
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Inventario</h1>
-            <p className="text-sm text-muted-foreground">Control de stock y movimientos</p>
-          </div>
-          <Button className="shrink-0 gap-2" onClick={() => setDialogOpen(true)}>
-            <Plus className="h-4 w-4" />
-            Registrar Movimiento
-          </Button>
-        </div>
+        <ModuleTabs
+          tabs={[
+            { key: 'stock', label: 'Stock' },
+            { key: 'movimientos', label: 'Movimientos' },
+          ]}
+          value={tab}
+          onChange={handleTabChange}
+        />
 
-        {/* Summary (stock tab only) */}
-        {tab === 'stock' && !loadingStock && !errorStock && <SummaryBar items={filteredStock} />}
-
-        {/* KPI cards por categoría */}
         {tab === 'stock' &&
           !loadingStock &&
           !errorStock &&
           (() => {
-            const cats = [
-              'Alimentos',
-              'Bebidas',
-              'Licores',
-              'Artículos',
-              'Deportes',
-              'Consumibles',
-              'Propinas',
-            ];
-            type CatStat = { count: number; valor: number };
-            const stats = cats.reduce<Record<string, CatStat>>((acc, c) => {
-              acc[c] = { count: 0, valor: 0 };
-              return acc;
-            }, {});
-            for (const item of filteredStock) {
-              const c = item.categoria ?? 'Otros';
-              if (!stats[c]) stats[c] = { count: 0, valor: 0 };
-              stats[c].count++;
-              stats[c].valor += Number(item.valor_inventario) || 0;
-            }
-            const sorted = Object.entries(stats)
-              .filter(([, s]) => s.count > 0)
-              .sort((a, b) => b[1].valor - a[1].valor);
-            if (sorted.length === 0) return null;
+            const s = computeStockStats(filteredStock);
             return (
-              <div className="grid grid-cols-4 gap-2 sm:grid-cols-7">
-                {sorted.map(([cat, s]) => (
-                  <button
-                    key={cat}
-                    type="button"
-                    onClick={() => setCategoriaFiltro(categoriaFiltro === cat ? '' : cat)}
-                    className={[
-                      'rounded-lg border px-3 py-2 text-left transition-colors hover:bg-muted/60',
-                      categoriaFiltro === cat ? 'border-primary bg-primary/10' : 'bg-card',
-                    ].join(' ')}
-                  >
-                    <div className="text-xs font-medium text-muted-foreground truncate">{cat}</div>
-                    <div className="mt-0.5 text-sm font-semibold tabular-nums">
-                      {new Intl.NumberFormat('es-MX', {
-                        style: 'currency',
-                        currency: 'MXN',
-                        maximumFractionDigits: 0,
-                      }).format(s.valor)}
-                    </div>
-                    <div className="text-xs text-muted-foreground">{s.count} prod.</div>
-                  </button>
-                ))}
-              </div>
+              <ModuleKpiStrip
+                stats={[
+                  {
+                    key: 'productos',
+                    label: 'Productos',
+                    value: s.productos,
+                    icon: <Boxes className="h-3.5 w-3.5" />,
+                  },
+                  {
+                    key: 'bajo',
+                    label: 'Bajo mínimo',
+                    value: s.bajosMinimo,
+                    icon: <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />,
+                    valueClassName: s.bajosMinimo > 0 ? 'text-amber-500' : '',
+                  },
+                  {
+                    key: 'sin',
+                    label: 'Sin stock',
+                    value: s.sinStock,
+                    icon: <TrendingDown className="h-3.5 w-3.5 text-destructive" />,
+                    valueClassName: s.sinStock > 0 ? 'text-destructive' : '',
+                  },
+                  {
+                    key: 'valor',
+                    label: 'Valor Inventario',
+                    value: formatCurrency(s.totalValue),
+                    icon: <TrendingUp className="h-3.5 w-3.5" />,
+                  },
+                ]}
+              />
             );
           })()}
 
-        {/* Tab toggle */}
-        <div className="flex w-fit gap-1 rounded-lg border bg-muted/30 p-1">
-          <button
-            type="button"
-            onClick={() => handleTabChange('stock')}
-            className={[
-              'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-              tab === 'stock'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            ].join(' ')}
-          >
-            <Boxes className="h-4 w-4" />
-            Stock Actual
-          </button>
-          <button
-            type="button"
-            onClick={() => handleTabChange('movimientos')}
-            className={[
-              'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-              tab === 'movimientos'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            ].join(' ')}
-          >
-            <ClipboardList className="h-4 w-4" />
-            Movimientos
-          </button>
-        </div>
+        {tab === 'stock' && !loadingStock && !errorStock && (
+          <CategoryFilterStrip
+            items={filteredStock}
+            activeCategory={categoriaFiltro}
+            onSelect={setCategoriaFiltro}
+          />
+        )}
 
-        {/* Filters */}
-        <div className="flex flex-wrap items-center gap-3">
+        <ModuleFilters
+          count={
+            isLoading
+              ? 'Cargando…'
+              : tab === 'stock'
+                ? `${filteredStock.length} producto${filteredStock.length !== 1 ? 's' : ''}`
+                : `${filteredMovimientos.length} movimiento${filteredMovimientos.length !== 1 ? 's' : ''}`
+          }
+          actions={
+            tab === 'stock' ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handlePrintLista(filteredStock)}
+                className="gap-2"
+              >
+                <Printer className="h-3.5 w-3.5" />
+                Imprimir lista
+              </Button>
+            ) : null
+          }
+        >
           <div className="relative min-w-52">
             <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
@@ -1150,36 +1102,14 @@ export default function InventarioPage() {
           <Button variant="outline" size="icon" onClick={handleRefresh} aria-label="Actualizar">
             <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
           </Button>
+        </ModuleFilters>
 
-          {tab === 'stock' && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handlePrintLista(filteredStock)}
-              className="gap-2"
-            >
-              <Printer className="h-3.5 w-3.5" />
-              Imprimir lista
-            </Button>
-          )}
-
-          <span className="text-sm text-muted-foreground">
-            {isLoading
-              ? 'Cargando…'
-              : tab === 'stock'
-                ? `${filteredStock.length} producto${filteredStock.length !== 1 ? 's' : ''}`
-                : `${filteredMovimientos.length} movimiento${filteredMovimientos.length !== 1 ? 's' : ''}`}
-          </span>
-        </div>
-
-        {/* Error */}
         {currentError && (
           <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {currentError}
           </div>
         )}
 
-        {/* Historical date banner */}
         {fechaCorte && tab === 'stock' && (
           <div className="flex items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm text-blue-600 dark:text-blue-400">
             <span>📅</span>
@@ -1187,253 +1117,253 @@ export default function InventarioPage() {
           </div>
         )}
 
-        {/* ── Stock Table ────────────────────────────────────────────────────── */}
-        {tab === 'stock' && (
-          <div className="rounded-xl border bg-card">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <SortableHead
-                    sortKey="nombre"
-                    label="Producto"
-                    currentSort={sortKey}
-                    currentDir={sortDir}
-                    onSort={onSort}
-                  />
-                  <SortableHead
-                    sortKey="clasificacion"
-                    label="Clasif."
-                    currentSort={sortKey}
-                    currentDir={sortDir}
-                    onSort={onSort}
-                  />
-                  <SortableHead
-                    sortKey="categoria"
-                    label="Categoría"
-                    currentSort={sortKey}
-                    currentDir={sortDir}
-                    onSort={onSort}
-                  />
-                  <SortableHead
-                    sortKey="stock_actual"
-                    label="Stock Actual"
-                    currentSort={sortKey}
-                    currentDir={sortDir}
-                    onSort={onSort}
-                    className="text-right"
-                  />
-                  <SortableHead
-                    sortKey="stock_minimo"
-                    label="Mínimo"
-                    currentSort={sortKey}
-                    currentDir={sortDir}
-                    onSort={onSort}
-                    className="text-right"
-                  />
-                  <SortableHead
-                    sortKey="ultimo_costo"
-                    label="Último Costo"
-                    currentSort={sortKey}
-                    currentDir={sortDir}
-                    onSort={onSort}
-                    className="text-right"
-                  />
-                  <SortableHead
-                    sortKey="valor_inventario"
-                    label="Valor Total"
-                    currentSort={sortKey}
-                    currentDir={sortDir}
-                    onSort={onSort}
-                    className="text-right"
-                  />
-                  <SortableHead
-                    sortKey="bajo_minimo"
-                    label="Estado"
-                    currentSort={sortKey}
-                    currentDir={sortDir}
-                    onSort={onSort}
-                  />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loadingStock ? (
-                  Array.from({ length: 8 }).map((_, i) => (
-                    <TableRow key={i}>
-                      {Array.from({ length: 8 }).map((__, j) => (
-                        <TableCell key={j}>
-                          <Skeleton className="h-4 w-full" />
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : filteredStock.length === 0 ? (
+        <ModuleContent>
+          {tab === 'stock' && (
+            <div className="rounded-xl border bg-card">
+              <Table>
+                <TableHeader>
                   <TableRow>
-                    <TableCell colSpan={8} className="py-12 text-center text-muted-foreground">
-                      No se encontraron productos.
-                    </TableCell>
+                    <SortableHead
+                      sortKey="nombre"
+                      label="Producto"
+                      currentSort={sortKey}
+                      currentDir={sortDir}
+                      onSort={onSort}
+                    />
+                    <SortableHead
+                      sortKey="clasificacion"
+                      label="Clasif."
+                      currentSort={sortKey}
+                      currentDir={sortDir}
+                      onSort={onSort}
+                    />
+                    <SortableHead
+                      sortKey="categoria"
+                      label="Categoría"
+                      currentSort={sortKey}
+                      currentDir={sortDir}
+                      onSort={onSort}
+                    />
+                    <SortableHead
+                      sortKey="stock_actual"
+                      label="Stock Actual"
+                      currentSort={sortKey}
+                      currentDir={sortDir}
+                      onSort={onSort}
+                      className="text-right"
+                    />
+                    <SortableHead
+                      sortKey="stock_minimo"
+                      label="Mínimo"
+                      currentSort={sortKey}
+                      currentDir={sortDir}
+                      onSort={onSort}
+                      className="text-right"
+                    />
+                    <SortableHead
+                      sortKey="ultimo_costo"
+                      label="Último Costo"
+                      currentSort={sortKey}
+                      currentDir={sortDir}
+                      onSort={onSort}
+                      className="text-right"
+                    />
+                    <SortableHead
+                      sortKey="valor_inventario"
+                      label="Valor Total"
+                      currentSort={sortKey}
+                      currentDir={sortDir}
+                      onSort={onSort}
+                      className="text-right"
+                    />
+                    <SortableHead
+                      sortKey="bajo_minimo"
+                      label="Estado"
+                      currentSort={sortKey}
+                      currentDir={sortDir}
+                      onSort={onSort}
+                    />
                   </TableRow>
-                ) : (
-                  sortData(filteredStock).map((item) => (
-                    <TableRow
-                      key={item.id}
-                      className="cursor-pointer hover:bg-muted/50"
-                      onClick={() => {
-                        setSelectedItem(item);
-                        setDrawerOpen(true);
-                      }}
-                    >
-                      <TableCell>
-                        <span className="font-medium">{item.nombre}</span>
+                </TableHeader>
+                <TableBody>
+                  {loadingStock ? (
+                    Array.from({ length: 8 }).map((_, i) => (
+                      <TableRow key={i}>
+                        {Array.from({ length: 8 }).map((__, j) => (
+                          <TableCell key={j}>
+                            <Skeleton className="h-4 w-full" />
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))
+                  ) : filteredStock.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={8} className="py-12 text-center text-muted-foreground">
+                        No se encontraron productos.
                       </TableCell>
-                      <TableCell>
-                        <Badge variant="outline" className="text-xs font-normal">
-                          {item.clasificacion ?? '—'}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {item.categoria ?? '—'}
-                      </TableCell>
-                      <TableCell
-                        className={[
-                          'text-right font-semibold tabular-nums',
-                          item.stock_actual <= 0
-                            ? 'text-destructive'
-                            : item.bajo_minimo
-                              ? 'text-amber-500'
-                              : '',
-                        ].join(' ')}
+                    </TableRow>
+                  ) : (
+                    sortData(filteredStock).map((item) => (
+                      <TableRow
+                        key={item.id}
+                        className="cursor-pointer hover:bg-muted/50"
+                        onClick={() => {
+                          setSelectedItem(item);
+                          setDrawerOpen(true);
+                        }}
                       >
-                        {item.stock_actual} {item.unidad ?? 'pzs'}
-                      </TableCell>
-                      <TableCell className="text-right text-sm tabular-nums text-muted-foreground">
-                        {item.stock_minimo ?? '—'} {item.unidad ?? 'pzs'}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatCurrency(item.costo_unitario ?? item.ultimo_costo)}
-                      </TableCell>
-                      <TableCell className="text-right font-semibold tabular-nums">
-                        {formatCurrency(item.valor_inventario)}
-                      </TableCell>
-                      <TableCell>
-                        {item.stock_actual <= 0 ? (
-                          <Badge variant="destructive">Sin stock</Badge>
-                        ) : item.bajo_minimo ? (
-                          <Badge variant="outline" className="border-amber-500/50 text-amber-500">
-                            Bajo mínimo
-                          </Badge>
-                        ) : (
-                          <Badge variant="default">OK</Badge>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
-        )}
-
-        {/* ── Movimientos Table (Kardex) ─────────────────────────────────────── */}
-        {tab === 'movimientos' && (
-          <div className="rounded-xl border bg-card">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Fecha</TableHead>
-                  <TableHead>Producto</TableHead>
-                  <TableHead>Tipo</TableHead>
-                  <TableHead className="text-right">Cantidad</TableHead>
-                  <TableHead className="text-right">Costo Unit.</TableHead>
-                  <TableHead>Detalle / Referencia</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loadingMovimientos ? (
-                  Array.from({ length: 8 }).map((_, i) => (
-                    <TableRow key={i}>
-                      {Array.from({ length: 6 }).map((__, j) => (
-                        <TableCell key={j}>
-                          <Skeleton className="h-4 w-full" />
+                        <TableCell>
+                          <span className="font-medium">{item.nombre}</span>
                         </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : filteredMovimientos.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={6} className="py-12 text-center text-muted-foreground">
-                      No se encontraron movimientos.
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  filteredMovimientos.map((mov) => (
-                    <TableRow key={mov.id}>
-                      <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
-                        {formatDate(mov.created_at)}
-                      </TableCell>
-                      <TableCell className="font-medium">{mov.productos?.nombre ?? '—'}</TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-1.5">
-                          {mov.tipo_movimiento === 'entrada' ||
-                          (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0) ? (
-                            <TrendingUp className="h-3.5 w-3.5 text-emerald-500" />
+                        <TableCell>
+                          <Badge variant="outline" className="text-xs font-normal">
+                            {item.clasificacion ?? '—'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {item.categoria ?? '—'}
+                        </TableCell>
+                        <TableCell
+                          className={[
+                            'text-right font-semibold tabular-nums',
+                            item.stock_actual <= 0
+                              ? 'text-destructive'
+                              : item.bajo_minimo
+                                ? 'text-amber-500'
+                                : '',
+                          ].join(' ')}
+                        >
+                          {item.stock_actual} {item.unidad ?? 'pzs'}
+                        </TableCell>
+                        <TableCell className="text-right text-sm tabular-nums text-muted-foreground">
+                          {item.stock_minimo ?? '—'} {item.unidad ?? 'pzs'}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {formatCurrency(item.costo_unitario ?? item.ultimo_costo)}
+                        </TableCell>
+                        <TableCell className="text-right font-semibold tabular-nums">
+                          {formatCurrency(item.valor_inventario)}
+                        </TableCell>
+                        <TableCell>
+                          {item.stock_actual <= 0 ? (
+                            <Badge variant="destructive">Sin stock</Badge>
+                          ) : item.bajo_minimo ? (
+                            <Badge variant="outline" className="border-amber-500/50 text-amber-500">
+                              Bajo mínimo
+                            </Badge>
                           ) : (
-                            <TrendingDown className="h-3.5 w-3.5 text-destructive" />
+                            <Badge variant="default">OK</Badge>
                           )}
-                          <Badge
-                            variant="outline"
-                            className={tipoColorClass(mov.tipo_movimiento, mov.cantidad)}
-                          >
-                            {tipoLabel(mov.tipo_movimiento, mov.cantidad)}
-                          </Badge>
-                        </div>
-                      </TableCell>
-                      <TableCell
-                        className={[
-                          'text-right font-semibold tabular-nums',
-                          mov.tipo_movimiento === 'entrada' ||
-                          (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0)
-                            ? 'text-emerald-600 dark:text-emerald-400'
-                            : 'text-destructive',
-                        ].join(' ')}
-                      >
-                        {mov.tipo_movimiento === 'entrada' ||
-                        (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0)
-                          ? '+'
-                          : '\u2212'}
-                        {Math.abs(mov.cantidad)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums text-sm">
-                        {formatCurrency(mov.costo_unitario)}
-                      </TableCell>
-                      <TableCell className="max-w-[200px] truncate text-sm text-muted-foreground">
-                        <div className="font-medium text-foreground">
-                          {mov.referencia_tipo === 'orden_compra' ? 'OC' : 'Manual'}
-                        </div>
-                        <div className="truncate">{mov.notas ?? '—'}</div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+
+          {tab === 'movimientos' && (
+            <div className="rounded-xl border bg-card">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Fecha</TableHead>
+                    <TableHead>Producto</TableHead>
+                    <TableHead>Tipo</TableHead>
+                    <TableHead className="text-right">Cantidad</TableHead>
+                    <TableHead className="text-right">Costo Unit.</TableHead>
+                    <TableHead>Detalle / Referencia</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {loadingMovimientos ? (
+                    Array.from({ length: 8 }).map((_, i) => (
+                      <TableRow key={i}>
+                        {Array.from({ length: 6 }).map((__, j) => (
+                          <TableCell key={j}>
+                            <Skeleton className="h-4 w-full" />
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))
+                  ) : filteredMovimientos.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={6} className="py-12 text-center text-muted-foreground">
+                        No se encontraron movimientos.
                       </TableCell>
                     </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
-        )}
+                  ) : (
+                    filteredMovimientos.map((mov) => (
+                      <TableRow key={mov.id}>
+                        <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                          {formatDate(mov.created_at)}
+                        </TableCell>
+                        <TableCell className="font-medium">
+                          {mov.productos?.nombre ?? '—'}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1.5">
+                            {mov.tipo_movimiento === 'entrada' ||
+                            (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0) ? (
+                              <TrendingUp className="h-3.5 w-3.5 text-emerald-500" />
+                            ) : (
+                              <TrendingDown className="h-3.5 w-3.5 text-destructive" />
+                            )}
+                            <Badge
+                              variant="outline"
+                              className={tipoColorClass(mov.tipo_movimiento, mov.cantidad)}
+                            >
+                              {tipoLabel(mov.tipo_movimiento, mov.cantidad)}
+                            </Badge>
+                          </div>
+                        </TableCell>
+                        <TableCell
+                          className={[
+                            'text-right font-semibold tabular-nums',
+                            mov.tipo_movimiento === 'entrada' ||
+                            (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0)
+                              ? 'text-emerald-600 dark:text-emerald-400'
+                              : 'text-destructive',
+                          ].join(' ')}
+                        >
+                          {mov.tipo_movimiento === 'entrada' ||
+                          (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0)
+                            ? '+'
+                            : '\u2212'}
+                          {Math.abs(mov.cantidad)}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums text-sm">
+                          {formatCurrency(mov.costo_unitario)}
+                        </TableCell>
+                        <TableCell className="max-w-[200px] truncate text-sm text-muted-foreground">
+                          <div className="font-medium text-foreground">
+                            {mov.referencia_tipo === 'orden_compra' ? 'OC' : 'Manual'}
+                          </div>
+                          <div className="truncate">{mov.notas ?? '—'}</div>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </ModuleContent>
 
-        {/* Stock detail drawer */}
         <StockDetailDrawer
           item={selectedItem}
           open={drawerOpen}
           onClose={() => setDrawerOpen(false)}
         />
 
-        {/* Registrar movimiento dialog */}
         <RegistrarMovimientoDialog
           open={dialogOpen}
           onClose={() => setDialogOpen(false)}
           productos={items}
           onSuccess={handleSuccess}
         />
-      </div>
+      </ModulePage>
     </RequireAccess>
   );
 }

--- a/components/inventario/category-filter-strip.tsx
+++ b/components/inventario/category-filter-strip.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useMemo } from 'react';
+
+const CAT_ORDER = [
+  'Alimentos',
+  'Bebidas',
+  'Licores',
+  'Artículos',
+  'Deportes',
+  'Consumibles',
+  'Propinas',
+] as const;
+
+export interface CategoryFilterItem {
+  categoria: string | null;
+  valor_inventario: number | null;
+}
+
+export interface CategoryFilterStripProps {
+  items: ReadonlyArray<CategoryFilterItem>;
+  activeCategory: string;
+  onSelect: (next: string) => void;
+}
+
+/**
+ * Per ADR-004 R6/R7: dimensional breakdowns (categoría, segmento) are filters,
+ * not KPIs. They live in their own component below the filter bar — never inside
+ * <ModuleKpiStrip>.
+ *
+ * Click on a card toggles that category as the active filter; clicking the
+ * already-active card clears it.
+ */
+export function CategoryFilterStrip({ items, activeCategory, onSelect }: CategoryFilterStripProps) {
+  const sorted = useMemo(() => {
+    type CatStat = { count: number; valor: number };
+    const stats: Record<string, CatStat> = {};
+    for (const c of CAT_ORDER) stats[c] = { count: 0, valor: 0 };
+    for (const item of items) {
+      const c = item.categoria ?? 'Otros';
+      if (!stats[c]) stats[c] = { count: 0, valor: 0 };
+      stats[c].count++;
+      stats[c].valor += Number(item.valor_inventario) || 0;
+    }
+    return Object.entries(stats)
+      .filter(([, s]) => s.count > 0)
+      .sort((a, b) => b[1].valor - a[1].valor);
+  }, [items]);
+
+  if (sorted.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-4 gap-2 sm:grid-cols-7">
+      {sorted.map(([cat, s]) => {
+        const active = activeCategory === cat;
+        return (
+          <button
+            key={cat}
+            type="button"
+            onClick={() => onSelect(active ? '' : cat)}
+            className={[
+              'rounded-lg border px-3 py-2 text-left transition-colors hover:bg-muted/60',
+              active ? 'border-primary bg-primary/10' : 'bg-card',
+            ].join(' ')}
+          >
+            <div className="text-xs font-medium text-muted-foreground truncate">{cat}</div>
+            <div className="mt-0.5 text-sm font-semibold tabular-nums">
+              {new Intl.NumberFormat('es-MX', {
+                style: 'currency',
+                currency: 'MXN',
+                maximumFractionDigits: 0,
+              }).format(s.valor)}
+            </div>
+            <div className="text-xs text-muted-foreground">{s.count} prod.</div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/inventario/inventario-tabs.tsx
+++ b/components/inventario/inventario-tabs.tsx
@@ -1,6 +1,13 @@
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 
+/**
+ * @deprecated ADR-004 R1 (un solo nivel de tabs). El módulo Inventario ya no usa
+ * este componente — sus tabs internos (Stock | Movimientos) se renderizan vía
+ * `<ModuleTabs>` (components/module-page). `Levantamientos` sigue importándolo
+ * temporalmente; se eliminará junto con la migración de Levantamientos a la
+ * anatomía de `<ModulePage>` (Fase 2 + actualización de sidebar).
+ */
 export type InventarioTabKey = 'overview' | 'levantamientos' | 'analisis';
 
 const TABS: { key: InventarioTabKey; label: string; href: string }[] = [
@@ -18,6 +25,7 @@ export interface InventarioTabsProps {
   className?: string;
 }
 
+/** @deprecated Ver ADR-004 R1. Será eliminado en Fase 2. */
 export function InventarioTabs({ activeKey, className }: InventarioTabsProps) {
   return (
     <nav

--- a/components/module-page/index.ts
+++ b/components/module-page/index.ts
@@ -1,0 +1,12 @@
+export { ModulePage } from './module-page';
+export type { ModulePageProps } from './module-page';
+export { ModuleHeader } from './module-header';
+export type { ModuleHeaderProps } from './module-header';
+export { ModuleTabs } from './module-tabs';
+export type { ModuleTab, ModuleTabsProps } from './module-tabs';
+export { ModuleKpiStrip } from './module-kpi-strip';
+export type { ModuleKpi, ModuleKpiStripProps } from './module-kpi-strip';
+export { ModuleFilters } from './module-filters';
+export type { ModuleFiltersProps } from './module-filters';
+export { ModuleContent } from './module-content';
+export type { ModuleContentProps } from './module-content';

--- a/components/module-page/module-content.tsx
+++ b/components/module-page/module-content.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { type ReactNode } from 'react';
+
+export interface ModuleContentProps {
+  children: ReactNode;
+}
+
+/**
+ * Pass-through slot. Exists to make the anatomy explicit and match
+ * ADR-004 1:1 in the JSX. No styling.
+ */
+export function ModuleContent({ children }: ModuleContentProps) {
+  return <>{children}</>;
+}

--- a/components/module-page/module-filters.tsx
+++ b/components/module-page/module-filters.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { type ReactNode } from 'react';
+
+export interface ModuleFiltersProps {
+  /** Filter controls in left-to-right reading order. */
+  children: ReactNode;
+  /** Right-aligned count / status text (e.g. "115 productos"). */
+  count?: ReactNode;
+  /** Right-aligned secondary actions (e.g. Imprimir, Exportar). Per ADR-004 R5. */
+  actions?: ReactNode;
+}
+
+export function ModuleFilters({ children, count, actions }: ModuleFiltersProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {children}
+      {actions ? <div className="ml-auto flex items-center gap-2">{actions}</div> : null}
+      {count ? (
+        <span className={['text-sm text-muted-foreground', actions ? '' : 'ml-auto'].join(' ')}>
+          {count}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/components/module-page/module-header.tsx
+++ b/components/module-page/module-header.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { type ReactNode } from 'react';
+
+export interface ModuleHeaderProps {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  /** Single primary action (e.g. "Registrar Movimiento", "+ Nuevo"). Optional. */
+  action?: ReactNode;
+}
+
+export function ModuleHeader({ title, subtitle, action }: ModuleHeaderProps) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        {subtitle ? <p className="text-sm text-muted-foreground">{subtitle}</p> : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}

--- a/components/module-page/module-kpi-strip.tsx
+++ b/components/module-page/module-kpi-strip.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { type ReactNode } from 'react';
+
+export interface ModuleKpi {
+  key: string;
+  label: ReactNode;
+  value: ReactNode;
+  /** Optional small icon to render left of the label. */
+  icon?: ReactNode;
+  /** Optional accent class for value (e.g. 'text-amber-500'). */
+  valueClassName?: string;
+}
+
+export interface ModuleKpiStripProps {
+  stats: ReadonlyArray<ModuleKpi>;
+  /** Default 4. KPIs >5 should be re-thought per ADR-004 R3, not crammed in. */
+  cols?: 2 | 3 | 4 | 5;
+}
+
+const COL_CLASS: Record<NonNullable<ModuleKpiStripProps['cols']>, string> = {
+  2: 'grid-cols-2',
+  3: 'grid-cols-2 md:grid-cols-3',
+  4: 'grid-cols-2 md:grid-cols-4',
+  5: 'grid-cols-2 md:grid-cols-3 lg:grid-cols-5',
+};
+
+export function ModuleKpiStrip({ stats, cols = 4 }: ModuleKpiStripProps) {
+  if (stats.length === 0) return null;
+  if (stats.length > 5 && process.env.NODE_ENV !== 'production') {
+    // Per ADR-004 R3: more than 5 KPIs is a product decision, not a layout problem.
+    console.warn(
+      `[ModuleKpiStrip] ${stats.length} KPIs received; rendering first 5. ` +
+        `See ADR-004 R3 — split into a separate dimension strip or re-prioritize.`
+    );
+  }
+  const visible = stats.slice(0, 5);
+  return (
+    <div className={['grid gap-3', COL_CLASS[cols]].join(' ')}>
+      {visible.map((s) => (
+        <div key={s.key} className="rounded-xl border bg-card px-4 py-3">
+          <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            {s.icon}
+            {s.label}
+          </div>
+          <div
+            className={['mt-1 text-2xl font-semibold tabular-nums', s.valueClassName ?? ''].join(
+              ' '
+            )}
+          >
+            {s.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/module-page/module-page.tsx
+++ b/components/module-page/module-page.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { type ReactNode } from 'react';
+
+export interface ModulePageProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Root wrapper for all ERP module pages. Enforces the canonical anatomy:
+ * Header → Tabs → KPIs → Filters → Content (in that vertical order).
+ *
+ * See ADR-004 (supabase/adr/004_module_page_layout_convention.md) for the rules.
+ */
+export function ModulePage({ children, className }: ModulePageProps) {
+  return <div className={['space-y-6', className].filter(Boolean).join(' ')}>{children}</div>;
+}

--- a/components/module-page/module-tabs.tsx
+++ b/components/module-page/module-tabs.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { type ReactNode } from 'react';
+
+export interface ModuleTab<K extends string = string> {
+  key: K;
+  label: ReactNode;
+}
+
+export interface ModuleTabsProps<K extends string = string> {
+  tabs: ReadonlyArray<ModuleTab<K>>;
+  value: K;
+  onChange: (next: K) => void;
+}
+
+/**
+ * Underline-style module tabs. Hidden when there's only one tab (per ADR-004).
+ * Matches the pattern in components/ventas/ventas-view.tsx.
+ */
+export function ModuleTabs<K extends string = string>({
+  tabs,
+  value,
+  onChange,
+}: ModuleTabsProps<K>) {
+  if (tabs.length < 2) return null;
+  return (
+    <div className="flex flex-wrap gap-2 border-b" role="tablist">
+      {tabs.map(({ key, label }) => {
+        const active = key === value;
+        return (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(key)}
+            className={[
+              '-mb-px border-b-2 px-4 py-2 text-sm font-medium transition',
+              active
+                ? 'border-emerald-500 text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground',
+            ].join(' ')}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/supabase/adr/004_module_page_layout_convention.md
+++ b/supabase/adr/004_module_page_layout_convention.md
@@ -1,0 +1,132 @@
+# ADR-004 — Convención de layout para páginas de módulo (`<ModulePage>`)
+
+- **Status**: Accepted
+- **Date**: 2026-04-25
+- **Authors**: Beto (auditoría visual Cowork-BSOP-UI), implementación inicial en PR `feat/module-page-component-fase1`
+- **Supersedes**: —
+
+---
+
+## Contexto
+
+BSOP creció de 4 a ~20 módulos en pocos meses. Cada módulo se construyó con su propio scaffolding ad-hoc, lo que produjo deriva visual y estructural entre páginas que conceptualmente son la misma cosa: **una vista tabular con header, tabs, KPIs, filtros y contenido**.
+
+La auditoría del 2026-04-25 sobre `/rdb/ventas` (limpio) e `/rdb/inventario` (con deriva) detectó tres síntomas reproducibles:
+
+1. **Doble navegación** — un `InventarioTabs` routed (Stock & Movimientos / Levantamientos / Análisis) montado encima del toggle local Stock ↔ Movimientos. Dos niveles de "dónde estoy" compitiendo.
+2. **KPIs huérfanos** — el strip principal de 4 cards (Productos, Bajo mínimo, Sin stock, Valor) seguido inmediatamente por un grid de 7 cards "por categoría" que en realidad son filtros disfrazados de KPI. Esto produce el card huérfano "$342,479 / 216 prod." que no es parte del estado del negocio sino una vista de la dimensión categoría.
+3. **Acciones secundarias en el filters bar** — "Imprimir lista" mezclado con los toggles "Ver no inventariables" y "Solo bajo mínimo", sin separación visual entre filtro y acción.
+
+Sin una convención compartida, cada módulo nuevo tiene 50% de probabilidad de heredar la deriva. Antes de migrar los ~20 módulos pendientes, fijamos la anatomía.
+
+## Decisión
+
+Introducimos `<ModulePage>`: un componente raíz compartido que enforza la **anatomía canónica** de toda página tabular de módulo en BSOP. La anatomía se compone de cinco slots verticales en orden estricto:
+
+```
+ModulePage
+├── ModuleHeader        (título + subtítulo + 1 acción primaria)
+├── ModuleTabs          (1 nivel; underline; oculto si <2 tabs)
+├── ModuleKpiStrip      (≤5 KPIs ortogonales)
+├── ModuleFilters       (filtros + 1 slot opcional para acciones secundarias + count)
+└── ModuleContent       (la tabla / lista / grid de datos)
+```
+
+Drawers, dialogs y banners contextuales (error, fecha histórica, etc.) **no** son slots — viven fuera del árbol del wrapper o entre filters/content según corresponda.
+
+Ventas (`components/ventas/ventas-view.tsx` líneas 186-294) ya implementa esta anatomía a mano y sirve como baseline visual. Inventario es la primera migración explícita al componente compartido.
+
+### Las 10 reglas (R1–R10)
+
+#### R1 — Un solo nivel de tabs
+
+Una página de módulo tiene **un** `<ModuleTabs>` o ninguno. Si conceptualmente hay un agrupador padre (e.g. "Inventario" como módulo), se resuelve vía sidebar — no vía un segundo strip de tabs.
+
+> **Por qué**: La doble navegación obliga al usuario a parsear "¿en qué nivel estoy?". Un solo strip = una sola pregunta.
+
+#### R2 — Orden vertical canónico es no-negociable
+
+Header → Tabs → KPIs → Filtros → Contenido. `<ModulePage>` no enforza el orden con runtime checks (sería un componente pesado), pero el código ejemplo y el barrel `index.ts` exponen los slots en este orden. Code review valida.
+
+> **Por qué**: La consistencia entre módulos es lo que hace que el segundo módulo se sienta "obvio".
+
+#### R3 — Máximo 5 KPIs en el strip principal
+
+`<ModuleKpiStrip>` acepta hasta 5 stats. >5 es un problema de producto, no de layout: o (a) están sobrando KPIs, o (b) hay dos dimensiones distintas que merecen secciones separadas. El componente trunca a 5 + warning en dev.
+
+> **Por qué**: Más de 5 cards en una fila se vuelven ruido — el ojo no los procesa como un estado, sino como una sopa.
+
+#### R4 — Tabs estilo underline, no pills
+
+Misma estética que Ventas: borde inferior emerald en activo, transparente en inactivo. El estilo "pills" (botones con fondo gris en un contenedor) está prohibido — es ambiguo con los toggles de filtro y rompe la jerarquía visual.
+
+> **Por qué**: Pills compiten con botones de acción y con toggles segmentados. Underline es la única forma sin colisión semántica.
+
+#### R5 — Acciones secundarias van en `<ModuleFilters actions={…}>`
+
+"Imprimir", "Exportar", "Limpiar filtros" — todo lo que **depende del estado de filtros** vive en el slot `actions` del filter bar (alineado a la derecha, antes del count). No se mezclan con los controles de filtro.
+
+> **Por qué**: Una acción que opera sobre los datos filtrados pertenece al filter bar conceptualmente. Mezclarla con los toggles confunde — el usuario no sabe si va a aplicar un filtro o disparar una acción.
+
+#### R6 — KPIs muestran estado, no filtros
+
+Una card en `<ModuleKpiStrip>` debe representar un agregado real del estado del negocio (productos totales, monto en pesos, % cumplimiento). Si la card es realmente "número de productos en categoría X" y al click filtra la tabla, **es un filtro visual, no un KPI** — pertenece a un componente separado (e.g. `<CategoryFilterStrip>`).
+
+> **Por qué**: El KPI strip debe contestar "¿cómo está el negocio?". Si lo que muestra es "¿cuánto pesa cada categoría?", esa es otra pregunta — vive en otro componente.
+
+#### R7 — KPIs por dimensión (categoría, segmento) van fuera del strip principal
+
+Corolario de R6. Cuando hay valor en mostrar la descomposición por una dimensión (categoría, ubicación, segmento), va en su propio componente local del módulo, debajo del filter bar o entre KPIs y filtros — nunca dentro de `<ModuleKpiStrip>`.
+
+> **Por qué**: Mantiene el strip principal con 4-5 KPIs ortogonales (R3) y deja claro que la descomposición es una herramienta de filtrado / inspección, no un dashboard.
+
+#### R8 — Una sola acción primaria (CTA) en el header
+
+`<ModuleHeader action={…}>` acepta exactamente un nodo. "Registrar Movimiento", "+ Nuevo", "Crear Reporte". Si el módulo tiene dos acciones de peso similar, una de las dos no es realmente primaria — repensar.
+
+> **Por qué**: La acción primaria es la respuesta a "¿qué hago aquí ahora?". Dos respuestas = ninguna respuesta.
+
+#### R9 — Drawers, dialogs y popovers viven fuera de los slots
+
+Componentes de overlay (Sheet, Dialog, Drawer, Popover global) van como hermanos de `<ModulePage>` o al final del árbol — no dentro de un slot. Su posición en el DOM no importa visualmente porque se renderizan en portal; ponerlos en un slot solo confunde la lectura del JSX.
+
+> **Por qué**: Los slots son las regiones visuales fijas de la página. Los overlays son condicionales y portal-rendered — no compiten por espacio físico.
+
+#### R10 — Banners contextuales viven entre filters y content
+
+Errores de fetch, banners de fecha histórica, alertas de estado del módulo — todo va **después de `<ModuleFilters>` y antes de `<ModuleContent>`**, no como un slot del wrapper.
+
+> **Por qué**: Un banner es una pieza condicional, no estructural. Modelarlo como slot obliga a ramificar el wrapper para cada nuevo tipo de banner. Mejor dejar la región abierta y que cada módulo renderice los banners que necesite, en el lugar canónico.
+
+## Implementación por fases
+
+- **Fase 1 (este PR)** — Crear `components/module-page/` y migrar `/rdb/inventario` como prueba. Sin cambios en Ventas (que ya cumple la anatomía a mano).
+- **Fase 2** — Migrar el resto de módulos al componente compartido. Cada migración es un PR separado, sin cambios funcionales esperados. Empezar por Ventas (porque ya cumple, es paridad pura) y luego avanzar por orden de tráfico de usuarios.
+- **Fase 3 (opcional)** — Lint rule custom que detecte páginas en `app/**/page.tsx` que usan `<h1>` sin `<ModulePage>` arriba, para evitar deriva futura.
+
+## Consecuencias
+
+### Positivas
+
+- Una página nueva de módulo se escribe en ~30 líneas de JSX. La forma es obvia.
+- Code review tiene un check binario: "¿usa `<ModulePage>` con los slots en orden?"
+- Cuando el sistema de diseño ajusta el espaciado, color de tabs, tamaño de KPI cards — se cambia en un lugar.
+- Onboarding de nuevos colaboradores baja drásticamente: la anatomía es visible en `components/module-page/index.ts`.
+
+### Negativas
+
+- Páginas no-tabulares (dashboards, formularios largos, vistas custom) no encajan en la anatomía. **Esto es por diseño** — `<ModulePage>` no es para "todas las páginas", es para "todas las páginas tabulares de módulo". Las excepciones son explícitas y conscientes.
+- Una migración mal hecha puede introducir regresiones visuales sutiles (gaps, paddings). Mitigación: screenshots before/after en cada PR de migración.
+
+### Cosas que NO cambian
+
+- Queries, fetches, RPCs, lógica de filtrado, lógica de impresión — todo el código no-estructural se preserva 1:1 en cada migración.
+- Routing, permisos (`<RequireAccess>`), navegación de sidebar.
+- Drawers y dialogs específicos del módulo — siguen siendo locales al módulo.
+
+## Referencias
+
+- Auditoría visual del 2026-04-25 (Beto, Cowork-BSOP-UI).
+- Baseline visual: `components/ventas/ventas-view.tsx` líneas 186-294.
+- Rúbrica de QA UI: `docs/qa/ui-rubric.md` (módulo audit log).
+- PR de implementación inicial: `feat/module-page-component-fase1` (Inventario como primer migrado).


### PR DESCRIPTION
Implementa Fase 1 del [ADR-004](../blob/feat/module-page-component-fase1/supabase/adr/004_module_page_layout_convention.md): componente compartido `<ModulePage>` que enforza la anatomía estándar de páginas de módulo (Header → Tabs → KPIs → Filters → Content), y migra `/rdb/inventario` como prueba.

## Cambios

- **Nuevo**: `components/module-page/` — wrapper, header, tabs, kpi-strip, filters, content + barrel.
- **Nuevo**: `components/inventario/category-filter-strip.tsx` — extracción del strip de cards "por categoría" que actuaban como filtros disfrazados de KPI.
- **Nuevo**: `supabase/adr/004_module_page_layout_convention.md` — ADR completo con reglas R1–R10, justificación, fases, consecuencias.
- **Refactor**: `app/rdb/inventario/page.tsx` — usa `<ModulePage>`, colapsa el doble toggle, mueve "Imprimir lista" al filters bar, separa los KPIs por categoría, elimina el componente local `SummaryBar` (reemplazado por helper + `<ModuleKpiStrip>`).
- **Deprecated**: `components/inventario/inventario-tabs.tsx` — marcado `@deprecated`. Sigue usado por `app/rdb/inventario/levantamientos/page.tsx`; eliminación completa + sidebar update en Fase 2.

**Sin cambios funcionales**: queries, fetches, handlers, dialogs, drawers, lógica de impresión preservados 1:1.

## Reglas ADR-004 aplicadas

- **R1** (1 nivel de tabs) — eliminado el toggle interno duplicado; tabs Stock/Movimientos ahora son los únicos.
- **R3** (max 5 KPIs en strip) — strip principal queda con 4 cards ortogonales, sin huérfanos.
- **R4** (tabs underline, no pills) — toggle interno de pills reemplazado por `<ModuleTabs>` con borde inferior emerald.
- **R5** (acciones secundarias en filters bar) — "Imprimir lista" movido a `<ModuleFilters actions={…}>`.
- **R6/R7** (KPIs por dimensión van fuera del strip principal) — categoría chips ahora son `<CategoryFilterStrip>` separado.
- **R10** (banners entre filters y content) — error y banner de fecha histórica preservados en su posición canónica.

## Verificación

- [x] `npm run typecheck` — 0 errores en archivos del PR. Los 3 errores en `components/cortes/*` (`tesseract.js`, `heic2any`, `browser-image-compression`) son pre-existentes en `main` (verificado con `git stash`).
- [x] `npm run lint` — 0 errores nuevos. 57 warnings, todos pre-existentes en otros archivos.
- [x] `npm run format:check` — todos los archivos del PR pasan prettier.
- [x] `npm run build` — `✓ Compiled successfully in 4.1s`. El typecheck final del build falla solo por los 3 errores pre-existentes mencionados.
- [ ] **Smoke manual** sobre `/rdb/inventario` (Stock, Movimientos, filtros, drawer, dialog, impresión, fecha al corte) — pendiente.
- [ ] **Smoke regresión** sobre `/rdb/ventas` — pendiente.
- [ ] **Screenshots before/after** del happy path — pendiente.

## Decisión pendiente

Levantamientos y Análisis siguen como rutas hermanas (Opción A del prompt). `InventarioTabs` se deprecó en lugar de eliminarse porque `app/rdb/inventario/levantamientos/page.tsx` aún lo importa. Eliminación completa + agregar `Levantamientos` al sidebar van en PR de seguimiento (Fase 2). La ruta `/rdb/inventario/analisis` no existe — esos tabs apuntan a un destino fantasma, también limpieza de Fase 2.

## Out of scope

- Migración de Ventas a `<ModulePage>` (ya cumple la anatomía a mano — Fase 2, sin cambios funcionales esperados).
- Migración del resto de módulos (Fase 2 según [ui-rubric.md](../blob/feat/module-page-component-fase1/docs/qa/ui-rubric.md) §Module audit log).
- Lint rule custom para forzar uso de `<ModulePage>` (Fase 3 opcional).
- Eliminación completa de `inventario-tabs.tsx` + actualización de sidebar (PR seguimiento, Fase 2).

## Test plan

- [ ] `/rdb/inventario` carga sin errores; muestra 4 KPIs sin huérfanos.
- [ ] Click en una categoría del `<CategoryFilterStrip>` filtra la tabla; click en la activa la limpia.
- [ ] Toggle Stock ↔ Movimientos funciona; el filters bar cambia su contenido condicional.
- [ ] "Registrar Movimiento" abre el dialog y guarda correctamente.
- [ ] "Imprimir lista" abre el preview y renderiza membrete + tabla + resumen por categoría.
- [ ] Click en una fila de stock abre el `<StockDetailDrawer>` con kardex.
- [ ] "Al corte" con una fecha pasada cambia los datos vía `fn_inventario_al_corte`.
- [ ] `/rdb/ventas` carga igual que antes (regresión).
- [ ] `/rdb/inventario/levantamientos` carga (sigue usando `InventarioTabs` deprecado).