### PR TITLE
feat(juntas): paridad multi-empresa RDB e INICIO con DILESA

### DIFF
--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import { normalizeHtmlImagesToPaths, rewriteHtmlImagesToSigned } from '@/lib/adjuntos';
+import { htmlHasCodaImages, importCodaImagesInHtml } from '@/lib/coda-paste-import';
 import { fetchJuntaUpdates } from '@/lib/juntas/fetch-updates';
 import { TasksCreateForm } from '@/components/tasks/tasks-create-form';
 import { emptyTaskForm, type TaskFormValues } from '@/components/tasks/tasks-shared';
@@ -105,7 +106,12 @@ type TaskUpdate = {
   creado_por: string | null;
   created_at: string;
   usuario?: { nombre: string } | null;
-  task_titulo?: string | null;
+  task?: {
+    titulo: string;
+    estado: string;
+    asignado_a: string | null;
+    fecha_vence: string | null;
+  } | null;
 };
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -133,23 +139,32 @@ const ESTADO_TASK: Record<string, { label: string; cls: string }> = {
 
 const PRIORIDAD_OPTIONS = ['Urgente', 'Alta', 'Media', 'Baja'] as const;
 
-const TIPO_CONFIG: Record<string, string> = {
-  operativa: '⚙️ Operativa',
-  directiva: '🏛️ Directiva',
-  seguimiento: '📊 Seguimiento',
-  emergencia: '🚨 Emergencia',
-  Consejo: '🏢 Consejo',
-  'Comite Ejecutivo': '👔 Comité Ejecutivo',
-  Ventas: '💰 Ventas',
-  'Atención PosVenta': '🔧 Atención PosVenta',
-  Administración: '📁 Administración',
-  Mercadotecnia: '📣 Mercadotecnia',
-  Construcción: '🏗️ Construcción',
-  'Compras y Admon. Inventario': '📦 Compras y Admon. Inventario',
-  Maquinaria: '🚜 Maquinaria',
-  Proyectos: '🗂️ Proyectos',
-  'Rincón del Bosque': '🌲 Rincón del Bosque',
-};
+const TIPO_OPTIONS: { value: string; label: string; icon: string }[] = [
+  { value: 'Comité Ejecutivo', label: 'Comité Ejecutivo', icon: '👔' },
+  { value: 'Consejo', label: 'Consejo', icon: '🏢' },
+  { value: 'Ventas', label: 'Ventas', icon: '💰' },
+  { value: 'Atención PosVenta', label: 'Atención PosVenta', icon: '🔧' },
+  { value: 'Administración', label: 'Administración', icon: '📁' },
+  { value: 'Mercadotecnia', label: 'Mercadotecnia', icon: '📣' },
+  { value: 'Construcción', label: 'Construcción', icon: '🏗️' },
+  { value: 'Compras y Admon. Inventario', label: 'Compras y Admon. Inv.', icon: '📦' },
+  { value: 'Maquinaria', label: 'Maquinaria', icon: '🚜' },
+  { value: 'Proyectos', label: 'Proyectos', icon: '🗂️' },
+  { value: 'Rincón del Bosque', label: 'Rincón del Bosque', icon: '🌲' },
+  { value: 'Extraordinaria', label: 'Extraordinaria', icon: '🚨' },
+  { value: 'Otro', label: 'Otro', icon: '📌' },
+];
+
+const TIPO_CONFIG: Record<string, string> = Object.fromEntries([
+  ...TIPO_OPTIONS.map((t) => [t.value, `${t.icon} ${t.label}`]),
+  ['Comite Ejecutivo', '👔 Comité Ejecutivo'],
+  ['Junta Operativa', '⚙️ Junta Operativa'],
+  ['Junta de Área', '📋 Junta de Área'],
+  ['operativa', '⚙️ Operativa'],
+  ['directiva', '🏛️ Directiva'],
+  ['seguimiento', '📊 Seguimiento'],
+  ['emergencia', '🚨 Emergencia'],
+]);
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -163,6 +178,19 @@ function formatDate(s: string | null) {
   if (!s) return '—';
   const d = new Date(s.includes('T') ? s : `${s}T00:00:00`);
   return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+function formatDateTime(s: string | null) {
+  if (!s) return '—';
+  const d = new Date(s);
+  return d.toLocaleString('es-MX', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  });
 }
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
@@ -180,6 +208,7 @@ function JuntaDetailInner() {
   const router = useRouter();
   const id = params.id as string;
   const supabase = createSupabaseERPClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [junta, setJunta] = useState<Junta | null>(null);
   const [asistencia, setAsistencia] = useState<Asistencia[]>([]);
@@ -189,6 +218,7 @@ function JuntaDetailInner() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [uploadingImage, setUploadingImage] = useState(false);
 
   // Editable fields
   const [titulo, setTitulo] = useState('');
@@ -203,6 +233,9 @@ function JuntaDetailInner() {
   const [showTerminarDialog, setShowTerminarDialog] = useState(false);
   const [reenviando, setReenviando] = useState(false);
   const [showReenviarDialog, setShowReenviarDialog] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [isDireccion, setIsDireccion] = useState(false);
 
   // Tiptap editor
   const editor = useEditor({
@@ -212,7 +245,7 @@ function JuntaDetailInner() {
     extensions: [
       StarterKit,
       Underline,
-      Image,
+      Image.configure({ inline: false, allowBase64: false }),
       Table.configure({ resizable: true }),
       TableRow,
       TableHeader,
@@ -222,6 +255,37 @@ function JuntaDetailInner() {
     editorProps: {
       attributes: {
         class: 'prose prose-sm max-w-none focus:outline-none min-h-[200px] p-4 text-[var(--text)]',
+      },
+      handleDrop(view, event, _slice, moved) {
+        if (moved || !event.dataTransfer?.files.length) return false;
+        const file = event.dataTransfer.files[0];
+        if (!file?.type.startsWith('image/')) return false;
+        event.preventDefault();
+        void handleImageUpload(file);
+        return true;
+      },
+      handlePaste(view, event) {
+        // 1) Single image blob (right-click → Copy image in Coda, or screenshot)
+        const items = event.clipboardData?.items;
+        if (items) {
+          for (const item of Array.from(items)) {
+            if (item.type.startsWith('image/')) {
+              event.preventDefault();
+              const file = item.getAsFile();
+              if (file) void handleImageUpload(file);
+              return true;
+            }
+          }
+        }
+        // 2) HTML paste with external Coda <img> URLs (Cmd+A + Cmd+C from Coda junta).
+        //    Intercept only when we actually see Coda-hosted image references.
+        const html = event.clipboardData?.getData('text/html') || '';
+        if (htmlHasCodaImages(html)) {
+          event.preventDefault();
+          void handlePasteWithCodaImages(html);
+          return true;
+        }
+        return false;
       },
     },
   });
@@ -241,6 +305,82 @@ function JuntaDetailInner() {
   const [showAddUpdate, setShowAddUpdate] = useState<string | null>(null);
   const [updateForm, setUpdateForm] = useState({ contenido: '', nuevoEstado: '', nuevaFecha: '' });
   const [savingUpdate, setSavingUpdate] = useState(false);
+
+  const handlePasteWithCodaImages = async (html: string) => {
+    if (!editor) return;
+    setUploadingImage(true);
+    try {
+      const { html: rewritten, imported, failed } = await importCodaImagesInHtml(html, id);
+      editor.chain().focus().insertContent(rewritten).run();
+      if (failed > 0) {
+        alert(
+          `Imágenes importadas: ${imported}. Fallaron ${failed} — revisa la consola del navegador.`
+        );
+      }
+    } finally {
+      setUploadingImage(false);
+    }
+  };
+
+  const handleImageUpload = async (file: File) => {
+    if (!editor || uploadingImage) return;
+    setUploadingImage(true);
+    try {
+      const ext = file.name.split('.').pop() ?? 'png';
+      const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+      const path = `juntas/${id}/${filename}`;
+      const { error: uploadErr } = await supabase.storage
+        .from('adjuntos')
+        .upload(path, file, { upsert: false });
+      if (uploadErr) {
+        alert(`Error al subir imagen: ${uploadErr.message}`);
+        return;
+      }
+      editor
+        .chain()
+        .focus()
+        .setImage({ src: `/api/adjuntos/${path}` })
+        .run();
+    } finally {
+      setUploadingImage(false);
+    }
+  };
+
+  const handleInsertImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void handleImageUpload(file);
+    e.target.value = '';
+  };
+
+  const handleDelete = async () => {
+    if (!junta) return;
+    setDeleting(true);
+    try {
+      await supabase.schema('erp').from('juntas_asistencia').delete().eq('junta_id', junta.id);
+      await supabase
+        .schema('erp')
+        .from('tasks')
+        .update({ entidad_tipo: null, entidad_id: null })
+        .eq('entidad_tipo', 'junta')
+        .eq('entidad_id', junta.id);
+      const { error: err } = await supabase
+        .schema('erp')
+        .from('juntas')
+        .delete()
+        .eq('id', junta.id);
+      if (err) {
+        alert(`Error al eliminar: ${err.message}`);
+        return;
+      }
+      router.push('/inicio/juntas');
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   const fetchAll = useCallback(async () => {
     // Load junta
@@ -311,16 +451,30 @@ function JuntaDetailInner() {
           ? supabase.schema('core').from('usuarios').select('id, first_name').in('id', userIds)
           : Promise.resolve({ data: [] as any[] }),
         uTaskIds.length > 0
-          ? supabase.schema('erp').from('tasks').select('id, titulo').in('id', uTaskIds)
+          ? supabase
+              .schema('erp')
+              .from('tasks')
+              .select('id, titulo, estado, asignado_a, fecha_vence')
+              .in('id', uTaskIds)
           : Promise.resolve({ data: [] as any[] }),
       ]);
       const userMap = new Map((usersData ?? []).map((u: any) => [u.id, u.first_name]));
-      const taskMap = new Map((uTasksData ?? []).map((t: any) => [t.id, t.titulo]));
+      const taskMap = new Map(
+        (uTasksData ?? []).map((t: any) => [
+          t.id,
+          {
+            titulo: t.titulo as string,
+            estado: t.estado as string,
+            asignado_a: (t.asignado_a as string | null) ?? null,
+            fecha_vence: (t.fecha_vence as string | null) ?? null,
+          },
+        ])
+      );
       setTaskUpdates(
         updatesData.map((u: any) => ({
           ...u,
           usuario: u.creado_por ? { nombre: userMap.get(u.creado_por) ?? 'Usuario' } : null,
-          task_titulo: taskMap.get(u.task_id) ?? null,
+          task: taskMap.get(u.task_id) ?? null,
         }))
       );
     } else {
@@ -359,6 +513,19 @@ function JuntaDetailInner() {
         nombre: [e.persona?.nombre, e.persona?.apellido_paterno].filter(Boolean).join(' '),
       }))
     );
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user?.email) {
+      const { data: coreUser } = await supabase
+        .schema('core')
+        .from('usuarios')
+        .select('rol')
+        .eq('email', user.email)
+        .maybeSingle();
+      if (coreUser?.rol === 'admin') setIsDireccion(true);
+    }
 
     setLoading(false);
   }, [id, supabase, editor]);
@@ -574,16 +741,30 @@ function JuntaDetailInner() {
               ? supabase.schema('core').from('usuarios').select('id, first_name').in('id', uIds)
               : Promise.resolve({ data: [] as any[] }),
             uTaskIds.length > 0
-              ? supabase.schema('erp').from('tasks').select('id, titulo').in('id', uTaskIds)
+              ? supabase
+                  .schema('erp')
+                  .from('tasks')
+                  .select('id, titulo, estado, asignado_a, fecha_vence')
+                  .in('id', uTaskIds)
               : Promise.resolve({ data: [] as any[] }),
           ]);
           const uMap = new Map((uData ?? []).map((u: any) => [u.id, u.first_name]));
-          const tMap = new Map((uTasksData ?? []).map((t: any) => [t.id, t.titulo]));
+          const tMap = new Map(
+            (uTasksData ?? []).map((t: any) => [
+              t.id,
+              {
+                titulo: t.titulo as string,
+                estado: t.estado as string,
+                asignado_a: (t.asignado_a as string | null) ?? null,
+                fecha_vence: (t.fecha_vence as string | null) ?? null,
+              },
+            ])
+          );
           setTaskUpdates(
             updData.map((u: any) => ({
               ...u,
               usuario: u.creado_por ? { nombre: uMap.get(u.creado_por) ?? 'Usuario' } : null,
-              task_titulo: tMap.get(u.task_id) ?? null,
+              task: tMap.get(u.task_id) ?? null,
             }))
           );
         }
@@ -873,6 +1054,14 @@ function JuntaDetailInner() {
 
   return (
     <div className="space-y-6 pb-12">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-center gap-3">
@@ -902,6 +1091,17 @@ function JuntaDetailInner() {
           </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          {isDireccion && (
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(true)}
+              disabled={deleting}
+              className="gap-1.5 rounded-xl border-red-500/40 text-red-500 hover:bg-red-500/10 hover:border-red-500/60"
+            >
+              <Trash2 className="h-4 w-4" />
+              Eliminar
+            </Button>
+          )}
           {estado !== 'completada' && estado !== 'cancelada' && (
             <Button
               variant="outline"
@@ -999,9 +1199,9 @@ function JuntaDetailInner() {
             <Combobox
               value={tipo ?? ''}
               onChange={(v) => setTipo(v)}
-              options={Object.entries(TIPO_CONFIG).map(([k, v]) => ({
-                value: k,
-                label: String(v),
+              options={TIPO_OPTIONS.map((t) => ({
+                value: t.value,
+                label: `${t.icon} ${t.label}`,
               }))}
               placeholder="Sin tipo"
               allowClear
@@ -1025,117 +1225,150 @@ function JuntaDetailInner() {
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5">
         <SectionTitle>Notas y minuta</SectionTitle>
         <div className="rounded-xl border border-[var(--border)]">
-          <EditorToolbar editor={editor} />
+          <EditorToolbar editor={editor} onInsertImage={handleInsertImageClick} />
           <div className="rounded-b-xl bg-[var(--panel)]">
             <style>{MINUTA_EDITOR_STYLES}</style>
             <EditorContent editor={editor} />
           </div>
         </div>
-        <p className="mt-2 text-[10px] text-[var(--text-subtle)]">
-          {estado !== 'completada' && estado !== 'cancelada'
-            ? autoSaveStatus === 'saving'
-              ? '⏳ Guardando notas...'
-              : autoSaveStatus === 'saved'
-                ? '✅ Notas guardadas'
-                : 'Las notas se auto-guardan mientras escribes'
-            : 'Las notas se guardan al presionar "Guardar cambios"'}
-        </p>
-        {lastPoll && estado !== 'completada' && estado !== 'cancelada' && (
-          <span className="text-[10px] text-[var(--text)]/30">• Sync: {lastPoll}</span>
-        )}
+        <div className="flex items-center gap-2 mt-2">
+          <p className="text-[10px] text-[var(--text-subtle)] flex-1">
+            {estado !== 'completada' && estado !== 'cancelada'
+              ? autoSaveStatus === 'saving'
+                ? '⏳ Guardando notas...'
+                : autoSaveStatus === 'saved'
+                  ? '✅ Notas guardadas'
+                  : 'Las notas se auto-guardan mientras escribes'
+              : 'Las notas se guardan al presionar "Guardar cambios"'}
+          </p>
+          {uploadingImage && (
+            <span className="text-[10px] text-[var(--accent)] flex items-center gap-1">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Subiendo imagen...
+            </span>
+          )}
+          {lastPoll && estado !== 'completada' && estado !== 'cancelada' && (
+            <span className="text-[10px] text-[var(--text)]/30">• Sync: {lastPoll}</span>
+          )}
+        </div>
       </div>
 
       {/* ── Actualizaciones de tareas ─────────────────────────── */}
-      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5">
-        <SectionTitle>Actualizaciones de tareas</SectionTitle>
-        {taskUpdates.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-6 text-center">
-            <Clock className="mb-2 h-8 w-8 text-[var(--text)]/20" />
-            <p className="text-sm text-[var(--text)]/50">No hay actualizaciones registradas</p>
-          </div>
-        ) : (
-          (() => {
-            const grouped = new Map<string, TaskUpdate[]>();
-            for (const u of taskUpdates) {
-              const arr = grouped.get(u.task_id) ?? [];
-              arr.push(u);
-              grouped.set(u.task_id, arr);
-            }
-            return (
-              <div className="space-y-4">
-                {Array.from(grouped.entries()).map(([taskId, updates]) => {
-                  const titulo =
-                    updates[0]?.task_titulo ??
-                    tasks.find((t) => t.id === taskId)?.titulo ??
-                    'Tarea';
-                  return (
-                    <div key={taskId} className="space-y-2">
-                      <p className="text-xs font-semibold text-[var(--text)]/50 uppercase tracking-wide">
-                        {titulo}
-                      </p>
-                      {updates.map((u) => {
-                        const tipoCfg: Record<string, { label: string; cls: string }> = {
-                          avance: {
-                            label: 'Avance',
-                            cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
-                          },
-                          cambio_estado: {
-                            label: 'Estado',
-                            cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
-                          },
-                          cambio_fecha: {
-                            label: 'Fecha',
-                            cls: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
-                          },
-                          nota: {
-                            label: 'Nota',
-                            cls: 'bg-[var(--border)]/60 text-[var(--text)]/60 border-[var(--border)]',
-                          },
-                          cambio_responsable: {
-                            label: 'Responsable',
-                            cls: 'bg-teal-500/15 text-teal-400 border-teal-500/20',
-                          },
-                        };
-                        const tc = tipoCfg[u.tipo] ?? { label: u.tipo, cls: '' };
-                        return (
-                          <div
-                            key={u.id}
-                            className="rounded-xl border border-[var(--border)] bg-[var(--panel)] px-3 py-2.5"
+      {(tasks.length > 0 || taskUpdates.length > 0) && (
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5">
+          <SectionTitle>Actualizaciones de tareas</SectionTitle>
+          {taskUpdates.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-6 text-center">
+              <Clock className="mb-2 h-8 w-8 text-[var(--text)]/20" />
+              <p className="text-sm text-[var(--text)]/50">No hay actualizaciones registradas</p>
+            </div>
+          ) : (
+            (() => {
+              // Agrupar actualizaciones por tarea y ordenar ASC dentro del
+              // grupo para que se lea como timeline (antigua → reciente).
+              const grouped = new Map<string, TaskUpdate[]>();
+              for (const u of taskUpdates) {
+                const arr = grouped.get(u.task_id) ?? [];
+                arr.push(u);
+                grouped.set(u.task_id, arr);
+              }
+              for (const arr of grouped.values()) {
+                arr.sort(
+                  (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+                );
+              }
+              const tipoCfg: Record<string, { label: string; cls: string }> = {
+                avance: {
+                  label: 'Avance',
+                  cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+                },
+                cambio_estado: {
+                  label: 'Estado',
+                  cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+                },
+                cambio_fecha: {
+                  label: 'Fecha',
+                  cls: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
+                },
+                nota: {
+                  label: 'Nota',
+                  cls: 'bg-[var(--border)]/60 text-[var(--text)]/60 border-[var(--border)]',
+                },
+                cambio_responsable: {
+                  label: 'Responsable',
+                  cls: 'bg-teal-500/15 text-teal-400 border-teal-500/20',
+                },
+              };
+              return (
+                <div className="divide-y divide-[var(--border)]">
+                  {Array.from(grouped.entries()).map(([taskId, updates]) => {
+                    const task = updates[0]?.task ?? tasks.find((t) => t.id === taskId);
+                    if (!task) return null;
+                    const estadoCfg = ESTADO_TASK[task.estado] ?? {
+                      label: task.estado,
+                      cls: '',
+                    };
+                    const asignado = empleadoMap.get(task.asignado_a ?? '');
+                    return (
+                      <div key={taskId} className="py-2.5 first:pt-0 last:pb-0">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mb-1.5">
+                          <span className="text-sm font-medium text-[var(--text)]">
+                            {task.titulo}
+                          </span>
+                          <span
+                            className={`inline-flex items-center rounded-md border px-1.5 py-px text-[10px] font-medium ${estadoCfg.cls}`}
                           >
-                            <div className="flex items-center gap-2 mb-1">
-                              <span
-                                className={`inline-flex items-center rounded-lg border px-2 py-0.5 text-[10px] font-medium ${tc.cls}`}
-                              >
-                                {tc.label}
-                              </span>
-                              <span className="text-[10px] text-[var(--text-subtle)]">
-                                {u.usuario?.nombre ?? 'Sistema'}
-                              </span>
-                              <span className="text-[10px] text-[var(--text)]/30 ml-auto">
-                                {formatDate(u.created_at)}
-                              </span>
-                            </div>
-                            {u.contenido && (
-                              <p className="text-sm text-[var(--text)]/80">{u.contenido}</p>
-                            )}
-                            {u.valor_anterior != null && u.valor_nuevo != null && (
-                              <p className="text-xs text-[var(--text)]/50">
-                                {u.tipo === 'cambio_estado'
-                                  ? `${ESTADO_TASK[u.valor_anterior]?.label ?? u.valor_anterior} → ${ESTADO_TASK[u.valor_nuevo]?.label ?? u.valor_nuevo}`
-                                  : `${u.valor_anterior || '—'} → ${u.valor_nuevo || '—'}`}
-                              </p>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  );
-                })}
-              </div>
-            );
-          })()
-        )}
-      </div>
+                            {estadoCfg.label}
+                          </span>
+                          <span className="text-[10px] text-[var(--text)]/45">
+                            {asignado?.nombre ?? '—'}
+                            {task.fecha_vence && ` · vence ${formatDate(task.fecha_vence)}`}
+                            {` · ${updates.length} ${updates.length === 1 ? 'nota' : 'notas'}`}
+                          </span>
+                        </div>
+                        <ul className="space-y-1 pl-2 border-l-2 border-[var(--border)]">
+                          {updates.map((u) => {
+                            const tc = tipoCfg[u.tipo] ?? { label: u.tipo, cls: '' };
+                            const hasDelta = u.valor_anterior != null && u.valor_nuevo != null;
+                            return (
+                              <li key={u.id} className="text-xs leading-snug text-[var(--text)]/80">
+                                <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-[var(--text)]/45">
+                                  <span
+                                    className={`inline-flex items-center rounded border px-1.5 py-px font-medium ${tc.cls}`}
+                                  >
+                                    {tc.label}
+                                  </span>
+                                  <span className="text-[var(--text)]/65">
+                                    {u.usuario?.nombre ?? 'Sistema'}
+                                  </span>
+                                  <span>·</span>
+                                  <span>{formatDateTime(u.created_at)}</span>
+                                </div>
+                                {u.contenido && (
+                                  <p className="text-xs text-[var(--text)]/80 whitespace-pre-wrap">
+                                    {u.contenido}
+                                  </p>
+                                )}
+                                {hasDelta && (
+                                  <p className="text-[11px] text-[var(--text)]/50">
+                                    {u.tipo === 'cambio_estado'
+                                      ? `${ESTADO_TASK[u.valor_anterior!]?.label ?? u.valor_anterior} → ${ESTADO_TASK[u.valor_nuevo!]?.label ?? u.valor_nuevo}`
+                                      : `${u.valor_anterior || '—'} → ${u.valor_nuevo || '—'}`}
+                                  </p>
+                                )}
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })()
+          )}
+        </div>
+      )}
 
       {/* Participants */}
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5">
@@ -1490,7 +1723,7 @@ function JuntaDetailInner() {
 
       {/* Add task dialog */}
       <TasksCreateForm
-        variant="simple"
+        variant="rich"
         open={showAddTask}
         onOpenChange={setShowAddTask}
         value={taskForm}
@@ -1566,6 +1799,40 @@ function JuntaDetailInner() {
                 <CheckCircle2 className="h-4 w-4" />
               )}
               Sí, terminar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <DialogContent className="max-w-sm rounded-3xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]">
+          <DialogHeader>
+            <DialogTitle className="text-red-400">Eliminar junta</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-[var(--text)]/70 pb-2">
+            Esta acción es <strong>irreversible</strong>. Se eliminará la junta, su asistencia y se
+            desvincularán las tareas asociadas. ¿Estás seguro?
+          </p>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(false)}
+              disabled={deleting}
+              className="rounded-xl border-[var(--border)] text-[var(--text)]"
+            >
+              Cancelar
+            </Button>
+            <Button
+              onClick={handleDelete}
+              disabled={deleting}
+              className="gap-1.5 rounded-xl bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+            >
+              {deleting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="h-4 w-4" />
+              )}
+              Sí, eliminar
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/rdb/admin/juntas/[id]/page.tsx
+++ b/app/rdb/admin/juntas/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import { normalizeHtmlImagesToPaths, rewriteHtmlImagesToSigned } from '@/lib/adjuntos';
+import { htmlHasCodaImages, importCodaImagesInHtml } from '@/lib/coda-paste-import';
 import { fetchJuntaUpdates } from '@/lib/juntas/fetch-updates';
 import { TasksCreateForm } from '@/components/tasks/tasks-create-form';
 import { emptyTaskForm, type TaskFormValues } from '@/components/tasks/tasks-shared';
@@ -134,23 +135,32 @@ const ESTADO_TASK: Record<string, { label: string; cls: string }> = {
 
 const PRIORIDAD_OPTIONS = ['Urgente', 'Alta', 'Media', 'Baja'] as const;
 
-const TIPO_CONFIG: Record<string, string> = {
-  operativa: '⚙️ Operativa',
-  directiva: '🏛️ Directiva',
-  seguimiento: '📊 Seguimiento',
-  emergencia: '🚨 Emergencia',
-  Consejo: '🏢 Consejo',
-  'Comite Ejecutivo': '👔 Comité Ejecutivo',
-  Ventas: '💰 Ventas',
-  'Atención PosVenta': '🔧 Atención PosVenta',
-  Administración: '📁 Administración',
-  Mercadotecnia: '📣 Mercadotecnia',
-  Construcción: '🏗️ Construcción',
-  'Compras y Admon. Inventario': '📦 Compras y Admon. Inventario',
-  Maquinaria: '🚜 Maquinaria',
-  Proyectos: '🗂️ Proyectos',
-  'Rincón del Bosque': '🌲 Rincón del Bosque',
-};
+const TIPO_OPTIONS: { value: string; label: string; icon: string }[] = [
+  { value: 'Comité Ejecutivo', label: 'Comité Ejecutivo', icon: '👔' },
+  { value: 'Consejo', label: 'Consejo', icon: '🏢' },
+  { value: 'Ventas', label: 'Ventas', icon: '💰' },
+  { value: 'Atención PosVenta', label: 'Atención PosVenta', icon: '🔧' },
+  { value: 'Administración', label: 'Administración', icon: '📁' },
+  { value: 'Mercadotecnia', label: 'Mercadotecnia', icon: '📣' },
+  { value: 'Construcción', label: 'Construcción', icon: '🏗️' },
+  { value: 'Compras y Admon. Inventario', label: 'Compras y Admon. Inv.', icon: '📦' },
+  { value: 'Maquinaria', label: 'Maquinaria', icon: '🚜' },
+  { value: 'Proyectos', label: 'Proyectos', icon: '🗂️' },
+  { value: 'Rincón del Bosque', label: 'Rincón del Bosque', icon: '🌲' },
+  { value: 'Extraordinaria', label: 'Extraordinaria', icon: '🚨' },
+  { value: 'Otro', label: 'Otro', icon: '📌' },
+];
+
+const TIPO_CONFIG: Record<string, string> = Object.fromEntries([
+  ...TIPO_OPTIONS.map((t) => [t.value, `${t.icon} ${t.label}`]),
+  ['Comite Ejecutivo', '👔 Comité Ejecutivo'],
+  ['Junta Operativa', '⚙️ Junta Operativa'],
+  ['Junta de Área', '📋 Junta de Área'],
+  ['operativa', '⚙️ Operativa'],
+  ['directiva', '🏛️ Directiva'],
+  ['seguimiento', '📊 Seguimiento'],
+  ['emergencia', '🚨 Emergencia'],
+]);
 
 function toDatetimeLocal(iso: string) {
   const d = new Date(iso);
@@ -162,6 +172,19 @@ function formatDate(s: string | null) {
   if (!s) return '—';
   const d = new Date(s.includes('T') ? s : `${s}T00:00:00`);
   return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+function formatDateTime(s: string | null) {
+  if (!s) return '—';
+  const d = new Date(s);
+  return d.toLocaleString('es-MX', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  });
 }
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
@@ -177,6 +200,7 @@ function JuntaDetailInner() {
   const router = useRouter();
   const id = params.id as string;
   const supabase = createSupabaseERPClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [junta, setJunta] = useState<Junta | null>(null);
   const [asistencia, setAsistencia] = useState<Asistencia[]>([]);
@@ -186,6 +210,7 @@ function JuntaDetailInner() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [uploadingImage, setUploadingImage] = useState(false);
 
   const [titulo, setTitulo] = useState('');
   const [fechaHora, setFechaHora] = useState('');
@@ -199,6 +224,9 @@ function JuntaDetailInner() {
   const [showTerminarDialog, setShowTerminarDialog] = useState(false);
   const [reenviando, setReenviando] = useState(false);
   const [showReenviarDialog, setShowReenviarDialog] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [isDireccion, setIsDireccion] = useState(false);
 
   const editor = useEditor({
     // TipTap v3 exige `immediatelyRender: false` para Next.js SSR/RSC; evita
@@ -207,7 +235,7 @@ function JuntaDetailInner() {
     extensions: [
       StarterKit,
       Underline,
-      Image,
+      Image.configure({ inline: false, allowBase64: false }),
       Table.configure({ resizable: true }),
       TableRow,
       TableHeader,
@@ -217,6 +245,37 @@ function JuntaDetailInner() {
     editorProps: {
       attributes: {
         class: 'prose prose-sm max-w-none focus:outline-none min-h-[200px] p-4 text-[var(--text)]',
+      },
+      handleDrop(view, event, _slice, moved) {
+        if (moved || !event.dataTransfer?.files.length) return false;
+        const file = event.dataTransfer.files[0];
+        if (!file?.type.startsWith('image/')) return false;
+        event.preventDefault();
+        void handleImageUpload(file);
+        return true;
+      },
+      handlePaste(view, event) {
+        // 1) Single image blob (right-click → Copy image in Coda, or screenshot)
+        const items = event.clipboardData?.items;
+        if (items) {
+          for (const item of Array.from(items)) {
+            if (item.type.startsWith('image/')) {
+              event.preventDefault();
+              const file = item.getAsFile();
+              if (file) void handleImageUpload(file);
+              return true;
+            }
+          }
+        }
+        // 2) HTML paste with external Coda <img> URLs (Cmd+A + Cmd+C from Coda junta).
+        //    Intercept only when we actually see Coda-hosted image references.
+        const html = event.clipboardData?.getData('text/html') || '';
+        if (htmlHasCodaImages(html)) {
+          event.preventDefault();
+          void handlePasteWithCodaImages(html);
+          return true;
+        }
+        return false;
       },
     },
   });
@@ -234,6 +293,82 @@ function JuntaDetailInner() {
   const [showAddUpdate, setShowAddUpdate] = useState<string | null>(null);
   const [updateForm, setUpdateForm] = useState({ contenido: '', nuevoEstado: '', nuevaFecha: '' });
   const [savingUpdate, setSavingUpdate] = useState(false);
+
+  const handlePasteWithCodaImages = async (html: string) => {
+    if (!editor) return;
+    setUploadingImage(true);
+    try {
+      const { html: rewritten, imported, failed } = await importCodaImagesInHtml(html, id);
+      editor.chain().focus().insertContent(rewritten).run();
+      if (failed > 0) {
+        alert(
+          `Imágenes importadas: ${imported}. Fallaron ${failed} — revisa la consola del navegador.`
+        );
+      }
+    } finally {
+      setUploadingImage(false);
+    }
+  };
+
+  const handleImageUpload = async (file: File) => {
+    if (!editor || uploadingImage) return;
+    setUploadingImage(true);
+    try {
+      const ext = file.name.split('.').pop() ?? 'png';
+      const filename = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+      const path = `juntas/${id}/${filename}`;
+      const { error: uploadErr } = await supabase.storage
+        .from('adjuntos')
+        .upload(path, file, { upsert: false });
+      if (uploadErr) {
+        alert(`Error al subir imagen: ${uploadErr.message}`);
+        return;
+      }
+      editor
+        .chain()
+        .focus()
+        .setImage({ src: `/api/adjuntos/${path}` })
+        .run();
+    } finally {
+      setUploadingImage(false);
+    }
+  };
+
+  const handleInsertImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void handleImageUpload(file);
+    e.target.value = '';
+  };
+
+  const handleDelete = async () => {
+    if (!junta) return;
+    setDeleting(true);
+    try {
+      await supabase.schema('erp').from('juntas_asistencia').delete().eq('junta_id', junta.id);
+      await supabase
+        .schema('erp')
+        .from('tasks')
+        .update({ entidad_tipo: null, entidad_id: null })
+        .eq('entidad_tipo', 'junta')
+        .eq('entidad_id', junta.id);
+      const { error: err } = await supabase
+        .schema('erp')
+        .from('juntas')
+        .delete()
+        .eq('id', junta.id);
+      if (err) {
+        alert(`Error al eliminar: ${err.message}`);
+        return;
+      }
+      router.push('/rdb/admin/juntas');
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   const fetchAll = useCallback(async () => {
     const { data: juntaData, error: jErr } = await supabase
@@ -357,6 +492,19 @@ function JuntaDetailInner() {
         nombre: [e.persona?.nombre, e.persona?.apellido_paterno].filter(Boolean).join(' '),
       }))
     );
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user?.email) {
+      const { data: coreUser } = await supabase
+        .schema('core')
+        .from('usuarios')
+        .select('rol')
+        .eq('email', user.email)
+        .maybeSingle();
+      if (coreUser?.rol === 'admin') setIsDireccion(true);
+    }
 
     setLoading(false);
   }, [id, supabase, editor]);
@@ -874,6 +1022,14 @@ function JuntaDetailInner() {
 
   return (
     <div className="space-y-6 pb-12">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-center gap-3">
           <Button
@@ -902,6 +1058,17 @@ function JuntaDetailInner() {
           </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          {isDireccion && (
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(true)}
+              disabled={deleting}
+              className="gap-1.5 rounded-xl border-red-500/40 text-red-500 hover:bg-red-500/10 hover:border-red-500/60"
+            >
+              <Trash2 className="h-4 w-4" />
+              Eliminar
+            </Button>
+          )}
           {estado !== 'completada' && estado !== 'cancelada' && (
             <Button
               variant="outline"
@@ -998,9 +1165,9 @@ function JuntaDetailInner() {
             <Combobox
               value={tipo ?? ''}
               onChange={(v) => setTipo(v)}
-              options={Object.entries(TIPO_CONFIG).map(([k, v]) => ({
-                value: k,
-                label: String(v),
+              options={TIPO_OPTIONS.map((t) => ({
+                value: t.value,
+                label: `${t.icon} ${t.label}`,
               }))}
               placeholder="Sin tipo"
               allowClear
@@ -1023,24 +1190,32 @@ function JuntaDetailInner() {
       <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5">
         <SectionTitle>Notas y minuta</SectionTitle>
         <div className="rounded-xl border border-[var(--border)]">
-          <EditorToolbar editor={editor} />
+          <EditorToolbar editor={editor} onInsertImage={handleInsertImageClick} />
           <div className="rounded-b-xl bg-[var(--panel)]">
             <style>{MINUTA_EDITOR_STYLES}</style>
             <EditorContent editor={editor} />
           </div>
         </div>
-        <p className="mt-2 text-[10px] text-[var(--text-subtle)]">
-          {estado !== 'completada' && estado !== 'cancelada'
-            ? autoSaveStatus === 'saving'
-              ? '⏳ Guardando notas...'
-              : autoSaveStatus === 'saved'
-                ? '✅ Notas guardadas'
-                : 'Las notas se auto-guardan mientras escribes'
-            : 'Las notas se guardan al presionar "Guardar cambios"'}
-        </p>
-        {lastPoll && estado !== 'completada' && estado !== 'cancelada' && (
-          <span className="text-[10px] text-[var(--text)]/30">• Sync: {lastPoll}</span>
-        )}
+        <div className="flex items-center gap-2 mt-2">
+          <p className="text-[10px] text-[var(--text-subtle)] flex-1">
+            {estado !== 'completada' && estado !== 'cancelada'
+              ? autoSaveStatus === 'saving'
+                ? '⏳ Guardando notas...'
+                : autoSaveStatus === 'saved'
+                  ? '✅ Notas guardadas'
+                  : 'Las notas se auto-guardan mientras escribes'
+              : 'Las notas se guardan al presionar "Guardar cambios"'}
+          </p>
+          {uploadingImage && (
+            <span className="text-[10px] text-[var(--accent)] flex items-center gap-1">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Subiendo imagen...
+            </span>
+          )}
+          {lastPoll && estado !== 'completada' && estado !== 'cancelada' && (
+            <span className="text-[10px] text-[var(--text)]/30">• Sync: {lastPoll}</span>
+          )}
+        </div>
       </div>
 
       {/* ── Actualizaciones de tareas ─────────────────────────── */}
@@ -1054,77 +1229,102 @@ function JuntaDetailInner() {
             </div>
           ) : (
             (() => {
+              // Agrupar actualizaciones por tarea y ordenar ASC dentro del
+              // grupo para que se lea como timeline (antigua → reciente).
               const grouped = new Map<string, TaskUpdate[]>();
               for (const u of taskUpdates) {
                 const arr = grouped.get(u.task_id) ?? [];
                 arr.push(u);
                 grouped.set(u.task_id, arr);
               }
+              for (const arr of grouped.values()) {
+                arr.sort(
+                  (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+                );
+              }
+              const tipoCfg: Record<string, { label: string; cls: string }> = {
+                avance: {
+                  label: 'Avance',
+                  cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+                },
+                cambio_estado: {
+                  label: 'Estado',
+                  cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+                },
+                cambio_fecha: {
+                  label: 'Fecha',
+                  cls: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
+                },
+                nota: {
+                  label: 'Nota',
+                  cls: 'bg-[var(--border)]/60 text-[var(--text)]/60 border-[var(--border)]',
+                },
+                cambio_responsable: {
+                  label: 'Responsable',
+                  cls: 'bg-teal-500/15 text-teal-400 border-teal-500/20',
+                },
+              };
               return (
-                <div className="space-y-4">
+                <div className="divide-y divide-[var(--border)]">
                   {Array.from(grouped.entries()).map(([taskId, updates]) => {
                     const task = updates[0]?.task ?? tasks.find((t) => t.id === taskId);
                     if (!task) return null;
+                    const estadoCfg = ESTADO_TASK[task.estado] ?? {
+                      label: task.estado,
+                      cls: '',
+                    };
+                    const asignado = empleadoMap.get(task.asignado_a ?? '');
                     return (
-                      <div key={taskId} className="space-y-2">
-                        <p className="text-xs font-semibold text-[var(--text)]/50 uppercase tracking-wide">
-                          {task.titulo}
-                        </p>
-                        {updates.map((u) => {
-                          const tipoCfg: Record<string, { label: string; cls: string }> = {
-                            avance: {
-                              label: 'Avance',
-                              cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
-                            },
-                            cambio_estado: {
-                              label: 'Estado',
-                              cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
-                            },
-                            cambio_fecha: {
-                              label: 'Fecha',
-                              cls: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
-                            },
-                            nota: {
-                              label: 'Nota',
-                              cls: 'bg-[var(--border)]/60 text-[var(--text)]/60 border-[var(--border)]',
-                            },
-                            cambio_responsable: {
-                              label: 'Responsable',
-                              cls: 'bg-teal-500/15 text-teal-400 border-teal-500/20',
-                            },
-                          };
-                          const tc = tipoCfg[u.tipo] ?? { label: u.tipo, cls: '' };
-                          return (
-                            <div
-                              key={u.id}
-                              className="rounded-xl border border-[var(--border)] bg-[var(--panel)] px-3 py-2.5"
-                            >
-                              <div className="flex items-center gap-2 mb-1">
-                                <span
-                                  className={`inline-flex items-center rounded-lg border px-2 py-0.5 text-[10px] font-medium ${tc.cls}`}
-                                >
-                                  {tc.label}
-                                </span>
-                                <span className="text-[10px] text-[var(--text-subtle)]">
-                                  {u.usuario?.nombre ?? 'Sistema'}
-                                </span>
-                                <span className="text-[10px] text-[var(--text)]/30 ml-auto">
-                                  {formatDate(u.created_at)}
-                                </span>
-                              </div>
-                              {u.contenido && (
-                                <p className="text-sm text-[var(--text)]/80">{u.contenido}</p>
-                              )}
-                              {u.valor_anterior != null && u.valor_nuevo != null && (
-                                <p className="text-xs text-[var(--text)]/50">
-                                  {u.tipo === 'cambio_estado'
-                                    ? `${ESTADO_TASK[u.valor_anterior]?.label ?? u.valor_anterior} → ${ESTADO_TASK[u.valor_nuevo]?.label ?? u.valor_nuevo}`
-                                    : `${u.valor_anterior || '—'} → ${u.valor_nuevo || '—'}`}
-                                </p>
-                              )}
-                            </div>
-                          );
-                        })}
+                      <div key={taskId} className="py-2.5 first:pt-0 last:pb-0">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mb-1.5">
+                          <span className="text-sm font-medium text-[var(--text)]">
+                            {task.titulo}
+                          </span>
+                          <span
+                            className={`inline-flex items-center rounded-md border px-1.5 py-px text-[10px] font-medium ${estadoCfg.cls}`}
+                          >
+                            {estadoCfg.label}
+                          </span>
+                          <span className="text-[10px] text-[var(--text)]/45">
+                            {asignado?.nombre ?? '—'}
+                            {task.fecha_vence && ` · vence ${formatDate(task.fecha_vence)}`}
+                            {` · ${updates.length} ${updates.length === 1 ? 'nota' : 'notas'}`}
+                          </span>
+                        </div>
+                        <ul className="space-y-1 pl-2 border-l-2 border-[var(--border)]">
+                          {updates.map((u) => {
+                            const tc = tipoCfg[u.tipo] ?? { label: u.tipo, cls: '' };
+                            const hasDelta = u.valor_anterior != null && u.valor_nuevo != null;
+                            return (
+                              <li key={u.id} className="text-xs leading-snug text-[var(--text)]/80">
+                                <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-[var(--text)]/45">
+                                  <span
+                                    className={`inline-flex items-center rounded border px-1.5 py-px font-medium ${tc.cls}`}
+                                  >
+                                    {tc.label}
+                                  </span>
+                                  <span className="text-[var(--text)]/65">
+                                    {u.usuario?.nombre ?? 'Sistema'}
+                                  </span>
+                                  <span>·</span>
+                                  <span>{formatDateTime(u.created_at)}</span>
+                                </div>
+                                {u.contenido && (
+                                  <p className="text-xs text-[var(--text)]/80 whitespace-pre-wrap">
+                                    {u.contenido}
+                                  </p>
+                                )}
+                                {hasDelta && (
+                                  <p className="text-[11px] text-[var(--text)]/50">
+                                    {u.tipo === 'cambio_estado'
+                                      ? `${ESTADO_TASK[u.valor_anterior!]?.label ?? u.valor_anterior} → ${ESTADO_TASK[u.valor_nuevo!]?.label ?? u.valor_nuevo}`
+                                      : `${u.valor_anterior || '—'} → ${u.valor_nuevo || '—'}`}
+                                  </p>
+                                )}
+                              </li>
+                            );
+                          })}
+                        </ul>
                       </div>
                     );
                   })}
@@ -1479,7 +1679,7 @@ function JuntaDetailInner() {
       </Sheet>
 
       <TasksCreateForm
-        variant="simple"
+        variant="rich"
         open={showAddTask}
         onOpenChange={setShowAddTask}
         value={taskForm}
@@ -1553,6 +1753,40 @@ function JuntaDetailInner() {
                 <CheckCircle2 className="h-4 w-4" />
               )}
               Sí, terminar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <DialogContent className="max-w-sm rounded-3xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]">
+          <DialogHeader>
+            <DialogTitle className="text-red-400">Eliminar junta</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-[var(--text)]/70 pb-2">
+            Esta acción es <strong>irreversible</strong>. Se eliminará la junta, su asistencia y se
+            desvincularán las tareas asociadas. ¿Estás seguro?
+          </p>
+          <DialogFooter className="gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(false)}
+              disabled={deleting}
+              className="rounded-xl border-[var(--border)] text-[var(--text)]"
+            >
+              Cancelar
+            </Button>
+            <Button
+              onClick={handleDelete}
+              disabled={deleting}
+              className="gap-1.5 rounded-xl bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+            >
+              {deleting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="h-4 w-4" />
+              )}
+              Sí, eliminar
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/lib/juntas/email.ts
+++ b/lib/juntas/email.ts
@@ -11,9 +11,52 @@ import { fetchJuntaUpdates } from '@/lib/juntas/fetch-updates';
 // La firma es server-side con service role, sin costo por TTLs largos.
 export const EMAIL_IMAGE_TTL_SECONDS = 365 * 24 * 60 * 60;
 
-export const CONSEJO_EMAIL = 'consejo@dilesa.mx';
+// Asset base para resolver rutas relativas (/logos/foo.jpg) en correos enviados.
+const ASSET_BASE_URL = 'https://bsop.io';
 
-const HEADER_IMAGE_URL = 'https://bsop.io/logos/dilesa-header.jpg';
+// Header de fallback cuando la empresa no tiene `header_url` configurado en
+// `core.empresas`. Mantener apuntando a DILESA hasta que cada empresa cargue
+// su propio asset.
+const FALLBACK_HEADER_URL = `${ASSET_BASE_URL}/logos/dilesa-header.jpg`;
+
+// Mientras cada empresa configura su propio buzón de consejo, todas usan el de
+// DILESA. Agregar entradas aquí cuando una empresa estrene el suyo.
+const CONSEJO_EMAIL_DEFAULT = 'consejo@dilesa.mx';
+const CONSEJO_EMAIL_BY_EMPRESA: Record<string, string> = {
+  'f5942ed4-7a6b-4c39-af18-67b9fbf7f479': 'consejo@dilesa.mx', // DILESA
+};
+
+// Override del display name del "From"; preserva la identidad histórica
+// (razón social) que ya estaba en uso para DILESA. Si una empresa no tiene
+// override aquí, se cae a `nombre_comercial || nombre`.
+const FROM_DISPLAY_OVERRIDE: Record<string, string> = {
+  'f5942ed4-7a6b-4c39-af18-67b9fbf7f479': 'Desarrollo Inmobiliario los Encinos', // DILESA
+};
+
+// Compat: callers externos importaban `CONSEJO_EMAIL`. Hoy nadie lo usa pero
+// se exporta para no romper integraciones futuras que lo busquen.
+export const CONSEJO_EMAIL = CONSEJO_EMAIL_DEFAULT;
+
+function resolveAssetUrl(path: string | null | undefined): string | null {
+  if (!path) return null;
+  if (/^https?:\/\//i.test(path)) return path;
+  return `${ASSET_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+function consejoEmailFor(empresaId: string | null | undefined): string {
+  if (!empresaId) return CONSEJO_EMAIL_DEFAULT;
+  return CONSEJO_EMAIL_BY_EMPRESA[empresaId] ?? CONSEJO_EMAIL_DEFAULT;
+}
+
+function fromAddressFor(empresa: {
+  id: string;
+  nombre: string;
+  nombre_comercial: string | null;
+}): string {
+  const display =
+    FROM_DISPLAY_OVERRIDE[empresa.id] || empresa.nombre_comercial?.trim() || empresa.nombre;
+  return `${display} <noreply@bsop.io>`;
+}
 
 function formatDateCST(iso: string): string {
   return new Date(iso).toLocaleString('es-MX', {
@@ -55,6 +98,8 @@ export function generateMinutaHtml(opts: {
   tareasCreadas: { titulo: string; responsable: string; fecha_compromiso: string | null }[];
   tareasCompletadas: { titulo: string; responsable: string }[];
   actualizaciones?: { tarea: string; contenido: string; tipo: string; autor: string }[];
+  empresaNombre: string;
+  headerImageUrl: string;
 }): string {
   const {
     titulo,
@@ -65,6 +110,8 @@ export function generateMinutaHtml(opts: {
     tareasCreadas,
     tareasCompletadas,
     actualizaciones,
+    empresaNombre,
+    headerImageUrl,
   } = opts;
 
   const asistentesStr =
@@ -106,7 +153,7 @@ export function generateMinutaHtml(opts: {
 
     <!-- Header Image -->
     <div style="background:#1a1a2e;">
-      <img src="${HEADER_IMAGE_URL}" alt="DILESA" style="display:block;width:100%;height:auto;" />
+      <img src="${headerImageUrl}" alt="${empresaNombre}" style="display:block;width:100%;height:auto;" />
     </div>
 
     <!-- Title Bar -->
@@ -229,6 +276,7 @@ export async function buildMinutaEmailPayload(
       ok: true;
       html: string;
       subject: string;
+      from: string;
       recipients: string[];
       asistentesCount: number;
     }
@@ -246,6 +294,35 @@ export async function buildMinutaEmailPayload(
   if (jErr || !junta) {
     return { ok: false, status: 404, error: jErr?.message ?? 'Junta not found' };
   }
+
+  // Branding por empresa: logo del header + display name del "From".
+  const empresaId = (junta as any).empresa_id as string | null;
+  const { data: empresaRow } = empresaId
+    ? await supabase
+        .schema('core')
+        .from('empresas')
+        .select('id, nombre, nombre_comercial, header_url, logo_url')
+        .eq('id', empresaId)
+        .single()
+    : { data: null };
+
+  const empresa = (empresaRow ?? {
+    id: empresaId ?? '',
+    nombre: 'BSOP',
+    nombre_comercial: null,
+    header_url: null,
+    logo_url: null,
+  }) as {
+    id: string;
+    nombre: string;
+    nombre_comercial: string | null;
+    header_url: string | null;
+    logo_url: string | null;
+  };
+
+  const headerImageUrl =
+    resolveAssetUrl(empresa.header_url) ?? resolveAssetUrl(empresa.logo_url) ?? FALLBACK_HEADER_URL;
+  const fromAddress = fromAddressFor(empresa);
 
   const { data: asistencia } = await supabase
     .schema('erp')
@@ -265,7 +342,7 @@ export async function buildMinutaEmailPayload(
     .map((a) => (a.email as string).toLowerCase());
   const enviarAConsejo = (junta as any).enviar_a_consejo ?? true;
   const recipients = enviarAConsejo
-    ? Array.from(new Set([...attendeeEmails, CONSEJO_EMAIL]))
+    ? Array.from(new Set([...attendeeEmails, consejoEmailFor(empresaId)]))
     : attendeeEmails;
 
   const { data: tasksData } = await supabase
@@ -369,12 +446,15 @@ export async function buildMinutaEmailPayload(
     tareasCreadas,
     tareasCompletadas,
     actualizaciones,
+    empresaNombre: empresa.nombre_comercial?.trim() || empresa.nombre,
+    headerImageUrl,
   });
 
   return {
     ok: true,
     html,
     subject: junta.titulo as string,
+    from: fromAddress,
     recipients,
     asistentesCount: asistentes.length,
   };
@@ -382,7 +462,7 @@ export async function buildMinutaEmailPayload(
 
 export async function sendMinutaEmail(
   resendKey: string,
-  payload: { html: string; subject: string; recipients: string[] }
+  payload: { html: string; subject: string; from: string; recipients: string[] }
 ): Promise<{ ok: true; emailId: string } | { ok: false; emailError: unknown }> {
   const emailRes = await fetch('https://api.resend.com/emails', {
     method: 'POST',
@@ -391,7 +471,7 @@ export async function sendMinutaEmail(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: 'Desarrollo Inmobiliario los Encinos <noreply@bsop.io>',
+      from: payload.from,
       to: payload.recipients,
       subject: payload.subject,
       html: payload.html,


### PR DESCRIPTION
## Problema

El bug visible: en RDB no se podían **pegar imágenes** en la minuta. En DILESA sí. Al investigar se encontró drift más amplio entre las tres páginas de detalle de junta:

- `/dilesa/admin/juntas/[id]` (1821 líneas — referencia)
- `/rdb/admin/juntas/[id]` (drift)
- `/inicio/juntas/[id]` (drift)

Más crítico: **el correo de minuta llevaba el branding de DILESA hardcodeado**, así que al terminar una junta de RDB se enviaba con logo, alt y "from" de DILESA al `consejo@dilesa.mx`.

## Cambios

### Paste de imágenes y HTML de Coda → RDB + INICIO
Portados los handlers de DILESA: `handleDrop`, `handlePaste`, `handleImageUpload`, `handlePasteWithCodaImages` + input file oculto + indicador "Subiendo imagen…". Usa `lib/coda-paste-import` que ya existía.

### Email multi-empresa (`lib/juntas/email.ts`)
- Consulta `core.empresas` por `empresa_id`
- Header con `header_url` (fallback a DILESA si la empresa no lo tiene)
- "From" con `nombre_comercial || nombre` (con override histórico para DILESA → "Desarrollo Inmobiliario los Encinos")
- Map `CONSEJO_EMAIL_BY_EMPRESA` por empresa (todas caen a `consejo@dilesa.mx` mientras cada empresa configura el suyo)
- **Update aplicado a la DB**: `core.empresas.header_url` poblado para DILESA (`/logos/dilesa-header.jpg`) y RDB (`/logos/rdb.jpg`)

### Eliminar junta → RDB + INICIO
- `handleDelete` + flag `isDireccion` (rol admin desde `core.usuarios`)
- Dialog rojo de confirmación
- Antes solo DILESA podía borrar

### Layout compacto de "Actualizaciones de tareas"
- Render con `divide-y` y timeline ASC con `formatDateTime` (hora exacta)
- En vez de cards separadas
- INICIO: cambio de shape de `TaskUpdate` (`task_titulo` → `task: { titulo, estado, asignado_a, fecha_vence }`) para alinear con DILESA/RDB

### Otras
- `TasksCreateForm` con `variant="rich"` (antes `"simple"`)
- `TIPO_OPTIONS` array con icons reemplaza `TIPO_CONFIG` static

### Pendientes
Mejoras menores (`useMemo` en `empleadoOptions`, `FieldLabel.required`, `canCreateTask`) quedaron skipeadas. Bajo impacto.

## Test plan

- [ ] Pegar una imagen (Cmd+V tras screenshot) en la minuta de una junta de RDB y de "inicio" → debe insertarla
- [ ] Cmd+A + Cmd+C desde una junta de Coda y pegar en RDB → imágenes se importan via `/api/adjuntos/import-url`
- [ ] Terminar una junta de RDB → correo llega con logo de RDB (`/logos/rdb.jpg`) y "from: Rincón del Bosque"
- [ ] Terminar una junta de DILESA → correo llega con logo DILESA y "from: Desarrollo Inmobiliario los Encinos" (sin regresión)
- [ ] Como admin, ver botón rojo "Eliminar" en RDB e inicio → eliminar funciona y redirige
- [ ] Como no-admin, no ver el botón "Eliminar"
- [ ] Sección "Actualizaciones de tareas" en RDB: ver formato compacto con timeline (estado badge, responsable, fecha vence en encabezado)

## Notas

Refs: política de módulos compartidos multi-empresa (memoria de proyecto). **El siguiente paso natural** es extraer `<JuntaDetail empresaId={...} />` como componente compartido para evitar la próxima ronda de drift — son ~1700 líneas duplicadas en 3 lugares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)