### PR TITLE
feat(proveedores-csf-ai): Sprint 2.B — UI drawer con flujo CSF (RDB)

### DIFF
--- a/app/api/proveedores/create-with-csf/route.ts
+++ b/app/api/proveedores/create-with-csf/route.ts
@@ -1,0 +1,294 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public` por default; para leer/escribir
+ * en `erp` usamos `as any`. Es el mismo patrón que el resto del proyecto
+ * (ver app/api/documentos/[id]/extract/route.ts).
+ */
+
+/**
+ * POST /api/proveedores/create-with-csf
+ *
+ * Crea un proveedor nuevo a partir de los datos extraídos de su CSF (Sprint 1.B)
+ * más el PDF original. El cliente arma el flujo así:
+ *
+ *   1. Sube CSF a `/api/proveedores/extract-csf` → recibe los campos extraídos.
+ *   2. UI muestra los campos pre-llenados; el usuario revisa/corrige.
+ *   3. Al guardar, llama a este endpoint con FormData:
+ *        - `file`: el mismo PDF que se subió a extract-csf.
+ *        - `payload`: JSON con { empresa_id, extraccion, proveedor_extras? }.
+ *
+ * Persistencia (sin transacción explícita — orden recuperable):
+ *   1. Dedup por (empresa_id, rfc, activo=true) en `erp.personas`. Si ya
+ *      existe → 409 con `existing_persona_id` y `existing_proveedor_id`.
+ *   2. INSERT erp.personas (con tipo_persona, nombre/razón social, apellidos,
+ *      rfc, curp, tipo='proveedor').
+ *   3. INSERT erp.proveedores (link + extras opcionales).
+ *   4. Upload PDF a bucket `adjuntos` en `proveedores/{empresa_id}/{persona_id}/csf-{ts}.pdf`.
+ *   5. INSERT erp.adjuntos (entidad_tipo='persona', rol='csf').
+ *   6. INSERT erp.personas_datos_fiscales (con csf_adjunto_id apuntando al row creado).
+ *
+ * Si falla después del paso 2, devuelve 500 indicando qué quedó persistido
+ * para que el cliente pueda recuperar via flujos de update existentes.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { CreateProveedorPayloadSchema } from '@/lib/proveedores/extract-csf';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+const BUCKET = 'adjuntos';
+const MAX_INCOMING_BYTES = 50 * 1024 * 1024; // 50 MB
+
+export async function POST(req: NextRequest) {
+  // 1) Auth
+  const userSupa = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await userSupa.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+  }
+
+  // 2) Parse multipart
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `multipart inválido: ${msg}` }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  const payloadRaw = formData.get('payload');
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'Falta el campo "file" (multipart/form-data).' },
+      { status: 400 }
+    );
+  }
+  if (file.type && file.type !== 'application/pdf') {
+    return NextResponse.json(
+      { error: `Tipo de archivo no soportado: ${file.type}. Solo application/pdf.` },
+      { status: 415 }
+    );
+  }
+  if (file.size > MAX_INCOMING_BYTES) {
+    return NextResponse.json(
+      { error: `Archivo muy grande (${(file.size / 1024 / 1024).toFixed(1)} MB). Máximo 50 MB.` },
+      { status: 413 }
+    );
+  }
+  if (typeof payloadRaw !== 'string' || !payloadRaw.length) {
+    return NextResponse.json(
+      { error: 'Falta el campo "payload" (JSON con empresa_id, extraccion, proveedor_extras?).' },
+      { status: 400 }
+    );
+  }
+
+  // 3) Validate payload
+  let payload;
+  try {
+    payload = CreateProveedorPayloadSchema.parse(JSON.parse(payloadRaw));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  const { empresa_id, extraccion, proveedor_extras } = payload;
+  const rfcNormalized = extraccion.rfc.trim().toUpperCase();
+
+  // 4) Dedup por RFC en esta empresa. Usamos admin para que sea independiente
+  //    de RLS — la verificación de empresa_id se hace en el INSERT (RLS de
+  //    erp.personas requiere fn_has_empresa o fn_is_admin).
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const { data: existingPersona, error: dedupErr } = await (admin.schema('erp') as any)
+    .from('personas')
+    .select('id')
+    .eq('empresa_id', empresa_id)
+    .eq('rfc', rfcNormalized)
+    .eq('activo', true)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (dedupErr) {
+    return NextResponse.json({ error: `dedup query: ${dedupErr.message}` }, { status: 500 });
+  }
+
+  if (existingPersona) {
+    const { data: existingProv } = await (admin.schema('erp') as any)
+      .from('proveedores')
+      .select('id')
+      .eq('empresa_id', empresa_id)
+      .eq('persona_id', existingPersona.id)
+      .is('deleted_at', null)
+      .maybeSingle();
+
+    return NextResponse.json(
+      {
+        error: 'rfc_duplicado',
+        existing_persona_id: existingPersona.id,
+        existing_proveedor_id: existingProv?.id ?? null,
+      },
+      { status: 409 }
+    );
+  }
+
+  // 5) INSERT erp.personas — usamos user client para que RLS valide acceso a
+  //    la empresa. Si el user no pertenece a empresa_id, RLS bloquea aquí.
+  const isMoral = extraccion.tipo_persona === 'moral';
+  const personaInsert = {
+    empresa_id,
+    tipo_persona: extraccion.tipo_persona,
+    tipo: 'proveedor',
+    // Convención del repo: para morales, `nombre` = razón social (lo que la
+    // UI muestra como nombre principal). Razón social oficial también vive
+    // en personas_datos_fiscales para preservar la versión literal del SAT.
+    nombre: isMoral
+      ? (extraccion.razon_social ?? 'SIN NOMBRE')
+      : (extraccion.nombre ?? 'SIN NOMBRE'),
+    apellido_paterno: isMoral ? null : extraccion.apellido_paterno,
+    apellido_materno: isMoral ? null : extraccion.apellido_materno,
+    rfc: rfcNormalized,
+    curp: extraccion.curp,
+  };
+
+  const { data: persona, error: personaErr } = await (userSupa.schema('erp') as any)
+    .from('personas')
+    .insert(personaInsert)
+    .select('id')
+    .single();
+
+  if (personaErr) {
+    const isRlsErr = /row-level security|permission denied/i.test(personaErr.message);
+    return NextResponse.json(
+      { error: `insert persona: ${personaErr.message}` },
+      { status: isRlsErr ? 403 : 500 }
+    );
+  }
+
+  const personaId: string = persona.id;
+  const created: {
+    persona_id: string;
+    proveedor_id?: string;
+    adjunto_id?: string;
+    datos_fiscales_id?: string;
+  } = {
+    persona_id: personaId,
+  };
+
+  // 6) INSERT erp.proveedores
+  const proveedorInsert = {
+    empresa_id,
+    persona_id: personaId,
+    activo: true,
+    codigo: proveedor_extras?.codigo ?? null,
+    condiciones_pago: proveedor_extras?.condiciones_pago ?? null,
+    limite_credito: proveedor_extras?.limite_credito ?? null,
+    categoria: proveedor_extras?.categoria ?? null,
+  };
+
+  const { data: proveedor, error: proveedorErr } = await (userSupa.schema('erp') as any)
+    .from('proveedores')
+    .insert(proveedorInsert)
+    .select('id')
+    .single();
+
+  if (proveedorErr) {
+    return NextResponse.json(
+      { error: `insert proveedor: ${proveedorErr.message}`, partial: created },
+      { status: 500 }
+    );
+  }
+  created.proveedor_id = proveedor.id;
+
+  // 7) Upload PDF al bucket
+  const ts = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80);
+  const path = `proveedores/${empresa_id}/${personaId}/csf-${ts}-${safeName}`;
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const { error: uploadErr } = await admin.storage.from(BUCKET).upload(path, bytes, {
+    contentType: 'application/pdf',
+    upsert: false,
+  });
+
+  if (uploadErr) {
+    return NextResponse.json(
+      { error: `upload csf: ${uploadErr.message}`, partial: created },
+      { status: 500 }
+    );
+  }
+
+  // 8) INSERT erp.adjuntos
+  const adjuntoInsert = {
+    empresa_id,
+    entidad_tipo: 'persona',
+    entidad_id: personaId,
+    rol: 'csf',
+    nombre: file.name,
+    url: path,
+    tipo_mime: 'application/pdf',
+    tamano_bytes: file.size,
+    uploaded_by: user.id,
+  };
+
+  const { data: adjunto, error: adjuntoErr } = await (userSupa.schema('erp') as any)
+    .from('adjuntos')
+    .insert(adjuntoInsert)
+    .select('id')
+    .single();
+
+  if (adjuntoErr) {
+    return NextResponse.json(
+      { error: `insert adjunto: ${adjuntoErr.message}`, partial: created },
+      { status: 500 }
+    );
+  }
+  created.adjunto_id = adjunto.id;
+
+  // 9) INSERT erp.personas_datos_fiscales
+  const datosFiscalesInsert = {
+    empresa_id,
+    persona_id: personaId,
+    razon_social: extraccion.razon_social,
+    nombre_comercial: extraccion.nombre_comercial,
+    regimen_fiscal_codigo: extraccion.regimen_fiscal_codigo,
+    regimen_fiscal_nombre: extraccion.regimen_fiscal_nombre,
+    regimenes_adicionales: extraccion.regimenes_adicionales,
+    domicilio_calle: extraccion.domicilio_calle,
+    domicilio_num_ext: extraccion.domicilio_num_ext,
+    domicilio_num_int: extraccion.domicilio_num_int,
+    domicilio_colonia: extraccion.domicilio_colonia,
+    domicilio_cp: extraccion.domicilio_cp,
+    domicilio_municipio: extraccion.domicilio_municipio,
+    domicilio_estado: extraccion.domicilio_estado,
+    obligaciones: extraccion.obligaciones,
+    csf_adjunto_id: adjunto.id,
+    csf_fecha_emision: extraccion.fecha_emision,
+    fecha_inicio_operaciones: extraccion.fecha_inicio_operaciones,
+  };
+
+  const { data: datosFiscales, error: datosErr } = await (userSupa.schema('erp') as any)
+    .from('personas_datos_fiscales')
+    .insert(datosFiscalesInsert)
+    .select('id')
+    .single();
+
+  if (datosErr) {
+    return NextResponse.json(
+      { error: `insert personas_datos_fiscales: ${datosErr.message}`, partial: created },
+      { status: 500 }
+    );
+  }
+  created.datos_fiscales_id = datosFiscales.id;
+
+  return NextResponse.json({ ok: true, ...created });
+}

--- a/app/rdb/proveedores/page.tsx
+++ b/app/rdb/proveedores/page.tsx
@@ -23,7 +23,12 @@ import {
   Pencil,
   Ban,
   RotateCcw,
+  Upload,
+  Sparkles,
+  AlertTriangle,
+  ExternalLink,
 } from 'lucide-react';
+import type { CsfExtraccion } from '@/lib/proveedores/extract-csf';
 
 const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
@@ -230,6 +235,100 @@ export default function ProveedoresPage() {
   const [editEmail, setEditEmail] = useState('');
   const [editRFC, setEditRFC] = useState('');
 
+  // ─── CSF flow state (Sprint 2.B) ────────────────────────────────────────────
+  const [csfFile, setCsfFile] = useState<File | null>(null);
+  const [csfProcessing, setCsfProcessing] = useState(false);
+  const [csfError, setCsfError] = useState<string | null>(null);
+  const [csfExtraccion, setCsfExtraccion] = useState<CsfExtraccion | null>(null);
+
+  // Campos adicionales del modelo CSF (ADR-007), editables tras la extracción
+  const [newTipoPersona, setNewTipoPersona] = useState<'fisica' | 'moral'>('fisica');
+  const [newRazonSocial, setNewRazonSocial] = useState('');
+  const [newNombreComercial, setNewNombreComercial] = useState('');
+  const [newCurp, setNewCurp] = useState('');
+  const [newRegimenCodigo, setNewRegimenCodigo] = useState('');
+  const [newRegimenNombre, setNewRegimenNombre] = useState('');
+  const [newDomCalle, setNewDomCalle] = useState('');
+  const [newDomNumExt, setNewDomNumExt] = useState('');
+  const [newDomNumInt, setNewDomNumInt] = useState('');
+  const [newDomColonia, setNewDomColonia] = useState('');
+  const [newDomCp, setNewDomCp] = useState('');
+  const [newDomMunicipio, setNewDomMunicipio] = useState('');
+  const [newDomEstado, setNewDomEstado] = useState('');
+
+  // Modal de duplicado por RFC
+  const [duplicadoOpen, setDuplicadoOpen] = useState(false);
+  const [duplicadoInfo, setDuplicadoInfo] = useState<{
+    persona_id: string;
+    proveedor_id: string | null;
+    rfc: string;
+  } | null>(null);
+
+  const resetCreateForm = () => {
+    setNewNombre('');
+    setNewApellidoPaterno('');
+    setNewApellidoMaterno('');
+    setNewContacto('');
+    setNewTelefono('');
+    setNewEmail('');
+    setNewRFC('');
+    setNewDireccion('');
+    setNewNotas('');
+    setCsfFile(null);
+    setCsfProcessing(false);
+    setCsfError(null);
+    setCsfExtraccion(null);
+    setNewTipoPersona('fisica');
+    setNewRazonSocial('');
+    setNewNombreComercial('');
+    setNewCurp('');
+    setNewRegimenCodigo('');
+    setNewRegimenNombre('');
+    setNewDomCalle('');
+    setNewDomNumExt('');
+    setNewDomNumInt('');
+    setNewDomColonia('');
+    setNewDomCp('');
+    setNewDomMunicipio('');
+    setNewDomEstado('');
+  };
+
+  const handleProcessCsf = async () => {
+    if (!csfFile) return;
+    setCsfProcessing(true);
+    setCsfError(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', csfFile);
+      const res = await fetch('/api/proveedores/extract-csf', { method: 'POST', body: fd });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? 'Error al procesar CSF');
+      const e = json.extraccion as CsfExtraccion;
+      setCsfExtraccion(e);
+      setNewTipoPersona(e.tipo_persona);
+      setNewRazonSocial(e.razon_social ?? '');
+      setNewNombreComercial(e.nombre_comercial ?? '');
+      setNewNombre(e.tipo_persona === 'fisica' ? (e.nombre ?? '') : (e.razon_social ?? ''));
+      setNewApellidoPaterno(e.tipo_persona === 'fisica' ? (e.apellido_paterno ?? '') : '');
+      setNewApellidoMaterno(e.tipo_persona === 'fisica' ? (e.apellido_materno ?? '') : '');
+      setNewRFC(e.rfc);
+      setNewCurp(e.curp ?? '');
+      setNewRegimenCodigo(e.regimen_fiscal_codigo ?? '');
+      setNewRegimenNombre(e.regimen_fiscal_nombre ?? '');
+      setNewDomCalle(e.domicilio_calle ?? '');
+      setNewDomNumExt(e.domicilio_num_ext ?? '');
+      setNewDomNumInt(e.domicilio_num_int ?? '');
+      setNewDomColonia(e.domicilio_colonia ?? '');
+      setNewDomCp(e.domicilio_cp ?? '');
+      setNewDomMunicipio(e.domicilio_municipio ?? '');
+      setNewDomEstado(e.domicilio_estado ?? '');
+    } catch (err) {
+      setCsfError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCsfProcessing(false);
+    }
+  };
+
   const handleCreate = async () => {
     if (!newNombre.trim()) {
       alert('El nombre es obligatorio');
@@ -237,6 +336,63 @@ export default function ProveedoresPage() {
     }
     setCreating(true);
     try {
+      // ── Flujo con CSF ──────────────────────────────────────────────
+      if (csfFile && csfExtraccion) {
+        const editedExtraccion: CsfExtraccion = {
+          ...csfExtraccion,
+          tipo_persona: newTipoPersona,
+          razon_social: newTipoPersona === 'moral' ? newRazonSocial.trim() || null : null,
+          nombre_comercial: newNombreComercial.trim() || null,
+          nombre: newTipoPersona === 'fisica' ? newNombre.trim() || null : null,
+          apellido_paterno: newTipoPersona === 'fisica' ? newApellidoPaterno.trim() || null : null,
+          apellido_materno: newTipoPersona === 'fisica' ? newApellidoMaterno.trim() || null : null,
+          rfc: newRFC.trim().toUpperCase(),
+          curp: newCurp.trim() || null,
+          regimen_fiscal_codigo: newRegimenCodigo.trim() || null,
+          regimen_fiscal_nombre: newRegimenNombre.trim() || null,
+          domicilio_calle: newDomCalle.trim() || null,
+          domicilio_num_ext: newDomNumExt.trim() || null,
+          domicilio_num_int: newDomNumInt.trim() || null,
+          domicilio_colonia: newDomColonia.trim() || null,
+          domicilio_cp: newDomCp.trim() || null,
+          domicilio_municipio: newDomMunicipio.trim() || null,
+          domicilio_estado: newDomEstado.trim() || null,
+        };
+
+        const fd = new FormData();
+        fd.append('file', csfFile);
+        fd.append(
+          'payload',
+          JSON.stringify({
+            empresa_id: RDB_EMPRESA_ID,
+            extraccion: editedExtraccion,
+          })
+        );
+
+        const res = await fetch('/api/proveedores/create-with-csf', {
+          method: 'POST',
+          body: fd,
+        });
+        const json = await res.json();
+
+        if (res.status === 409 && json.error === 'rfc_duplicado') {
+          setDuplicadoInfo({
+            persona_id: json.existing_persona_id,
+            proveedor_id: json.existing_proveedor_id,
+            rfc: editedExtraccion.rfc,
+          });
+          setDuplicadoOpen(true);
+          return;
+        }
+        if (!res.ok) throw new Error(json.error ?? 'Error al crear proveedor con CSF');
+
+        setCreateDrawerOpen(false);
+        resetCreateForm();
+        void fetchProveedores();
+        return;
+      }
+
+      // ── Flujo manual (sin CSF) — preserva el flujo previo ─────────
       const supabase = createSupabaseBrowserClient();
       const { data: persona, error: personaErr } = await supabase
         .schema('erp')
@@ -265,19 +421,11 @@ export default function ProveedoresPage() {
       if (err) throw err;
 
       setCreateDrawerOpen(false);
-      setNewNombre('');
-      setNewApellidoPaterno('');
-      setNewApellidoMaterno('');
-      setNewContacto('');
-      setNewTelefono('');
-      setNewEmail('');
-      setNewRFC('');
-      setNewDireccion('');
-      setNewNotas('');
+      resetCreateForm();
       void fetchProveedores();
     } catch (e) {
       console.error(e);
-      alert('Error al crear el proveedor');
+      alert(e instanceof Error ? e.message : 'Error al crear el proveedor');
     } finally {
       setCreating(false);
     }
@@ -588,102 +736,340 @@ export default function ProveedoresPage() {
         </Sheet>
 
         {/* Create Proveedor Drawer */}
-        <Sheet open={createDrawerOpen} onOpenChange={setCreateDrawerOpen}>
-          <SheetContent className="sm:max-w-[600px] overflow-y-auto">
+        <Sheet
+          open={createDrawerOpen}
+          onOpenChange={(v) => {
+            setCreateDrawerOpen(v);
+            if (!v) resetCreateForm();
+          }}
+        >
+          <SheetContent className="sm:max-w-[640px] overflow-y-auto">
             <SheetHeader>
               <SheetTitle>Nuevo Proveedor</SheetTitle>
             </SheetHeader>
 
             <div className="mt-8 space-y-6">
+              {/* ── Sección CSF (Sprint 2.B) ────────────────────────── */}
+              <div className="rounded-lg border border-emerald-300/40 bg-emerald-50/40 p-4 dark:bg-emerald-950/20">
+                <div className="flex items-start gap-3">
+                  <Sparkles className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                  <div className="flex-1 space-y-3">
+                    <div>
+                      <h3 className="text-sm font-medium">Sube CSF (recomendado)</h3>
+                      <p className="text-xs text-muted-foreground">
+                        Auto-llena el formulario con los datos extraídos de la Constancia de
+                        Situación Fiscal del SAT. Soporta personas físicas y morales.
+                      </p>
+                    </div>
+
+                    {!csfExtraccion && (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <input
+                          type="file"
+                          accept="application/pdf"
+                          onChange={(e) => {
+                            const f = e.target.files?.[0] ?? null;
+                            setCsfFile(f);
+                            setCsfError(null);
+                          }}
+                          className="text-xs file:mr-3 file:rounded-md file:border-0 file:bg-emerald-600 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-white hover:file:bg-emerald-700"
+                          disabled={csfProcessing}
+                        />
+                        <Button
+                          size="sm"
+                          variant="default"
+                          onClick={handleProcessCsf}
+                          disabled={!csfFile || csfProcessing}
+                          className="gap-1.5"
+                        >
+                          {csfProcessing ? (
+                            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <Upload className="h-3.5 w-3.5" />
+                          )}
+                          {csfProcessing ? 'Procesando…' : 'Procesar CSF'}
+                        </Button>
+                      </div>
+                    )}
+
+                    {csfProcessing && (
+                      <p className="text-xs text-muted-foreground">
+                        Claude está leyendo el PDF — puede tardar 30-90 segundos.
+                      </p>
+                    )}
+
+                    {csfError && (
+                      <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
+                        <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                        <div>
+                          <strong>Error al procesar:</strong> {csfError}
+                          <div className="mt-1 text-muted-foreground">
+                            Puedes reintentar o capturar manualmente abajo.
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {csfExtraccion && (
+                      <div className="flex items-center justify-between rounded-md border border-emerald-300/60 bg-white/60 p-2 text-xs dark:bg-emerald-900/20">
+                        <span className="text-emerald-700 dark:text-emerald-400">
+                          ✓ CSF procesada — {csfFile?.name}
+                        </span>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => {
+                            setCsfFile(null);
+                            setCsfExtraccion(null);
+                            setCsfError(null);
+                          }}
+                          className="h-6 px-2 text-xs"
+                        >
+                          Cambiar PDF
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* ── Form ────────────────────────────────────────────── */}
               <div className="space-y-4">
+                {/* Tipo de persona */}
                 <div className="space-y-2">
-                  <label className="text-sm font-medium leading-none">
-                    Nombre / Razón Social <span className="text-destructive">*</span>
-                  </label>
-                  <Input
-                    value={newNombre}
-                    onChange={(e) => setNewNombre(e.target.value)}
-                    placeholder="Persona física: nombre de pila. Moral: razón social."
-                  />
-                </div>
-
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium leading-none">Apellido paterno</label>
-                    <Input
-                      value={newApellidoPaterno}
-                      onChange={(e) => setNewApellidoPaterno(e.target.value)}
-                      placeholder="Sólo personas físicas"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium leading-none">Apellido materno</label>
-                    <Input
-                      value={newApellidoMaterno}
-                      onChange={(e) => setNewApellidoMaterno(e.target.value)}
-                      placeholder="Sólo personas físicas"
-                    />
+                  <label className="text-sm font-medium leading-none">Tipo de persona</label>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant={newTipoPersona === 'fisica' ? 'default' : 'outline'}
+                      onClick={() => setNewTipoPersona('fisica')}
+                    >
+                      Física
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant={newTipoPersona === 'moral' ? 'default' : 'outline'}
+                      onClick={() => setNewTipoPersona('moral')}
+                    >
+                      Moral
+                    </Button>
                   </div>
                 </div>
 
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium leading-none">Contacto</label>
-                    <Input
-                      value={newContacto}
-                      onChange={(e) => setNewContacto(e.target.value)}
-                      placeholder="Ej. Juan Pérez"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium leading-none">Teléfono</label>
-                    <Input
-                      value={newTelefono}
-                      onChange={(e) => setNewTelefono(e.target.value)}
-                      placeholder="Ej. 878 123 4567"
-                    />
-                  </div>
-                </div>
+                {/* Identidad: depende de tipo_persona */}
+                {newTipoPersona === 'moral' ? (
+                  <>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium leading-none">
+                        Razón social <span className="text-destructive">*</span>
+                      </label>
+                      <Input
+                        value={newRazonSocial}
+                        onChange={(e) => {
+                          setNewRazonSocial(e.target.value);
+                          setNewNombre(e.target.value); // morales: nombre = razón social
+                        }}
+                        placeholder="EJEMPLO SA DE CV"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium leading-none">Nombre comercial</label>
+                      <Input
+                        value={newNombreComercial}
+                        onChange={(e) => setNewNombreComercial(e.target.value)}
+                        placeholder="Opcional"
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium leading-none">
+                        Nombre <span className="text-destructive">*</span>
+                      </label>
+                      <Input
+                        value={newNombre}
+                        onChange={(e) => setNewNombre(e.target.value)}
+                        placeholder="Nombre de pila"
+                      />
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium leading-none">Apellido paterno</label>
+                        <Input
+                          value={newApellidoPaterno}
+                          onChange={(e) => setNewApellidoPaterno(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium leading-none">Apellido materno</label>
+                        <Input
+                          value={newApellidoMaterno}
+                          onChange={(e) => setNewApellidoMaterno(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
 
+                {/* Identificadores fiscales */}
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium leading-none">Email</label>
-                    <Input
-                      value={newEmail}
-                      onChange={(e) => setNewEmail(e.target.value)}
-                      placeholder="Ej. ventas@empresa.com"
-                    />
-                  </div>
                   <div className="space-y-2">
                     <label className="text-sm font-medium leading-none">RFC</label>
                     <Input
                       value={newRFC}
                       onChange={(e) => setNewRFC(e.target.value)}
-                      placeholder="Ej. XAXX010101000"
-                      className="uppercase"
+                      placeholder={newTipoPersona === 'moral' ? '12 caracteres' : '13 caracteres'}
+                      className="uppercase font-mono"
                     />
+                  </div>
+                  {newTipoPersona === 'fisica' && (
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium leading-none">CURP</label>
+                      <Input
+                        value={newCurp}
+                        onChange={(e) => setNewCurp(e.target.value)}
+                        className="uppercase font-mono"
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* Régimen fiscal — solo si hubo CSF */}
+                {csfExtraccion && (
+                  <>
+                    <Separator />
+                    <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Régimen fiscal
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-[100px_1fr]">
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">Código</label>
+                        <Input
+                          value={newRegimenCodigo}
+                          onChange={(e) => setNewRegimenCodigo(e.target.value)}
+                          placeholder="601"
+                          className="font-mono"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">Descripción</label>
+                        <Input
+                          value={newRegimenNombre}
+                          onChange={(e) => setNewRegimenNombre(e.target.value)}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Domicilio fiscal
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-[1fr_120px_120px]">
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">Calle</label>
+                        <Input
+                          value={newDomCalle}
+                          onChange={(e) => setNewDomCalle(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">Núm. ext.</label>
+                        <Input
+                          value={newDomNumExt}
+                          onChange={(e) => setNewDomNumExt(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">Núm. int.</label>
+                        <Input
+                          value={newDomNumInt}
+                          onChange={(e) => setNewDomNumInt(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-[1fr_100px]">
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">Colonia</label>
+                        <Input
+                          value={newDomColonia}
+                          onChange={(e) => setNewDomColonia(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">CP</label>
+                        <Input
+                          value={newDomCp}
+                          onChange={(e) => setNewDomCp(e.target.value)}
+                          className="font-mono"
+                        />
+                      </div>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">Municipio</label>
+                        <Input
+                          value={newDomMunicipio}
+                          onChange={(e) => setNewDomMunicipio(e.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-xs font-medium leading-none">Estado</label>
+                        <Input
+                          value={newDomEstado}
+                          onChange={(e) => setNewDomEstado(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {/* Contacto (común a ambos flujos) */}
+                <Separator />
+                <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Contacto
+                </div>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium leading-none">Teléfono</label>
+                    <Input value={newTelefono} onChange={(e) => setNewTelefono(e.target.value)} />
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium leading-none">Email</label>
+                    <Input value={newEmail} onChange={(e) => setNewEmail(e.target.value)} />
                   </div>
                 </div>
 
-                <div className="space-y-2">
-                  <label className="text-sm font-medium leading-none">Dirección</label>
-                  <Input
-                    value={newDireccion}
-                    onChange={(e) => setNewDireccion(e.target.value)}
-                    placeholder="Calle, Número, Colonia, Ciudad..."
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <label className="text-sm font-medium leading-none">
-                    Notas / Detalles adicionales
-                  </label>
-                  <Input
-                    value={newNotas}
-                    onChange={(e) => setNewNotas(e.target.value)}
-                    placeholder="Ej. Días de entrega, condiciones de crédito..."
-                  />
-                </div>
+                {/* Solo flujo manual: contacto + dirección legacy + notas */}
+                {!csfExtraccion && (
+                  <>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium leading-none">Contacto</label>
+                      <Input
+                        value={newContacto}
+                        onChange={(e) => setNewContacto(e.target.value)}
+                        placeholder="Ej. Juan Pérez"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium leading-none">Dirección</label>
+                      <Input
+                        value={newDireccion}
+                        onChange={(e) => setNewDireccion(e.target.value)}
+                        placeholder="Calle, número, colonia, ciudad…"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium leading-none">
+                        Notas / Detalles adicionales
+                      </label>
+                      <Input
+                        value={newNotas}
+                        onChange={(e) => setNewNotas(e.target.value)}
+                        placeholder="Ej. Días de entrega, condiciones de crédito…"
+                      />
+                    </div>
+                  </>
+                )}
               </div>
 
               <div className="flex justify-end pt-6 border-t">
@@ -696,6 +1082,64 @@ export default function ProveedoresPage() {
                   Crear Proveedor
                 </Button>
               </div>
+            </div>
+          </SheetContent>
+        </Sheet>
+
+        {/* Modal: RFC duplicado */}
+        <Sheet open={duplicadoOpen} onOpenChange={setDuplicadoOpen}>
+          <SheetContent className="sm:max-w-[480px]">
+            <SheetHeader>
+              <SheetTitle className="flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-amber-500" />
+                RFC ya registrado
+              </SheetTitle>
+            </SheetHeader>
+            <div className="mt-8 space-y-6">
+              <p className="text-sm">
+                El RFC{' '}
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                  {duplicadoInfo?.rfc}
+                </code>{' '}
+                ya está registrado como proveedor activo en RDB. Para evitar duplicados, elige una
+                acción:
+              </p>
+              <div className="space-y-2">
+                <Button
+                  className="w-full justify-start gap-2"
+                  variant="outline"
+                  onClick={() => {
+                    setDuplicadoOpen(false);
+                    setCreateDrawerOpen(false);
+                    if (duplicadoInfo) {
+                      const target = proveedores.find(
+                        (p) => p.persona_id === duplicadoInfo.persona_id
+                      );
+                      if (target) {
+                        setSelected(target);
+                        setDrawerOpen(true);
+                      } else {
+                        void fetchProveedores();
+                      }
+                    }
+                  }}
+                  disabled={!duplicadoInfo?.proveedor_id}
+                >
+                  <ExternalLink className="h-4 w-4" />
+                  Ir al proveedor existente
+                </Button>
+                <Button
+                  className="w-full justify-start gap-2"
+                  variant="ghost"
+                  onClick={() => setDuplicadoOpen(false)}
+                >
+                  Volver al formulario y editar RFC
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Si necesitas actualizar la CSF del proveedor existente, usa el botón &ldquo;Cargar /
+                Actualizar CSF&rdquo; en su detalle (Sprint 3 — próximamente).
+              </p>
             </div>
           </SheetContent>
         </Sheet>

--- a/docs/planning/proveedores-csf-ai.md
+++ b/docs/planning/proveedores-csf-ai.md
@@ -70,17 +70,25 @@ El módulo de Documentos ya tiene el patrón de extracción IA con Claude (`/api
 - [x] `supabase/SCHEMA_REF.md` regenerado con `npm run schema:ref`.
 - [x] `types/supabase.ts` actualizado con los nuevos types (manualmente, `npm run db:types` bloqueado en sandbox).
 
-### Sprint 1.B — Endpoint de extracción IA
+### Sprint 1.B — Endpoint de extracción IA ✅
 
-- [ ] `POST /api/proveedores/extract-csf` que reciba PDF, lo procese con Claude usando schema dedicado a CSF (todos los campos del ADR-007), y devuelva los datos pre-llenados sin persistir. Reutiliza `lib/documentos/extraction-core.ts`.
-- [ ] Tests unitarios del schema de extracción con CSFs reales (3-5 PDFs de ejemplo, físicas y morales).
+- [x] `POST /api/proveedores/extract-csf` que recibe PDF (multipart/form-data), lo procesa con Claude usando schema dedicado a CSF, devuelve los datos pre-llenados sin persistir. Reutiliza `lib/documentos/extraction-core.ts` (anthropic, MODELO_CLAUDE, ensurePdfFitsForClaude).
+- [x] Schema `CsfExtraccionSchema` (Zod) en `lib/proveedores/extract-csf.ts` cubre todos los campos del ADR-007.
+- [x] Tests unitarios del schema (9 tests pasando — moral, física, múltiples regímenes, rechazos).
+- _Smoke con CSFs reales pendiente para cuando exista UI Sprint 2 (alternativa: curl)._
 
-### Sprint 2 — UI de alta nueva (RDB primero)
+### Sprint 2.A — Backend de alta con CSF
 
-- [ ] Drawer `+ Nuevo Proveedor` con sección "Sube CSF (recomendado)" + link "Capturar manualmente".
-- [ ] Flujo upload → spinner ~60s → form pre-llenado → revisar/corregir → guardar.
-- [ ] Detección de duplicado por RFC al guardar (bloqueo + dos CTAs).
-- [ ] CSF archivada en `erp.adjuntos` con `entidad_tipo='persona', rol='csf'`; `csf_adjunto_id` apuntando al row creado.
+- [ ] `POST /api/proveedores/create-with-csf` que recibe FormData con PDF + JSON de campos editados + `empresa_id`. Persiste en orden: dedup RFC → `erp.personas` → `erp.proveedores` → upload PDF a storage → `erp.adjuntos` (rol='csf') → `erp.personas_datos_fiscales`.
+- [ ] Detección de duplicado por RFC al inicio (`empresa_id + rfc + activo=true` en `erp.personas`). Si existe, 409 con `existing_persona_id` y `existing_proveedor_id`.
+- [ ] Tests unitarios del schema de input + tests de la lógica de dedup.
+
+### Sprint 2.B — UI de alta nueva (RDB primero)
+
+- [ ] Drawer `+ Nuevo Proveedor` con sección "Sube CSF (recomendado)" + link "Capturar manualmente" (preserva flujo actual).
+- [ ] Flujo upload → spinner ~60s → form pre-llenado → revisar/corregir → guardar (llama `create-with-csf`).
+- [ ] UI de duplicado: cuando 409 con `existing_persona_id`, modal con dos CTAs ("Ir al proveedor existente" / "Actualizar su CSF con este PDF" — esto último vincula con Sprint 3).
+- [ ] Detección persona física vs moral: la extracción setea `tipo_persona`; UI muestra/oculta campos correspondientes.
 - [ ] Estados de error (Claude falla, PDF no es CSF, timeout) con CTA a captura manual.
 
 ### Sprint 3 — UI de update existente (diff campo-por-campo)
@@ -106,3 +114,4 @@ El módulo de Documentos ya tiene el patrón de extracción IA con Claude (`/api
 
 - **2026-04-27 — Sesión de arranque.** Se registra la iniciativa en `INITIATIVES.md` (PR [#234](https://github.com/beto-sudo/BSOP/pull/234)). Beto aprueba alcance v1 inmediatamente. Se promueve estado `proposed → planned` y se cierra la decisión de modelo DB con [ADR-007](../../supabase/adr/007_personas_datos_fiscales.md).
 - **2026-04-27 — Sprint 1.A cerrado (PR [#235](https://github.com/beto-sudo/BSOP/pull/235)).** Migración aplicada a la DB: columna `tipo_persona` en `erp.personas` + tabla `erp.personas_datos_fiscales` con RLS y trigger updated_at. SCHEMA_REF y types regenerados. CI verde (typecheck/lint/test/format/drift-check). Estado `planned → in_progress`. Próximo: Sprint 1.B (endpoint extract-csf).
+- **2026-04-27 — Sprint 1.B cerrado (PR [#236](https://github.com/beto-sudo/BSOP/pull/236)).** Endpoint `POST /api/proveedores/extract-csf` que recibe PDF y devuelve campos extraídos (sin persistir). `CsfExtraccionSchema` con todos los campos del ADR-007. 9 tests unitarios del schema pasando. Reutiliza `lib/documentos/extraction-core.ts`. Como efecto colateral, descubrimos un bug del workflow `db-types.yml` que regeneraba types sin schemas `dilesa`/`maquinaria` (causando typecheck fail en su PR auto-generado #227); arreglado en PR [#239](https://github.com/beto-sudo/BSOP/pull/239) y memoria `reference_db_types_workflow_sync.md` agregada. Próximo: Sprint 2.A (endpoint create-with-csf + dedup RFC).

--- a/lib/proveedores/extract-csf.test.ts
+++ b/lib/proveedores/extract-csf.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { CsfExtraccionSchema, RegimenSchema, ObligacionSchema } from './extract-csf';
+import {
+  CsfExtraccionSchema,
+  CreateProveedorPayloadSchema,
+  RegimenSchema,
+  ObligacionSchema,
+} from './extract-csf';
 
 /**
  * Tests del schema Zod para la extracción CSF.
@@ -299,5 +304,87 @@ describe('RegimenSchema y ObligacionSchema standalone', () => {
         fecha_fin: null,
       })
     ).toMatchObject({ descripcion: 'DIOT' });
+  });
+});
+
+describe('CreateProveedorPayloadSchema', () => {
+  const validExtraccion = {
+    tipo_persona: 'moral',
+    rfc: 'ABC010101AB1',
+    curp: null,
+    nombre: null,
+    apellido_paterno: null,
+    apellido_materno: null,
+    razon_social: 'EJEMPLO SA DE CV',
+    nombre_comercial: null,
+    regimen_fiscal_codigo: '601',
+    regimen_fiscal_nombre: 'General de Ley Personas Morales',
+    regimenes_adicionales: [
+      {
+        codigo: '601',
+        nombre: 'General de Ley Personas Morales',
+        fecha_inicio: '2020-01-01',
+        fecha_fin: null,
+      },
+    ],
+    domicilio_calle: null,
+    domicilio_num_ext: null,
+    domicilio_num_int: null,
+    domicilio_colonia: null,
+    domicilio_cp: null,
+    domicilio_municipio: null,
+    domicilio_estado: null,
+    obligaciones: [],
+    fecha_inicio_operaciones: null,
+    fecha_emision: null,
+  };
+
+  it('parsea payload completo con proveedor_extras', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+      proveedor_extras: {
+        codigo: 'PROV-001',
+        condiciones_pago: '30 días',
+        limite_credito: 50000,
+        categoria: 'Ferretería',
+      },
+    };
+    expect(CreateProveedorPayloadSchema.parse(payload)).toMatchObject({
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      proveedor_extras: { codigo: 'PROV-001' },
+    });
+  });
+
+  it('parsea payload sin proveedor_extras (opcional)', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+    };
+    const parsed = CreateProveedorPayloadSchema.parse(payload);
+    expect(parsed.proveedor_extras).toBeUndefined();
+  });
+
+  it('rechaza empresa_id que no es UUID', () => {
+    const payload = {
+      empresa_id: 'no-es-uuid',
+      extraccion: validExtraccion,
+    };
+    expect(() => CreateProveedorPayloadSchema.parse(payload)).toThrow();
+  });
+
+  it('rechaza si extraccion es inválida (RFC faltante)', () => {
+    const { rfc: _rfc, ...extraccionSinRfc } = validExtraccion;
+    void _rfc;
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: extraccionSinRfc,
+    };
+    expect(() => CreateProveedorPayloadSchema.parse(payload)).toThrow();
+  });
+
+  it('rechaza si falta empresa_id', () => {
+    const payload = { extraccion: validExtraccion };
+    expect(() => CreateProveedorPayloadSchema.parse(payload)).toThrow();
   });
 });

--- a/lib/proveedores/extract-csf.ts
+++ b/lib/proveedores/extract-csf.ts
@@ -146,6 +146,37 @@ export const CsfExtraccionSchema = z.object({
 
 export type CsfExtraccion = z.infer<typeof CsfExtraccionSchema>;
 
+// ─── Input para create-with-csf ──────────────────────────────────────────────
+
+/**
+ * Payload del endpoint `POST /api/proveedores/create-with-csf`.
+ *
+ * El cliente envía esto como JSON dentro del campo "payload" del multipart,
+ * más el PDF en el campo "file".
+ *
+ * - `extraccion` viene del flujo de Sprint 1.B: el cliente llama primero a
+ *   `/api/proveedores/extract-csf`, el usuario revisa/edita los campos en la
+ *   UI, y al guardar manda los campos finales (que pueden o no coincidir con
+ *   lo que Claude extrajo).
+ * - `proveedor_extras` es opcional — son atributos de `erp.proveedores` que no
+ *   vienen en la CSF (código interno, condiciones de pago, etc.). Si la UI no
+ *   los pide, se omiten y la fila de proveedor queda con defaults.
+ */
+export const CreateProveedorPayloadSchema = z.object({
+  empresa_id: z.string().uuid('empresa_id debe ser UUID'),
+  extraccion: CsfExtraccionSchema,
+  proveedor_extras: z
+    .object({
+      codigo: z.string().nullable().optional(),
+      condiciones_pago: z.string().nullable().optional(),
+      limite_credito: z.number().nullable().optional(),
+      categoria: z.string().nullable().optional(),
+    })
+    .optional(),
+});
+
+export type CreateProveedorPayload = z.infer<typeof CreateProveedorPayloadSchema>;
+
 // ─── Llamada al modelo ───────────────────────────────────────────────────────
 
 const PROMPT = `


### PR DESCRIPTION
## Summary

Sprint 2.B de [\`proveedores-csf-ai\`](docs/planning/proveedores-csf-ai.md): UI del drawer "+ Nuevo Proveedor" en RDB con flujo CSF integrado. **Stacked sobre [#241](https://github.com/beto-sudo/BSOP/pull/241)** (Sprint 2.A — endpoint create-with-csf). Cuando #241 mergee a main, GitHub re-targetea este PR a main automáticamente.

## Cambios

Solo modifica [\`app/rdb/proveedores/page.tsx\`](app/rdb/proveedores/page.tsx):

### Sección "Sube CSF (recomendado)"
- Input \`file\` (PDF) + botón "Procesar CSF" → llama \`/api/proveedores/extract-csf\` (Sprint 1.B).
- Spinner durante el procesamiento (~30-90s); banner rojo con error si Claude falla, manteniendo opción de captura manual.
- Tras éxito, indicador verde "✓ CSF procesada — {nombre.pdf}" + botón "Cambiar PDF".

### Pre-llenado del formulario
Auto-fill tras extracción:
- \`tipo_persona\` (toggle Física / Moral, editable).
- Físicas: nombre, apellidos, CURP.
- Morales: razón social (que también copia a \`nombre\` por convención del repo), nombre comercial.
- RFC en mayúsculas + monoespaciado.
- Régimen fiscal (código + descripción).
- Domicilio fiscal estructurado: calle, núm ext/int, colonia, CP, municipio, estado.
- Los campos de domicilio + régimen solo se muestran si hubo CSF (no aplican al flujo manual legacy).

### Submit dual
- **Con CSF**: \`POST /api/proveedores/create-with-csf\` (Sprint 2.A) con FormData (file + payload editado por el usuario).
- **Sin CSF**: flujo manual previo intacto — INSERT directo a \`erp.personas\` + \`erp.proveedores\` con browser client.

### Modal de RFC duplicado
Cuando el endpoint devuelve \`409 rfc_duplicado\`:
- Sheet con icono ⚠️ y el RFC en código mono.
- CTA "Ir al proveedor existente" → cierra create, abre detail drawer del row.
- CTA "Volver al formulario y editar RFC" → cierra modal, mantiene form.
- Mensaje sobre Sprint 3 ("Cargar / Actualizar CSF" en el detalle).

### Reset al cerrar
\`resetCreateForm()\` limpia todos los campos (legacy + CSF + nuevos) al cerrar el drawer, evitando arrastrar state entre altas consecutivas.

## Test plan

- [x] \`npm run typecheck\` verde.
- [x] \`npm run test:run\` 217/217 pasando.
- [x] \`npm run lint\` 0 errores.
- [x] \`npm run format:check\` clean.
- [ ] CI verde en este PR.
- [ ] Smoke manual end-to-end con CSF real (física y moral) en preview deploy:
      1. Subir PDF → ver spinner → form pre-llenado.
      2. Editar campos → guardar → verificar registros en DB (persona + proveedor + adjunto + datos_fiscales).
      3. Re-intentar con misma CSF → ver modal duplicado.
      4. Captura manual sin CSF → verificar que el flujo legacy sigue funcionando.

## Decisiones técnicas

- **Sin tests UI nuevos.** El repo no tiene tests de \`page.tsx\` — el smoke manual es la convención. Los tests del schema input (Sprint 2.A) ya cubren la validación del payload.
- **Toggle tipo_persona como botones, no radio.** Sigue el patrón de toggles del módulo (e.g. "Mostrar inactivos") para consistencia visual.
- **Modal con Sheet, no Dialog.** Reusa el componente Sheet ya importado, evita una dependencia adicional.
- **Comillas escapadas con \`&ldquo;\`/\`&rdquo;\`** para pasar lint \`react/no-unescaped-entities\`.

## Próximo

- **Sprint 2.C** (opcional): replicar el flujo en módulo de Proveedores DILESA (módulo nuevo si no existe).
- **Sprint 3**: UI de update con diff campo-por-campo + botón "Cargar / Actualizar CSF" en el detalle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)