### PR TITLE
fix(rdb): filtros de fecha respetan TZ Matamoros en OC y requisiciones

### DIFF
--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -8,6 +8,7 @@
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { getLocalDayBoundsUtc } from '@/lib/timezone';
 import {
   Table,
   TableBody,
@@ -713,8 +714,8 @@ export default function OrdenesCompraPage() {
         .eq('empresa_id', RDB_EMPRESA_ID)
         .order('created_at', { ascending: false });
 
-      if (dateFrom) query = query.gte('created_at', `${dateFrom}T00:00:00`);
-      if (dateTo) query = query.lte('created_at', `${dateTo}T23:59:59`);
+      if (dateFrom) query = query.gte('created_at', getLocalDayBoundsUtc(dateFrom, TZ).start);
+      if (dateTo) query = query.lte('created_at', getLocalDayBoundsUtc(dateTo, TZ).end);
 
       const { data, error: queryError } = await query;
       if (queryError) throw queryError;

--- a/app/rdb/requisiciones/page.tsx
+++ b/app/rdb/requisiciones/page.tsx
@@ -3,6 +3,7 @@
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { getLocalDayBoundsUtc } from '@/lib/timezone';
 import {
   guardarRequisicion,
   actualizarRequisicion,
@@ -987,10 +988,10 @@ export default function RequisicionesPage() {
         .limit(200);
 
       if (dateFrom) {
-        query = query.gte('created_at', `${dateFrom}T00:00:00`);
+        query = query.gte('created_at', getLocalDayBoundsUtc(dateFrom, TZ).start);
       }
       if (dateTo) {
-        query = query.lte('created_at', `${dateTo}T23:59:59`);
+        query = query.lte('created_at', getLocalDayBoundsUtc(dateTo, TZ).end);
       }
 
       const { data, error: fetchError } = await query;


### PR DESCRIPTION
## Resumen

- Las queries de Órdenes de Compra y Requisiciones (RDB) construían filtros con \`\${date}T00:00:00\` / \`T23:59:59\` sin offset. PostgREST los interpreta como UTC, así que después de las ~7 PM CDT (cuando UTC ya pasó al día siguiente) las filas recién creadas quedaban fuera del rango "Hoy"/"Este mes".
- Reportado por Pablo (RDB): tras "Guardar requisición" la fila no aparecía en la lista. Insert sí funcionaba — revisé en DB que las 3 requisiciones se guardaron OK; el filtro era el que las ocultaba.
- Fix: usar el helper \`getLocalDayBoundsUtc(date, TZ)\` que ya existe en \`lib/timezone.ts\` (con tests) y ya se usa en \`components/ventas/*\` y \`components/playtomic/*\`.

## Archivos

- [app/rdb/requisiciones/page.tsx](app/rdb/requisiciones/page.tsx)
- [app/rdb/ordenes-compra/page.tsx](app/rdb/ordenes-compra/page.tsx)

## Test plan

- [x] \`npm run typecheck\` → verde
- [x] \`npm run test:run\` → 222 passed
- [x] \`npm run lint\` → 0 errors (solo warnings preexistentes)
- [x] \`npm run format:check\` → ok
- [ ] Verificación post-merge: con preset "Hoy" después de las 7 PM CDT, las requisiciones/OCs creadas en ese momento aparecen en la lista de inmediato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)