### PR TITLE
docs(ui-roadmap): alta de 8 iniciativas UI en cola secuencial

### DIFF
--- a/docs/planning/a11y-baseline.md
+++ b/docs/planning/a11y-baseline.md
@@ -1,0 +1,78 @@
+# Iniciativa — Accessibility baseline (WCAG 2.1 AA)
+
+**Slug:** `a11y-baseline`
+**Empresas:** todas
+**Schemas afectados:** n/a (UI)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-26
+**Última actualización:** 2026-04-26
+
+> **Bloqueada hasta cierre de `responsive-policy`.** Alcance v1 detallado
+> se cierra cuando arranque su turno.
+
+## Problema
+
+Cero documentado sobre accesibilidad. Riesgo bajo hoy (uso interno, base
+de usuarios chica), pero crece con cada empleado nuevo (operadores con
+distintas capacidades, uso prolongado que exige buena ergonomía visual,
+posible obligación legal a futuro). Costo de corrección crece con el
+tamaño del producto: mejor fijar baseline ahora que cuando haya 50
+módulos.
+
+## Outcome esperado
+
+- Baseline WCAG 2.1 AA documentado y testeable.
+- `<ModulePage>`, `<DataTable>`, `<EmptyState>`, etc. cumplen el
+  baseline by default.
+- Audit script (`npm run audit:a11y` con axe-core o similar) corre en
+  CI y bloquea PRs con regresiones críticas.
+- Convenciones explícitas: contrast ratios, focus visible, keyboard
+  nav, labels, ARIA.
+
+## Alcance v1 (tentativo — refinar al arrancar)
+
+- [ ] ADR fijando WCAG 2.1 AA como baseline mínimo.
+- [ ] Audit baseline con axe DevTools sobre módulos clave.
+- [ ] Reglas: contraste 4.5:1 en texto normal, focus visible
+      siempre, todo elemento interactivo navegable por teclado.
+- [ ] Convención de aria-label / aria-labelledby para componentes
+      compartidos.
+- [ ] Script `audit:a11y` en CI sobre rutas representativas.
+- [ ] Capacitación / referencia rápida en `docs/qa/a11y-rubric.md`.
+
+## Fuera de alcance
+
+- WCAG AAA (más estricto, no es estándar internacional para apps
+  internas).
+- Soporte completo de screen readers en flujos OCR / camera (caso
+  edge — documentar como excepción).
+- Audit manual con usuarios con discapacidad — costoso, postergar.
+
+## Métricas de éxito
+
+- axe-core reporta 0 issues críticas o serias en módulos auditados.
+- Keyboard-only walkthrough completo de 3 módulos clave sin bloqueo.
+- Contraste mínimo 4.5:1 en todo texto (verificado con tool).
+
+## Riesgos / preguntas abiertas
+
+- [ ] ¿Algunos componentes shadcn/radix ya cumplen baseline o hay que
+      ajustarlos?
+- [ ] Tablas grandes con `<DataTable>` — ¿navegación por teclado entre
+      celdas o solo entre filas?
+- [ ] Modales y drawers — focus trap correcto.
+- [ ] Color como único indicador de estado (badges) — agregar texto o
+      icono.
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/planning/access-denied-ux.md
+++ b/docs/planning/access-denied-ux.md
@@ -1,0 +1,81 @@
+# Iniciativa — Access Denied UX (`<RequireAccess>`)
+
+**Slug:** `access-denied-ux`
+**Empresas:** todas
+**Schemas afectados:** n/a (UI)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-26
+**Última actualización:** 2026-04-26
+
+> **Bloqueada hasta cierre de `a11y-baseline`.** Alcance v1 detallado se
+> cierra cuando arranque su turno.
+
+## Problema
+
+El componente `<RequireAccess>` decide qué se renderiza cuando un usuario
+no tiene permiso, pero el "qué" varía por módulo. La rúbrica
+(`docs/qa/ui-rubric.md` Section 1) menciona "Acceso restringido" pero no
+fija copy ni diseño. Probablemente hay deriva: pantalla en blanco,
+mensaje genérico, redirección silenciosa a `/`, o `<RequireAccess>` no
+aplicado consistentemente.
+
+Síntomas anticipables:
+
+- "Acceso restringido" sin acción — el usuario no sabe a quién pedirle
+  el permiso.
+- Algunos módulos redirigen, otros muestran mensaje, otros no protegen
+  nada (ouch).
+
+## Outcome esperado
+
+- Componente compartido `<AccessDenied>` con copy estándar, indicación
+  del permiso requerido, y CTA "Pedir acceso a [admin]" o link a
+  página de soporte.
+- `<RequireAccess>` aplicado consistentemente en todas las rutas
+  protegidas.
+- Lint rule o test que detecte páginas sin protección de acceso.
+
+## Alcance v1 (tentativo — refinar al arrancar)
+
+- [ ] Auditoría: catalogar uso de `<RequireAccess>` en `app/**`.
+- [ ] Componente `<AccessDenied permissionRequired>` con copy
+      estándar y acción.
+- [ ] Decisión: ¿mostrar la página con `<AccessDenied>` o redirigir
+      a `/`? (Recomendación previa: mostrar — el usuario sabe que el
+      módulo existe pero no tiene acceso.)
+- [ ] CTA "Pedir acceso" — definir qué hace (mailto, slack, ticket).
+- [ ] Documentar en ADR.
+
+## Fuera de alcance
+
+- Sistema de solicitud de acceso self-service con aprobación. Eso es
+  feature de producto.
+- RLS / permisos a nivel DB — eso es DB, no UI.
+
+## Métricas de éxito
+
+- 100% de rutas en `app/<empresa>/**` protegidas con `<RequireAccess>`.
+- `<AccessDenied>` reusa componente compartido (cero copy ad-hoc).
+- Usuarios reportan menos confusión cuando no tienen acceso.
+
+## Riesgos / preguntas abiertas
+
+- [ ] ¿Detectar permiso requerido por convención de path o explícito
+      por prop?
+- [ ] ¿Mostrar "no tienes acceso" para módulos completos que el rol
+      del usuario no incluye en sidebar (consistencia con la nav)?
+- [ ] Coordinar con `a11y-baseline` (focus en mensaje al cargar,
+      role="alert").
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/planning/action-feedback.md
+++ b/docs/planning/action-feedback.md
@@ -1,0 +1,77 @@
+# Iniciativa — Action Feedback (toast + confirm destructive)
+
+**Slug:** `action-feedback`
+**Empresas:** todas
+**Schemas afectados:** n/a (UI)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-26
+**Última actualización:** 2026-04-26
+
+> **Bloqueada hasta cierre de `filters-url-sync`.** Alcance v1 detallado
+> se cierra cuando arranque su turno.
+
+## Problema
+
+Cada módulo decide por su cuenta cómo dar feedback después de una
+mutación: a veces toast, a veces banner inline, a veces nada y el
+usuario no sabe si su acción tuvo efecto. Igual con confirmaciones
+destructivas (eliminar, desactivar, anular) — algunos módulos
+preguntan, otros no, y el copy varía.
+
+Síntomas:
+
+- Posición y duración de toasts inconsistente.
+- "¿Estás seguro?" con copy distinto entre módulos.
+- Sin pattern de "undo" donde tendría sentido (ej. desactivar producto).
+- Errores de mutación a veces caen a `console` sin feedback al user.
+
+## Outcome esperado
+
+- Toast pattern único (sonner u shadcn toast) con convención de copy,
+  posición, duración por tipo (success / error / info).
+- `<ConfirmDestructive>` componente compartido para acciones
+  irreversibles, con copy parametrizado por entidad.
+- "Undo" donde la operación lo permita (soft-delete que se puede
+  revertir en N segundos).
+- Cero `alert()` o feedback ad-hoc en módulos.
+
+## Alcance v1 (tentativo — refinar al arrancar)
+
+- [ ] Decidir librería: sonner (ya común en shadcn) vs alternativa.
+- [ ] Helper `toast.success/error/info(message)` con defaults.
+- [ ] `<ConfirmDestructive entity action onConfirm>` modal compartido.
+- [ ] Convención: toast para no-destructivo, modal para destructivo.
+- [ ] Migrar 2-3 mutaciones existentes como prueba (probable:
+      eliminar movimiento de inventario, anular venta, desactivar
+      producto).
+
+## Fuera de alcance
+
+- Sistema de notificaciones persistente (notif center). Eso es feature.
+- Feedback en tiempo real (websockets, presencia). Out of scope.
+
+## Métricas de éxito
+
+- Toda mutación visible al usuario tiene feedback (toast o modal).
+- Cero `alert()` / `confirm()` nativos en el código.
+- Copy de "¿Estás seguro?" reusa el componente compartido.
+
+## Riesgos / preguntas abiertas
+
+- [ ] ¿Toast en mobile? Posición y safe-areas.
+- [ ] ¿Stacking de múltiples toasts simultáneos?
+- [ ] Coexistencia con `<ErrorBanner>` de `module-states` — toast es
+      efímero, banner es persistente. Definir cuándo cada uno.
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/planning/data-table.md
+++ b/docs/planning/data-table.md
@@ -1,0 +1,80 @@
+# Iniciativa — Data Table compartido
+
+**Slug:** `data-table`
+**Empresas:** todas
+**Schemas afectados:** n/a (UI)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-26
+**Última actualización:** 2026-04-26
+
+> **Bloqueada hasta cierre de `detail-page`.** Alcance v1 detallado se
+> cierra cuando arranque su turno.
+
+## Problema
+
+Cada `<ModuleContent>` arma su tabla con su propio scaffolding: sorting
+manual, paginación a veces (cuando hay), density variable (compact en
+unos, comfortable en otros), sticky headers donde alguien se acordó.
+A 20 módulos en el horizonte, multiplica variantes y bugs sutiles
+(orden de columnas inconsistente, paginación cortando filas, headers
+que no se quedan).
+
+## Outcome esperado
+
+- Componente `<DataTable>` compartido (probable wrapper sobre
+  `@tanstack/react-table` o similar) con:
+  - Sorting por columna (declarativo).
+  - Paginación opcional + "Cargar más" como alternativa.
+  - Density toggle (compact / comfortable) persistido en URL o local.
+  - Sticky header.
+  - Selección múltiple (bulk actions) opt-in.
+  - Virtualización para tablas >500 filas.
+- Convención de columnas: typeof formatter (currency, date, badge),
+  alineación (numérica derecha, texto izquierda), truncate con tooltip.
+- Row actions menu (kebab) consistente.
+
+## Alcance v1 (tentativo — refinar al arrancar)
+
+- [ ] Decidir base: tanstack-table vs custom. tanstack es estándar,
+      pero peso del bundle hay que evaluar.
+- [ ] API de columns (config declarativo).
+- [ ] Sorting + paginación + sticky.
+- [ ] Density toggle.
+- [ ] Migrar 1-2 tablas existentes (probable: Productos, Ventas).
+- [ ] ADR.
+
+## Fuera de alcance
+
+- Editable cells / inline editing. Patrón aparte.
+- Drag-to-reorder columnas. Útil pero no v1.
+- Export a CSV / XLSX en el componente — eso es feature de cada
+  módulo, no del wrapper.
+
+## Métricas de éxito
+
+- 100% de tablas en módulos migrados usan `<DataTable>`.
+- Cero implementaciones custom de sort/sticky en módulos posteriores.
+- Tablas grandes (Movimientos histórico, Productos) sin lag visible.
+
+## Riesgos / preguntas abiertas
+
+- [ ] Bundle size de tanstack-table — medir antes de decidir.
+- [ ] Compatibilidad con sorting server-side (cuando la query lo
+      necesita).
+- [ ] Bulk select interactúa con `<ModuleFilters>` (filtros activos
+      definen "todos los seleccionables").
+- [ ] Print layout — la tabla compartida tiene que respetar
+      `@media print` (relacionado con `print-pattern` futuro).
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/planning/detail-page.md
+++ b/docs/planning/detail-page.md
@@ -1,0 +1,82 @@
+# Iniciativa — Detail Page anatomy (`[id]`)
+
+**Slug:** `detail-page`
+**Empresas:** todas
+**Schemas afectados:** n/a (UI)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-26
+**Última actualización:** 2026-04-26
+
+> **Bloqueada hasta cierre de `action-feedback`.** Alcance v1 detallado
+> se cierra cuando arranque su turno.
+
+## Problema
+
+ADR-004 fija anatomía para páginas tabulares de módulo (`<ModulePage>`),
+pero explícitamente excluye no-tabulares. Las páginas de detalle
+(`/<modulo>/[id]`, ej. `/dilesa/terrenos/[id]`, `/rdb/cortes/[id]`,
+una venta abierta) están sin convención: cada módulo decide su propio
+header, distribución de meta, ubicación de tabs internos, drawer vs
+página completa.
+
+Síntomas anticipables:
+
+- Drawers de detalle (Ventas) y páginas de detalle (probable
+  Terrenos en `dilesa-ui-terrenos`) coexisten sin regla de cuándo
+  usar cada uno.
+- Header de detalle inconsistente: a veces breadcrumb, a veces back
+  button, a veces título grande, a veces compacto con meta inline.
+- Tabs internos de detalle varían: pills vs underline (R4 de ADR-004
+  dice underline para módulos, ¿aplica a detalles?).
+
+## Outcome esperado
+
+- Anatomía canónica para páginas de detalle: header (back + título +
+  meta + acciones), tabs internos opcionales, content.
+- Decisión clara: ¿drawer o página? Criterio simple por tamaño/complejidad.
+- Componente `<DetailPage>` compartido (paralelo a `<ModulePage>`).
+- ADR documentando el patrón.
+
+## Alcance v1 (tentativo — refinar al arrancar)
+
+- [ ] Auditoría de páginas de detalle existentes (Cortes, Movimientos,
+      Levantamientos, próximamente Terrenos).
+- [ ] Componente `<DetailPage>` con slots: header, meta strip, tabs,
+      content, actions.
+- [ ] Regla drawer vs página: criterio por densidad de info y
+      profundidad de navegación.
+- [ ] Migrar 1-2 detalles existentes como prueba.
+- [ ] ADR documentando.
+
+## Fuera de alcance
+
+- Vistas tipo timeline / activity log para entidades. Eso es feature
+  de producto, no anatomy.
+- Edición inline en el header (rename click-to-edit). Patrón aparte.
+
+## Métricas de éxito
+
+- Páginas de detalle usan `<DetailPage>` o tienen ADR de excepción.
+- Decisión drawer-vs-page documentada en review checklist.
+
+## Riesgos / preguntas abiertas
+
+- [ ] Reusar `<ModuleTabs>` (underline) en detail tabs — ¿genera
+      ambigüedad con tabs del módulo padre? (Ojo con ADR-005.)
+- [ ] Mobile: detalles full-screen vs drawer modal. Coordinar con
+      `responsive-policy`.
+- [ ] ¿`<DetailPage>` necesita su propio routing layout (similar a
+      ADR-005) cuando hay tabs internos con sub-rutas?
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/planning/filters-url-sync.md
+++ b/docs/planning/filters-url-sync.md
@@ -1,0 +1,75 @@
+# Iniciativa — Filters URL-sync
+
+**Slug:** `filters-url-sync`
+**Empresas:** todas
+**Schemas afectados:** n/a (UI)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-26
+**Última actualización:** 2026-04-26
+
+> **Bloqueada hasta cierre de `module-states`.** Alcance v1 detallado se
+> cierra cuando arranque su turno — el alcance acá es preliminar para
+> que CC tenga contexto.
+
+## Problema
+
+Los filtros de cada `<ModuleFilters>` viven en `useState` local: refrescar
+la página los pierde, no se pueden compartir como link, browser back no
+funciona, y bookmarks no sirven. Inconsistente con el patrón de routed
+tabs (ADR-005) que ya gana share/bookmark/back para la nav primaria.
+
+A eso se suma que cada módulo implementa "Limpiar filtros" y el contador
+de "N filtros activos" por su cuenta — duplicación y deriva.
+
+## Outcome esperado
+
+- Los filtros viven en la URL (`?almacen=X&estado=activo&q=texto`).
+- Refresh, share y browser back funcionan igual que con routed tabs.
+- "Limpiar todo" y contador de filtros activos como pattern compartido.
+- Hook compartido (ej. `useUrlFilters`) que cada `<ModuleFilters>` usa.
+
+## Alcance v1 (tentativo — refinar al arrancar)
+
+- [ ] Hook `useUrlFilters` que lee/escribe `searchParams` con tipos.
+- [ ] Convención de nombres de query params (snake_case vs camelCase,
+      booleanos como `1`/`0` vs `true`/`false`).
+- [ ] Componente / API para "Limpiar todo" + contador de filtros
+      activos (badge en el filter bar).
+- [ ] Migrar 1-2 módulos de prueba (probable: Ventas e Inventario).
+- [ ] ADR-007 documentando la decisión.
+
+## Fuera de alcance
+
+- Persistencia server-side de filtros por usuario (ej. "mis vistas
+  guardadas"). Eso es feature de producto, no convención de UI.
+- Filtros complejos con AND/OR explícito — v1 asume AND implícito
+  entre todos los filtros activos.
+
+## Métricas de éxito
+
+- Compartir un link con filtros aplicados reproduce la misma vista en
+  otro browser.
+- Browser back navega correctamente entre estados de filtros.
+- Cero `useState` local para filtros en módulos migrados.
+
+## Riesgos / preguntas abiertas
+
+- [ ] Compatibilidad con Next.js App Router — `useSearchParams` es
+      cliente, hay que confirmar que no rompe SSR ni revalidate.
+- [ ] Filtros con muchos valores (multi-select largo) en URL — ¿hay
+      límite de longitud? ¿hash vs ids?
+- [ ] Coexistencia con `?tab=...` de routed tabs (ADR-005). Definir
+      orden y conflict resolution.
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/planning/module-states.md
+++ b/docs/planning/module-states.md
@@ -1,0 +1,144 @@
+# Iniciativa — Module States (empty / loading / error)
+
+**Slug:** `module-states`
+**Empresas:** todas
+**Schemas afectados:** n/a (UI)
+**Estado:** planned
+**Dueño:** Beto
+**Creada:** 2026-04-26
+**Última actualización:** 2026-04-26
+
+## Problema
+
+Cada migración a `<ModulePage>` (ADR-004) decide ad-hoc qué mostrar mientras
+carga, cuando no hay datos, o cuando el fetch revienta. ADR-004 R10 fija
+que los banners viven entre `<ModuleFilters>` y `<ModuleContent>`, pero no
+hay componente compartido ni copy estándar — cada módulo inventa el suyo.
+
+Síntomas observados:
+
+- Inventario y Ventas usan distinto skeleton (algunas filas vs spinner
+  centrado vs nada y "salto" cuando llegan datos).
+- El estado vacío con filtros aplicados a veces no distingue de "nunca
+  hubo datos" — el usuario no sabe si limpiar filtros o crear una entidad.
+- Errores de fetch caen en `console.error` o en un toast efímero; no hay
+  banner persistente con retry.
+- Cada PR de migración a `<ModulePage>` repite la misma decisión —
+  superficie de inconsistencia que crece con cada módulo nuevo.
+
+A 20 módulos en el horizonte, el costo de no tener pattern es ~20×
+decisiones repetidas + drift visual + copy disperso.
+
+## Outcome esperado
+
+- Tres componentes compartidos en `components/module-page/`:
+  `<EmptyState>`, `<TableSkeleton>`, `<ErrorBanner>`.
+- Copy estándar (es-MX) documentado y reusable, parametrizado por
+  entidad ("ventas", "movimientos", "terrenos", etc.).
+- Tiempo de migración a `<ModulePage>` baja: la página nueva ya no
+  inventa empty/loading/error, los importa.
+- Auditoría visual de los 3 estados se vuelve binaria: ¿usa el
+  componente compartido? sí/no.
+
+## Alcance v1
+
+### Componentes
+
+- [ ] `<EmptyState>` — props: `icon` (lucide), `title`, `description`,
+      `action` (CTA opcional como ReactNode). Renderiza centrado,
+      padding consistente con `<ModuleContent>`.
+- [ ] `<TableSkeleton>` — props: `rows` (default 5), `columns` (number
+      o array de widths para reflejar el shape real de la tabla).
+      Animación shimmer suave, mismo border-radius que la tabla real.
+- [ ] `<ErrorBanner>` — props: `error` (Error | string), `onRetry`
+      (función opcional), `dismissible` (bool, default false).
+      Color/borde rojo coherente con el sistema. Si hay `onRetry`,
+      muestra botón "Reintentar".
+
+### Variantes documentadas
+
+- [ ] **Vacío sin filtros (módulo virgen)** — copy: "Aún no hay
+      [entidad]." + CTA opcional para crear (mismo botón que el
+      `action` del header del módulo).
+- [ ] **Vacío con filtros activos** — copy: "Ningún resultado coincide
+      con los filtros." + CTA "Limpiar filtros" que dispara el
+      `clear-all` del filter bar.
+- [ ] **Cargando primera vez** — `<TableSkeleton>` con shape coherente
+      con la tabla esperada (no spinner centrado).
+- [ ] **Recargando con datos previos** — mantener tabla vieja, mostrar
+      indicador discreto en KPI strip o filter bar (opacity / spinner
+      pequeño). No reemplazar tabla por skeleton.
+- [ ] **Error de fetch** — `<ErrorBanner>` con mensaje legible (no
+      stack trace), botón "Reintentar" si la operación es idempotente.
+- [ ] **Error parcial** (algunos KPIs OK, fetch secundario falló) — el
+      banner aparece entre filters y content, los KPIs cargados se
+      mantienen.
+
+### Migración
+
+- [ ] Migrar Ventas (`/<empresa>/ventas`) — baseline limpio, sirve de
+      golden path.
+- [ ] Migrar Inventario (`/rdb/inventario`) — primer módulo con
+      `<ModulePage>` real, tiene los 3 estados en uso.
+- [ ] Documentar en `docs/adr/006_module_states.md` la decisión y los
+      3 componentes (subordinado a ADR-004 R10).
+- [ ] Actualizar `docs/qa/ui-rubric.md` Section 1 y 2 con checks que
+      apunten a los componentes nuevos.
+
+### A11y mínimo (sin bloquear v1)
+
+- [ ] `<TableSkeleton>` con `role="status"` y `aria-label="Cargando [entidad]"`.
+- [ ] `<ErrorBanner>` con `role="alert"` y `aria-live="polite"`.
+- [ ] `<EmptyState>` con heading semántico (`<h2>` o `<h3>`).
+
+## Fuera de alcance
+
+- Toasts / snackbar globales para feedback de mutaciones (eso vive en
+  `action-feedback`, iniciativa #3).
+- Skeletons para drawers / sheets / forms (postergar; v1 cubre módulos
+  tabulares solo).
+- Animaciones / transiciones sofisticadas entre estados.
+- Internacionalización del copy — todo el ERP es es-MX, no hay i18n
+  pendiente.
+- Estados de loading de acciones individuales (botón "Guardando...");
+  eso vive cerca del componente de acción, no acá.
+
+## Métricas de éxito
+
+- 100% de páginas migradas a `<ModulePage>` usan los 3 componentes
+  compartidos al cierre de Fase 2 de `module-page`.
+- Cero copy de empty/loading/error nuevo escrito ad-hoc en migraciones
+  posteriores (verificable en code review con check binario).
+- Reducción medible de líneas JSX: registrar antes/después en el PR de
+  Inventario (target: -30 líneas por página migrada).
+- Auditoría manual con la rúbrica reporta los 3 estados ✅ en cada
+  módulo migrado.
+
+## Riesgos / preguntas abiertas
+
+- [ ] **Coordinación con `module-page` (Fase 2 in_progress).** Esta
+      iniciativa puede arrancar en paralelo: los componentes se crean
+      y se aplican a Ventas como primer migrado de Fase 2. No bloquea.
+- [ ] **Páginas no-tabulares** (dashboards, formularios largos) —
+      `<EmptyState>` y `<ErrorBanner>` son reusables, `<TableSkeleton>`
+      no aplica. Documentar que los 3 son opt-in para no-tabulares.
+- [ ] **Diseño visual del shimmer** — ¿gradiente animado o pulse
+      simple? Decisión chica que vale screenshot review.
+- [ ] **¿`<EmptyState>` con ilustración o solo icono lucide?** v1 con
+      icono lucide para no traer assets nuevos. Ilustraciones se
+      pueden agregar después por módulo si justifican.
+- [ ] **Copy del CTA en empty con filtros** — ¿"Limpiar filtros" o
+      "Quitar filtros" o "Mostrar todo"? Ver consistencia con el
+      filter bar actual de Ventas.
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/planning/responsive-policy.md
+++ b/docs/planning/responsive-policy.md
@@ -1,0 +1,71 @@
+# Iniciativa — Responsive policy
+
+**Slug:** `responsive-policy`
+**Empresas:** todas
+**Schemas afectados:** n/a (UI)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-26
+**Última actualización:** 2026-04-26
+
+> **Bloqueada hasta cierre de `data-table`.** Alcance v1 detallado se
+> cierra cuando arranque su turno.
+
+## Problema
+
+Algunos módulos son inherentemente mobile-first (RDB Inventario captura
+con código de barras, Marbete impreso, Conciliación en piso) y otros
+son desktop-only (Cortes financiero, Productos admin, dashboards). Hoy
+cada módulo decide sin regla — y cuando alguien abre el módulo equivocado
+en su teléfono, la experiencia varía entre "funciona", "funciona feo" y
+"no se puede usar".
+
+## Outcome esperado
+
+- Cada módulo declara su perfil responsive: `mobile-first`,
+  `desktop-only`, o `responsive` (degrada gracefully).
+- Convención clara de breakpoints (Tailwind defaults o custom).
+- Componentes compartidos saben cómo degradan: `<DataTable>` →
+  cards en mobile, drawers full-screen en mobile, etc.
+- Para módulos `desktop-only`, copy explícito en mobile: "Este módulo
+  está optimizado para desktop. Abrilo en una pantalla más grande."
+
+## Alcance v1 (tentativo — refinar al arrancar)
+
+- [ ] Auditoría: catalogar perfil responsive actual de cada módulo.
+- [ ] ADR fijando los 3 perfiles + breakpoints canónicos.
+- [ ] Componente `<DesktopOnlyNotice>` para módulos no-mobile.
+- [ ] Reglas de degradación de `<DataTable>`, `<ModuleKpiStrip>`,
+      `<ModuleFilters>` en mobile.
+- [ ] Touch target mínimo (44x44 en mobile).
+
+## Fuera de alcance
+
+- Apps nativas (RN, Capacitor). Solo web.
+- PWA installability — feature aparte.
+
+## Métricas de éxito
+
+- Cada módulo tiene perfil declarado en su page o layout.
+- Mobile audit (Chrome DevTools) sin overlap ni overflow horizontal
+  en ninguno de los módulos `mobile-first` o `responsive`.
+
+## Riesgos / preguntas abiertas
+
+- [ ] ¿Detectar mobile por viewport o user-agent? Viewport es estándar
+      pero pierde casos edge (tablet en portrait).
+- [ ] Sidebar en mobile — ¿drawer hamburger o tab bar inferior?
+- [ ] Coordinar con `module-states` (skeletons en mobile son distintos
+      al desktop) y `data-table` (degradación a cards).
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -4,7 +4,7 @@
 > abre `docs/planning/<slug>.md`. Mantenido por Cowork (cuando se crea o
 > cambia el alcance) y por Claude Code (cuando ejecuta y cierra hitos).
 >
-> **Última actualización:** 2026-04-26 (`rdb-waitry-ingesta-dedup` arranca Fase 2.A Opción C)
+> **Última actualización:** 2026-04-26 (UI roadmap inicial — 8 iniciativas agregadas en cola: `module-states` planned + 7 proposed)
 
 ## Convenciones
 
@@ -23,13 +23,38 @@
 
 ## Activas
 
-| Iniciativa               | Slug                       | Empresas             | Schemas                     | Estado      | Próximo hito                                                                                                       | Última actualización |
-| ------------------------ | -------------------------- | -------------------- | --------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------ | -------------------- |
-| Analytics (BI externo)   | `analytics`                | todas                | analytics, erp, dilesa, rdb | blocked     | Sprint 0 — desbloquear export del bootstrap (Metabase + Caddy + Postgres) desde Cowork al repo Analytics           | 2026-04-25           |
-| DILESA UI Terrenos       | `dilesa-ui-terrenos`       | DILESA               | dilesa                      | in_progress | Cerrar `feat/dilesa-ui-terrenos` y abrir PR                                                                        | 2026-04-??           |
-| Module Page (UI ADR-004) | `module-page`              | todas                | n/a (UI)                    | in_progress | Fase 2 — migrar segunda página al componente `<ModulePage>`                                                        | 2026-04-25           |
-| Module-page sub-módulos  | `module-page-submodules`   | RDB (primero), todas | n/a (UI)                    | in_progress | PR de refactor RDB Inventario abierto → smoke manual + merge (Beto)                                                | 2026-04-26           |
-| Waitry ingesta + dedup   | `rdb-waitry-ingesta-dedup` | RDB                  | rdb (waitry\_\*), erp       | in_progress | Fase 2.B — fix de `compute_content_hash` (incluir `tableId`) + backfill + re-detección, fuera de horario operativo | 2026-04-26           |
+| Iniciativa                  | Slug                       | Empresas             | Schemas                     | Estado      | Próximo hito                                                                                                       | Última actualización |
+| --------------------------- | -------------------------- | -------------------- | --------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------ | -------------------- |
+| Accessibility Baseline (UI) | `a11y-baseline`            | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`responsive-policy`)                                                           | 2026-04-26           |
+| Access Denied UX (UI)       | `access-denied-ux`         | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`a11y-baseline`)                                                               | 2026-04-26           |
+| Action Feedback (UI)        | `action-feedback`          | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`filters-url-sync`)                                                            | 2026-04-26           |
+| Analytics (BI externo)      | `analytics`                | todas                | analytics, erp, dilesa, rdb | blocked     | Sprint 0 — desbloquear export del bootstrap (Metabase + Caddy + Postgres) desde Cowork al repo Analytics           | 2026-04-25           |
+| Data Table compartido (UI)  | `data-table`               | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`detail-page`)                                                                 | 2026-04-26           |
+| Detail Page anatomy (UI)    | `detail-page`              | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`action-feedback`)                                                             | 2026-04-26           |
+| DILESA UI Terrenos          | `dilesa-ui-terrenos`       | DILESA               | dilesa                      | in_progress | Cerrar `feat/dilesa-ui-terrenos` y abrir PR                                                                        | 2026-04-??           |
+| Filters URL-sync (UI)       | `filters-url-sync`         | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`module-states`)                                                               | 2026-04-26           |
+| Module Page (UI ADR-004)    | `module-page`              | todas                | n/a (UI)                    | in_progress | Fase 2 — migrar segunda página al componente `<ModulePage>`                                                        | 2026-04-25           |
+| Module-page sub-módulos     | `module-page-submodules`   | RDB (primero), todas | n/a (UI)                    | in_progress | PR de refactor RDB Inventario abierto → smoke manual + merge (Beto)                                                | 2026-04-26           |
+| Module States (UI)          | `module-states`            | todas                | n/a (UI)                    | planned     | CC implementa `<EmptyState>` + `<TableSkeleton>` + `<ErrorBanner>` y migra Ventas/Inventario como prueba           | 2026-04-26           |
+| Waitry ingesta + dedup      | `rdb-waitry-ingesta-dedup` | RDB                  | rdb (waitry\_\*), erp       | in_progress | Fase 2.B — fix de `compute_content_hash` (incluir `tableId`) + backfill + re-detección, fuera de horario operativo | 2026-04-26           |
+| Responsive Policy (UI)      | `responsive-policy`        | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`data-table`)                                                                  | 2026-04-26           |
+
+## Roadmap UI (orden de ejecución secuencial)
+
+> Las 8 iniciativas con sufijo "(UI)" arriba son una cola secuencial.
+> Cada una arranca cuando la anterior cierra (en `done` o, mínimo,
+> última fase mergeada). El alcance v1 detallado se cierra al arrancar
+> cada turno — los docs en `docs/planning/<slug>.md` tienen un esqueleto
+> con Problema + Outcome + Alcance tentativo para que CC tenga contexto.
+
+1. `module-states` — empty + loading + error compartidos. **Arranca primero.**
+2. `filters-url-sync` — URL sync + clear all + contador.
+3. `action-feedback` — toast + confirm destructive.
+4. `detail-page` — anatomy de páginas `[id]` no-tabulares.
+5. `data-table` — `<DataTable>` compartido (sort, paginación, density, sticky).
+6. `responsive-policy` — mobile-first vs desktop-only por módulo.
+7. `a11y-baseline` — WCAG 2.1 AA mínimo.
+8. `access-denied-ux` — `<RequireAccess>` UX.
 
 ## Done (referencia histórica)
 


### PR DESCRIPTION
## Summary

- Cowork promovió un **roadmap de UI** con 8 iniciativas que se ejecutan en cola secuencial: cada una arranca al cerrar la anterior.
- Solo `module-states` (la primera) tiene alcance v1 cerrado completo. Las otras 7 quedan en `proposed` con esqueleto preliminar (Problema + Outcome + Alcance tentativo) y se refinan al arrancar su turno.
- `INITIATIVES.md` se actualizó con las 13 iniciativas activas (5 previas + 8 nuevas) y un nuevo bloque **Roadmap UI (orden de ejecución secuencial)** que documenta la cola.

## Roadmap UI

| # | Slug | Estado | Alcance |
|---|---|---|---|
| 1 | `module-states` | **planned** | `<EmptyState>` + `<TableSkeleton>` + `<ErrorBanner>` compartidos. Arranca primero. |
| 2 | `filters-url-sync` | proposed | URL sync + clear-all + contador. |
| 3 | `action-feedback` | proposed | Toast + confirm destructivo. |
| 4 | `detail-page` | proposed | Anatomy de páginas `[id]` no-tabulares. |
| 5 | `data-table` | proposed | `<DataTable>` compartido (sort, paginación, density, sticky). |
| 6 | `responsive-policy` | proposed | Mobile-first vs desktop-only por módulo. |
| 7 | `a11y-baseline` | proposed | WCAG 2.1 AA mínimo. |
| 8 | `access-denied-ux` | proposed | `<RequireAccess>` UX. |

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run test:run` — 161 passed
- [x] `npm run lint` — 0 errors (warnings preexistentes)
- [x] `npm run format:check` — pass (fix de idempotency en `module-states.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)