### PR TITLE
feat(data-table): migra DILESA stack (PR-K)

### DIFF
--- a/app/dilesa/anteproyectos/page.tsx
+++ b/app/dilesa/anteproyectos/page.tsx
@@ -28,16 +28,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { SortableHead } from '@/components/ui/sortable-head';
-import { useSortableTable } from '@/hooks/use-sortable-table';
+import { DataTable, type Column } from '@/components/module-page';
 import {
   Sheet,
   SheetContent,
@@ -315,12 +306,6 @@ function AnteproyectosInner() {
     });
   }, [rows, search, filterEstado]);
 
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable<Row>('created_at', 'desc');
-  const sorted = useMemo(
-    () => sortData(filtered as unknown as Record<string, unknown>[]) as unknown as Row[],
-    [filtered, sortData]
-  );
-
   const terrenoOptions: ComboboxOption[] = useMemo(
     () =>
       terrenos.map((t) => ({
@@ -375,16 +360,14 @@ function AnteproyectosInner() {
 
       <TabPanel tabKey="consulta" active={active}>
         <ConsultaPanel
-          rows={sorted}
+          data={filtered}
+          universeCount={rows.length}
           loading={loading}
           error={error}
           search={search}
           setSearch={setSearch}
           filterEstado={filterEstado}
           setFilterEstado={setFilterEstado}
-          sortKey={sortKey}
-          sortDir={sortDir}
-          onSort={onSort}
           onOpenCreate={openCreate}
           onOpenDetail={(id) => router.push(`/dilesa/anteproyectos/${id}`)}
         />
@@ -560,33 +543,135 @@ function AnteproyectosInner() {
 }
 
 function ConsultaPanel(props: {
-  rows: Row[];
+  data: Row[];
+  universeCount: number;
   loading: boolean;
   error: string | null;
   search: string;
   setSearch: (v: string) => void;
   filterEstado: string;
   setFilterEstado: (v: string) => void;
-  sortKey: string;
-  sortDir: 'asc' | 'desc';
-  onSort: (key: string) => void;
   onOpenCreate: () => void;
   onOpenDetail: (id: string) => void;
 }) {
   const {
-    rows,
+    data,
+    universeCount,
     loading,
     error,
     search,
     setSearch,
     filterEstado,
     setFilterEstado,
-    sortKey,
-    sortDir,
-    onSort,
     onOpenCreate,
     onOpenDetail,
   } = props;
+
+  const columns: Column<Row>[] = [
+    {
+      key: 'nombre',
+      label: 'Nombre',
+      render: (r) => (
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate font-medium text-[var(--text)]">{r.nombre}</span>
+          {r.clave_interna ? (
+            <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/45">
+              {r.clave_interna}
+            </span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: 'terreno',
+      label: 'Terreno',
+      sortable: false,
+      render: (r) => (
+        <div className="flex min-w-0 flex-col text-xs">
+          <span className="truncate text-[var(--text)]/80">{r.terreno?.nombre ?? '—'}</span>
+          {r.terreno?.municipio ? (
+            <span className="truncate text-[var(--text)]/45">{r.terreno.municipio}</span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: 'tipo_proyecto',
+      label: 'Tipo',
+      sortable: false,
+      cellClassName: 'text-xs text-[var(--text)]/70',
+      render: (r) => r.tipo_proyecto?.nombre ?? <span className="text-[var(--text)]/35">—</span>,
+    },
+    {
+      key: 'cantidad_lotes',
+      label: 'Lotes',
+      type: 'number',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (r) => r.cantidad_lotes ?? '—',
+    },
+    {
+      key: 'area_vendible_m2',
+      label: 'Área vendible',
+      type: 'number',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (r) => formatM2(r.area_vendible_m2),
+    },
+    {
+      key: 'aprovechamiento_pct',
+      label: 'Aprov. %',
+      type: 'number',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (r) => formatPercent(r.aprovechamiento_pct),
+    },
+    {
+      key: 'utilidad_proyecto',
+      label: 'Utilidad',
+      type: 'currency',
+      render: (r) => (
+        <span
+          className={
+            r.utilidad_proyecto != null && r.utilidad_proyecto < 0
+              ? 'text-red-400'
+              : 'text-[var(--text)]/75'
+          }
+        >
+          {formatCurrency(r.utilidad_proyecto, { compact: true })}
+        </span>
+      ),
+    },
+    {
+      key: 'margen_pct',
+      label: 'Margen %',
+      type: 'number',
+      render: (r) => (
+        <span
+          className={
+            r.margen_pct != null && r.margen_pct < 0 ? 'text-red-400' : 'text-[var(--text)]/75'
+          }
+        >
+          {formatPercent(r.margen_pct)}
+        </span>
+      ),
+    },
+    {
+      key: 'estado',
+      label: 'Estado',
+      sortable: false,
+      render: (r) => <EstadoBadge estado={r.estado} />,
+    },
+    {
+      key: 'prioridad',
+      label: 'Prioridad',
+      sortable: false,
+      render: (r) => <PrioridadDot prioridad={r.prioridad} />,
+    },
+    {
+      key: 'fecha_ultima_revision',
+      label: 'Última revisión',
+      cellClassName: 'whitespace-nowrap text-xs text-[var(--text)]/60',
+      render: (r) => formatDateShort(r.fecha_ultima_revision),
+    },
+  ];
 
   return (
     <div className="space-y-3">
@@ -615,154 +700,25 @@ function ConsultaPanel(props: {
         </select>
       </div>
 
-      {loading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 w-full" />
-          ))}
-        </div>
-      ) : error ? (
-        <div
-          role="alert"
-          className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-400"
-        >
-          No se pudieron cargar los anteproyectos: {error}
-        </div>
-      ) : rows.length === 0 ? (
+      {universeCount === 0 && !loading && !error ? (
         <EmptyStateImported
           entityLabel="Anteproyectos"
           description="Crea el primer anteproyecto para evaluar un terreno. Necesitarás al menos un terreno capturado."
           onCreate={onOpenCreate}
         />
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-[var(--card)]">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <SortableHead
-                  sortKey="nombre"
-                  label="Nombre"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <TableHead>Terreno</TableHead>
-                <TableHead>Tipo</TableHead>
-                <SortableHead
-                  sortKey="cantidad_lotes"
-                  label="Lotes"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="area_vendible_m2"
-                  label="Área vendible"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="aprovechamiento_pct"
-                  label="Aprov. %"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="utilidad_proyecto"
-                  label="Utilidad"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="margen_pct"
-                  label="Margen %"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <TableHead>Estado</TableHead>
-                <TableHead>Prioridad</TableHead>
-                <SortableHead
-                  sortKey="fecha_ultima_revision"
-                  label="Última revisión"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map((r) => (
-                <TableRow key={r.id} onClick={() => onOpenDetail(r.id)} className="cursor-pointer">
-                  <TableCell>
-                    <div className="flex min-w-0 flex-col">
-                      <span className="truncate font-medium text-[var(--text)]">{r.nombre}</span>
-                      {r.clave_interna ? (
-                        <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/45">
-                          {r.clave_interna}
-                        </span>
-                      ) : null}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex min-w-0 flex-col text-xs">
-                      <span className="truncate text-[var(--text)]/80">
-                        {r.terreno?.nombre ?? '—'}
-                      </span>
-                      {r.terreno?.municipio ? (
-                        <span className="truncate text-[var(--text)]/45">
-                          {r.terreno.municipio}
-                        </span>
-                      ) : null}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-xs text-[var(--text)]/70">
-                    {r.tipo_proyecto?.nombre ?? <span className="text-[var(--text)]/35">—</span>}
-                  </TableCell>
-                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                    {r.cantidad_lotes ?? '—'}
-                  </TableCell>
-                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                    {formatM2(r.area_vendible_m2)}
-                  </TableCell>
-                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                    {formatPercent(r.aprovechamiento_pct)}
-                  </TableCell>
-                  <TableCell
-                    className={`text-xs tabular-nums ${
-                      r.utilidad_proyecto != null && r.utilidad_proyecto < 0
-                        ? 'text-red-400'
-                        : 'text-[var(--text)]/75'
-                    }`}
-                  >
-                    {formatCurrency(r.utilidad_proyecto, { compact: true })}
-                  </TableCell>
-                  <TableCell
-                    className={`text-xs tabular-nums ${
-                      r.margen_pct != null && r.margen_pct < 0
-                        ? 'text-red-400'
-                        : 'text-[var(--text)]/75'
-                    }`}
-                  >
-                    {formatPercent(r.margen_pct)}
-                  </TableCell>
-                  <TableCell>
-                    <EstadoBadge estado={r.estado} />
-                  </TableCell>
-                  <TableCell>
-                    <PrioridadDot prioridad={r.prioridad} />
-                  </TableCell>
-                  <TableCell className="whitespace-nowrap text-xs text-[var(--text)]/60">
-                    {formatDateShort(r.fecha_ultima_revision)}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+        <DataTable<Row>
+          data={data}
+          columns={columns}
+          rowKey="id"
+          loading={loading}
+          error={error}
+          onRowClick={(r) => onOpenDetail(r.id)}
+          initialSort={{ key: 'nombre', dir: 'asc' }}
+          showDensityToggle={false}
+          emptyTitle="Sin resultados"
+          emptyDescription="Limpia los filtros para ver todos los anteproyectos."
+        />
       )}
     </div>
   );

--- a/app/dilesa/prototipos/page.tsx
+++ b/app/dilesa/prototipos/page.tsx
@@ -29,16 +29,7 @@ import { RequireAccess } from '@/components/require-access';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { SortableHead } from '@/components/ui/sortable-head';
-import { useSortableTable } from '@/hooks/use-sortable-table';
+import { DataTable, type Column } from '@/components/module-page';
 import {
   Sheet,
   SheetContent,
@@ -260,12 +251,6 @@ function PrototiposInner() {
     });
   }, [prototipos, search, filterEtapa]);
 
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable<Prototipo>('created_at', 'desc');
-  const sorted = useMemo(
-    () => sortData(filtered as unknown as Record<string, unknown>[]) as unknown as Prototipo[],
-    [filtered, sortData]
-  );
-
   return (
     <div className="space-y-6">
       <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -304,16 +289,14 @@ function PrototiposInner() {
 
       <TabPanel tabKey="consulta" active={active}>
         <ConsultaPanel
-          prototipos={sorted}
+          data={filtered}
+          universeCount={prototipos.length}
           loading={loading}
           error={error}
           search={search}
           setSearch={setSearch}
           filterEtapa={filterEtapa}
           setFilterEtapa={setFilterEtapa}
-          sortKey={sortKey}
-          sortDir={sortDir}
-          onSort={onSort}
           onOpenCreate={openCreate}
           onOpenDetail={(id) => router.push(`/dilesa/prototipos/${id}`)}
         />
@@ -551,33 +534,146 @@ function PrototiposInner() {
 }
 
 function ConsultaPanel(props: {
-  prototipos: Prototipo[];
+  data: Prototipo[];
+  universeCount: number;
   loading: boolean;
   error: string | null;
   search: string;
   setSearch: (v: string) => void;
   filterEtapa: string;
   setFilterEtapa: (v: string) => void;
-  sortKey: string;
-  sortDir: 'asc' | 'desc';
-  onSort: (key: string) => void;
   onOpenCreate: () => void;
   onOpenDetail: (id: string) => void;
 }) {
   const {
-    prototipos,
+    data,
+    universeCount,
     loading,
     error,
     search,
     setSearch,
     filterEtapa,
     setFilterEtapa,
-    sortKey,
-    sortDir,
-    onSort,
     onOpenCreate,
     onOpenDetail,
   } = props;
+
+  const columns: Column<Prototipo>[] = [
+    {
+      key: 'nombre',
+      label: 'Nombre',
+      render: (p) => (
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate font-medium text-[var(--text)]">{p.nombre}</span>
+          {p.codigo ? (
+            <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/45">
+              {p.codigo}
+            </span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: 'clasificacion_inmobiliaria',
+      label: 'Clasificación',
+      sortable: false,
+      cellClassName: 'text-xs text-[var(--text)]/70',
+      render: (p) =>
+        p.clasificacion_inmobiliaria?.nombre ?? (
+          <span className="text-[var(--text)]/40">(sin clasificar)</span>
+        ),
+    },
+    {
+      key: 'superficie_construida_m2',
+      label: 'Sup. construida',
+      type: 'number',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (p) => formatM2(p.superficie_construida_m2),
+    },
+    {
+      key: 'recamaras',
+      label: 'Rec.',
+      type: 'number',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (p) => p.recamaras ?? '—',
+    },
+    {
+      key: 'banos',
+      label: 'Baños',
+      type: 'number',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (p) => p.banos ?? '—',
+    },
+    {
+      key: 'valor_comercial',
+      label: 'Valor comercial',
+      type: 'currency',
+      cellClassName: 'text-xs font-medium text-[var(--text)]',
+      render: (p) => formatCurrency(p.valor_comercial),
+    },
+    {
+      key: 'costo_total_unitario',
+      label: 'Costo total',
+      type: 'currency',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (p) => formatCurrency(p.costo_total_unitario),
+    },
+    {
+      key: 'margen',
+      label: 'Margen',
+      type: 'currency',
+      sortable: false,
+      accessor: (p) =>
+        p.valor_comercial != null && p.costo_total_unitario != null
+          ? p.valor_comercial - p.costo_total_unitario
+          : null,
+      render: (p) => {
+        const margen =
+          p.valor_comercial != null && p.costo_total_unitario != null
+            ? p.valor_comercial - p.costo_total_unitario
+            : null;
+        return (
+          <span
+            className={
+              margen != null && margen < 0 ? 'font-semibold text-red-400' : 'text-[var(--text)]/75'
+            }
+          >
+            {margen != null ? formatCurrency(margen) : '—'}
+          </span>
+        );
+      },
+    },
+    {
+      key: 'etapa',
+      label: 'Etapa',
+      sortable: false,
+      render: (p) => <EtapaBadge etapa={p.etapa} />,
+    },
+    {
+      key: 'prioridad',
+      label: 'Prioridad',
+      sortable: false,
+      render: (p) => <PrioridadDot prioridad={p.prioridad} />,
+    },
+    {
+      key: 'responsable_id',
+      label: 'Responsable',
+      sortable: false,
+      cellClassName: 'text-xs text-[var(--text)]/60',
+      render: (p) =>
+        p.responsable_id ? (
+          <span className="font-mono text-[10px]">{p.responsable_id.slice(0, 8)}…</span>
+        ) : (
+          '—'
+        ),
+    },
+    {
+      key: 'fecha_ultima_revision',
+      label: 'Última revisión',
+      cellClassName: 'whitespace-nowrap text-xs text-[var(--text)]/60',
+      render: (p) => formatDateShort(p.fecha_ultima_revision),
+    },
+  ];
 
   return (
     <div className="space-y-3">
@@ -606,161 +702,25 @@ function ConsultaPanel(props: {
         </select>
       </div>
 
-      {loading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 w-full" />
-          ))}
-        </div>
-      ) : error ? (
-        <div
-          role="alert"
-          className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-400"
-        >
-          No se pudieron cargar los prototipos: {error}
-        </div>
-      ) : prototipos.length === 0 ? (
+      {universeCount === 0 && !loading && !error ? (
         <EmptyStateImported
           entityLabel="Prototipos"
           description="Captura el primer prototipo para arrancar el catálogo o importa desde Coda cuando esté disponible."
           onCreate={onOpenCreate}
         />
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-[var(--card)]">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <SortableHead
-                  sortKey="nombre"
-                  label="Nombre"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <TableHead>Clasificación</TableHead>
-                <SortableHead
-                  sortKey="superficie_construida_m2"
-                  label="Sup. construida"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="recamaras"
-                  label="Rec."
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="banos"
-                  label="Baños"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="valor_comercial"
-                  label="Valor comercial"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="costo_total_unitario"
-                  label="Costo total"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <TableHead>Margen</TableHead>
-                <TableHead>Etapa</TableHead>
-                <TableHead>Prioridad</TableHead>
-                <TableHead>Responsable</TableHead>
-                <SortableHead
-                  sortKey="fecha_ultima_revision"
-                  label="Última revisión"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {prototipos.map((p) => {
-                const margen =
-                  p.valor_comercial != null && p.costo_total_unitario != null
-                    ? p.valor_comercial - p.costo_total_unitario
-                    : null;
-                return (
-                  <TableRow
-                    key={p.id}
-                    onClick={() => onOpenDetail(p.id)}
-                    className="cursor-pointer"
-                  >
-                    <TableCell>
-                      <div className="flex min-w-0 flex-col">
-                        <span className="truncate font-medium text-[var(--text)]">{p.nombre}</span>
-                        {p.codigo ? (
-                          <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/45">
-                            {p.codigo}
-                          </span>
-                        ) : null}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-xs text-[var(--text)]/70">
-                      {p.clasificacion_inmobiliaria?.nombre ?? (
-                        <span className="text-[var(--text)]/40">(sin clasificar)</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                      {formatM2(p.superficie_construida_m2)}
-                    </TableCell>
-                    <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                      {p.recamaras ?? '—'}
-                    </TableCell>
-                    <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                      {p.banos ?? '—'}
-                    </TableCell>
-                    <TableCell className="text-xs font-medium tabular-nums text-[var(--text)]">
-                      {formatCurrency(p.valor_comercial)}
-                    </TableCell>
-                    <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                      {formatCurrency(p.costo_total_unitario)}
-                    </TableCell>
-                    <TableCell
-                      className={`text-xs tabular-nums ${
-                        margen != null && margen < 0
-                          ? 'font-semibold text-red-400'
-                          : 'text-[var(--text)]/75'
-                      }`}
-                    >
-                      {margen != null ? formatCurrency(margen) : '—'}
-                    </TableCell>
-                    <TableCell>
-                      <EtapaBadge etapa={p.etapa} />
-                    </TableCell>
-                    <TableCell>
-                      <PrioridadDot prioridad={p.prioridad} />
-                    </TableCell>
-                    <TableCell className="text-xs text-[var(--text)]/60">
-                      {p.responsable_id ? (
-                        <span className="font-mono text-[10px]">
-                          {p.responsable_id.slice(0, 8)}…
-                        </span>
-                      ) : (
-                        '—'
-                      )}
-                    </TableCell>
-                    <TableCell className="whitespace-nowrap text-xs text-[var(--text)]/60">
-                      {formatDateShort(p.fecha_ultima_revision)}
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </div>
+        <DataTable<Prototipo>
+          data={data}
+          columns={columns}
+          rowKey="id"
+          loading={loading}
+          error={error}
+          onRowClick={(p) => onOpenDetail(p.id)}
+          initialSort={{ key: 'nombre', dir: 'asc' }}
+          showDensityToggle={false}
+          emptyTitle="Sin resultados"
+          emptyDescription="Limpia los filtros para ver todos los prototipos."
+        />
       )}
     </div>
   );

--- a/app/dilesa/proyectos/page.tsx
+++ b/app/dilesa/proyectos/page.tsx
@@ -30,16 +30,7 @@ import { RequireAccess } from '@/components/require-access';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { SortableHead } from '@/components/ui/sortable-head';
-import { useSortableTable } from '@/hooks/use-sortable-table';
+import { DataTable, type Column } from '@/components/module-page';
 import {
   Sheet,
   SheetContent,
@@ -304,12 +295,6 @@ function ProyectosInner() {
     });
   }, [proyectos, search, filterFase]);
 
-  const { sortKey, sortDir, onSort, sortData } = useSortableTable<Proyecto>('created_at', 'desc');
-  const sorted = useMemo(
-    () => sortData(filtered as unknown as Record<string, unknown>[]) as unknown as Proyecto[],
-    [filtered, sortData]
-  );
-
   const terrenoOptions = useMemo<ComboboxOption[]>(
     () =>
       terrenos.map((t) => ({
@@ -362,16 +347,14 @@ function ProyectosInner() {
 
       <TabPanel tabKey="consulta" active={active}>
         <ConsultaPanel
-          proyectos={sorted}
+          data={filtered}
+          universeCount={proyectos.length}
           loading={loading}
           error={error}
           search={search}
           setSearch={setSearch}
           filterFase={filterFase}
           setFilterFase={setFilterFase}
-          sortKey={sortKey}
-          sortDir={sortDir}
-          onSort={onSort}
           onOpenCreate={openCreate}
           onOpenDetail={(id) => router.push(`/dilesa/proyectos/${id}`)}
         />
@@ -509,33 +492,169 @@ function ProyectosInner() {
 }
 
 function ConsultaPanel(props: {
-  proyectos: Proyecto[];
+  data: Proyecto[];
+  universeCount: number;
   loading: boolean;
   error: string | null;
   search: string;
   setSearch: (v: string) => void;
   filterFase: string;
   setFilterFase: (v: string) => void;
-  sortKey: string;
-  sortDir: 'asc' | 'desc';
-  onSort: (key: string) => void;
   onOpenCreate: () => void;
   onOpenDetail: (id: string) => void;
 }) {
   const {
-    proyectos,
+    data,
+    universeCount,
     loading,
     error,
     search,
     setSearch,
     filterFase,
     setFilterFase,
-    sortKey,
-    sortDir,
-    onSort,
     onOpenCreate,
     onOpenDetail,
   } = props;
+
+  const columns: Column<Proyecto>[] = [
+    {
+      key: 'nombre',
+      label: 'Nombre',
+      render: (p) => (
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate font-medium text-[var(--text)]">{p.nombre}</span>
+          {p.codigo ? (
+            <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/45">
+              {p.codigo}
+            </span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: 'terreno',
+      label: 'Terreno',
+      sortable: false,
+      cellClassName: 'text-xs text-[var(--text)]/70',
+      render: (p) =>
+        p.terreno ? (
+          <div className="flex min-w-0 flex-col">
+            <span className="truncate">{p.terreno.nombre}</span>
+            {p.terreno.clave_interna ? (
+              <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/40">
+                {p.terreno.clave_interna}
+              </span>
+            ) : null}
+          </div>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'anteproyecto',
+      label: 'Anteproyecto',
+      sortable: false,
+      render: (p) =>
+        p.anteproyecto_id ? (
+          <span
+            className="inline-flex items-center gap-1 rounded-lg border border-[var(--accent)]/25 bg-[var(--accent)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--accent)]"
+            title={
+              p.anteproyecto?.nombre
+                ? `← Desde anteproyecto: ${p.anteproyecto.nombre}`
+                : '← Desde anteproyecto'
+            }
+          >
+            <Link2 className="size-3" />
+            {p.anteproyecto?.clave_interna ?? p.anteproyecto?.nombre?.slice(0, 22) ?? 'origen'}
+          </span>
+        ) : (
+          <span className="text-[10px] uppercase tracking-wide text-[var(--text)]/40">manual</span>
+        ),
+    },
+    {
+      key: 'tipo_proyecto',
+      label: 'Tipo',
+      sortable: false,
+      cellClassName: 'text-xs text-[var(--text)]/70',
+      render: (p) => p.tipo_proyecto?.nombre ?? <span className="text-[var(--text)]/40">—</span>,
+    },
+    {
+      key: 'fase',
+      label: 'Fase',
+      render: (p) => <FaseBadge fase={p.fase} />,
+    },
+    {
+      key: 'fecha_inicio',
+      label: 'Inicio',
+      cellClassName: 'whitespace-nowrap text-xs text-[var(--text)]/70',
+      render: (p) => formatDateShort(p.fecha_inicio),
+    },
+    {
+      key: 'fecha_estimada_cierre',
+      label: 'Cierre est.',
+      cellClassName: 'whitespace-nowrap text-xs text-[var(--text)]/70',
+      render: (p) => formatDateShort(p.fecha_estimada_cierre),
+    },
+    {
+      key: 'cantidad_lotes_total',
+      label: 'Lotes',
+      type: 'number',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (p) => p.cantidad_lotes_total ?? '—',
+    },
+    {
+      key: 'area_vendible_m2',
+      label: 'Área vendible',
+      type: 'number',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (p) => formatM2(p.area_vendible_m2),
+    },
+    {
+      key: 'presupuesto_total',
+      label: 'Presupuesto',
+      type: 'currency',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (p) => formatCurrency(p.presupuesto_total, { compact: true }),
+    },
+    {
+      key: 'inversion_total',
+      label: 'Inversión',
+      type: 'currency',
+      cellClassName: 'text-xs text-[var(--text)]/75',
+      render: (p) => formatCurrency(p.inversion_total, { compact: true }),
+    },
+    {
+      key: 'etapa',
+      label: 'Etapa',
+      sortable: false,
+      cellClassName: 'text-xs text-[var(--text)]/70',
+      render: (p) => p.etapa ?? '—',
+    },
+    {
+      key: 'prioridad',
+      label: 'Prioridad',
+      sortable: false,
+      render: (p) => <PrioridadDot prioridad={p.prioridad} />,
+    },
+    {
+      key: 'responsable_id',
+      label: 'Responsable',
+      sortable: false,
+      cellClassName: 'text-xs text-[var(--text)]/60',
+      render: (p) =>
+        p.responsable_id ? (
+          <span className="font-mono text-[10px]">{p.responsable_id.slice(0, 8)}…</span>
+        ) : (
+          '—'
+        ),
+    },
+    {
+      key: 'fecha_ultima_revision',
+      label: 'Última rev.',
+      cellClassName: 'whitespace-nowrap text-xs text-[var(--text)]/60',
+      render: (p) => formatDateShort(p.fecha_ultima_revision),
+    },
+  ];
 
   return (
     <div className="space-y-3">
@@ -564,186 +683,25 @@ function ConsultaPanel(props: {
         </select>
       </div>
 
-      {loading ? (
-        <div className="space-y-2">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 w-full" />
-          ))}
-        </div>
-      ) : error ? (
-        <div
-          role="alert"
-          className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-400"
-        >
-          No se pudieron cargar los proyectos: {error}
-        </div>
-      ) : proyectos.length === 0 ? (
+      {universeCount === 0 && !loading && !error ? (
         <EmptyStateImported
           entityLabel="Proyectos"
           description="Convierte un anteproyecto desde su detalle, o captura manualmente un proyecto legacy si no tiene origen en anteproyectos."
           onCreate={onOpenCreate}
         />
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-[var(--card)]">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <SortableHead
-                  sortKey="nombre"
-                  label="Nombre"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <TableHead>Terreno</TableHead>
-                <TableHead>Anteproyecto</TableHead>
-                <TableHead>Tipo</TableHead>
-                <TableHead>Fase</TableHead>
-                <SortableHead
-                  sortKey="fecha_inicio"
-                  label="Inicio"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="fecha_estimada_cierre"
-                  label="Cierre est."
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="cantidad_lotes_total"
-                  label="Lotes"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="area_vendible_m2"
-                  label="Área vendible"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="presupuesto_total"
-                  label="Presupuesto"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <SortableHead
-                  sortKey="inversion_total"
-                  label="Inversión"
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-                <TableHead>Etapa</TableHead>
-                <TableHead>Prioridad</TableHead>
-                <TableHead>Responsable</TableHead>
-                <SortableHead
-                  sortKey="fecha_ultima_revision"
-                  label="Última rev."
-                  currentSort={sortKey}
-                  currentDir={sortDir}
-                  onSort={onSort}
-                />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {proyectos.map((p) => (
-                <TableRow key={p.id} onClick={() => onOpenDetail(p.id)} className="cursor-pointer">
-                  <TableCell>
-                    <div className="flex min-w-0 flex-col">
-                      <span className="truncate font-medium text-[var(--text)]">{p.nombre}</span>
-                      {p.codigo ? (
-                        <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/45">
-                          {p.codigo}
-                        </span>
-                      ) : null}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-xs text-[var(--text)]/70">
-                    {p.terreno ? (
-                      <div className="flex min-w-0 flex-col">
-                        <span className="truncate">{p.terreno.nombre}</span>
-                        {p.terreno.clave_interna ? (
-                          <span className="font-mono text-[10px] uppercase tracking-wide text-[var(--text)]/40">
-                            {p.terreno.clave_interna}
-                          </span>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <span className="text-[var(--text)]/40">—</span>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    {p.anteproyecto_id ? (
-                      <span
-                        className="inline-flex items-center gap-1 rounded-lg border border-[var(--accent)]/25 bg-[var(--accent)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--accent)]"
-                        title={
-                          p.anteproyecto?.nombre
-                            ? `← Desde anteproyecto: ${p.anteproyecto.nombre}`
-                            : '← Desde anteproyecto'
-                        }
-                      >
-                        <Link2 className="size-3" />
-                        {p.anteproyecto?.clave_interna ??
-                          p.anteproyecto?.nombre?.slice(0, 22) ??
-                          'origen'}
-                      </span>
-                    ) : (
-                      <span className="text-[10px] uppercase tracking-wide text-[var(--text)]/40">
-                        manual
-                      </span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-xs text-[var(--text)]/70">
-                    {p.tipo_proyecto?.nombre ?? <span className="text-[var(--text)]/40">—</span>}
-                  </TableCell>
-                  <TableCell>
-                    <FaseBadge fase={p.fase} />
-                  </TableCell>
-                  <TableCell className="whitespace-nowrap text-xs text-[var(--text)]/70">
-                    {formatDateShort(p.fecha_inicio)}
-                  </TableCell>
-                  <TableCell className="whitespace-nowrap text-xs text-[var(--text)]/70">
-                    {formatDateShort(p.fecha_estimada_cierre)}
-                  </TableCell>
-                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                    {p.cantidad_lotes_total ?? '—'}
-                  </TableCell>
-                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                    {formatM2(p.area_vendible_m2)}
-                  </TableCell>
-                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                    {formatCurrency(p.presupuesto_total, { compact: true })}
-                  </TableCell>
-                  <TableCell className="text-xs tabular-nums text-[var(--text)]/75">
-                    {formatCurrency(p.inversion_total, { compact: true })}
-                  </TableCell>
-                  <TableCell className="text-xs text-[var(--text)]/70">{p.etapa ?? '—'}</TableCell>
-                  <TableCell>
-                    <PrioridadDot prioridad={p.prioridad} />
-                  </TableCell>
-                  <TableCell className="text-xs text-[var(--text)]/60">
-                    {p.responsable_id ? (
-                      <span className="font-mono text-[10px]">{p.responsable_id.slice(0, 8)}…</span>
-                    ) : (
-                      '—'
-                    )}
-                  </TableCell>
-                  <TableCell className="whitespace-nowrap text-xs text-[var(--text)]/60">
-                    {formatDateShort(p.fecha_ultima_revision)}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+        <DataTable<Proyecto>
+          data={data}
+          columns={columns}
+          rowKey="id"
+          loading={loading}
+          error={error}
+          onRowClick={(p) => onOpenDetail(p.id)}
+          initialSort={{ key: 'fecha_inicio', dir: 'desc' }}
+          showDensityToggle={false}
+          emptyTitle="Sin resultados"
+          emptyDescription="Limpia los filtros para ver todos los proyectos."
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

PR-K de Fase 2 incremental de la iniciativa `data-table` (ADR-010). Cierra los 3 archivos DILESA que quedaron como Fase 2 en PR-F (PR #224): proyectos, prototipos y anteproyectos. Cada uno tiene 11–15 columnas con badges custom (FaseBadge, EtapaBadge, EstadoBadge, PrioridadDot) y formatters específicos del dominio inmobiliario (formatM2, formatPercent, compact currency).

Las 3 páginas comparten un patrón de panel (\`ConsultaPanel\`) con Tabs. El refactor:
- ConsultaPanel ahora recibe \`data\` (filtered) + \`universeCount\` en lugar de la versión \`sorted\` y las props de sort externo.
- DataTable maneja sort interno via tanstack.
- \`EmptyStateImported\` se preserva para universo-vacío con su mensaje específico del dominio (ej. "Convierte un anteproyecto desde su detalle…").

## Archivos migrados

- \`app/dilesa/proyectos/page.tsx\` ✅ (-42 líneas netas)
- \`app/dilesa/prototipos/page.tsx\` ✅ (-40 líneas netas)
- \`app/dilesa/anteproyectos/page.tsx\` ✅ (-44 líneas netas)

## Test plan

- [ ] CI verde (typecheck/lint/format/test).
- [ ] Smoke \`/dilesa/proyectos\`: tabla se carga, sort por nombre/fechas/lotes/área/montos funciona, badges (Fase, Prioridad) renderean correctamente, click en row navega a detail.
- [ ] Smoke \`/dilesa/prototipos\`: columna derivada "Margen" computa correctamente y aparece en rojo cuando es negativa; sort por accessor numérico funciona.
- [ ] Smoke \`/dilesa/anteproyectos\`: utilidad y margen % se ven en rojo cuando son negativos; tabla integra datos de la vista \`v_anteproyectos_analisis\`.
- [ ] Smoke universo vacío: \`EmptyStateImported\` aparece (con su botón de Crear) — DataTable NO renderea su empty default en este caso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)