### PR TITLE
docs(planning,adr): iniciativa module-page-submodules + ADR-005

### DIFF
--- a/docs/adr/005_module_with_submodules_routed_tabs.md
+++ b/docs/adr/005_module_with_submodules_routed_tabs.md
@@ -1,0 +1,120 @@
+# ADR-005 — Módulos con sub-módulos: routed tabs en layout compartido
+
+**Fecha:** 2026-04-25
+**Estado:** propuesto
+**Iniciativa(s):** `module-page-submodules`
+
+## Contexto
+
+ADR-004 estableció `<ModulePage>` y la regla R1: "un solo nivel de tabs por página, los hermanos viven en sidebar". El primer caso (Inventario en PR #202) se migró con state tabs internos `Stock | Movimientos`, y se decidió que Levantamientos saliera del módulo a entry de sidebar (PR #203, mergeado 2026-04-25).
+
+Aplicado en producción, el resultado se ve incorrecto: Levantamientos aparenta ser un módulo independiente al mismo nivel que Ventas, Cortes, Productos. Funcionalmente NO lo es — comparte permisos (`rdb.inventario`), almacenes, productos. Adicionalmente, las sub-rutas de Levantamientos siguen montando un `<InventarioTabs>` antiguo (pill) con `Stock & Movimientos | Levantamientos | Análisis`, generando dos estilos de navegación coexistiendo en el mismo módulo.
+
+R1 era correcta como anti-pattern (no anidar pills sobre pills) pero demasiado restrictiva como regla. La realidad es que los módulos del ERP tienen sub-módulos (Inventario→Levantamientos hoy; Cortes→Conciliación/Marbete/Vouchers; Productos→Variantes/Categorías/SKUs después), y necesitamos un patrón canónico.
+
+## Opciones
+
+### Opción A — Sub-módulos como sidebar siblings (status quo post-#203)
+
+Cada sub-módulo aparece como entry hermana al módulo padre en el sidebar.
+
+**Pros:**
+
+- Cumple R1 literal (1 nivel por page).
+- URL plana.
+
+**Contras:**
+
+- Sidebar bloated: Inventario + Levantamientos + Análisis + Conciliación + Marbete + Vouchers + Variantes + ... = N entradas que el usuario no agrupa mentalmente.
+- Visualmente: sub-módulos aparentan ser independientes cuando no lo son.
+- Sin breadcrumb claro de pertenencia.
+- Validado en uso: Beto reportó 2026-04-25 que se "ve mal".
+
+**Riesgo:** alto — UX se degrada con cada sub-módulo nuevo.
+
+### Opción B — Sub-módulos como state tabs adentro del page raíz (`?tab=...` o estado local)
+
+El page raíz del módulo tiene tab state interno; cambiar tab muta state local sin cambiar URL.
+
+**Pros:**
+
+- Implementación simple.
+
+**Contras:**
+
+- URL no refleja el tab → no bookmark, no share, refresh pierde tab.
+- Sub-detalles (`[id]`, `nuevo`, etc.) son rutas reales, así que hay inconsistencia: tabs son state pero los detalles tienen URL real.
+- Browser back navega rutas, no tabs.
+
+**Riesgo:** medio — funciona técnicamente, falla en UX.
+
+### Opción C — Sub-módulos como routed tabs en `layout.tsx` compartido (recomendada)
+
+`app/<modulo>/layout.tsx` renderiza el shell de `<ModulePage>` (header + `<ModuleTabs>`) con N tabs que son rutas hermanas:
+
+- `/<modulo>` (sin sub-ruta) = primer tab (default landing).
+- `/<modulo>/<sub1>`, `/<modulo>/<sub2>`, ... = tabs adicionales.
+
+Tab activo se deriva de `usePathname()`. Sub-detalles profundos (`/<modulo>/<sub>/[id]`, etc.) heredan el mismo layout para mantener el strip visible.
+
+**Pros:**
+
+- URL refleja el tab → bookmarks y share funcionan.
+- Browser back/forward navega entre tabs.
+- Un solo strip visible (cumple el espíritu de R1: un nivel visible, no anidación).
+- Sub-detalles tienen contexto: el usuario sabe dónde está y puede saltar a otro tab del módulo.
+- Patrón estándar Next.js (route groups + layouts).
+- Generalizable a Cortes, Productos, etc.
+
+**Contras:**
+
+- Si un sub-detalle muy inmersivo (ej. flujo de captura full-screen) NO debería mostrar el strip, hace falta un layout anidado para "salirse" — overhead manejable.
+- Migrar módulos existentes con state tabs requiere split del page.tsx en N rutas. Costo único por módulo.
+
+**Riesgo:** bajo. Estructura estándar de Next.js, regression contained al módulo migrado.
+
+### Opción D — Sub-módulos como pills/segments adentro del page (estilo viejo `InventarioTabs`)
+
+Tabs en el page con estilo distinto al strip principal (pills), tratando de evitar la anidación visual.
+
+**Pros:** intento de R1.
+
+**Contras:**
+
+- Dos estilos de tab distintos confunden al usuario (¿cuál es la nav primaria?).
+- Validado: el `InventarioTabs` viejo en `/rdb/inventario/levantamientos/*` no se distingue claramente del strip principal.
+- No resuelve URL sync.
+
+**Riesgo:** alto — el patrón ya falló en producción.
+
+## Decisión
+
+**Opción C.** Routed tabs en `layout.tsx` compartido entre rutas hermanas.
+
+## Consecuencias
+
+### Aclaración a ADR-004 R1
+
+R1 originalmente decía: *"Un solo nivel de tabs por página. Si necesitas otro nivel, son módulos hermanos en el sidebar."*
+
+Se aclara: **"Un solo nivel de tabs visible por página."** Los tabs pueden vivir en un `layout.tsx` compartido entre rutas hermanas siempre que solo se vea un strip — la fuente del strip (page o layout) es indistinta para el usuario. Sub-detalles profundos heredan el strip por consistencia, manteniendo "un strip visible".
+
+Sub-módulos NO van al sidebar como hermanos del módulo padre cuando comparten dominio funcional (mismo permiso base, mismas entidades). Solo van al sidebar como hermanos cuando son módulos genuinamente independientes (ej. Ventas vs Cortes vs Productos — entidades distintas, casos de uso distintos).
+
+### Positivas
+
+- Patrón consistente para módulos con sub-módulos.
+- URL share-able para cada tab.
+- Sidebar limpio: solo módulos top-level.
+- Aplicable a Cortes (siguiente candidato natural), Productos, etc.
+- Browser back/forward y refresh son intuitivos.
+
+### Neutras / a monitorear
+
+- Sub-detalles muy inmersivos (ej. flujo de captura mobile-first) pueden requerir esconder el strip. Caso edge — manejar con layout anidado en vez de hacer regla nueva.
+- Si un sub-módulo crece y eventualmente justifica salir como módulo independiente, el refactor es simétrico (layout tab → sidebar entry).
+
+### Negativas
+
+- Migrar módulos existentes con state tabs implica split de `page.tsx` en N rutas. Costo único por módulo (Inventario primero, Cortes después).
+- ADR-004 R1 necesitó aclaración después de aplicarlo en producción — recordatorio de que reglas demasiado estrictas se descubren al chocar con casos reales (PR #203 fue el caso real).

--- a/docs/planning/module-page-submodules.md
+++ b/docs/planning/module-page-submodules.md
@@ -1,0 +1,82 @@
+# Iniciativa — Module-page sub-módulos (routed tabs at layout)
+
+**Slug:** `module-page-submodules`
+**Empresas:** RDB (primero), todas (el patrón es cross-empresa)
+**Schemas afectados:** n/a (UI)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-25
+**Última actualización:** 2026-04-25
+
+## Problema
+
+Después del PR #202 (ADR-004 Fase 1 — `<ModulePage>` migrado a `/rdb/inventario`), surgió un gap visible: los sub-módulos de un módulo (ej. Levantamientos dentro de Inventario) no tienen un patrón claro de presentación.
+
+PR #203 intentó resolverlo agregando "Levantamientos" como entrada hermana en el sidebar bajo "Operaciones" (junto a Ventas, Cortes, Productos, Inventario, etc.). Aplicado y revisado por Beto el 2026-04-25, el resultado se ve incorrecto: visualmente, Levantamientos aparenta ser un módulo independiente al mismo nivel que Inventario, cuando funcionalmente es una vista del módulo Inventario (mismos productos, mismo almacén, mismo permiso `rdb.inventario`).
+
+Adicionalmente, la implementación actual deja una inconsistencia visible:
+
+- En `/rdb/inventario` solo se ven los state tabs internos `Stock | Movimientos` (estilo underline, vía `<ModuleTabs>`).
+- En `/rdb/inventario/levantamientos/*` se monta `InventarioTabs` (estilo pill, viejo) con `Stock & Movimientos | Levantamientos | Análisis`.
+
+Dos navegaciones distintas, dos estilos visuales, sin coherencia de "dónde estoy". Aunque cada page individual cumple ADR-004 R1 (un solo nivel de tabs por page), en la práctica el módulo entero tiene navegación inconsistente.
+
+El patrón que necesitamos resuelve esto en general: cualquier módulo con sub-módulos (Inventario → Levantamientos hoy; Cortes → Conciliación / Marbete / Vouchers después; Productos → Variantes / Categorías / SKUs después) debe tener UNA forma canónica de exponerlos.
+
+## Outcome esperado
+
+- Levantamientos vive como tab del módulo Inventario, no como entry de sidebar.
+- Patrón generalizable a otros módulos con sub-módulos.
+- Un solo strip de tabs visible en cualquier ruta de Inventario, mismo estilo (underline emerald-500, vía `<ModuleTabs>`).
+- URL refleja el tab activo (bookmark-eable, share-able, browser back/forward funciona entre tabs).
+- Sub-detalles profundos (`/[id]`, `/[id]/capturar`, `/[id]/diferencias`, `/[id]/reporte`, `/nuevo`) mantienen el strip de tabs visible para que el usuario pueda navegar entre Stock/Movimientos/Levantamientos sin perder contexto. (Decisión confirmada como Opción A en discusión 2026-04-25.)
+
+## Alcance v1
+
+- [ ] **Revertir** la entrada `Levantamientos` del sidebar (deshacer PR #203 en `components/app-shell/nav-config.ts`).
+- [ ] **Crear `app/rdb/inventario/layout.tsx`** que renderiza el shell de `<ModulePage>` (header + `<ModuleTabs>`) con 3 tabs routed: Stock, Movimientos, Levantamientos. Tab activo derivado de `usePathname()`.
+- [ ] **Splittear el page actual** (que hoy tiene state tabs internos):
+  - `app/rdb/inventario/page.tsx` → solo Stock view (default landing del módulo).
+  - `app/rdb/inventario/movimientos/page.tsx` (nuevo) → Movimientos view extraído del page actual.
+  - `app/rdb/inventario/levantamientos/page.tsx` → ya existe, hereda el nuevo layout.
+- [ ] **Sub-detalle de Levantamientos** (`[id]`, `[id]/capturar`, `[id]/diferencias`, `[id]/reporte`, `nuevo`) hereda el layout — los 3 tabs siguen visibles arriba con "Levantamientos" como tab activo.
+- [ ] **Borrar `components/inventario/inventario-tabs.tsx`** — el viejo componente pill queda obsoleto. Verificar con `git grep` que ningún otro page lo importe antes de borrar.
+- [ ] **Estados `loading` / `empty` / `error`** consistentes en cada tab (preservar lo que ya tiene cada page).
+- [ ] **Responsive (375px mínimo):** los 3 tabs caben sin scroll horizontal en pantalla angosta. Si no caben, primero intentar reducir padding del tab antes de truncar texto.
+- [ ] **A11y:** `role="tablist"` en el strip, `aria-current="page"` en el tab activo de los routed tabs (Next.js convención para routed tabs).
+
+## Fuera de alcance
+
+- Cortes (Conciliación / Marbete / Vouchers) y otros módulos con sub-módulos — vendrá en iniciativas siguientes una vez validado el patrón en Inventario.
+- Cambios en lógica de queries, fetches, RLS, permisos del módulo.
+- Cambios en `<ModulePage>`, `<ModuleHeader>`, `<ModuleTabs>` (componentes ya existen y se reusan tal cual).
+- Migración de otros módulos sin sub-módulos (Ventas, Productos hoy) — si no tienen sub-módulos, no aplica este patrón.
+
+## Métricas de éxito
+
+- 0 inconsistencias visuales entre `/rdb/inventario`, `/rdb/inventario/movimientos`, `/rdb/inventario/levantamientos`, y sub-detalles. Verificar con screenshots before/after en el PR.
+- 0 entradas duplicadas u huérfanas en sidebar (RDB queda con módulos top-level únicamente).
+- Tiempo subjetivo del equipo RDB para encontrar Levantamientos: "obvio en <3s" desde abrir Inventario.
+- Build passing, type-check passing, lint passing en el PR.
+- Smoke manual: refresh sobre cada ruta no rompe; browser back/forward navega entre tabs correctamente.
+
+## Riesgos / preguntas abiertas
+
+- [ ] **Compat con state tabs actuales** — la migración de Stock/Movimientos de state-based a routed implica perder el state tab logic actual. Revisar handlers que dependen de `tab === 'stock'` vs `tab === 'movimientos'` (ej. en filters bar). CC debe garantizar que cada page nuevo tenga sus propios filtros/KPIs/handlers correspondientes.
+- [ ] **Default landing del módulo** — `/rdb/inventario` queda como Stock view (default). Confirmado 2026-04-25.
+- [ ] **Estado del sub-detalle profundo** — al estar dentro de `/rdb/inventario/levantamientos/[id]/capturar`, los tabs de Inventario siguen visibles. Si el usuario hace click en "Stock" o "Movimientos", pierde el progreso de captura no guardado. CC decide si agregar pop-up de confirmación durante implementación; no bloquea v1.
+- [ ] **Mobile (≤375px)** — 3 tabs underline con texto "Stock | Movimientos | Levantamientos" caben aprox 250px. Validar en dispositivo. Si no caben, considerar reducir padding antes de truncar texto o aplicar scroll horizontal.
+- [ ] **Permisos por tab** — actualmente `rdb.inventario` cubre stock + movimientos + levantamientos. Si en el futuro Levantamientos requiere permiso específico (ej. `rdb.inventario.levantamientos`), el layout deberá esconder el tab para usuarios sin acceso. No bloquea v1.
+- [ ] **`InventarioTabs` borrado** — antes de borrar, `git grep -l "InventarioTabs\|inventario-tabs"` y migrar cualquier consumidor restante al nuevo layout.
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -28,6 +28,7 @@
 | Analytics (BI externo)   | `analytics`          | todas    | analytics, erp, dilesa, rdb | blocked     | Sprint 0 — desbloquear export del bootstrap (Metabase + Caddy + Postgres) desde Cowork al repo Analytics | 2026-04-25           |
 | DILESA UI Terrenos       | `dilesa-ui-terrenos` | DILESA   | dilesa                      | in_progress | Cerrar `feat/dilesa-ui-terrenos` y abrir PR                                                              | 2026-04-??           |
 | Module Page (UI ADR-004) | `module-page`        | todas    | n/a (UI)                    | in_progress | Fase 2 — migrar segunda página al componente `<ModulePage>`                                              | 2026-04-25           |
+| Module-page sub-módulos  | `module-page-submodules` | RDB (primero), todas | n/a (UI)                    | proposed    | Plan + ADR-005 aprobados → CC ejecuta refactor de Inventario                                             | 2026-04-25           |
 
 ## Done (referencia histórica)
 


### PR DESCRIPTION
Promueve a iniciativa la corrección que Beto pidió el 2026-04-25: los sub-módulos de un módulo (Levantamientos dentro de Inventario) deben presentarse como tabs routed en un layout compartido, no como sidebar siblings.

**Este PR no toca código.** Solo docs en `docs/strategy/`, `docs/planning/`, `docs/adr/`. La ejecución del refactor la hace Claude Code en un PR siguiente, leyendo `docs/planning/module-page-submodules.md`.

## Cambios

- **`docs/strategy/INITIATIVES.md`** — agrega fila `module-page-submodules` (proposed, RDB primero + patrón cross-empresa). 1 línea.
- **`docs/planning/module-page-submodules.md`** (nuevo) — planning doc completo con Problema, Outcome, Alcance v1, Métricas, Riesgos. Sin tocar Bitácora/Decisiones (las llena CC al ejecutar).
- **`docs/adr/005_module_with_submodules_routed_tabs.md`** (nuevo) — decisión arquitectónica: aclara R1 de ADR-004 ("un solo nivel **visible**", no "un solo nivel de tabs por page") y establece routed tabs en `layout.tsx` compartido como patrón canónico para módulos con sub-módulos.

## Motivación

- PR #202 mergeó ADR-004 Fase 1 con state tabs internos en Inventario.
- PR #203 (yo, fuera de rol — debí haber pasado por planning doc) agregó Levantamientos como sidebar entry, mergeado y aplicado.
- Beto validó en uso que el sidebar sibling se ve mal: visualmente Levantamientos aparenta módulo independiente cuando funcionalmente es vista del módulo Inventario.
- Adicionalmente, sub-rutas de Levantamientos siguen mostrando `<InventarioTabs>` viejo (pill) que compite con `<ModuleTabs>` nuevo (underline), generando dos estilos de nav coexistiendo.

ADR-005 documenta el patrón canónico. Planning doc cubre el alcance del refactor en RDB Inventario (revert sidebar + layout.tsx + split routes + delete `inventario-tabs.tsx`).

## Decisión confirmada en discusión 2026-04-25

- Sub-detalles profundos (`/[id]`, `/[id]/capturar`, etc.) **mantienen el strip de tabs visible** (Opción A).
- Default landing del módulo: **Stock**.

## Próximo paso (después de merge)

Claude Code lee `docs/planning/module-page-submodules.md` y abre PR ejecutando alcance v1.