### PR TITLE
feat(rdb): botón Borrar requisición (admin-only, soft delete)

### DIFF
--- a/app/rdb/requisiciones/actions.ts
+++ b/app/rdb/requisiciones/actions.ts
@@ -276,3 +276,59 @@ export async function generarOrdenCompra(
 
   return { id: oc.id, folio: oc.codigo } as { id: string; folio: string };
 }
+
+// ── Borrar (soft delete, admin-only) ──────────────────────────────────────────
+
+async function requireAdmin() {
+  const { supabase, user } = await requireAuth();
+  const { data: profile, error: profileError } = await supabase
+    .schema('core')
+    .from('usuarios')
+    .select('rol')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (profileError) throw new Error(profileError.message);
+  if (profile?.rol !== 'admin') {
+    throw new Error('Solo un administrador puede borrar requisiciones');
+  }
+
+  return { supabase, user };
+}
+
+export async function borrarRequisicion(id: string): Promise<void> {
+  const { supabase } = await requireAdmin();
+
+  const { data: existing, error: existingError } = await supabase
+    .schema('erp')
+    .from('requisiciones')
+    .select('id, deleted_at')
+    .eq('id', id)
+    .eq('empresa_id', RDB_EMPRESA_ID)
+    .maybeSingle();
+
+  if (existingError) throw new Error(existingError.message);
+  if (!existing) throw new Error('Requisición no encontrada');
+  if (existing.deleted_at) throw new Error('La requisición ya fue borrada');
+
+  const { count: ocCount, error: ocError } = await supabase
+    .schema('erp')
+    .from('ordenes_compra')
+    .select('id', { count: 'exact', head: true })
+    .eq('requisicion_id', id)
+    .eq('empresa_id', RDB_EMPRESA_ID);
+
+  if (ocError) throw new Error(ocError.message);
+  if ((ocCount ?? 0) > 0) {
+    throw new Error('No se puede borrar: la requisición tiene órdenes de compra derivadas');
+  }
+
+  const { error: deleteError } = await supabase
+    .schema('erp')
+    .from('requisiciones')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('empresa_id', RDB_EMPRESA_ID);
+
+  if (deleteError) throw new Error(deleteError.message);
+}

--- a/app/rdb/requisiciones/page.tsx
+++ b/app/rdb/requisiciones/page.tsx
@@ -8,9 +8,11 @@ import {
   guardarRequisicion,
   actualizarRequisicion,
   aprobarRequisicion,
+  borrarRequisicion,
   generarOrdenCompra,
   type DraftItemInput,
 } from './actions';
+import { usePermissions } from '@/components/providers';
 import {
   Table,
   TableBody,
@@ -52,6 +54,7 @@ import {
   RefreshCw,
   Search,
   ShoppingBasket,
+  Trash2,
   User2,
   XCircle,
   ChevronsUpDown,
@@ -319,11 +322,14 @@ function ExistingRequestSheet({
 }) {
   const [isPending, startTransition] = useTransition();
   const [actionError, setActionError] = useState<string | null>(null);
+  const { permissions } = usePermissions();
+  const isAdmin = permissions.isAdmin;
 
   if (!requisicion) return null;
 
   const status = normalizeStatus(requisicion.estatus);
   const items = requisicion.items ?? [];
+  const canDelete = isAdmin && status === 'pendiente';
 
   function handleAprobar() {
     setActionError(null);
@@ -347,6 +353,24 @@ function ExistingRequestSheet({
         onClose();
       } catch (err) {
         setActionError(err instanceof Error ? err.message : 'Error al generar OC');
+      }
+    });
+  }
+
+  function handleBorrar() {
+    if (!requisicion) return;
+    const confirmed = window.confirm(
+      `¿Borrar la requisición ${requisicion.folio || 'sin folio'}? Esta acción es solo para administradores.`
+    );
+    if (!confirmed) return;
+    setActionError(null);
+    startTransition(async () => {
+      try {
+        await borrarRequisicion(requisicion!.id);
+        onAction();
+        onClose();
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : 'Error al borrar');
       }
     });
   }
@@ -498,6 +522,17 @@ function ExistingRequestSheet({
 
             {(status === 'pendiente' || status === 'autorizada') && (
               <div className="flex flex-wrap justify-end gap-3">
+                {canDelete && (
+                  <Button
+                    variant="outline"
+                    onClick={handleBorrar}
+                    disabled={isPending}
+                    className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    {isPending ? 'Borrando…' : 'Borrar'}
+                  </Button>
+                )}
                 {status === 'pendiente' && (
                   <>
                     <Button
@@ -984,6 +1019,7 @@ export default function RequisicionesPage() {
         .from('requisiciones')
         .select('id, codigo, justificacion, autorizada_at, solicitante_id, created_at')
         .eq('empresa_id', RDB_EMPRESA_ID)
+        .is('deleted_at', null)
         .order('created_at', { ascending: false })
         .limit(200);
 


### PR DESCRIPTION
## Resumen

- Agrega botón **Borrar** rojo en el detail sheet de Requisiciones (RDB), visible solo para usuarios con \`usuarios.rol = 'admin'\` (gate en cliente Y servidor).
- Soft delete vía \`deleted_at\` (preserva trazabilidad — CLAUDE.md hard rule). La lista filtra \`is('deleted_at', null)\`.
- Reglas de negocio:
  - Solo requisiciones en estado pendiente (no autorizadas).
  - Bloqueado si la requisición ya generó OCs.
  - \`window.confirm()\` antes de invocar el server action.

Solicitado por Beto tras detectar requisiciones duplicadas en pruebas hoy. Las 2 duplicadas (\`REQ-20260428-DUXS\`, \`REQ-20260428-NQZ2\`) ya fueron borradas a mano vía MCP — este PR es para que el patrón quede en producto y no necesite intervención manual.

## Alcance multi-empresa

Hoy el módulo de requisiciones solo existe para RDB ([app/rdb/requisiciones](app/rdb/requisiciones)). Cuando se replique a otras empresas (DILESA, COAGAN, etc.), el botón viajará con el componente. No hay módulo compartido aún para extraer.

## Archivos

- [app/rdb/requisiciones/actions.ts](app/rdb/requisiciones/actions.ts) — \`requireAdmin\` + \`borrarRequisicion\` server action
- [app/rdb/requisiciones/page.tsx](app/rdb/requisiciones/page.tsx) — botón en sheet, filtro \`deleted_at IS NULL\`, \`usePermissions\`

## Test plan

- [x] \`npm run typecheck\` → verde
- [x] \`npm run test:run\` → 222 passed
- [x] \`npm run lint\` → 0 errors
- [x] \`npm run format:check\` → ok
- [ ] Verificación post-merge: como admin, abrir una requisición pendiente → ver botón Borrar; click → confirma → desaparece de la lista. Como viewer, NO ver el botón.
- [ ] Verificación: intentar borrar una requisición con OC derivada → server action rechaza con mensaje claro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)