### PR TITLE
feat(data-table): migra Inventario stack + Productos (PR-D)

### DIFF
--- a/app/rdb/inventario/levantamientos/page.tsx
+++ b/app/rdb/inventario/levantamientos/page.tsx
@@ -12,20 +12,12 @@ import { ClipboardList, Plus, RefreshCw } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { Skeleton } from '@/components/ui/skeleton';
+import { DataTable, ErrorBanner, type Column } from '@/components/module-page';
 import {
   LevantamientoStatusBadge,
   type LevantamientoEstado,
 } from '@/components/inventario/levantamiento-status-badge';
-import { formatDateShort, formatDateTime } from '@/lib/inventario/format';
+import { formatDate, formatDateTime } from '@/lib/format';
 
 const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
@@ -42,6 +34,57 @@ type LevantamientoRow = {
   created_at: string;
   almacenes: { nombre: string } | null;
 };
+
+const columns: Column<LevantamientoRow>[] = [
+  {
+    key: 'folio',
+    label: 'Folio',
+    cellClassName: 'font-medium tabular-nums',
+    render: (r) => r.folio ?? '—',
+  },
+  {
+    key: 'estado',
+    label: 'Estado',
+    render: (r) => <LevantamientoStatusBadge estado={r.estado as LevantamientoEstado} />,
+  },
+  {
+    key: 'almacen',
+    label: 'Almacén',
+    accessor: (r) => r.almacenes?.nombre ?? '',
+    render: (r) => r.almacenes?.nombre ?? '—',
+  },
+  {
+    key: 'fecha_programada',
+    label: 'Programado',
+    cellClassName: 'tabular-nums',
+    render: (r) => formatDate(r.fecha_programada),
+  },
+  {
+    key: 'ultima_actividad',
+    label: 'Última actividad',
+    cellClassName: 'tabular-nums text-muted-foreground',
+    accessor: (r) => r.fecha_aplicado ?? r.fecha_cierre ?? r.fecha_inicio ?? r.created_at,
+    render: (r) => {
+      const ultima = r.fecha_aplicado ?? r.fecha_cierre ?? r.fecha_inicio ?? r.created_at;
+      return formatDateTime(ultima);
+    },
+  },
+  {
+    key: 'accion',
+    label: 'Acción',
+    sortable: false,
+    align: 'right',
+    render: (r) => (
+      <DataTable.InteractiveCell>
+        <Link href={`/rdb/inventario/levantamientos/${r.id}`}>
+          <Button variant="outline" size="sm">
+            Abrir
+          </Button>
+        </Link>
+      </DataTable.InteractiveCell>
+    ),
+  },
+];
 
 export default function LevantamientosListaPage() {
   return (
@@ -118,128 +161,47 @@ function LevantamientosListaInner() {
         </div>
       </header>
 
-      {error && (
-        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
-          {error}
-        </div>
-      )}
+      {error && <ErrorBanner error={error} onRetry={() => void load()} />}
 
       <section>
         <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
           Activos
         </h2>
-        {loading ? (
-          <ListSkeleton />
-        ) : activos.length === 0 ? (
-          <EmptyState
-            title="No hay levantamientos activos"
-            description="Inicia uno nuevo para comenzar el conteo."
-            cta={
-              <Link href="/rdb/inventario/levantamientos/nuevo">
-                <Button>
-                  <Plus className="size-4" />
-                  Nuevo levantamiento
-                </Button>
-              </Link>
-            }
-          />
-        ) : (
-          <LevantamientosTable rows={activos} />
-        )}
+        <DataTable<LevantamientoRow>
+          data={activos}
+          columns={columns}
+          rowKey="id"
+          loading={loading}
+          initialSort={{ key: 'fecha_programada', dir: 'desc' }}
+          emptyIcon={<ClipboardList className="size-8" />}
+          emptyTitle="No hay levantamientos activos"
+          emptyDescription="Inicia uno nuevo para comenzar el conteo."
+          emptyAction={
+            <Link href="/rdb/inventario/levantamientos/nuevo">
+              <Button>
+                <Plus className="size-4" />
+                Nuevo levantamiento
+              </Button>
+            </Link>
+          }
+          showDensityToggle={false}
+        />
       </section>
 
       <section>
         <h2 className="mb-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
           Histórico reciente
         </h2>
-        {loading ? (
-          <ListSkeleton rows={3} />
-        ) : cerrados.length === 0 ? (
-          <p className="rounded-lg border bg-muted/40 p-4 text-sm text-muted-foreground">
-            Sin levantamientos cerrados todavía.
-          </p>
-        ) : (
-          <LevantamientosTable rows={cerrados} />
-        )}
+        <DataTable<LevantamientoRow>
+          data={cerrados}
+          columns={columns}
+          rowKey="id"
+          loading={loading}
+          initialSort={{ key: 'ultima_actividad', dir: 'desc' }}
+          emptyTitle="Sin levantamientos cerrados todavía"
+          showDensityToggle={false}
+        />
       </section>
-    </div>
-  );
-}
-
-function LevantamientosTable({ rows }: { rows: LevantamientoRow[] }) {
-  return (
-    <div className="rounded-lg border bg-card">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Folio</TableHead>
-            <TableHead>Estado</TableHead>
-            <TableHead>Almacén</TableHead>
-            <TableHead>Programado</TableHead>
-            <TableHead>Última actividad</TableHead>
-            <TableHead className="text-right">Acción</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {rows.map((row) => {
-            const ultima =
-              row.fecha_aplicado ?? row.fecha_cierre ?? row.fecha_inicio ?? row.created_at;
-            return (
-              <TableRow key={row.id}>
-                <TableCell className="font-medium tabular-nums">{row.folio ?? '—'}</TableCell>
-                <TableCell>
-                  <LevantamientoStatusBadge estado={row.estado as LevantamientoEstado} />
-                </TableCell>
-                <TableCell>{row.almacenes?.nombre ?? '—'}</TableCell>
-                <TableCell className="tabular-nums">
-                  {formatDateShort(row.fecha_programada)}
-                </TableCell>
-                <TableCell className="tabular-nums text-muted-foreground">
-                  {formatDateTime(ultima)}
-                </TableCell>
-                <TableCell className="text-right">
-                  <Link href={`/rdb/inventario/levantamientos/${row.id}`}>
-                    <Button variant="outline" size="sm">
-                      Abrir
-                    </Button>
-                  </Link>
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
-  );
-}
-
-function ListSkeleton({ rows = 4 }: { rows?: number }) {
-  return (
-    <div className="space-y-2">
-      {Array.from({ length: rows }).map((_, i) => (
-        <Skeleton key={i} className="h-12 w-full rounded-lg" />
-      ))}
-    </div>
-  );
-}
-
-function EmptyState({
-  title,
-  description,
-  cta,
-}: {
-  title: string;
-  description: string;
-  cta?: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-muted/30 p-10 text-center">
-      <ClipboardList className="size-10 text-muted-foreground/60" />
-      <div>
-        <div className="font-medium">{title}</div>
-        <div className="mt-1 text-sm text-muted-foreground">{description}</div>
-      </div>
-      {cta}
     </div>
   );
 }

--- a/app/rdb/inventario/movimientos/page.tsx
+++ b/app/rdb/inventario/movimientos/page.tsx
@@ -3,26 +3,92 @@
 import { useCallback, useEffect, useState } from 'react';
 import { RefreshCw, Search, TrendingDown, TrendingUp } from 'lucide-react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import { ModuleFilters, ModuleContent } from '@/components/module-page';
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+  ModuleFilters,
+  ModuleContent,
+  ErrorBanner,
+  DataTable,
+  type Column,
+} from '@/components/module-page';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
 import { RDB_EMPRESA_ID, type MovimientoRow } from '@/components/inventario/types';
-import {
-  formatCurrency,
-  formatDate,
-  tipoColorClass,
-  tipoLabel,
-} from '@/components/inventario/utils';
+import { tipoColorClass, tipoLabel } from '@/components/inventario/utils';
+import { formatCurrency, formatDateTime } from '@/lib/format';
+
+const movimientoColumns: Column<MovimientoRow>[] = [
+  {
+    key: 'created_at',
+    label: 'Fecha',
+    cellClassName: 'whitespace-nowrap text-sm text-muted-foreground',
+    render: (m) => formatDateTime(m.created_at),
+  },
+  {
+    key: 'producto',
+    label: 'Producto',
+    cellClassName: 'font-medium',
+    accessor: (m) => m.productos?.nombre ?? '',
+    render: (m) => m.productos?.nombre ?? '—',
+  },
+  {
+    key: 'tipo_movimiento',
+    label: 'Tipo',
+    render: (m) => {
+      const isPositive =
+        m.tipo_movimiento === 'entrada' || (m.tipo_movimiento === 'ajuste' && m.cantidad >= 0);
+      return (
+        <div className="flex items-center gap-1.5">
+          {isPositive ? (
+            <TrendingUp className="h-3.5 w-3.5 text-emerald-500" />
+          ) : (
+            <TrendingDown className="h-3.5 w-3.5 text-destructive" />
+          )}
+          <Badge variant="outline" className={tipoColorClass(m.tipo_movimiento, m.cantidad)}>
+            {tipoLabel(m.tipo_movimiento, m.cantidad)}
+          </Badge>
+        </div>
+      );
+    },
+  },
+  {
+    key: 'cantidad',
+    label: 'Cantidad',
+    type: 'number',
+    render: (m) => {
+      const isPositive =
+        m.tipo_movimiento === 'entrada' || (m.tipo_movimiento === 'ajuste' && m.cantidad >= 0);
+      const color = isPositive ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive';
+      return (
+        <span className={`font-semibold ${color}`}>
+          {isPositive ? '+' : '−'}
+          {Math.abs(m.cantidad)}
+        </span>
+      );
+    },
+  },
+  {
+    key: 'costo_unitario',
+    label: 'Costo Unit.',
+    type: 'currency',
+    cellClassName: 'text-sm',
+    render: (m) => formatCurrency(m.costo_unitario),
+  },
+  {
+    key: 'detalle',
+    label: 'Detalle / Referencia',
+    sortable: false,
+    cellClassName: 'max-w-[200px] truncate text-sm text-muted-foreground',
+    render: (m) => (
+      <>
+        <div className="font-medium text-foreground">
+          {m.referencia_tipo === 'orden_compra' ? 'OC' : 'Manual'}
+        </div>
+        <div className="truncate">{m.notas ?? '—'}</div>
+      </>
+    ),
+  },
+];
 
 /**
  * Inventario · tab "Movimientos" (kardex consolidado).
@@ -107,95 +173,19 @@ export default function InventarioMovimientosPage() {
         </Button>
       </ModuleFilters>
 
-      {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          {error}
-        </div>
-      )}
+      {error && <ErrorBanner error={error} onRetry={() => void fetchMovimientos()} />}
 
       <ModuleContent>
-        <div className="rounded-xl border bg-card">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Fecha</TableHead>
-                <TableHead>Producto</TableHead>
-                <TableHead>Tipo</TableHead>
-                <TableHead className="text-right">Cantidad</TableHead>
-                <TableHead className="text-right">Costo Unit.</TableHead>
-                <TableHead>Detalle / Referencia</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {loading ? (
-                Array.from({ length: 8 }).map((_, i) => (
-                  <TableRow key={i}>
-                    {Array.from({ length: 6 }).map((__, j) => (
-                      <TableCell key={j}>
-                        <Skeleton className="h-4 w-full" />
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))
-              ) : filteredMovimientos.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={6} className="py-12 text-center text-muted-foreground">
-                    No se encontraron movimientos.
-                  </TableCell>
-                </TableRow>
-              ) : (
-                filteredMovimientos.map((mov) => (
-                  <TableRow key={mov.id}>
-                    <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
-                      {formatDate(mov.created_at)}
-                    </TableCell>
-                    <TableCell className="font-medium">{mov.productos?.nombre ?? '—'}</TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1.5">
-                        {mov.tipo_movimiento === 'entrada' ||
-                        (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0) ? (
-                          <TrendingUp className="h-3.5 w-3.5 text-emerald-500" />
-                        ) : (
-                          <TrendingDown className="h-3.5 w-3.5 text-destructive" />
-                        )}
-                        <Badge
-                          variant="outline"
-                          className={tipoColorClass(mov.tipo_movimiento, mov.cantidad)}
-                        >
-                          {tipoLabel(mov.tipo_movimiento, mov.cantidad)}
-                        </Badge>
-                      </div>
-                    </TableCell>
-                    <TableCell
-                      className={[
-                        'text-right font-semibold tabular-nums',
-                        mov.tipo_movimiento === 'entrada' ||
-                        (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0)
-                          ? 'text-emerald-600 dark:text-emerald-400'
-                          : 'text-destructive',
-                      ].join(' ')}
-                    >
-                      {mov.tipo_movimiento === 'entrada' ||
-                      (mov.tipo_movimiento === 'ajuste' && mov.cantidad >= 0)
-                        ? '+'
-                        : '−'}
-                      {Math.abs(mov.cantidad)}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums text-sm">
-                      {formatCurrency(mov.costo_unitario)}
-                    </TableCell>
-                    <TableCell className="max-w-[200px] truncate text-sm text-muted-foreground">
-                      <div className="font-medium text-foreground">
-                        {mov.referencia_tipo === 'orden_compra' ? 'OC' : 'Manual'}
-                      </div>
-                      <div className="truncate">{mov.notas ?? '—'}</div>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </div>
+        <DataTable<MovimientoRow>
+          data={filteredMovimientos}
+          columns={movimientoColumns}
+          rowKey="id"
+          loading={loading}
+          initialSort={{ key: 'created_at', dir: 'desc' }}
+          emptyTitle={search ? 'Ningún movimiento coincide' : 'Sin movimientos registrados'}
+          emptyDescription={search ? 'Limpia la búsqueda para ver todo.' : undefined}
+          showDensityToggle={false}
+        />
       </ModuleContent>
     </>
   );

--- a/app/rdb/inventario/page.tsx
+++ b/app/rdb/inventario/page.tsx
@@ -16,15 +16,12 @@ import {
   ModuleKpiStrip,
   ModuleFilters,
   ModuleContent,
-  EmptyState,
-  TableSkeleton,
   ErrorBanner,
   ActiveFiltersChip,
+  DataTable,
+  type Column,
 } from '@/components/module-page';
 import { CategoryFilterStrip } from '@/components/inventario/category-filter-strip';
-import { Table, TableBody, TableCell, TableHeader, TableRow } from '@/components/ui/table';
-import { SortableHead } from '@/components/ui/sortable-head';
-import { useSortableTable } from '@/hooks/use-sortable-table';
 import { useUrlFilters } from '@/hooks/use-url-filters';
 import { Combobox } from '@/components/ui/combobox';
 import { Badge } from '@/components/ui/badge';
@@ -34,7 +31,8 @@ import { StockDetailDrawer } from '@/components/inventario/stock-detail-drawer';
 import { RegistrarMovimientoDialog } from '@/components/inventario/registrar-movimiento-dialog';
 import { printStockList } from '@/components/inventario/print-stock-list';
 import { type StockItem } from '@/components/inventario/types';
-import { computeStockStats, formatCurrency } from '@/components/inventario/utils';
+import { computeStockStats } from '@/components/inventario/utils';
+import { formatCurrency } from '@/lib/format';
 
 const FILTER_DEFAULTS = {
   search: '',
@@ -44,6 +42,77 @@ const FILTER_DEFAULTS = {
   clasificacionFiltro: '',
   fechaCorte: '',
 };
+
+const stockColumns: Column<StockItem>[] = [
+  {
+    key: 'nombre',
+    label: 'Producto',
+    cellClassName: 'font-medium',
+  },
+  {
+    key: 'clasificacion',
+    label: 'Clasif.',
+    render: (i) => (
+      <Badge variant="outline" className="text-xs font-normal">
+        {i.clasificacion ?? '—'}
+      </Badge>
+    ),
+  },
+  {
+    key: 'categoria',
+    label: 'Categoría',
+    cellClassName: 'text-sm text-muted-foreground',
+    render: (i) => i.categoria ?? '—',
+  },
+  {
+    key: 'stock_actual',
+    label: 'Stock Actual',
+    type: 'number',
+    render: (i) => {
+      const color =
+        i.stock_actual <= 0 ? 'text-destructive' : i.bajo_minimo ? 'text-amber-500' : '';
+      return (
+        <span className={`font-semibold ${color}`}>
+          {i.stock_actual} {i.unidad ?? 'pzs'}
+        </span>
+      );
+    },
+  },
+  {
+    key: 'stock_minimo',
+    label: 'Mínimo',
+    type: 'number',
+    cellClassName: 'text-sm text-muted-foreground',
+    render: (i) => `${i.stock_minimo ?? '—'} ${i.unidad ?? 'pzs'}`,
+  },
+  {
+    key: 'ultimo_costo',
+    label: 'Último Costo',
+    type: 'currency',
+    render: (i) => formatCurrency(i.costo_unitario ?? i.ultimo_costo),
+  },
+  {
+    key: 'valor_inventario',
+    label: 'Valor Total',
+    type: 'currency',
+    cellClassName: 'font-semibold',
+  },
+  {
+    key: 'bajo_minimo',
+    label: 'Estado',
+    render: (i) =>
+      i.stock_actual <= 0 ? (
+        <Badge variant="destructive">Sin stock</Badge>
+      ) : i.bajo_minimo ? (
+        <Badge variant="outline" className="border-amber-500/50 text-amber-500">
+          Bajo mínimo
+        </Badge>
+      ) : (
+        <Badge variant="default">OK</Badge>
+      ),
+    accessor: (i) => (i.stock_actual <= 0 ? 0 : i.bajo_minimo ? 1 : 2),
+  },
+];
 
 /**
  * Inventario · tab "Stock" (default landing del módulo).
@@ -59,7 +128,6 @@ export default function InventarioStockPage() {
   const [items, setItems] = useState<StockItem[]>([]);
   const [loadingStock, setLoadingStock] = useState(true);
   const [errorStock, setErrorStock] = useState<string | null>(null);
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable('nombre', 'asc');
 
   // URL-synced filters
   const { filters, setFilter, clearAll, activeCount } = useUrlFilters(FILTER_DEFAULTS);
@@ -323,152 +391,27 @@ export default function InventarioStockPage() {
       )}
 
       <ModuleContent>
-        <div className="rounded-xl border bg-card">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <SortableHead
-                  sortKey="nombre"
-                  label="Producto"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="clasificacion"
-                  label="Clasif."
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="categoria"
-                  label="Categoría"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="stock_actual"
-                  label="Stock Actual"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="text-right"
-                />
-                <SortableHead
-                  sortKey="stock_minimo"
-                  label="Mínimo"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="text-right"
-                />
-                <SortableHead
-                  sortKey="ultimo_costo"
-                  label="Último Costo"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="text-right"
-                />
-                <SortableHead
-                  sortKey="valor_inventario"
-                  label="Valor Total"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="text-right"
-                />
-                <SortableHead
-                  sortKey="bajo_minimo"
-                  label="Estado"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {loadingStock ? (
-                <TableSkeleton rows={8} columns={8} />
-              ) : filteredStock.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={8} className="p-0">
-                    <EmptyState
-                      icon={<Boxes className="h-8 w-8" />}
-                      title={
-                        activeCount > 0
-                          ? 'Ningún producto coincide con los filtros'
-                          : 'Aún no hay productos'
-                      }
-                      description={
-                        activeCount > 0
-                          ? 'Limpia los filtros para ver el inventario completo.'
-                          : 'Registra el primer movimiento para que aparezca aquí.'
-                      }
-                    />
-                  </TableCell>
-                </TableRow>
-              ) : (
-                sortData(filteredStock).map((item) => (
-                  <TableRow
-                    key={item.id}
-                    className="cursor-pointer hover:bg-muted/50"
-                    onClick={() => {
-                      setSelectedItem(item);
-                      setDrawerOpen(true);
-                    }}
-                  >
-                    <TableCell>
-                      <span className="font-medium">{item.nombre}</span>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant="outline" className="text-xs font-normal">
-                        {item.clasificacion ?? '—'}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {item.categoria ?? '—'}
-                    </TableCell>
-                    <TableCell
-                      className={[
-                        'text-right font-semibold tabular-nums',
-                        item.stock_actual <= 0
-                          ? 'text-destructive'
-                          : item.bajo_minimo
-                            ? 'text-amber-500'
-                            : '',
-                      ].join(' ')}
-                    >
-                      {item.stock_actual} {item.unidad ?? 'pzs'}
-                    </TableCell>
-                    <TableCell className="text-right text-sm tabular-nums text-muted-foreground">
-                      {item.stock_minimo ?? '—'} {item.unidad ?? 'pzs'}
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums">
-                      {formatCurrency(item.costo_unitario ?? item.ultimo_costo)}
-                    </TableCell>
-                    <TableCell className="text-right font-semibold tabular-nums">
-                      {formatCurrency(item.valor_inventario)}
-                    </TableCell>
-                    <TableCell>
-                      {item.stock_actual <= 0 ? (
-                        <Badge variant="destructive">Sin stock</Badge>
-                      ) : item.bajo_minimo ? (
-                        <Badge variant="outline" className="border-amber-500/50 text-amber-500">
-                          Bajo mínimo
-                        </Badge>
-                      ) : (
-                        <Badge variant="default">OK</Badge>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </div>
+        <DataTable<StockItem>
+          data={filteredStock}
+          columns={stockColumns}
+          rowKey="id"
+          loading={loadingStock}
+          onRowClick={(item) => {
+            setSelectedItem(item);
+            setDrawerOpen(true);
+          }}
+          initialSort={{ key: 'nombre', dir: 'asc' }}
+          emptyIcon={<Boxes className="h-8 w-8" />}
+          emptyTitle={
+            activeCount > 0 ? 'Ningún producto coincide con los filtros' : 'Aún no hay productos'
+          }
+          emptyDescription={
+            activeCount > 0
+              ? 'Limpia los filtros para ver el inventario completo.'
+              : 'Registra el primer movimiento para que aparezca aquí.'
+          }
+          showDensityToggle={false}
+        />
       </ModuleContent>
 
       <StockDetailDrawer

--- a/app/rdb/productos/page.tsx
+++ b/app/rdb/productos/page.tsx
@@ -4,16 +4,7 @@ import { RequireAccess } from '@/components/require-access';
 import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { SortableHead } from '@/components/ui/sortable-head';
-import { useSortableTable } from '@/hooks/use-sortable-table';
+import { DataTable, type Column } from '@/components/module-page';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -77,15 +68,7 @@ type InsumoDisponible = {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function formatCurrency(amount: number | null | undefined) {
-  if (amount == null) return '—';
-  return amount.toLocaleString('es-MX', { style: 'currency', currency: 'MXN' });
-}
-
-function formatNumber(n: number | null | undefined, frac = 0) {
-  if (n == null) return '—';
-  return n.toLocaleString('es-MX', { minimumFractionDigits: frac, maximumFractionDigits: frac });
-}
+import { formatCurrency, formatNumber } from '@/lib/format';
 
 function MargenBadge({ pct }: { pct: number | null }) {
   if (pct === null || pct === undefined)
@@ -110,6 +93,103 @@ function UltimaVentaCell({ at, now }: { at: string | null; now: number }) {
   if (days <= 7) return <span className="text-emerald-600 text-xs">Hace {days}d</span>;
   if (days <= 30) return <span className="text-amber-600 text-xs">Hace {days}d</span>;
   return <span className="text-red-600 text-xs">Hace {days}d</span>;
+}
+
+function productoColumns(now: number, openDrawer: (p: Producto) => void): Column<Producto>[] {
+  return [
+    {
+      key: 'nombre',
+      label: 'Nombre',
+      render: (p) => (
+        <>
+          <div className="font-medium">{p.nombre}</div>
+          {p.descripcion && <div className="text-xs text-muted-foreground">{p.descripcion}</div>}
+        </>
+      ),
+    },
+    {
+      key: 'codigo',
+      label: 'Código',
+      cellClassName: 'text-xs text-muted-foreground tabular-nums',
+      render: (p) => p.codigo ?? '—',
+    },
+    {
+      key: 'inventariable',
+      label: 'Inventario',
+      render: (p) =>
+        (p.inventariable ?? true) ? (
+          <Badge variant="outline" className="text-emerald-600 border-emerald-200 bg-emerald-50">
+            Producto físico
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="text-blue-600 border-blue-200 bg-blue-50">
+            Servicio
+          </Badge>
+        ),
+    },
+    {
+      key: 'categoria_nombre',
+      label: 'Categoría',
+      render: (p) => <CategoriaBadge nombre={p.categoria_nombre} color={p.categoria_color} />,
+    },
+    {
+      key: 'ultimo_costo',
+      label: 'Costo',
+      type: 'currency',
+      cellClassName: 'text-sm',
+    },
+    {
+      key: 'ultimo_precio_venta',
+      label: 'Precio',
+      type: 'currency',
+      cellClassName: 'text-sm font-medium',
+    },
+    {
+      key: 'margen_pct',
+      label: 'Margen',
+      align: 'right',
+      render: (p) => <MargenBadge pct={p.margen_pct} />,
+    },
+    {
+      key: 'stock_actual',
+      label: 'Stock',
+      type: 'number',
+      cellClassName: 'text-sm',
+      render: (p) => (p.inventariable ? formatNumber(p.stock_actual, { decimals: 0 }) : '—'),
+    },
+    {
+      key: 'ultima_venta_at',
+      label: 'Última venta',
+      render: (p) => <UltimaVentaCell at={p.ultima_venta_at} now={now} />,
+    },
+    {
+      key: 'activo',
+      label: 'Estado',
+      render: (p) => (
+        <Badge variant={p.activo ? 'default' : 'secondary'}>
+          {p.activo ? 'Activo' : 'Inactivo'}
+        </Badge>
+      ),
+    },
+    {
+      key: 'acciones',
+      label: '',
+      sortable: false,
+      align: 'right',
+      render: (p) => (
+        <DataTable.InteractiveCell>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-muted-foreground"
+            onClick={() => openDrawer(p)}
+          >
+            <Settings2 className="h-4 w-4" />
+          </Button>
+        </DataTable.InteractiveCell>
+      ),
+    },
+  ];
 }
 
 function CategoriaBadge({ nombre, color }: { nombre: string | null; color: string | null }) {
@@ -438,8 +518,6 @@ export default function ProductosPage() {
     now,
   ]);
 
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable<Producto>('nombre', 'asc');
-
   return (
     <RequireAccess empresa="rdb" modulo="rdb.productos">
       <div className="space-y-6">
@@ -555,179 +633,16 @@ export default function ProductosPage() {
         )}
 
         {/* Table */}
-        <div className="rounded-xl border bg-card">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <SortableHead
-                  sortKey="nombre"
-                  label="Nombre"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="codigo"
-                  label="Código"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="inventariable"
-                  label="Inventario"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="categoria_nombre"
-                  label="Categoría"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="ultimo_costo"
-                  label="Costo"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="text-right"
-                />
-                <SortableHead
-                  sortKey="ultimo_precio_venta"
-                  label="Precio"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="text-right"
-                />
-                <SortableHead
-                  sortKey="margen_pct"
-                  label="Margen"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="text-right"
-                />
-                <SortableHead
-                  sortKey="stock_actual"
-                  label="Stock"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="text-right"
-                />
-                <SortableHead
-                  sortKey="ultima_venta_at"
-                  label="Última venta"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="activo"
-                  label="Estado"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <TableHead></TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {loading ? (
-                Array.from({ length: 8 }).map((_, i) => (
-                  <TableRow key={i}>
-                    {Array.from({ length: 11 }).map((__, j) => (
-                      <TableCell key={j}>
-                        <Skeleton className="h-4 w-full" />
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))
-              ) : filtered.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={11} className="py-12 text-center text-muted-foreground">
-                    No se encontraron productos.
-                  </TableCell>
-                </TableRow>
-              ) : (
-                sortData(filtered).map((p) => (
-                  <TableRow
-                    key={p.id}
-                    className="cursor-pointer hover:bg-muted/50"
-                    onClick={() => openDrawer(p)}
-                  >
-                    <TableCell>
-                      <div className="font-medium">{p.nombre}</div>
-                      {p.descripcion && (
-                        <div className="text-xs text-muted-foreground">{p.descripcion}</div>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground tabular-nums">
-                      {p.codigo ?? '—'}
-                    </TableCell>
-                    <TableCell>
-                      {(p.inventariable ?? true) ? (
-                        <Badge
-                          variant="outline"
-                          className="text-emerald-600 border-emerald-200 bg-emerald-50"
-                        >
-                          Producto físico
-                        </Badge>
-                      ) : (
-                        <Badge
-                          variant="outline"
-                          className="text-blue-600 border-blue-200 bg-blue-50"
-                        >
-                          Servicio
-                        </Badge>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <CategoriaBadge nombre={p.categoria_nombre} color={p.categoria_color} />
-                    </TableCell>
-                    <TableCell className="text-right text-sm tabular-nums">
-                      {formatCurrency(p.ultimo_costo)}
-                    </TableCell>
-                    <TableCell className="text-right text-sm tabular-nums font-medium">
-                      {formatCurrency(p.ultimo_precio_venta)}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <MargenBadge pct={p.margen_pct} />
-                    </TableCell>
-                    <TableCell className="text-right text-sm tabular-nums">
-                      {p.inventariable ? formatNumber(p.stock_actual, 0) : '—'}
-                    </TableCell>
-                    <TableCell>
-                      <UltimaVentaCell at={p.ultima_venta_at} now={now} />
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={p.activo ? 'default' : 'secondary'}>
-                        {p.activo ? 'Activo' : 'Inactivo'}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-muted-foreground"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          openDrawer(p);
-                        }}
-                      >
-                        <Settings2 className="h-4 w-4" />
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </div>
+        <DataTable<Producto>
+          data={filtered}
+          columns={productoColumns(now, openDrawer)}
+          rowKey="id"
+          loading={loading}
+          onRowClick={openDrawer}
+          initialSort={{ key: 'nombre', dir: 'asc' }}
+          emptyTitle="No se encontraron productos"
+          showDensityToggle={false}
+        />
 
         {/* Detail/Config Drawer */}
         <Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
@@ -757,7 +672,7 @@ export default function ProductosPage() {
                     <MargenBadge pct={selectedProducto.margen_pct} />
                     {selectedProducto.inventariable && (
                       <span className="text-xs text-muted-foreground">
-                        Stock: {formatNumber(selectedProducto.stock_actual, 0)}
+                        Stock: {formatNumber(selectedProducto.stock_actual, { decimals: 0 })}
                       </span>
                     )}
                     <UltimaVentaCell at={selectedProducto.ultima_venta_at} now={now} />


### PR DESCRIPTION
PR-D de la iniciativa data-table. Migra:

- `app/rdb/inventario/page.tsx` (Stock, 8 columnas con coloreado de estado).
- `app/rdb/inventario/movimientos/page.tsx` (kardex, 6 columnas con tipo + signo).
- `app/rdb/inventario/levantamientos/page.tsx` (2 secciones Activos + Histórico, ambas con `<DataTable>` y empty states diferenciados).
- `app/rdb/productos/page.tsx` (11 columnas: nombre+desc, código, inventariable, categoría con CategoriaBadge, costo, precio, margen, stock, última venta, estado, acción).

Reducción: -570 / +380 (-190 líneas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)