### PR TITLE
feat(proveedores-csf-ai): Sprint 3.A — endpoint update-csf con diff selectivo

### DIFF
--- a/app/api/proveedores/[persona_id]/update-csf/route.ts
+++ b/app/api/proveedores/[persona_id]/update-csf/route.ts
@@ -1,0 +1,309 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public` por default; para leer/escribir
+ * en `erp` usamos `as any`. Es el mismo patrón que el resto del proyecto.
+ */
+
+/**
+ * POST /api/proveedores/[persona_id]/update-csf
+ *
+ * Actualiza la CSF de un proveedor existente, con aplicación selectiva de
+ * cambios campo-por-campo. El cliente:
+ *
+ *   1. Sube el PDF a `/api/proveedores/extract-csf` → recibe los campos.
+ *   2. UI muestra modal de diff: estado actual vs valor nuevo, checkbox por
+ *      campo.
+ *   3. Al aplicar, llama a este endpoint con FormData:
+ *        - `file`: el PDF subido a extract-csf.
+ *        - `payload`: JSON con { empresa_id, extraccion, accepted_fields[] }.
+ *
+ * Comportamiento según accepted_fields:
+ *   - **Vacío**: archiva PDF en erp.adjuntos como histórico, NO toca personas
+ *     ni personas_datos_fiscales. csf_adjunto_id se queda como estaba.
+ *   - **No vacío**: archiva PDF nuevo + UPDATEs selectivos sobre las dos
+ *     tablas + csf_adjunto_id se actualiza al nuevo adjunto.
+ *
+ * Caso edge: si la persona no tiene fila en personas_datos_fiscales (legacy
+ * pre-Sprint-1), el primer "update" es realmente un INSERT con los campos
+ * aceptados.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import {
+  UpdateCsfPayloadSchema,
+  type CsfExtraccion,
+  type CsfUpdatableField,
+} from '@/lib/proveedores/extract-csf';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+const BUCKET = 'adjuntos';
+const MAX_INCOMING_BYTES = 50 * 1024 * 1024;
+
+// Mapeo de cada campo del CsfExtraccionSchema a (tabla destino, columna).
+// Algunos campos viven en personas (identidad), otros en personas_datos_fiscales.
+type FieldTarget = {
+  table: 'personas' | 'personas_datos_fiscales';
+  column: string;
+};
+
+const FIELD_MAP: Record<CsfUpdatableField, FieldTarget> = {
+  tipo_persona: { table: 'personas', column: 'tipo_persona' },
+  rfc: { table: 'personas', column: 'rfc' },
+  curp: { table: 'personas', column: 'curp' },
+  nombre: { table: 'personas', column: 'nombre' },
+  apellido_paterno: { table: 'personas', column: 'apellido_paterno' },
+  apellido_materno: { table: 'personas', column: 'apellido_materno' },
+  razon_social: { table: 'personas_datos_fiscales', column: 'razon_social' },
+  nombre_comercial: { table: 'personas_datos_fiscales', column: 'nombre_comercial' },
+  regimen_fiscal_codigo: { table: 'personas_datos_fiscales', column: 'regimen_fiscal_codigo' },
+  regimen_fiscal_nombre: { table: 'personas_datos_fiscales', column: 'regimen_fiscal_nombre' },
+  regimenes_adicionales: { table: 'personas_datos_fiscales', column: 'regimenes_adicionales' },
+  domicilio_calle: { table: 'personas_datos_fiscales', column: 'domicilio_calle' },
+  domicilio_num_ext: { table: 'personas_datos_fiscales', column: 'domicilio_num_ext' },
+  domicilio_num_int: { table: 'personas_datos_fiscales', column: 'domicilio_num_int' },
+  domicilio_colonia: { table: 'personas_datos_fiscales', column: 'domicilio_colonia' },
+  domicilio_cp: { table: 'personas_datos_fiscales', column: 'domicilio_cp' },
+  domicilio_municipio: { table: 'personas_datos_fiscales', column: 'domicilio_municipio' },
+  domicilio_estado: { table: 'personas_datos_fiscales', column: 'domicilio_estado' },
+  obligaciones: { table: 'personas_datos_fiscales', column: 'obligaciones' },
+  fecha_inicio_operaciones: {
+    table: 'personas_datos_fiscales',
+    column: 'fecha_inicio_operaciones',
+  },
+  fecha_emision: { table: 'personas_datos_fiscales', column: 'csf_fecha_emision' },
+};
+
+type Params = { params: Promise<{ persona_id: string }> };
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const { persona_id } = await params;
+
+  // 1) Auth
+  const userSupa = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await userSupa.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+  }
+
+  // 2) Parse multipart
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `multipart inválido: ${msg}` }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  const payloadRaw = formData.get('payload');
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'Falta el campo "file" (multipart/form-data).' },
+      { status: 400 }
+    );
+  }
+  if (file.type && file.type !== 'application/pdf') {
+    return NextResponse.json(
+      { error: `Tipo de archivo no soportado: ${file.type}. Solo application/pdf.` },
+      { status: 415 }
+    );
+  }
+  if (file.size > MAX_INCOMING_BYTES) {
+    return NextResponse.json(
+      { error: `Archivo muy grande (${(file.size / 1024 / 1024).toFixed(1)} MB). Máximo 50 MB.` },
+      { status: 413 }
+    );
+  }
+  if (typeof payloadRaw !== 'string' || !payloadRaw.length) {
+    return NextResponse.json({ error: 'Falta el campo "payload".' }, { status: 400 });
+  }
+
+  // 3) Validate payload
+  let payload;
+  try {
+    payload = UpdateCsfPayloadSchema.parse(JSON.parse(payloadRaw));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  const { empresa_id, extraccion, accepted_fields } = payload;
+
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  // 4) Verifica que la persona existe en esta empresa.
+  const { data: existingPersona, error: personaErr } = await (admin.schema('erp') as any)
+    .from('personas')
+    .select('id, tipo_persona')
+    .eq('id', persona_id)
+    .eq('empresa_id', empresa_id)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (personaErr) {
+    return NextResponse.json({ error: `fetch persona: ${personaErr.message}` }, { status: 500 });
+  }
+  if (!existingPersona) {
+    return NextResponse.json({ error: 'Persona no encontrada en esta empresa.' }, { status: 404 });
+  }
+
+  // 5) Sube PDF a storage SIEMPRE (archiva como histórico aunque rechacen
+  //    todos los cambios — el alcance del Sprint 3 lo pide explícitamente).
+  const ts = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80);
+  const path = `proveedores/${empresa_id}/${persona_id}/csf-${ts}-${safeName}`;
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const { error: uploadErr } = await admin.storage.from(BUCKET).upload(path, bytes, {
+    contentType: 'application/pdf',
+    upsert: false,
+  });
+  if (uploadErr) {
+    return NextResponse.json({ error: `upload csf: ${uploadErr.message}` }, { status: 500 });
+  }
+
+  // 6) Crea row en erp.adjuntos para el PDF nuevo.
+  const { data: newAdjunto, error: adjErr } = await (userSupa.schema('erp') as any)
+    .from('adjuntos')
+    .insert({
+      empresa_id,
+      entidad_tipo: 'persona',
+      entidad_id: persona_id,
+      rol: 'csf',
+      nombre: file.name,
+      url: path,
+      tipo_mime: 'application/pdf',
+      tamano_bytes: file.size,
+      uploaded_by: user.id,
+    })
+    .select('id')
+    .single();
+  if (adjErr) {
+    return NextResponse.json({ error: `insert adjunto: ${adjErr.message}` }, { status: 500 });
+  }
+  const newAdjuntoId: string = newAdjunto.id;
+
+  // 7) Si accepted_fields está vacío → terminamos. PDF queda archivado, no
+  //    se aplican cambios, csf_adjunto_id no se actualiza.
+  if (accepted_fields.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      new_adjunto_id: newAdjuntoId,
+      fields_updated: 0,
+      csf_pointer_updated: false,
+    });
+  }
+
+  // 8) Calcula updates por tabla a partir de los campos aceptados.
+  const personasUpdates: Record<string, unknown> = {};
+  const datosFiscalesUpdates: Record<string, unknown> = {};
+
+  for (const field of accepted_fields) {
+    const target = FIELD_MAP[field];
+    const value = (extraccion as Partial<Record<CsfUpdatableField, unknown>>)[field];
+    if (target.table === 'personas') {
+      personasUpdates[target.column] = value;
+    } else {
+      datosFiscalesUpdates[target.column] = value;
+    }
+  }
+
+  // Convención del repo: si la persona es moral y se aceptó razon_social,
+  // también propagar a personas.nombre.
+  const tipoFinal =
+    'tipo_persona' in personasUpdates
+      ? (personasUpdates.tipo_persona as 'fisica' | 'moral')
+      : (existingPersona.tipo_persona as 'fisica' | 'moral');
+
+  if (tipoFinal === 'moral' && accepted_fields.includes('razon_social')) {
+    personasUpdates.nombre = (extraccion as CsfExtraccion).razon_social ?? personasUpdates.nombre;
+  }
+
+  // 9) UPDATE personas (si hay campos para esa tabla).
+  if (Object.keys(personasUpdates).length > 0) {
+    personasUpdates.updated_at = new Date().toISOString();
+    const { error: updPersErr } = await (userSupa.schema('erp') as any)
+      .from('personas')
+      .update(personasUpdates)
+      .eq('id', persona_id)
+      .eq('empresa_id', empresa_id);
+    if (updPersErr) {
+      const isRlsErr = /row-level security|permission denied/i.test(updPersErr.message);
+      return NextResponse.json(
+        {
+          error: `update persona: ${updPersErr.message}`,
+          partial: { new_adjunto_id: newAdjuntoId },
+        },
+        { status: isRlsErr ? 403 : 500 }
+      );
+    }
+  }
+
+  // 10) UPDATE / INSERT personas_datos_fiscales. Verifica si existe primero.
+  //     Siempre incluye csf_adjunto_id (apuntando al nuevo PDF) cuando hay
+  //     al menos un cambio aplicado.
+  const { data: existingDatosFiscales } = await (admin.schema('erp') as any)
+    .from('personas_datos_fiscales')
+    .select('id')
+    .eq('persona_id', persona_id)
+    .maybeSingle();
+
+  const datosFiscalesPayload = {
+    ...datosFiscalesUpdates,
+    csf_adjunto_id: newAdjuntoId,
+  };
+
+  if (existingDatosFiscales) {
+    // Siempre actualizamos al menos csf_adjunto_id cuando hay cambios aceptados.
+    const { error: updDfErr } = await (userSupa.schema('erp') as any)
+      .from('personas_datos_fiscales')
+      .update(datosFiscalesPayload)
+      .eq('id', existingDatosFiscales.id);
+    if (updDfErr) {
+      return NextResponse.json(
+        {
+          error: `update personas_datos_fiscales: ${updDfErr.message}`,
+          partial: { new_adjunto_id: newAdjuntoId },
+        },
+        { status: 500 }
+      );
+    }
+  } else {
+    // No existe — primer update sobre persona legacy. INSERT con los campos
+    // aceptados + csf_adjunto_id.
+    const { error: insDfErr } = await (userSupa.schema('erp') as any)
+      .from('personas_datos_fiscales')
+      .insert({
+        empresa_id,
+        persona_id,
+        ...datosFiscalesUpdates,
+        csf_adjunto_id: newAdjuntoId,
+      });
+    if (insDfErr) {
+      return NextResponse.json(
+        {
+          error: `insert personas_datos_fiscales: ${insDfErr.message}`,
+          partial: { new_adjunto_id: newAdjuntoId },
+        },
+        { status: 500 }
+      );
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    new_adjunto_id: newAdjuntoId,
+    fields_updated: accepted_fields.length,
+    csf_pointer_updated: true,
+  });
+}

--- a/docs/planning/proveedores-csf-ai.md
+++ b/docs/planning/proveedores-csf-ai.md
@@ -91,12 +91,19 @@ El módulo de Documentos ya tiene el patrón de extracción IA con Claude (`/api
 - [ ] Detección persona física vs moral: la extracción setea `tipo_persona`; UI muestra/oculta campos correspondientes.
 - [ ] Estados de error (Claude falla, PDF no es CSF, timeout) con CTA a captura manual.
 
-### Sprint 3 — UI de update existente (diff campo-por-campo)
+### Sprint 3.A — Backend de update con CSF
 
-- [ ] Botón "Cargar / Actualizar CSF" en drawer/detalle del proveedor.
+- [ ] `POST /api/proveedores/[persona_id]/update-csf` recibe FormData (PDF + payload con `accepted_fields[]`).
+- [ ] PDF siempre se archiva en `erp.adjuntos` como histórico; UPDATEs selectivos a `personas` y `personas_datos_fiscales` solo de los campos en `accepted_fields`. `csf_adjunto_id` se actualiza al nuevo solo si hay aceptados.
+- [ ] Edge case: persona legacy sin `personas_datos_fiscales` → primer "update" hace INSERT.
+- [ ] Tests del schema `UpdateCsfPayloadSchema` con `accepted_fields` enum.
+
+### Sprint 3.B — UI de update con diff (RDB primero)
+
+- [ ] Botón "Cargar / Actualizar CSF" en detalle del proveedor.
 - [ ] Modal de diff: valor actual → valor nuevo, checkbox por campo, "Aplicar cambios".
-- [ ] CSF nueva queda archivada como histórico aunque el usuario rechace todos los cambios. `csf_adjunto_id` se actualiza al PDF nuevo solo si se aceptó al menos un cambio.
-- [ ] Vista "Ver históricos" lista CSFs anteriores con fecha.
+- [ ] Manejo de tres outcomes: (a) aceptan todo, (b) aceptan algunos, (c) rechazan todo (PDF queda archivado igual).
+- [ ] Vista "Ver históricos" lista CSFs anteriores con fecha (opcional para v1).
 
 ### Sprint 4 — Rollout DILESA y cierre
 
@@ -115,3 +122,6 @@ El módulo de Documentos ya tiene el patrón de extracción IA con Claude (`/api
 - **2026-04-27 — Sesión de arranque.** Se registra la iniciativa en `INITIATIVES.md` (PR [#234](https://github.com/beto-sudo/BSOP/pull/234)). Beto aprueba alcance v1 inmediatamente. Se promueve estado `proposed → planned` y se cierra la decisión de modelo DB con [ADR-007](../../supabase/adr/007_personas_datos_fiscales.md).
 - **2026-04-27 — Sprint 1.A cerrado (PR [#235](https://github.com/beto-sudo/BSOP/pull/235)).** Migración aplicada a la DB: columna `tipo_persona` en `erp.personas` + tabla `erp.personas_datos_fiscales` con RLS y trigger updated_at. SCHEMA_REF y types regenerados. CI verde (typecheck/lint/test/format/drift-check). Estado `planned → in_progress`. Próximo: Sprint 1.B (endpoint extract-csf).
 - **2026-04-27 — Sprint 1.B cerrado (PR [#236](https://github.com/beto-sudo/BSOP/pull/236)).** Endpoint `POST /api/proveedores/extract-csf` que recibe PDF y devuelve campos extraídos (sin persistir). `CsfExtraccionSchema` con todos los campos del ADR-007. 9 tests unitarios del schema pasando. Reutiliza `lib/documentos/extraction-core.ts`. Como efecto colateral, descubrimos un bug del workflow `db-types.yml` que regeneraba types sin schemas `dilesa`/`maquinaria` (causando typecheck fail en su PR auto-generado #227); arreglado en PR [#239](https://github.com/beto-sudo/BSOP/pull/239) y memoria `reference_db_types_workflow_sync.md` agregada. Próximo: Sprint 2.A (endpoint create-with-csf + dedup RFC).
+- **2026-04-27 — Sprint 2.A cerrado (PR [#241](https://github.com/beto-sudo/BSOP/pull/241)).** Endpoint `POST /api/proveedores/create-with-csf` que recibe FormData (PDF + payload) y persiste persona + proveedor + adjunto + datos_fiscales en orden recuperable. Dedup por RFC con 409 + `existing_persona_id`. `CreateProveedorPayloadSchema` (Zod) compartido con cliente; 5 tests nuevos.
+- **2026-04-27 — Sprint 2.B cerrado (PR [#242](https://github.com/beto-sudo/BSOP/pull/242)).** UI del drawer "+ Nuevo Proveedor" en RDB con sección "Sube CSF (recomendado)" arriba del form. File input + botón "Procesar CSF" → spinner → form pre-llenado (tipo_persona toggle, identidad, RFC, CURP, régimen, domicilio fiscal). Submit dual: con CSF llama `create-with-csf`, sin CSF preserva el flujo manual existente. Modal Sheet de RFC duplicado con CTAs "Ir al existente" / "Volver al form". Solo modifica `app/rdb/proveedores/page.tsx`. 217 tests pasando.
+- **2026-04-27 — Sprint 3.A arranque.** Backend `POST /api/proveedores/[persona_id]/update-csf` con aplicación selectiva por `accepted_fields`. Mapeo `FIELD_MAP` decide qué campo va a `personas` vs `personas_datos_fiscales`. PDF siempre archivado; `csf_adjunto_id` se actualiza solo si hay aceptados. Maneja edge case de persona legacy sin `personas_datos_fiscales` (INSERT en lugar de UPDATE). `UpdateCsfPayloadSchema` con enum de campos válidos (`CSF_UPDATABLE_FIELDS`); 5 tests del schema. Próximo: Sprint 3.B (UI con modal de diff).

--- a/lib/proveedores/extract-csf.test.ts
+++ b/lib/proveedores/extract-csf.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
   CsfExtraccionSchema,
   CreateProveedorPayloadSchema,
+  UpdateCsfPayloadSchema,
   RegimenSchema,
   ObligacionSchema,
 } from './extract-csf';
@@ -386,5 +387,85 @@ describe('CreateProveedorPayloadSchema', () => {
   it('rechaza si falta empresa_id', () => {
     const payload = { extraccion: validExtraccion };
     expect(() => CreateProveedorPayloadSchema.parse(payload)).toThrow();
+  });
+});
+
+describe('UpdateCsfPayloadSchema', () => {
+  const validExtraccion = {
+    tipo_persona: 'moral',
+    rfc: 'ABC010101AB1',
+    curp: null,
+    nombre: null,
+    apellido_paterno: null,
+    apellido_materno: null,
+    razon_social: 'EJEMPLO SA DE CV (NUEVA)',
+    nombre_comercial: null,
+    regimen_fiscal_codigo: '601',
+    regimen_fiscal_nombre: 'General de Ley Personas Morales',
+    regimenes_adicionales: [
+      {
+        codigo: '601',
+        nombre: 'General de Ley Personas Morales',
+        fecha_inicio: '2020-01-01',
+        fecha_fin: null,
+      },
+    ],
+    domicilio_calle: 'Nueva Calle',
+    domicilio_num_ext: '500',
+    domicilio_num_int: null,
+    domicilio_colonia: 'Centro',
+    domicilio_cp: '06000',
+    domicilio_municipio: 'Cuauhtémoc',
+    domicilio_estado: 'CDMX',
+    obligaciones: [],
+    fecha_inicio_operaciones: '2020-01-01',
+    fecha_emision: '2026-04-27',
+  };
+
+  it('parsea payload con accepted_fields no vacío (aplicación parcial)', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+      accepted_fields: ['razon_social', 'domicilio_calle', 'domicilio_num_ext'],
+    };
+    const parsed = UpdateCsfPayloadSchema.parse(payload);
+    expect(parsed.accepted_fields).toHaveLength(3);
+    expect(parsed.accepted_fields).toContain('razon_social');
+  });
+
+  it('parsea payload con accepted_fields vacío (solo archiva PDF)', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+      accepted_fields: [],
+    };
+    const parsed = UpdateCsfPayloadSchema.parse(payload);
+    expect(parsed.accepted_fields).toHaveLength(0);
+  });
+
+  it('rechaza accepted_fields con un key no listado en CSF_UPDATABLE_FIELDS', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+      accepted_fields: ['razon_social', 'campo_inventado'],
+    };
+    expect(() => UpdateCsfPayloadSchema.parse(payload)).toThrow();
+  });
+
+  it('rechaza si falta accepted_fields', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+    };
+    expect(() => UpdateCsfPayloadSchema.parse(payload)).toThrow();
+  });
+
+  it('rechaza empresa_id no UUID', () => {
+    const payload = {
+      empresa_id: 'no-uuid',
+      extraccion: validExtraccion,
+      accepted_fields: [],
+    };
+    expect(() => UpdateCsfPayloadSchema.parse(payload)).toThrow();
   });
 });

--- a/lib/proveedores/extract-csf.ts
+++ b/lib/proveedores/extract-csf.ts
@@ -177,6 +177,62 @@ export const CreateProveedorPayloadSchema = z.object({
 
 export type CreateProveedorPayload = z.infer<typeof CreateProveedorPayloadSchema>;
 
+// ─── Input para update-csf (Sprint 3.A) ──────────────────────────────────────
+
+/**
+ * Conjunto canónico de campos del modelo CSF que el usuario puede elegir
+ * aplicar/ignorar en el flujo de update. Cada key del enum corresponde a un
+ * campo de `CsfExtraccionSchema`. El endpoint mapea estos keys a columnas en
+ * `erp.personas` o `erp.personas_datos_fiscales`.
+ */
+export const CSF_UPDATABLE_FIELDS = [
+  'tipo_persona',
+  'rfc',
+  'curp',
+  'nombre',
+  'apellido_paterno',
+  'apellido_materno',
+  'razon_social',
+  'nombre_comercial',
+  'regimen_fiscal_codigo',
+  'regimen_fiscal_nombre',
+  'regimenes_adicionales',
+  'domicilio_calle',
+  'domicilio_num_ext',
+  'domicilio_num_int',
+  'domicilio_colonia',
+  'domicilio_cp',
+  'domicilio_municipio',
+  'domicilio_estado',
+  'obligaciones',
+  'fecha_inicio_operaciones',
+  'fecha_emision',
+] as const;
+
+export type CsfUpdatableField = (typeof CSF_UPDATABLE_FIELDS)[number];
+
+/**
+ * Payload del endpoint `POST /api/proveedores/[persona_id]/update-csf`.
+ *
+ * El cliente arma esto tras revisar el diff entre la extracción nueva y el
+ * estado actual de la persona. `accepted_fields` lista los keys que el
+ * usuario marcó con checkbox en el modal.
+ *
+ * Comportamiento del endpoint según `accepted_fields`:
+ * - **Vacío:** solo archiva el PDF nuevo en `erp.adjuntos` como histórico.
+ *   No toca `personas` ni `personas_datos_fiscales`. `csf_adjunto_id` queda
+ *   apuntando al PDF anterior.
+ * - **No vacío:** archiva el PDF nuevo, aplica UPDATEs selectivos solo a los
+ *   campos listados, y actualiza `csf_adjunto_id` al nuevo adjunto.
+ */
+export const UpdateCsfPayloadSchema = z.object({
+  empresa_id: z.string().uuid('empresa_id debe ser UUID'),
+  extraccion: CsfExtraccionSchema,
+  accepted_fields: z.array(z.enum(CSF_UPDATABLE_FIELDS)),
+});
+
+export type UpdateCsfPayload = z.infer<typeof UpdateCsfPayloadSchema>;
+
 // ─── Llamada al modelo ───────────────────────────────────────────────────────
 
 const PROMPT = `


### PR DESCRIPTION
## Summary

Sprint 3.A de [\`proveedores-csf-ai\`](docs/planning/proveedores-csf-ai.md): backend del flujo de actualización de CSF con aplicación campo-por-campo. Sprint 3.B (UI con modal de diff + botón "Cargar / Actualizar CSF" en el detalle del proveedor) viene en PR siguiente.

## Cambios

- 🆕 [\`app/api/proveedores/[persona_id]/update-csf/route.ts\`](app/api/proveedores/[persona_id]/update-csf/route.ts) — POST que actualiza CSF con aplicación selectiva.
- 🧱 [\`lib/proveedores/extract-csf.ts\`](lib/proveedores/extract-csf.ts) — agrega \`UpdateCsfPayloadSchema\` + enum \`CSF_UPDATABLE_FIELDS\` (21 keys válidos) + tipo \`CsfUpdatableField\`.
- ✅ [\`lib/proveedores/extract-csf.test.ts\`](lib/proveedores/extract-csf.test.ts) — 5 tests nuevos del schema (19 totales).
- 📋 [\`docs/planning/proveedores-csf-ai.md\`](docs/planning/proveedores-csf-ai.md) — Sprint 2.A/2.B ✅, Sprint 3 dividido en 3.A/3.B, bitácora.

## Comportamiento

**Input** (multipart/form-data + path \`persona_id\`):
- \`file\`: PDF de la CSF nueva.
- \`payload\` (JSON):
  \`\`\`ts
  {
    empresa_id: uuid,
    extraccion: CsfExtraccion,           // valores nuevos extraídos por Claude
    accepted_fields: CsfUpdatableField[] // los keys que el usuario marcó en checkbox
  }
  \`\`\`

**Outcomes según \`accepted_fields\`:**

| accepted_fields | PDF archivado | personas / datos_fiscales | csf_adjunto_id |
|---|---|---|---|
| Vacío (rechazan todo) | ✅ Sí (histórico) | ❌ Sin tocar | Apunta al anterior |
| No vacío (aceptan algunos) | ✅ Sí | ✅ UPDATE selectivo | Apunta al nuevo |

**\`FIELD_MAP\` decide la tabla destino:**

| Tabla | Campos |
|---|---|
| \`personas\` | tipo_persona, rfc, curp, nombre, apellido_paterno, apellido_materno |
| \`personas_datos_fiscales\` | razón social, nombre comercial, régimen (código/nombre/adicionales), domicilio fiscal (8 campos), obligaciones, fecha_inicio_operaciones, csf_fecha_emision |

Si \`tipo_persona\` es moral y se aceptó \`razon_social\`, también propaga a \`personas.nombre\` (convención del repo).

**Edge cases:**
- Persona legacy sin fila en \`personas_datos_fiscales\` (creada antes de Sprint 1.A) → primer "update" hace **INSERT** en lugar de UPDATE, con los campos aceptados.
- Persona no existe en \`empresa_id\` → \`404\`.
- RLS bloquea UPDATE → \`403\`.
- Failure post-upload → \`500 { partial: { new_adjunto_id } }\` para que el cliente sepa qué quedó persistido.

## Test plan

- [x] \`npm run typecheck\` verde.
- [x] \`npm run test:run\` 222/222 pasando (203 base + 19 lib/proveedores).
- [x] \`npm run lint\` 0 errores.
- [x] \`npm run format:check\` clean.
- [ ] CI verde en este PR.
- [ ] Smoke manual end-to-end llega con Sprint 3.B (UI).

## Próximo

**Sprint 3.B**: UI del modal de diff campo-por-campo + botón "Cargar / Actualizar CSF" en el detalle del proveedor (lo que Beto preguntó en preview de #242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)