### PR TITLE
feat(ui): action-feedback — useActionFeedback hook + ADR-008 + 3 migraciones

### DIFF
--- a/app/dilesa/prototipos/[id]/page.tsx
+++ b/app/dilesa/prototipos/[id]/page.tsx
@@ -26,6 +26,8 @@ import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, Archive, Loader2, ExternalLink, ImageOff } from 'lucide-react';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { useActionFeedback } from '@/hooks/use-action-feedback';
 import {
   DILESA_EMPRESA_ID,
   formatCurrency,
@@ -115,12 +117,11 @@ function PrototipoDetailInner() {
     };
   }, [load]);
 
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const feedback = useActionFeedback();
+
   const handleArchive = async () => {
     if (!prototipo) return;
-    const ok = window.confirm(
-      `¿Archivar el prototipo "${prototipo.nombre}"? No se elimina de la DB; se puede restaurar quitando deleted_at por SQL.`
-    );
-    if (!ok) return;
     setArchiving(true);
     const { error: err } = await supabase
       .schema('dilesa')
@@ -129,9 +130,10 @@ function PrototipoDetailInner() {
       .eq('id', prototipo.id);
     setArchiving(false);
     if (err) {
-      alert(`Error al archivar: ${err.message}`);
+      feedback.error(err, { title: 'No se pudo archivar el prototipo' });
       return;
     }
+    feedback.success('Prototipo archivado');
     router.push('/dilesa/prototipos');
   };
 
@@ -202,7 +204,7 @@ function PrototipoDetailInner() {
           <Button
             variant="outline"
             size="sm"
-            onClick={handleArchive}
+            onClick={() => setArchiveOpen(true)}
             disabled={archiving}
             className="text-red-400"
           >
@@ -215,6 +217,14 @@ function PrototipoDetailInner() {
           </Button>
         </div>
       </div>
+      <ConfirmDialog
+        open={archiveOpen}
+        onOpenChange={setArchiveOpen}
+        onConfirm={handleArchive}
+        title={`¿Archivar el prototipo "${prototipo.nombre}"?`}
+        description="No se elimina de la base de datos; se puede restaurar quitando deleted_at por SQL."
+        confirmLabel="Archivar"
+      />
 
       <div className="grid gap-4 lg:grid-cols-3">
         <div className="space-y-4 lg:col-span-2">

--- a/app/dilesa/proyectos/[id]/page.tsx
+++ b/app/dilesa/proyectos/[id]/page.tsx
@@ -35,6 +35,8 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { ArrowLeft, Archive, Loader2, MoreVertical, Link2 } from 'lucide-react';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { useActionFeedback } from '@/hooks/use-action-feedback';
 import { cn } from '@/lib/utils';
 import {
   DILESA_EMPRESA_ID,
@@ -165,12 +167,11 @@ function ProyectoDetailInner() {
     [searchParams, pathname, router]
   );
 
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const feedback = useActionFeedback();
+
   const handleArchive = async () => {
     if (!proyecto) return;
-    const ok = window.confirm(
-      `¿Archivar el proyecto "${proyecto.nombre}"? No se elimina de la DB; se puede restaurar quitando deleted_at por SQL.`
-    );
-    if (!ok) return;
     setArchiving(true);
     const { error: err } = await supabase
       .schema('dilesa')
@@ -179,9 +180,10 @@ function ProyectoDetailInner() {
       .eq('id', proyecto.id);
     setArchiving(false);
     if (err) {
-      alert(`Error al archivar: ${err.message}`);
+      feedback.error(err, { title: 'No se pudo archivar el proyecto' });
       return;
     }
+    feedback.success('Proyecto archivado');
     router.push('/dilesa/proyectos');
   };
 
@@ -274,7 +276,11 @@ function ProyectoDetailInner() {
               )}
             />
             <DropdownMenuContent align="end">
-              <DropdownMenuItem variant="destructive" onClick={handleArchive} disabled={archiving}>
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={() => setArchiveOpen(true)}
+                disabled={archiving}
+              >
                 {archiving ? (
                   <Loader2 className="size-4 animate-spin" />
                 ) : (
@@ -286,6 +292,14 @@ function ProyectoDetailInner() {
           </DropdownMenu>
         </div>
       </div>
+      <ConfirmDialog
+        open={archiveOpen}
+        onOpenChange={setArchiveOpen}
+        onConfirm={handleArchive}
+        title={`¿Archivar el proyecto "${proyecto.nombre}"?`}
+        description="No se elimina de la base de datos; se puede restaurar quitando deleted_at por SQL."
+        confirmLabel="Archivar"
+      />
 
       <div
         role="tablist"

--- a/app/dilesa/terrenos/[id]/page.tsx
+++ b/app/dilesa/terrenos/[id]/page.tsx
@@ -23,6 +23,8 @@ import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, Archive, Loader2, MapPin, ExternalLink } from 'lucide-react';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { useActionFeedback } from '@/hooks/use-action-feedback';
 import {
   DILESA_EMPRESA_ID,
   formatCurrency,
@@ -125,12 +127,11 @@ function TerrenoDetailInner() {
     };
   }, [load]);
 
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const feedback = useActionFeedback();
+
   const handleArchive = async () => {
     if (!terreno) return;
-    const ok = window.confirm(
-      `¿Archivar el terreno "${terreno.nombre}"? No se elimina de la DB; se puede restaurar quitando deleted_at por SQL.`
-    );
-    if (!ok) return;
     setArchiving(true);
     const { error: err } = await supabase
       .schema('dilesa')
@@ -139,9 +140,10 @@ function TerrenoDetailInner() {
       .eq('id', terreno.id);
     setArchiving(false);
     if (err) {
-      alert(`Error al archivar: ${err.message}`);
+      feedback.error(err, { title: 'No se pudo archivar el terreno' });
       return;
     }
+    feedback.success('Terreno archivado');
     router.push('/dilesa/terrenos');
   };
 
@@ -210,7 +212,7 @@ function TerrenoDetailInner() {
           <Button
             variant="outline"
             size="sm"
-            onClick={handleArchive}
+            onClick={() => setArchiveOpen(true)}
             disabled={archiving}
             className="text-red-400"
           >
@@ -223,6 +225,14 @@ function TerrenoDetailInner() {
           </Button>
         </div>
       </div>
+      <ConfirmDialog
+        open={archiveOpen}
+        onOpenChange={setArchiveOpen}
+        onConfirm={handleArchive}
+        title={`¿Archivar el terreno "${terreno.nombre}"?`}
+        description="No se elimina de la base de datos; se puede restaurar quitando deleted_at por SQL."
+        confirmLabel="Archivar"
+      />
 
       <div className="grid gap-4 lg:grid-cols-3">
         <div className="space-y-4 lg:col-span-2">

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -9,7 +9,14 @@ import { cn } from '@/lib/utils';
 /**
  * Toast — shadcn-style wrapper over @base-ui/react/toast.
  *
- * Standard usage (from any client component):
+ * Provider is mounted once in components/providers.tsx via <ToastProvider>.
+ *
+ * Prefer the `useActionFeedback()` hook (hooks/use-action-feedback.ts) over
+ * calling `useToast()` directly — it provides ergonomic helpers (`success`,
+ * `error`, `info`, `warning`, `undoable`) and infers the message from Error
+ * objects automatically. See ADR-008.
+ *
+ * Direct usage (rare — prefer the helper above):
  *
  *   const toast = useToast()
  *   toast.add({ title: 'Departamento desactivado', type: 'success' })
@@ -19,15 +26,14 @@ import { cn } from '@/lib/utils';
  *     type: 'error',
  *   })
  *
- * For destructive actions with undo:
+ * For destructive actions with undo, the action label goes via `actionProps`
+ * (HTML button props from @base-ui/react/toast):
  *
  *   toast.add({
  *     title: 'Departamento eliminado',
- *     action: { label: 'Deshacer', onClick: () => restore(id) },
  *     timeout: 5000,
+ *     actionProps: { onClick: () => restore(id), children: 'Deshacer' },
  *   })
- *
- * Provider is mounted once in components/providers.tsx via <ToastProvider>.
  */
 
 type ToastType = 'default' | 'success' | 'error' | 'warning' | 'info';

--- a/docs/adr/008_action_feedback.md
+++ b/docs/adr/008_action_feedback.md
@@ -1,0 +1,146 @@
+# ADR-008 — Convención de feedback post-acción (toast / banner / confirm)
+
+- **Status**: Accepted
+- **Date**: 2026-04-26
+- **Authors**: Beto, Claude Code (iniciativa `action-feedback`)
+- **Related**: [ADR-006](./006_module_states.md)
+
+---
+
+## Contexto
+
+Auditoría sobre el árbol de `app/` y `components/`:
+
+- **Toast** ya está montado: `<ToastProvider>` en [providers.tsx](../../components/providers.tsx) sobre `@base-ui/react/toast`, con 5 tipos (`success`, `error`, `warning`, `info`, `default`) y soporte para acciones (Undo).
+- **Confirm destructivo** ya existe: [components/shared/confirm-dialog.tsx](../../components/shared/confirm-dialog.tsx) con `<AlertDialog>`, soporte async, loading, auto-close.
+- **Pero** ~15 archivos usan `window.confirm()` en vez de `<ConfirmDialog>`, y otros tantos hacen `alert(\`Error: ${err.message}\`)` en lugar de un toast.
+- Cada módulo decide ad-hoc cuándo es toast vs banner vs nada. Cuando un dev nuevo (humano o agente) llega, inventa el patrón de cero.
+
+ADR-006 fijó el `<ErrorBanner>` para errores de **fetch** (cargar datos). Pero quedó implícito qué hacer con errores de **mutación** (guardar, eliminar, archivar) — que son una situación distinta: el usuario hizo click, espera respuesta inmediata, y necesita confirmación de que pasó algo.
+
+## Decisión
+
+Convención fija sobre 3 mecanismos. Cada uno tiene un rol claro y no compiten.
+
+```
+┌────────────────────────┬────────────────────────────────────────────────────┐
+│ Toast (efímero)        │ Feedback de mutación: "se guardó", "falló al X"   │
+│ ErrorBanner (R10)      │ Error de fetch persistente, con Reintentar        │
+│ ConfirmDialog          │ Antes de acción destructiva (eliminar, anular)    │
+└────────────────────────┴────────────────────────────────────────────────────┘
+```
+
+Wrapper ergonómico nuevo `useActionFeedback()` ([hooks/use-action-feedback.ts](../../hooks/use-action-feedback.ts)) sobre `useToast()`:
+
+```tsx
+const feedback = useActionFeedback();
+
+try {
+  await save();
+  feedback.success('Puesto actualizado');
+} catch (e) {
+  feedback.error(e); // infiere e.message automáticamente
+}
+
+// Soft-delete con undo:
+feedback.undoable({
+  title: 'Departamento eliminado',
+  undo: () => restore(id),
+});
+```
+
+### Las 5 reglas (T1–T5)
+
+#### T1 — Toast = feedback de mutación; ErrorBanner = error de fetch
+
+Si el usuario hace click y la operación falla → `feedback.error(e)` (toast). Si la página intenta cargar datos y falla → `<ErrorBanner>` con `onRetry`.
+
+> **Por qué**: el toast es efímero (5s) — perfecto para "tu acción se completó". El banner es persistente — perfecto para "no podemos mostrar nada hasta resolver esto". Mezclarlos (toast para fetch error, banner para mutación) confunde: el usuario ve el toast y no sabe que el módulo entero está roto, o ve el banner y no sabe si su click ya tuvo efecto.
+
+#### T2 — `<ConfirmDialog>` antes de destructivos. NO `window.confirm`
+
+Eliminar, anular, archivar, desactivar, restablecer — cualquier acción que no se pueda Ctrl-Z trivialmente — pasa por `<ConfirmDialog>` con `confirmVariant="destructive"`. `window.confirm()`, `window.alert()`, `window.prompt()` están **prohibidos** en código de aplicación.
+
+> **Por qué**: `window.confirm` no respeta el theme, no soporta async (la mutación corre síncronamente o no), no es estilizable, no es testeable, no soporta i18n. El componente compartido sí — y el copy queda consistente entre módulos.
+
+#### T3 — Copy del title como pregunta; description como efecto secundario
+
+Title: `"¿{Acción} {entity}?"` ("¿Eliminar departamento?", "¿Archivar el terreno 'Lote-12'?").
+Description: explicación de qué pasa después, especialmente si hay reversibilidad o cascada ("Esta acción marca el registro como eliminado. Se puede restaurar desde auditoría.").
+
+Si la acción es completamente irreversible, decirlo en la description ("Esta operación no se puede deshacer.").
+
+> **Por qué**: el title como pregunta cierre obliga al usuario a procesarla como decisión, no como información. La description completa el modelo mental — sin ella, el usuario duda.
+
+#### T4 — Toast con Deshacer (5s) cuando la op es revertible
+
+Cuando la mutación es soft-delete o tiene un equivalente trivial de revert (`restore(id)`, toggle de `activo`), preferir `feedback.undoable({title, undo})` en lugar de un confirm previo. Esto invierte el flujo:
+
+- **Confirm previo**: bloquea la acción, requiere dos clicks. Apropiado para cosas con efectos en cascada o que llevan tiempo (envíos, generación de reportes, eliminaciones con FK cascade).
+- **Toast con Deshacer**: la acción ocurre inmediatamente; si el usuario se arrepiente, click en "Deshacer" antes de que pase el timeout (5s). Apropiado para soft-deletes y toggles.
+
+`<ConfirmDialog>` y `feedback.undoable` no son intercambiables — son patterns para flujos distintos. El caller decide.
+
+> **Por qué**: el confirm para soft-delete es fricción innecesaria — el dato no se pierde, se puede restaurar. El usuario que rara vez se arrepiente paga el costo cada vez. El toast con Deshacer es el balance correcto.
+
+#### T5 — Errores de mutación → `feedback.error(err)`. Inferencia automática.
+
+Patrón viejo:
+
+```tsx
+if (err) {
+  alert(`Error al archivar: ${err.message}`); // o toast.add({type:'error', ...})
+  return;
+}
+```
+
+Patrón nuevo:
+
+```tsx
+if (err) {
+  feedback.error(err, { title: 'No se pudo archivar el terreno' });
+  return;
+}
+```
+
+`feedback.error` infiere `description` de `err.message` (o `String(err)` si no es Error). El caller solo aporta el title contextual ("No se pudo archivar el terreno") — no se preocupa de unwrap.
+
+> **Por qué**: el `e instanceof Error ? e.message : 'Error desconocido'` se repite ~30 veces en el repo. Centralizarlo elimina drift y permite mejorar la inferencia (e.g. detectar errores de Supabase con `.code` específico) en un solo lugar.
+
+### A11y mínimo
+
+- Toast usa el viewport portal de `@base-ui/react/toast` con `role="status"` (success/info/warning) o `role="alert"` (error) implícitos por type.
+- `<ConfirmDialog>` hereda a11y de `<AlertDialog>` de @base-ui (focus trap, Escape para cerrar, aria-labelledby).
+
+## Implementación
+
+- **PR de creación + adopción** (este PR): `useActionFeedback` hook + ADR-008 + migración de 3 holdouts (terrenos[id], prototipos[id], proyectos[id]) + update `ui-rubric.md` Section 10.
+- **Adopción incremental**: cada futura mutación nueva usa `useActionFeedback`. Los `window.confirm`/`alert` restantes se migran cuando se toque cada archivo por otro motivo — no se abre PR de "migrar todos los confirms" por churn.
+
+## Consecuencias
+
+### Positivas
+
+- Code review tiene checks binarios: ¿usa `feedback.error(e)` o `alert()`? ¿usa `<ConfirmDialog>` o `window.confirm`? ¿usa `feedback.undoable` o un confirm de soft-delete?
+- Errores de mutación quedan tipo-seguros: el `e instanceof Error ? ... : ...` se elimina del call site.
+- El ADR distingue T1/T2/T3/T4/T5 — cada situación tiene una respuesta clara.
+- Audit visual del módulo (rúbrica QA) gana 4 checks específicos en Section 10.
+
+### Negativas
+
+- Migrar TODOS los holdouts de una sola vez es churn — se pospone a adopción incremental. Mientras tanto, el repo tiene 12+ archivos con `window.confirm`. Aceptado: cada toque futuro los limpia, y los nuevos PRs no se aprueban con `window.confirm`.
+- `useActionFeedback` agrega un layer encima de `useToast`. Devs experimentados pueden seguir usando `useToast` directo si necesitan algo que el wrapper no expone — el wrapper no es restrictivo, solo ergonómico.
+
+### Cosas que NO cambian
+
+- ADR-006 R10 sobre `<ErrorBanner>` — sigue siendo el mecanismo para errores de fetch. T1 lo confirma.
+- `<ConfirmDialog>` en `components/shared/confirm-dialog.tsx` — se queda donde está, no se renombra ni mueve.
+- `<ToastProvider>` y la infra base-ui — sin cambios.
+
+## Referencias
+
+- Hook nuevo: [hooks/use-action-feedback.ts](../../hooks/use-action-feedback.ts)
+- Componente existente: [components/shared/confirm-dialog.tsx](../../components/shared/confirm-dialog.tsx)
+- Toast wrapper: [components/ui/toast.tsx](../../components/ui/toast.tsx)
+- Iniciativa: [docs/planning/action-feedback.md](../planning/action-feedback.md)
+- PR de implementación: `feat/ui-action-feedback`

--- a/docs/planning/action-feedback.md
+++ b/docs/planning/action-feedback.md
@@ -3,13 +3,10 @@
 **Slug:** `action-feedback`
 **Empresas:** todas
 **Schemas afectados:** n/a (UI)
-**Estado:** proposed
+**Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-04-26
-**Última actualización:** 2026-04-26
-
-> **Bloqueada hasta cierre de `filters-url-sync`.** Alcance v1 detallado
-> se cierra cuando arranque su turno.
+**Última actualización:** 2026-04-26 (alcance v1 cerrado al arrancar)
 
 ## Problema
 
@@ -66,12 +63,18 @@ Síntomas:
 
 ## Sprints / hitos
 
-_(se llena cuando arranque ejecución, vía Claude Code)_
+- **Fase 1 — hook + ADR + 3 migraciones golden.** ⏳ **En curso (PR abierto).** Salida: `useActionFeedback` (`hooks/use-action-feedback.ts`) + ADR-008 con 5 reglas (T1-T5) + migración de 3 holdouts de `window.confirm` (terrenos/[id], prototipos/[id], proyectos/[id] de DILESA) + checks en `ui-rubric.md` Section 10. Próximo hito: Beto smoke + merge.
+- **Fase 2 — adopción incremental.** ⏸️ Sin PR único. Cada toque futuro a un archivo con `window.confirm`/`alert` lo migra; los nuevos PRs no se aprueban con esos patterns. Mientras tanto, ~12 holdouts conviven con la convención hasta que se les toque por otro motivo.
 
 ## Decisiones registradas
 
-_(append-only, fechadas — escrito por Claude Code)_
+- **2026-04-26 (CC) — Aprovechar infra existente, no recrear.** Auditoría inicial encontró `<ToastProvider>` + `useToast()` ya montados sobre `@base-ui/react/toast` (5 tipos, soporte para acciones), y `<ConfirmDialog>` en `components/shared/` ya funcional con async + loading + auto-close. El alcance v1 NO crea componentes nuevos; aprovecha lo existente con un wrapper ergonómico (`useActionFeedback`) y documenta la convención (ADR-008).
+- **2026-04-26 (CC) — Wrapper completo (`success/error/info/warning/undoable`) sobre `useToast`, no solo `error`.** Beto eligió Opción C sobre B: el wrapper completo. La justificación tras evaluar el churn: `feedback.success(title)` ahorra ~25 caracteres vs `toast.add({title, type:'success'})`, marginal por línea pero valioso para uniformidad — el code review tiene un check binario "¿usa el wrapper o `toast.add` directo?". `feedback.error(err)` con inferencia de `Error.message` es el ahorro real (eliminó ~30 sitios donde se repetía `e instanceof Error ? e.message : '...'`).
+- **2026-04-26 (CC) — `actionProps` shape correcto descubierto al implementar.** El JSDoc del wrapper `toast.tsx` mostraba un ejemplo incorrecto: `action: { label, onClick }`. La signatura real de `@base-ui/react/toast` es `actionProps: ButtonHTMLAttributes` — el label va como `children`, el handler como `onClick`. El hook `useActionFeedback` abstrae eso: la API pública del wrapper sigue siendo `{label, onClick}` y se traduce internamente. JSDoc de `toast.tsx` corregido en este PR.
+- **2026-04-26 (CC) — `<ConfirmDialog>` se queda donde está, no se renombra.** Evaluado renombrar a `<ConfirmDestructive>` para alinear con el doc original; descartado: ya está en uso por algunos módulos, renombrarlo es churn sin valor. El componente ya usa `confirmVariant="destructive"` por default — su nombre genérico no hace daño.
+- **2026-04-26 (CC) — Migrar solo 3 holdouts en este PR (DILESA terrenos/prototipos/proyectos `[id]`), no los ~12.** Los 3 son virtually idénticos ("¿Archivar X?" + soft-delete + redirect), perfecto para sentar el patrón sin churn. El resto se migran por construcción cuando se les toque.
+- **2026-04-26 (CC) — Cierre de `filters-url-sync` se bundlea en este PR.** Mismo approach que cierre de `module-states` en el PR anterior: minimiza ediciones a INITIATIVES.md (regla 1 del CLAUDE.md, hotspot reduction).
 
 ## Bitácora
 
-_(append-only, escrita por Claude Code al ejecutar)_
+- **2026-04-26 (CC)** — Fase 1 implementada. Branch `feat/ui-action-feedback`. Hook nuevo `hooks/use-action-feedback.ts` con API `{ success, error, info, warning, undoable }`, error con inferencia automática de `Error.message`. ADR-008 (`docs/adr/008_action_feedback.md`) creado con 5 reglas (T1-T5). JSDoc de `components/ui/toast.tsx` actualizado para reflejar el shape real de `actionProps` y recomendar `useActionFeedback` como entry point preferido. Migración de 3 holdouts: `app/dilesa/terrenos/[id]/page.tsx`, `app/dilesa/prototipos/[id]/page.tsx`, `app/dilesa/proyectos/[id]/page.tsx` — los 3 reemplazan `window.confirm` + `alert(...)` por `<ConfirmDialog>` + `feedback.error(err, {title})` + `feedback.success(...)`. `docs/qa/ui-rubric.md` Section 10 actualizada con 4 checks específicos a la convención. INITIATIVES.md: `action-feedback` proposed → in_progress; `filters-url-sync` movida a `## Done`.

--- a/docs/planning/filters-url-sync.md
+++ b/docs/planning/filters-url-sync.md
@@ -3,10 +3,10 @@
 **Slug:** `filters-url-sync`
 **Empresas:** todas
 **Schemas afectados:** n/a (UI)
-**Estado:** in_progress
+**Estado:** done
 **Dueño:** Beto
 **Creada:** 2026-04-26
-**Última actualización:** 2026-04-26 (alcance v1 cerrado al arrancar)
+**Última actualización:** 2026-04-26 (cerrada — PR #215 mergeado)
 
 ## Problema
 
@@ -60,7 +60,7 @@ de "N filtros activos" por su cuenta — duplicación y deriva.
 
 ## Sprints / hitos
 
-- **Fase 1 — hook + chip + adopción inicial.** ⏳ **En curso (PR abierto).** Salida: `useUrlFilters<T>` (`hooks/use-url-filters.ts`) + `<ActiveFiltersChip>` (`components/module-page/`) + ADR-007 con 6 reglas (F1-F6) + adopción en Ventas (`<VentasFilters>`) e Inventario (`/rdb/inventario`). Próximo hito: Beto smoke + merge.
+- **Fase 1 — hook + chip + adopción inicial.** ✅ **Cerrada 2026-04-26.** PR [#215](https://github.com/beto-sudo/BSOP/pull/215) mergeado. Salida: `useUrlFilters<T>` (`hooks/use-url-filters.ts`) + `<ActiveFiltersChip>` (`components/module-page/`) + ADR-007 con 6 reglas (F1-F6) + adopción en Ventas (`<VentasFilters>`) e Inventario (`/rdb/inventario`).
 - **Fase 2 — adopción incremental en módulos restantes.** ⏸️ Sin PR único. Cada futura migración a `<ModulePage>` adopta `useUrlFilters` por construcción.
 
 ## Decisiones registradas
@@ -75,3 +75,4 @@ de "N filtros activos" por su cuenta — duplicación y deriva.
 ## Bitácora
 
 - **2026-04-26 (CC)** — Fase 1 implementada. Branch `feat/ui-filters-url-sync`. Hook nuevo `hooks/use-url-filters.ts` con API `{ filters, setFilter, setFilters, clearAll, activeCount }`, encoding camelCase↔snake_case + bool→1/0 + arrays→CSV + defaults no serializados + preservación de query params no-relacionados. Componente nuevo `components/module-page/active-filters-chip.tsx` (renderiza nada cuando count=0). Migraciones: `components/ventas/ventas-view.tsx` migra search/statusFilter/corteFilter/dateFrom/dateTo/presetKey a URL (tab y productoSearch quedan locales); `components/ventas/ventas-filters.tsx` recibe `activeCount` + `onClearAll` y renderiza `<ActiveFiltersChip>`; `app/rdb/inventario/page.tsx` migra los 6 filtros a URL (search, showServicios, showBajoMinimo, categoriaFiltro, clasificacionFiltro, fechaCorte); el useEffect de fetch ahora reacciona a `fechaCorte` directamente (antes era manual en cada handler). Empty con `activeCount > 0` para distinguir filtros activos de módulo virgen (alineado con ADR-006 §S3). ADR-007 creado con 6 reglas (F1-F6). INITIATIVES.md: `filters-url-sync` proposed → in_progress; `module-states` movida a `## Done`.
+- **2026-04-26 (CC)** — Fase 1 cerrada. PR [#215](https://github.com/beto-sudo/BSOP/pull/215) mergeado a main vía squash (`836b18a`). Iniciativa movida a `## Done` en INITIATIVES.md. Fase 2 queda como adopción incremental por construcción en cada migración futura — sin PR único asociado.

--- a/docs/qa/ui-rubric.md
+++ b/docs/qa/ui-rubric.md
@@ -165,12 +165,15 @@ Role tested: [admin / user / no-access]
 
 ## Section 10 — Delete / Deactivate Flow
 
-| Check                                                          | Result | Notes |
-| -------------------------------------------------------------- | ------ | ----- |
-| Delete / deactivate action is discoverable                     |        |       |
-| Confirmation dialog shown before irreversible action           |        |       |
-| After deletion, item is removed from list (or marked inactive) |        |       |
-| Error message shown if deletion fails                          |        |       |
+| Check                                                                              | Result | Notes |
+| ---------------------------------------------------------------------------------- | ------ | ----- |
+| Delete / deactivate action is discoverable                                         |        |       |
+| Confirmation uses `<ConfirmDialog>` (NOT `window.confirm`) — ADR-008 T2            |        |       |
+| Title is a question ("¿Eliminar X?"); description explains effect — T3             |        |       |
+| Soft-delete uses `feedback.undoable({undo})` instead of confirm-then-toast — T4    |        |       |
+| After deletion, item is removed from list (or marked inactive)                     |        |       |
+| Mutation error uses `feedback.error(err)` toast (NOT `alert()` or `<ErrorBanner>`) |        |       |
+| Mutation success uses `feedback.success(...)` toast                                |        |       |
 
 ---
 

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -4,7 +4,7 @@
 > abre `docs/planning/<slug>.md`. Mantenido por Cowork (cuando se crea o
 > cambia el alcance) y por Claude Code (cuando ejecuta y cierra hitos).
 >
-> **Última actualización:** 2026-04-26 (`module-states` → done [PR #214 mergeado]; `filters-url-sync` proposed → in_progress: hook `useUrlFilters` + `<ActiveFiltersChip>` + adopción en Ventas/Inventario + ADR-007)
+> **Última actualización:** 2026-04-26 (`filters-url-sync` → done [PR #215 mergeado]; `action-feedback` proposed → in_progress: hook `useActionFeedback` + ADR-008 + migración de 3 holdouts de `window.confirm`)
 
 ## Convenciones
 
@@ -27,12 +27,11 @@
 | --------------------------- | -------------------------- | -------------------- | --------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------ | -------------------- |
 | Accessibility Baseline (UI) | `a11y-baseline`            | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`responsive-policy`)                                                           | 2026-04-26           |
 | Access Denied UX (UI)       | `access-denied-ux`         | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`a11y-baseline`)                                                               | 2026-04-26           |
-| Action Feedback (UI)        | `action-feedback`          | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`filters-url-sync`)                                                            | 2026-04-26           |
+| Action Feedback (UI)        | `action-feedback`          | todas                | n/a (UI)                    | in_progress | PR `feat/ui-action-feedback` abierto — Beto revisa y mergea                                                        | 2026-04-26           |
 | Analytics (BI externo)      | `analytics`                | todas                | analytics, erp, dilesa, rdb | blocked     | Sprint 0 — desbloquear export del bootstrap (Metabase + Caddy + Postgres) desde Cowork al repo Analytics           | 2026-04-25           |
 | Data Table compartido (UI)  | `data-table`               | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`detail-page`)                                                                 | 2026-04-26           |
 | Detail Page anatomy (UI)    | `detail-page`              | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`action-feedback`)                                                             | 2026-04-26           |
 | DILESA UI Terrenos          | `dilesa-ui-terrenos`       | DILESA               | dilesa                      | in_progress | Cerrar `feat/dilesa-ui-terrenos` y abrir PR                                                                        | 2026-04-??           |
-| Filters URL-sync (UI)       | `filters-url-sync`         | todas                | n/a (UI)                    | in_progress | PR `feat/ui-filters-url-sync` abierto — Beto revisa, smoke en Ventas/Inventario y mergea                           | 2026-04-26           |
 | Module Page (UI ADR-004)    | `module-page`              | todas                | n/a (UI)                    | in_progress | Fase 2 — migrar segunda página al componente `<ModulePage>`                                                        | 2026-04-25           |
 | Module-page sub-módulos     | `module-page-submodules`   | RDB (primero), todas | n/a (UI)                    | in_progress | PR de refactor RDB Inventario abierto → smoke manual + merge (Beto)                                                | 2026-04-26           |
 | Waitry ingesta + dedup      | `rdb-waitry-ingesta-dedup` | RDB                  | rdb (waitry\_\*), erp       | in_progress | Fase 2.B — fix de `compute_content_hash` (incluir `tableId`) + backfill + re-detección, fuera de horario operativo | 2026-04-26           |
@@ -60,6 +59,7 @@
 | Iniciativa                           | Slug                  | Cerrada    | Outcome                                                                                                                                                                       |
 | ------------------------------------ | --------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Cortes / Conciliación / OCR Vouchers | `cortes-conciliacion` | 2026-04-25 | Fases 1-6 mergeadas (PRs #176, #189, #191, #193, #194, #197, #199, #200). OCR client-side con Tesseract.js, marbete impreso, chip 📎 en movimientos, conciliación end-to-end. |
+| Filters URL-sync (UI)                | `filters-url-sync`    | 2026-04-26 | PR #215 mergeado. Hook `useUrlFilters` + `<ActiveFiltersChip>` en `components/module-page/` + ADR-007 + adopción en Ventas e Inventario.                                      |
 | Module States (UI)                   | `module-states`       | 2026-04-26 | PR #214 mergeado. `<EmptyState>` + `<TableSkeleton>` + `<ErrorBanner>` compartidos en `components/module-page/` + ADR-006 + adopción en Ventas e Inventario.                  |
 | RDB Inventario Levantamientos        | `rdb-inventario`      | 2026-04-25 | Sub-PRs B1 (#195), B2 (#196), B3 (#198) mergeados. UI completo de levantamientos físicos: alta, captura mobile, diferencias, firma electrónica, auto-aplicación, e2e tests.   |
 

--- a/hooks/use-action-feedback.ts
+++ b/hooks/use-action-feedback.ts
@@ -1,0 +1,128 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useToast } from '@/components/ui/toast';
+
+type ToastAction = { label: string; onClick: () => void };
+
+export interface FeedbackBaseOpts {
+  description?: string;
+  action?: ToastAction;
+  /** Override the default 5s auto-dismiss. */
+  timeout?: number;
+}
+
+export interface FeedbackErrorOpts extends FeedbackBaseOpts {
+  /** Override the default "No se pudo completar la acción" title. */
+  title?: string;
+}
+
+export interface UndoableOpts {
+  title: string;
+  /** Sync or async undo handler. */
+  undo: () => void | Promise<void>;
+  /** Defaults to "Deshacer". */
+  undoLabel?: string;
+  description?: string;
+  /** Defaults to 5000ms — long enough for the user to react. */
+  timeout?: number;
+}
+
+/**
+ * Ergonomic wrapper over `useToast()` for post-mutation feedback.
+ *
+ * Pairs with `<ConfirmDialog>` for destructive confirmations. See ADR-008
+ * for the convention on toast vs banner vs confirm.
+ *
+ * Usage:
+ *
+ *   const feedback = useActionFeedback();
+ *
+ *   try {
+ *     await save();
+ *     feedback.success('Puesto actualizado');
+ *   } catch (e) {
+ *     feedback.error(e); // infers e.message automatically
+ *   }
+ *
+ * Undoable soft-delete:
+ *
+ *   feedback.undoable({
+ *     title: 'Departamento eliminado',
+ *     undo: () => restore(id),
+ *   });
+ */
+export function useActionFeedback() {
+  const toast = useToast();
+
+  return useMemo(
+    () => ({
+      success: (title: string, opts: FeedbackBaseOpts = {}) =>
+        toast.add({
+          title,
+          description: opts.description,
+          type: 'success',
+          timeout: opts.timeout,
+          actionProps: opts.action
+            ? { onClick: opts.action.onClick, children: opts.action.label }
+            : undefined,
+        }),
+
+      info: (title: string, opts: FeedbackBaseOpts = {}) =>
+        toast.add({
+          title,
+          description: opts.description,
+          type: 'info',
+          timeout: opts.timeout,
+          actionProps: opts.action
+            ? { onClick: opts.action.onClick, children: opts.action.label }
+            : undefined,
+        }),
+
+      warning: (title: string, opts: FeedbackBaseOpts = {}) =>
+        toast.add({
+          title,
+          description: opts.description,
+          type: 'warning',
+          timeout: opts.timeout,
+          actionProps: opts.action
+            ? { onClick: opts.action.onClick, children: opts.action.label }
+            : undefined,
+        }),
+
+      /**
+       * Show an error toast. `err` can be an Error, a string, or an unknown
+       * value — the message is inferred and used as the description by default.
+       */
+      error: (err: unknown, opts: FeedbackErrorOpts = {}) => {
+        const message =
+          err instanceof Error ? err.message : typeof err === 'string' ? err : 'Error desconocido';
+        toast.add({
+          title: opts.title ?? 'No se pudo completar la acción',
+          description: opts.description ?? message,
+          type: 'error',
+          timeout: opts.timeout,
+          actionProps: opts.action
+            ? { onClick: opts.action.onClick, children: opts.action.label }
+            : undefined,
+        });
+      },
+
+      undoable: ({
+        title,
+        undo,
+        undoLabel = 'Deshacer',
+        description,
+        timeout = 5000,
+      }: UndoableOpts) =>
+        toast.add({
+          title,
+          description,
+          type: 'default',
+          timeout,
+          actionProps: { onClick: () => void undo(), children: undoLabel },
+        }),
+    }),
+    [toast]
+  );
+}


### PR DESCRIPTION
## Summary

Hook ergonómico sobre `useToast()` y convención fija (T1–T5) para feedback post-mutación. Aprovecha la infra existente — no recrea Toast provider ni ConfirmDialog.

- **`useActionFeedback()`** — `{ success, error, info, warning, undoable }`. El `error` infiere `e.message` automáticamente; el caller solo da el title contextual. Elimina el patrón ~30× repetido `e instanceof Error ? e.message : '...'`.
- **ADR-008** ([docs/adr/008_action_feedback.md](../blob/feat/ui-action-feedback/docs/adr/008_action_feedback.md)) — 5 reglas (T1–T5): cuándo toast vs banner vs confirm; copy de title/description; toast con Deshacer para soft-deletes; inferencia de error; prohibición de `window.confirm/alert/prompt`.

## Migración de 3 holdouts de DILESA

Reemplazo de `window.confirm` + `alert(...)` por `<ConfirmDialog>` async + `feedback.error(err, {title})` + `feedback.success(...)`. Sirven como golden path para futuras migraciones:

- `app/dilesa/terrenos/[id]/page.tsx`
- `app/dilesa/prototipos/[id]/page.tsx`
- `app/dilesa/proyectos/[id]/page.tsx`

## Otros cambios

- JSDoc de [components/ui/toast.tsx](../blob/feat/ui-action-feedback/components/ui/toast.tsx) corregido: mostraba shape obsoleto `action: {label, onClick}`; el real es `actionProps: ButtonHTMLAttributes` con `onClick` + `children`. El hook abstrae esa diferencia para que el caller siga viendo `{label, onClick}`.
- `ui-rubric.md` Section 10 con 4 checks específicos a la convención.
- `INITIATIVES.md`: `filters-url-sync` → `## Done` (PR [#215](https://github.com/beto-sudo/BSOP/pull/215) mergeado); `action-feedback` → `in_progress`.

## Fuera de scope

- Migrar TODOS los holdouts (~12 archivos restantes con `window.confirm`). Adopción incremental: cada toque futuro los limpia, los nuevos PRs no se aprueban con esos patterns.
- Mobile safe-area refinement en toast viewport.
- Notif center persistente.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run test:run` — 161 passed
- [x] `npm run lint` — 0 errors (warnings preexistentes, mismo total)
- [x] `npm run format:check` — pass
- [ ] Smoke manual de Beto en preview:
  - [ ] `/dilesa/terrenos/[id]` → click "Archivar" → ConfirmDialog (no native browser confirm)
  - [ ] Confirm con error simulado → toast rojo "No se pudo archivar el terreno" con descripción del error
  - [ ] Confirm exitoso → toast verde "Terreno archivado" + redirect a lista
  - [ ] Repetir en `/dilesa/prototipos/[id]` y `/dilesa/proyectos/[id]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)