### PR TITLE
chore(branding): unificar paths de logos a /brand/<empresa>/

### DIFF
--- a/app/dilesa/page.tsx
+++ b/app/dilesa/page.tsx
@@ -121,7 +121,7 @@ export default function DilesaPage() {
           <div className="flex items-center gap-4">
             <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-white p-1 shadow-sm ring-1 ring-inset ring-[var(--border)]">
               <img
-                src="/logos/dilesa-header.jpg"
+                src="/brand/dilesa/isotipo.png"
                 alt="DILESA"
                 className="h-full w-full rounded-lg object-contain"
               />

--- a/app/dilesa/proveedores/page.tsx
+++ b/app/dilesa/proveedores/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
       <ProveedoresModule
         empresaId={DILESA_EMPRESA_ID}
         empresaSlug="dilesa"
-        logoPath="/logos/dilesa-header.jpg"
+        logoPath="/brand/dilesa/header-email.png"
         membreteAlt="Membrete DILESA"
       />
     </RequireAccess>

--- a/app/rdb/inventario/levantamientos/[id]/reporte/page.tsx
+++ b/app/rdb/inventario/levantamientos/[id]/reporte/page.tsx
@@ -283,7 +283,7 @@ function ReporteInner() {
         {/* Membrete */}
         <div className="mb-1">
           <Image
-            src="/membrete-rdb.jpg"
+            src="/brand/rdb/header-email.png"
             alt="Rincón del Bosque"
             width={1240}
             height={300}

--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -323,7 +323,7 @@ function OrdenDetail({
         {/* ═══ PRINT: Header block ═══ */}
         <div className="hidden print:block">
           <img
-            src="/membrete-rdb.jpg"
+            src="/brand/rdb/header-email.png"
             alt="Membrete Rincón del Bosque"
             className="mb-4 max-h-28 w-full object-contain"
           />

--- a/app/rdb/proveedores/page.tsx
+++ b/app/rdb/proveedores/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
       <ProveedoresModule
         empresaId={RDB_EMPRESA_ID}
         empresaSlug="rdb"
-        logoPath="/membrete-rdb.jpg"
+        logoPath="/brand/rdb/header-email.png"
         membreteAlt="Membrete Rincón del Bosque"
       />
     </RequireAccess>

--- a/app/rdb/requisiciones/page.tsx
+++ b/app/rdb/requisiciones/page.tsx
@@ -356,7 +356,7 @@ function ExistingRequestSheet({
         {/* Membrete y encabezado solo para impresión */}
         <div className="hidden print:block mb-8">
           <img
-            src="/membrete-rdb.jpg"
+            src="/brand/rdb/header-email.png"
             alt="Membrete Rincón del Bosque"
             className="w-full object-contain mb-6 max-h-32"
           />
@@ -601,7 +601,7 @@ function NewRequestSheet({
       <SheetContent className="sm:max-w-[700px] flex min-h-0 flex-col overflow-hidden p-6 print:p-0">
         <div className="hidden print:block mb-8">
           <img
-            src="/membrete-rdb.jpg"
+            src="/brand/rdb/header-email.png"
             alt="Membrete Rincón del Bosque"
             className="w-full object-contain mb-6 max-h-32"
           />

--- a/app/settings/acceso/actions.ts
+++ b/app/settings/acceso/actions.ts
@@ -319,9 +319,9 @@ export async function updateUsuarioEmpresaRol(
 // ── Welcome email via Resend ────────────────────────────────────────────────
 
 const LOGO_MAP: Record<string, string> = {
-  rdb: 'https://bsop.io/logos/rdb.jpg',
-  dilesa: 'https://bsop.io/logos/dilesa.jpg',
-  ansa: 'https://bsop.io/logos/ansa.jpg',
+  rdb: 'https://bsop.io/brand/rdb/isotipo.png',
+  dilesa: 'https://bsop.io/brand/dilesa/isotipo.png',
+  ansa: 'https://bsop.io/brand/ansa/isotipo.png',
 };
 
 async function sendWelcomeEmail(usuarioId: string): Promise<void> {

--- a/components/app-shell/header.tsx
+++ b/components/app-shell/header.tsx
@@ -37,7 +37,7 @@ export function Header({
           {sectionName === 'DILESA' && (
             <div className="flex h-[3.25rem] w-[3.25rem] shrink-0 items-center justify-center rounded-xl bg-white p-1 shadow-sm ring-1 ring-inset ring-[var(--border)]">
               <img
-                src="/logos/dilesa.jpg"
+                src="/brand/dilesa/isotipo.png"
                 alt="DILESA"
                 className="h-full w-full rounded-lg object-contain"
               />
@@ -46,7 +46,7 @@ export function Header({
           {sectionName === 'Rincón del Bosque' && (
             <div className="flex h-[3.25rem] w-[3.25rem] shrink-0 items-center justify-center rounded-xl bg-white p-1 shadow-sm ring-1 ring-inset ring-[var(--border)]">
               <img
-                src="/logos/rdb.jpg"
+                src="/brand/rdb/isotipo.png"
                 alt="RDB"
                 className="h-full w-full rounded-lg object-contain"
               />

--- a/components/app-shell/sidebar.tsx
+++ b/components/app-shell/sidebar.tsx
@@ -37,8 +37,9 @@ const LOGO_BY_KEY: Record<
   'dilesa-logo' | 'rdb-logo' | 'sanren-logo',
   { src: string; alt: string }
 > = {
-  'dilesa-logo': { src: '/logos/dilesa.jpg', alt: 'DILESA' },
-  'rdb-logo': { src: '/logos/rdb.jpg', alt: 'RDB' },
+  'dilesa-logo': { src: '/brand/dilesa/isotipo.png', alt: 'DILESA' },
+  'rdb-logo': { src: '/brand/rdb/isotipo.png', alt: 'RDB' },
+  // SANREN se mantiene en `/logos/sanren.png` hasta que tenga assets en `/brand/sanren/`.
   'sanren-logo': { src: '/logos/sanren.png', alt: 'SANREN' },
 };
 

--- a/components/inventario/print-stock-list.ts
+++ b/components/inventario/print-stock-list.ts
@@ -131,7 +131,7 @@ export function printStockList(stock: StockItem[], fechaCorte: string | null) {
 <body>
   <!-- Membrete empresa -->
   <div class="membrete">
-    <img src="/membrete-rdb.jpg" alt="Rincón del Bosque" />
+    <img src="/brand/rdb/header-email.png" alt="Rincón del Bosque" />
   </div>
   <div class="doc-meta">
     <span>${fechaCorte ? `Inventario al Corte: <strong>${fecha}</strong>` : `Inventario de Stock &mdash; <strong>${fecha}</strong>`}</span>

--- a/components/inventario/stock-detail-drawer.tsx
+++ b/components/inventario/stock-detail-drawer.tsx
@@ -76,7 +76,7 @@ export function StockDetailDrawer({ item, open, onClose }: StockDetailDrawerProp
       <SheetContent className="sm:max-w-[600px]">
         {/* Membrete solo para impresión */}
         <img
-          src="/membrete-rdb.jpg"
+          src="/brand/rdb/header-email.png"
           alt="Membrete Rincón del Bosque"
           className="hidden print:block w-full object-contain mb-6"
         />

--- a/components/ventas/order-detail.tsx
+++ b/components/ventas/order-detail.tsx
@@ -54,7 +54,7 @@ export function OrderDetail({
       <SheetContent className="sm:max-w-[600px]">
         {/* Membrete solo para impresión */}
         <img
-          src="/membrete-rdb.jpg"
+          src="/brand/rdb/header-email.png"
           alt="Membrete Rincón del Bosque"
           className="hidden print:block w-full object-contain mb-6"
         />

--- a/lib/juntas/email.ts
+++ b/lib/juntas/email.ts
@@ -15,9 +15,10 @@ export const EMAIL_IMAGE_TTL_SECONDS = 365 * 24 * 60 * 60;
 const ASSET_BASE_URL = 'https://bsop.io';
 
 // Header de fallback cuando la empresa no tiene `header_url` configurado en
-// `core.empresas`. Mantener apuntando a DILESA hasta que cada empresa cargue
-// su propio asset.
-const FALLBACK_HEADER_URL = `${ASSET_BASE_URL}/logos/dilesa-header.jpg`;
+// `core.empresas`. RDB y DILESA ya tienen su `header_url` apuntando a
+// `/brand/<empresa>/header-email.png`; este fallback solo se usa si una
+// empresa nueva entra al repo sin configurar branding todavía.
+const FALLBACK_HEADER_URL = `${ASSET_BASE_URL}/brand/dilesa/header-email.png`;
 
 // Mientras cada empresa configura su propio buzón de consejo, todas usan el de
 // DILESA. Agregar entradas aquí cuando una empresa estrene el suyo.

--- a/proxy.ts
+++ b/proxy.ts
@@ -16,7 +16,7 @@ function isPublicPath(pathname: string) {
     pathname === '/logo-bs.png' ||
     pathname === '/logo-bs.jpg' ||
     pathname === '/logo-bsop.jpg' ||
-    pathname === '/membrete-rdb.jpg'
+    pathname.startsWith('/brand/')
   );
 }
 


### PR DESCRIPTION
## Resumen

Migra todas las referencias a logos/membretes legacy hacia el sistema de branding canónico que ya está en `public/brand/<empresa>/`. Cada empresa tiene su set completo (header-email, isotipo, logo-horizontal, watermark, footer-doc, etc.) y la app ahora usa estos assets uniformemente.

**Net diff:** 14 archivos modificados, 23 insertions / 21 deletions.

## El bug que detonó este PR

El email de minuta de juntas RDB salía con un logo enorme y deformado. Causa: `core.empresas.header_url` para RDB apuntaba a `/logos/rdb.jpg` (logo cuadrado de 52×52 del sidebar), no a un banner. Cuando el email lo renderizaba al 100% del ancho, salía gigantesco y pixelado.

DILESA tenía un `header_url` apuntando al asset legacy correcto (`/logos/dilesa-header.jpg`) pero del path antiguo, no del sistema `/brand/`.

## Cambios

### Código (14 archivos)

| Categoría | Archivos | Path nuevo |
| --- | --- | --- |
| Membretes (banners) en print y otros | 8 archivos | `/brand/<empresa>/header-email.png` |
| Logos cuadrados (sidebar, top bar, welcome email) | 3 archivos | `/brand/<empresa>/isotipo.png` |
| Whitelist de proxy | `proxy.ts` | `pathname.startsWith('/brand/')` (cubre todo el árbol) |
| Fallback del email de juntas | `lib/juntas/email.ts` | `/brand/dilesa/header-email.png` |

SANREN se mantiene en `/logos/sanren.png` porque no tiene assets en `/brand/sanren/` todavía.

### Base de datos (Supabase, ejecutado junto a este commit)

```sql
UPDATE core.empresas
   SET header_url = '/brand/rdb/header-email.png',
       logo_url   = '/brand/rdb/isotipo.png'
 WHERE slug = 'rdb';

UPDATE core.empresas
   SET header_url = '/brand/dilesa/header-email.png',
       logo_url   = '/brand/dilesa/isotipo.png'
 WHERE slug = 'dilesa';
```

## Verificación

- typecheck ✅
- lint ✅ (sin warnings nuevos)
- format:check ✅
- 222 tests ✅
- `grep -rn '/membrete-rdb\|/logos/rdb\|/logos/dilesa\|/logos/ansa'` en código → 0 ocurrencias (solo SANREN sigue legacy a propósito)

## Test plan

- [ ] **Email de minuta RDB**: terminar una junta de prueba en RDB → header llega al tamaño correcto, asset de `/brand/rdb/header-email.png`.
- [ ] **Email de minuta DILESA**: idem, sin cambio visual (el banner es el mismo asset, solo cambia el path canónico).
- [ ] **Top bar (header del app-shell)** en RDB y DILESA: cuadrito 52×52 con el isotipo correcto, sin distorsión.
- [ ] **Sidebar**: idem.
- [ ] **Print** de Proveedores, Requisiciones, Órdenes de Compra, Inventario stock-detail, Ventas, Reporte de levantamientos en RDB → membrete sigue saliendo bien.
- [ ] **Welcome email por Resend** (al dar acceso a un usuario): logo de la empresa correcto.

## Follow-ups (no bloqueantes)

- Borrar los assets legacy huérfanos (`public/membrete-rdb.jpg`, `public/logos/{rdb,dilesa,dilesa-header,ansa}.jpg`) en otro PR — primero verificar que no haya links externos (emails antiguos, exports a PDF guardados) que dependan de esos paths.
- Subir assets de SANREN a `public/brand/sanren/` y migrar las referencias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)