### PR TITLE
feat(data-table): migra Documentos (PR-H)

### DIFF
--- a/components/documentos/documentos-module.tsx
+++ b/components/documentos/documentos-module.tsx
@@ -49,7 +49,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
 // Combobox queda disponible si se necesita en form fields (ver documento-form-fields.tsx).
-import { useSortableTable } from '@/hooks/use-sortable-table';
 
 import type { Adjunto, Documento, NotariaOption } from './types';
 import { getVencStatus } from './helpers';
@@ -397,28 +396,18 @@ export function DocumentosModule({
   ).length;
   const soonCount = documentos.filter((d) => getVencStatus(d.fecha_vencimiento) === 'soon').length;
 
-  const baseSortCtx = useSortableTable('fecha_emision', 'desc');
-
-  // Si hay búsqueda semántica activa, override sortData para respetar el rank
-  // devuelto por la API (el doc más similar primero). Los filtros, sorts por
-  // columna y reset siguen disponibles — el usuario puede ordenar por fecha
-  // si prefiere, pero el default mientras dure la búsqueda es el rank IA.
-  const sortCtx = useMemo(() => {
-    if (!semanticRankMap) return baseSortCtx;
-    return {
-      ...baseSortCtx,
-      sortData: <T extends Record<string, unknown>>(rows: T[]): T[] => {
-        if (baseSortCtx.sortKey !== 'fecha_emision' || baseSortCtx.sortDir !== 'desc') {
-          return baseSortCtx.sortData(rows);
-        }
-        return [...rows].sort((a, b) => {
-          const ra = semanticRankMap.get(a.id as string) ?? Number.MAX_SAFE_INTEGER;
-          const rb = semanticRankMap.get(b.id as string) ?? Number.MAX_SAFE_INTEGER;
-          return ra - rb;
-        });
-      },
-    };
-  }, [baseSortCtx, semanticRankMap]);
+  // Si hay búsqueda semántica activa, pre-orden por rank antes de pasar a la
+  // tabla (el doc más similar primero). DataTable respeta el orden recibido
+  // cuando no se pasa initialSort. El usuario puede re-ordenar clickeando una
+  // columna; el rank semántico se pierde al hacerlo (comportamiento esperado).
+  const displayed = useMemo(() => {
+    if (!semanticRankMap) return filtered;
+    return [...filtered].sort((a, b) => {
+      const ra = semanticRankMap.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+      const rb = semanticRankMap.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+      return ra - rb;
+    });
+  }, [filtered, semanticRankMap]);
 
   // Scope the detail sheet's update query by empresa_id for single-empresa
   // mounts (defense-in-depth). The cross-empresa admin view relies on RLS.
@@ -540,12 +529,12 @@ export function DocumentosModule({
       <DocumentosTable
         loading={loading}
         error={error}
-        filtered={filtered}
+        filtered={displayed}
         documentos={documentos}
         adjuntosPorDoc={adjuntosPorDoc}
         onSelect={setSelectedDoc}
         onCreate={() => setShowCreate(true)}
-        sort={sortCtx}
+        semanticActive={!!semanticRankMap}
       />
 
       {!loading && documentos.length > 0 && (

--- a/components/documentos/documentos-table.tsx
+++ b/components/documentos/documentos-table.tsx
@@ -3,6 +3,12 @@
 /**
  * DocumentosTable — list rendering for the documentos module.
  *
+ * Migrated to `<DataTable>` (ADR-010). The 4 IA-extraction columns
+ * (Operación, Monto, Superficie, $/m²) use `column.showIf` to appear only
+ * when the universe of documents has at least one row with that field.
+ * PDF/IMG/Anexos cells use `<DataTable.InteractiveCell>` to keep their
+ * link clicks from triggering `onRowClick`.
+ *
  * Expects rows to have already been enriched with signed URLs upstream
  * (documentos-module.tsx calls getAdjuntoSignedUrls). Each PDF / IMG link
  * here renders a short-lived signed URL straight from `a.url`.
@@ -11,27 +17,11 @@
 import { AlertTriangle, FileText, Image as ImageIcon, Paperclip, Plus } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
-import { SortableHead } from '@/components/ui/sortable-head';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { DataTable, type Column } from '@/components/module-page';
+import { formatCurrency, formatDate, formatPrecioM2, formatSuperficie } from '@/lib/format';
 
 import type { Adjunto, Documento } from './types';
-import { formatDate, formatMonto, formatPrecioM2, formatSuperficie } from './helpers';
 import { TipoBadge, TipoOperacionBadge, VencBadge } from './ui';
-
-type SortCtx = {
-  sortKey: string;
-  sortDir: 'asc' | 'desc';
-  onSort: (key: string) => void;
-  sortData: <T extends Record<string, unknown>>(rows: T[]) => T[];
-};
 
 export function DocumentosTable({
   loading,
@@ -41,7 +31,7 @@ export function DocumentosTable({
   adjuntosPorDoc,
   onSelect,
   onCreate,
-  sort,
+  semanticActive = false,
 }: {
   loading: boolean;
   error: string | null;
@@ -50,302 +40,233 @@ export function DocumentosTable({
   adjuntosPorDoc: Record<string, Adjunto[]>;
   onSelect: (doc: Documento) => void;
   onCreate: () => void;
-  sort: SortCtx;
+  /** When true the rows are already pre-sorted by semantic rank — disable
+   *  initialSort so DataTable doesn't override the rank with a default sort. */
+  semanticActive?: boolean;
 }) {
-  const { sortKey, sortDir, onSort, sortData } = sort;
-
-  // Mostrar columnas derivadas de la extracción IA solo si al menos un
-  // documento del dataset las tiene (evita columnas siempre vacías antes de
-  // que se corra el pipeline en esa empresa).
+  // Show derived AI-extraction columns only when at least one document in the
+  // entire universe (not just the filtered subset) has data for them.
   const hasTipoOperacion = documentos.some((d) => d.tipo_operacion);
   const hasMonto = documentos.some((d) => d.monto != null);
   const hasSuperficie = documentos.some((d) => d.superficie_m2 != null);
   const hasPrecioM2 = documentos.some((d) => d.precio_m2 != null);
 
-  if (error) {
-    return (
-      <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)]">
-        <div className="flex items-center justify-center p-16 text-red-400">Error: {error}</div>
-      </div>
-    );
-  }
-
-  if (loading) {
-    return (
-      <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)]">
-        <div className="space-y-0 divide-y divide-[var(--border)]">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-4 p-4">
-              <Skeleton className="h-4 w-64" />
-              <Skeleton className="h-5 w-24 ml-auto" />
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-4 w-28" />
+  const columns: Column<Documento>[] = [
+    {
+      key: 'titulo',
+      label: 'Título',
+      render: (doc) => {
+        const docAdj = adjuntosPorDoc[doc.id] ?? [];
+        const pdfs = docAdj.filter((a) => a.rol === 'documento_principal');
+        return (
+          <div>
+            <div className="flex items-center gap-1.5">
+              <span className="line-clamp-1 font-medium text-[var(--text)]">{doc.titulo}</span>
+              {doc.tipo && doc.tipo !== 'Otro' && pdfs.length === 0 && (
+                <span title="Sin PDF principal" className="shrink-0 text-amber-400">
+                  <AlertTriangle className="h-3 w-3" />
+                </span>
+              )}
             </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (filtered.length === 0) {
-    return (
-      <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)]">
-        <div className="flex flex-col items-center justify-center p-16 text-center">
-          <FileText className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-          <p className="text-sm text-[var(--text-muted)]">
-            {documentos.length === 0 ? 'No hay documentos capturados aún' : 'Sin resultados'}
-          </p>
-          {documentos.length === 0 && (
-            <Button
-              size="sm"
-              onClick={onCreate}
-              className="mt-4 gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
-            >
-              <Plus className="h-4 w-4" />
-              Capturar primer documento
-            </Button>
-          )}
-        </div>
-      </div>
-    );
-  }
+            {doc.notaria && (
+              <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">{doc.notaria}</span>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      key: 'tipo',
+      label: 'Tipo',
+      width: 'w-32',
+      render: (doc) => <TipoBadge tipo={doc.tipo} />,
+    },
+    {
+      key: 'tipo_operacion',
+      label: 'Operación',
+      width: 'w-40',
+      showIf: () => hasTipoOperacion,
+      render: (doc) => <TipoOperacionBadge tipo={doc.tipo_operacion} />,
+    },
+    {
+      key: 'monto',
+      label: 'Monto',
+      width: 'w-32',
+      type: 'currency',
+      showIf: () => hasMonto,
+      cellClassName: 'font-mono text-sm text-[var(--text)]/80',
+      render: (doc) =>
+        doc.monto != null ? (
+          formatCurrency(doc.monto, { decimals: 0, currency: doc.moneda || 'MXN' })
+        ) : (
+          <span className="text-xs text-[var(--text)]/25">—</span>
+        ),
+    },
+    {
+      key: 'superficie_m2',
+      label: 'Superficie',
+      width: 'w-28',
+      align: 'right',
+      type: 'number',
+      showIf: () => hasSuperficie,
+      cellClassName: 'font-mono text-xs text-[var(--text)]/70',
+      render: (doc) =>
+        doc.superficie_m2 != null ? (
+          formatSuperficie(doc.superficie_m2)
+        ) : (
+          <span className="text-xs text-[var(--text)]/25">—</span>
+        ),
+    },
+    {
+      key: 'precio_m2',
+      label: '$/m²',
+      width: 'w-28',
+      align: 'right',
+      type: 'number',
+      showIf: () => hasPrecioM2,
+      cellClassName: 'font-mono text-xs text-[var(--text)]/70',
+      render: (doc) =>
+        doc.precio_m2 != null ? (
+          formatPrecioM2(doc.precio_m2, doc.moneda)
+        ) : (
+          <span className="text-xs text-[var(--text)]/25">—</span>
+        ),
+    },
+    {
+      key: 'descripcion',
+      label: 'Descripción',
+      sortable: false,
+      render: (doc) =>
+        doc.descripcion ? (
+          <span
+            className="line-clamp-2 block max-w-xs text-xs text-[var(--text)]/65"
+            title={doc.descripcion}
+          >
+            {doc.descripcion}
+          </span>
+        ) : (
+          <span className="text-xs text-[var(--text)]/25">—</span>
+        ),
+    },
+    {
+      key: 'pdf',
+      label: 'PDF',
+      width: 'w-24',
+      sortable: false,
+      render: (doc) => {
+        const pdfs = (adjuntosPorDoc[doc.id] ?? []).filter((a) => a.rol === 'documento_principal');
+        if (pdfs.length === 0) return <span className="text-xs text-[var(--text)]/25">—</span>;
+        return (
+          <DataTable.InteractiveCell>
+            <div className="flex gap-1">
+              {pdfs.map((a) => (
+                <a
+                  key={a.id}
+                  href={a.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 rounded-lg bg-red-500/10 px-2 py-1 text-xs font-medium text-red-400 hover:bg-red-500/20 transition-colors"
+                  title={a.nombre}
+                >
+                  <FileText className="h-3 w-3" />
+                  PDF
+                </a>
+              ))}
+            </div>
+          </DataTable.InteractiveCell>
+        );
+      },
+    },
+    {
+      key: 'img',
+      label: 'Imagen',
+      width: 'w-24',
+      sortable: false,
+      render: (doc) => {
+        const imgs = (adjuntosPorDoc[doc.id] ?? []).filter((a) => a.rol === 'imagen_referencia');
+        if (imgs.length === 0) return <span className="text-xs text-[var(--text)]/25">—</span>;
+        return (
+          <DataTable.InteractiveCell>
+            <div className="flex gap-1">
+              {imgs.map((a) => (
+                <a
+                  key={a.id}
+                  href={a.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group/img relative inline-flex items-center gap-1 rounded-lg bg-blue-500/10 px-2 py-1 text-xs font-medium text-blue-400 hover:bg-blue-500/20 transition-colors"
+                  title={a.nombre}
+                >
+                  <ImageIcon className="h-3 w-3" />
+                  IMG
+                  <span className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 scale-95 opacity-0 transition-all duration-150 group-hover/img:scale-100 group-hover/img:opacity-100">
+                    <img
+                      src={a.url}
+                      alt={a.nombre}
+                      className="max-h-48 max-w-64 rounded-xl border border-[var(--border)] shadow-xl object-contain bg-white"
+                    />
+                  </span>
+                </a>
+              ))}
+            </div>
+          </DataTable.InteractiveCell>
+        );
+      },
+    },
+    {
+      key: 'anexos',
+      label: 'Anexos',
+      width: 'w-20',
+      sortable: false,
+      render: (doc) => {
+        const anx = (adjuntosPorDoc[doc.id] ?? []).filter((a) => a.rol === 'anexo');
+        if (anx.length === 0) return <span className="text-xs text-[var(--text)]/25">—</span>;
+        return (
+          <span className="inline-flex items-center gap-1 rounded-lg bg-[var(--panel)] px-2 py-1 text-xs font-medium text-[var(--text)]/50">
+            <Paperclip className="h-3 w-3" />
+            {anx.length}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'fecha_emision',
+      label: 'Emisión',
+      width: 'w-28',
+      cellClassName: 'text-sm text-[var(--text)]/70',
+      render: (doc) => formatDate(doc.fecha_emision),
+    },
+    {
+      key: 'fecha_vencimiento',
+      label: 'Vencimiento',
+      width: 'w-36',
+      render: (doc) => <VencBadge d={doc.fecha_vencimiento} />,
+    },
+  ];
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)]">
-      <Table>
-        <TableHeader>
-          <TableRow className="border-[var(--border)] hover:bg-transparent">
-            <SortableHead
-              sortKey="titulo"
-              label="Título"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-            />
-            <SortableHead
-              sortKey="tipo"
-              label="Tipo"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-              className="w-32"
-            />
-            {hasTipoOperacion && (
-              <SortableHead
-                sortKey="tipo_operacion"
-                label="Operación"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="w-40"
-              />
-            )}
-            {hasMonto && (
-              <SortableHead
-                sortKey="monto"
-                label="Monto"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="w-32 text-right"
-              />
-            )}
-            {hasSuperficie && (
-              <SortableHead
-                sortKey="superficie_m2"
-                label="Superficie"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="w-28 text-right"
-              />
-            )}
-            {hasPrecioM2 && (
-              <SortableHead
-                sortKey="precio_m2"
-                label="$/m²"
-                currentSort={sortKey}
-                currentDir={sortDir}
-                onSort={onSort}
-                className="w-28 text-right"
-              />
-            )}
-            <TableHead className="font-medium text-[var(--text-muted)]">Descripción</TableHead>
-            <TableHead className="w-24 font-medium text-[var(--text-muted)]">PDF</TableHead>
-            <TableHead className="w-24 font-medium text-[var(--text-muted)]">Imagen</TableHead>
-            <TableHead className="w-20 font-medium text-[var(--text-muted)]">Anexos</TableHead>
-            <SortableHead
-              sortKey="fecha_emision"
-              label="Emisión"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-              className="w-28"
-            />
-            <SortableHead
-              sortKey="fecha_vencimiento"
-              label="Vencimiento"
-              currentSort={sortKey}
-              currentDir={sortDir}
-              onSort={onSort}
-              className="w-36"
-            />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {sortData(filtered).map((doc) => {
-            const docAdj = adjuntosPorDoc[doc.id] ?? [];
-            const pdfs = docAdj.filter((a) => a.rol === 'documento_principal');
-            const imgs = docAdj.filter((a) => a.rol === 'imagen_referencia');
-            const anx = docAdj.filter((a) => a.rol === 'anexo');
-            return (
-              <TableRow
-                key={doc.id}
-                className="border-[var(--border)] cursor-pointer hover:bg-[var(--panel)]/50"
-                onClick={() => onSelect(doc)}
-              >
-                <TableCell>
-                  <div className="flex items-center gap-1.5">
-                    <span className="line-clamp-1 font-medium text-[var(--text)]">
-                      {doc.titulo}
-                    </span>
-                    {doc.tipo && doc.tipo !== 'Otro' && pdfs.length === 0 && (
-                      <span title="Sin PDF principal" className="shrink-0 text-amber-400">
-                        <AlertTriangle className="h-3 w-3" />
-                      </span>
-                    )}
-                  </div>
-                  {doc.notaria && (
-                    <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">
-                      {doc.notaria}
-                    </span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <TipoBadge tipo={doc.tipo} />
-                </TableCell>
-                {hasTipoOperacion && (
-                  <TableCell>
-                    <TipoOperacionBadge tipo={doc.tipo_operacion} />
-                  </TableCell>
-                )}
-                {hasMonto && (
-                  <TableCell className="text-right">
-                    {doc.monto != null ? (
-                      <span className="font-mono text-sm text-[var(--text)]/80">
-                        {formatMonto(doc.monto, doc.moneda)}
-                      </span>
-                    ) : (
-                      <span className="text-xs text-[var(--text)]/25">—</span>
-                    )}
-                  </TableCell>
-                )}
-                {hasSuperficie && (
-                  <TableCell className="text-right">
-                    {doc.superficie_m2 != null ? (
-                      <span className="font-mono text-xs text-[var(--text)]/70">
-                        {formatSuperficie(doc.superficie_m2)}
-                      </span>
-                    ) : (
-                      <span className="text-xs text-[var(--text)]/25">—</span>
-                    )}
-                  </TableCell>
-                )}
-                {hasPrecioM2 && (
-                  <TableCell className="text-right">
-                    {doc.precio_m2 != null ? (
-                      <span className="font-mono text-xs text-[var(--text)]/70">
-                        {formatPrecioM2(doc.precio_m2, doc.moneda)}
-                      </span>
-                    ) : (
-                      <span className="text-xs text-[var(--text)]/25">—</span>
-                    )}
-                  </TableCell>
-                )}
-                <TableCell>
-                  {doc.descripcion ? (
-                    <span
-                      className="line-clamp-2 block max-w-xs text-xs text-[var(--text)]/65"
-                      title={doc.descripcion}
-                    >
-                      {doc.descripcion}
-                    </span>
-                  ) : (
-                    <span className="text-xs text-[var(--text)]/25">—</span>
-                  )}
-                </TableCell>
-                <TableCell onClick={(e) => e.stopPropagation()}>
-                  {pdfs.length > 0 ? (
-                    <div className="flex gap-1">
-                      {pdfs.map((a) => (
-                        <a
-                          key={a.id}
-                          href={a.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 rounded-lg bg-red-500/10 px-2 py-1 text-xs font-medium text-red-400 hover:bg-red-500/20 transition-colors"
-                          title={a.nombre}
-                        >
-                          <FileText className="h-3 w-3" />
-                          PDF
-                        </a>
-                      ))}
-                    </div>
-                  ) : (
-                    <span className="text-xs text-[var(--text)]/25">—</span>
-                  )}
-                </TableCell>
-                <TableCell onClick={(e) => e.stopPropagation()}>
-                  {imgs.length > 0 ? (
-                    <div className="flex gap-1">
-                      {imgs.map((a) => (
-                        <a
-                          key={a.id}
-                          href={a.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="group/img relative inline-flex items-center gap-1 rounded-lg bg-blue-500/10 px-2 py-1 text-xs font-medium text-blue-400 hover:bg-blue-500/20 transition-colors"
-                          title={a.nombre}
-                        >
-                          <ImageIcon className="h-3 w-3" />
-                          IMG
-                          <span className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 scale-95 opacity-0 transition-all duration-150 group-hover/img:scale-100 group-hover/img:opacity-100">
-                            <img
-                              src={a.url}
-                              alt={a.nombre}
-                              className="max-h-48 max-w-64 rounded-xl border border-[var(--border)] shadow-xl object-contain bg-white"
-                            />
-                          </span>
-                        </a>
-                      ))}
-                    </div>
-                  ) : (
-                    <span className="text-xs text-[var(--text)]/25">—</span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  {anx.length > 0 ? (
-                    <span className="inline-flex items-center gap-1 rounded-lg bg-[var(--panel)] px-2 py-1 text-xs font-medium text-[var(--text)]/50">
-                      <Paperclip className="h-3 w-3" />
-                      {anx.length}
-                    </span>
-                  ) : (
-                    <span className="text-xs text-[var(--text)]/25">—</span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <span className="text-sm text-[var(--text)]/70">
-                    {formatDate(doc.fecha_emision)}
-                  </span>
-                </TableCell>
-                <TableCell>
-                  <VencBadge d={doc.fecha_vencimiento} />
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </div>
+    <DataTable<Documento>
+      data={filtered}
+      columns={columns}
+      rowKey="id"
+      loading={loading}
+      error={error}
+      onRowClick={onSelect}
+      initialSort={semanticActive ? undefined : { key: 'fecha_emision', dir: 'desc' }}
+      showDensityToggle={false}
+      emptyTitle={documentos.length === 0 ? 'No hay documentos capturados aún' : 'Sin resultados'}
+      emptyAction={
+        documentos.length === 0 ? (
+          <Button
+            size="sm"
+            onClick={onCreate}
+            className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
+          >
+            <Plus className="h-4 w-4" />
+            Capturar primer documento
+          </Button>
+        ) : undefined
+      }
+    />
   );
 }


### PR DESCRIPTION
## Summary

PR-H de Fase 2 incremental de la iniciativa `data-table` (ADR-010). Cierra el último archivo del stack de Documentos.

- Reescribe `components/documentos/documentos-table.tsx` sobre `<DataTable>` (-79 líneas netas).
- Las 4 columnas dinámicas (Operación, Monto, Superficie, \$/m²) se expresan vía `column.showIf`.
- Celdas PDF/IMG/Anexos usan `<DataTable.InteractiveCell>` (DT5).
- Simplifica `components/documentos/documentos-module.tsx`: elimina `useSortableTable` + `sortCtx`. El ranking por similitud semántica ahora se aplica como pre-sort sobre el array antes de pasarlo a la tabla.

## Archivos migrados

- `components/documentos/documentos-table.tsx` ✅
- `components/documentos/documentos-module.tsx` ✅ (caller cleanup)

## Test plan

- [ ] CI verde (typecheck/lint/format/test).
- [ ] Smoke: abrir `/dilesa/admin/documentos` o `/rdb/admin/documentos` — la tabla se carga, sort por columnas funciona, click en row abre detail sheet.
- [ ] Smoke con filtros activos: las 4 columnas dinámicas (Operación/Monto/Superficie/\$/m²) aparecen solo si hay datos en el universo de docs.
- [ ] Smoke PDF/IMG: click en PDF o IMG abre el archivo en nueva pestaña sin disparar el detail sheet.
- [ ] Smoke búsqueda IA: con \"Búsqueda IA\" activa, los docs aparecen ordenados por relevancia. Si el usuario clickea una columna, el orden cambia (rank se pierde — comportamiento esperado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)