### PR TITLE
feat(data-table): Productos analisis + excepciones Acceso/Playtomic (PR-L)

### DIFF
--- a/app/rdb/productos/analisis/page.tsx
+++ b/app/rdb/productos/analisis/page.tsx
@@ -4,14 +4,7 @@ import { RequireAccess } from '@/components/require-access';
 import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { DataTable, type Column } from '@/components/module-page';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -535,63 +528,55 @@ export default function ProductosAnalisisPage() {
             subtitle="Candidatos a promoción urgente o baja. Ordenados por valor en stock."
             onExport={sinMovimiento.length > 0 ? exportSinMov : undefined}
           />
-          <div className="rounded-xl border bg-card overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Producto</TableHead>
-                  <TableHead>Categoría</TableHead>
-                  <TableHead className="text-right">Stock</TableHead>
-                  <TableHead className="text-right">Días sin venta</TableHead>
-                  <TableHead className="text-right">Valor en stock</TableHead>
-                  <TableHead>Última venta</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loading ? (
-                  Array.from({ length: 5 }).map((_, i) => (
-                    <TableRow key={i}>
-                      {Array.from({ length: 6 }).map((__, j) => (
-                        <TableCell key={j}>
-                          <Skeleton className="h-4 w-full" />
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : sinMovimiento.length === 0 ? (
-                  <TableRow>
-                    <TableCell
-                      colSpan={6}
-                      className="py-10 text-center text-muted-foreground text-sm"
-                    >
-                      Ningún producto inventariable con stock y sin venta en &gt;30 días. ✓
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  sinMovimiento.map((m) => (
-                    <TableRow key={m.id}>
-                      <TableCell className="font-medium">{m.nombre}</TableCell>
-                      <TableCell>
-                        <CategoriaBadge nombre={m.categoria_nombre} color={m.categoria_color} />
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatNumber(m.stock_actual, 0)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums text-red-600">
-                        {m.dias_sin_venta === 9999 ? 'Nunca' : `${m.dias_sin_venta}d`}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums font-medium">
-                        {formatCurrency(m.valor_stock)}
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {formatDate(m.ultima_venta_at)}
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
+          <DataTable<Metrica>
+            data={sinMovimiento}
+            columns={[
+              {
+                key: 'nombre',
+                label: 'Producto',
+                cellClassName: 'font-medium',
+              },
+              {
+                key: 'categoria_nombre',
+                label: 'Categoría',
+                sortable: false,
+                render: (m) => (
+                  <CategoriaBadge nombre={m.categoria_nombre} color={m.categoria_color} />
+                ),
+              },
+              {
+                key: 'stock_actual',
+                label: 'Stock',
+                type: 'number',
+                render: (m) => formatNumber(m.stock_actual, 0),
+              },
+              {
+                key: 'dias_sin_venta',
+                label: 'Días sin venta',
+                type: 'number',
+                cellClassName: 'text-red-600',
+                render: (m) => (m.dias_sin_venta === 9999 ? 'Nunca' : `${m.dias_sin_venta}d`),
+              },
+              {
+                key: 'valor_stock',
+                label: 'Valor en stock',
+                type: 'currency',
+                cellClassName: 'font-medium',
+                render: (m) => formatCurrency(m.valor_stock),
+              },
+              {
+                key: 'ultima_venta_at',
+                label: 'Última venta',
+                cellClassName: 'text-xs text-muted-foreground',
+                render: (m) => formatDate(m.ultima_venta_at),
+              },
+            ]}
+            rowKey="id"
+            loading={loading}
+            initialSort={{ key: 'valor_stock', dir: 'desc' }}
+            showDensityToggle={false}
+            emptyTitle="Ningún producto inventariable con stock y sin venta en >30 días. ✓"
+          />
         </section>
 
         {/* Estrellas */}
@@ -602,67 +587,60 @@ export default function ProductosAnalisisPage() {
             subtitle="Productos rentables clave (≥30 unidades 30d, margen ≥30%). No te quedes sin stock."
             onExport={estrellas.length > 0 ? exportEstrellas : undefined}
           />
-          <div className="rounded-xl border bg-card overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Producto</TableHead>
-                  <TableHead>Categoría</TableHead>
-                  <TableHead className="text-right">Unidades 30d</TableHead>
-                  <TableHead className="text-right">Importe 30d</TableHead>
-                  <TableHead className="text-right">Margen</TableHead>
-                  <TableHead className="text-right">Utilidad 30d</TableHead>
-                  <TableHead className="text-right">Stock</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loading ? (
-                  Array.from({ length: 5 }).map((_, i) => (
-                    <TableRow key={i}>
-                      {Array.from({ length: 7 }).map((__, j) => (
-                        <TableCell key={j}>
-                          <Skeleton className="h-4 w-full" />
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : estrellas.length === 0 ? (
-                  <TableRow>
-                    <TableCell
-                      colSpan={7}
-                      className="py-10 text-center text-muted-foreground text-sm"
-                    >
-                      Sin estrellas que cumplan el criterio. Revisa precios y costos.
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  estrellas.map((m) => (
-                    <TableRow key={m.id}>
-                      <TableCell className="font-medium">{m.nombre}</TableCell>
-                      <TableCell>
-                        <CategoriaBadge nombre={m.categoria_nombre} color={m.categoria_color} />
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatNumber(m.unidades_30d, 0)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatCurrency(m.importe_30d)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <MargenBadge pct={m.margen_pct} />
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums font-medium text-emerald-600">
-                        {formatCurrency(m.utilidad_30d)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {m.inventariable ? formatNumber(m.stock_actual, 0) : '—'}
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
+          <DataTable<Metrica>
+            data={estrellas}
+            columns={[
+              {
+                key: 'nombre',
+                label: 'Producto',
+                cellClassName: 'font-medium',
+              },
+              {
+                key: 'categoria_nombre',
+                label: 'Categoría',
+                sortable: false,
+                render: (m) => (
+                  <CategoriaBadge nombre={m.categoria_nombre} color={m.categoria_color} />
+                ),
+              },
+              {
+                key: 'unidades_30d',
+                label: 'Unidades 30d',
+                type: 'number',
+                render: (m) => formatNumber(m.unidades_30d, 0),
+              },
+              {
+                key: 'importe_30d',
+                label: 'Importe 30d',
+                type: 'currency',
+                render: (m) => formatCurrency(m.importe_30d),
+              },
+              {
+                key: 'margen_pct',
+                label: 'Margen',
+                align: 'right',
+                render: (m) => <MargenBadge pct={m.margen_pct} />,
+              },
+              {
+                key: 'utilidad_30d',
+                label: 'Utilidad 30d',
+                type: 'currency',
+                cellClassName: 'font-medium text-emerald-600',
+                render: (m) => formatCurrency(m.utilidad_30d),
+              },
+              {
+                key: 'stock_actual',
+                label: 'Stock',
+                type: 'number',
+                render: (m) => (m.inventariable ? formatNumber(m.stock_actual, 0) : '—'),
+              },
+            ]}
+            rowKey="id"
+            loading={loading}
+            initialSort={{ key: 'utilidad_30d', dir: 'desc' }}
+            showDensityToggle={false}
+            emptyTitle="Sin estrellas que cumplan el criterio. Revisa precios y costos."
+          />
         </section>
 
         {/* Margen bajo */}
@@ -673,75 +651,69 @@ export default function ProductosAnalisisPage() {
             subtitle="Alta rotación (≥30 unidades 30d) + margen <20%."
             onExport={margenBajo.length > 0 ? exportMargenBajo : undefined}
           />
-          <div className="rounded-xl border bg-card overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Producto</TableHead>
-                  <TableHead>Categoría</TableHead>
-                  <TableHead className="text-right">Unidades 30d</TableHead>
-                  <TableHead className="text-right">Importe 30d</TableHead>
-                  <TableHead className="text-right">Costo</TableHead>
-                  <TableHead className="text-right">Precio</TableHead>
-                  <TableHead className="text-right">Margen</TableHead>
-                  <TableHead className="text-right">Utilidad 30d</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loading ? (
-                  Array.from({ length: 5 }).map((_, i) => (
-                    <TableRow key={i}>
-                      {Array.from({ length: 8 }).map((__, j) => (
-                        <TableCell key={j}>
-                          <Skeleton className="h-4 w-full" />
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : margenBajo.length === 0 ? (
-                  <TableRow>
-                    <TableCell
-                      colSpan={8}
-                      className="py-10 text-center text-muted-foreground text-sm"
-                    >
-                      Ningún producto con alta rotación y margen bajo. ✓
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  margenBajo.map((m) => (
-                    <TableRow key={m.id}>
-                      <TableCell className="font-medium">{m.nombre}</TableCell>
-                      <TableCell>
-                        <CategoriaBadge nombre={m.categoria_nombre} color={m.categoria_color} />
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatNumber(m.unidades_30d, 0)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatCurrency(m.importe_30d)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatCurrency(m.costo)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums">
-                        {formatCurrency(m.precio_venta)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <MargenBadge pct={m.margen_pct} />
-                      </TableCell>
-                      <TableCell
-                        className={`text-right tabular-nums font-medium ${
-                          m.utilidad_30d < 0 ? 'text-red-600' : ''
-                        }`}
-                      >
-                        {formatCurrency(m.utilidad_30d)}
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
+          <DataTable<Metrica>
+            data={margenBajo}
+            columns={[
+              {
+                key: 'nombre',
+                label: 'Producto',
+                cellClassName: 'font-medium',
+              },
+              {
+                key: 'categoria_nombre',
+                label: 'Categoría',
+                sortable: false,
+                render: (m) => (
+                  <CategoriaBadge nombre={m.categoria_nombre} color={m.categoria_color} />
+                ),
+              },
+              {
+                key: 'unidades_30d',
+                label: 'Unidades 30d',
+                type: 'number',
+                render: (m) => formatNumber(m.unidades_30d, 0),
+              },
+              {
+                key: 'importe_30d',
+                label: 'Importe 30d',
+                type: 'currency',
+                render: (m) => formatCurrency(m.importe_30d),
+              },
+              {
+                key: 'costo',
+                label: 'Costo',
+                type: 'currency',
+                render: (m) => formatCurrency(m.costo),
+              },
+              {
+                key: 'precio_venta',
+                label: 'Precio',
+                type: 'currency',
+                render: (m) => formatCurrency(m.precio_venta),
+              },
+              {
+                key: 'margen_pct',
+                label: 'Margen',
+                align: 'right',
+                render: (m) => <MargenBadge pct={m.margen_pct} />,
+              },
+              {
+                key: 'utilidad_30d',
+                label: 'Utilidad 30d',
+                type: 'currency',
+                render: (m) => (
+                  <span className={m.utilidad_30d < 0 ? 'font-medium text-red-600' : 'font-medium'}>
+                    {formatCurrency(m.utilidad_30d)}
+                  </span>
+                ),
+              },
+            ]}
+            rowKey="id"
+            loading={loading}
+            initialSort={{ key: 'unidades_30d', dir: 'desc' }}
+            showDensityToggle={false}
+            emptyTitle="Ningún producto con alta rotación y margen bajo. ✓"
+          />
         </section>
 
         {/* Comparativa por categoría — bar chart CSS */}

--- a/app/settings/acceso/acceso-client.tsx
+++ b/app/settings/acceso/acceso-client.tsx
@@ -1,5 +1,21 @@
 'use client';
 
+/**
+ * Migration to `<DataTable>` (ADR-010) not applied.
+ *
+ * Reason: this is a settings state-machine UI with three tabs (empresas,
+ * roles, usuarios), a sidebar+matrix pattern for role permissions, and
+ * inline-edit checkboxes. The value `<DataTable>` adds (sort, density
+ * toggle, sticky, ADR-006 empty/loading) does not apply here:
+ *   - No sortable columns. The order is intrinsic to the state machine.
+ *   - No filters or density preference — settings UIs render once.
+ *   - The permissions matrix has a sidebar (role list) coupled to the
+ *     content (per-module checkboxes), which is not a tabular contract.
+ *
+ * Decision logged in docs/planning/data-table.md bitácora 2026-04-27 as
+ * a permanent exception.
+ */
+
 import { type ReactNode, useState, useTransition } from 'react';
 import { usePermissions } from '@/components/providers';
 import {

--- a/components/playtomic/pending-payments-section.tsx
+++ b/components/playtomic/pending-payments-section.tsx
@@ -1,3 +1,18 @@
+/**
+ * Migration to `<DataTable>` (ADR-010) not applied.
+ *
+ * Reason: the section contains two tables. The first (resumen por jugador,
+ * top 20) renders an aggregated "Totales" footer row — same constraint as
+ * `reconciliation-table.tsx` (DataTable v1 has no totals API). The second
+ * (detalle de reservas pendientes) is gated by `showPendingDetails` toggle
+ * and uses external sort props (`pendingSortKey`/`pendingOnSort`/
+ * `pendingSortData`) shared with the parent — DataTable manages sort
+ * internally, which would break that contract.
+ *
+ * Decision logged in docs/planning/data-table.md bitácora 2026-04-27 as
+ * a permanent exception.
+ */
+
 import { Button } from '@/components/ui/button';
 import {
   Table,

--- a/components/playtomic/players-section.tsx
+++ b/components/playtomic/players-section.tsx
@@ -1,3 +1,18 @@
+/**
+ * Migration to `<DataTable>` (ADR-010) not applied.
+ *
+ * Reason: this section renders two tightly-coupled tables (top jugadores +
+ * top canceladores) inside a single `xl:grid-cols-[1.4fr_1fr]` layout, and
+ * the sort of the top-jugadores table is driven by an external `<Combobox>`
+ * (gasto/reservas/name/sport), not by clicking column headers. The
+ * `slice(0,10)` truncation also conflicts with DataTable's "show all rows
+ * matching filter" model. Migrating would split the layout and break the
+ * external-sort contract.
+ *
+ * Decision logged in docs/planning/data-table.md bitácora 2026-04-27 as
+ * a permanent exception.
+ */
+
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Combobox } from '@/components/ui/combobox';

--- a/components/playtomic/reconciliation-table.tsx
+++ b/components/playtomic/reconciliation-table.tsx
@@ -1,3 +1,16 @@
+/**
+ * Migration to `<DataTable>` (ADR-010) not applied.
+ *
+ * Reason: the table renders a footer "totals" row with aggregated values
+ * across all visible rows. `<DataTable>` v1 has no first-class API for
+ * footer/totals (out of scope per the §"Fuera de alcance v1" of the
+ * planning doc). Replicating the totals via a separate table or as a
+ * card footer would be visually inconsistent with the body rows.
+ *
+ * Decision logged in docs/planning/data-table.md bitácora 2026-04-27 as
+ * a permanent exception.
+ */
+
 import {
   Table,
   TableBody,


### PR DESCRIPTION
## Summary

PR-L de Fase 2 incremental de la iniciativa `data-table` (ADR-010). Cierra el último archivo migrable + documenta las 4 excepciones permanentes del audit.

### Migrado a `<DataTable>`

- `app/rdb/productos/analisis/page.tsx` — 3 tablas analíticas read-only (Sin movimiento, Estrellas, Margen bajo). Cada una con su \`initialSort\` específico por relevancia de la vista.

### Excepciones permanentes (con JSDoc al inicio del archivo)

- \`app/settings/acceso/acceso-client.tsx\` — settings state-machine UI con 3 tabs y patrón sidebar+matriz; las 3 tablas no se benefician de sort/density/sticky.
- \`components/playtomic/reconciliation-table.tsx\` — footer "totals" row agregado, no soportado por DataTable v1.
- \`components/playtomic/players-section.tsx\` — dos tablas tightly coupled, sort externo via Combobox, slice(0,10) trunca el modelo de DataTable.
- \`components/playtomic/pending-payments-section.tsx\` — totals row + sort externo compartido con parent.

## Test plan

- [ ] CI verde (typecheck/lint/format/test).
- [ ] Smoke \`/rdb/productos/analisis\`: las 3 tablas se cargan, sort por columnas funciona, MargenBadge y CategoriaBadge renderean correctamente.
- [ ] Verificar que las páginas de excepción siguen funcionando sin cambios funcionales (Playtomic + Settings/Acceso).

🤖 Generated with [Claude Code](https://claude.com/claude-code)