### PR TITLE
feat(proveedores-csf-ai): Sprint 2.A — endpoint create-with-csf

### DIFF
--- a/app/api/proveedores/create-with-csf/route.ts
+++ b/app/api/proveedores/create-with-csf/route.ts
@@ -1,0 +1,294 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public` por default; para leer/escribir
+ * en `erp` usamos `as any`. Es el mismo patrón que el resto del proyecto
+ * (ver app/api/documentos/[id]/extract/route.ts).
+ */
+
+/**
+ * POST /api/proveedores/create-with-csf
+ *
+ * Crea un proveedor nuevo a partir de los datos extraídos de su CSF (Sprint 1.B)
+ * más el PDF original. El cliente arma el flujo así:
+ *
+ *   1. Sube CSF a `/api/proveedores/extract-csf` → recibe los campos extraídos.
+ *   2. UI muestra los campos pre-llenados; el usuario revisa/corrige.
+ *   3. Al guardar, llama a este endpoint con FormData:
+ *        - `file`: el mismo PDF que se subió a extract-csf.
+ *        - `payload`: JSON con { empresa_id, extraccion, proveedor_extras? }.
+ *
+ * Persistencia (sin transacción explícita — orden recuperable):
+ *   1. Dedup por (empresa_id, rfc, activo=true) en `erp.personas`. Si ya
+ *      existe → 409 con `existing_persona_id` y `existing_proveedor_id`.
+ *   2. INSERT erp.personas (con tipo_persona, nombre/razón social, apellidos,
+ *      rfc, curp, tipo='proveedor').
+ *   3. INSERT erp.proveedores (link + extras opcionales).
+ *   4. Upload PDF a bucket `adjuntos` en `proveedores/{empresa_id}/{persona_id}/csf-{ts}.pdf`.
+ *   5. INSERT erp.adjuntos (entidad_tipo='persona', rol='csf').
+ *   6. INSERT erp.personas_datos_fiscales (con csf_adjunto_id apuntando al row creado).
+ *
+ * Si falla después del paso 2, devuelve 500 indicando qué quedó persistido
+ * para que el cliente pueda recuperar via flujos de update existentes.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { CreateProveedorPayloadSchema } from '@/lib/proveedores/extract-csf';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+const BUCKET = 'adjuntos';
+const MAX_INCOMING_BYTES = 50 * 1024 * 1024; // 50 MB
+
+export async function POST(req: NextRequest) {
+  // 1) Auth
+  const userSupa = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await userSupa.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+  }
+
+  // 2) Parse multipart
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `multipart inválido: ${msg}` }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  const payloadRaw = formData.get('payload');
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'Falta el campo "file" (multipart/form-data).' },
+      { status: 400 }
+    );
+  }
+  if (file.type && file.type !== 'application/pdf') {
+    return NextResponse.json(
+      { error: `Tipo de archivo no soportado: ${file.type}. Solo application/pdf.` },
+      { status: 415 }
+    );
+  }
+  if (file.size > MAX_INCOMING_BYTES) {
+    return NextResponse.json(
+      { error: `Archivo muy grande (${(file.size / 1024 / 1024).toFixed(1)} MB). Máximo 50 MB.` },
+      { status: 413 }
+    );
+  }
+  if (typeof payloadRaw !== 'string' || !payloadRaw.length) {
+    return NextResponse.json(
+      { error: 'Falta el campo "payload" (JSON con empresa_id, extraccion, proveedor_extras?).' },
+      { status: 400 }
+    );
+  }
+
+  // 3) Validate payload
+  let payload;
+  try {
+    payload = CreateProveedorPayloadSchema.parse(JSON.parse(payloadRaw));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  const { empresa_id, extraccion, proveedor_extras } = payload;
+  const rfcNormalized = extraccion.rfc.trim().toUpperCase();
+
+  // 4) Dedup por RFC en esta empresa. Usamos admin para que sea independiente
+  //    de RLS — la verificación de empresa_id se hace en el INSERT (RLS de
+  //    erp.personas requiere fn_has_empresa o fn_is_admin).
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const { data: existingPersona, error: dedupErr } = await (admin.schema('erp') as any)
+    .from('personas')
+    .select('id')
+    .eq('empresa_id', empresa_id)
+    .eq('rfc', rfcNormalized)
+    .eq('activo', true)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (dedupErr) {
+    return NextResponse.json({ error: `dedup query: ${dedupErr.message}` }, { status: 500 });
+  }
+
+  if (existingPersona) {
+    const { data: existingProv } = await (admin.schema('erp') as any)
+      .from('proveedores')
+      .select('id')
+      .eq('empresa_id', empresa_id)
+      .eq('persona_id', existingPersona.id)
+      .is('deleted_at', null)
+      .maybeSingle();
+
+    return NextResponse.json(
+      {
+        error: 'rfc_duplicado',
+        existing_persona_id: existingPersona.id,
+        existing_proveedor_id: existingProv?.id ?? null,
+      },
+      { status: 409 }
+    );
+  }
+
+  // 5) INSERT erp.personas — usamos user client para que RLS valide acceso a
+  //    la empresa. Si el user no pertenece a empresa_id, RLS bloquea aquí.
+  const isMoral = extraccion.tipo_persona === 'moral';
+  const personaInsert = {
+    empresa_id,
+    tipo_persona: extraccion.tipo_persona,
+    tipo: 'proveedor',
+    // Convención del repo: para morales, `nombre` = razón social (lo que la
+    // UI muestra como nombre principal). Razón social oficial también vive
+    // en personas_datos_fiscales para preservar la versión literal del SAT.
+    nombre: isMoral
+      ? (extraccion.razon_social ?? 'SIN NOMBRE')
+      : (extraccion.nombre ?? 'SIN NOMBRE'),
+    apellido_paterno: isMoral ? null : extraccion.apellido_paterno,
+    apellido_materno: isMoral ? null : extraccion.apellido_materno,
+    rfc: rfcNormalized,
+    curp: extraccion.curp,
+  };
+
+  const { data: persona, error: personaErr } = await (userSupa.schema('erp') as any)
+    .from('personas')
+    .insert(personaInsert)
+    .select('id')
+    .single();
+
+  if (personaErr) {
+    const isRlsErr = /row-level security|permission denied/i.test(personaErr.message);
+    return NextResponse.json(
+      { error: `insert persona: ${personaErr.message}` },
+      { status: isRlsErr ? 403 : 500 }
+    );
+  }
+
+  const personaId: string = persona.id;
+  const created: {
+    persona_id: string;
+    proveedor_id?: string;
+    adjunto_id?: string;
+    datos_fiscales_id?: string;
+  } = {
+    persona_id: personaId,
+  };
+
+  // 6) INSERT erp.proveedores
+  const proveedorInsert = {
+    empresa_id,
+    persona_id: personaId,
+    activo: true,
+    codigo: proveedor_extras?.codigo ?? null,
+    condiciones_pago: proveedor_extras?.condiciones_pago ?? null,
+    limite_credito: proveedor_extras?.limite_credito ?? null,
+    categoria: proveedor_extras?.categoria ?? null,
+  };
+
+  const { data: proveedor, error: proveedorErr } = await (userSupa.schema('erp') as any)
+    .from('proveedores')
+    .insert(proveedorInsert)
+    .select('id')
+    .single();
+
+  if (proveedorErr) {
+    return NextResponse.json(
+      { error: `insert proveedor: ${proveedorErr.message}`, partial: created },
+      { status: 500 }
+    );
+  }
+  created.proveedor_id = proveedor.id;
+
+  // 7) Upload PDF al bucket
+  const ts = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80);
+  const path = `proveedores/${empresa_id}/${personaId}/csf-${ts}-${safeName}`;
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const { error: uploadErr } = await admin.storage.from(BUCKET).upload(path, bytes, {
+    contentType: 'application/pdf',
+    upsert: false,
+  });
+
+  if (uploadErr) {
+    return NextResponse.json(
+      { error: `upload csf: ${uploadErr.message}`, partial: created },
+      { status: 500 }
+    );
+  }
+
+  // 8) INSERT erp.adjuntos
+  const adjuntoInsert = {
+    empresa_id,
+    entidad_tipo: 'persona',
+    entidad_id: personaId,
+    rol: 'csf',
+    nombre: file.name,
+    url: path,
+    tipo_mime: 'application/pdf',
+    tamano_bytes: file.size,
+    uploaded_by: user.id,
+  };
+
+  const { data: adjunto, error: adjuntoErr } = await (userSupa.schema('erp') as any)
+    .from('adjuntos')
+    .insert(adjuntoInsert)
+    .select('id')
+    .single();
+
+  if (adjuntoErr) {
+    return NextResponse.json(
+      { error: `insert adjunto: ${adjuntoErr.message}`, partial: created },
+      { status: 500 }
+    );
+  }
+  created.adjunto_id = adjunto.id;
+
+  // 9) INSERT erp.personas_datos_fiscales
+  const datosFiscalesInsert = {
+    empresa_id,
+    persona_id: personaId,
+    razon_social: extraccion.razon_social,
+    nombre_comercial: extraccion.nombre_comercial,
+    regimen_fiscal_codigo: extraccion.regimen_fiscal_codigo,
+    regimen_fiscal_nombre: extraccion.regimen_fiscal_nombre,
+    regimenes_adicionales: extraccion.regimenes_adicionales,
+    domicilio_calle: extraccion.domicilio_calle,
+    domicilio_num_ext: extraccion.domicilio_num_ext,
+    domicilio_num_int: extraccion.domicilio_num_int,
+    domicilio_colonia: extraccion.domicilio_colonia,
+    domicilio_cp: extraccion.domicilio_cp,
+    domicilio_municipio: extraccion.domicilio_municipio,
+    domicilio_estado: extraccion.domicilio_estado,
+    obligaciones: extraccion.obligaciones,
+    csf_adjunto_id: adjunto.id,
+    csf_fecha_emision: extraccion.fecha_emision,
+    fecha_inicio_operaciones: extraccion.fecha_inicio_operaciones,
+  };
+
+  const { data: datosFiscales, error: datosErr } = await (userSupa.schema('erp') as any)
+    .from('personas_datos_fiscales')
+    .insert(datosFiscalesInsert)
+    .select('id')
+    .single();
+
+  if (datosErr) {
+    return NextResponse.json(
+      { error: `insert personas_datos_fiscales: ${datosErr.message}`, partial: created },
+      { status: 500 }
+    );
+  }
+  created.datos_fiscales_id = datosFiscales.id;
+
+  return NextResponse.json({ ok: true, ...created });
+}

--- a/docs/planning/proveedores-csf-ai.md
+++ b/docs/planning/proveedores-csf-ai.md
@@ -70,17 +70,25 @@ El módulo de Documentos ya tiene el patrón de extracción IA con Claude (`/api
 - [x] `supabase/SCHEMA_REF.md` regenerado con `npm run schema:ref`.
 - [x] `types/supabase.ts` actualizado con los nuevos types (manualmente, `npm run db:types` bloqueado en sandbox).
 
-### Sprint 1.B — Endpoint de extracción IA
+### Sprint 1.B — Endpoint de extracción IA ✅
 
-- [ ] `POST /api/proveedores/extract-csf` que reciba PDF, lo procese con Claude usando schema dedicado a CSF (todos los campos del ADR-007), y devuelva los datos pre-llenados sin persistir. Reutiliza `lib/documentos/extraction-core.ts`.
-- [ ] Tests unitarios del schema de extracción con CSFs reales (3-5 PDFs de ejemplo, físicas y morales).
+- [x] `POST /api/proveedores/extract-csf` que recibe PDF (multipart/form-data), lo procesa con Claude usando schema dedicado a CSF, devuelve los datos pre-llenados sin persistir. Reutiliza `lib/documentos/extraction-core.ts` (anthropic, MODELO_CLAUDE, ensurePdfFitsForClaude).
+- [x] Schema `CsfExtraccionSchema` (Zod) en `lib/proveedores/extract-csf.ts` cubre todos los campos del ADR-007.
+- [x] Tests unitarios del schema (9 tests pasando — moral, física, múltiples regímenes, rechazos).
+- _Smoke con CSFs reales pendiente para cuando exista UI Sprint 2 (alternativa: curl)._
 
-### Sprint 2 — UI de alta nueva (RDB primero)
+### Sprint 2.A — Backend de alta con CSF
 
-- [ ] Drawer `+ Nuevo Proveedor` con sección "Sube CSF (recomendado)" + link "Capturar manualmente".
-- [ ] Flujo upload → spinner ~60s → form pre-llenado → revisar/corregir → guardar.
-- [ ] Detección de duplicado por RFC al guardar (bloqueo + dos CTAs).
-- [ ] CSF archivada en `erp.adjuntos` con `entidad_tipo='persona', rol='csf'`; `csf_adjunto_id` apuntando al row creado.
+- [ ] `POST /api/proveedores/create-with-csf` que recibe FormData con PDF + JSON de campos editados + `empresa_id`. Persiste en orden: dedup RFC → `erp.personas` → `erp.proveedores` → upload PDF a storage → `erp.adjuntos` (rol='csf') → `erp.personas_datos_fiscales`.
+- [ ] Detección de duplicado por RFC al inicio (`empresa_id + rfc + activo=true` en `erp.personas`). Si existe, 409 con `existing_persona_id` y `existing_proveedor_id`.
+- [ ] Tests unitarios del schema de input + tests de la lógica de dedup.
+
+### Sprint 2.B — UI de alta nueva (RDB primero)
+
+- [ ] Drawer `+ Nuevo Proveedor` con sección "Sube CSF (recomendado)" + link "Capturar manualmente" (preserva flujo actual).
+- [ ] Flujo upload → spinner ~60s → form pre-llenado → revisar/corregir → guardar (llama `create-with-csf`).
+- [ ] UI de duplicado: cuando 409 con `existing_persona_id`, modal con dos CTAs ("Ir al proveedor existente" / "Actualizar su CSF con este PDF" — esto último vincula con Sprint 3).
+- [ ] Detección persona física vs moral: la extracción setea `tipo_persona`; UI muestra/oculta campos correspondientes.
 - [ ] Estados de error (Claude falla, PDF no es CSF, timeout) con CTA a captura manual.
 
 ### Sprint 3 — UI de update existente (diff campo-por-campo)
@@ -106,3 +114,4 @@ El módulo de Documentos ya tiene el patrón de extracción IA con Claude (`/api
 
 - **2026-04-27 — Sesión de arranque.** Se registra la iniciativa en `INITIATIVES.md` (PR [#234](https://github.com/beto-sudo/BSOP/pull/234)). Beto aprueba alcance v1 inmediatamente. Se promueve estado `proposed → planned` y se cierra la decisión de modelo DB con [ADR-007](../../supabase/adr/007_personas_datos_fiscales.md).
 - **2026-04-27 — Sprint 1.A cerrado (PR [#235](https://github.com/beto-sudo/BSOP/pull/235)).** Migración aplicada a la DB: columna `tipo_persona` en `erp.personas` + tabla `erp.personas_datos_fiscales` con RLS y trigger updated_at. SCHEMA_REF y types regenerados. CI verde (typecheck/lint/test/format/drift-check). Estado `planned → in_progress`. Próximo: Sprint 1.B (endpoint extract-csf).
+- **2026-04-27 — Sprint 1.B cerrado (PR [#236](https://github.com/beto-sudo/BSOP/pull/236)).** Endpoint `POST /api/proveedores/extract-csf` que recibe PDF y devuelve campos extraídos (sin persistir). `CsfExtraccionSchema` con todos los campos del ADR-007. 9 tests unitarios del schema pasando. Reutiliza `lib/documentos/extraction-core.ts`. Como efecto colateral, descubrimos un bug del workflow `db-types.yml` que regeneraba types sin schemas `dilesa`/`maquinaria` (causando typecheck fail en su PR auto-generado #227); arreglado en PR [#239](https://github.com/beto-sudo/BSOP/pull/239) y memoria `reference_db_types_workflow_sync.md` agregada. Próximo: Sprint 2.A (endpoint create-with-csf + dedup RFC).

--- a/lib/proveedores/extract-csf.test.ts
+++ b/lib/proveedores/extract-csf.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { CsfExtraccionSchema, RegimenSchema, ObligacionSchema } from './extract-csf';
+import {
+  CsfExtraccionSchema,
+  CreateProveedorPayloadSchema,
+  RegimenSchema,
+  ObligacionSchema,
+} from './extract-csf';
 
 /**
  * Tests del schema Zod para la extracción CSF.
@@ -299,5 +304,87 @@ describe('RegimenSchema y ObligacionSchema standalone', () => {
         fecha_fin: null,
       })
     ).toMatchObject({ descripcion: 'DIOT' });
+  });
+});
+
+describe('CreateProveedorPayloadSchema', () => {
+  const validExtraccion = {
+    tipo_persona: 'moral',
+    rfc: 'ABC010101AB1',
+    curp: null,
+    nombre: null,
+    apellido_paterno: null,
+    apellido_materno: null,
+    razon_social: 'EJEMPLO SA DE CV',
+    nombre_comercial: null,
+    regimen_fiscal_codigo: '601',
+    regimen_fiscal_nombre: 'General de Ley Personas Morales',
+    regimenes_adicionales: [
+      {
+        codigo: '601',
+        nombre: 'General de Ley Personas Morales',
+        fecha_inicio: '2020-01-01',
+        fecha_fin: null,
+      },
+    ],
+    domicilio_calle: null,
+    domicilio_num_ext: null,
+    domicilio_num_int: null,
+    domicilio_colonia: null,
+    domicilio_cp: null,
+    domicilio_municipio: null,
+    domicilio_estado: null,
+    obligaciones: [],
+    fecha_inicio_operaciones: null,
+    fecha_emision: null,
+  };
+
+  it('parsea payload completo con proveedor_extras', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+      proveedor_extras: {
+        codigo: 'PROV-001',
+        condiciones_pago: '30 días',
+        limite_credito: 50000,
+        categoria: 'Ferretería',
+      },
+    };
+    expect(CreateProveedorPayloadSchema.parse(payload)).toMatchObject({
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      proveedor_extras: { codigo: 'PROV-001' },
+    });
+  });
+
+  it('parsea payload sin proveedor_extras (opcional)', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+    };
+    const parsed = CreateProveedorPayloadSchema.parse(payload);
+    expect(parsed.proveedor_extras).toBeUndefined();
+  });
+
+  it('rechaza empresa_id que no es UUID', () => {
+    const payload = {
+      empresa_id: 'no-es-uuid',
+      extraccion: validExtraccion,
+    };
+    expect(() => CreateProveedorPayloadSchema.parse(payload)).toThrow();
+  });
+
+  it('rechaza si extraccion es inválida (RFC faltante)', () => {
+    const { rfc: _rfc, ...extraccionSinRfc } = validExtraccion;
+    void _rfc;
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: extraccionSinRfc,
+    };
+    expect(() => CreateProveedorPayloadSchema.parse(payload)).toThrow();
+  });
+
+  it('rechaza si falta empresa_id', () => {
+    const payload = { extraccion: validExtraccion };
+    expect(() => CreateProveedorPayloadSchema.parse(payload)).toThrow();
   });
 });

--- a/lib/proveedores/extract-csf.ts
+++ b/lib/proveedores/extract-csf.ts
@@ -146,6 +146,37 @@ export const CsfExtraccionSchema = z.object({
 
 export type CsfExtraccion = z.infer<typeof CsfExtraccionSchema>;
 
+// ─── Input para create-with-csf ──────────────────────────────────────────────
+
+/**
+ * Payload del endpoint `POST /api/proveedores/create-with-csf`.
+ *
+ * El cliente envía esto como JSON dentro del campo "payload" del multipart,
+ * más el PDF en el campo "file".
+ *
+ * - `extraccion` viene del flujo de Sprint 1.B: el cliente llama primero a
+ *   `/api/proveedores/extract-csf`, el usuario revisa/edita los campos en la
+ *   UI, y al guardar manda los campos finales (que pueden o no coincidir con
+ *   lo que Claude extrajo).
+ * - `proveedor_extras` es opcional — son atributos de `erp.proveedores` que no
+ *   vienen en la CSF (código interno, condiciones de pago, etc.). Si la UI no
+ *   los pide, se omiten y la fila de proveedor queda con defaults.
+ */
+export const CreateProveedorPayloadSchema = z.object({
+  empresa_id: z.string().uuid('empresa_id debe ser UUID'),
+  extraccion: CsfExtraccionSchema,
+  proveedor_extras: z
+    .object({
+      codigo: z.string().nullable().optional(),
+      condiciones_pago: z.string().nullable().optional(),
+      limite_credito: z.number().nullable().optional(),
+      categoria: z.string().nullable().optional(),
+    })
+    .optional(),
+});
+
+export type CreateProveedorPayload = z.infer<typeof CreateProveedorPayloadSchema>;
+
 // ─── Llamada al modelo ───────────────────────────────────────────────────────
 
 const PROMPT = `


### PR DESCRIPTION
## Summary

Sprint 2.A de [\`proveedores-csf-ai\`](docs/planning/proveedores-csf-ai.md): backend endpoint que persiste un proveedor nuevo (con su CSF) en la DB, complemento del endpoint de extracción Sprint 1.B. Próximo PR (Sprint 2.B) consume este endpoint desde la UI.

## Cambios

- 🆕 [\`app/api/proveedores/create-with-csf/route.ts\`](app/api/proveedores/create-with-csf/route.ts) — POST que recibe FormData (\`file\` + \`payload\` JSON) y crea persona + proveedor + adjunto CSF + datos_fiscales.
- 🧱 [\`lib/proveedores/extract-csf.ts\`](lib/proveedores/extract-csf.ts) — agrega \`CreateProveedorPayloadSchema\` (Zod) compartido entre cliente y servidor.
- ✅ [\`lib/proveedores/extract-csf.test.ts\`](lib/proveedores/extract-csf.test.ts) — 5 tests nuevos del schema (14 totales pasando).
- 📋 [\`docs/planning/proveedores-csf-ai.md\`](docs/planning/proveedores-csf-ai.md) — Sprint 1.B marcado ✅, Sprint 2 dividido en 2.A (este PR) + 2.B (UI), bitácora actualizada.

## Comportamiento

**Input** (multipart/form-data):
- \`file\`: PDF de la CSF (≤ 50 MB).
- \`payload\` (JSON):
  \`\`\`ts
  {
    empresa_id: uuid,
    extraccion: CsfExtraccion,         // del Sprint 1.B, posiblemente editado por el usuario
    proveedor_extras?: { codigo?, condiciones_pago?, limite_credito?, categoria? }
  }
  \`\`\`

**Flujo de persistencia** (orden recuperable — sin transacción explícita):

1. Auth + parse + Zod validate.
2. **Dedup** por \`(empresa_id, rfc, activo=true)\` en \`erp.personas\`.
   - Si existe → \`409 { error: 'rfc_duplicado', existing_persona_id, existing_proveedor_id }\`.
3. INSERT \`erp.personas\` (tipo_persona, nombre/apellidos o razón social, rfc, curp).
4. INSERT \`erp.proveedores\` (link + extras opcionales).
5. Upload PDF a bucket \`adjuntos\` en \`proveedores/{empresa_id}/{persona_id}/csf-{ts}-{nombre}.pdf\`.
6. INSERT \`erp.adjuntos\` (\`entidad_tipo='persona'\`, \`rol='csf'\`).
7. INSERT \`erp.personas_datos_fiscales\` con \`csf_adjunto_id\` apuntando al row.
8. \`200 { ok: true, persona_id, proveedor_id, adjunto_id, datos_fiscales_id }\`.

Si falla post-paso 3 (cualquier escritura), devuelve \`500 { error, partial: { persona_id, ... } }\` para que el cliente pueda recuperar.

## Decisiones técnicas

- **Sin transacción explícita.** Mantener un orden recuperable (persona/proveedor primero, luego adjunto y datos_fiscales) es suficiente para v1. Si más adelante hace falta atomicidad estricta, se puede mover a una RPC en Postgres.
- **\`nombre\` para morales = razón social.** Sigue la convención del módulo actual ([\`app/rdb/proveedores/page.tsx:248\`](app/rdb/proveedores/page.tsx)). La razón social oficial también vive en \`personas_datos_fiscales\` para preservar el texto literal del SAT.
- **Dedup con admin client, INSERTS con user client.** Dedup necesita ver toda la tabla por empresa (admin); INSERTS pasan por RLS para validar acceso (\`fn_has_empresa\`).
- **No instrumentation de OTel.** Sigue el patrón del repo — ningún route handler tiene observability custom.

## Test plan

- [x] \`npm run typecheck\` verde.
- [x] \`npm run test:run\` 212/212 pasando.
- [x] \`npm run lint\` 0 errores.
- [x] \`npm run format:check\` clean.
- [ ] CI verde en este PR.
- [ ] Smoke manual: lo hace el Sprint 2.B cuando la UI consuma el endpoint con CSFs reales.

## Próximo

Sprint 2.B — UI del drawer "+ Nuevo Proveedor" en RDB con sección "Sube CSF (recomendado)" + manejo del 409 (modal con CTAs de duplicado) + estados de error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)