### PR TITLE
feat(oc-recepciones): Sprint 4 — vista movimientos enlazada a OC

### DIFF
--- a/app/rdb/inventario/movimientos/page.tsx
+++ b/app/rdb/inventario/movimientos/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { RefreshCw, Search, TrendingDown, TrendingUp } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Package, RefreshCw, Search, TrendingDown, TrendingUp, Truck } from 'lucide-react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import {
   ModuleFilters,
@@ -13,9 +14,22 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { Combobox } from '@/components/ui/combobox';
 import { RDB_EMPRESA_ID, type MovimientoRow } from '@/components/inventario/types';
 import { tipoColorClass, tipoLabel } from '@/components/inventario/utils';
 import { formatCurrency, formatDateTime } from '@/lib/format';
+
+type OrigenKey = 'todos' | 'oc' | 'venta' | 'manual';
+
+function origenLabel(referenciaTipo: string | null): { key: OrigenKey; label: string } {
+  if (referenciaTipo === 'oc_recepcion' || referenciaTipo === 'orden_compra') {
+    return { key: 'oc', label: 'Por compra' };
+  }
+  if (referenciaTipo === 'venta_waitry' || referenciaTipo?.startsWith('venta')) {
+    return { key: 'venta', label: 'Venta' };
+  }
+  return { key: 'manual', label: 'Manual' };
+}
 
 const movimientoColumns: Column<MovimientoRow>[] = [
   {
@@ -75,18 +89,46 @@ const movimientoColumns: Column<MovimientoRow>[] = [
     render: (m) => formatCurrency(m.costo_unitario),
   },
   {
-    key: 'detalle',
-    label: 'Detalle / Referencia',
+    key: 'origen',
+    label: 'Origen',
     sortable: false,
-    cellClassName: 'max-w-[200px] truncate text-sm text-muted-foreground',
-    render: (m) => (
-      <>
-        <div className="font-medium text-foreground">
-          {m.referencia_tipo === 'orden_compra' ? 'OC' : 'Manual'}
-        </div>
-        <div className="truncate">{m.notas ?? '—'}</div>
-      </>
-    ),
+    accessor: (m) => origenLabel(m.referencia_tipo).label,
+    render: (m) => {
+      const origen = origenLabel(m.referencia_tipo);
+      if (origen.key === 'oc' && m.oc_codigo && m.referencia_id) {
+        return (
+          <Link
+            href={`/rdb/ordenes-compra?focus=${m.referencia_id}`}
+            className="inline-flex items-center gap-1 rounded border border-emerald-500/40 bg-emerald-500/5 px-1.5 py-0.5 text-xs font-medium text-emerald-700 hover:bg-emerald-500/10 dark:text-emerald-400"
+            title="Abrir OC origen"
+          >
+            <Truck className="h-3 w-3" />
+            <span className="font-mono">{m.oc_codigo}</span>
+          </Link>
+        );
+      }
+      if (origen.key === 'oc') {
+        return (
+          <Badge variant="outline" className="gap-1">
+            <Truck className="h-3 w-3" />
+            Por compra
+          </Badge>
+        );
+      }
+      return (
+        <Badge variant="outline" className="gap-1 text-muted-foreground">
+          <Package className="h-3 w-3" />
+          {origen.label}
+        </Badge>
+      );
+    },
+  },
+  {
+    key: 'notas',
+    label: 'Notas',
+    sortable: false,
+    cellClassName: 'max-w-[220px] truncate text-sm text-muted-foreground',
+    render: (m) => m.notas ?? '—',
   },
 ];
 
@@ -107,6 +149,7 @@ export default function InventarioMovimientosPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [origenFilter, setOrigenFilter] = useState<OrigenKey>('todos');
 
   const fetchMovimientos = useCallback(async () => {
     setLoading(true);
@@ -117,13 +160,44 @@ export default function InventarioMovimientosPage() {
         .schema('erp')
         .from('movimientos_inventario')
         .select(
-          'id, producto_id, tipo_movimiento, cantidad, costo_unitario, referencia_tipo, notas, created_at, productos(nombre)'
+          'id, producto_id, tipo_movimiento, cantidad, costo_unitario, referencia_tipo, referencia_id, notas, created_at, productos(nombre)'
         )
         .eq('empresa_id', RDB_EMPRESA_ID)
         .order('created_at', { ascending: false })
         .limit(300);
       if (queryError) throw queryError;
-      setMovimientos((data ?? []) as unknown as MovimientoRow[]);
+
+      const rows = ((data ?? []) as unknown as MovimientoRow[]).map((m) => ({
+        ...m,
+        oc_codigo: null as string | null,
+      }));
+
+      // Resolver codigo de OC para movimientos con referencia_tipo='oc_recepcion'
+      const ocIds = Array.from(
+        new Set(
+          rows
+            .filter((m) => m.referencia_tipo === 'oc_recepcion' && m.referencia_id)
+            .map((m) => m.referencia_id as string)
+        )
+      );
+      if (ocIds.length > 0) {
+        const { data: ocsData } = await supabase
+          .schema('erp')
+          .from('ordenes_compra')
+          .select('id, codigo')
+          .in('id', ocIds);
+        const ocMap = new Map<string, string>();
+        for (const oc of ocsData ?? []) {
+          if (oc.id && oc.codigo) ocMap.set(oc.id, oc.codigo);
+        }
+        for (const m of rows) {
+          if (m.referencia_id && ocMap.has(m.referencia_id)) {
+            m.oc_codigo = ocMap.get(m.referencia_id) ?? null;
+          }
+        }
+      }
+
+      setMovimientos(rows);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Error al cargar movimientos');
     } finally {
@@ -135,14 +209,21 @@ export default function InventarioMovimientosPage() {
     void fetchMovimientos();
   }, [fetchMovimientos]);
 
-  const filteredMovimientos = movimientos.filter((m) => {
-    if (!search) return true;
-    const q = search.toLowerCase();
-    return (
-      (m.productos?.nombre ?? '').toLowerCase().includes(q) ||
-      (m.notas ?? '').toLowerCase().includes(q)
-    );
-  });
+  const filteredMovimientos = useMemo(() => {
+    return movimientos.filter((m) => {
+      if (origenFilter !== 'todos') {
+        const origen = origenLabel(m.referencia_tipo).key;
+        if (origen !== origenFilter) return false;
+      }
+      if (!search) return true;
+      const q = search.toLowerCase();
+      return (
+        (m.productos?.nombre ?? '').toLowerCase().includes(q) ||
+        (m.notas ?? '').toLowerCase().includes(q) ||
+        (m.oc_codigo ?? '').toLowerCase().includes(q)
+      );
+    });
+  }, [movimientos, search, origenFilter]);
 
   return (
     <>
@@ -156,12 +237,25 @@ export default function InventarioMovimientosPage() {
         <div className="relative min-w-52">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
-            placeholder="Buscar producto o nota…"
+            placeholder="Buscar producto, nota u OC…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9"
           />
         </div>
+
+        <Combobox
+          value={origenFilter}
+          onChange={(v) => setOrigenFilter((v as OrigenKey) ?? 'todos')}
+          options={[
+            { value: 'todos', label: 'Todos los orígenes' },
+            { value: 'oc', label: 'Por compra (OC)' },
+            { value: 'venta', label: 'Venta' },
+            { value: 'manual', label: 'Manual' },
+          ]}
+          placeholder="Origen…"
+          className="w-[180px]"
+        />
 
         <Button
           variant="outline"

--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -6,7 +6,7 @@
  */
 
 import { RequireAccess } from '@/components/require-access';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getLocalDayBoundsUtc } from '@/lib/timezone';
@@ -886,6 +886,18 @@ function OrdenDetail({
 // ── Main Page ─────────────────────────────────────────────────────────────────
 
 export default function OrdenesCompraPage() {
+  // useSearchParams (en OrdenesCompraContent) requiere boundary de Suspense
+  // para que Next.js no falle al prerender la página estática.
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.ordenes_compra">
+      <Suspense fallback={null}>
+        <OrdenesCompraContent />
+      </Suspense>
+    </RequireAccess>
+  );
+}
+
+function OrdenesCompraContent() {
   const feedback = useActionFeedback();
   const { permissions } = usePermissions();
   const isAdmin = permissions.isAdmin;
@@ -1424,125 +1436,123 @@ export default function OrdenesCompraPage() {
   }, [ordenes, search]);
 
   return (
-    <RequireAccess empresa="rdb" modulo="rdb.ordenes_compra">
-      <div className="space-y-6">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Órdenes de Compra</h1>
-            <p className="text-sm text-muted-foreground">
-              Gestión operativa de compras a proveedores
-            </p>
-          </div>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Órdenes de Compra</h1>
+          <p className="text-sm text-muted-foreground">
+            Gestión operativa de compras a proveedores
+          </p>
         </div>
-
-        {!loading && !error ? <SummaryBar ordenes={filtered} /> : null}
-
-        <div className="flex flex-wrap items-end gap-3">
-          <div className="relative min-w-52">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder="Buscar folio, proveedor o requisición…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-9"
-            />
-          </div>
-
-          <div className="flex items-center gap-2">
-            <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <Input
-              type="date"
-              value={dateFrom}
-              onChange={(e) => {
-                setDateFrom(e.target.value);
-                setPresetKey('custom');
-              }}
-              className="w-36"
-            />
-            <span className="text-muted-foreground">—</span>
-            <Input
-              type="date"
-              value={dateTo}
-              onChange={(e) => {
-                setDateTo(e.target.value);
-                setPresetKey('custom');
-              }}
-              className="w-36"
-            />
-          </div>
-
-          <Combobox
-            value={presetKey}
-            onChange={handlePreset}
-            options={[
-              { value: 'hoy', label: 'Hoy' },
-              { value: 'ayer', label: 'Ayer' },
-              { value: 'semana', label: 'Esta semana' },
-              { value: '7dias', label: 'Últimos 7 días' },
-              { value: 'mes', label: 'Este mes' },
-              { value: '30dias', label: 'Últimos 30 días' },
-              { value: 'ano', label: 'Este año' },
-            ]}
-            placeholder="Rango..."
-            className="w-[140px]"
-          />
-
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => void fetchOrdenes()}
-            aria-label="Actualizar"
-          >
-            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-          </Button>
-
-          <span className="text-sm text-muted-foreground">
-            {loading ? 'Cargando…' : `${filtered.length} orden${filtered.length === 1 ? '' : 'es'}`}
-            {saving ? ' · guardando…' : ''}
-          </span>
-        </div>
-
-        {error ? (
-          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {error}
-          </div>
-        ) : null}
-
-        <DataTable<(typeof filtered)[number]>
-          data={filtered}
-          columns={ordenColumns}
-          rowKey="id"
-          loading={loading}
-          onRowClick={(o) => void openDetail(o)}
-          initialSort={{ key: 'fecha_emision', dir: 'desc' }}
-          emptyTitle="No se encontraron órdenes de compra"
-          showDensityToggle={false}
-        />
-
-        <OrdenDetail
-          orden={selected}
-          proveedores={proveedores}
-          loadingItems={loadingItems}
-          open={drawerOpen}
-          editedReceipts={editedReceipts}
-          editedPrices={editedPrices}
-          isAdmin={isAdmin}
-          onClose={() => setDrawerOpen(false)}
-          onReceiveChange={handleReceiveChange}
-          onPriceChange={handlePriceChange}
-          onReceivePartial={async () => {
-            await persistReception(false);
-          }}
-          onReceiveAll={async () => {
-            await persistReception(true);
-          }}
-          onAsignarProveedor={handleAsignarProveedor}
-          onMarcarEnviada={handleSavePricesAndMarkEnviada}
-          onCancelarLinea={handleCancelarLinea}
-          onCerrarOrden={handleCerrarOrden}
-          onPriceOverride={handlePriceOverride}
-        />
       </div>
-    </RequireAccess>
+
+      {!loading && !error ? <SummaryBar ordenes={filtered} /> : null}
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="relative min-w-52">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Buscar folio, proveedor o requisición…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <CalendarDays className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <Input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => {
+              setDateFrom(e.target.value);
+              setPresetKey('custom');
+            }}
+            className="w-36"
+          />
+          <span className="text-muted-foreground">—</span>
+          <Input
+            type="date"
+            value={dateTo}
+            onChange={(e) => {
+              setDateTo(e.target.value);
+              setPresetKey('custom');
+            }}
+            className="w-36"
+          />
+        </div>
+
+        <Combobox
+          value={presetKey}
+          onChange={handlePreset}
+          options={[
+            { value: 'hoy', label: 'Hoy' },
+            { value: 'ayer', label: 'Ayer' },
+            { value: 'semana', label: 'Esta semana' },
+            { value: '7dias', label: 'Últimos 7 días' },
+            { value: 'mes', label: 'Este mes' },
+            { value: '30dias', label: 'Últimos 30 días' },
+            { value: 'ano', label: 'Este año' },
+          ]}
+          placeholder="Rango..."
+          className="w-[140px]"
+        />
+
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => void fetchOrdenes()}
+          aria-label="Actualizar"
+        >
+          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+        </Button>
+
+        <span className="text-sm text-muted-foreground">
+          {loading ? 'Cargando…' : `${filtered.length} orden${filtered.length === 1 ? '' : 'es'}`}
+          {saving ? ' · guardando…' : ''}
+        </span>
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <DataTable<(typeof filtered)[number]>
+        data={filtered}
+        columns={ordenColumns}
+        rowKey="id"
+        loading={loading}
+        onRowClick={(o) => void openDetail(o)}
+        initialSort={{ key: 'fecha_emision', dir: 'desc' }}
+        emptyTitle="No se encontraron órdenes de compra"
+        showDensityToggle={false}
+      />
+
+      <OrdenDetail
+        orden={selected}
+        proveedores={proveedores}
+        loadingItems={loadingItems}
+        open={drawerOpen}
+        editedReceipts={editedReceipts}
+        editedPrices={editedPrices}
+        isAdmin={isAdmin}
+        onClose={() => setDrawerOpen(false)}
+        onReceiveChange={handleReceiveChange}
+        onPriceChange={handlePriceChange}
+        onReceivePartial={async () => {
+          await persistReception(false);
+        }}
+        onReceiveAll={async () => {
+          await persistReception(true);
+        }}
+        onAsignarProveedor={handleAsignarProveedor}
+        onMarcarEnviada={handleSavePricesAndMarkEnviada}
+        onCancelarLinea={handleCancelarLinea}
+        onCerrarOrden={handleCerrarOrden}
+        onPriceOverride={handlePriceOverride}
+      />
+    </div>
   );
 }

--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -7,6 +7,7 @@
 
 import { RequireAccess } from '@/components/require-access';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getLocalDayBoundsUtc } from '@/lib/timezone';
 import {
@@ -1089,6 +1090,11 @@ export default function OrdenesCompraPage() {
     void fetchOrdenes();
   }, [fetchOrdenes]);
 
+  // Auto-abrir drawer si llega ?focus={oc_id} (deep-link desde /inventario/movimientos)
+  const searchParams = useSearchParams();
+  const focusOcId = searchParams.get('focus');
+  const [autoOpenedFocusId, setAutoOpenedFocusId] = useState<string | null>(null);
+
   const openDetail = useCallback(async (orden: OrdenCompra) => {
     setSelected(orden);
     setDrawerOpen(true);
@@ -1131,6 +1137,15 @@ export default function OrdenesCompraPage() {
       setLoadingItems(false);
     }
   }, []);
+
+  useEffect(() => {
+    if (!focusOcId || autoOpenedFocusId === focusOcId || ordenes.length === 0) return;
+    const target = ordenes.find((o) => o.id === focusOcId);
+    if (target) {
+      setAutoOpenedFocusId(focusOcId);
+      void openDetail(target);
+    }
+  }, [focusOcId, ordenes, autoOpenedFocusId, openDetail]);
 
   const handleReceiveChange = useCallback((itemId: string, value: string, max: number) => {
     const normalized = value === '' ? '' : String(Math.min(Math.max(Number(value) || 0, 0), max));

--- a/components/inventario/types.ts
+++ b/components/inventario/types.ts
@@ -26,9 +26,12 @@ export type MovimientoRow = {
   cantidad: number;
   costo_unitario: number | null;
   referencia_tipo: string | null;
+  referencia_id: string | null;
   notas: string | null;
   created_at: string | null;
   productos: { nombre: string } | null;
+  /** Resuelto en cliente: si referencia_tipo='oc_recepcion', el codigo de la OC origen. */
+  oc_codigo?: string | null;
 };
 
 export type TipoUI = 'ajuste_positivo' | 'ajuste_negativo' | 'merma' | 'consumo_interno';


### PR DESCRIPTION
## Resumen

Sprint 4 de [`oc-recepciones`](docs/planning/oc-recepciones.md). Cierra el ciclo de trazabilidad — desde el listado de movimientos de inventario el usuario identifica visualmente los que vinieron de una OC y navega de regreso al detalle.

## Cambios

### `/rdb/inventario/movimientos`

- Columna **Origen** reemplaza "Detalle / Referencia". Si `referencia_tipo='oc_recepcion'`, muestra chip verde con 🚚 + folio de la OC, clickable → `/rdb/ordenes-compra?focus={oc_id}`. Otros orígenes (venta, manual) muestran chip neutro.
- Columna **Notas** separada del origen.
- Filtro nuevo: combobox de Origen (Todos / Por compra (OC) / Venta / Manual).
- Búsqueda extendida: ahora matchea también contra el folio de OC.

### `/rdb/ordenes-compra`

- Lee `?focus={oc_id}` del URL — si la OC está en el listado, auto-abre el drawer. Cierra el deep-link desde movimientos. Estado `autoOpenedFocusId` previene re-abrir si el usuario cierra el drawer manualmente.

### Tipos

- `MovimientoRow.referencia_id` y `MovimientoRow.oc_codigo` (opcional, resuelto en cliente).

## Resolución del folio OC

Query secundaria a `erp.ordenes_compra` filtrada por los `referencia_id` únicos con `tipo='oc_recepcion'`. Se mergea en cliente — PostgREST no permite embed dinámico sobre `referencia_id` porque es polymorphic (no hay FK declarada).

## Test plan

- [x] `npm run typecheck` — 0 errores
- [x] `npm run lint` — 0 errores (warnings heredados)
- [x] `npm run format:check` — `All matched files use Prettier code style!`
- [x] `npm run test:run` — 444/444 tests passed
- [ ] CI verde

## Lo que sigue

- Sprint 5 (último): rollout multi-empresa — replicar `/dilesa/ordenes-compra`, `/coagan/ordenes-compra`, `/ansa/ordenes-compra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)