### PR TITLE
feat(data-table): migra Tasks (PR-I)

### DIFF
--- a/app/rdb/tasks/page.tsx
+++ b/app/rdb/tasks/page.tsx
@@ -10,16 +10,7 @@ import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { SortableHead } from '@/components/ui/sortable-head';
-import { useSortableTable } from '@/hooks/use-sortable-table';
+import { DataTable, type Column } from '@/components/module-page';
 import {
   Dialog,
   DialogContent,
@@ -39,13 +30,11 @@ import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
-import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import {
   Plus,
   Search,
   RefreshCw,
-  ChevronRight,
   Loader2,
   TicketCheck,
   MessageSquarePlus,
@@ -365,9 +354,71 @@ function TasksInner() {
     return true;
   });
 
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable<
-    ErpTask & { prioridad_peso: number | null; asignado_nombre: string | null }
-  >('created_at', 'desc');
+  const tasksColumns: Column<ErpTask>[] = [
+    {
+      key: 'titulo',
+      label: 'Título',
+      render: (task) => (
+        <>
+          <span className="line-clamp-1 font-medium text-[var(--text)]">{task.titulo}</span>
+          {task.entidad_tipo && (
+            <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">
+              {task.entidad_tipo}
+            </span>
+          )}
+        </>
+      ),
+    },
+    {
+      key: 'estado',
+      label: 'Estado',
+      width: 'w-28',
+      render: (task) => <EstadoBadge estado={task.estado} />,
+    },
+    {
+      key: 'prioridad',
+      label: 'Prioridad',
+      width: 'w-28',
+      accessor: (t) => {
+        const idx = (PRIORIDAD_OPTIONS as readonly string[]).indexOf(t.prioridad ?? '');
+        return idx === -1 ? null : idx;
+      },
+      render: (task) => <PrioridadBadge prioridad={task.prioridad} />,
+    },
+    {
+      key: 'asignado_a',
+      label: 'Asignado a',
+      width: 'w-40',
+      accessor: (t) => empleadoMap.get(t.asignado_a ?? '')?.nombre ?? null,
+      cellClassName: 'text-sm text-[var(--text)]/70',
+      render: (task) => empleadoMap.get(task.asignado_a ?? '')?.nombre ?? '—',
+    },
+    {
+      key: 'fecha_vence',
+      label: 'Vence',
+      width: 'w-28',
+      cellClassName: 'text-sm text-[var(--text)]/70',
+      render: (task) => formatDate(task.fecha_vence),
+    },
+    {
+      key: 'updates',
+      label: '',
+      sortable: false,
+      width: 'w-10',
+      render: (task) => (
+        <DataTable.InteractiveCell>
+          <button
+            type="button"
+            title="Ver / agregar avances"
+            onClick={() => handleOpenUpdatesSheet(task.id)}
+            className="inline-flex h-6 w-6 items-center justify-center rounded-lg border border-[var(--accent)]/30 bg-[var(--accent)]/10 text-[var(--accent)] transition hover:bg-[var(--accent)]/20"
+          >
+            <MessageSquarePlus className="h-3 w-3" />
+          </button>
+        </DataTable.InteractiveCell>
+      ),
+    },
+  ];
 
   return (
     <div className="space-y-6">
@@ -445,147 +496,34 @@ function TasksInner() {
 
       {/* Table */}
       <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)]">
-        {error ? (
-          <div className="flex items-center justify-center p-16 text-red-400">Error: {error}</div>
-        ) : loading ? (
-          <div className="space-y-0 divide-y divide-[var(--border)]">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-4 p-4">
-                <Skeleton className="h-4 w-64" />
-                <Skeleton className="h-5 w-20 ml-auto" />
-                <Skeleton className="h-5 w-20" />
-                <Skeleton className="h-4 w-28" />
-              </div>
-            ))}
-          </div>
-        ) : filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center p-16 text-center">
-            <TicketCheck className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text-muted)]">
-              {tasks.length === 0
-                ? 'No hay tareas creadas aún'
-                : 'No hay tareas que coincidan con los filtros'}
-            </p>
-            {tasks.length === 0 && (
+        <DataTable<ErpTask>
+          data={filtered}
+          columns={tasksColumns}
+          rowKey="id"
+          loading={loading}
+          error={error}
+          onRowClick={(task) => router.push(`/rdb/tasks/${task.id}`)}
+          initialSort={{ key: 'created_at', dir: 'desc' }}
+          showDensityToggle={false}
+          emptyIcon={<TicketCheck className="h-10 w-10 text-[var(--text)]/20" />}
+          emptyTitle={
+            tasks.length === 0
+              ? 'No hay tareas creadas aún'
+              : 'No hay tareas que coincidan con los filtros'
+          }
+          emptyAction={
+            tasks.length === 0 ? (
               <Button
                 size="sm"
                 onClick={() => setShowCreate(true)}
-                className="mt-4 gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
+                className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
               >
                 <Plus className="h-4 w-4" />
                 Crear primera tarea
               </Button>
-            )}
-          </div>
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow className="border-[var(--border)] hover:bg-transparent">
-                <SortableHead
-                  sortKey="titulo"
-                  label="Título"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="estado"
-                  label="Estado"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="w-28"
-                />
-                <SortableHead
-                  sortKey="prioridad_peso"
-                  label="Prioridad"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="w-28"
-                />
-                <SortableHead
-                  sortKey="asignado_nombre"
-                  label="Asignado a"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="w-40"
-                />
-                <SortableHead
-                  sortKey="fecha_vence"
-                  label="Vence"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                  className="w-28"
-                />
-                <TableHead className="w-10" />
-                <TableHead className="w-10" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {sortData(
-                filtered.map((t) => ({
-                  ...t,
-                  prioridad_peso: t.prioridad
-                    ? PRIORIDAD_OPTIONS.indexOf(t.prioridad as any)
-                    : null,
-                  asignado_nombre: empleadoMap.get(t.asignado_a ?? '')?.nombre ?? null,
-                }))
-              ).map((task) => {
-                const empleado = empleadoMap.get(task.asignado_a ?? '');
-                return (
-                  <TableRow
-                    key={task.id}
-                    className="cursor-pointer border-[var(--border)] transition-colors hover:bg-[var(--panel)]"
-                    onClick={() => router.push(`/rdb/tasks/${task.id}`)}
-                  >
-                    <TableCell>
-                      <span className="line-clamp-1 font-medium text-[var(--text)]">
-                        {task.titulo}
-                      </span>
-                      {task.entidad_tipo && (
-                        <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">
-                          {task.entidad_tipo}
-                        </span>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <EstadoBadge estado={task.estado} />
-                    </TableCell>
-                    <TableCell>
-                      <PrioridadBadge prioridad={task.prioridad} />
-                    </TableCell>
-                    <TableCell>
-                      <span className="text-sm text-[var(--text)]/70">
-                        {empleado ? empleado.nombre : '—'}
-                      </span>
-                    </TableCell>
-                    <TableCell>
-                      <span className="text-sm text-[var(--text)]/70">
-                        {formatDate(task.fecha_vence)}
-                      </span>
-                    </TableCell>
-                    <TableCell onClick={(e) => e.stopPropagation()}>
-                      <button
-                        type="button"
-                        title="Ver / agregar avances"
-                        onClick={() => handleOpenUpdatesSheet(task.id)}
-                        className="inline-flex h-6 w-6 items-center justify-center rounded-lg border border-[var(--accent)]/30 bg-[var(--accent)]/10 text-[var(--accent)] transition hover:bg-[var(--accent)]/20"
-                      >
-                        <MessageSquarePlus className="h-3 w-3" />
-                      </button>
-                    </TableCell>
-                    <TableCell>
-                      <ChevronRight className="h-4 w-4 text-[var(--text)]/30" />
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        )}
+            ) : undefined
+          }
+        />
       </div>
 
       {/* Summary */}

--- a/components/tasks/tasks-module.tsx
+++ b/components/tasks/tasks-module.tsx
@@ -35,7 +35,6 @@ import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import type { TablesInsert, TablesUpdate } from '@/types/supabase';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
-import { useSortableTable } from '@/hooks/use-sortable-table';
 
 import { emptyTaskForm } from './tasks-shared';
 import type { Empleado, ErpTask, TaskEstado, TaskFormValues, TaskUpdateRow } from './tasks-shared';
@@ -711,8 +710,6 @@ export function TasksModule({
     [empleados]
   );
 
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable('created_at', 'desc');
-
   const visibleTasks = useMemo(() => {
     if (onlyMine) {
       // While resolving ids, hide everything (avoid flashing all tasks).
@@ -856,17 +853,12 @@ export function TasksModule({
         <TasksTable
           variant={isRich ? 'rich' : 'simple'}
           tasks={filtered}
-          filteredCount={filtered.length}
           totalCount={visibleTasks.length}
           empleadoMap={empleadoMap}
           loading={loading}
           error={error}
           onRowClick={openEdit}
           onCreateEmpty={() => setShowCreate(true)}
-          sortKey={sortKey}
-          sortDir={sortDir}
-          onSort={onSort}
-          sortData={sortData}
           canEditInline={canEditInline}
           completingTaskId={completingTaskId}
           onQuickComplete={handleQuickComplete}

--- a/components/tasks/tasks-table.tsx
+++ b/components/tasks/tasks-table.tsx
@@ -3,33 +3,29 @@
 /**
  * TasksTable — renders the tasks grid.
  *
- * Variants:
- *  - `variant="simple"` → used by rdb/inicio. 5 columns, no inline editing,
+ * Internamente usa `<DataTable>` (ADR-010). La API externa del componente
+ * preserva las dos variantes:
+ *
+ *  - `variant="simple"` → rdb/inicio. 5 columns, no inline editing,
  *     no actions cell, row click opens edit.
- *  - `variant="rich"`   → used by DILESA. Adds actions cell (quick-complete +
+ *  - `variant="rich"`   → DILESA. Adds actions cell (quick-complete +
  *     open updates), inline estado + avance editing (admin/direccion only),
  *     extra "Avance" + "Días" columns.
+ *
+ * El sort se maneja internamente con DataTable; los callers ya no
+ * necesitan pasar `useSortableTable` props.
  */
 
 import { Check, Loader2, MessageSquarePlus, Plus, TicketCheck } from 'lucide-react';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { SortableHead } from '@/components/ui/sortable-head';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { DataTable, type Column } from '@/components/module-page';
+import { formatDate } from '@/lib/format';
 import {
   Empleado,
   ErpTask,
   ESTADO_ORDER,
   EstadoBadge,
-  formatDate,
   PRIORIDAD_OPTIONS,
   PrioridadBadge,
   PrioridadTextBadge,
@@ -37,20 +33,14 @@ import {
   TaskEstado,
 } from './tasks-shared';
 
-// ── Row type the table actually renders (after the enrichment step in parent)
-
 export type SortableTask = ErpTask & {
   asignado_nombre: string | null;
   prioridad_peso: number | null;
 };
 
-type SortKey = string;
-type SortDir = 'asc' | 'desc';
-
 export type TasksTableProps = {
   variant: 'simple' | 'rich';
   tasks: ErpTask[];
-  filteredCount: number;
   totalCount: number;
   empleadoMap: Map<string, Empleado>;
   loading: boolean;
@@ -58,12 +48,7 @@ export type TasksTableProps = {
   onRowClick: (task: ErpTask) => void;
   onCreateEmpty?: () => void;
 
-  sortKey: SortKey;
-  sortDir: SortDir;
-  onSort: (key: SortKey) => void;
-  sortData: <T extends Record<string, unknown>>(rows: T[]) => T[];
-
-  // Rich-only ------------------------------------------------------------------
+  // Rich-only ----------------------------------------------------------------
   /** Direccion or admin — unlocks the actions column + inline editing. */
   canEditInline?: boolean;
   /** Task id currently being quick-completed (shows spinner). */
@@ -77,406 +62,304 @@ export type TasksTableProps = {
 };
 
 export function TasksTable(props: TasksTableProps) {
-  const { variant, filteredCount, totalCount, loading, error, onCreateEmpty } = props;
+  const { variant, totalCount, loading, error, onCreateEmpty } = props;
 
-  if (error) {
-    return <div className="flex items-center justify-center p-16 text-red-400">Error: {error}</div>;
-  }
+  // Empty state copy depends on whether the universe is truly empty or just
+  // filtered out — DataTable receives the parametrized copy below.
+  const emptyTitle =
+    totalCount === 0 ? 'No hay tareas creadas aún' : 'No hay tareas que coincidan con los filtros';
+  const emptyAction =
+    totalCount === 0 && onCreateEmpty ? (
+      <Button
+        size="sm"
+        onClick={onCreateEmpty}
+        className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
+      >
+        <Plus className="h-4 w-4" />
+        Crear primera tarea
+      </Button>
+    ) : undefined;
 
-  if (loading) {
-    return (
-      <div className="space-y-0 divide-y divide-[var(--border)]">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-4 p-4">
-            <Skeleton className="h-4 w-64" />
-            <Skeleton className="h-5 w-20 ml-auto" />
-            <Skeleton className="h-5 w-20" />
-            <Skeleton className="h-4 w-28" />
+  const columns = variant === 'simple' ? buildSimpleColumns(props) : buildRichColumns(props);
+
+  return (
+    <DataTable<ErpTask>
+      data={props.tasks}
+      columns={columns as Column<ErpTask>[]}
+      rowKey="id"
+      loading={loading}
+      error={error}
+      onRowClick={props.onRowClick}
+      initialSort={{ key: 'created_at', dir: 'desc' }}
+      showDensityToggle={false}
+      emptyIcon={<TicketCheck className="h-10 w-10 text-[var(--text)]/20" />}
+      emptyTitle={emptyTitle}
+      emptyAction={emptyAction}
+    />
+  );
+}
+
+// ─── Simple variant columns (rdb + inicio) ────────────────────────────────────
+
+function buildSimpleColumns({ empleadoMap }: TasksTableProps): Column<ErpTask>[] {
+  return [
+    {
+      key: 'titulo',
+      label: 'Título',
+      render: (task) => (
+        <>
+          <span className="line-clamp-1 font-medium text-[var(--text)]">{task.titulo}</span>
+          {task.entidad_tipo && (
+            <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">
+              {task.entidad_tipo}
+            </span>
+          )}
+        </>
+      ),
+    },
+    {
+      key: 'estado',
+      label: 'Estado',
+      width: 'w-28',
+      render: (task) => <EstadoBadge estado={task.estado} />,
+    },
+    {
+      key: 'prioridad',
+      label: 'Prioridad',
+      width: 'w-28',
+      accessor: (t) => {
+        const idx = (PRIORIDAD_OPTIONS as readonly string[]).indexOf(t.prioridad ?? '');
+        return idx === -1 ? null : idx;
+      },
+      render: (task) => <PrioridadBadge prioridad={task.prioridad} />,
+    },
+    {
+      key: 'asignado_a',
+      label: 'Asignado a',
+      width: 'w-40',
+      accessor: (t) => empleadoMap.get(t.asignado_a ?? '')?.nombre ?? null,
+      cellClassName: 'text-sm text-[var(--text)]/70',
+      render: (task) => empleadoMap.get(task.asignado_a ?? '')?.nombre ?? '—',
+    },
+    {
+      key: 'fecha_vence',
+      label: 'Vence',
+      width: 'w-28',
+      cellClassName: 'text-sm text-[var(--text)]/70',
+      render: (task) => formatDate(task.fecha_vence),
+    },
+  ];
+}
+
+// ─── Rich variant columns (DILESA) ────────────────────────────────────────────
+
+function buildRichColumns(props: TasksTableProps): Column<ErpTask>[] {
+  const {
+    empleadoMap,
+    canEditInline = false,
+    completingTaskId,
+    onQuickComplete,
+    onOpenUpdates,
+    onInlineEstadoChange,
+    onInlineAvanceChange,
+    inlineAvance,
+    setInlineAvance,
+  } = props;
+
+  const cols: Column<ErpTask>[] = [];
+
+  if (canEditInline) {
+    cols.push({
+      key: 'actions',
+      label: '',
+      sortable: false,
+      width: 'w-10',
+      render: (task) => (
+        <DataTable.InteractiveCell>
+          <div className="flex items-center gap-1">
+            {task.estado !== 'completado' && task.estado !== 'cancelado' ? (
+              <button
+                type="button"
+                title="Completar tarea"
+                disabled={completingTaskId === task.id}
+                onClick={() => onQuickComplete?.(task.id)}
+                className="inline-flex h-6 w-6 items-center justify-center rounded-lg border border-green-500/30 bg-green-500/10 text-green-400 transition hover:bg-green-500/20 disabled:opacity-50"
+              >
+                {completingTaskId === task.id ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Check className="h-3 w-3" />
+                )}
+              </button>
+            ) : (
+              <Check className="h-4 w-4 text-green-400/40" />
+            )}
+            <button
+              type="button"
+              title="Ver / agregar avances"
+              onClick={() => onOpenUpdates?.(task.id)}
+              className="inline-flex h-6 w-6 items-center justify-center rounded-lg border border-[var(--accent)]/30 bg-[var(--accent)]/10 text-[var(--accent)] transition hover:bg-[var(--accent)]/20"
+            >
+              <MessageSquarePlus className="h-3 w-3" />
+            </button>
           </div>
-        ))}
-      </div>
-    );
+        </DataTable.InteractiveCell>
+      ),
+    });
   }
 
-  if (filteredCount === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center p-16 text-center">
-        <TicketCheck className="mb-3 h-10 w-10 text-[var(--text)]/20" />
-        <p className="text-sm text-[var(--text-muted)]">
-          {totalCount === 0
-            ? 'No hay tareas creadas aún'
-            : 'No hay tareas que coincidan con los filtros'}
-        </p>
-        {totalCount === 0 && onCreateEmpty && (
-          <Button
-            size="sm"
-            onClick={onCreateEmpty}
-            className="mt-4 gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
-          >
-            <Plus className="h-4 w-4" />
-            Crear primera tarea
-          </Button>
-        )}
-      </div>
-    );
-  }
+  cols.push({
+    key: 'titulo',
+    label: 'Tarea',
+    width: 'min-w-[140px] max-w-[220px]',
+    cellClassName: 'whitespace-normal',
+    render: (task) => (
+      <>
+        <span className="line-clamp-1 font-medium text-[var(--text)]">{task.titulo}</span>
+        <span className="mt-0.5 line-clamp-1 block text-xs text-[var(--text-subtle)]">
+          {[task.departamento_nombre, task.descripcion].filter(Boolean).join(' · ') || ' '}
+        </span>
+      </>
+    ),
+  });
 
-  return variant === 'simple' ? <SimpleTable {...props} /> : <RichTable {...props} />;
-}
+  cols.push({
+    key: 'prioridad',
+    label: 'Prioridad',
+    width: 'min-w-[100px]',
+    render: (task) => <PrioridadTextBadge text={task.prioridad} />,
+  });
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Simple variant (rdb + inicio)
-// ─────────────────────────────────────────────────────────────────────────────
-
-function SimpleTable({
-  tasks,
-  empleadoMap,
-  onRowClick,
-  sortKey,
-  sortDir,
-  onSort,
-  sortData,
-}: TasksTableProps) {
-  return (
-    <Table>
-      <TableHeader>
-        <TableRow className="border-[var(--border)] hover:bg-transparent">
-          <SortableHead
-            sortKey="titulo"
-            label="Título"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-          />
-          <SortableHead
-            sortKey="estado"
-            label="Estado"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="w-28"
-          />
-          <SortableHead
-            sortKey="prioridad_peso"
-            label="Prioridad"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="w-28"
-          />
-          <SortableHead
-            sortKey="asignado_nombre"
-            label="Asignado a"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="w-40"
-          />
-          <SortableHead
-            sortKey="fecha_vence"
-            label="Vence"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="w-28"
-          />
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {sortData(
-          tasks.map((t) => ({
-            ...t,
-            prioridad_peso: t.prioridad
-              ? (PRIORIDAD_OPTIONS as readonly string[]).indexOf(t.prioridad)
-              : null,
-            asignado_nombre: empleadoMap.get(t.asignado_a ?? '')?.nombre ?? null,
-          }))
-        ).map((task) => {
-          const empleado = empleadoMap.get(task.asignado_a ?? '');
-          return (
-            <TableRow
-              key={task.id}
-              className="cursor-pointer border-[var(--border)] transition-colors hover:bg-[var(--panel)]"
-              onClick={() => onRowClick(task)}
-            >
-              <TableCell>
-                <span className="line-clamp-1 font-medium text-[var(--text)]">{task.titulo}</span>
-                {task.entidad_tipo && (
-                  <span className="mt-0.5 block text-xs text-[var(--text-subtle)]">
-                    {task.entidad_tipo}
-                  </span>
-                )}
-              </TableCell>
-              <TableCell>
+  cols.push({
+    key: 'estado',
+    label: 'Estado',
+    width: 'min-w-[90px]',
+    render: (task) => {
+      if (canEditInline && task.estado !== 'completado' && task.estado !== 'cancelado') {
+        return (
+          <DataTable.InteractiveCell>
+            <Popover>
+              <PopoverTrigger className="cursor-pointer">
                 <EstadoBadge estado={task.estado} />
-              </TableCell>
-              <TableCell>
-                <PrioridadBadge prioridad={task.prioridad} />
-              </TableCell>
-              <TableCell>
-                <span className="text-sm text-[var(--text)]/70">
-                  {empleado ? empleado.nombre : '—'}
-                </span>
-              </TableCell>
-              <TableCell>
-                <span className="text-sm text-[var(--text)]/70">
-                  {formatDate(task.fecha_vence)}
-                </span>
-              </TableCell>
-            </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
-  );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Rich variant (DILESA)
-// ─────────────────────────────────────────────────────────────────────────────
-
-function RichTable({
-  tasks,
-  empleadoMap,
-  onRowClick,
-  sortKey,
-  sortDir,
-  onSort,
-  sortData,
-  canEditInline = false,
-  completingTaskId,
-  onQuickComplete,
-  onOpenUpdates,
-  onInlineEstadoChange,
-  onInlineAvanceChange,
-  inlineAvance,
-  setInlineAvance,
-}: TasksTableProps) {
-  return (
-    <Table>
-      <TableHeader>
-        <TableRow className="border-[var(--border)] hover:bg-transparent">
-          {canEditInline && <TableHead className="w-10 min-w-[40px]" />}
-          <SortableHead
-            sortKey="titulo"
-            label="Tarea"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="min-w-[140px] max-w-[220px]"
-          />
-          <SortableHead
-            sortKey="prioridad"
-            label="Prioridad"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="min-w-[100px]"
-          />
-          <SortableHead
-            sortKey="estado"
-            label="Estado"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="min-w-[90px]"
-          />
-          <SortableHead
-            sortKey="porcentaje_avance"
-            label="Avance"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="min-w-[90px]"
-          />
-          <SortableHead
-            sortKey="asignado_nombre"
-            label="Responsable"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="min-w-[120px]"
-          />
-          <SortableHead
-            sortKey="fecha_compromiso"
-            label="Compromiso"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="min-w-[95px]"
-          />
-          <SortableHead
-            sortKey="created_at"
-            label="Días"
-            currentSort={sortKey}
-            currentDir={sortDir}
-            onSort={onSort}
-            className="min-w-[55px]"
-          />
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {sortData(
-          tasks.map((t) => ({
-            ...t,
-            asignado_nombre: empleadoMap.get(t.asignado_a ?? '')?.nombre ?? null,
-          }))
-        ).map((task) => {
-          const empleado = empleadoMap.get(task.asignado_a ?? '');
-          return (
-            <TableRow
-              key={task.id}
-              className="cursor-pointer border-[var(--border)] transition-colors hover:bg-[var(--panel)]"
-              onClick={() => onRowClick(task)}
-            >
-              {canEditInline && (
-                <TableCell className="w-10" onClick={(e) => e.stopPropagation()}>
-                  <div className="flex items-center gap-1">
-                    {task.estado !== 'completado' && task.estado !== 'cancelado' ? (
-                      <button
-                        type="button"
-                        title="Completar tarea"
-                        disabled={completingTaskId === task.id}
-                        onClick={() => onQuickComplete?.(task.id)}
-                        className="inline-flex h-6 w-6 items-center justify-center rounded-lg border border-green-500/30 bg-green-500/10 text-green-400 transition hover:bg-green-500/20 disabled:opacity-50"
-                      >
-                        {completingTaskId === task.id ? (
-                          <Loader2 className="h-3 w-3 animate-spin" />
-                        ) : (
-                          <Check className="h-3 w-3" />
-                        )}
-                      </button>
-                    ) : (
-                      <Check className="h-4 w-4 text-green-400/40" />
-                    )}
+              </PopoverTrigger>
+              <PopoverContent className="w-40 p-1" align="start">
+                <div className="flex flex-col gap-0.5">
+                  {ESTADO_ORDER.map((est) => (
                     <button
+                      key={est}
                       type="button"
-                      title="Ver / agregar avances"
-                      onClick={() => onOpenUpdates?.(task.id)}
-                      className="inline-flex h-6 w-6 items-center justify-center rounded-lg border border-[var(--accent)]/30 bg-[var(--accent)]/10 text-[var(--accent)] transition hover:bg-[var(--accent)]/20"
+                      onClick={() => onInlineEstadoChange?.(task.id, est)}
+                      className={`w-full text-left px-2 py-1.5 rounded-lg text-sm transition-colors hover:bg-[var(--panel)] ${
+                        task.estado === est ? 'bg-[var(--panel)]' : ''
+                      }`}
                     >
-                      <MessageSquarePlus className="h-3 w-3" />
+                      <EstadoBadge estado={est} />
                     </button>
+                  ))}
+                </div>
+              </PopoverContent>
+            </Popover>
+          </DataTable.InteractiveCell>
+        );
+      }
+      return <EstadoBadge estado={task.estado} />;
+    },
+  });
+
+  cols.push({
+    key: 'porcentaje_avance',
+    label: 'Avance',
+    width: 'min-w-[90px]',
+    accessor: (t) => t.porcentaje_avance ?? 0,
+    render: (task) => {
+      if (canEditInline) {
+        return (
+          <DataTable.InteractiveCell>
+            <Popover
+              open={inlineAvance?.taskId === task.id}
+              onOpenChange={(open) => {
+                if (open) {
+                  setInlineAvance?.({ taskId: task.id, value: task.porcentaje_avance ?? 0 });
+                } else if (inlineAvance && inlineAvance.taskId === task.id) {
+                  onInlineAvanceChange?.(task.id, inlineAvance.value);
+                }
+              }}
+            >
+              <PopoverTrigger className="cursor-pointer">
+                <ProgressBar value={task.porcentaje_avance ?? 0} />
+              </PopoverTrigger>
+              <PopoverContent className="w-48 p-3" align="start">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-xs text-[var(--text)]/60">
+                    <span>Avance</span>
+                    <span className="font-medium text-[var(--text)]">
+                      {inlineAvance?.taskId === task.id
+                        ? inlineAvance.value
+                        : (task.porcentaje_avance ?? 0)}
+                      %
+                    </span>
                   </div>
-                </TableCell>
-              )}
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={5}
+                    value={
+                      inlineAvance?.taskId === task.id
+                        ? inlineAvance.value
+                        : (task.porcentaje_avance ?? 0)
+                    }
+                    onChange={(e) =>
+                      setInlineAvance?.(
+                        inlineAvance && inlineAvance.taskId === task.id
+                          ? { ...inlineAvance, value: Number(e.target.value) }
+                          : { taskId: task.id, value: Number(e.target.value) }
+                      )
+                    }
+                    className="w-full accent-[var(--accent)]"
+                  />
+                </div>
+              </PopoverContent>
+            </Popover>
+          </DataTable.InteractiveCell>
+        );
+      }
+      return <ProgressBar value={task.porcentaje_avance ?? 0} />;
+    },
+  });
 
-              <TableCell className="whitespace-normal">
-                <span className="line-clamp-1 font-medium text-[var(--text)]">{task.titulo}</span>
-                <span className="mt-0.5 block text-xs text-[var(--text-subtle)] line-clamp-1">
-                  {[task.departamento_nombre, task.descripcion].filter(Boolean).join(' · ') || ' '}
-                </span>
-              </TableCell>
+  cols.push({
+    key: 'asignado_a',
+    label: 'Responsable',
+    width: 'min-w-[120px]',
+    accessor: (t) => empleadoMap.get(t.asignado_a ?? '')?.nombre ?? null,
+    cellClassName: 'text-xs text-[var(--text)]/70',
+    render: (task) => (
+      <span className="block truncate">
+        {empleadoMap.get(task.asignado_a ?? '')?.nombre ?? '—'}
+      </span>
+    ),
+  });
 
-              <TableCell>
-                <PrioridadTextBadge text={task.prioridad} />
-              </TableCell>
+  cols.push({
+    key: 'fecha_compromiso',
+    label: 'Compromiso',
+    width: 'min-w-[95px]',
+    cellClassName: 'text-xs text-[var(--text)]/60',
+    render: (task) => formatDate(task.fecha_compromiso),
+  });
 
-              {/* Inline estado editing */}
-              <TableCell onClick={(e) => (canEditInline ? e.stopPropagation() : undefined)}>
-                {canEditInline && task.estado !== 'completado' && task.estado !== 'cancelado' ? (
-                  <Popover>
-                    <PopoverTrigger className="cursor-pointer">
-                      <EstadoBadge estado={task.estado} />
-                    </PopoverTrigger>
-                    <PopoverContent className="w-40 p-1" align="start">
-                      <div className="flex flex-col gap-0.5">
-                        {ESTADO_ORDER.map((est) => (
-                          <button
-                            key={est}
-                            type="button"
-                            onClick={() => onInlineEstadoChange?.(task.id, est)}
-                            className={`w-full text-left px-2 py-1.5 rounded-lg text-sm transition-colors hover:bg-[var(--panel)] ${task.estado === est ? 'bg-[var(--panel)]' : ''}`}
-                          >
-                            <EstadoBadge estado={est} />
-                          </button>
-                        ))}
-                      </div>
-                    </PopoverContent>
-                  </Popover>
-                ) : (
-                  <EstadoBadge estado={task.estado} />
-                )}
-              </TableCell>
+  cols.push({
+    key: 'created_at',
+    label: 'Días',
+    width: 'min-w-[55px]',
+    cellClassName: 'text-xs text-[var(--text)]/60',
+    accessor: (t) => new Date(t.created_at).getTime(),
+    render: (task) => {
+      const days = Math.floor((Date.now() - new Date(task.created_at).getTime()) / 86400000);
+      return days === 0 ? 'Hoy' : `${days}d`;
+    },
+  });
 
-              {/* Avance inline */}
-              <TableCell onClick={(e) => (canEditInline ? e.stopPropagation() : undefined)}>
-                {canEditInline ? (
-                  <Popover
-                    open={inlineAvance?.taskId === task.id}
-                    onOpenChange={(open) => {
-                      if (open) {
-                        setInlineAvance?.({ taskId: task.id, value: task.porcentaje_avance ?? 0 });
-                      } else if (inlineAvance && inlineAvance.taskId === task.id) {
-                        onInlineAvanceChange?.(task.id, inlineAvance.value);
-                      }
-                    }}
-                  >
-                    <PopoverTrigger className="cursor-pointer">
-                      <ProgressBar value={task.porcentaje_avance ?? 0} />
-                    </PopoverTrigger>
-                    <PopoverContent className="w-48 p-3" align="start">
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-xs text-[var(--text)]/60">
-                          <span>Avance</span>
-                          <span className="font-medium text-[var(--text)]">
-                            {inlineAvance?.taskId === task.id
-                              ? inlineAvance.value
-                              : (task.porcentaje_avance ?? 0)}
-                            %
-                          </span>
-                        </div>
-                        <input
-                          type="range"
-                          min={0}
-                          max={100}
-                          step={5}
-                          value={
-                            inlineAvance?.taskId === task.id
-                              ? inlineAvance.value
-                              : (task.porcentaje_avance ?? 0)
-                          }
-                          onChange={(e) =>
-                            setInlineAvance?.(
-                              inlineAvance && inlineAvance.taskId === task.id
-                                ? { ...inlineAvance, value: Number(e.target.value) }
-                                : { taskId: task.id, value: Number(e.target.value) }
-                            )
-                          }
-                          className="w-full accent-[var(--accent)]"
-                        />
-                      </div>
-                    </PopoverContent>
-                  </Popover>
-                ) : (
-                  <ProgressBar value={task.porcentaje_avance ?? 0} />
-                )}
-              </TableCell>
-
-              <TableCell>
-                <span className="text-xs text-[var(--text)]/70 truncate block">
-                  {empleado ? empleado.nombre : '—'}
-                </span>
-              </TableCell>
-              <TableCell>
-                <span className="text-xs text-[var(--text)]/60">
-                  {formatDate(task.fecha_compromiso)}
-                </span>
-              </TableCell>
-              <TableCell>
-                <span className="text-xs text-[var(--text)]/60">
-                  {(() => {
-                    const days = Math.floor(
-                      (Date.now() - new Date(task.created_at).getTime()) / 86400000
-                    );
-                    return days === 0 ? 'Hoy' : `${days}d`;
-                  })()}
-                </span>
-              </TableCell>
-            </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
-  );
+  return cols;
 }


### PR DESCRIPTION
## Summary

PR-I de Fase 2 incremental de la iniciativa `data-table` (ADR-010). Migra el stack de Tasks preservando la API de variantes simple/rich del componente compartido.

- `components/tasks/tasks-table.tsx` reescrito sobre `<DataTable>`. Sort interno, dos column-builders (`buildSimpleColumns`, `buildRichColumns`).
- `components/tasks/tasks-module.tsx` eliminado el `useSortableTable` hook + props redundantes (`sortKey`/`sortDir`/`onSort`/`sortData`/`filteredCount`).
- `app/rdb/tasks/page.tsx` (mini-tasks duplicado, no usa el componente compartido) también migrado a `<DataTable>` directamente.

## Archivos migrados

- `components/tasks/tasks-table.tsx` ✅
- `components/tasks/tasks-module.tsx` ✅ (caller cleanup)
- `app/rdb/tasks/page.tsx` ✅

## Test plan

- [ ] CI verde (typecheck/lint/format/test).
- [ ] Smoke variante `simple`: abrir `/rdb/tasks` (RDB) o `/inicio/tasks` — la tabla se carga, sort por columnas funciona, click en row abre detail.
- [ ] Smoke variante `rich`: abrir `/dilesa/admin/tasks` con cuenta admin/dirección — botones quick-complete + open-updates aparecen y funcionan; click en estado abre Popover sin disparar el detail; click en avance abre slider sin disparar el detail.
- [ ] Smoke `/rdb/tasks` botón de updates: click NO abre el detail de la tarea, solo el sheet de updates (legacy en este page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)