### PR TITLE
docs: empleados-multi-puesto + ADR-012 cierre del split Cowork/CC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,12 @@
    `docs/planning/<slug>.md` antes de empezar a actuar — ahí vive el
    contexto, alcance, decisiones y bitácora.
 3. Si lo que el usuario pide no encaja con ninguna iniciativa existente,
-   pregúntale si es una iniciativa nueva (entonces se crea un doc de
-   planning vía Cowork) o un task suelto (no requiere doc nuevo).
+   estresá la idea con preguntas (¿qué problema resuelve?, ¿qué
+   pantallas/schemas toca?, ¿métrica de éxito?, ¿riesgos?, ¿hay ADR
+   pendiente?) y proponé promoverla a iniciativa. Solo creá el doc de
+   planning + la fila en `INITIATIVES.md` cuando Beto diga
+   explícitamente _"sí, promovela"_. Si es un task suelto, no requiere
+   doc nuevo.
 
 ### Al cerrar trabajo en una iniciativa
 
@@ -30,20 +34,22 @@ Reflejá el cambio de estado en `docs/strategy/INITIATIVES.md` también
 iniciativa quedó completa, movela a la sección `## Done` con fecha de
 cierre y outcome — no borres su doc de planning, queda como referencia.
 
-### División de roles (Cowork vs Claude Code)
+### Roles
 
-- **Cowork escribe el QUÉ y el POR QUÉ**: Problema, Outcome esperado,
-  Alcance v1, Fuera de alcance, Métricas de éxito, Riesgos. Edita header
-  y secciones de planning.
-- **Claude Code (yo) escribe el CÓMO y el CUÁNDO**: Bitácora, Decisiones
-  registradas, Sprints/hitos al ejecutar, ADRs durante ejecución, código.
-- **Beto decide y mergea**: aprueba transiciones de estado (proposed →
-  planned → in_progress → done), mergea PRs.
+- **Claude Code (yo)** soy dueño de planeación + ejecución end-to-end:
+  Problema, Outcome, Alcance, Riesgos, Métricas, Bitácora, Decisiones
+  registradas, Sprints/hitos, ADRs, código, PRs.
+- **Beto decide y mergea**: aprueba promoción de ideas a iniciativas,
+  transiciones de estado (`proposed → planned → in_progress → done`),
+  mergea PRs.
 
-Si en una sesión el usuario me pide redefinir alcance o crear una
-iniciativa nueva, propóngale que lo haga vía Cowork para mantener la
-división. Excepción: si Cowork no está disponible y el cambio es chico,
-puedo hacerlo yo y dejar registro claro en la bitácora.
+Cuando Beto suelta una idea cruda, mi trabajo es estresarla con
+preguntas (¿qué problema resuelve?, ¿qué pantallas/schemas toca?,
+¿métrica de éxito?, ¿riesgos?, ¿hay ADR pendiente?) antes de
+proponerle promoverla a iniciativa. Solo creo el doc de planning +
+agrego la fila a `INITIATIVES.md` cuando Beto diga explícitamente
+_"sí, promovela"_. Ver ADR-012 para el contexto histórico de esta
+decisión (deprecación del split Cowork/CC).
 
 ### Cuándo crear un ADR
 
@@ -95,10 +101,11 @@ Si `format:check` reporta archivos que no toqué, igual los formateo en
 este PR — su mal estado bloquea CI tanto si lo causé yo como si lo
 heredé. Mejor un commit chico de "chore(format)" que un CI rojo.
 
-Mecanismo común de drift: alguien (Cowork u otro agente) crea un
-archivo formateado correctamente en su sub-set, su PR pasa porque no
-corrió `prettier --check .` global, y el archivo se mergea malformatado.
-La regla de "todo el repo, no solo lo tocado" detecta eso.
+Mecanismo común de drift: una herramienta externa (formateador de IDE,
+otro agente, generador de código) escribe un archivo formateado
+correctamente en su sub-set, el PR pasa porque no corrió
+`prettier --check .` global, y el archivo se mergea malformatado. La
+regla de "todo el repo, no solo lo tocado" detecta eso.
 
 ### Después de `git push` (vigilancia obligatoria)
 
@@ -169,10 +176,10 @@ solo actualizo `docs/planning/<slug>.md` (que casi nunca conflicta —
 un archivo por iniciativa). El próximo hito y la última actividad se
 infieren del header del planning doc.
 
-Resultado: ~70% menos ediciones al archivo hotspot. Cowork edita
-`INITIATIVES.md` cuando crea iniciativas y cuando ajusta alcance; yo
-edito solo en transiciones mayores. Los dos roles raramente coinciden
-en el mismo PR.
+Resultado: ~70% menos ediciones al archivo hotspot. Toco
+`INITIATIVES.md` solo cuando promuevo una iniciativa nueva o cuando
+cruza una transición mayor de estado. Los hitos intermedios viven solo
+en el planning doc.
 
 #### Regla 2: rebase preventivo sobre `origin/main`
 

--- a/docs/adr/012_workflow_cc_owns_planning.md
+++ b/docs/adr/012_workflow_cc_owns_planning.md
@@ -1,0 +1,48 @@
+# ADR-012 — Claude Code dueño de planeación + ejecución (deprecación del split Cowork)
+
+**Fecha:** 2026-04-27
+**Estado:** aceptado
+**Iniciativa(s):** afecta a todas (decisión de proceso)
+
+## Contexto
+
+El repo originalmente usaba dos agentes en paralelo para gestionar iniciativas:
+
+- **Cowork** escribía planning docs (Problema / Outcome / Alcance v1 / Fuera de alcance / Métricas / Riesgos) y mantenía la sección `## Activas` de `docs/strategy/INITIATIVES.md`.
+- **Claude Code** ejecutaba: código, Bitácora, Decisiones registradas, Sprints/hitos, ADRs durante ejecución.
+
+La división conceptual era "QUÉ + POR QUÉ" (Cowork) vs "CÓMO + CUÁNDO" (CC). En la práctica el split generó tres tipos de fricción:
+
+1. **Desincronización temporal entre chats**. Los dos agentes vivían en sesiones separadas sin verse. Mientras Cowork planeaba `empleados-multi-puesto` (2026-04-27), CC cerraba Sub-PR 3 y Sub-PR 4 de `shared-modules-refactor` sin que Cowork lo supiera, y viceversa. La única forma de mantener coherencia era que Beto repitiera contexto entre chats — costo cognitivo crónico.
+2. **Race condition en working tree compartido**. Ambos operaban sobre `/Users/Beto/BSOP`. Ediciones de Cowork a `docs/strategy/INITIATIVES.md` se colaron dentro del commit `22e5a1e` de Sub-PR 3 sin intención del autor humano.
+3. **Lock contention en `.git/index.lock`**. Durante operaciones git de CC, Cowork no podía hacer commits ni abrir PRs desde su lado. Falla observada en al menos dos sesiones distintas.
+
+Adicionalmente, la división "QUÉ vs CÓMO" eran secciones del mismo doc de planning. Partir la autoría agregaba complejidad de coordinación sin agregar separación real de responsabilidades.
+
+## Opciones consideradas
+
+- **A: Mantener split + Cowork opera vía GitHub API (sin tocar working tree local).** Resuelve los locks y el race en filesystem, pero no resuelve la desincronización temporal entre chats — el problema raíz queda intacto.
+- **B: Mantener split + Cowork solo entrega bloques de markdown.** Beto pega manualmente las secciones en CC. Cero git desde Cowork, pero introduce copy-paste manual por iniciativa y tampoco resuelve la desincronización.
+- **C: Matar el split. CC owns planeación + ejecución end-to-end.** Cero contención, un solo canal, sin desincronización por diseño. Costo: Beto pierde Cowork como "thinking partner separado" para BSOP.
+
+## Decisión
+
+Elegimos **C**. Claude Code pasa a ser dueño de planeación + ejecución end-to-end. Cowork BSOP UI queda deprecado para este repo.
+
+## Consecuencias
+
+- **Pro**: cero race conditions en working tree, cero locks compartidos, cero desincronización temporal entre chats.
+- **Pro**: planning + ejecución viven en el mismo agente que ya conoce el código y el git state actual del repo.
+- **Pro**: una sola fuente de verdad para el flujo de trabajo (`CLAUDE.md` de este repo), sin secciones que dependan de qué agente las edita.
+- **Contra**: Beto pierde Cowork como canal "thinking partner separado" para BSOP. Mitigación: el rol de "estresar idea con preguntas antes de promover" se mueve dentro del mismo chat de CC. Cuando Beto suelta una idea cruda, CC la cuestiona (¿qué problema resuelve?, ¿qué pantallas/schemas toca?, ¿métrica de éxito?, ¿riesgos?) antes de proponer promoverla.
+- **Neutral**: Cowork queda libre para otros usos no-BSOP (file management, multi-app workflows, planeación de cosas que no son código).
+
+## Migración
+
+- `CLAUDE.md` actualizado: la sección "División de roles (Cowork vs Claude Code)" se reescribe como "Roles" (CC + Beto). Se eliminan las menciones a Cowork como autor de planning y la excepción "si Cowork no está disponible".
+- `docs/strategy/INITIATIVES.md` actualizado: el header dice "Mantenido por Claude Code"; la sección "Cómo se actualiza este archivo" colapsa los bullets de Cowork + CC en uno solo. La mención operativa a Cowork en la fila de la iniciativa `analytics` se mantiene — es contenido de esa iniciativa, no del proceso de planning.
+- Project Cowork "BSOP UI" puede archivarse o borrarse a discreción de Beto.
+
+## No aplica retroactivamente
+
+Los planning docs ya creados por Cowork (incluyendo `empleados-multi-puesto` promovido en este mismo PR) quedan tal cual. No se atribuye autoría retroactiva ni se reescribe el header de planning docs viejos.

--- a/docs/planning/empleados-multi-puesto.md
+++ b/docs/planning/empleados-multi-puesto.md
@@ -1,0 +1,87 @@
+# Iniciativa — Empleados multi-puesto + rename a Personal
+
+**Slug:** `empleados-multi-puesto`
+**Empresas:** todas
+**Schemas afectados:** `erp` (nueva tabla `empleados_puestos`, refactor de `v_empleados_full`, posible deprecación de `empleados.puesto_id`) + UI (rename módulo "Empleados" → "Personal" en sidebar/URL/detalle/listado)
+**Estado:** proposed
+**Dueño:** Beto
+**Creada:** 2026-04-27
+**Última actualización:** 2026-04-27
+
+## Problema
+
+`erp.empleados.puesto_id` es escalar — una persona-por-empresa con un solo puesto. El modelo se rompe en cuanto una persona tiene **más de un rol** dentro de la misma empresa, que ya no es hipótesis sino realidad operativa:
+
+- Hoy mismo migramos a Juan Pablo Hernandez (Gerente Deportivo, mal capturado en DILESA) a RDB junto con 62 juntas tipo "Rincón del Bosque" + 272 tasks + 305 asistencias.
+- Creamos empleados RDB espejo para los 10 accionistas DILESA + las 3 personas que operamos las empresas (Beto, Alejandra Chavarría, Michelle Santos).
+- Las 3 personas operativas tienen **3 puestos cada una**: Accionista + Comité Ejecutivo + Consejo de Administración. Como `puesto_id` es escalar, quedaron como **3 filas en RDB cada una** — 9 filas duplicadas que en `/rdb/rh/empleados` se ven como 9 personas distintas.
+- Mismo problema va a pasar en DILESA en cuanto repliquemos.
+
+Además, el listado ya no es solo "empleados operativos": incluye accionistas y consejeros que no cobran nómina ni operan el día a día. El nombre "Empleados" en el sidebar/módulo es engañoso — el concepto correcto es **personas-por-empresa con uno o más roles**, que en castellano operativo se llama **Personal**.
+
+## Outcome esperado
+
+- **Una sola fila por persona+empresa** en `erp.empleados`, sin duplicados artificiales.
+- **Múltiples puestos por empleado** modelados explícitamente en una tabla N:M (`erp.empleados_puestos`), con marcador de puesto principal y fechas de vigencia opcionales.
+- **`erp.v_empleados_full` devuelve los puestos como array/objeto** para que la UI pueda mostrar todos los roles de una persona sin joins manuales en cada query.
+- **Módulo renombrado a "Personal"** en sidebar, encabezados de pantalla y (si aplica) URL de las 4 empresas. El listado y el detalle muestran múltiples puestos por persona sin duplicarla.
+- **Datos limpios post-migración**: las 9 filas duplicadas en RDB (Beto/Alejandra/Michelle × 3 puestos) colapsan a 3 filas, cada una con sus 3 puestos asociados. Lo mismo se replica en DILESA cuando aplique.
+
+## Alcance v1
+
+- [ ] **Migración DB — modelo N:M**:
+  - Nueva tabla `erp.empleados_puestos` (`empleado_id`, `puesto_id`, `principal` bool, `fecha_inicio`, `fecha_fin` nullable, índices y FKs apropiadas).
+  - Backfill desde `erp.empleados.puesto_id` actual: cada fila genera 1 entrada en `empleados_puestos` con `principal = true`.
+  - Decidir destino de `erp.empleados.puesto_id`: (a) queda como apuntador al puesto principal por compatibilidad, o (b) se deprecia y se reemplaza por una columna calculada / lookup vía la tabla nueva. Decisión la cierra Claude Code en ADR al arrancar ejecución.
+- [ ] **Refactor de `erp.v_empleados_full`**: la vista pasa a devolver puestos como array/objeto (formato exacto a definir — `jsonb` con array de `{puesto_id, nombre, principal}` es el candidato natural, queda a decisión de CC).
+- [ ] **Barrido de queries directas**: detectar y refactorizar todos los lugares en la app que leen `empleados.puesto_id` directo (sin pasar por la vista). Riesgo alto de queries dispersas — el barrido debe ser exhaustivo (grep + revisión cruzada por feature).
+- [ ] **UI — rename Empleados → Personal**:
+  - Sidebar/menú de RH en las 4 empresas.
+  - Encabezados de pantalla (`<ModulePage>` title) y breadcrumbs.
+  - URL: decidir si `/<empresa>/rh/empleados` se renombra a `/<empresa>/rh/personal` (con redirect 301 desde la ruta vieja para no romper deep-links). Decisión la cierra Beto al arrancar ejecución.
+- [ ] **UI — listado de Personal**: cada fila es una persona; columna de puestos muestra el principal con badge + indicador "+N más" si tiene secundarios; filtros pueden filtrar por cualquiera de los puestos.
+- [ ] **UI — detalle de Personal**: mostrar todos los puestos del empleado, con marcador del principal; permitir agregar/quitar puestos y cambiar el principal.
+- [ ] **UI — alta/edición**: el formulario permite seleccionar N puestos (el primero queda como principal por default, el usuario puede cambiarlo).
+- [ ] **Cleanup de datos post-modelo nuevo**:
+  - Deshacer las 6 filas duplicadas extras en RDB (Comité Ejecutivo + Consejo de Administración × Beto/Alejandra/Michelle), quedándose con 1 fila por persona y los 2 puestos secundarios sumados via `empleados_puestos`.
+  - Replicar el mismo cleanup en DILESA para las mismas 3 personas (sumar Comité + Consejo a su fila Accionista existente).
+- [ ] **Pendiente operativo previo (no parte de v1, pero a coordinar)**: cleanup temporal hoy mismo — borrar las 6 filas extras en RDB para Beto/Alejandra/Michelle (Comité y Consejo), dejando solo Accionista por persona-empresa. Es un parche para que `/rdb/rh/empleados` no muestre 9 personas duplicadas mientras esta iniciativa aterriza.
+
+## Fuera de alcance
+
+- **Compensación distinta por puesto**: la compensación sigue ligada al `empleado_id`, no al puesto. Modelar comp por-puesto queda fuera de v1.
+- **Jerarquía / "reporta a" por puesto**: si una persona tiene 2 puestos con jefes distintos, no modelamos eso en v1.
+- **Organigrama visual** de la empresa basado en puestos.
+- **Fechas de vigencia por puesto** si no son operativamente necesarias todavía: la columna `fecha_inicio/fecha_fin` queda en la tabla nueva pero no se vuelve UI-visible en v1 a menos que aparezca un caso real.
+- **Migración de DILESA en bloque** — la migración del modelo aplica a las 4 empresas; el cleanup de datos solo cubre las 3 personas operativas + 10 accionistas, no un barrido completo de todas las filas en DILESA.
+
+## Métricas de éxito
+
+- **1 fila por persona+empresa** en `erp.empleados` (verificable con `SELECT empresa_id, persona_id, COUNT(*) FROM erp.empleados GROUP BY 1,2 HAVING COUNT(*) > 1` → cero filas).
+- **Listado y detalle de Personal muestran múltiples puestos** sin duplicar a la persona — verificación visual en RDB con Beto/Alejandra/Michelle (3 puestos cada una, 1 fila cada una).
+- **Sidebar de las 4 empresas dice "Personal"** y no "Empleados". Encabezado del módulo y breadcrumbs alineados.
+- **Cero queries directas** a `empleados.puesto_id` fuera de la vista o de migraciones (verificable con grep al final del refactor).
+- **Deep-links viejos siguen funcionando** si se renombra la URL (smoke test de `/<empresa>/rh/empleados` en las 4 empresas).
+
+## Riesgos / preguntas abiertas
+
+- [ ] **Queries dispersas que leen `empleados.puesto_id` directo** (sin vista) — riesgo principal. Algunas pueden estar en endpoints API, otras en componentes que joinean manual. Sin barrido exhaustivo se pueden romper features sin que CI lo detecte. Mitigación: grep agresivo + revisión por feature antes de mergear.
+- [ ] **Rename de URL puede romper deep-links** si alguien tiene bookmarks o links pegados en docs/Slack. Mitigación: redirect 301 desde la ruta vieja a la nueva (decisión final del rename + redirect la cierra Beto).
+- [ ] **Compensación está ligada a `empleado_id`** (no a `puesto_id`). En teoría no se rompe porque el `empleado_id` se preserva — confirmar con un check rápido a `erp.empleados_compensacion` (o tabla equivalente) durante el ADR.
+- [ ] **Decisión sobre `empleados.puesto_id`**: dejar como apuntador al principal (más simple de migrar, posible drift con la tabla N:M) vs deprecar (más limpio, requiere refactorear todas las queries directas). Tradeoff a cerrar en ADR.
+- [ ] **Formato de puestos en `v_empleados_full`**: `jsonb` array, columna `puestos_array text[]`, o sub-objetos. Afecta cómo la UI consume la vista. Decisión en ejecución.
+- [ ] **Catálogo de puestos**: hoy `erp.puestos` (o similar) ya existe. Confirmar que tiene los puestos "Accionista", "Comité Ejecutivo", "Consejo de Administración" para las 4 empresas — si no, hay que sembrarlos antes de cargar las relaciones.
+- [ ] **Auditoría / changelog de cambios de puesto**: si una persona cambia de puesto principal o se le suma uno nuevo, ¿queremos histórico? La tabla nueva ya tiene `fecha_inicio/fecha_fin` para soportarlo, pero la UI/API de cambio aún no está pensada como append-only.
+- [ ] **Orden respecto al Roadmap UI**: esta iniciativa cruza DB + UI y no está en la cola UI secuencial. Beto decide si entra en paralelo (es DB-pesada, no choca con el Roadmap UI), o si espera turno.
+
+## Sprints / hitos
+
+_(se llena cuando arranque ejecución, vía Claude Code)_
+
+## Decisiones registradas
+
+_(append-only, fechadas — escrito por Claude Code)_
+
+## Bitácora
+
+_(append-only, escrita por Claude Code al ejecutar)_

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -1,8 +1,9 @@
 # Iniciativas — BSOP
 
 > Índice activo de iniciativas del repo BSOP. Para detalle de cada una,
-> abre `docs/planning/<slug>.md`. Mantenido por Cowork (cuando se crea o
-> cambia el alcance) y por Claude Code (cuando ejecuta y cierra hitos).
+> abre `docs/planning/<slug>.md`. Mantenido por Claude Code (ver
+> ADR-012 para el contexto histórico de la deprecación del split
+> Cowork/CC).
 >
 > **Última actualización:** 2026-04-27 (Sub-PR 4 de `shared-modules-refactor` entregado: extraído `<AdminJuntasListModule>` cross-empresa (502/687 → 14 líneas cada page) adoptando DILESA como base correcta — RDB hereda auto-title, filtro por mes, content preview, task counts granulares. Auditoría concluyó que `/inicio/juntas` es módulo standalone (no se extrae). Bug `<RequireAccess empresa="rdb">` hardcoded en `/inicio/juntas/{lista,detalle}` arreglado oportunísticamente. Próximo hito: Sub-PR 5 `empleados-detail-audit`. Iniciativa `empleados-multi-puesto` sigue `proposed`.)
 
@@ -99,10 +100,9 @@
 
 ## Cómo se actualiza este archivo
 
-- **Cowork** edita la sección `## Activas` cuando:
-  - Beto promueve una idea nueva a iniciativa → agrega fila con estado `proposed`.
+- **Claude Code** edita la sección `## Activas` cuando:
+  - Beto aprueba promover una idea a iniciativa → agrega fila con estado `proposed`.
   - Beto modifica alcance, dueño o próximo hito → ajusta la fila.
-- **Claude Code** edita cuando:
-  - Ejecuta un hito → actualiza `Estado` y `Próximo hito` y `Última actualización`.
+  - Ejecuta un hito de transición mayor (`proposed → planned → in_progress → done` o `* → blocked`) → actualiza `Estado`, `Próximo hito` y `Última actualización`.
   - Una iniciativa queda completa → la mueve a `## Done` con fecha y outcome.
-- **Beto** aprueba transiciones de estado en cualquier dirección.
+- **Beto** aprueba la promoción a iniciativa y todas las transiciones de estado.


### PR DESCRIPTION
Promueve la iniciativa cross-empresa `empleados-multi-puesto` a `proposed` y documenta la decisión de cerrar el split Cowork/CC para este repo.

## Cambios

- **`docs/planning/empleados-multi-puesto.md`** — iniciativa nueva. Refactor de `erp.empleados.puesto_id` (escalar) a un modelo N:M (`erp.empleados_puestos`) + rename del módulo "Empleados" → "Personal". Detonado por las 9 filas duplicadas que generó la migración de accionistas RDB del 2026-04-27 (Beto/Alejandra/Michelle × 3 puestos cada una). La fila en `INITIATIVES.md` ya está en `origin/main` desde Sub-PR 4 (#249), no se duplica acá.
- **`CLAUDE.md`** — sección "División de roles (Cowork vs Claude Code)" reescrita como "Roles" (CC + Beto). Limpieza de menciones a Cowork en el flujo "Al inicio de toda sesión", en la regla de drift de prettier, y en la regla 1 de hotspot management.
- **`docs/strategy/INITIATIVES.md`** — header dice "Mantenido por Claude Code". Sección "Cómo se actualiza este archivo" colapsa los bullets de Cowork + CC en uno solo. La mención a Cowork en la fila de la iniciativa `analytics` se preserva — es contenido operativo, no proceso.
- **`docs/adr/012_workflow_cc_owns_planning.md`** — ADR documentando contexto, opciones consideradas (A/B/C), decisión y consecuencias.

## Por qué

Tres tipos de fricción detectados durante el último ciclo:

1. **Race condition** en working tree compartido (`/Users/Beto/BSOP`): ediciones de Cowork a `INITIATIVES.md` se colaron en el commit `22e5a1e` de Sub-PR 3.
2. **Lock contention** en `.git/index.lock` durante operaciones de CC bloqueaba commits/PRs de Cowork.
3. **Desincronización temporal** entre chats sin valor agregado por la división conceptual "QUÉ vs CÓMO" — eran secciones del mismo planning doc.

Detalle completo en ADR-012.

## Test plan

- [ ] CI verde (typecheck, vitest, eslint, prettier)
- [ ] Verificar que la fila `Empleados multi-puesto` en `INITIATIVES.md` no se duplica al merge (ya viene de Sub-PR 4)
- [ ] ADR-012 en `docs/adr/` con número siguiente al ADR-011

🤖 Generated with [Claude Code](https://claude.com/claude-code)