### PR TITLE
feat(data-table): migra Ventas + ventas-por-producto (PR-C)

### DIFF
--- a/components/ventas/ventas-por-producto.tsx
+++ b/components/ventas/ventas-por-producto.tsx
@@ -3,14 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getLocalDayBoundsUtc } from '@/lib/timezone';
-import { useSortableTable } from '@/hooks/use-sortable-table';
-import { SortableHead } from '@/components/ui/sortable-head';
-import { Table, TableBody, TableCell, TableHeader, TableRow } from '@/components/ui/table';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
+import { DataTable, type Column } from '@/components/module-page';
+import { formatCurrency } from '@/lib/format';
 import { Download, Package, Search } from 'lucide-react';
-import { TZ, formatCurrency } from './utils';
+import { TZ } from './utils';
 
 type ProductoAgg = {
   product_id: string;
@@ -150,8 +148,6 @@ export function VentasPorProducto({
     void fetchData();
   }, [fetchData]);
 
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable<ProductoAgg>('importe', 'desc');
-
   const filtered = useMemo(() => {
     if (!search) return rows;
     const q = search.toLowerCase();
@@ -170,7 +166,9 @@ export function VentasPorProducto({
   const exportCsv = () => {
     const header = ['Producto', 'Unidades', 'Importe', 'Pedidos', 'Ticket prom.', '% del total'];
     const lines = [header.join(',')];
-    for (const r of sortData(filtered)) {
+    // Sort by importe desc to match the visible table default sort.
+    const sorted = [...filtered].sort((a, b) => b.importe - a.importe);
+    for (const r of sorted) {
       lines.push(
         [
           `"${r.product_name.replace(/"/g, '""')}"`,
@@ -239,116 +237,68 @@ export function VentasPorProducto({
         </Button>
       </div>
 
-      {error ? (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
-        </div>
-      ) : null}
-
-      <div className="rounded-xl border bg-card">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <SortableHead
-                sortKey="product_name"
-                label="Producto"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-              />
-              <SortableHead
-                sortKey="unidades"
-                label="Unidades"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="text-right"
-              />
-              <SortableHead
-                sortKey="importe"
-                label="Importe"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="text-right"
-              />
-              <SortableHead
-                sortKey="pedidos"
-                label="Pedidos"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="text-right"
-              />
-              <SortableHead
-                sortKey="ticket_prom"
-                label="Ticket prom."
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="text-right"
-              />
-              <SortableHead
-                sortKey="pct_total"
-                label="% del total"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="text-right"
-              />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {loading ? (
-              Array.from({ length: 8 }).map((_, i) => (
-                <TableRow key={i}>
-                  {Array.from({ length: 6 }).map((__, j) => (
-                    <TableCell key={j}>
-                      <Skeleton className="h-4 w-full" />
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : filtered.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="py-12 text-center text-muted-foreground">
-                  <Package className="mx-auto mb-2 h-5 w-5 opacity-50" />
-                  Sin ventas en el rango seleccionado.
-                </TableCell>
-              </TableRow>
-            ) : (
-              sortData(filtered).map((r) => (
-                <TableRow key={r.product_id}>
-                  <TableCell className="font-medium">{r.product_name}</TableCell>
-                  <TableCell className="text-right tabular-nums">
-                    {r.unidades.toLocaleString('es-MX')}
-                  </TableCell>
-                  <TableCell className="text-right font-medium tabular-nums">
-                    {formatCurrency(r.importe)}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums text-muted-foreground">
-                    {r.pedidos}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums text-muted-foreground">
-                    {formatCurrency(r.ticket_prom)}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums">
-                    <div className="flex items-center justify-end gap-2">
-                      <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
-                        <div
-                          className="h-full bg-emerald-500/70"
-                          style={{ width: `${Math.min(100, r.pct_total)}%` }}
-                        />
-                      </div>
-                      <span className="w-12 text-right">{r.pct_total.toFixed(1)}%</span>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+      <DataTable<ProductoAgg>
+        data={filtered}
+        columns={productoColumns}
+        rowKey="product_id"
+        loading={loading}
+        error={error}
+        onRetry={() => void fetchData()}
+        initialSort={{ key: 'importe', dir: 'desc' }}
+        emptyIcon={<Package className="h-8 w-8 opacity-50" />}
+        emptyTitle="Sin ventas en el rango seleccionado"
+        showDensityToggle={false}
+      />
     </div>
   );
 }
+
+const productoColumns: Column<ProductoAgg>[] = [
+  {
+    key: 'product_name',
+    label: 'Producto',
+    cellClassName: 'font-medium',
+  },
+  {
+    key: 'unidades',
+    label: 'Unidades',
+    type: 'number',
+    render: (r) => r.unidades.toLocaleString('es-MX'),
+  },
+  {
+    key: 'importe',
+    label: 'Importe',
+    type: 'currency',
+    cellClassName: 'font-medium',
+  },
+  {
+    key: 'pedidos',
+    label: 'Pedidos',
+    type: 'number',
+    cellClassName: 'text-muted-foreground',
+    render: (r) => r.pedidos,
+  },
+  {
+    key: 'ticket_prom',
+    label: 'Ticket prom.',
+    type: 'currency',
+    cellClassName: 'text-muted-foreground',
+  },
+  {
+    key: 'pct_total',
+    label: '% del total',
+    align: 'right',
+    cellClassName: 'tabular-nums',
+    render: (r) => (
+      <div className="flex items-center justify-end gap-2">
+        <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full bg-emerald-500/70"
+            style={{ width: `${Math.min(100, r.pct_total)}%` }}
+          />
+        </div>
+        <span className="w-12 text-right">{r.pct_total.toFixed(1)}%</span>
+      </div>
+    ),
+  },
+];

--- a/components/ventas/ventas-table.tsx
+++ b/components/ventas/ventas-table.tsx
@@ -1,125 +1,71 @@
 'use client';
 
 import { Inbox } from 'lucide-react';
-import { Table, TableBody, TableCell, TableHeader, TableRow } from '@/components/ui/table';
-import { SortableHead } from '@/components/ui/sortable-head';
 import { Badge } from '@/components/ui/badge';
-import { EmptyState, TableSkeleton } from '@/components/module-page';
+import { DataTable, type Column } from '@/components/module-page';
+import { formatCurrency, formatDate } from '@/lib/format';
 import type { Pedido } from './types';
-import { formatCurrency, formatDate, statusVariant } from './utils';
+import { statusVariant } from './utils';
 
-type SortDir = 'asc' | 'desc';
+const columns: Column<Pedido>[] = [
+  {
+    key: 'order_id',
+    label: 'Folio',
+    cellClassName: 'font-mono text-xs font-medium',
+    render: (p) => `#${p.order_id ?? p.id}`,
+  },
+  {
+    key: 'timestamp',
+    label: 'Fecha/Hora',
+    cellClassName: 'text-sm text-muted-foreground',
+    render: (p) => formatDate(p.timestamp),
+  },
+  {
+    key: 'place_name',
+    label: 'Área',
+    cellClassName: 'text-sm text-muted-foreground',
+    render: (p) => p.layout_name || '-',
+    accessor: (p) => p.layout_name ?? '',
+  },
+  {
+    key: 'table_name',
+    label: 'Mesa',
+    cellClassName: 'text-sm font-medium',
+    render: (p) => p.table_name || '-',
+  },
+  {
+    key: 'total_amount',
+    label: 'Total',
+    type: 'currency',
+    cellClassName: 'font-medium',
+    render: (p) => formatCurrency(p.total_amount),
+  },
+  {
+    key: 'status',
+    label: 'Estado',
+    render: (p) => <Badge variant={statusVariant(p.status)}>{p.status ?? '—'}</Badge>,
+  },
+];
 
 export type VentasTableProps = {
   pedidos: Pedido[];
   loading: boolean;
-  sortKey: string;
-  sortDir: SortDir;
-  onSort: (key: string) => void;
-  sortData: <T extends Record<string, unknown>>(data: T[]) => T[];
   onRowClick: (pedido: Pedido) => void;
 };
 
-export function VentasTable({
-  pedidos,
-  loading,
-  sortKey,
-  sortDir,
-  onSort,
-  sortData,
-  onRowClick,
-}: VentasTableProps) {
+export function VentasTable({ pedidos, loading, onRowClick }: VentasTableProps) {
   return (
-    <div className="rounded-xl border bg-card">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <SortableHead
-              sortKey="order_id"
-              label="Folio"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-            />
-            <SortableHead
-              sortKey="timestamp"
-              label="Fecha/Hora"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-            />
-            <SortableHead
-              sortKey="place_name"
-              label="Área"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-            />
-            <SortableHead
-              sortKey="table_name"
-              label="Mesa"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-            />
-            <SortableHead
-              sortKey="total_amount"
-              label="Total"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-              className="text-right"
-            />
-            <SortableHead
-              sortKey="status"
-              label="Estado"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-            />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {loading ? (
-            <TableSkeleton rows={8} columns={6} />
-          ) : pedidos.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={6} className="p-0">
-                <EmptyState
-                  icon={<Inbox className="h-8 w-8" />}
-                  title="Sin pedidos en el rango seleccionado"
-                  description="Ajusta las fechas, el corte o los filtros activos para ver pedidos."
-                />
-              </TableCell>
-            </TableRow>
-          ) : (
-            sortData(pedidos).map((pedido) => (
-              <TableRow
-                key={String(pedido.id)}
-                className="cursor-pointer hover:bg-muted/50"
-                onClick={() => onRowClick(pedido)}
-              >
-                <TableCell className="font-mono text-xs font-medium">
-                  #{pedido.order_id ?? pedido.id}
-                </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
-                  {formatDate(pedido.timestamp)}
-                </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
-                  {pedido.layout_name || '-'}
-                </TableCell>
-                <TableCell className="text-sm font-medium">{pedido.table_name || '-'}</TableCell>
-                <TableCell className="text-right font-medium tabular-nums">
-                  {formatCurrency(pedido.total_amount)}
-                </TableCell>
-                <TableCell>
-                  <Badge variant={statusVariant(pedido.status)}>{pedido.status ?? '—'}</Badge>
-                </TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
-    </div>
+    <DataTable<Pedido>
+      data={pedidos}
+      columns={columns}
+      rowKey="id"
+      loading={loading}
+      onRowClick={onRowClick}
+      initialSort={{ key: 'timestamp', dir: 'desc' }}
+      emptyIcon={<Inbox className="h-8 w-8" />}
+      emptyTitle="Sin pedidos en el rango seleccionado"
+      emptyDescription="Ajusta las fechas, el corte o los filtros activos para ver pedidos."
+      showDensityToggle={false}
+    />
   );
 }

--- a/components/ventas/ventas-view.tsx
+++ b/components/ventas/ventas-view.tsx
@@ -19,7 +19,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getLocalDayBoundsUtc } from '@/lib/timezone';
-import { useSortableTable } from '@/hooks/use-sortable-table';
 import { useUrlFilters } from '@/hooks/use-url-filters';
 import { ErrorBanner } from '@/components/module-page';
 import { OrderDetail } from './order-detail';
@@ -39,7 +38,6 @@ export function VentasView() {
   const [loadingDetail, setLoadingDetail] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [productoSearch, setProductoSearch] = useState('');
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable<Pedido>('timestamp', 'desc');
   const [cortes, setCortes] = useState<CorteOption[]>([]);
 
   // URL-synced filter defaults are captured once at mount (today's date range).
@@ -264,10 +262,6 @@ export function VentasView() {
           <VentasTable
             pedidos={filtered}
             loading={loading}
-            sortKey={sortKey}
-            sortDir={sortDir}
-            onSort={onSort}
-            sortData={sortData}
             onRowClick={(pedido) => void openDetail(pedido)}
           />
           <OrderDetail


### PR DESCRIPTION
PR-C de la iniciativa data-table. Migra:

- `components/ventas/ventas-table.tsx` — 6 columnas (Folio, Fecha/Hora, Área, Mesa, Total, Estado).
- `components/ventas/ventas-por-producto.tsx` — 6 columnas con barra de % visual custom + summary stats arriba.

`<VentasView>` ya no necesita `useSortableTable` ni `<SortableHead>` para Ventas. Reducción: -233 / +123 (110 líneas menos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)