### PR TITLE
docs(data-table): cierra alcance v1 detallado (Paso 0)

### DIFF
--- a/docs/planning/data-table.md
+++ b/docs/planning/data-table.md
@@ -3,13 +3,10 @@
 **Slug:** `data-table`
 **Empresas:** todas
 **Schemas afectados:** n/a (UI)
-**Estado:** proposed
+**Estado:** planned
 **Dueño:** Beto
 **Creada:** 2026-04-26
-**Última actualización:** 2026-04-26
-
-> **Bloqueada hasta cierre de `detail-page`.** Alcance v1 detallado se
-> cierra cuando arranque su turno.
+**Última actualización:** 2026-04-26 (alcance v1 cerrado)
 
 ## Problema
 
@@ -20,61 +17,390 @@ A 20 módulos en el horizonte, multiplica variantes y bugs sutiles
 (orden de columnas inconsistente, paginación cortando filas, headers
 que no se quedan).
 
+Inventario actual: **25 tablas** distribuidas en cross-empresa, RDB,
+DILESA, RH e Inicio (ver §Inventario abajo). Cada una con su propio
+mix de `<Table>` shadcn + `useSortableTable` + `<SortableHead>` +
+formatters locales + estados manualmente armados.
+
 ## Outcome esperado
 
-- Componente `<DataTable>` compartido (probable wrapper sobre
-  `@tanstack/react-table` o similar) con:
-  - Sorting por columna (declarativo).
-  - Paginación opcional + "Cargar más" como alternativa.
-  - Density toggle (compact / comfortable) persistido en URL o local.
-  - Sticky header.
-  - Selección múltiple (bulk actions) opt-in.
-  - Virtualización para tablas >500 filas.
-- Convención de columnas: typeof formatter (currency, date, badge),
-  alineación (numérica derecha, texto izquierda), truncate con tooltip.
-- Row actions menu (kebab) consistente.
+- Componente `<DataTable>` compartido sobre `@tanstack/react-table`
+  headless (core only), bundle target ≤16kb gzipped.
+- API declarativa de columnas con tipos semánticos
+  (`text | number | currency | date | datetime | badge | delta | titleWithMeta | custom`).
+- Sticky header + sticky primera columna opt-in.
+- Density toggle (`compact | comfortable`) persistido vía
+  `useUrlFilters` (ADR-007).
+- Virtualización automática cuando `data.length > 200` vía
+  `@tanstack/react-virtual`.
+- Print stylesheet que desactiva sticky/virt y cae a `display: table`
+  plano.
+- Hereda los 3 estados de ADR-006 (`<EmptyState>`, `<TableSkeleton>`,
+  `<ErrorBanner>`) por construcción.
+- 100% de tablas en módulos del repo migradas a `<DataTable>` en una
+  sola pasada (excepciones documentadas explícitamente).
+- Hook `useSortableTable` y componente `<SortableHead>` marcados
+  `@deprecated` (no se borran v1, hay sitios residuales en
+  excepciones).
 
-## Alcance v1 (tentativo — refinar al arrancar)
+## Alcance v1 (cerrado)
 
-- [ ] Decidir base: tanstack-table vs custom. tanstack es estándar,
-      pero peso del bundle hay que evaluar.
-- [ ] API de columns (config declarativo).
-- [ ] Sorting + paginación + sticky.
-- [ ] Density toggle.
-- [ ] Migrar 1-2 tablas existentes (probable: Productos, Ventas).
-- [ ] ADR.
+### Foundation (PR-B)
 
-## Fuera de alcance
+#### `<DataTable>` componente
 
-- Editable cells / inline editing. Patrón aparte.
-- Drag-to-reorder columnas. Útil pero no v1.
-- Export a CSV / XLSX en el componente — eso es feature de cada
-  módulo, no del wrapper.
+Ubicación: `components/module-page/data-table/`. Exportado desde el
+barrel `components/module-page/index.ts`.
+
+API declarativa:
+
+```tsx
+<DataTable
+  data={rows}
+  columns={columns}
+  rowKey="id"
+  onRowClick={(row) => /* abrir drawer / navegar */}
+  sticky={{ header: true, firstColumn: true }}
+  density="comfortable" // 'compact' | 'comfortable', persistido vía useUrlFilters
+  loading={loading}
+  error={error}
+  onRetry={() => fetchData()}
+  emptyTitle="Sin resultados"
+  emptyDescription="Limpia los filtros para ver todo."
+  emptyAction={<Button onClick={clearAll}>Limpiar filtros</Button>}
+/>
+```
+
+#### Tipo `Column<T>`
+
+```ts
+type ColumnType =
+  | 'text'
+  | 'number'
+  | 'currency'
+  | 'date'
+  | 'datetime'
+  | 'badge'
+  | 'delta'
+  | 'titleWithMeta'
+  | 'custom';
+
+type Column<T> = {
+  key: string;
+  label: string;
+  type?: ColumnType;
+  sortable?: boolean; // default true
+  sortKey?: keyof T; // default = key
+  width?: string; // 'w-32' | 'min-w-[120px]' | etc.
+  align?: 'left' | 'right' | 'center'; // inferido por type si no se pasa
+  sticky?: boolean; // sticky on horizontal scroll
+  showIf?: (rows: T[]) => boolean; // para columnas dinámicas
+  render?: (row: T) => ReactNode; // override para 'custom' o ajuste
+  accessor?: (row: T) => unknown; // para sort cuando key no aplica
+};
+```
+
+#### Column types con estilos automáticos
+
+- `currency`, `number`, `delta` → `text-right tabular-nums whitespace-nowrap`.
+- `delta` → además color por signo (verde+/rojo–/muted=0) usando
+  `formatDelta` de `lib/format/`.
+- `date`, `datetime` → formato es-MX vía `lib/format/`.
+- `badge` → respeta `<Badge variant>` con mapping semántico.
+- `titleWithMeta` → render de "título grande + subtítulo chico" (el
+  render function recibe `{title, meta}`).
+
+#### `<DataTable.InteractiveCell>`
+
+Wrapper para celdas con popover/inline-edit. Hace `stopPropagation`
+automático y desactiva el row-click ahí. Documentar en JSDoc para que
+las migraciones de Tasks RichTable lo usen.
+
+#### Sticky
+
+Header + primera columna opt-in. CSS puro (`position: sticky`), sin
+JS. Bajo virtualización siguen funcionando.
+
+#### Density
+
+Toggle UI (icon button) en el toolbar arriba a la derecha de la tabla.
+Estado persistido vía `useUrlFilters({ density: 'comfortable' })`.
+El default es `comfortable`; `compact` baja `py-2` a `py-1` y font-size
+un step.
+
+#### Virtualización
+
+Usar `@tanstack/react-virtual`. Se activa automáticamente cuando
+`data.length > 200`. Imperceptible al usuario. Bajo virt, sticky
+header + first column siguen funcionando.
+
+`useMemo` sobre `columns.filter(c => !c.showIf || c.showIf(data))`
+para evitar re-eval cada render.
+
+#### Print stylesheet
+
+`@media print` desactiva sticky, virt, density toggle, y fuerza
+`display: table` plano. Usar `print:` Tailwind utilities donde aplique.
+
+#### Hereda los 3 estados de ADR-006
+
+- `loading=true` → renderiza `<TableSkeleton rows={data?.length ?? 8} columns={columns.length} />` adentro del wrapper.
+- `data.length === 0` → renderiza `<EmptyState>` con copy parametrizado
+  por el caller (props `emptyTitle`, `emptyDescription`, `emptyAction`).
+- `error != null` → renderiza `<ErrorBanner error={error} onRetry={onRetry} />`
+  arriba de la tabla.
+
+#### A11y mínimo
+
+- `<table role="table">` (default), header `<th scope="col">`.
+- Sortable headers con `aria-sort`.
+- Sticky cells con `aria-` apropiado.
+- Keyboard nav básica (ArrowUp/Down entre filas si `onRowClick`).
+
+### Sub-tarea (PR-A) — `lib/format/`
+
+Antes de PR-B, abrir PR pequeño que centraliza formatters dispersos:
+
+- Crear `lib/format/index.ts` con: `formatCurrency`, `formatNumber`,
+  `formatPercent`, `formatDate`, `formatDateTime`, `formatTime`,
+  `formatDelta` (devuelve `{value, sign, color}` para uso en column
+  type 'delta'), `formatRelativeDays` ("Hoy", "3d", "1mes"),
+  `formatSuperficie`, `formatPrecioM2`.
+- Locale es-MX siempre. TZ `America/Matamoros` para fechas.
+- Tests unitarios cubriendo edge cases (null, 0, negativos, decimales
+  raros, fechas DST).
+- Migrar callers obvios: `components/cortes/helpers.ts`,
+  `components/documentos/helpers.ts`, `components/ventas/utils.ts`,
+  `components/tasks/tasks-shared.tsx`. Re-exportar desde los helpers
+  locales por compat (deprecar a futuro), pero los nuevos call sites
+  importan de `@/lib/format`.
+- ADR no necesario — esto es refactor/centralización, no decisión
+  arquitectónica.
+
+### Migración full (PRs C–K)
+
+Migrar **todas** las tablas listadas en el inventario a `<DataTable>`.
+Estrategia: un PR por área. Dentro de cada PR, **un commit por tabla**.
+Cada commit:
+
+1. Reemplaza JSX manual de `<Table><TableHeader>...</Table>` por
+   `<DataTable>` declarativo.
+2. Define el array `columns` arriba del componente o en archivo
+   `.columns.ts` adyacente si supera ~80 líneas.
+3. Adopta los 3 estados de ADR-006 si no estaban (Cortes, Tasks,
+   Documentos los necesitan; Ventas ya está parcial).
+4. Sustituye formatters locales por imports de `@/lib/format`.
+5. Para celdas con popover/inline-edit (Tasks RichTable): envolver en
+   `<DataTable.InteractiveCell>`. Verificar que el row-click sigue
+   funcionando en celdas no-interactivas.
+6. Verificación local: `npm run typecheck && npm run lint && npm run format:check && npm run test:run`. Smoke manual de la página migrada.
+7. Mensaje del commit: `feat(data-table): migra <modulo>/<tabla>`.
+
+### Excepciones aceptables (NO migrar)
+
+- Drawers (ADR-009 D2 ya los gobierna): `<OrderDetail>`,
+  `<StockDetailDrawer>`, `<CorteDetail>`, `<DocumentoDetailSheet>`.
+  Son sheets, no tablas tabulares.
+- `app/rdb/inventario/levantamientos/[id]/diferencias/page.tsx` —
+  sub-vista state-machine (excepción D5 de ADR-009).
+- `components/module-page/table-skeleton.tsx` — es nuestro componente.
+- Tablas dentro de `app/settings/acceso/acceso-client.tsx` — auditar
+  primero; si tiene shape complejo de permisos, dejar con comentario
+  JSDoc.
+- Playtomic sections (`reconciliation-table`, `players-section`,
+  `pending-payments-section`) — auditar; si son agregaciones
+  específicas, pueden quedar fuera con comentario JSDoc.
+
+### Deprecaciones
+
+- `hooks/use-sortable-table.ts` → mantener exportado pero marcar
+  `@deprecated` con JSDoc apuntando a `<DataTable>`. No borrar
+  todavía — hay sitios residuales en excepciones.
+- `components/ui/sortable-head.tsx` → idem, `@deprecated`. Se borra
+  cuando los call sites residuales migren o se decida que son
+  permanentes.
+
+### ADR-010
+
+Crear `docs/adr/010_data_table.md` con las decisiones. Status:
+Accepted. Authors: Beto, Claude Code. Related: ADR-004, ADR-006,
+ADR-007. Estructura: Contexto + Decisión + 6-8 reglas (DT1–DT8) +
+A11y + Implementación + Consecuencias + Referencias. Estilo coherente
+con ADR-006/007/008/009.
+
+## Inventario exhaustivo de tablas (25)
+
+### Cross-empresa (afectan a todas)
+
+1. `components/cortes/cortes-table.tsx`
+2. `components/ventas/ventas-table.tsx`
+3. `components/ventas/ventas-por-producto.tsx`
+4. `components/documentos/documentos-table.tsx`
+5. `components/tasks/tasks-table.tsx` (variantes simple + rich;
+   mantener API pero implementación interna usa `<DataTable>`)
+
+### RDB
+
+6. `app/rdb/inventario/page.tsx`
+7. `app/rdb/inventario/movimientos/page.tsx`
+8. `app/rdb/inventario/levantamientos/page.tsx`
+9. `app/rdb/productos/page.tsx`
+10. `app/rdb/productos/analisis/page.tsx`
+11. `app/rdb/proveedores/page.tsx`
+12. `app/rdb/ordenes-compra/page.tsx`
+13. `app/rdb/requisiciones/page.tsx`
+14. `app/rdb/tasks/page.tsx` (renderiza `<TasksTable>`; verificar nada
+    más)
+15. `app/rdb/admin/juntas/page.tsx`
+
+### DILESA
+
+16. `app/dilesa/terrenos/page.tsx`
+17. `app/dilesa/proyectos/page.tsx`
+18. `app/dilesa/prototipos/page.tsx`
+19. `app/dilesa/anteproyectos/page.tsx`
+20. `app/dilesa/admin/juntas/page.tsx`
+
+### RH (cross)
+
+21. `components/rh/puestos-module.tsx`
+22. `components/rh/empleados-module.tsx`
+23. `components/rh/departamentos-module.tsx`
+
+### Inicio
+
+24. `app/inicio/juntas/page.tsx`
+
+### Auditar / posibles excepciones (decisión durante migración)
+
+25. `components/playtomic/reconciliation-table.tsx`
+26. `components/playtomic/players-section.tsx`
+27. `components/playtomic/pending-payments-section.tsx`
+28. `app/settings/acceso/acceso-client.tsx`
+
+## Plan de PRs
+
+- **PR-A**: `lib/format/` + tests + migración de helpers locales.
+- **PR-B**: `<DataTable>` foundation + ADR-010 + migración de
+  Productos + Cortes (golden path: tabla simple + tabla con muchas
+  columnas, sticky, deltas).
+- **PR-C**: Ventas + ventas-por-producto.
+- **PR-D**: Inventario stack (3 tablas: principal, movimientos,
+  levantamientos).
+- **PR-E**: Compras (proveedores, ordenes-compra, requisiciones).
+- **PR-F**: DILESA (terrenos, proyectos, prototipos, anteproyectos).
+- **PR-G**: RH (departamentos, empleados, puestos).
+- **PR-H**: Documentos.
+- **PR-I**: Tasks (preserva variant API simple/rich, refactor interno).
+- **PR-J**: Juntas (3 lugares: rdb/admin, dilesa/admin, inicio).
+- **PR-K**: Productos analisis + auditoría de Playtomic + settings/
+  acceso (lo que sobreviva como excepción documentada se queda con
+  comentario JSDoc).
+
+Cada PR cumple:
+
+- Validación local de los 4 checks de CI sobre **TODO el repo**
+  (typecheck/test/lint/format), per `CLAUDE.md`.
+- Rebase preventivo sobre `origin/main` antes de push.
+- `gh pr checks <PR> --watch --interval 15` hasta verde.
+- Body del PR explica qué tablas migra + screenshots before/after de
+  al menos una tabla representativa.
+- Conventional commit: `feat(data-table): migra <area>` o
+  `feat(data-table): foundation + ADR-010` para PR-B.
+
+## Fuera de alcance v1
+
+- Editable cells / inline editing (más allá del wrapper
+  `<DataTable.InteractiveCell>` que solo absorbe popovers/inline edits
+  existentes).
+- Drag-to-reorder columnas.
+- Export a CSV / XLSX en el componente — feature de cada módulo, no
+  del wrapper.
+- Selección múltiple (bulk actions) — postergar hasta caso real.
+- Faceted filters — postergar; los filtros viven en `<ModuleFilters>`
+  - `useUrlFilters`.
 
 ## Métricas de éxito
 
-- 100% de tablas en módulos migrados usan `<DataTable>`.
-- Cero implementaciones custom de sort/sticky en módulos posteriores.
-- Tablas grandes (Movimientos histórico, Productos) sin lag visible.
+- 100% de tablas del inventario migradas (excepciones documentadas
+  explícitamente con comentario JSDoc en el archivo).
+- Cero implementaciones nuevas de sort/sticky/skeleton/empty manual en
+  módulos posteriores al cierre — verificable en code review con check
+  binario.
+- Tablas grandes (Movimientos histórico, Productos, Levantamientos
+  con muchas líneas) sin lag visible al scroll.
+- Print de marbetes / listas sigue funcionando en módulos donde
+  aplica (Inventario stock, Cortes).
 
-## Riesgos / preguntas abiertas
+## Riesgos / preguntas abiertas (resueltas o aceptadas)
 
-- [ ] Bundle size de tanstack-table — medir antes de decidir.
-- [ ] Compatibilidad con sorting server-side (cuando la query lo
-      necesita).
-- [ ] Bulk select interactúa con `<ModuleFilters>` (filtros activos
-      definen "todos los seleccionables").
-- [ ] Print layout — la tabla compartida tiene que respetar
-      `@media print` (relacionado con `print-pattern` futuro).
+- ✅ Bundle size de tanstack-table — usar core headless + react-virtual,
+  target ≤16kb gzipped. Medir antes de mergear PR-B.
+- ✅ Sorting server-side — fuera de v1; si surge un caso real, se
+  extiende `Column<T>` con un flag `serverSort` que delegue a un
+  callback en lugar del sort client-side.
+- ✅ Bulk select interactúa con `<ModuleFilters>` — fuera de v1
+  (postergar selección múltiple).
+- ✅ Print layout — la tabla compartida respeta `@media print` por
+  diseño (DT3 del ADR-010).
+- ✅ Density persistence interactúa con `useUrlFilters` — F4 del
+  ADR-007 garantiza que `?density=…` coexiste con otras keys de
+  filtros sin colisión.
 
 ## Sprints / hitos
 
-_(se llena cuando arranque ejecución, vía Claude Code)_
+- **Paso 0 — Cerrar alcance v1.** ⏳ Este PR (`docs/data-table-alcance-v1`).
+  Estado: pendiente review/merge. Mergea sin código, solo doc.
+- **PR-A — `lib/format/` + helpers.** ⏸️ Próximo. No-bloqueante por
+  PR-B (los formatters viven aparte).
+- **PR-B — Foundation + ADR-010 + golden paths.** ⏸️ Después de PR-A.
+  Bloquea PRs C-K.
+- **PRs C-K — Migración full.** ⏸️ Encadenados.
+- **Closeout — Movida a `## Done`.** ⏸️ Después de mergear PR-K.
 
 ## Decisiones registradas
 
-_(append-only, fechadas — escrito por Claude Code)_
+- **2026-04-26 (CC) — Alcance v1 cerrado vía prompt extendido de Beto.**
+  Beto pasó plan completo en chat para sesión nocturna autónoma:
+  Foundation + ADR + lib/format/ + 25 migraciones distribuidas en
+  PRs A-K + closeout. Decantado al doc en este Paso 0.
+- **2026-04-26 (CC) — Base: `@tanstack/react-table` headless (core only).**
+  Evaluado vs custom thin sobre patterns existentes. Tanstack pesa
+  ≤16kb gzipped target, soporta virtualización con `@tanstack/react-virtual`,
+  y la API es estable. Custom thin obliga a reimplementar sort + virt
+  - sticky + density. Tanstack es la decisión correcta para escala
+    de 25 tablas + 20 módulos en horizonte. Beto confirmó al pasar el
+    prompt extendido.
+- **2026-04-26 (CC) — Threshold de virtualización: 200 filas.**
+  Por debajo, `<table>` plano (más simple, mejor a11y).
+  Por encima, virt automática transparente para el caller.
+- **2026-04-26 (CC) — `<DataTable.InteractiveCell>` para popover/inline.**
+  Tasks RichTable y otros módulos tienen celdas con popovers que no
+  deben disparar `onRowClick`. El wrapper es la API explícita —
+  alternativa (auto-detect via `event.target`) es frágil.
+- **2026-04-26 (CC) — Density vía `useUrlFilters`, no localStorage.**
+  Coherente con ADR-007 (URL es la fuente de verdad para preferencias
+  de filtro/vista). El usuario puede compartir un link con
+  `?density=compact` y el receptor ve la misma vista.
+- **2026-04-26 (CC) — `lib/format/` separado del foundation PR.**
+  Los formatters son pre-requisito para los column types (`currency`,
+  `delta`, `date`), pero el refactor de formatters dispersos es
+  ortogonal y vale por sí mismo. PR-A standalone permite mergear más
+  rápido.
+- **2026-04-26 (CC) — `useSortableTable` + `<SortableHead>` deprecados,
+  no borrados.** ~24 sitios usan el hook. Borrar todo de una vez es
+  churn inmenso. Marcar `@deprecated` permite que cada PR de migración
+  los limpie del archivo migrado, y los borramos cuando solo queden
+  call sites en excepciones documentadas.
+- **2026-04-26 (CC) — Excepciones explícitas con comentario JSDoc.**
+  Drawers (gobernados por ADR-009 D2), state-machine UIs (D5),
+  Playtomic agregaciones especiales, settings/acceso si tiene shape
+  raro de permisos. Cada excepción se queda con un comentario al inicio
+  del archivo justificando por qué no encaja en `<DataTable>`.
 
 ## Bitácora
 
-_(append-only, escrita por Claude Code al ejecutar)_
+- **2026-04-26 (CC)** — Paso 0: alcance v1 cerrado en este doc.
+  Branch `docs/data-table-alcance-v1`. Estado `proposed → planned`.
+  PR docs-only abierto y mergeado (auto-merge tras CI verde dado
+  contexto de sesión nocturna autónoma autorizada por Beto).


### PR DESCRIPTION
## Summary

Paso 0 del plan de sesión nocturna para la iniciativa `data-table`. Cierra el alcance v1 en [docs/planning/data-table.md](../blob/docs/data-table-alcance-v1/docs/planning/data-table.md). Estado: `proposed → planned`. Sin código.

Pasa el doc preliminar (5 bullets tentativos) a alcance cerrado:

- Foundation con `@tanstack/react-table` headless (≤16kb gzipped).
- API declarativa `Column<T>` con types semánticos.
- Sticky + density (vía `useUrlFilters`) + virt (>200 filas) + print.
- Hereda los 3 estados de ADR-006 por construcción.
- `lib/format/` centralizado en PR-A previo.
- 25 tablas en inventario para migrar full en PRs C-K.
- Excepciones documentadas explícitamente.
- `useSortableTable` + `<SortableHead>` deprecados (no borrados).
- ADR-010 en PR-B con DT1-DT8.

## Plan de PRs siguientes

- **PR-A**: `lib/format/` + tests + helpers locales.
- **PR-B**: `<DataTable>` foundation + ADR-010 + golden paths Productos + Cortes.
- **PR-C → PR-K**: migración por área (Ventas, Inventario stack, Compras, DILESA, RH, Documentos, Tasks, Juntas, Productos analisis + auditorías).
- **Closeout**: `INITIATIVES.md` y planning a Done.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run test:run` — 161 passed
- [x] `npm run lint` — 0 errors (warnings preexistentes, mismo total)
- [x] `npm run format:check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)