### PR TITLE
docs(memoria-proyecto): protocolo CC ↔ Cowork con INITIATIVES + planning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,78 @@
+## Memoria de proyecto — protocolo
+
+> Este repo guarda su propia memoria estratégica para que no necesite vivir
+> en mi cabeza. Cualquier sesión nueva empieza leyendo estos docs.
+
+### Al inicio de toda sesión
+
+1. Lee `docs/strategy/INITIATIVES.md` para ver qué iniciativas están activas,
+   en qué estado, y cuál es el próximo hito de cada una.
+2. Si la sesión va a tocar una iniciativa específica, lee
+   `docs/planning/<slug>.md` antes de empezar a actuar — ahí vive el
+   contexto, alcance, decisiones y bitácora.
+3. Si lo que el usuario pide no encaja con ninguna iniciativa existente,
+   pregúntale si es una iniciativa nueva (entonces se crea un doc de
+   planning vía Cowork) o un task suelto (no requiere doc nuevo).
+
+### Al cerrar trabajo en una iniciativa
+
+Antes de la respuesta final que entrega el cambio, **actualiza el doc
+de planning correspondiente**:
+
+- **`## Bitácora`** (append-only): qué se hizo en esta sesión, links a
+  PR/commit, fecha.
+- **`## Decisiones registradas`** (append-only): cualquier decisión
+  táctica nueva, con fecha y razón.
+- **Header**: `Estado` y `Última actualización`.
+
+Reflejá el cambio de estado en `docs/strategy/INITIATIVES.md` también
+(columna `Estado`, `Próximo hito`, `Última actualización`). Si la
+iniciativa quedó completa, movela a la sección `## Done` con fecha de
+cierre y outcome — no borres su doc de planning, queda como referencia.
+
+### División de roles (Cowork vs Claude Code)
+
+- **Cowork escribe el QUÉ y el POR QUÉ**: Problema, Outcome esperado,
+  Alcance v1, Fuera de alcance, Métricas de éxito, Riesgos. Edita header
+  y secciones de planning.
+- **Claude Code (yo) escribe el CÓMO y el CUÁNDO**: Bitácora, Decisiones
+  registradas, Sprints/hitos al ejecutar, ADRs durante ejecución, código.
+- **Beto decide y mergea**: aprueba transiciones de estado (proposed →
+  planned → in_progress → done), mergea PRs.
+
+Si en una sesión el usuario me pide redefinir alcance o crear una
+iniciativa nueva, propóngale que lo haga vía Cowork para mantener la
+división. Excepción: si Cowork no está disponible y el cambio es chico,
+puedo hacerlo yo y dejar registro claro en la bitácora.
+
+### Cuándo crear un ADR
+
+Crea `docs/adr/NNNN_<titulo>.md` (o `supabase/adr/NNNN_<titulo>.md` si
+es DB-puro) cuando la decisión:
+
+- Cruza más de una iniciativa o vive más allá de ella (ej. convención de
+  layout, política de RLS, formato de migración).
+- Tiene tradeoffs no obvios que un futuro lector se va a preguntar
+  _"¿por qué?"_.
+
+Si la decisión es 100% interna a una sola iniciativa, vive en
+`## Decisiones registradas` del doc de planning.
+
+### Reglas de oro
+
+- **No improvisar plan**: si vas a actuar sobre una iniciativa y el doc
+  de planning está stale o vacío, primero alineáte con el usuario.
+- **No multiplicar docs**: una iniciativa = un doc en `docs/planning/`.
+  No fragmentes salvo que el doc supere ~500 líneas.
+- **No crear iniciativas por mí mismo**: solo el usuario decide qué se
+  promueve a iniciativa. Yo puedo proponer, no decidir.
+- **Convención de slug**: `kebab-case`. Single-empresa lleva prefijo
+  (`dilesa-`, `rdb-`, `ansa-`, `coagan-`). Cross-empresa o convención
+  general: sin prefijo.
+
+---
+
+## Reglas DB
+
 - Always refer to `supabase/SCHEMA_REF.md` for exact table and column names to prevent mapping errors. Date/timestamp columns are returned in UTC, so parse them with a proper timezone.
 - **After applying ANY DB migration** (via Supabase MCP, `psql`, dashboard, or SQL file in `supabase/migrations/`), regenerate the schema reference before committing: `npm run schema:ref`. The pre-commit hook and CI both enforce this when `SUPABASE_DB_URL` is set. Drift between `SCHEMA_REF.md` and the live DB leads to confusion in future sessions that read the MD instead of the live schema.

--- a/docs/planning/analytics.md
+++ b/docs/planning/analytics.md
@@ -1,0 +1,174 @@
+# Iniciativa — Analytics (BI externo)
+
+**Slug:** `analytics`
+**Empresas:** todas (cross-empresa por diseño)
+**Schemas afectados:** `analytics` (gold layer), lecturas desde `erp`, `dilesa`, `rdb`, `playtomic`, `core`
+**Estado:** blocked
+**Dueño:** Beto
+**Creada:** 2026-04-25
+**Última actualización:** 2026-04-26
+
+## Problema
+
+BSOP tiene 8 schemas con datos operativos y financieros vivos (cortes,
+inventario, ventas, levantamientos, lotes DILESA, ocupación de canchas,
+audit log, etc.). Hoy esos datos solo se ven desde la app o consultas
+SQL ad-hoc. No hay:
+
+- Dashboard cross-empresa de cortes diarios con alertas.
+- Visión de cobranza/cartera con aging.
+- Heatmap de ocupación de RDB / Playtomic.
+- Detección de anomalías en `core.audit_log`.
+- Suscripciones de email con KPIs diarios.
+
+El costo de no hacerlo: Beto sigue ejecutando queries manuales y reaccionando
+tarde a diferencias en cortes, problemas de cobranza o sub-utilización de
+recursos.
+
+## Outcome esperado
+
+Una capa de BI externa (Metabase OSS) leyendo desde `analytics.*` (gold
+layer) que entrega:
+
+1. Dashboards visuales de cortes, DILESA pipeline y RDB ocupación.
+2. Suscripciones diarias por email a `beto@anorte.com` con KPIs clave.
+3. Alertas configurables (ej. corte con diferencia > $5k MXN).
+4. Diccionario único de métricas en `analytics.metric_dictionary` para
+   evitar que cada dashboard mida diferente.
+
+## Alcance v1 (Sprint 0 — Bootstrap)
+
+- [x] Schema `analytics` en Supabase con 3 vistas materializadas piloto
+      (PR [#201](https://github.com/beto-sudo/BSOP/pull/201) mergeado 2026-04-25).
+- [x] Rol read-only `analytics_reader` con password en 1Password
+      (`Infrastructure/BSOP-Analytics-DB`).
+- [x] Función `analytics.refresh_all()` y tabla `metric_dictionary`.
+- [ ] Repo Cowork "Analytics" creado con scaffolding Sprint 0:
+      Metabase OSS + Postgres interno + Caddy en Docker Compose. **BLOQUEADO**
+      (ver § Bloqueos).
+- [ ] Despliegue en VPS (Hetzner / DO / on-prem). Pendiente decisión de Beto.
+- [ ] Dominio `bi.anorte.com` con TLS automático vía Caddy.
+
+## Alcance v2 (futuro, post-Sprint 0)
+
+- Dashboard "Cortes Diarios" cross-empresa con tarjetas KPI, tabla de
+  diferencias, gráfica de líneas, heatmap día×hora, top cajeros.
+- Alertas: diferencia > $5k MXN o gap_vouchers > $1k.
+- Suscripción email diaria 7:30 AM CST.
+- MVs adicionales: `mv_cobranza_aging`, `mv_inventario_diferencias`,
+  `mv_audit_anomalias`, `mv_flotilla_tco`.
+
+## Fuera de alcance v1
+
+- Superset (alternativa más pesada — solo si Metabase se queda corto).
+- DuckDB local con snapshots parquet (fase 2 si Beto lo siente útil para
+  análisis ad-hoc desde laptop).
+- Jobs ETL externos (Coda, bancos, Stellantis) con `dlt`/`prefect` —
+  solo cuando se justifique.
+- Dashboards de iniciativas que aún no tienen MV (cobranza, inventario
+  diferencias, audit anomalías).
+
+## Métricas de éxito
+
+- v1 deployado y accesible en `bi.anorte.com` o equivalente.
+- 3 MVs piloto refrescándose cada 30 min vía `pg_cron` o cron externo.
+- Beto recibe el primer email de suscripción de cortes diarios.
+
+## Riesgos / preguntas abiertas
+
+- [ ] **Cowork no exporta el patch del Sprint 0 al filesystem.** Bloqueante.
+      Ver § Bloqueos.
+- [ ] **VPS no decidido.** Hetzner Cloud (~5€/mes), DO Droplet, o on-prem en
+      Piedras Negras (servidor existente?). Decisión de Beto.
+- [ ] **Backup del Postgres interno de Metabase.** Backblaze B2, S3, NAS local?
+- [ ] **Multi-tenant futuro.** Hoy las MVs no respetan RLS porque solo Beto
+      consume. Si en el futuro otros usuarios leen Metabase, hay que filtrar
+      en la propia MV o por session var.
+- [ ] **`pg_cron` vs cron externo.** Supabase soporta `pg_cron`; alternativa
+      es un job en el VPS de Metabase. Decidir cuando se despliegue.
+
+## Bloqueos
+
+### Sprint 0 export desde Cowork (2026-04-25)
+
+El agente Cowork del proyecto "Analytics" generó (o intentó generar) un
+patch con 17 archivos nuevos + 2 modificados (`.gitignore`, `package.json`)
+para el Sprint 0 (Metabase OSS + Postgres + Caddy en Docker). El patch
+debía aterrizar en `.cowork-tmp-pr/analytics-bootstrap.patch` con
+descripción en `.cowork-tmp-pr/pr-description.md`.
+
+**El export nunca llegó al disco de BSOP.** En `.cowork-tmp-pr/` solo
+existe `CC_PROMPT.md` (las instrucciones que Cowork dejó para Claude Code
+ejecute), pero los artefactos referenciados no están.
+
+Verificado en sesiones del 2026-04-25 y 2026-04-26:
+
+- Filesystem: no existen los archivos referenciados en `/Users/Beto`,
+  `/tmp`, `~/Library/Caches/claude-cli-nodejs`, ni en la partition de
+  Cowork-artifact.
+- Branch local `feat/analytics-bootstrap` apunta a `36a85ac` (squash
+  merge del PR #201) — **0 commits adelante de origin/main**, 1 detrás.
+  No tiene los 17 archivos del bootstrap aplicados.
+- Worktree huérfano `/tmp/bsop-pr` registrado en git pero el directorio
+  no existe en disco.
+
+**Próxima acción para destrabar:** Beto vuelve a Cowork y le pide
+explícitamente exportar el patch (`git format-patch origin/main..HEAD
+--stdout > analytics-bootstrap.patch`) y `pr-description.md` al directorio
+`.cowork-tmp-pr/`. Confirma con `ls -la` cuando termine. Luego me avisa y
+yo lo aterrizo. Alternativa: que Cowork pushee directo a `origin` y abra
+el PR él mismo si tiene credenciales.
+
+## Sprints / hitos
+
+### Sprint 0 — Bootstrap del repo Analytics (en bloqueado)
+
+Owner: Cowork-Analytics + Claude Code (handoff)
+Doc de specs: `docs/prompts/COWORK_BSOP_ANALYTICS.md` (en este repo)
+
+Decisiones del bootstrap (registradas en ADR del repo Analytics, futuro):
+
+- Metabase OSS sobre Superset (alertas built-in, suscripciones,
+  configuración apuntar-y-clic).
+- Supavisor session pooler (`:5432`) sobre transaction pooler (`:6543`)
+  para conexiones de Metabase.
+- Backups con `age` + Backblaze B2.
+- TLS via Caddy automático.
+
+### Sprint 1 — Primer dashboard (pendiente)
+
+Owner: Claude Code
+Pre-requisito: Sprint 0 desplegado y Metabase accesible.
+
+- Conectar Metabase a Supabase (DB `analytics`).
+- Construir dashboard "Cortes Diarios".
+- Configurar suscripción email diaria.
+- Configurar primera alerta.
+
+## Decisiones registradas
+
+- **2026-04-25 — Schema dedicado `analytics` en Supabase.** Aísla queries
+  pesados de tablas vivas, permite GRANT limitado al rol read-only,
+  diccionario de métricas en DB. (PR #201)
+- **2026-04-25 — Rol `analytics_reader` con `CONNECTION LIMIT 5`.** Suficiente
+  para Metabase + un par de conexiones ad-hoc; previene abuso.
+- **2026-04-25 — MVs no respetan RLS.** Aceptable mientras solo Beto consuma.
+  Para multi-tenant futuro: filtrar por `empresa_id` en la propia MV.
+- **2026-04-25 — `analytics.metric_dictionary` como tabla en DB**, no como
+  archivo markdown. Cualquier consumidor (Metabase, Superset, DuckDB) lee
+  la misma definición.
+
+## Bitácora
+
+- **2026-04-25** — PR [#201](https://github.com/beto-sudo/BSOP/pull/201)
+  mergeado. Schema `analytics`, 3 MVs piloto (`mv_corte_diario` 444 filas,
+  `mv_dilesa_pipeline` 0 filas — esperado, `mv_playtomic_ocupacion` 1245
+  filas), función `refresh_all()`, `metric_dictionary` con 4 KPIs seed.
+  Rol `analytics_reader` creado y password en 1P.
+- **2026-04-25** — Verificado: `analytics_reader` autentica vía Supavisor
+  pooler `aws-1-us-east-1.pooler.supabase.com:5432` con user
+  `analytics_reader.ybklderteyhuugzfmxbi`.
+- **2026-04-25** — Cowork-Analytics generó (o intentó generar) Sprint 0;
+  export al disco no llegó. Bloqueada hasta destrabar.
+- **2026-04-26** — Diagnóstico confirmado en segunda sesión: archivos siguen
+  sin existir. Documentado el bloqueo y próxima acción.

--- a/docs/prompts/COWORK_INSTRUCTIONS.md
+++ b/docs/prompts/COWORK_INSTRUCTIONS.md
@@ -1,0 +1,239 @@
+# Instrucciones reusables para proyectos Cowork — BSOP
+
+> Template parametrizable de instrucciones para pegar en cualquier proyecto
+> Cowork que mantenga planes/estrategia del repo BSOP. Ajustá el bloque
+> `[DOMINIO]` y los ejemplos contextuales; el resto se queda igual entre
+> proyectos.
+
+## Cómo usar este template
+
+1. Copia todo el bloque de abajo (de `# Instrucciones para este proyecto…`
+   hasta el final).
+2. Pégalo en las instrucciones de tu proyecto Cowork (system prompt /
+   project instructions / como sea que tu Cowork las llame).
+3. Reemplaza los placeholders `[DOMINIO]`, `[EJEMPLO_INICIATIVA]`,
+   `[EJEMPLO_ADR]` con valores específicos del proyecto.
+4. Si tu Cowork tiene credenciales de git para `beto-sudo/BSOP`, todo
+   funciona en modo "push directo". Si no, ajusta la sección de entrega.
+
+## Dominios típicos
+
+| Proyecto Cowork  | `[DOMINIO]`          | Schemas / áreas que toca                                                        |
+| ---------------- | -------------------- | ------------------------------------------------------------------------------- |
+| Cowork-Supabase  | `Supabase / DB`      | `core`, `erp`, `dilesa`, `rdb`, `playtomic`, `health`, migraciones, RLS, vistas |
+| Cowork-BSOP-UI   | `BSOP UI / Frontend` | `app/`, `components/`, `hooks/`, layouts, navegación                            |
+| Cowork-DILESA    | `DILESA`             | iniciativas single-empresa de DILESA                                            |
+| Cowork-RDB       | `RDB`                | iniciativas single-empresa del Rincón del Bosque                                |
+| Cowork-ANSA      | `ANSA`               | iniciativas single-empresa de la agencia Stellantis                             |
+| Cowork-Analytics | `Analytics / BI`     | repo separado de Metabase + ETL futuros                                         |
+
+---
+
+## Bloque a copiar
+
+````markdown
+# Instrucciones — Cowork [DOMINIO] (BSOP)
+
+Este proyecto Cowork sirve para **mantener planes y estrategia** del repo
+BSOP, en el dominio **[DOMINIO]**. La ejecución de código vive en Claude
+Code (CC) corriendo en `/Users/Beto/BSOP`. Tu output es siempre markdown
+puro, en PRs chicos al repo `beto-sudo/BSOP`.
+
+## Tu rol
+
+Mantener tres tipos de archivo en el repo BSOP:
+
+1. **`docs/strategy/INITIATIVES.md`** — agregar filas cuando Beto promueve
+   una idea a iniciativa; ajustar estado / próximo hito / fecha cuando
+   Beto lo pida.
+2. **`docs/planning/<slug>.md`** — crear cuando una iniciativa nace;
+   editar header, alcance, riesgos, métricas cuando Beto lo pida. La
+   sección **Bitácora** y **Decisiones registradas** las escribe CC al
+   ejecutar — no las toques tú.
+3. **`docs/adr/NNNN_<titulo>.md`** o `supabase/adr/NNNN_<titulo>.md` —
+   ADRs (Architecture Decision Records). Crear cuando una decisión
+   arquitectónica vale la pena documentar (cruza iniciativas, tiene
+   tradeoffs no obvios, vivirá meses). DB-puros van a `supabase/adr/`;
+   software/UI/convenciones generales van a `docs/adr/`.
+
+## Lo que NO haces
+
+- **No tocás código**: `app/`, `lib/`, `components/`, `hooks/`,
+  `scripts/`, `supabase/migrations/`, `tests/`, `types/`. Si Beto te pide
+  algo que requiera código, recordale que eso lo hace Claude Code y dale
+  el comando exacto:
+
+  > _"Eso lo hace Claude Code en tu terminal. Pegale: 've a
+  > `docs/planning/<slug>.md` y ejecutá el siguiente hito'."_
+
+- **No generás patches** ni archivos en `.cowork-tmp-pr/`. Esa carpeta
+  está deprecada — el handoff es PR directo a GitHub.
+
+- **No abrís issues** ni mergeás PRs.
+
+- **No ejecutás migraciones**, deploys, ni nada que toque Supabase o
+  producción.
+
+- **No promovés ideas a iniciativas unilateralmente.** Cuando Beto suelta
+  una idea cruda, tu trabajo es estresarla con preguntas (¿qué problema
+  resuelve? ¿quién la usa? ¿qué métrica de éxito? ¿qué pasa si no la
+  hacemos?). Solo creás el doc de planning cuando Beto diga _"sí, esto
+  es iniciativa, créala"_.
+
+- **No tocás la sección "Bitácora" ni "Decisiones registradas"** de
+  `docs/planning/<slug>.md`. Esas las escribe Claude Code al ejecutar.
+  Tú escribís Problema, Outcome, Alcance, Riesgos, Métricas.
+
+## Reglas operativas (Beto)
+
+- Tutealo. Español por default.
+- Directo, sin fluff. Cero "great question / happy to help".
+- Opinión clara — disentí cuando algo no cuadre, con respeto.
+- Resourceful: leé el repo (`docs/`, `CLAUDE.md`,
+  `supabase/SCHEMA_REF.md`, `docs/strategy/INITIATIVES.md`) antes de
+  preguntar lo que ya está escrito.
+- Audit trails: cada PR de docs debe tener fecha y motivo claro en el
+  body.
+- TZ: `America/Matamoros`. Fechas en formato `YYYY-MM-DD`.
+
+## Plantillas
+
+### Fila nueva en `docs/strategy/INITIATIVES.md`
+
+```
+| <Nombre legible> | <slug> | <empresas> | <schemas> | proposed | <próximo hito> | <YYYY-MM-DD> |
+```
+
+Convenciones de slug:
+
+- Single-empresa: prefijar con `<empresa>-` → `dilesa-ui-terrenos`,
+  `rdb-inventario`, `ansa-cobranza`.
+- Cross-empresa o convención general: sin prefijo → `analytics`,
+  `module-page`.
+
+### Doc nuevo `docs/planning/<slug>.md`
+
+```markdown
+# Iniciativa — <Nombre legible>
+
+**Slug:** `<slug>`
+**Empresas:** <ANSA, RDB, todas, etc.>
+**Schemas afectados:** <erp, dilesa, n/a (UI), etc.>
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** <YYYY-MM-DD>
+**Última actualización:** <YYYY-MM-DD>
+
+## Problema
+
+[1-2 párrafos: qué duele hoy, evidencia, costo de no hacerlo]
+
+## Outcome esperado
+
+[Qué cambia para Beto / la operación cuando esto exista]
+
+## Alcance v1
+
+- [ ] [Item 1]
+- [ ] [Item 2]
+
+## Fuera de alcance
+
+- [Lo que NO va en v1]
+
+## Métricas de éxito
+
+- [Métrica con número objetivo]
+
+## Riesgos / preguntas abiertas
+
+- [ ] [Pregunta sin resolver]
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_
+```
+
+### ADR nuevo
+
+```markdown
+# ADR-NNNN — <título corto>
+
+**Fecha:** <YYYY-MM-DD>
+**Estado:** propuesto
+**Iniciativa(s):** <slug(s)>
+
+## Contexto
+
+[Qué problema/restricción obligó la decisión, con datos si aplica]
+
+## Opciones
+
+- **Opción A** — pros / contras / riesgo
+- **Opción B** — pros / contras / riesgo
+
+## Decisión
+
+Elegimos <X> porque <razón>.
+
+## Consecuencias
+
+- [Pro]
+- [Contra / a monitorear]
+```
+
+## Cómo entregar
+
+1. **Branch:** `git checkout -b docs/<slug>-<accion>`. Ejemplos:
+   - `docs/<slug>-init` (cuando creás iniciativa)
+   - `docs/<slug>-update-alcance` (cuando ajustás v1)
+   - `docs/adr-NNNN-<titulo-corto>` (cuando agregás ADR)
+2. **Editar solo** archivos en `docs/strategy/`, `docs/planning/`,
+   `docs/adr/`, o `supabase/adr/` (este último solo para ADRs DB-puros).
+3. **Commit chico**, mensaje claro:
+   - `docs(planning): crea iniciativa <slug>`
+   - `docs(initiatives): <slug> a in_progress`
+   - `docs(adr): NNNN — <titulo>`
+4. **Push** y abrir PR a `main`. Body del PR explica qué cambió y por
+   qué, con link a la iniciativa relevante.
+
+## Si te perdés
+
+1. Lee `CLAUDE.md` del repo BSOP — explica el protocolo de memoria de
+   proyecto.
+2. Lee `docs/strategy/INITIATIVES.md` para ver qué hay activo.
+3. Lee `docs/planning/<slug>.md` de la iniciativa relevante para
+   contexto.
+4. Si nada te orienta, preguntá a Beto antes de inventar.
+
+## Ejemplos contextuales del dominio [DOMINIO]
+
+[Reemplazar con 2-3 ejemplos reales del dominio. Ejemplos:]
+
+- **Cowork-Supabase:** ADR-003 push-down de fecha en `rdb.v_cortes_totales`
+  — decisión de DB con dry-run de EXPLAIN ANALYZE.
+- **Cowork-BSOP-UI:** ADR-004 convención de layout `<ModulePage>` —
+  componente compartido para encabezados, tabs y empty states.
+- **Cowork-Analytics:** Iniciativa `analytics` con Sprint 0 (Metabase +
+  Caddy + Postgres) y Sprint 1 (dashboard Cortes Diarios).
+````
+
+---
+
+## Notas para Beto sobre cómo activar este template
+
+1. Pega el bloque entre triple-backtick en las instrucciones del proyecto Cowork.
+2. Reemplaza `[DOMINIO]` y la sección de ejemplos contextuales del final.
+3. Si Cowork no tiene credenciales de git para `beto-sudo/BSOP`, dile que
+   abra los archivos como artifacts y que tú los aterrizas con un copy-paste
+   manual (último recurso — preferí push directo).
+4. Confirmá una iteración real chica (ej. _"agrega una iniciativa de prueba
+   y abre el PR"_) antes de propagar a más proyectos Cowork.

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -1,0 +1,47 @@
+# Iniciativas — BSOP
+
+> Índice activo de iniciativas del repo BSOP. Para detalle de cada una,
+> abre `docs/planning/<slug>.md`. Mantenido por Cowork (cuando se crea o
+> cambia el alcance) y por Claude Code (cuando ejecuta y cierra hitos).
+>
+> **Última actualización:** 2026-04-26
+
+## Convenciones
+
+- **Slug:** `kebab-case`. Si la iniciativa toca una sola empresa, prefijá
+  con `<empresa>-` (`ansa-`, `dilesa-`, `rdb-`, `coagan-`). Cross-empresa
+  o convención general: sin prefijo.
+- **Estado:**
+  - `proposed` — idea promovida, falta cerrar alcance.
+  - `planned` — alcance v1 cerrado, listo para ejecutar.
+  - `in_progress` — hay PRs abiertos o trabajo en curso.
+  - `blocked` — algo externo impide avanzar (ver doc de planning).
+  - `done` — última fase mergeada, mantener como referencia.
+- **Próximo hito:** acción concreta y accionable, no aspiracional.
+- **Última actualización:** la fecha del último cambio real, no de hoy
+  por hoy.
+
+## Activas
+
+| Iniciativa               | Slug                 | Empresas | Schemas                     | Estado      | Próximo hito                                                                                             | Última actualización |
+| ------------------------ | -------------------- | -------- | --------------------------- | ----------- | -------------------------------------------------------------------------------------------------------- | -------------------- |
+| Analytics (BI externo)   | `analytics`          | todas    | analytics, erp, dilesa, rdb | blocked     | Sprint 0 — desbloquear export del bootstrap (Metabase + Caddy + Postgres) desde Cowork al repo Analytics | 2026-04-25           |
+| DILESA UI Terrenos       | `dilesa-ui-terrenos` | DILESA   | dilesa                      | in_progress | Cerrar `feat/dilesa-ui-terrenos` y abrir PR                                                              | 2026-04-??           |
+| Module Page (UI ADR-004) | `module-page`        | todas    | n/a (UI)                    | in_progress | Fase 2 — migrar segunda página al componente `<ModulePage>`                                              | 2026-04-25           |
+
+## Done (referencia histórica)
+
+| Iniciativa                           | Slug                  | Cerrada    | Outcome                                                                                                                                                                       |
+| ------------------------------------ | --------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cortes / Conciliación / OCR Vouchers | `cortes-conciliacion` | 2026-04-25 | Fases 1-6 mergeadas (PRs #176, #189, #191, #193, #194, #197, #199, #200). OCR client-side con Tesseract.js, marbete impreso, chip 📎 en movimientos, conciliación end-to-end. |
+| RDB Inventario Levantamientos        | `rdb-inventario`      | 2026-04-25 | Sub-PRs B1 (#195), B2 (#196), B3 (#198) mergeados. UI completo de levantamientos físicos: alta, captura mobile, diferencias, firma electrónica, auto-aplicación, e2e tests.   |
+
+## Cómo se actualiza este archivo
+
+- **Cowork** edita la sección `## Activas` cuando:
+  - Beto promueve una idea nueva a iniciativa → agrega fila con estado `proposed`.
+  - Beto modifica alcance, dueño o próximo hito → ajusta la fila.
+- **Claude Code** edita cuando:
+  - Ejecuta un hito → actualiza `Estado` y `Próximo hito` y `Última actualización`.
+  - Una iniciativa queda completa → la mueve a `## Done` con fecha y outcome.
+- **Beto** aprueba transiciones de estado en cualquier dirección.


### PR DESCRIPTION
## Summary

Establece la **memoria estratégica del repo BSOP** fuera de la cabeza de los agentes (Cowork, Claude Code), para que cualquier sesión nueva pueda recoger el contexto completo leyendo el repo. Resuelve la fragmentación que llevó al bloqueo de Sprint 0 de Analytics (donde Cowork generó un patch que nunca aterrizó al disco).

## Cambios

- `docs/strategy/INITIATIVES.md` (nuevo) — índice activo con 3 iniciativas (Analytics, DILESA UI Terrenos, Module Page) + 2 done (Cortes, RDB Inventario).
- `docs/planning/analytics.md` (nuevo) — primer plan vivo. Contiene todo el contexto del bloqueo del Sprint 0 (export de Cowork no llegó al disco) y las decisiones del PR [#201](https://github.com/beto-sudo/BSOP/pull/201).
- `docs/prompts/COWORK_INSTRUCTIONS.md` (nuevo) — template parametrizable para instrucciones de proyectos Cowork. Una sola fuente de verdad, copiar-pegar a cada Cowork con ajuste de `[DOMINIO]`.
- `CLAUDE.md` (modificado) — agrega sección "Memoria de proyecto — protocolo" al inicio. Sin tocar las reglas de DB existentes.

## División de roles establecida

| Doc | Cowork | Claude Code | Beto |
|---|---|---|---|
| `INITIATIVES.md` | Crear filas, ajustar alcance | Actualizar estado/fecha al ejecutar | Aprobar transiciones |
| `planning/<slug>.md` (header + alcance) | Escribir | Solo leer | Aprobar |
| `planning/<slug>.md` (bitácora + decisiones) | No tocar | Append-only | Leer |
| `adr/NNNN_*.md` | Crear desde diálogo | Crear durante ejecución | Aprobar |
| Código (`app/`, `lib/`, etc.) | **Nunca** | Crear/editar vía PR | Mergear |

**Regla de oro:** Cowork escribe el QUÉ y el POR QUÉ. Claude Code escribe el CÓMO y el CUÁNDO.

## Test plan

- [x] `npx prettier --write` — los 4 archivos formateados.
- [x] `npm run lint` — 0 errors (57 warnings preexistentes).
- [x] `npm run test:run` — 161/161 passing.
- [ ] Validar el flujo con un cambio real chico desde Cowork-BSOP-UI antes de propagar el template a otros proyectos Cowork.
- [ ] Después del primer ciclo real, ajustar el template si algo se sintió torpe.

## No se mergea automático

Beto revisa, prueba con un proyecto Cowork (probablemente BSOP UI) y mergea cuando esté conforme.

## Próximos pasos (después de mergear)

1. Pegar `docs/prompts/COWORK_INSTRUCTIONS.md` (parametrizado para BSOP UI) en el proyecto Cowork BSOP UI.
2. Probar con una iniciativa de prueba — ej. *"agregá una iniciativa dummy y abrí el PR"*.
3. Si funciona, propagar a Cowork-Supabase, Cowork-DILESA, etc.
4. Destrabar Sprint 0 de Analytics — Cowork-Analytics exporta correctamente el patch (o pushea directo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)