### PR TITLE
feat(ui): detail-page — DetailPage/DetailHeader/DetailContent + ADR-009

### DIFF
--- a/app/dilesa/prototipos/[id]/page.tsx
+++ b/app/dilesa/prototipos/[id]/page.tsx
@@ -27,6 +27,7 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, Archive, Loader2, ExternalLink, ImageOff } from 'lucide-react';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { DetailPage, DetailHeader } from '@/components/detail-page';
 import { useActionFeedback } from '@/hooks/use-action-feedback';
 import {
   DILESA_EMPRESA_ID,
@@ -174,33 +175,14 @@ function PrototipoDetailInner() {
       : null;
 
   return (
-    <div className="space-y-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex items-start gap-2">
-          <Button
-            variant="outline"
-            size="icon-sm"
-            onClick={() => router.push('/dilesa/prototipos')}
-            aria-label="Volver a Prototipos"
-          >
-            <ArrowLeft className="size-4" />
-          </Button>
-          <div>
-            <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">
-              DILESA · Prototipo
-            </div>
-            <h1 className="mt-0.5 text-2xl font-semibold tracking-tight text-[var(--text)]">
-              {prototipo.nombre}
-            </h1>
-            {prototipo.codigo ? (
-              <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-[var(--text)]/45">
-                {prototipo.codigo}
-              </p>
-            ) : null}
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <EtapaBadgeLarge etapa={prototipo.etapa} />
+    <DetailPage>
+      <DetailHeader
+        back={{ onClick: () => router.push('/dilesa/prototipos'), label: 'Volver a Prototipos' }}
+        eyebrow="DILESA · Prototipo"
+        title={prototipo.nombre}
+        subtitle={prototipo.codigo ?? undefined}
+        meta={<EtapaBadgeLarge etapa={prototipo.etapa} />}
+        actions={
           <Button
             variant="outline"
             size="sm"
@@ -215,8 +197,8 @@ function PrototipoDetailInner() {
             )}
             Archivar
           </Button>
-        </div>
-      </div>
+        }
+      />
       <ConfirmDialog
         open={archiveOpen}
         onOpenChange={setArchiveOpen}
@@ -397,7 +379,7 @@ function PrototipoDetailInner() {
           </Section>
         </div>
       </div>
-    </div>
+    </DetailPage>
   );
 }
 

--- a/app/dilesa/terrenos/[id]/page.tsx
+++ b/app/dilesa/terrenos/[id]/page.tsx
@@ -24,6 +24,7 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, Archive, Loader2, MapPin, ExternalLink } from 'lucide-react';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { DetailPage, DetailHeader } from '@/components/detail-page';
 import { useActionFeedback } from '@/hooks/use-action-feedback';
 import {
   DILESA_EMPRESA_ID,
@@ -182,33 +183,14 @@ function TerrenoDetailInner() {
   const mapSrc = mapQuery ? `https://www.google.com/maps?q=${mapQuery}&output=embed` : null;
 
   return (
-    <div className="space-y-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex items-start gap-2">
-          <Button
-            variant="outline"
-            size="icon-sm"
-            onClick={() => router.push('/dilesa/terrenos')}
-            aria-label="Volver a Terrenos"
-          >
-            <ArrowLeft className="size-4" />
-          </Button>
-          <div>
-            <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">
-              DILESA · Terreno
-            </div>
-            <h1 className="mt-0.5 text-2xl font-semibold tracking-tight text-[var(--text)]">
-              {terreno.nombre}
-            </h1>
-            {terreno.clave_interna ? (
-              <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-[var(--text)]/45">
-                {terreno.clave_interna}
-              </p>
-            ) : null}
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <EtapaBadgeLarge etapa={terreno.etapa} />
+    <DetailPage>
+      <DetailHeader
+        back={{ onClick: () => router.push('/dilesa/terrenos'), label: 'Volver a Terrenos' }}
+        eyebrow="DILESA · Terreno"
+        title={terreno.nombre}
+        subtitle={terreno.clave_interna ?? undefined}
+        meta={<EtapaBadgeLarge etapa={terreno.etapa} />}
+        actions={
           <Button
             variant="outline"
             size="sm"
@@ -223,8 +205,8 @@ function TerrenoDetailInner() {
             )}
             Archivar
           </Button>
-        </div>
-      </div>
+        }
+      />
       <ConfirmDialog
         open={archiveOpen}
         onOpenChange={setArchiveOpen}
@@ -382,7 +364,7 @@ function TerrenoDetailInner() {
           </Section>
         </div>
       </div>
-    </div>
+    </DetailPage>
   );
 }
 

--- a/components/detail-page/detail-content.tsx
+++ b/components/detail-page/detail-content.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { type ReactNode } from 'react';
+
+export interface DetailContentProps {
+  children: ReactNode;
+}
+
+/**
+ * Pass-through slot. Exists to make the anatomy explicit and match
+ * ADR-009 1:1 in JSX. No styling — caller defines its own grid / sections.
+ */
+export function DetailContent({ children }: DetailContentProps) {
+  return <>{children}</>;
+}

--- a/components/detail-page/detail-header.tsx
+++ b/components/detail-page/detail-header.tsx
@@ -1,0 +1,69 @@
+'use client';
+import { type ReactNode } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export interface DetailHeaderBackProps {
+  onClick: () => void;
+  /** Used as `aria-label`. e.g. "Volver a Terrenos". */
+  label: string;
+}
+
+export interface DetailHeaderProps {
+  /** Back navigation control. Renders an icon-only outline button. */
+  back?: DetailHeaderBackProps;
+  /** Small uppercase context line above the title. e.g. "DILESA · Prototipo". */
+  eyebrow?: ReactNode;
+  /** Main title. Plain text or ReactNode. */
+  title: ReactNode;
+  /** Optional secondary line under the title (mono code, slug, ID). */
+  subtitle?: ReactNode;
+  /** Right side: status badges, etapa indicator, etc. Visual peers of actions. */
+  meta?: ReactNode;
+  /** Right side: action buttons. Single primary or 1-2 secondary. */
+  actions?: ReactNode;
+}
+
+/**
+ * Header de página de detalle. Anatomía canónica (ADR-009 D1):
+ *
+ *   [back] [eyebrow / title / subtitle]               [meta] [actions]
+ *
+ * En mobile (sm:flex-row), el bloque derecho cae a una segunda fila.
+ */
+export function DetailHeader({ back, eyebrow, title, subtitle, meta, actions }: DetailHeaderProps) {
+  const backButton = back ? (
+    <Button variant="outline" size="icon-sm" onClick={back.onClick} aria-label={back.label}>
+      <ArrowLeft className="size-4" />
+    </Button>
+  ) : null;
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex items-start gap-2">
+        {backButton}
+        <div>
+          {eyebrow ? (
+            <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--text)]/45">
+              {eyebrow}
+            </div>
+          ) : null}
+          <h1 className="mt-0.5 text-2xl font-semibold tracking-tight text-[var(--text)]">
+            {title}
+          </h1>
+          {subtitle ? (
+            <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-[var(--text)]/45">
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {meta || actions ? (
+        <div className="flex items-center gap-2">
+          {meta}
+          {actions}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/detail-page/detail-page.tsx
+++ b/components/detail-page/detail-page.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { type ReactNode } from 'react';
+
+export interface DetailPageProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Root wrapper for entity detail pages (`/<modulo>/[id]`). Companion to
+ * `<ModulePage>` (ADR-004) but for non-tabular detail anatomy. See ADR-009.
+ *
+ * Anatomy (vertical, in order):
+ *
+ *   DetailPage
+ *   ├── DetailHeader       (back + eyebrow + title + subtitle + meta + actions)
+ *   ├── DetailTabs         (optional, ?section=… routed; underline style — R4)
+ *   └── DetailContent      (sections, grid, drawers — caller-defined)
+ */
+export function DetailPage({ children, className }: DetailPageProps) {
+  return <div className={['space-y-5', className].filter(Boolean).join(' ')}>{children}</div>;
+}

--- a/components/detail-page/index.ts
+++ b/components/detail-page/index.ts
@@ -1,0 +1,6 @@
+export { DetailPage } from './detail-page';
+export type { DetailPageProps } from './detail-page';
+export { DetailHeader } from './detail-header';
+export type { DetailHeaderProps, DetailHeaderBackProps } from './detail-header';
+export { DetailContent } from './detail-content';
+export type { DetailContentProps } from './detail-content';

--- a/docs/adr/009_detail_page.md
+++ b/docs/adr/009_detail_page.md
@@ -1,0 +1,125 @@
+# ADR-009 — Anatomía de páginas de detalle (`<DetailPage>`)
+
+- **Status**: Accepted
+- **Date**: 2026-04-26
+- **Authors**: Beto, Claude Code (iniciativa `detail-page`)
+- **Companion to**: [ADR-004](../../supabase/adr/004_module_page_layout_convention.md) (`<ModulePage>` para tabulares)
+
+---
+
+## Contexto
+
+ADR-004 fija la anatomía de **páginas tabulares de módulo** (header → tabs → KPIs → filters → content) vía `<ModulePage>`. Pero excluye explícitamente las páginas no-tabulares — y las páginas de detalle (`/<modulo>/[id]`) son justo eso: vista de una entidad, no una lista.
+
+Auditoría sobre detail pages existentes:
+
+- `app/dilesa/terrenos/[id]/page.tsx` — header artesanal con back + eyebrow + título + subtitle + status badge + acción.
+- `app/dilesa/prototipos/[id]/page.tsx` — anatomía **idéntica** al header de terrenos.
+- `app/dilesa/proyectos/[id]/page.tsx` — header similar pero con DropdownMenu de acciones y sub-tabs `?section=…`.
+- `app/dilesa/anteproyectos/[id]/page.tsx` — mismo patrón.
+- `app/rdb/inventario/levantamientos/[id]/page.tsx` — UI dependiente del estado del levantamiento (5 estados con UIs distintas). **No encaja** en una anatomía simple.
+- Drawers: `<OrderDetail>` (Ventas), `<StockDetailDrawer>` (Inventario), `<CorteDetail>` (Cortes), `<DocumentoDetailSheet>` (Documentos).
+
+Patrón común detectado en DILESA detail pages: `back + eyebrow + título + subtitle + meta + actions`. Cada uno lo armaba a mano, idéntico píxel a píxel — perfecto para abstraer.
+
+## Decisión
+
+Introducimos `<DetailPage>`, `<DetailHeader>` y `<DetailContent>` en `components/detail-page/`. Anatomía canónica:
+
+```
+DetailPage
+├── DetailHeader      (back + eyebrow + title + subtitle + meta + actions)
+├── (banners)         (errores de mutación → toast por T1; banners contextuales)
+├── (sub-nav)         (tabs internos opcionales — ver D5)
+└── DetailContent     (sections, grid, drawers — caller-defined)
+```
+
+`<DetailHeader>` recibe slots tipados:
+
+```tsx
+<DetailHeader
+  back={{ onClick: () => router.push('/dilesa/terrenos'), label: 'Volver a Terrenos' }}
+  eyebrow="DILESA · Terreno"
+  title={terreno.nombre}
+  subtitle={terreno.clave_interna}
+  meta={<EtapaBadgeLarge etapa={terreno.etapa} />}
+  actions={<Button onClick={() => setArchiveOpen(true)}>Archivar</Button>}
+/>
+```
+
+### Las 5 reglas (D1–D5)
+
+#### D1 — Header tiene 6 slots, en orden de izquierda a derecha
+
+`back · eyebrow / title / subtitle · meta · actions`. En desktop, todo en una fila. En mobile (`< sm`), `meta + actions` cae a una segunda fila debajo del título. Los slots son opcionales excepto `title`.
+
+> **Por qué**: la anatomía artesanal que ya tenían los 4 detail pages de DILESA es exactamente esta — el componente solo elimina la duplicación.
+
+#### D2 — Drawer vs página: criterio por densidad y profundidad
+
+Decisión binaria según dos preguntas:
+
+1. ¿La info es ≥3 secciones lógicas distintas, o tiene sub-tabs internos? → **Página**.
+2. ¿Es la "verdad operativa" del registro (expediente terreno, corte de caja, levantamiento)? → **Página**.
+
+Si ambas respuestas son "no" → **Drawer** (Sheet de shadcn) como hijo del listado padre. La elección NO depende del tamaño en líneas — un drawer de 200 líneas con 1 sección sigue siendo drawer.
+
+> **Por qué**: el drawer mantiene el contexto del listado (el usuario sigue viendo la fila padre detrás). La página rompe ese contexto pero gana share/bookmark/back. Para entidades que merecen su propio link (terrenos, cortes), la página es correcta.
+
+#### D3 — Tabs internos de detalle son **routed** (URL state), no `useState`
+
+Si el detalle tiene sub-vistas (e.g. proyecto con secciones Info / Lotes / Prototipos / Presupuesto / Documentos), cada sub-vista vive en `?section=…` (consistente con [ADR-005](./005_module_with_submodules_routed_tabs.md) para módulos con sub-módulos). Underline style — NO pills (R4 de ADR-004).
+
+> **Por qué**: misma justificación que ADR-005 para módulos. Browser back, share, bookmark; el fragmento del expediente que estás revisando es parte de la URL.
+
+#### D4 — Una sola acción primaria en `actions`
+
+Mismo principio que ADR-004 R8: si hay 2 acciones de peso similar, una de las dos no es primaria. Para múltiples acciones secundarias, usar un `<DropdownMenu>` con `<MoreVertical />` (ver `proyectos/[id]` como referencia).
+
+> **Por qué**: el header no es el lugar para una barra de toolbar. Las acciones contextuales del registro viven cerca de la sección que afectan; la acción primaria del registro completo vive arriba.
+
+#### D5 — Excepciones documentadas (state-machine UIs)
+
+Detalles cuya UI cambia drásticamente según un estado interno (ej. `levantamientos/[id]` con 5 estados, `cortes/[id]` con abierto/cerrado) son **excepciones aceptables** a `<DetailPage>` — pueden seguir con su anatomía custom siempre que justifiquen la divergencia en un comentario JSDoc al inicio del archivo.
+
+`<DetailPage>` no se sobre-diseña para acomodar todas las posibles UIs de detalle. Si el módulo tiene un flujo state-machine complejo, su lectura es más clara con código local que con slots forzados.
+
+> **Por qué**: el costo de hacer `<DetailPage>` lo suficientemente flexible para state-machines es mayor al beneficio. La regla "anatomía canónica con excepciones documentadas" sigue siendo más clara que "todos los detalles deben usar el wrapper".
+
+### A11y mínimo
+
+- `<DetailHeader>` usa `<h1>` semántico para el título.
+- Back button con `aria-label` explícito (e.g. "Volver a Terrenos").
+
+## Implementación
+
+- **PR de creación + adopción** (este PR): los 3 componentes + ADR-009 + migración de `prototipos/[id]` y `terrenos/[id]` (DILESA).
+- **`proyectos/[id]` y `anteproyectos/[id]` no migrados en este PR** — tienen sub-tabs `?section=…` y la migración requiere extender el wrapper (D3, futuro). Quedan para PR de seguimiento o para adopción incremental cuando se les toque por otro motivo.
+- **`levantamientos/[id]` no migrará** — excepción documentada por D5.
+
+## Consecuencias
+
+### Positivas
+
+- Detalles nuevos heredan anatomía consistente sin reinventar el header.
+- Code review tiene check binario: ¿usa `<DetailPage>` + `<DetailHeader>` o tiene comentario JSDoc justificando la excepción?
+- El componente `<DetailHeader>` tipado obliga a llenar `title`, hace opcionales los demás. Olvidar back en una página de detalle (que rompe el flujo) ya no es un descuido — es una omisión visible.
+
+### Negativas
+
+- 2 anatomías compitiendo (`<ModulePage>` para tabulares, `<DetailPage>` para detalles). Aceptable: son dos preguntas distintas del usuario ("¿cómo está mi negocio?" vs "¿qué es esta cosa específica?").
+- `<DetailHeader>` no soporta hoy edición inline del title (rename click-to-edit). Postergado — ningún módulo lo pide en v1.
+
+### Cosas que NO cambian
+
+- Drawers existentes (`<OrderDetail>`, `<StockDetailDrawer>`, etc.) — siguen siendo drawers. D2 valida la elección.
+- Detalles state-machine (`levantamientos/[id]`) — siguen con su anatomía custom por D5.
+- Módulos que ya usan `<ModulePage>` — sin cambios.
+
+## Referencias
+
+- Componentes: [components/detail-page/](../../components/detail-page/)
+- Iniciativa: [docs/planning/detail-page.md](../planning/detail-page.md)
+- PR de implementación: `feat/ui-detail-page`
+- ADR-004 — anatomía de módulos tabulares.
+- ADR-005 — routed tabs (D3 referencia este patrón).

--- a/docs/planning/action-feedback.md
+++ b/docs/planning/action-feedback.md
@@ -3,10 +3,10 @@
 **Slug:** `action-feedback`
 **Empresas:** todas
 **Schemas afectados:** n/a (UI)
-**Estado:** in_progress
+**Estado:** done
 **Dueño:** Beto
 **Creada:** 2026-04-26
-**Última actualización:** 2026-04-26 (alcance v1 cerrado al arrancar)
+**Última actualización:** 2026-04-26 (cerrada — PR #216 mergeado)
 
 ## Problema
 
@@ -63,7 +63,7 @@ Síntomas:
 
 ## Sprints / hitos
 
-- **Fase 1 — hook + ADR + 3 migraciones golden.** ⏳ **En curso (PR abierto).** Salida: `useActionFeedback` (`hooks/use-action-feedback.ts`) + ADR-008 con 5 reglas (T1-T5) + migración de 3 holdouts de `window.confirm` (terrenos/[id], prototipos/[id], proyectos/[id] de DILESA) + checks en `ui-rubric.md` Section 10. Próximo hito: Beto smoke + merge.
+- **Fase 1 — hook + ADR + 3 migraciones golden.** ✅ **Cerrada 2026-04-26.** PR [#216](https://github.com/beto-sudo/BSOP/pull/216) mergeado (commit `2018c42`). Salida: `useActionFeedback` (`hooks/use-action-feedback.ts`) + ADR-008 con 5 reglas (T1-T5) + migración de 3 holdouts de `window.confirm` (terrenos/[id], prototipos/[id], proyectos/[id] de DILESA) + checks en `ui-rubric.md` Section 10.
 - **Fase 2 — adopción incremental.** ⏸️ Sin PR único. Cada toque futuro a un archivo con `window.confirm`/`alert` lo migra; los nuevos PRs no se aprueban con esos patterns. Mientras tanto, ~12 holdouts conviven con la convención hasta que se les toque por otro motivo.
 
 ## Decisiones registradas
@@ -78,3 +78,4 @@ Síntomas:
 ## Bitácora
 
 - **2026-04-26 (CC)** — Fase 1 implementada. Branch `feat/ui-action-feedback`. Hook nuevo `hooks/use-action-feedback.ts` con API `{ success, error, info, warning, undoable }`, error con inferencia automática de `Error.message`. ADR-008 (`docs/adr/008_action_feedback.md`) creado con 5 reglas (T1-T5). JSDoc de `components/ui/toast.tsx` actualizado para reflejar el shape real de `actionProps` y recomendar `useActionFeedback` como entry point preferido. Migración de 3 holdouts: `app/dilesa/terrenos/[id]/page.tsx`, `app/dilesa/prototipos/[id]/page.tsx`, `app/dilesa/proyectos/[id]/page.tsx` — los 3 reemplazan `window.confirm` + `alert(...)` por `<ConfirmDialog>` + `feedback.error(err, {title})` + `feedback.success(...)`. `docs/qa/ui-rubric.md` Section 10 actualizada con 4 checks específicos a la convención. INITIATIVES.md: `action-feedback` proposed → in_progress; `filters-url-sync` movida a `## Done`.
+- **2026-04-26 (CC)** — Fase 1 cerrada. PR [#216](https://github.com/beto-sudo/BSOP/pull/216) mergeado a main vía squash (`2018c42`). Iniciativa movida a `## Done` en INITIATIVES.md. Fase 2 queda como adopción incremental por construcción en cada toque futuro a archivos con `window.confirm`/`alert`.

--- a/docs/planning/detail-page.md
+++ b/docs/planning/detail-page.md
@@ -3,13 +3,10 @@
 **Slug:** `detail-page`
 **Empresas:** todas
 **Schemas afectados:** n/a (UI)
-**Estado:** proposed
+**Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-04-26
-**Última actualización:** 2026-04-26
-
-> **Bloqueada hasta cierre de `action-feedback`.** Alcance v1 detallado
-> se cierra cuando arranque su turno.
+**Última actualización:** 2026-04-26 (alcance v1 cerrado al arrancar)
 
 ## Problema
 
@@ -71,12 +68,17 @@ Síntomas anticipables:
 
 ## Sprints / hitos
 
-_(se llena cuando arranque ejecución, vía Claude Code)_
+- **Fase 1 — wrapper + 2 migraciones golden de DILESA.** ⏳ **En curso (PR abierto).** Salida: `<DetailPage>` + `<DetailHeader>` + `<DetailContent>` en `components/detail-page/` + ADR-009 con 5 reglas (D1-D5) + migración de `app/dilesa/terrenos/[id]/page.tsx` y `app/dilesa/prototipos/[id]/page.tsx`. Próximo hito: Beto smoke + merge.
+- **Fase 2 — `<DetailTabs>` + migración de detalles con sub-tabs.** ⏸️ Postergado. `proyectos/[id]` y `anteproyectos/[id]` tienen `?section=…` y requieren extender el wrapper con un slot `<DetailTabs>` (D3 del ADR). Sale por PR separado o adopción incremental cuando se les toque.
 
 ## Decisiones registradas
 
-_(append-only, fechadas — escrito por Claude Code)_
+- **2026-04-26 (CC) — Alcance v1 cerrado localmente, no vía Cowork.** Mismo approach que iniciativas anteriores (filters-url-sync, action-feedback). El doc preliminar tenía un esqueleto de alcance; lo decanté tras una auditoría chica de 4-5 detail pages existentes y validé el patrón común de DILESA.
+- **2026-04-26 (CC) — Solo migrar 2 detail pages en este PR (terrenos[id] + prototipos[id]).** Los 4 detail pages de DILESA tienen anatomía idéntica de header. Migrar 2 valida el patrón sin sobre-extender el blast radius. `proyectos[id]` y `anteproyectos[id]` quedan para Fase 2 porque tienen sub-tabs `?section=…` que requieren `<DetailTabs>`. `levantamientos[id]` queda como excepción consciente por D5 (state-machine UI).
+- **2026-04-26 (CC) — `<DetailHeader.back>` solo acepta `onClick`, no `href`.** Inicialmente diseñé el slot para aceptar `href` con `Button asChild + Link`, pero `<Button>` del repo no soporta `asChild`. La API `{onClick, label}` es consistente con el código actual (todos los detail pages usan `router.push` directo). Si en el futuro vale la pena añadir el variant href, se hace sin breaking change.
+- **2026-04-26 (CC) — Cierre de `action-feedback` y descarte de `dilesa-ui-terrenos` se bundlean en este PR.** Mismo patrón que cierres anteriores. Para `dilesa-ui-terrenos`: investigación confirmó que la branch (HEAD `9769b96`) tenía 1 commit único con scaffold inicial del 2026-04-23 que fue completamente superado por trabajo posterior en main (4339 líneas adicionales en los mismos archivos). Branch local + remota borradas en este PR; iniciativa movida a `## Done` con outcome explicativo.
+- **2026-04-26 (CC) — `<DetailPage>` no captura banners ni un slot fijo entre header y content.** Los banners contextuales (errores de mutación → toast por T1, éxito de mutación → toast) ya viven en el flow ergonómico de `useActionFeedback`. Si una página de detalle necesita un banner persistente (ej. "este registro está archivado, modo solo-lectura"), lo renderiza como hijo directo entre `<DetailHeader>` y `<DetailContent>` — siguiendo el espíritu de R10 de ADR-004 sin formalizarlo como slot.
 
 ## Bitácora
 
-_(append-only, escrita por Claude Code al ejecutar)_
+- **2026-04-26 (CC)** — Fase 1 implementada. Branch `feat/ui-detail-page`. Componentes nuevos: `components/detail-page/detail-page.tsx` (wrapper `space-y-5`), `components/detail-page/detail-header.tsx` (slots `back / eyebrow / title / subtitle / meta / actions` con responsive collapse en mobile), `components/detail-page/detail-content.tsx` (pass-through), exportados desde `components/detail-page/index.ts`. Auditoría confirmó anatomía idéntica entre `terrenos/[id]`, `prototipos/[id]`, `proyectos/[id]` y `anteproyectos/[id]` de DILESA. Migraciones: `app/dilesa/terrenos/[id]/page.tsx` y `app/dilesa/prototipos/[id]/page.tsx` reemplazan el header artesanal por `<DetailPage> + <DetailHeader>` (eyebrow="DILESA · Terreno"/"DILESA · Prototipo", subtitle del clave_interna/codigo, meta con `<EtapaBadgeLarge>`, actions con botón Archivar). ADR-009 creado con 5 reglas (D1-D5), incluyendo criterio binario drawer-vs-página (D2) y excepción documentada para state-machine UIs como `levantamientos/[id]` (D5). INITIATIVES.md: `detail-page` proposed → in_progress; `action-feedback` movida a `## Done`; `dilesa-ui-terrenos` movida a `## Done` con outcome "descartada — branch borrada".

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -4,7 +4,7 @@
 > abre `docs/planning/<slug>.md`. Mantenido por Cowork (cuando se crea o
 > cambia el alcance) y por Claude Code (cuando ejecuta y cierra hitos).
 >
-> **Última actualización:** 2026-04-26 (`filters-url-sync` → done [PR #215 mergeado]; `action-feedback` proposed → in_progress: hook `useActionFeedback` + ADR-008 + migración de 3 holdouts de `window.confirm`)
+> **Última actualización:** 2026-04-26 (`action-feedback` → done [PR #216 mergeado]; `dilesa-ui-terrenos` descartada [branch borrada, work absorbido en main]; `detail-page` proposed → in_progress: `<DetailPage>` + `<DetailHeader>` + ADR-009 + migración de DILESA terrenos/prototipos `[id]`)
 
 ## Convenciones
 
@@ -27,11 +27,9 @@
 | --------------------------- | -------------------------- | -------------------- | --------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------ | -------------------- |
 | Accessibility Baseline (UI) | `a11y-baseline`            | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`responsive-policy`)                                                           | 2026-04-26           |
 | Access Denied UX (UI)       | `access-denied-ux`         | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`a11y-baseline`)                                                               | 2026-04-26           |
-| Action Feedback (UI)        | `action-feedback`          | todas                | n/a (UI)                    | in_progress | PR `feat/ui-action-feedback` abierto — Beto revisa y mergea                                                        | 2026-04-26           |
 | Analytics (BI externo)      | `analytics`                | todas                | analytics, erp, dilesa, rdb | blocked     | Sprint 0 — desbloquear export del bootstrap (Metabase + Caddy + Postgres) desde Cowork al repo Analytics           | 2026-04-25           |
 | Data Table compartido (UI)  | `data-table`               | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`detail-page`)                                                                 | 2026-04-26           |
-| Detail Page anatomy (UI)    | `detail-page`              | todas                | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (post-`action-feedback`)                                                             | 2026-04-26           |
-| DILESA UI Terrenos          | `dilesa-ui-terrenos`       | DILESA               | dilesa                      | in_progress | Cerrar `feat/dilesa-ui-terrenos` y abrir PR                                                                        | 2026-04-??           |
+| Detail Page anatomy (UI)    | `detail-page`              | todas                | n/a (UI)                    | in_progress | PR `feat/ui-detail-page` abierto — Beto revisa, smoke en terrenos/prototipos `[id]` y mergea                       | 2026-04-26           |
 | Module Page (UI ADR-004)    | `module-page`              | todas                | n/a (UI)                    | in_progress | Fase 2 — migrar segunda página al componente `<ModulePage>`                                                        | 2026-04-25           |
 | Module-page sub-módulos     | `module-page-submodules`   | RDB (primero), todas | n/a (UI)                    | in_progress | PR de refactor RDB Inventario abierto → smoke manual + merge (Beto)                                                | 2026-04-26           |
 | Waitry ingesta + dedup      | `rdb-waitry-ingesta-dedup` | RDB                  | rdb (waitry\_\*), erp       | in_progress | Fase 2.B — fix de `compute_content_hash` (incluir `tableId`) + backfill + re-detección, fuera de horario operativo | 2026-04-26           |
@@ -56,12 +54,14 @@
 
 ## Done (referencia histórica)
 
-| Iniciativa                           | Slug                  | Cerrada    | Outcome                                                                                                                                                                       |
-| ------------------------------------ | --------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cortes / Conciliación / OCR Vouchers | `cortes-conciliacion` | 2026-04-25 | Fases 1-6 mergeadas (PRs #176, #189, #191, #193, #194, #197, #199, #200). OCR client-side con Tesseract.js, marbete impreso, chip 📎 en movimientos, conciliación end-to-end. |
-| Filters URL-sync (UI)                | `filters-url-sync`    | 2026-04-26 | PR #215 mergeado. Hook `useUrlFilters` + `<ActiveFiltersChip>` en `components/module-page/` + ADR-007 + adopción en Ventas e Inventario.                                      |
-| Module States (UI)                   | `module-states`       | 2026-04-26 | PR #214 mergeado. `<EmptyState>` + `<TableSkeleton>` + `<ErrorBanner>` compartidos en `components/module-page/` + ADR-006 + adopción en Ventas e Inventario.                  |
-| RDB Inventario Levantamientos        | `rdb-inventario`      | 2026-04-25 | Sub-PRs B1 (#195), B2 (#196), B3 (#198) mergeados. UI completo de levantamientos físicos: alta, captura mobile, diferencias, firma electrónica, auto-aplicación, e2e tests.   |
+| Iniciativa                           | Slug                  | Cerrada    | Outcome                                                                                                                                                                                                                                                                                         |
+| ------------------------------------ | --------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Action Feedback (UI)                 | `action-feedback`     | 2026-04-26 | PR #216 mergeado. Hook `useActionFeedback` (`hooks/`) + ADR-008 con 5 reglas (T1-T5) + migración de 3 holdouts de `window.confirm` en DILESA detail pages.                                                                                                                                      |
+| Cortes / Conciliación / OCR Vouchers | `cortes-conciliacion` | 2026-04-25 | Fases 1-6 mergeadas (PRs #176, #189, #191, #193, #194, #197, #199, #200). OCR client-side con Tesseract.js, marbete impreso, chip 📎 en movimientos, conciliación end-to-end.                                                                                                                   |
+| DILESA UI Terrenos                   | `dilesa-ui-terrenos`  | 2026-04-26 | Iniciativa **descartada**. Branch `feat/dilesa-ui-terrenos` (commit `9769b96` del 2026-04-23) contenía scaffold inicial superado por trabajo posterior mergeado a main vía otros PRs (anteproyectos/prototipos/proyectos crecieron 3-10x). Branch local + remota borradas en PR del 2026-04-26. |
+| Filters URL-sync (UI)                | `filters-url-sync`    | 2026-04-26 | PR #215 mergeado. Hook `useUrlFilters` + `<ActiveFiltersChip>` en `components/module-page/` + ADR-007 + adopción en Ventas e Inventario.                                                                                                                                                        |
+| Module States (UI)                   | `module-states`       | 2026-04-26 | PR #214 mergeado. `<EmptyState>` + `<TableSkeleton>` + `<ErrorBanner>` compartidos en `components/module-page/` + ADR-006 + adopción en Ventas e Inventario.                                                                                                                                    |
+| RDB Inventario Levantamientos        | `rdb-inventario`      | 2026-04-25 | Sub-PRs B1 (#195), B2 (#196), B3 (#198) mergeados. UI completo de levantamientos físicos: alta, captura mobile, diferencias, firma electrónica, auto-aplicación, e2e tests.                                                                                                                     |
 
 ## Cómo se actualiza este archivo
 


### PR DESCRIPTION
## Summary

Anatomía canónica para páginas de detalle no-tabulares (`/<modulo>/[id]`), companion a [ADR-004](../blob/main/supabase/adr/004_module_page_layout_convention.md) que cubría módulos tabulares.

- **`<DetailPage>`** — wrapper `space-y-5` (paralelo a `<ModulePage>`).
- **`<DetailHeader>`** — slots tipados `back / eyebrow / title / subtitle / meta / actions`; en mobile el bloque derecho cae a segunda fila.
- **`<DetailContent>`** — pass-through; caller define grid/sections.
- **ADR-009** ([docs/adr/009_detail_page.md](../blob/feat/ui-detail-page/docs/adr/009_detail_page.md)) con 5 reglas (D1–D5).

## Migraciones golden

DILESA terrenos y prototipos `[id]` tenían anatomía idéntica de header (~40 líneas artesanales cada una). Migradas a `<DetailPage> + <DetailHeader>`:

- `app/dilesa/terrenos/[id]/page.tsx`
- `app/dilesa/prototipos/[id]/page.tsx`

## Cierres bundleados

- **`action-feedback` → `## Done`** (PR [#216](https://github.com/beto-sudo/BSOP/pull/216) mergeado en commit `2018c42`).
- **`dilesa-ui-terrenos` descartada** — branch local + remota borradas. Investigación confirmó que el commit "único" del remote (`9769b96` del 2026-04-23) era scaffold inicial **superado** por trabajo posterior mergeado a main vía otros PRs (anteproyectos/prototipos/proyectos crecieron 3-10x). Cero work se pierde. Movida a `## Done` con outcome explicativo.

## Fuera de scope

- **`<DetailTabs>` para sub-tabs `?section=…`** — `proyectos[id]` y `anteproyectos[id]` requieren extender el wrapper. Quedan para Fase 2 / adopción incremental cuando se les toque.
- **`levantamientos[id]`** — excepción documentada por D5 (state-machine UI con 5 estados).

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run test:run` — 161 passed
- [x] `npm run lint` — 0 errors (warnings preexistentes, mismo total)
- [x] `npm run format:check` — pass
- [ ] Smoke manual de Beto en preview:
  - [ ] `/dilesa/terrenos/[id]` → header con eyebrow "DILESA · Terreno" + clave_interna como subtitle + EtapaBadge + Archivar
  - [ ] Click back → vuelve a `/dilesa/terrenos`
  - [ ] Mobile (≤sm): meta + actions caen a segunda fila debajo del título
  - [ ] Repetir en `/dilesa/prototipos/[id]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)