### PR TITLE
chore(sidebar): eliminar footer "Hecho con 🦞 por Claw & Beto"

### DIFF
--- a/components/app-shell/sidebar.tsx
+++ b/components/app-shell/sidebar.tsx
@@ -308,10 +308,6 @@ export function Sidebar({
           })
         )}
       </nav>
-
-      <div className="border-t border-[var(--border)] px-3 py-4 text-xs dark:text-white/38 text-[var(--text)]/50">
-        {!collapsed ? t('footer.built_by') : '🦞'}
-      </div>
     </aside>
   );
 }

--- a/lib/locales/en.json
+++ b/lib/locales/en.json
@@ -23,8 +23,6 @@
   "header.toggle_theme": "Toggle theme",
   "header.toggle_locale": "Switch language",
 
-  "footer.built_by": "Built with 🦞 by Claw & Beto",
-
   "greeting.morning": "Good morning",
   "greeting.afternoon": "Good afternoon",
   "greeting.evening": "Good evening",

--- a/lib/locales/es.json
+++ b/lib/locales/es.json
@@ -23,8 +23,6 @@
   "header.toggle_theme": "Cambiar tema",
   "header.toggle_locale": "Cambiar idioma",
 
-  "footer.built_by": "Hecho con 🦞 por Claw & Beto",
-
   "greeting.morning": "Buenos días",
   "greeting.afternoon": "Buenas tardes",
   "greeting.evening": "Buenas noches",


### PR DESCRIPTION
## Summary
- Elimina el `<div>` del footer del sidebar (`components/app-shell/sidebar.tsx`).
- Borra la llave `footer.built_by` en `lib/locales/en.json` y `lib/locales/es.json` (era el único uso).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] `npm run test:run` (222/222)
- [ ] Verificar visualmente en preview que el sidebar ya no muestra el texto y que no quedó borde inferior huérfano

🤖 Generated with [Claude Code](https://claude.com/claude-code)