### PR TITLE
feat(proveedores-csf-ai): Sprint 3.B — UI modal de diff CSF (RDB)

### DIFF
--- a/app/api/proveedores/[persona_id]/update-csf/route.ts
+++ b/app/api/proveedores/[persona_id]/update-csf/route.ts
@@ -1,0 +1,309 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public` por default; para leer/escribir
+ * en `erp` usamos `as any`. Es el mismo patrón que el resto del proyecto.
+ */
+
+/**
+ * POST /api/proveedores/[persona_id]/update-csf
+ *
+ * Actualiza la CSF de un proveedor existente, con aplicación selectiva de
+ * cambios campo-por-campo. El cliente:
+ *
+ *   1. Sube el PDF a `/api/proveedores/extract-csf` → recibe los campos.
+ *   2. UI muestra modal de diff: estado actual vs valor nuevo, checkbox por
+ *      campo.
+ *   3. Al aplicar, llama a este endpoint con FormData:
+ *        - `file`: el PDF subido a extract-csf.
+ *        - `payload`: JSON con { empresa_id, extraccion, accepted_fields[] }.
+ *
+ * Comportamiento según accepted_fields:
+ *   - **Vacío**: archiva PDF en erp.adjuntos como histórico, NO toca personas
+ *     ni personas_datos_fiscales. csf_adjunto_id se queda como estaba.
+ *   - **No vacío**: archiva PDF nuevo + UPDATEs selectivos sobre las dos
+ *     tablas + csf_adjunto_id se actualiza al nuevo adjunto.
+ *
+ * Caso edge: si la persona no tiene fila en personas_datos_fiscales (legacy
+ * pre-Sprint-1), el primer "update" es realmente un INSERT con los campos
+ * aceptados.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import {
+  UpdateCsfPayloadSchema,
+  type CsfExtraccion,
+  type CsfUpdatableField,
+} from '@/lib/proveedores/extract-csf';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+const BUCKET = 'adjuntos';
+const MAX_INCOMING_BYTES = 50 * 1024 * 1024;
+
+// Mapeo de cada campo del CsfExtraccionSchema a (tabla destino, columna).
+// Algunos campos viven en personas (identidad), otros en personas_datos_fiscales.
+type FieldTarget = {
+  table: 'personas' | 'personas_datos_fiscales';
+  column: string;
+};
+
+const FIELD_MAP: Record<CsfUpdatableField, FieldTarget> = {
+  tipo_persona: { table: 'personas', column: 'tipo_persona' },
+  rfc: { table: 'personas', column: 'rfc' },
+  curp: { table: 'personas', column: 'curp' },
+  nombre: { table: 'personas', column: 'nombre' },
+  apellido_paterno: { table: 'personas', column: 'apellido_paterno' },
+  apellido_materno: { table: 'personas', column: 'apellido_materno' },
+  razon_social: { table: 'personas_datos_fiscales', column: 'razon_social' },
+  nombre_comercial: { table: 'personas_datos_fiscales', column: 'nombre_comercial' },
+  regimen_fiscal_codigo: { table: 'personas_datos_fiscales', column: 'regimen_fiscal_codigo' },
+  regimen_fiscal_nombre: { table: 'personas_datos_fiscales', column: 'regimen_fiscal_nombre' },
+  regimenes_adicionales: { table: 'personas_datos_fiscales', column: 'regimenes_adicionales' },
+  domicilio_calle: { table: 'personas_datos_fiscales', column: 'domicilio_calle' },
+  domicilio_num_ext: { table: 'personas_datos_fiscales', column: 'domicilio_num_ext' },
+  domicilio_num_int: { table: 'personas_datos_fiscales', column: 'domicilio_num_int' },
+  domicilio_colonia: { table: 'personas_datos_fiscales', column: 'domicilio_colonia' },
+  domicilio_cp: { table: 'personas_datos_fiscales', column: 'domicilio_cp' },
+  domicilio_municipio: { table: 'personas_datos_fiscales', column: 'domicilio_municipio' },
+  domicilio_estado: { table: 'personas_datos_fiscales', column: 'domicilio_estado' },
+  obligaciones: { table: 'personas_datos_fiscales', column: 'obligaciones' },
+  fecha_inicio_operaciones: {
+    table: 'personas_datos_fiscales',
+    column: 'fecha_inicio_operaciones',
+  },
+  fecha_emision: { table: 'personas_datos_fiscales', column: 'csf_fecha_emision' },
+};
+
+type Params = { params: Promise<{ persona_id: string }> };
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const { persona_id } = await params;
+
+  // 1) Auth
+  const userSupa = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await userSupa.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'No autenticado' }, { status: 401 });
+  }
+
+  // 2) Parse multipart
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `multipart inválido: ${msg}` }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  const payloadRaw = formData.get('payload');
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'Falta el campo "file" (multipart/form-data).' },
+      { status: 400 }
+    );
+  }
+  if (file.type && file.type !== 'application/pdf') {
+    return NextResponse.json(
+      { error: `Tipo de archivo no soportado: ${file.type}. Solo application/pdf.` },
+      { status: 415 }
+    );
+  }
+  if (file.size > MAX_INCOMING_BYTES) {
+    return NextResponse.json(
+      { error: `Archivo muy grande (${(file.size / 1024 / 1024).toFixed(1)} MB). Máximo 50 MB.` },
+      { status: 413 }
+    );
+  }
+  if (typeof payloadRaw !== 'string' || !payloadRaw.length) {
+    return NextResponse.json({ error: 'Falta el campo "payload".' }, { status: 400 });
+  }
+
+  // 3) Validate payload
+  let payload;
+  try {
+    payload = UpdateCsfPayloadSchema.parse(JSON.parse(payloadRaw));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  const { empresa_id, extraccion, accepted_fields } = payload;
+
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  // 4) Verifica que la persona existe en esta empresa.
+  const { data: existingPersona, error: personaErr } = await (admin.schema('erp') as any)
+    .from('personas')
+    .select('id, tipo_persona')
+    .eq('id', persona_id)
+    .eq('empresa_id', empresa_id)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (personaErr) {
+    return NextResponse.json({ error: `fetch persona: ${personaErr.message}` }, { status: 500 });
+  }
+  if (!existingPersona) {
+    return NextResponse.json({ error: 'Persona no encontrada en esta empresa.' }, { status: 404 });
+  }
+
+  // 5) Sube PDF a storage SIEMPRE (archiva como histórico aunque rechacen
+  //    todos los cambios — el alcance del Sprint 3 lo pide explícitamente).
+  const ts = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80);
+  const path = `proveedores/${empresa_id}/${persona_id}/csf-${ts}-${safeName}`;
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const { error: uploadErr } = await admin.storage.from(BUCKET).upload(path, bytes, {
+    contentType: 'application/pdf',
+    upsert: false,
+  });
+  if (uploadErr) {
+    return NextResponse.json({ error: `upload csf: ${uploadErr.message}` }, { status: 500 });
+  }
+
+  // 6) Crea row en erp.adjuntos para el PDF nuevo.
+  const { data: newAdjunto, error: adjErr } = await (userSupa.schema('erp') as any)
+    .from('adjuntos')
+    .insert({
+      empresa_id,
+      entidad_tipo: 'persona',
+      entidad_id: persona_id,
+      rol: 'csf',
+      nombre: file.name,
+      url: path,
+      tipo_mime: 'application/pdf',
+      tamano_bytes: file.size,
+      uploaded_by: user.id,
+    })
+    .select('id')
+    .single();
+  if (adjErr) {
+    return NextResponse.json({ error: `insert adjunto: ${adjErr.message}` }, { status: 500 });
+  }
+  const newAdjuntoId: string = newAdjunto.id;
+
+  // 7) Si accepted_fields está vacío → terminamos. PDF queda archivado, no
+  //    se aplican cambios, csf_adjunto_id no se actualiza.
+  if (accepted_fields.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      new_adjunto_id: newAdjuntoId,
+      fields_updated: 0,
+      csf_pointer_updated: false,
+    });
+  }
+
+  // 8) Calcula updates por tabla a partir de los campos aceptados.
+  const personasUpdates: Record<string, unknown> = {};
+  const datosFiscalesUpdates: Record<string, unknown> = {};
+
+  for (const field of accepted_fields) {
+    const target = FIELD_MAP[field];
+    const value = (extraccion as Partial<Record<CsfUpdatableField, unknown>>)[field];
+    if (target.table === 'personas') {
+      personasUpdates[target.column] = value;
+    } else {
+      datosFiscalesUpdates[target.column] = value;
+    }
+  }
+
+  // Convención del repo: si la persona es moral y se aceptó razon_social,
+  // también propagar a personas.nombre.
+  const tipoFinal =
+    'tipo_persona' in personasUpdates
+      ? (personasUpdates.tipo_persona as 'fisica' | 'moral')
+      : (existingPersona.tipo_persona as 'fisica' | 'moral');
+
+  if (tipoFinal === 'moral' && accepted_fields.includes('razon_social')) {
+    personasUpdates.nombre = (extraccion as CsfExtraccion).razon_social ?? personasUpdates.nombre;
+  }
+
+  // 9) UPDATE personas (si hay campos para esa tabla).
+  if (Object.keys(personasUpdates).length > 0) {
+    personasUpdates.updated_at = new Date().toISOString();
+    const { error: updPersErr } = await (userSupa.schema('erp') as any)
+      .from('personas')
+      .update(personasUpdates)
+      .eq('id', persona_id)
+      .eq('empresa_id', empresa_id);
+    if (updPersErr) {
+      const isRlsErr = /row-level security|permission denied/i.test(updPersErr.message);
+      return NextResponse.json(
+        {
+          error: `update persona: ${updPersErr.message}`,
+          partial: { new_adjunto_id: newAdjuntoId },
+        },
+        { status: isRlsErr ? 403 : 500 }
+      );
+    }
+  }
+
+  // 10) UPDATE / INSERT personas_datos_fiscales. Verifica si existe primero.
+  //     Siempre incluye csf_adjunto_id (apuntando al nuevo PDF) cuando hay
+  //     al menos un cambio aplicado.
+  const { data: existingDatosFiscales } = await (admin.schema('erp') as any)
+    .from('personas_datos_fiscales')
+    .select('id')
+    .eq('persona_id', persona_id)
+    .maybeSingle();
+
+  const datosFiscalesPayload = {
+    ...datosFiscalesUpdates,
+    csf_adjunto_id: newAdjuntoId,
+  };
+
+  if (existingDatosFiscales) {
+    // Siempre actualizamos al menos csf_adjunto_id cuando hay cambios aceptados.
+    const { error: updDfErr } = await (userSupa.schema('erp') as any)
+      .from('personas_datos_fiscales')
+      .update(datosFiscalesPayload)
+      .eq('id', existingDatosFiscales.id);
+    if (updDfErr) {
+      return NextResponse.json(
+        {
+          error: `update personas_datos_fiscales: ${updDfErr.message}`,
+          partial: { new_adjunto_id: newAdjuntoId },
+        },
+        { status: 500 }
+      );
+    }
+  } else {
+    // No existe — primer update sobre persona legacy. INSERT con los campos
+    // aceptados + csf_adjunto_id.
+    const { error: insDfErr } = await (userSupa.schema('erp') as any)
+      .from('personas_datos_fiscales')
+      .insert({
+        empresa_id,
+        persona_id,
+        ...datosFiscalesUpdates,
+        csf_adjunto_id: newAdjuntoId,
+      });
+    if (insDfErr) {
+      return NextResponse.json(
+        {
+          error: `insert personas_datos_fiscales: ${insDfErr.message}`,
+          partial: { new_adjunto_id: newAdjuntoId },
+        },
+        { status: 500 }
+      );
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    new_adjunto_id: newAdjuntoId,
+    fields_updated: accepted_fields.length,
+    csf_pointer_updated: true,
+  });
+}

--- a/app/rdb/proveedores/page.tsx
+++ b/app/rdb/proveedores/page.tsx
@@ -32,6 +32,95 @@ import type { CsfExtraccion } from '@/lib/proveedores/extract-csf';
 
 const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
+// ─── CSF diff helpers (Sprint 3.B) ───────────────────────────────────────────
+
+const CSF_DIFF_FIELDS = [
+  'tipo_persona',
+  'rfc',
+  'curp',
+  'nombre',
+  'apellido_paterno',
+  'apellido_materno',
+  'razon_social',
+  'nombre_comercial',
+  'regimen_fiscal_codigo',
+  'regimen_fiscal_nombre',
+  'regimenes_adicionales',
+  'domicilio_calle',
+  'domicilio_num_ext',
+  'domicilio_num_int',
+  'domicilio_colonia',
+  'domicilio_cp',
+  'domicilio_municipio',
+  'domicilio_estado',
+  'obligaciones',
+  'fecha_inicio_operaciones',
+  'fecha_emision',
+] as const;
+
+const FIELD_LABELS: Record<(typeof CSF_DIFF_FIELDS)[number], string> = {
+  tipo_persona: 'Tipo de persona',
+  rfc: 'RFC',
+  curp: 'CURP',
+  nombre: 'Nombre',
+  apellido_paterno: 'Apellido paterno',
+  apellido_materno: 'Apellido materno',
+  razon_social: 'Razón social',
+  nombre_comercial: 'Nombre comercial',
+  regimen_fiscal_codigo: 'Régimen — código',
+  regimen_fiscal_nombre: 'Régimen — descripción',
+  regimenes_adicionales: 'Regímenes adicionales',
+  domicilio_calle: 'Domicilio — calle',
+  domicilio_num_ext: 'Domicilio — núm. ext.',
+  domicilio_num_int: 'Domicilio — núm. int.',
+  domicilio_colonia: 'Domicilio — colonia',
+  domicilio_cp: 'Domicilio — CP',
+  domicilio_municipio: 'Domicilio — municipio',
+  domicilio_estado: 'Domicilio — estado',
+  obligaciones: 'Obligaciones',
+  fecha_inicio_operaciones: 'Fecha inicio operaciones',
+  fecha_emision: 'Fecha emisión CSF',
+};
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null && b == null) return true;
+  if (a == null || b == null) {
+    // Trata "" y null como equivalentes (común en datos de SAT).
+    if (a === '' && b == null) return true;
+    if (b === '' && a == null) return true;
+    return false;
+  }
+  if (typeof a === 'string' && typeof b === 'string') {
+    return a.trim() === b.trim();
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return false;
+}
+
+function formatDiffValue(v: unknown): string {
+  if (v == null || v === '') return '—';
+  if (Array.isArray(v)) {
+    if (v.length === 0) return '— (vacío)';
+    return v
+      .map((item: unknown) => {
+        if (item && typeof item === 'object') {
+          const obj = item as Record<string, unknown>;
+          if ('codigo' in obj && 'nombre' in obj) return `${obj.codigo} · ${obj.nombre}`;
+          if ('descripcion' in obj) return String(obj.descripcion);
+        }
+        return String(item);
+      })
+      .join('\n');
+  }
+  return String(v);
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type Proveedor = {
@@ -98,6 +187,7 @@ function ProveedorDetail({
   onClose,
   onEdit,
   onToggleActivo,
+  onUpdateCsf,
   saving,
 }: {
   proveedor: Proveedor | null;
@@ -105,6 +195,7 @@ function ProveedorDetail({
   onClose: () => void;
   onEdit: (p: Proveedor) => void;
   onToggleActivo: (p: Proveedor) => void;
+  onUpdateCsf: (p: Proveedor) => void;
   saving: boolean;
 }) {
   if (!proveedor) return null;
@@ -134,6 +225,10 @@ function ProveedorDetail({
         <SheetHeader>
           <SheetTitle>{proveedor.nombre}</SheetTitle>
           <div className="absolute right-12 top-4 hidden sm:flex gap-2 print:hidden">
+            <Button variant="outline" size="sm" onClick={() => onUpdateCsf(proveedor)}>
+              <Sparkles className="mr-2 h-4 w-4" />
+              Cargar / Actualizar CSF
+            </Button>
             <Button variant="outline" size="sm" onClick={() => onEdit(proveedor)}>
               <Pencil className="mr-2 h-4 w-4" />
               Editar
@@ -264,6 +359,17 @@ export default function ProveedoresPage() {
     rfc: string;
   } | null>(null);
 
+  // ─── Update CSF flow state (Sprint 3.B) ─────────────────────────────────────
+  const [updateCsfTarget, setUpdateCsfTarget] = useState<Proveedor | null>(null);
+  const [updateCsfFile, setUpdateCsfFile] = useState<File | null>(null);
+  const [updateCsfProcessing, setUpdateCsfProcessing] = useState(false);
+  const [updateCsfError, setUpdateCsfError] = useState<string | null>(null);
+  const [updateCsfExtraccion, setUpdateCsfExtraccion] = useState<CsfExtraccion | null>(null);
+  const [currentDatos, setCurrentDatos] = useState<Partial<CsfExtraccion> | null>(null);
+  const [diffOpen, setDiffOpen] = useState(false);
+  const [acceptedFields, setAcceptedFields] = useState<Set<string>>(new Set());
+  const [applyingDiff, setApplyingDiff] = useState(false);
+
   const resetCreateForm = () => {
     setNewNombre('');
     setNewApellidoPaterno('');
@@ -291,6 +397,133 @@ export default function ProveedoresPage() {
     setNewDomCp('');
     setNewDomMunicipio('');
     setNewDomEstado('');
+  };
+
+  // ─── Update CSF handlers (Sprint 3.B) ──────────────────────────────────────
+
+  const fetchCurrentDatos = async (personaId: string): Promise<Partial<CsfExtraccion>> => {
+    const supabase = createSupabaseBrowserClient();
+    const [pRes, dfRes] = await Promise.all([
+      supabase
+        .schema('erp')
+        .from('personas')
+        .select('tipo_persona, rfc, curp, nombre, apellido_paterno, apellido_materno')
+        .eq('id', personaId)
+        .single(),
+      supabase
+        .schema('erp')
+        .from('personas_datos_fiscales')
+        .select(
+          'razon_social, nombre_comercial, regimen_fiscal_codigo, regimen_fiscal_nombre, regimenes_adicionales, domicilio_calle, domicilio_num_ext, domicilio_num_int, domicilio_colonia, domicilio_cp, domicilio_municipio, domicilio_estado, obligaciones, fecha_inicio_operaciones, csf_fecha_emision'
+        )
+        .eq('persona_id', personaId)
+        .maybeSingle(),
+    ]);
+    const p = (pRes.data ?? {}) as Record<string, unknown>;
+    const df = (dfRes.data ?? {}) as Record<string, unknown>;
+    return {
+      tipo_persona: (p.tipo_persona as 'fisica' | 'moral' | undefined) ?? 'fisica',
+      rfc: (p.rfc as string | null) ?? '',
+      curp: (p.curp as string | null) ?? null,
+      nombre: (p.nombre as string | null) ?? null,
+      apellido_paterno: (p.apellido_paterno as string | null) ?? null,
+      apellido_materno: (p.apellido_materno as string | null) ?? null,
+      razon_social: (df.razon_social as string | null) ?? null,
+      nombre_comercial: (df.nombre_comercial as string | null) ?? null,
+      regimen_fiscal_codigo: (df.regimen_fiscal_codigo as string | null) ?? null,
+      regimen_fiscal_nombre: (df.regimen_fiscal_nombre as string | null) ?? null,
+      regimenes_adicionales:
+        (df.regimenes_adicionales as CsfExtraccion['regimenes_adicionales'] | null) ?? [],
+      domicilio_calle: (df.domicilio_calle as string | null) ?? null,
+      domicilio_num_ext: (df.domicilio_num_ext as string | null) ?? null,
+      domicilio_num_int: (df.domicilio_num_int as string | null) ?? null,
+      domicilio_colonia: (df.domicilio_colonia as string | null) ?? null,
+      domicilio_cp: (df.domicilio_cp as string | null) ?? null,
+      domicilio_municipio: (df.domicilio_municipio as string | null) ?? null,
+      domicilio_estado: (df.domicilio_estado as string | null) ?? null,
+      obligaciones: (df.obligaciones as CsfExtraccion['obligaciones'] | null) ?? [],
+      fecha_inicio_operaciones: (df.fecha_inicio_operaciones as string | null) ?? null,
+      fecha_emision: (df.csf_fecha_emision as string | null) ?? null,
+    };
+  };
+
+  const handleStartUpdateCsf = (p: Proveedor) => {
+    setUpdateCsfTarget(p);
+    setUpdateCsfFile(null);
+    setUpdateCsfExtraccion(null);
+    setUpdateCsfError(null);
+    setCurrentDatos(null);
+    setAcceptedFields(new Set());
+    // Trigger file picker via hidden input
+    document.getElementById('update-csf-file-input')?.click();
+  };
+
+  const handleUpdateCsfFileChosen = async (file: File | null) => {
+    if (!file || !updateCsfTarget?.persona_id) return;
+    setUpdateCsfFile(file);
+    setUpdateCsfProcessing(true);
+    setUpdateCsfError(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const [extractRes, current] = await Promise.all([
+        fetch('/api/proveedores/extract-csf', { method: 'POST', body: fd }),
+        fetchCurrentDatos(updateCsfTarget.persona_id),
+      ]);
+      const extractJson = await extractRes.json();
+      if (!extractRes.ok) throw new Error(extractJson.error ?? 'Error al procesar CSF');
+
+      const ex = extractJson.extraccion as CsfExtraccion;
+      setUpdateCsfExtraccion(ex);
+      setCurrentDatos(current);
+
+      // Pre-marca todos los campos que difieren.
+      const initial = new Set<string>();
+      for (const key of CSF_DIFF_FIELDS) {
+        const cur = (current as Record<string, unknown>)[key];
+        const nu = (ex as Record<string, unknown>)[key];
+        if (!valuesEqual(cur, nu)) initial.add(key);
+      }
+      setAcceptedFields(initial);
+      setDiffOpen(true);
+    } catch (err) {
+      setUpdateCsfError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUpdateCsfProcessing(false);
+    }
+  };
+
+  const handleApplyDiff = async () => {
+    if (!updateCsfFile || !updateCsfExtraccion || !updateCsfTarget?.persona_id) return;
+    setApplyingDiff(true);
+    try {
+      const fd = new FormData();
+      fd.append('file', updateCsfFile);
+      fd.append(
+        'payload',
+        JSON.stringify({
+          empresa_id: RDB_EMPRESA_ID,
+          extraccion: updateCsfExtraccion,
+          accepted_fields: Array.from(acceptedFields),
+        })
+      );
+      const res = await fetch(`/api/proveedores/${updateCsfTarget.persona_id}/update-csf`, {
+        method: 'POST',
+        body: fd,
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? 'Error al aplicar cambios');
+      setDiffOpen(false);
+      setUpdateCsfFile(null);
+      setUpdateCsfExtraccion(null);
+      setCurrentDatos(null);
+      setUpdateCsfTarget(null);
+      void fetchProveedores();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Error al aplicar cambios');
+    } finally {
+      setApplyingDiff(false);
+    }
   };
 
   const handleProcessCsf = async () => {
@@ -659,6 +892,19 @@ export default function ProveedoresPage() {
           showDensityToggle={false}
         />
 
+        {/* Hidden file input for the "Cargar / Actualizar CSF" flow */}
+        <input
+          id="update-csf-file-input"
+          type="file"
+          accept="application/pdf"
+          className="hidden"
+          onChange={(e) => {
+            const f = e.target.files?.[0] ?? null;
+            void handleUpdateCsfFileChosen(f);
+            e.target.value = ''; // permite re-elegir el mismo archivo después
+          }}
+        />
+
         {/* Detail drawer */}
         <ProveedorDetail
           proveedor={selected}
@@ -666,6 +912,7 @@ export default function ProveedoresPage() {
           onClose={() => setDrawerOpen(false)}
           onEdit={openEdit}
           onToggleActivo={handleToggleActivo}
+          onUpdateCsf={handleStartUpdateCsf}
           saving={savingEdit}
         />
 
@@ -1080,6 +1327,189 @@ export default function ProveedoresPage() {
                     <Save className="h-4 w-4" />
                   )}
                   Crear Proveedor
+                </Button>
+              </div>
+            </div>
+          </SheetContent>
+        </Sheet>
+
+        {/* Update CSF — overlay de procesamiento (mientras Claude lee el PDF) */}
+        {updateCsfProcessing && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+            <div className="rounded-lg bg-background p-6 shadow-lg">
+              <div className="flex items-center gap-3">
+                <RefreshCw className="h-5 w-5 animate-spin text-emerald-600" />
+                <div>
+                  <div className="text-sm font-medium">Procesando CSF…</div>
+                  <div className="text-xs text-muted-foreground">
+                    Claude está leyendo el PDF (30-90 segundos).
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Update CSF — banner de error */}
+        {updateCsfError && !diffOpen && (
+          <div className="fixed bottom-4 right-4 z-50 max-w-md rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive shadow-lg">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              <div className="flex-1">
+                <strong>Error al procesar CSF:</strong> {updateCsfError}
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="-mr-2 -mt-1 h-6 px-2"
+                onClick={() => setUpdateCsfError(null)}
+              >
+                ✕
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Modal: diff campo-por-campo (Sprint 3.B) */}
+        <Sheet
+          open={diffOpen}
+          onOpenChange={(v) => {
+            if (!v) {
+              setDiffOpen(false);
+              // No limpiamos el target ni file aquí — usuario puede cancelar y
+              // re-abrir si decide aplicar después. Limpieza completa pasa al
+              // aplicar exitosamente o al iniciar un nuevo update.
+            }
+          }}
+        >
+          <SheetContent className="sm:max-w-[800px] overflow-y-auto">
+            <SheetHeader>
+              <SheetTitle className="flex items-center gap-2">
+                <Sparkles className="h-5 w-5 text-emerald-600" />
+                Revisar cambios de la CSF
+              </SheetTitle>
+              <p className="text-xs text-muted-foreground">
+                {updateCsfTarget?.nombre} — marca los campos que quieras aplicar. La CSF nueva queda
+                archivada como histórico aunque rechaces todos los cambios.
+              </p>
+            </SheetHeader>
+
+            <div className="mt-6 space-y-4">
+              {/* Toolbar de selección */}
+              <div className="flex flex-wrap items-center gap-2 border-b pb-3">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    if (!updateCsfExtraccion || !currentDatos) return;
+                    const all = new Set<string>();
+                    for (const k of CSF_DIFF_FIELDS) {
+                      const cur = (currentDatos as Record<string, unknown>)[k];
+                      const nu = (updateCsfExtraccion as Record<string, unknown>)[k];
+                      if (!valuesEqual(cur, nu)) all.add(k);
+                    }
+                    setAcceptedFields(all);
+                  }}
+                >
+                  Seleccionar todos los cambios
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setAcceptedFields(new Set())}>
+                  Limpiar selección
+                </Button>
+                <span className="ml-auto text-xs text-muted-foreground">
+                  {acceptedFields.size} de {CSF_DIFF_FIELDS.length} campos seleccionados
+                </span>
+              </div>
+
+              {/* Lista de cambios */}
+              {updateCsfExtraccion && currentDatos && (
+                <div className="space-y-2">
+                  {(() => {
+                    const changes = CSF_DIFF_FIELDS.filter((k) => {
+                      const cur = (currentDatos as Record<string, unknown>)[k];
+                      const nu = (updateCsfExtraccion as Record<string, unknown>)[k];
+                      return !valuesEqual(cur, nu);
+                    });
+
+                    if (changes.length === 0) {
+                      return (
+                        <div className="rounded-md border border-emerald-300/40 bg-emerald-50/40 p-4 text-sm text-emerald-800 dark:bg-emerald-950/20 dark:text-emerald-300">
+                          ✓ La CSF nueva no trae cambios respecto a los datos actuales. Si la
+                          aplicas (o la cancelas), el PDF queda archivado igual como histórico.
+                        </div>
+                      );
+                    }
+
+                    return changes.map((k) => {
+                      const checked = acceptedFields.has(k);
+                      const cur = (currentDatos as Record<string, unknown>)[k];
+                      const nu = (updateCsfExtraccion as Record<string, unknown>)[k];
+                      return (
+                        <label
+                          key={k}
+                          className={`flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors ${
+                            checked
+                              ? 'border-emerald-400/60 bg-emerald-50/40 dark:bg-emerald-950/20'
+                              : 'border-border'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={(e) => {
+                              const next = new Set(acceptedFields);
+                              if (e.target.checked) next.add(k);
+                              else next.delete(k);
+                              setAcceptedFields(next);
+                            }}
+                            className="mt-0.5 h-4 w-4 shrink-0"
+                          />
+                          <div className="flex-1 space-y-2">
+                            <div className="text-sm font-medium">{FIELD_LABELS[k]}</div>
+                            <div className="grid gap-2 sm:grid-cols-2">
+                              <div className="space-y-1">
+                                <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                                  Actual
+                                </div>
+                                <div className="rounded bg-muted/50 px-2 py-1 text-xs font-mono whitespace-pre-wrap">
+                                  {formatDiffValue(cur)}
+                                </div>
+                              </div>
+                              <div className="space-y-1">
+                                <div className="text-[10px] font-semibold uppercase tracking-wider text-emerald-700 dark:text-emerald-400">
+                                  Nuevo
+                                </div>
+                                <div className="rounded bg-emerald-100/50 px-2 py-1 text-xs font-mono whitespace-pre-wrap dark:bg-emerald-950/30">
+                                  {formatDiffValue(nu)}
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </label>
+                      );
+                    });
+                  })()}
+                </div>
+              )}
+
+              {/* Footer de acciones */}
+              <div className="flex justify-end gap-2 border-t pt-4">
+                <Button
+                  variant="outline"
+                  onClick={() => setDiffOpen(false)}
+                  disabled={applyingDiff}
+                >
+                  Cancelar
+                </Button>
+                <Button onClick={handleApplyDiff} disabled={applyingDiff} className="gap-2">
+                  {applyingDiff ? (
+                    <RefreshCw className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Save className="h-4 w-4" />
+                  )}
+                  {acceptedFields.size === 0
+                    ? 'Solo archivar PDF'
+                    : `Aplicar ${acceptedFields.size} cambio${acceptedFields.size === 1 ? '' : 's'}`}
                 </Button>
               </div>
             </div>

--- a/docs/planning/proveedores-csf-ai.md
+++ b/docs/planning/proveedores-csf-ai.md
@@ -91,12 +91,19 @@ El módulo de Documentos ya tiene el patrón de extracción IA con Claude (`/api
 - [ ] Detección persona física vs moral: la extracción setea `tipo_persona`; UI muestra/oculta campos correspondientes.
 - [ ] Estados de error (Claude falla, PDF no es CSF, timeout) con CTA a captura manual.
 
-### Sprint 3 — UI de update existente (diff campo-por-campo)
+### Sprint 3.A — Backend de update con CSF
 
-- [ ] Botón "Cargar / Actualizar CSF" en drawer/detalle del proveedor.
+- [ ] `POST /api/proveedores/[persona_id]/update-csf` recibe FormData (PDF + payload con `accepted_fields[]`).
+- [ ] PDF siempre se archiva en `erp.adjuntos` como histórico; UPDATEs selectivos a `personas` y `personas_datos_fiscales` solo de los campos en `accepted_fields`. `csf_adjunto_id` se actualiza al nuevo solo si hay aceptados.
+- [ ] Edge case: persona legacy sin `personas_datos_fiscales` → primer "update" hace INSERT.
+- [ ] Tests del schema `UpdateCsfPayloadSchema` con `accepted_fields` enum.
+
+### Sprint 3.B — UI de update con diff (RDB primero)
+
+- [ ] Botón "Cargar / Actualizar CSF" en detalle del proveedor.
 - [ ] Modal de diff: valor actual → valor nuevo, checkbox por campo, "Aplicar cambios".
-- [ ] CSF nueva queda archivada como histórico aunque el usuario rechace todos los cambios. `csf_adjunto_id` se actualiza al PDF nuevo solo si se aceptó al menos un cambio.
-- [ ] Vista "Ver históricos" lista CSFs anteriores con fecha.
+- [ ] Manejo de tres outcomes: (a) aceptan todo, (b) aceptan algunos, (c) rechazan todo (PDF queda archivado igual).
+- [ ] Vista "Ver históricos" lista CSFs anteriores con fecha (opcional para v1).
 
 ### Sprint 4 — Rollout DILESA y cierre
 
@@ -115,3 +122,6 @@ El módulo de Documentos ya tiene el patrón de extracción IA con Claude (`/api
 - **2026-04-27 — Sesión de arranque.** Se registra la iniciativa en `INITIATIVES.md` (PR [#234](https://github.com/beto-sudo/BSOP/pull/234)). Beto aprueba alcance v1 inmediatamente. Se promueve estado `proposed → planned` y se cierra la decisión de modelo DB con [ADR-007](../../supabase/adr/007_personas_datos_fiscales.md).
 - **2026-04-27 — Sprint 1.A cerrado (PR [#235](https://github.com/beto-sudo/BSOP/pull/235)).** Migración aplicada a la DB: columna `tipo_persona` en `erp.personas` + tabla `erp.personas_datos_fiscales` con RLS y trigger updated_at. SCHEMA_REF y types regenerados. CI verde (typecheck/lint/test/format/drift-check). Estado `planned → in_progress`. Próximo: Sprint 1.B (endpoint extract-csf).
 - **2026-04-27 — Sprint 1.B cerrado (PR [#236](https://github.com/beto-sudo/BSOP/pull/236)).** Endpoint `POST /api/proveedores/extract-csf` que recibe PDF y devuelve campos extraídos (sin persistir). `CsfExtraccionSchema` con todos los campos del ADR-007. 9 tests unitarios del schema pasando. Reutiliza `lib/documentos/extraction-core.ts`. Como efecto colateral, descubrimos un bug del workflow `db-types.yml` que regeneraba types sin schemas `dilesa`/`maquinaria` (causando typecheck fail en su PR auto-generado #227); arreglado en PR [#239](https://github.com/beto-sudo/BSOP/pull/239) y memoria `reference_db_types_workflow_sync.md` agregada. Próximo: Sprint 2.A (endpoint create-with-csf + dedup RFC).
+- **2026-04-27 — Sprint 2.A cerrado (PR [#241](https://github.com/beto-sudo/BSOP/pull/241)).** Endpoint `POST /api/proveedores/create-with-csf` que recibe FormData (PDF + payload) y persiste persona + proveedor + adjunto + datos_fiscales en orden recuperable. Dedup por RFC con 409 + `existing_persona_id`. `CreateProveedorPayloadSchema` (Zod) compartido con cliente; 5 tests nuevos.
+- **2026-04-27 — Sprint 2.B cerrado (PR [#242](https://github.com/beto-sudo/BSOP/pull/242)).** UI del drawer "+ Nuevo Proveedor" en RDB con sección "Sube CSF (recomendado)" arriba del form. File input + botón "Procesar CSF" → spinner → form pre-llenado (tipo_persona toggle, identidad, RFC, CURP, régimen, domicilio fiscal). Submit dual: con CSF llama `create-with-csf`, sin CSF preserva el flujo manual existente. Modal Sheet de RFC duplicado con CTAs "Ir al existente" / "Volver al form". Solo modifica `app/rdb/proveedores/page.tsx`. 217 tests pasando.
+- **2026-04-27 — Sprint 3.A arranque.** Backend `POST /api/proveedores/[persona_id]/update-csf` con aplicación selectiva por `accepted_fields`. Mapeo `FIELD_MAP` decide qué campo va a `personas` vs `personas_datos_fiscales`. PDF siempre archivado; `csf_adjunto_id` se actualiza solo si hay aceptados. Maneja edge case de persona legacy sin `personas_datos_fiscales` (INSERT en lugar de UPDATE). `UpdateCsfPayloadSchema` con enum de campos válidos (`CSF_UPDATABLE_FIELDS`); 5 tests del schema. Próximo: Sprint 3.B (UI con modal de diff).

--- a/lib/proveedores/extract-csf.test.ts
+++ b/lib/proveedores/extract-csf.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
   CsfExtraccionSchema,
   CreateProveedorPayloadSchema,
+  UpdateCsfPayloadSchema,
   RegimenSchema,
   ObligacionSchema,
 } from './extract-csf';
@@ -386,5 +387,85 @@ describe('CreateProveedorPayloadSchema', () => {
   it('rechaza si falta empresa_id', () => {
     const payload = { extraccion: validExtraccion };
     expect(() => CreateProveedorPayloadSchema.parse(payload)).toThrow();
+  });
+});
+
+describe('UpdateCsfPayloadSchema', () => {
+  const validExtraccion = {
+    tipo_persona: 'moral',
+    rfc: 'ABC010101AB1',
+    curp: null,
+    nombre: null,
+    apellido_paterno: null,
+    apellido_materno: null,
+    razon_social: 'EJEMPLO SA DE CV (NUEVA)',
+    nombre_comercial: null,
+    regimen_fiscal_codigo: '601',
+    regimen_fiscal_nombre: 'General de Ley Personas Morales',
+    regimenes_adicionales: [
+      {
+        codigo: '601',
+        nombre: 'General de Ley Personas Morales',
+        fecha_inicio: '2020-01-01',
+        fecha_fin: null,
+      },
+    ],
+    domicilio_calle: 'Nueva Calle',
+    domicilio_num_ext: '500',
+    domicilio_num_int: null,
+    domicilio_colonia: 'Centro',
+    domicilio_cp: '06000',
+    domicilio_municipio: 'Cuauhtémoc',
+    domicilio_estado: 'CDMX',
+    obligaciones: [],
+    fecha_inicio_operaciones: '2020-01-01',
+    fecha_emision: '2026-04-27',
+  };
+
+  it('parsea payload con accepted_fields no vacío (aplicación parcial)', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+      accepted_fields: ['razon_social', 'domicilio_calle', 'domicilio_num_ext'],
+    };
+    const parsed = UpdateCsfPayloadSchema.parse(payload);
+    expect(parsed.accepted_fields).toHaveLength(3);
+    expect(parsed.accepted_fields).toContain('razon_social');
+  });
+
+  it('parsea payload con accepted_fields vacío (solo archiva PDF)', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+      accepted_fields: [],
+    };
+    const parsed = UpdateCsfPayloadSchema.parse(payload);
+    expect(parsed.accepted_fields).toHaveLength(0);
+  });
+
+  it('rechaza accepted_fields con un key no listado en CSF_UPDATABLE_FIELDS', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+      accepted_fields: ['razon_social', 'campo_inventado'],
+    };
+    expect(() => UpdateCsfPayloadSchema.parse(payload)).toThrow();
+  });
+
+  it('rechaza si falta accepted_fields', () => {
+    const payload = {
+      empresa_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      extraccion: validExtraccion,
+    };
+    expect(() => UpdateCsfPayloadSchema.parse(payload)).toThrow();
+  });
+
+  it('rechaza empresa_id no UUID', () => {
+    const payload = {
+      empresa_id: 'no-uuid',
+      extraccion: validExtraccion,
+      accepted_fields: [],
+    };
+    expect(() => UpdateCsfPayloadSchema.parse(payload)).toThrow();
   });
 });

--- a/lib/proveedores/extract-csf.ts
+++ b/lib/proveedores/extract-csf.ts
@@ -177,6 +177,62 @@ export const CreateProveedorPayloadSchema = z.object({
 
 export type CreateProveedorPayload = z.infer<typeof CreateProveedorPayloadSchema>;
 
+// ─── Input para update-csf (Sprint 3.A) ──────────────────────────────────────
+
+/**
+ * Conjunto canónico de campos del modelo CSF que el usuario puede elegir
+ * aplicar/ignorar en el flujo de update. Cada key del enum corresponde a un
+ * campo de `CsfExtraccionSchema`. El endpoint mapea estos keys a columnas en
+ * `erp.personas` o `erp.personas_datos_fiscales`.
+ */
+export const CSF_UPDATABLE_FIELDS = [
+  'tipo_persona',
+  'rfc',
+  'curp',
+  'nombre',
+  'apellido_paterno',
+  'apellido_materno',
+  'razon_social',
+  'nombre_comercial',
+  'regimen_fiscal_codigo',
+  'regimen_fiscal_nombre',
+  'regimenes_adicionales',
+  'domicilio_calle',
+  'domicilio_num_ext',
+  'domicilio_num_int',
+  'domicilio_colonia',
+  'domicilio_cp',
+  'domicilio_municipio',
+  'domicilio_estado',
+  'obligaciones',
+  'fecha_inicio_operaciones',
+  'fecha_emision',
+] as const;
+
+export type CsfUpdatableField = (typeof CSF_UPDATABLE_FIELDS)[number];
+
+/**
+ * Payload del endpoint `POST /api/proveedores/[persona_id]/update-csf`.
+ *
+ * El cliente arma esto tras revisar el diff entre la extracción nueva y el
+ * estado actual de la persona. `accepted_fields` lista los keys que el
+ * usuario marcó con checkbox en el modal.
+ *
+ * Comportamiento del endpoint según `accepted_fields`:
+ * - **Vacío:** solo archiva el PDF nuevo en `erp.adjuntos` como histórico.
+ *   No toca `personas` ni `personas_datos_fiscales`. `csf_adjunto_id` queda
+ *   apuntando al PDF anterior.
+ * - **No vacío:** archiva el PDF nuevo, aplica UPDATEs selectivos solo a los
+ *   campos listados, y actualiza `csf_adjunto_id` al nuevo adjunto.
+ */
+export const UpdateCsfPayloadSchema = z.object({
+  empresa_id: z.string().uuid('empresa_id debe ser UUID'),
+  extraccion: CsfExtraccionSchema,
+  accepted_fields: z.array(z.enum(CSF_UPDATABLE_FIELDS)),
+});
+
+export type UpdateCsfPayload = z.infer<typeof UpdateCsfPayloadSchema>;
+
 // ─── Llamada al modelo ───────────────────────────────────────────────────────
 
 const PROMPT = `


### PR DESCRIPTION
## Summary

Sprint 3.B de [\`proveedores-csf-ai\`](docs/planning/proveedores-csf-ai.md): UI del flujo de actualización de CSF con diff campo-por-campo. **Stacked sobre [#243](https://github.com/beto-sudo/BSOP/pull/243)** (Sprint 3.A — endpoint update-csf). Cuando #243 mergee, GitHub re-targetea este PR a main.

Cierra el feedback de Beto en preview de #242: el botón "Cargar / Actualizar CSF" en el detalle del proveedor que faltaba.

## Cambios

Solo modifica [\`app/rdb/proveedores/page.tsx\`](app/rdb/proveedores/page.tsx):

### Botón "Cargar / Actualizar CSF" en \`ProveedorDetail\`
Aparece en el header del drawer de detalle, junto a Editar / Inactivar / Imprimir. Al click abre un file picker oculto (PDF only).

### Flujo
1. Usuario selecciona PDF.
2. Overlay full-screen con spinner: "Procesando CSF… (30-90 segundos)".
3. **En paralelo**: \`/api/proveedores/extract-csf\` + query a \`personas\` + \`personas_datos_fiscales\` para obtener el estado actual.
4. Cuando ambos llegan, abre Sheet de diff (\`max-w-800\`).

### Modal de diff
- **Toolbar**: "Seleccionar todos los cambios" / "Limpiar selección" + contador "N de 21 campos seleccionados".
- **Solo muestra campos que cambiaron** (oculta los iguales para enfocar al usuario).
- Cada campo: label + side-by-side "Actual" (gris) vs "Nuevo" (verde) con \`whitespace-pre-wrap\` para arrays jsonb (regímenes, obligaciones).
- Checkbox por campo, **pre-marcado con todos los cambios detectados** (default seguro: aceptar todos).
- **Caso "sin cambios"**: mensaje verde "✓ La CSF nueva no trae cambios…" y el footer permite solo archivar el PDF.

### Footer
- **Cancelar**: cierra sin tocar nada (no archiva el PDF).
- **"Aplicar N cambios"** / **"Solo archivar PDF"** (si rejected todo) → llama \`POST /api/proveedores/[persona_id]/update-csf\` (Sprint 3.A) con \`accepted_fields\` array.

## Helpers nuevos (top-level del módulo)

- \`CSF_DIFF_FIELDS\` — orden canónico de los 21 campos.
- \`FIELD_LABELS\` — etiqueta humana de cada key.
- \`valuesEqual(a, b)\` — equivalencia tolerante: \`""\` ↔ \`null\` (común en SAT), arrays/objects comparados con \`JSON.stringify\`, strings con \`trim\`.
- \`formatDiffValue(v)\` — render: \`null\` → "—", array vacío → "— (vacío)", regímenes → "código · nombre" por línea, obligaciones → descripción por línea.

## Test plan

- [x] \`npm run typecheck\` verde.
- [x] \`npm run test:run\` 222/222 pasando.
- [x] \`npm run lint\` 0 errores.
- [x] \`npm run format:check\` clean.
- [ ] CI verde en este PR (cuando GitHub re-targetea a main al mergear #243).
- [ ] Smoke manual end-to-end:
      1. Subir CSF nueva a proveedor existente → ver overlay → modal diff con cambios pre-marcados.
      2. Probar "Cancelar" → no cambia nada en DB.
      3. Probar aplicar todos los cambios → verificar UPDATE en personas + personas_datos_fiscales + nuevo row en adjuntos + csf_adjunto_id apunta al nuevo.
      4. Probar aplicar solo algunos (deseleccionar varios) → verificar UPDATE selectivo.
      5. Probar deseleccionar todo → "Solo archivar PDF" → verificar adjunto creado pero personas_datos_fiscales sin tocar.
      6. Probar re-subir misma CSF → modal con "Sin cambios" → archiva si aplican, no archiva si cancelan.

## Cierre del Sprint 3

Tras este PR, el alcance v1 del Sprint 3 queda cerrado:

- ✅ Botón "Cargar / Actualizar CSF" en el detalle (este PR).
- ✅ Modal de diff con checkbox por campo (este PR).
- ✅ CSF archivada como histórico aunque rechacen todo (Sprint 3.A).
- ✅ csf_adjunto_id se actualiza solo si aceptaron al menos un cambio (Sprint 3.A).
- ⏳ "Vista de históricos" (lista CSFs anteriores) — quedó marcada como opcional en el alcance v1, no la implemento aquí. El PDF actual se ve via csf_adjunto_id; el histórico vive en \`adjuntos\` filtrable por \`(entidad_tipo='persona', rol='csf', entidad_id=persona_id)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)