### PR TITLE
fix(nav): add Levantamientos entry to RDB sidebar

### DIFF
--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -67,6 +67,7 @@ export const NAV_ITEMS: NavItem[] = [
       { label: 'Cortes', href: '/rdb/cortes' },
       { label: 'Productos', href: '/rdb/productos' },
       { label: 'Inventario', href: '/rdb/inventario' },
+      { label: 'Levantamientos', href: '/rdb/inventario/levantamientos' },
       { label: 'Proveedores', href: '/rdb/proveedores' },
       { label: 'Requisiciones', href: '/rdb/requisiciones' },
       { label: 'Órdenes de Compra', href: '/rdb/ordenes-compra' },


### PR DESCRIPTION
Después del PR #202 (que migró `/rdb/inventario` a `<ModulePage>` siguiendo ADR-004 R1: un solo nivel de tabs), el componente `InventarioTabs` ya no se monta en el page raíz de inventario — solo se renderiza adentro de las páginas hijas `/rdb/inventario/levantamientos/*`.

Con Levantamientos sin entrada en el sidebar, no hay punto de acceso desde la UI hacia esas páginas, aunque las rutas y el módulo están totalmente shipeados (PRs #192, #195, #196, #198).

Este PR agrega la entrada al sidebar bajo 'Operaciones', justo debajo de 'Inventario', desbloqueando la beta de campo en RDB esta semana.

Compatible con el plan A del ADR-004: Levantamientos vive como ruta hermana en el sidebar, no como sub-tab de Inventario.

### Cambio

```diff
       { label: 'Inventario', href: '/rdb/inventario' },
+      { label: 'Levantamientos', href: '/rdb/inventario/levantamientos' },
       { label: 'Proveedores', href: '/rdb/proveedores' },
```

Una sola línea agregada en `components/app-shell/nav-config.ts`.