### PR TITLE
feat(empresas-csf-config): Sprint 1 — endpoints API CSF + mapping

### DIFF
--- a/app/api/empresas/[id]/route.test.ts
+++ b/app/api/empresas/[id]/route.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { buildAdminMock, type AdminScript } from '../_test-helpers';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+let serverUser: { email: string } | null = null;
+let adminScript: AdminScript = {};
+let adminAvailable = true;
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: serverUser } }) },
+  }),
+}));
+
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdminClient: () => (adminAvailable ? buildAdminMock(adminScript) : null),
+}));
+
+// ── Test ───────────────────────────────────────────────────────────────
+
+import { PATCH } from './route';
+
+beforeEach(() => {
+  serverUser = { email: 'admin@example.com' };
+  adminScript = {
+    callerUser: { id: 'admin-uuid', email: 'admin@example.com', rol: 'admin', activo: true },
+    empresaById: { id: 'e1', slug: 'rdb', rfc: null },
+  };
+  adminAvailable = true;
+});
+
+function makeReq(
+  body: unknown,
+  id = 'e1'
+): { req: NextRequest; ctx: { params: Promise<{ id: string }> } } {
+  const req = new NextRequest(new URL(`http://localhost/api/empresas/${id}`), {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { req, ctx: { params: Promise.resolve({ id }) } };
+}
+
+describe('PATCH /api/empresas/[id]', () => {
+  it('401 si no hay user en JWT', async () => {
+    serverUser = null;
+    const { req, ctx } = makeReq({ registro_patronal_imss: 'A0000000000' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si el caller no es admin', async () => {
+    adminScript.callerUser = {
+      id: 'u1',
+      email: 'beto@anorte.com',
+      rol: 'usuario',
+      activo: true,
+    };
+    const { req, ctx } = makeReq({ registro_patronal_imss: 'A0000000000' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('500 si no hay admin client', async () => {
+    adminAvailable = false;
+    const { req, ctx } = makeReq({ registro_patronal_imss: 'A0000000000' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(500);
+  });
+
+  it('400 si registro_patronal_imss tiene formato inválido', async () => {
+    const { req, ctx } = makeReq({ registro_patronal_imss: '12345' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/payload inválido/i);
+  });
+
+  it('400 si el body trae llaves desconocidas (strict)', async () => {
+    const { req, ctx } = makeReq({ campo_random: 'x' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('400 si el body está vacío', async () => {
+    const { req, ctx } = makeReq({});
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('404 si la empresa no existe', async () => {
+    adminScript.empresaById = null;
+    const { req, ctx } = makeReq({ registro_patronal_imss: 'A0000000000' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('200 con un registro_patronal_imss válido', async () => {
+    const { req, ctx } = makeReq({ registro_patronal_imss: 'C8520138108' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.empresa_id).toBe('e1');
+    expect(json.fields_updated).toContain('registro_patronal_imss');
+  });
+
+  it('200 con cadena vacía limpia el campo (transforma a null)', async () => {
+    const { req, ctx } = makeReq({ registro_patronal_imss: '' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it('200 con null limpia el campo', async () => {
+    const { req, ctx } = makeReq({ registro_patronal_imss: null });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+  });
+});

--- a/app/api/empresas/[id]/route.ts
+++ b/app/api/empresas/[id]/route.ts
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public`; para `core` usamos `as any`.
+ */
+
+/**
+ * PATCH /api/empresas/[id]
+ *
+ * Actualiza campos sueltos de `core.empresas` que NO vienen del CSF y NO son
+ * branding. Hoy v1 cubre `registro_patronal_imss` (capturado a mano para
+ * contratos LFT) — el endpoint queda extensible para otros campos futuros
+ * con el mismo patrón.
+ *
+ * Para refrescar campos del CSF: usar `[id]/update-csf` con PDF.
+ * Para branding (colores/logos): hay otro flujo en `EmpresaBranding`.
+ *
+ * Solo admin.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { requireAdmin } from '@/lib/empresas/admin-guard';
+
+export const runtime = 'nodejs';
+
+// `registro_patronal_imss` formato SAT/IMSS: 1 letra + 10 dígitos.
+// Permitimos null/cadena vacía para limpiar el campo.
+const RegistroPatronalSchema = z
+  .union([
+    z
+      .string()
+      .regex(/^[A-Z]\d{10}$/, 'registro_patronal_imss inválido (formato esperado: A0000000000)'),
+    z.literal(''),
+    z.null(),
+  ])
+  .transform((v) => (v === '' ? null : v));
+
+const PayloadSchema = z
+  .object({
+    registro_patronal_imss: RegistroPatronalSchema.optional(),
+  })
+  .strict();
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const { id: empresaId } = await params;
+
+  const userSupa = await createSupabaseServerClient();
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const guard = await requireAdmin(userSupa, admin);
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `body JSON inválido: ${msg}` }, { status: 400 });
+  }
+
+  let payload;
+  try {
+    payload = PayloadSchema.parse(body);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  if (Object.keys(payload).length === 0) {
+    return NextResponse.json({ error: 'No hay campos para actualizar.' }, { status: 400 });
+  }
+
+  // Verifica que la empresa existe.
+  const { data: empresa, error: lookupErr } = await (admin.schema('core') as any)
+    .from('empresas')
+    .select('id, slug')
+    .eq('id', empresaId)
+    .maybeSingle();
+  if (lookupErr) {
+    return NextResponse.json({ error: `lookup empresa: ${lookupErr.message}` }, { status: 500 });
+  }
+  if (!empresa) {
+    return NextResponse.json({ error: 'Empresa no encontrada.' }, { status: 404 });
+  }
+
+  const { error: updErr } = await (admin.schema('core') as any)
+    .from('empresas')
+    .update(payload)
+    .eq('id', empresaId);
+
+  if (updErr) {
+    return NextResponse.json({ error: `update empresa: ${updErr.message}` }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    empresa_id: empresaId,
+    fields_updated: Object.keys(payload),
+  });
+}

--- a/app/api/empresas/[id]/update-csf/route.test.ts
+++ b/app/api/empresas/[id]/update-csf/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import {
+  buildAdminMock,
+  buildCsfFormData,
+  SAMPLE_EXTRACCION,
+  type AdminScript,
+} from '../../_test-helpers';
+
+let serverUser: { email: string } | null = null;
+let adminScript: AdminScript = {};
+let adminAvailable = true;
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: serverUser } }) },
+  }),
+}));
+
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdminClient: () => (adminAvailable ? buildAdminMock(adminScript) : null),
+}));
+
+import { POST } from './route';
+
+beforeEach(() => {
+  serverUser = { email: 'admin@example.com' };
+  adminScript = {
+    callerUser: { id: 'admin-uuid', email: 'admin@example.com', rol: 'admin', activo: true },
+    empresaById: { id: 'e1', slug: 'rdb', rfc: 'OLD123456XX0' },
+    insertAdjuntoResult: { data: { id: 'new-adj-id' }, error: null },
+    updateEmpresaResult: { error: null },
+    storageUploadResult: { error: null },
+  };
+  adminAvailable = true;
+});
+
+function makeReq(
+  formData: FormData,
+  id = 'e1'
+): { req: NextRequest; ctx: { params: Promise<{ id: string }> } } {
+  const req = new NextRequest(new URL(`http://localhost/api/empresas/${id}/update-csf`), {
+    method: 'POST',
+    body: formData,
+  });
+  return { req, ctx: { params: Promise.resolve({ id }) } };
+}
+
+describe('POST /api/empresas/[id]/update-csf', () => {
+  it('401 si no hay user', async () => {
+    serverUser = null;
+    const fd = buildCsfFormData({
+      payload: { extraccion: SAMPLE_EXTRACCION, accepted_fields: [] },
+    });
+    const { req, ctx } = makeReq(fd);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si el caller no es admin', async () => {
+    adminScript.callerUser = {
+      id: 'u1',
+      email: 'x@y.com',
+      rol: 'usuario',
+      activo: true,
+    };
+    const fd = buildCsfFormData({
+      payload: { extraccion: SAMPLE_EXTRACCION, accepted_fields: [] },
+    });
+    const { req, ctx } = makeReq(fd);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('404 si la empresa no existe', async () => {
+    adminScript.empresaById = null;
+    const fd = buildCsfFormData({
+      payload: { extraccion: SAMPLE_EXTRACCION, accepted_fields: [] },
+    });
+    const { req, ctx } = makeReq(fd);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('400 si el accepted_fields trae un key no soportado', async () => {
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        accepted_fields: ['campo_inventado'],
+      },
+    });
+    const { req, ctx } = makeReq(fd);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('200 con accepted_fields vacío archiva PDF y NO actualiza csf_url', async () => {
+    const fd = buildCsfFormData({
+      payload: { extraccion: SAMPLE_EXTRACCION, accepted_fields: [] },
+    });
+    const { req, ctx } = makeReq(fd);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.fields_updated).toBe(0);
+    expect(json.csf_pointer_updated).toBe(false);
+    expect(json.new_adjunto_id).toBe('new-adj-id');
+  });
+
+  it('200 con campos aceptados (incluye extras de empresa)', async () => {
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        accepted_fields: ['rfc', 'razon_social', 'id_cif', 'estatus_sat'],
+      },
+    });
+    const { req, ctx } = makeReq(fd);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.csf_pointer_updated).toBe(true);
+    expect(json.fields_updated).toBeGreaterThan(0);
+  });
+});

--- a/app/api/empresas/[id]/update-csf/route.ts
+++ b/app/api/empresas/[id]/update-csf/route.ts
@@ -1,0 +1,196 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public`; para `core` y `erp` usamos `as any`.
+ */
+
+/**
+ * POST /api/empresas/[id]/update-csf
+ *
+ * Refresca el CSF de una empresa existente con aplicación selectiva por
+ * campo. Flujo:
+ *
+ *   1. UI sube el PDF a `/api/empresas/extract-csf` → recibe los campos.
+ *   2. UI muestra modal de diff: estado actual de la empresa vs valor nuevo
+ *      del extractor, checkbox por campo.
+ *   3. Al aplicar, llama a este endpoint con FormData:
+ *        - `file`: el PDF subido a extract-csf.
+ *        - `payload`: JSON con { extraccion, accepted_fields[] }.
+ *
+ * Comportamiento según `accepted_fields`:
+ *   - **Vacío:** archiva PDF en erp.adjuntos como histórico, NO toca
+ *     `core.empresas`. `csf_url` queda como estaba.
+ *   - **No vacío:** archiva PDF nuevo, UPDATE selectivo sobre `core.empresas`,
+ *     `csf_url` se apunta al nuevo PDF.
+ *
+ * Solo admin.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { CsfExtraccionSchema, CSF_UPDATABLE_FIELDS } from '@/lib/proveedores/extract-csf';
+import { buildEmpresaUpdateFromAccepted, EMPRESA_EXTRA_FIELDS } from '@/lib/empresas/csf-mapping';
+import { requireAdmin } from '@/lib/empresas/admin-guard';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+const BUCKET = 'adjuntos';
+const MAX_INCOMING_BYTES = 50 * 1024 * 1024;
+
+const ACCEPTABLE_FIELDS = [...CSF_UPDATABLE_FIELDS, ...EMPRESA_EXTRA_FIELDS] as const;
+
+const PayloadSchema = z.object({
+  extraccion: CsfExtraccionSchema,
+  accepted_fields: z.array(z.enum(ACCEPTABLE_FIELDS)),
+});
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const { id: empresaId } = await params;
+
+  const userSupa = await createSupabaseServerClient();
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const guard = await requireAdmin(userSupa, admin);
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  // Verifica que la empresa existe.
+  const { data: empresa, error: empresaErr } = await (admin.schema('core') as any)
+    .from('empresas')
+    .select('id, slug, rfc')
+    .eq('id', empresaId)
+    .maybeSingle();
+
+  if (empresaErr) {
+    return NextResponse.json({ error: `lookup empresa: ${empresaErr.message}` }, { status: 500 });
+  }
+  if (!empresa) {
+    return NextResponse.json({ error: 'Empresa no encontrada.' }, { status: 404 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `multipart inválido: ${msg}` }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  const payloadRaw = formData.get('payload');
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'Falta el campo "file" (multipart/form-data).' },
+      { status: 400 }
+    );
+  }
+  if (file.type && file.type !== 'application/pdf') {
+    return NextResponse.json(
+      { error: `Tipo de archivo no soportado: ${file.type}. Solo application/pdf.` },
+      { status: 415 }
+    );
+  }
+  if (file.size > MAX_INCOMING_BYTES) {
+    return NextResponse.json(
+      { error: `Archivo muy grande (${(file.size / 1024 / 1024).toFixed(1)} MB). Máximo 50 MB.` },
+      { status: 413 }
+    );
+  }
+  if (typeof payloadRaw !== 'string' || !payloadRaw.length) {
+    return NextResponse.json({ error: 'Falta el campo "payload".' }, { status: 400 });
+  }
+
+  let payload;
+  try {
+    payload = PayloadSchema.parse(JSON.parse(payloadRaw));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  const { extraccion, accepted_fields } = payload;
+
+  // 1) Sube PDF a storage SIEMPRE — archiva como histórico aunque rechacen
+  //    todos los cambios.
+  const ts = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80);
+  const path = `empresas/${empresaId}/csf-${ts}-${safeName}`;
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const { error: uploadErr } = await admin.storage.from(BUCKET).upload(path, bytes, {
+    contentType: 'application/pdf',
+    upsert: false,
+  });
+  if (uploadErr) {
+    return NextResponse.json({ error: `upload csf: ${uploadErr.message}` }, { status: 500 });
+  }
+
+  // 2) Crea row en erp.adjuntos para el PDF nuevo.
+  const { data: newAdjunto, error: adjErr } = await (admin.schema('erp') as any)
+    .from('adjuntos')
+    .insert({
+      empresa_id: empresaId,
+      entidad_tipo: 'empresa',
+      entidad_id: empresaId,
+      rol: 'csf',
+      nombre: file.name,
+      url: path,
+      tipo_mime: 'application/pdf',
+      tamano_bytes: file.size,
+      uploaded_by: guard.usuario.id,
+    })
+    .select('id')
+    .single();
+  if (adjErr) {
+    return NextResponse.json({ error: `insert adjunto: ${adjErr.message}` }, { status: 500 });
+  }
+  const newAdjuntoId: string = newAdjunto.id;
+
+  // 3) Si accepted_fields está vacío → terminamos.
+  if (accepted_fields.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      new_adjunto_id: newAdjuntoId,
+      fields_updated: 0,
+      csf_pointer_updated: false,
+    });
+  }
+
+  // 4) Construye UPDATE selectivo + apunta csf_url al nuevo PDF.
+  const update = buildEmpresaUpdateFromAccepted({
+    extraccion,
+    accepted: accepted_fields,
+  });
+  const updatePayload = { ...update, csf_url: path };
+
+  const { error: updErr } = await (admin.schema('core') as any)
+    .from('empresas')
+    .update(updatePayload)
+    .eq('id', empresaId);
+
+  if (updErr) {
+    return NextResponse.json(
+      {
+        error: `update empresa: ${updErr.message}`,
+        partial: { new_adjunto_id: newAdjuntoId },
+      },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    new_adjunto_id: newAdjuntoId,
+    fields_updated: Object.keys(update).length,
+    csf_pointer_updated: true,
+  });
+}

--- a/app/api/empresas/_test-helpers.ts
+++ b/app/api/empresas/_test-helpers.ts
@@ -1,0 +1,221 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- Test fixtures for fluent Supabase mock chains. */
+
+/**
+ * Shared mocking infrastructure for `app/api/empresas/*` route tests.
+ *
+ * Mirrors the approach used in `app/api/impersonate/route.test.ts` but trimmed
+ * to the specific tables and operations these endpoints touch:
+ *
+ *   - `core.usuarios` for the admin guard
+ *   - `core.empresas` for lookup, dedup, insert, update
+ *   - `erp.adjuntos` for archiving the CSF PDF
+ *
+ * Each test reassigns the per-table results via `installAdminMock`, so a
+ * single test file can vary just the slice it cares about (e.g. RFC duplicate
+ * vs. slug duplicate vs. clean insert).
+ */
+
+export type AdminScript = {
+  // core.usuarios — admin guard
+  callerUser?: { id: string; email: string; rol: string; activo: boolean } | null;
+  // core.empresas
+  empresaByRfc?: { id: string; slug: string } | null;
+  empresaBySlug?: { id: string } | null;
+  empresaById?: { id: string; slug: string; rfc: string | null } | null;
+  // INSERT/UPDATE results
+  insertEmpresaResult?: {
+    data: { id: string; slug: string } | null;
+    error: { message: string } | null;
+  };
+  updateEmpresaResult?: { error: { message: string } | null };
+  insertAdjuntoResult?: { data: { id: string } | null; error: { message: string } | null };
+  // Storage
+  storageUploadResult?: { error: { message: string } | null };
+};
+
+export type FluentResult = {
+  data: any;
+  error: any;
+};
+
+/**
+ * Builds a fluent admin client matching the call shapes in the empresas
+ * routes. Routes by `(schema, table, op)` and inspects the `.eq()` chain to
+ * decide which fixture to return.
+ */
+export function buildAdminMock(script: AdminScript): any {
+  return {
+    schema(schemaName: string) {
+      return {
+        from(tableName: string) {
+          const key = `${schemaName}.${tableName}`;
+          // Track filters chain
+          const filters: Record<string, unknown> = {};
+          let pendingInsert: unknown = null;
+          let pendingUpdate: unknown = null;
+
+          const builder: any = {
+            select(_cols: string) {
+              return builder;
+            },
+            insert(row: unknown) {
+              pendingInsert = row;
+              return builder;
+            },
+            update(row: unknown) {
+              pendingUpdate = row;
+              return builder;
+            },
+            eq(col: string, val: unknown) {
+              filters[col] = val;
+              return builder;
+            },
+            is(_col: string, _val: unknown) {
+              return builder;
+            },
+            async maybeSingle(): Promise<FluentResult> {
+              return resolveSingle(key, filters, script);
+            },
+            async single(): Promise<FluentResult> {
+              return resolveInsertSingle(key, pendingInsert, script);
+            },
+            // Direct await on update chain (no .select().single() after)
+            then(
+              onFulfilled: (result: FluentResult) => unknown,
+              onRejected?: (reason: unknown) => unknown
+            ) {
+              const result = pendingUpdate
+                ? resolveUpdate(key, script)
+                : { data: null, error: null };
+              return Promise.resolve(result).then(onFulfilled, onRejected);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+    storage: {
+      from(_bucket: string) {
+        return {
+          async upload(_path: string, _bytes: Uint8Array, _opts: unknown) {
+            return script.storageUploadResult ?? { error: null };
+          },
+        };
+      },
+    },
+    auth: {
+      async getUser() {
+        return { data: { user: null } };
+      },
+    },
+  };
+}
+
+function resolveSingle(
+  key: string,
+  filters: Record<string, unknown>,
+  script: AdminScript
+): FluentResult {
+  if (key === 'core.usuarios') {
+    return { data: script.callerUser ?? null, error: null };
+  }
+  if (key === 'core.empresas') {
+    if ('rfc' in filters) {
+      return { data: script.empresaByRfc ?? null, error: null };
+    }
+    if ('slug' in filters) {
+      return { data: script.empresaBySlug ?? null, error: null };
+    }
+    if ('id' in filters) {
+      return { data: script.empresaById ?? null, error: null };
+    }
+  }
+  return { data: null, error: null };
+}
+
+function resolveInsertSingle(key: string, _row: unknown, script: AdminScript): FluentResult {
+  if (key === 'core.empresas') {
+    return (
+      script.insertEmpresaResult ?? {
+        data: { id: 'new-emp-id', slug: 'new-slug' },
+        error: null,
+      }
+    );
+  }
+  if (key === 'erp.adjuntos') {
+    return (
+      script.insertAdjuntoResult ?? {
+        data: { id: 'new-adj-id' },
+        error: null,
+      }
+    );
+  }
+  return { data: null, error: null };
+}
+
+function resolveUpdate(key: string, script: AdminScript): FluentResult {
+  if (key === 'core.empresas') {
+    const r = script.updateEmpresaResult ?? { error: null };
+    return { data: null, error: r.error };
+  }
+  return { data: null, error: null };
+}
+
+/**
+ * Builds a multipart FormData with a fake PDF blob + a JSON payload.
+ */
+export function buildCsfFormData(args: {
+  filename?: string;
+  fileType?: string;
+  fileSize?: number;
+  payload?: unknown;
+}): FormData {
+  const fd = new FormData();
+  const size = args.fileSize ?? 1024;
+  const blob = new Blob([new Uint8Array(size)], {
+    type: args.fileType ?? 'application/pdf',
+  });
+  const file = new File([blob], args.filename ?? 'csf.pdf', {
+    type: args.fileType ?? 'application/pdf',
+  });
+  fd.append('file', file);
+  if (args.payload !== undefined) {
+    fd.append('payload', JSON.stringify(args.payload));
+  }
+  return fd;
+}
+
+export const SAMPLE_EXTRACCION = {
+  tipo_persona: 'moral' as const,
+  rfc: 'ABC010101AB1',
+  curp: null,
+  nombre: null,
+  apellido_paterno: null,
+  apellido_materno: null,
+  razon_social: 'EJEMPLO SA DE CV',
+  nombre_comercial: null,
+  regimen_fiscal_codigo: '601',
+  regimen_fiscal_nombre: 'General de Ley Personas Morales',
+  regimenes_adicionales: [
+    {
+      codigo: '601',
+      nombre: 'General de Ley Personas Morales',
+      fecha_inicio: '2020-01-01',
+      fecha_fin: null,
+    },
+  ],
+  domicilio_calle: 'Av. Reforma',
+  domicilio_num_ext: '100',
+  domicilio_num_int: null,
+  domicilio_colonia: 'Centro',
+  domicilio_cp: '06000',
+  domicilio_municipio: 'Cuauhtémoc',
+  domicilio_estado: 'CDMX',
+  obligaciones: [],
+  fecha_inicio_operaciones: '2020-01-01',
+  fecha_emision: '2026-04-27',
+  id_cif: '14110980997',
+  estatus_sat: 'ACTIVO',
+  regimen_capital: 'SOCIEDAD ANONIMA DE CAPITAL VARIABLE',
+  actividades_economicas: [],
+};

--- a/app/api/empresas/create-with-csf/route.test.ts
+++ b/app/api/empresas/create-with-csf/route.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import {
+  buildAdminMock,
+  buildCsfFormData,
+  SAMPLE_EXTRACCION,
+  type AdminScript,
+} from '../_test-helpers';
+
+let serverUser: { email: string } | null = null;
+let adminScript: AdminScript = {};
+let adminAvailable = true;
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: serverUser } }) },
+  }),
+}));
+
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdminClient: () => (adminAvailable ? buildAdminMock(adminScript) : null),
+}));
+
+import { POST } from './route';
+
+beforeEach(() => {
+  serverUser = { email: 'admin@example.com' };
+  adminScript = {
+    callerUser: { id: 'admin-uuid', email: 'admin@example.com', rol: 'admin', activo: true },
+    empresaByRfc: null,
+    empresaBySlug: null,
+    insertEmpresaResult: { data: { id: 'new-emp-id', slug: 'test-empresa' }, error: null },
+    insertAdjuntoResult: { data: { id: 'new-adj-id' }, error: null },
+    updateEmpresaResult: { error: null },
+    storageUploadResult: { error: null },
+  };
+  adminAvailable = true;
+});
+
+function makeReq(formData: FormData): NextRequest {
+  return new NextRequest(new URL('http://localhost/api/empresas/create-with-csf'), {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+describe('POST /api/empresas/create-with-csf', () => {
+  it('401 si no hay user', async () => {
+    serverUser = null;
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        slug: 'test-empresa',
+        nombre: 'Test',
+      },
+    });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si el caller no es admin', async () => {
+    adminScript.callerUser = {
+      id: 'u1',
+      email: 'x@y.com',
+      rol: 'usuario',
+      activo: true,
+    };
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        slug: 'test-empresa',
+        nombre: 'Test',
+      },
+    });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(403);
+  });
+
+  it('400 si falta payload', async () => {
+    const fd = buildCsfFormData({});
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 si el slug no es kebab-case', async () => {
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        slug: 'BadSlug',
+        nombre: 'Test',
+      },
+    });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/payload inválido/i);
+  });
+
+  it('409 si el RFC ya existe en core.empresas', async () => {
+    adminScript.empresaByRfc = { id: 'old-emp', slug: 'rdb' };
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        slug: 'test-empresa',
+        nombre: 'Test',
+      },
+    });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toBe('rfc_duplicado');
+    expect(json.existing_empresa_id).toBe('old-emp');
+    expect(json.existing_slug).toBe('rdb');
+  });
+
+  it('409 si el slug ya existe en core.empresas', async () => {
+    adminScript.empresaBySlug = { id: 'other-emp' };
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        slug: 'test-empresa',
+        nombre: 'Test',
+      },
+    });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toBe('slug_duplicado');
+  });
+
+  it('500 si el upload del PDF falla (con partial)', async () => {
+    adminScript.storageUploadResult = { error: { message: 'storage broke' } };
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        slug: 'test-empresa',
+        nombre: 'Test',
+      },
+    });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.partial?.empresa_id).toBe('new-emp-id');
+  });
+
+  it('200 con flujo completo OK', async () => {
+    const fd = buildCsfFormData({
+      payload: {
+        extraccion: SAMPLE_EXTRACCION,
+        slug: 'test-empresa',
+        nombre: 'Test',
+      },
+    });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.empresa_id).toBe('new-emp-id');
+    expect(json.slug).toBe('test-empresa');
+    expect(json.adjunto_id).toBe('new-adj-id');
+  });
+});

--- a/app/api/empresas/create-with-csf/route.ts
+++ b/app/api/empresas/create-with-csf/route.ts
@@ -1,0 +1,225 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public` por default; para escribir en
+ * `core` y `erp` usamos `as any` (mismo patrón que proveedores).
+ */
+
+/**
+ * POST /api/empresas/create-with-csf
+ *
+ * Alta de empresa nueva a partir del PDF de su CSF + campos extraídos. Flujo:
+ *
+ *   1. UI sube el PDF a `/api/empresas/extract-csf` → recibe los campos.
+ *   2. UI completa `slug` (default = slugify del nombre) y `nombre` (default =
+ *      `razon_social`).
+ *   3. Al guardar, llama a este endpoint con FormData:
+ *        - `file`: el PDF subido a extract-csf.
+ *        - `payload`: JSON con { extraccion, slug, nombre, tipo_contribuyente? }.
+ *
+ * Persistencia (orden recuperable, sin transacción explícita):
+ *   1. Dedup por RFC (UNIQUE en core.empresas.rfc).
+ *   2. INSERT core.empresas con campos derivados de la CSF.
+ *   3. Upload PDF a bucket `adjuntos` en `empresas/{empresa_id}/csf-{ts}.pdf`.
+ *   4. INSERT erp.adjuntos (entidad_tipo='empresa', rol='csf').
+ *   5. UPDATE core.empresas.csf_url al path del nuevo adjunto.
+ *
+ * Si falla después del paso 2, devuelve 500 indicando qué quedó persistido —
+ * el operador puede recuperar via UI de update.
+ *
+ * Solo admin.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { CsfExtraccionSchema } from '@/lib/proveedores/extract-csf';
+import { buildEmpresaInsertFromExtraccion } from '@/lib/empresas/csf-mapping';
+import { requireAdmin } from '@/lib/empresas/admin-guard';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+const BUCKET = 'adjuntos';
+const MAX_INCOMING_BYTES = 50 * 1024 * 1024;
+
+const PayloadSchema = z.object({
+  extraccion: CsfExtraccionSchema,
+  slug: z
+    .string()
+    .min(2, 'slug muy corto')
+    .max(40)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'slug debe ser kebab-case (solo a-z, 0-9 y guiones)'),
+  nombre: z.string().min(1, 'nombre requerido').max(120),
+  tipo_contribuyente: z.enum(['persona_moral', 'persona_fisica']).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  const userSupa = await createSupabaseServerClient();
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const guard = await requireAdmin(userSupa, admin);
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `multipart inválido: ${msg}` }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  const payloadRaw = formData.get('payload');
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'Falta el campo "file" (multipart/form-data).' },
+      { status: 400 }
+    );
+  }
+  if (file.type && file.type !== 'application/pdf') {
+    return NextResponse.json(
+      { error: `Tipo de archivo no soportado: ${file.type}. Solo application/pdf.` },
+      { status: 415 }
+    );
+  }
+  if (file.size > MAX_INCOMING_BYTES) {
+    return NextResponse.json(
+      { error: `Archivo muy grande (${(file.size / 1024 / 1024).toFixed(1)} MB). Máximo 50 MB.` },
+      { status: 413 }
+    );
+  }
+  if (typeof payloadRaw !== 'string' || !payloadRaw.length) {
+    return NextResponse.json({ error: 'Falta el campo "payload" (JSON).' }, { status: 400 });
+  }
+
+  let payload;
+  try {
+    payload = PayloadSchema.parse(JSON.parse(payloadRaw));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  const { extraccion, slug, nombre, tipo_contribuyente } = payload;
+  const rfcNormalized = extraccion.rfc.trim().toUpperCase();
+
+  // 1) Dedup por RFC y por slug.
+  const [{ data: dupRfc }, { data: dupSlug }] = await Promise.all([
+    (admin.schema('core') as any)
+      .from('empresas')
+      .select('id, slug')
+      .eq('rfc', rfcNormalized)
+      .maybeSingle(),
+    (admin.schema('core') as any).from('empresas').select('id').eq('slug', slug).maybeSingle(),
+  ]);
+
+  if (dupRfc) {
+    return NextResponse.json(
+      { error: 'rfc_duplicado', existing_empresa_id: dupRfc.id, existing_slug: dupRfc.slug },
+      { status: 409 }
+    );
+  }
+  if (dupSlug) {
+    return NextResponse.json(
+      { error: 'slug_duplicado', existing_empresa_id: dupSlug.id },
+      { status: 409 }
+    );
+  }
+
+  // 2) INSERT core.empresas.
+  const insertRow = buildEmpresaInsertFromExtraccion({
+    extraccion,
+    slug,
+    nombre,
+    tipo_contribuyente,
+  });
+
+  const { data: empresa, error: empresaErr } = await (admin.schema('core') as any)
+    .from('empresas')
+    .insert({ ...insertRow, activa: true })
+    .select('id, slug')
+    .single();
+
+  if (empresaErr) {
+    return NextResponse.json({ error: `insert empresa: ${empresaErr.message}` }, { status: 500 });
+  }
+  const empresaId: string = empresa.id;
+
+  // 3) Upload PDF a storage.
+  const ts = Date.now();
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80);
+  const path = `empresas/${empresaId}/csf-${ts}-${safeName}`;
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const { error: uploadErr } = await admin.storage.from(BUCKET).upload(path, bytes, {
+    contentType: 'application/pdf',
+    upsert: false,
+  });
+
+  if (uploadErr) {
+    return NextResponse.json(
+      {
+        error: `upload csf: ${uploadErr.message}`,
+        partial: { empresa_id: empresaId, slug: empresa.slug },
+      },
+      { status: 500 }
+    );
+  }
+
+  // 4) INSERT erp.adjuntos.
+  const { data: adjunto, error: adjuntoErr } = await (admin.schema('erp') as any)
+    .from('adjuntos')
+    .insert({
+      empresa_id: empresaId,
+      entidad_tipo: 'empresa',
+      entidad_id: empresaId,
+      rol: 'csf',
+      nombre: file.name,
+      url: path,
+      tipo_mime: 'application/pdf',
+      tamano_bytes: file.size,
+      uploaded_by: guard.usuario.id,
+    })
+    .select('id')
+    .single();
+
+  if (adjuntoErr) {
+    return NextResponse.json(
+      {
+        error: `insert adjunto: ${adjuntoErr.message}`,
+        partial: { empresa_id: empresaId, slug: empresa.slug },
+      },
+      { status: 500 }
+    );
+  }
+
+  // 5) UPDATE empresa.csf_url al path del adjunto recién creado.
+  const { error: csfUrlErr } = await (admin.schema('core') as any)
+    .from('empresas')
+    .update({ csf_url: path })
+    .eq('id', empresaId);
+
+  if (csfUrlErr) {
+    return NextResponse.json(
+      {
+        error: `update csf_url: ${csfUrlErr.message}`,
+        partial: { empresa_id: empresaId, slug: empresa.slug, adjunto_id: adjunto.id },
+      },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    empresa_id: empresaId,
+    slug: empresa.slug,
+    adjunto_id: adjunto.id,
+  });
+}

--- a/app/api/empresas/extract-csf/route.test.ts
+++ b/app/api/empresas/extract-csf/route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+import { buildAdminMock, buildCsfFormData, type AdminScript } from '../_test-helpers';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+let serverUser: { email: string } | null = null;
+let adminScript: AdminScript = {};
+let adminAvailable = true;
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: serverUser } }) },
+  }),
+}));
+
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdminClient: () => (adminAvailable ? buildAdminMock(adminScript) : null),
+}));
+
+// extract-csf llama a Anthropic + Ghostscript-WASM. Mockeamos ambos.
+vi.mock('@/lib/documentos/extraction-core', () => ({
+  ensurePdfFitsForClaude: async (b: Uint8Array) => b,
+}));
+
+vi.mock('@/lib/proveedores/extract-csf', async () => {
+  // Re-export schemas + mock the LLM call.
+  const actual = await vi.importActual<typeof import('@/lib/proveedores/extract-csf')>(
+    '@/lib/proveedores/extract-csf'
+  );
+  return {
+    ...actual,
+    extractCsfWithClaude: async () => ({
+      tipo_persona: 'moral',
+      rfc: 'ANO8509243H3',
+      curp: null,
+      nombre: null,
+      apellido_paterno: null,
+      apellido_materno: null,
+      razon_social: 'AUTOS DEL NORTE',
+      nombre_comercial: null,
+      regimen_fiscal_codigo: '601',
+      regimen_fiscal_nombre: 'General de Ley Personas Morales',
+      regimenes_adicionales: [],
+      domicilio_calle: null,
+      domicilio_num_ext: null,
+      domicilio_num_int: null,
+      domicilio_colonia: null,
+      domicilio_cp: null,
+      domicilio_municipio: null,
+      domicilio_estado: null,
+      obligaciones: [],
+      fecha_inicio_operaciones: null,
+      fecha_emision: '2026-04-01',
+      id_cif: '14110980997',
+      estatus_sat: 'ACTIVO',
+      regimen_capital: 'SOCIEDAD ANONIMA DE CAPITAL VARIABLE',
+      actividades_economicas: [],
+    }),
+  };
+});
+
+import { POST } from './route';
+
+beforeEach(() => {
+  serverUser = { email: 'admin@example.com' };
+  adminScript = {
+    callerUser: { id: 'admin-uuid', email: 'admin@example.com', rol: 'admin', activo: true },
+  };
+  adminAvailable = true;
+  process.env.ANTHROPIC_API_KEY = 'test-key';
+});
+
+function makeReq(formData: FormData): NextRequest {
+  return new NextRequest(new URL('http://localhost/api/empresas/extract-csf'), {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+describe('POST /api/empresas/extract-csf', () => {
+  it('500 si no hay ANTHROPIC_API_KEY', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const fd = buildCsfFormData({});
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(500);
+  });
+
+  it('401 si no hay user', async () => {
+    serverUser = null;
+    const fd = buildCsfFormData({});
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si el caller no es admin', async () => {
+    adminScript.callerUser = {
+      id: 'u1',
+      email: 'beto@anorte.com',
+      rol: 'usuario',
+      activo: true,
+    };
+    const fd = buildCsfFormData({});
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(403);
+  });
+
+  it('400 si falta el campo "file"', async () => {
+    const fd = new FormData();
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(400);
+  });
+
+  it('415 si el archivo no es PDF', async () => {
+    const fd = buildCsfFormData({ fileType: 'image/png', filename: 'csf.png' });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(415);
+  });
+
+  it('413 si el archivo excede 50 MB', async () => {
+    // 51 MB
+    const fd = buildCsfFormData({ fileSize: 51 * 1024 * 1024 });
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(413);
+  });
+
+  it('200 con extracción cuando todo cuadra', async () => {
+    const fd = buildCsfFormData({});
+    const res = await POST(makeReq(fd));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.extraccion.rfc).toBe('ANO8509243H3');
+    expect(json.extraccion.id_cif).toBe('14110980997');
+    expect(json.extraccion.estatus_sat).toBe('ACTIVO');
+  });
+});

--- a/app/api/empresas/extract-csf/route.ts
+++ b/app/api/empresas/extract-csf/route.ts
@@ -1,0 +1,85 @@
+/**
+ * POST /api/empresas/extract-csf
+ *
+ * Recibe un PDF de Constancia de Situación Fiscal de empresa (multipart/
+ * form-data, campo "file"), lo procesa con el extractor compartido
+ * (`lib/proveedores/extract-csf.ts`) y devuelve los campos pre-llenados.
+ *
+ * NO persiste nada — la persistencia ocurre en `create-with-csf` (alta) o
+ * `[id]/update-csf` (refresh).
+ *
+ * Solo admin (decisión Beto en planning).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { ensurePdfFitsForClaude } from '@/lib/documentos/extraction-core';
+import { extractCsfWithClaude } from '@/lib/proveedores/extract-csf';
+import { requireAdmin } from '@/lib/empresas/admin-guard';
+
+export const runtime = 'nodejs';
+export const maxDuration = 300;
+
+const MAX_INCOMING_BYTES = 50 * 1024 * 1024; // 50 MB
+
+export async function POST(req: NextRequest) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: 'Servidor sin ANTHROPIC_API_KEY configurada.' },
+      { status: 500 }
+    );
+  }
+
+  const userSupa = await createSupabaseServerClient();
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const guard = await requireAdmin(userSupa, admin);
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `multipart inválido: ${msg}` }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'Falta el campo "file" (multipart/form-data).' },
+      { status: 400 }
+    );
+  }
+  if (file.type && file.type !== 'application/pdf') {
+    return NextResponse.json(
+      { error: `Tipo de archivo no soportado: ${file.type}. Solo application/pdf.` },
+      { status: 415 }
+    );
+  }
+  if (file.size > MAX_INCOMING_BYTES) {
+    return NextResponse.json(
+      {
+        error: `Archivo muy grande (${(file.size / 1024 / 1024).toFixed(1)} MB). Máximo 50 MB.`,
+      },
+      { status: 413 }
+    );
+  }
+
+  try {
+    const raw = new Uint8Array(await file.arrayBuffer());
+    const pdfBytes = await ensurePdfFitsForClaude(raw);
+    const extraccion = await extractCsfWithClaude(pdfBytes);
+    return NextResponse.json({ ok: true, extraccion });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/docs/planning/empresas-csf-config.md
+++ b/docs/planning/empresas-csf-config.md
@@ -3,10 +3,10 @@
 **Slug:** `empresas-csf-config`
 **Empresas:** todas (las 4 SA de CV ya cargadas; UI nueva en `/settings/empresas`)
 **Schemas afectados:** `core` (lectura/escritura `core.empresas`; `audit_log`; `erp.adjuntos` para archivar PDF)
-**Estado:** planned
+**Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-04-28
-**Última actualización:** 2026-04-28 (alcance v1 cerrado tras 5 decisiones de Beto: reuso directo del extractor de proveedores sin refactor previo, espejo simple de endpoints en `/api/empresas`, incluye flujo de alta nueva, drawer + campo registro patronal inline en `empresa-detail`, permisos solo admin)
+**Última actualización:** 2026-04-28 (Sprint 1 mergeado: extractor CSF extendido con `id_cif`/`estatus_sat`/`regimen_capital`/`actividades_economicas` opcionales, `lib/empresas/csf-mapping.ts` + 4 endpoints `/api/empresas` admin-only + tests; CI verde)
 
 ## Problema
 
@@ -98,13 +98,13 @@ Empresa es estructuralmente igual al proveedor moral: mismo PDF de SAT, mismos c
 
 ## Sprints / hitos
 
-| #   | Scope                                                                                                                                  | Estado    | PR  |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------- | --------- | --- |
-| 0   | Promoción: este doc + fila en INITIATIVES.md                                                                                           | _este PR_ | —   |
-| 1   | Endpoints `/api/empresas/extract-csf`, `create-with-csf`, `[id]/update-csf`, `PATCH [id]` (registro patronal) + tests con fixtures CSF | pending   | —   |
-| 2   | UI drawer "Actualizar CSF" en `/settings/empresas/[slug]` + campo `registro_patronal_imss` editable + reuso `<CsfDiffModal>`           | pending   | —   |
-| 3   | Botón "Nueva empresa" + drawer `create-with-csf` en lista `/settings/empresas`                                                         | pending   | —   |
-| 4   | Refresh operativo: subir CSF al día de RDB/DILESA/COAGAN/ANSA + capturar `registro_patronal_imss` faltantes                            | pending   | —   |
+| #   | Scope                                                                                                                                  | Estado  | PR   |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---- |
+| 0   | Promoción: este doc + fila en INITIATIVES.md                                                                                           | done    | #267 |
+| 1   | Endpoints `/api/empresas/extract-csf`, `create-with-csf`, `[id]/update-csf`, `PATCH [id]` (registro patronal) + tests con fixtures CSF | done    | TBD  |
+| 2   | UI drawer "Actualizar CSF" en `/settings/empresas/[slug]` + campo `registro_patronal_imss` editable + reuso `<CsfDiffModal>`           | pending | —    |
+| 3   | Botón "Nueva empresa" + drawer `create-with-csf` en lista `/settings/empresas`                                                         | pending | —    |
+| 4   | Refresh operativo: subir CSF al día de RDB/DILESA/COAGAN/ANSA + capturar `registro_patronal_imss` faltantes                            | pending | —    |
 
 ## Decisiones registradas
 
@@ -117,3 +117,27 @@ Empresa es estructuralmente igual al proveedor moral: mismo PDF de SAT, mismos c
 - **Permisos solo admin** (igual que la pantalla actual de `/settings/empresas`). No se introduce matriz de roles nueva. Si en el futuro se quiere "solo accionistas" o "solo consejeros", sub-iniciativa con su propio cambio de permisos.
 
 ## Bitácora
+
+### 2026-04-28 — Sprint 1: endpoints API empresas
+
+**Qué se hizo en esta sesión:**
+
+- Extendido `lib/proveedores/extract-csf.ts` con 4 campos opcionales que la CSF de empresa expone pero la de proveedor no usaba: `id_cif`, `estatus_sat`, `regimen_capital`, `actividades_economicas[]`. Backwards-compatible (defaults `null`/`[]`); proveedores no se rompe. Prompt actualizado para extraerlos.
+- Creado `lib/empresas/csf-mapping.ts` con `buildEmpresaInsertFromExtraccion` y `buildEmpresaUpdateFromAccepted` — mapean shape neutro del extractor (`domicilio_num_ext`) → shape de `core.empresas` (`domicilio_numero_ext`). Encapsulan también el mapeo `obligaciones[]` (extractor) → `obligaciones_fiscales` (jsonb empresa con `vencimiento` libre) y `actividades_economicas[]` con porcentaje string. Campos de personas físicas (`nombre`, `apellido_paterno`) se ignoran silenciosamente para empresa.
+- 4 endpoints admin-only en `/api/empresas/`:
+  - `POST extract-csf`: wrapper sobre el extractor compartido. No persiste.
+  - `POST create-with-csf`: alta de empresa nueva con dedup por RFC + slug, archive PDF en `erp.adjuntos` (`entidad_tipo='empresa'`, `rol='csf'`), apunta `csf_url` al path del adjunto.
+  - `POST [id]/update-csf`: diff selectivo sobre `accepted_fields[]` (acepta `CsfUpdatableField` + `EmpresaExtraField`). Archiva PDF siempre; UPDATE selectivo solo si `accepted_fields` no está vacío.
+  - `PATCH [id]`: body JSON estricto para `registro_patronal_imss` (regex `/^[A-Z]\d{10}$/`, cadena vacía/null limpian). Extensible a otros campos sueltos no-CSF.
+- Helper `lib/empresas/admin-guard.ts` para gate consistente en los 4 endpoints (lookup `core.usuarios.rol === 'admin'`, mismo patrón que `app/api/impersonate`).
+- Tests: 24 schema (extendido) + 15 mapper + 31 endpoints = +70 tests, suite completa 273 verdes.
+- CI local verde: `typecheck` ✓ `lint` ✓ `format:check` ✓ `test:run` ✓.
+
+**Decisiones tácticas registradas durante implementación:**
+
+- Sin migración DB: `core.empresas.rfc` ya tiene `UNIQUE` (constraint `empresas_rfc_key` desde `20260416000000_empresas_csf_fields.sql`); `erp.adjuntos.entidad_tipo` es `TEXT NOT NULL` sin `CHECK`, acepta `'empresa'` libremente.
+- `<CsfDiffModal>` no existe como componente standalone — vive inline dentro de `components/proveedores/proveedores-module.tsx` (1606 líneas). Sprint 2 espejará el patrón de diff inline en el detalle de empresa, sin extraer a componente compartido. La promoción a `components/csf/<CsfDiffModal>` queda como sub-iniciativa cuando ambos consumidores estén estables (mismo razonamiento que `lib/csf/`).
+
+**Links:**
+
+- PR Sprint 1: TBD (se agregará al merge).

--- a/lib/empresas/admin-guard.ts
+++ b/lib/empresas/admin-guard.ts
@@ -1,0 +1,68 @@
+/**
+ * Admin guard para los endpoints `/api/empresas/*`.
+ *
+ * El alcance v1 de la iniciativa `empresas-csf-config` es solo-admin
+ * (decisión cerrada por Beto: las pantallas de `/settings/empresas` ya
+ * son admin-only vía `<RequireAccess adminOnly>`; los endpoints reflejan
+ * lo mismo).
+ *
+ * Patrón: el client del usuario (con su JWT) consulta su email →
+ * `core.usuarios.rol === 'admin'`. Es el mismo patrón que `lib/permissions.ts`
+ * y `app/api/impersonate/route.ts`. No usamos el RPC `core.fn_is_admin()`
+ * porque queremos el shape `{ id, rol, email }` para devolverlo a quien lo
+ * necesita.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type AdminCheckResult =
+  | { ok: true; usuario: { id: string; email: string; rol: 'admin' } }
+  | { ok: false; status: 401 | 403; error: string };
+
+/**
+ * Verifica que el usuario autenticado en el `userClient` es admin.
+ * El `adminClient` se usa para leer `core.usuarios` con su email; RLS de
+ * `core.usuarios` puede no permitir self-read según la política, así que
+ * vamos por el admin client (el filtro por email es seguro porque el JWT
+ * ya está validado por Supabase).
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public` por default; para `core.usuarios`
+ * usamos `as any`. Mismo patrón que el resto del repo.
+ */
+export async function requireAdmin(
+  userClient: SupabaseClient,
+  adminClient: SupabaseClient
+): Promise<AdminCheckResult> {
+  const {
+    data: { user },
+  } = await userClient.auth.getUser();
+  if (!user) {
+    return { ok: false, status: 401, error: 'No autenticado' };
+  }
+  const email = user.email;
+  if (!email) {
+    return { ok: false, status: 401, error: 'JWT sin email claim' };
+  }
+
+  const { data: coreUser, error } = await (adminClient.schema('core') as any)
+    .from('usuarios')
+    .select('id, email, rol, activo')
+    .eq('email', email.toLowerCase())
+    .maybeSingle();
+
+  if (error) {
+    return { ok: false, status: 403, error: `lookup admin: ${error.message}` };
+  }
+  if (!coreUser || !coreUser.activo) {
+    return { ok: false, status: 403, error: 'Usuario sin acceso activo' };
+  }
+  if (coreUser.rol !== 'admin') {
+    return { ok: false, status: 403, error: 'Esta acción requiere rol admin' };
+  }
+
+  return {
+    ok: true,
+    usuario: { id: coreUser.id, email: coreUser.email, rol: 'admin' },
+  };
+}

--- a/lib/empresas/csf-mapping.test.ts
+++ b/lib/empresas/csf-mapping.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+
+import type { CsfExtraccion } from '@/lib/proveedores/extract-csf';
+import {
+  buildEmpresaInsertFromExtraccion,
+  buildEmpresaUpdateFromAccepted,
+  EMPRESA_DIFFABLE_FIELDS,
+  EMPRESA_FIELD_MAP,
+} from './csf-mapping';
+
+const extraccionAnsa: CsfExtraccion = {
+  tipo_persona: 'moral',
+  rfc: '  ano8509243h3  ',
+  curp: null,
+  nombre: null,
+  apellido_paterno: null,
+  apellido_materno: null,
+  razon_social: 'AUTOS DEL NORTE',
+  nombre_comercial: null,
+  regimen_fiscal_codigo: '601',
+  regimen_fiscal_nombre: 'General de Ley Personas Morales',
+  regimenes_adicionales: [
+    {
+      codigo: '601',
+      nombre: 'General de Ley Personas Morales',
+      fecha_inicio: '1958-12-01',
+      fecha_fin: null,
+    },
+  ],
+  domicilio_calle: 'CALLE HIDALGO NORTE',
+  domicilio_num_ext: '100',
+  domicilio_num_int: null,
+  domicilio_colonia: 'PIEDRAS NEGRAS CENTRO',
+  domicilio_cp: '26000',
+  domicilio_municipio: 'PIEDRAS NEGRAS',
+  domicilio_estado: 'COAHUILA DE ZARAGOZA',
+  obligaciones: [
+    {
+      descripcion: 'Pago provisional mensual de ISR personas morales régimen general',
+      fecha_inicio: '2002-03-31',
+      fecha_fin: null,
+    },
+  ],
+  fecha_inicio_operaciones: '1958-12-01',
+  fecha_emision: '2026-04-01',
+  id_cif: '14110980997',
+  estatus_sat: 'ACTIVO',
+  regimen_capital: 'SOCIEDAD ANONIMA DE CAPITAL VARIABLE',
+  actividades_economicas: [
+    {
+      orden: 1,
+      actividad: 'Comercio al por menor de automóviles y camionetas nuevos',
+      porcentaje: '90%',
+      fecha_inicio: '1999-04-09',
+      fecha_fin: null,
+    },
+    {
+      orden: 2,
+      actividad: 'Reparación mecánica',
+      porcentaje: '2%',
+      fecha_inicio: '2023-05-24',
+      fecha_fin: null,
+    },
+  ],
+};
+
+describe('buildEmpresaInsertFromExtraccion', () => {
+  it('produce un row completo para alta de empresa moral', () => {
+    const row = buildEmpresaInsertFromExtraccion({
+      extraccion: extraccionAnsa,
+      slug: 'ansa',
+      nombre: 'ANSA',
+    });
+    expect(row.slug).toBe('ansa');
+    expect(row.nombre).toBe('ANSA');
+    expect(row.tipo_contribuyente).toBe('persona_moral');
+    expect(row.rfc).toBe('ANO8509243H3'); // trim + uppercase
+    expect(row.razon_social).toBe('AUTOS DEL NORTE');
+    expect(row.regimen_fiscal).toBe('General de Ley Personas Morales');
+    expect(row.regimen_capital).toBe('SOCIEDAD ANONIMA DE CAPITAL VARIABLE');
+    expect(row.id_cif).toBe('14110980997');
+    expect(row.estatus_sat).toBe('ACTIVO');
+    expect(row.domicilio_numero_ext).toBe('100');
+    expect(row.domicilio_numero_int).toBeNull();
+    expect(row.csf_fecha_emision).toBe('2026-04-01');
+  });
+
+  it('mapea actividades económicas a shape de empresa (porcentaje string vacío si null)', () => {
+    const row = buildEmpresaInsertFromExtraccion({
+      extraccion: {
+        ...extraccionAnsa,
+        actividades_economicas: [
+          {
+            orden: 1,
+            actividad: 'Sin porcentaje',
+            porcentaje: null,
+            fecha_inicio: null,
+            fecha_fin: null,
+          },
+        ],
+      },
+      slug: 'x',
+      nombre: 'X',
+    });
+    expect(row.actividades_economicas).toEqual([
+      {
+        orden: 1,
+        actividad: 'Sin porcentaje',
+        porcentaje: '',
+        fecha_inicio: '',
+        fecha_fin: null,
+      },
+    ]);
+  });
+
+  it('mapea obligaciones a shape de empresa (vencimiento queda en cadena vacía)', () => {
+    const row = buildEmpresaInsertFromExtraccion({
+      extraccion: extraccionAnsa,
+      slug: 'ansa',
+      nombre: 'ANSA',
+    });
+    expect(row.obligaciones_fiscales).toEqual([
+      {
+        descripcion: 'Pago provisional mensual de ISR personas morales régimen general',
+        vencimiento: '',
+        fecha_inicio: '2002-03-31',
+        fecha_fin: null,
+      },
+    ]);
+  });
+
+  it('respeta override de tipo_contribuyente cuando se pasa explícito', () => {
+    const row = buildEmpresaInsertFromExtraccion({
+      extraccion: { ...extraccionAnsa, tipo_persona: 'fisica' },
+      slug: 'pf',
+      nombre: 'Persona Física',
+      tipo_contribuyente: 'persona_moral',
+    });
+    expect(row.tipo_contribuyente).toBe('persona_moral');
+  });
+
+  it('default tipo_contribuyente desde tipo_persona del extractor', () => {
+    const row = buildEmpresaInsertFromExtraccion({
+      extraccion: { ...extraccionAnsa, tipo_persona: 'fisica', razon_social: null },
+      slug: 'pf',
+      nombre: 'Persona Física',
+    });
+    expect(row.tipo_contribuyente).toBe('persona_fisica');
+  });
+});
+
+describe('buildEmpresaUpdateFromAccepted', () => {
+  it('aplica solo los campos en accepted_fields', () => {
+    const update = buildEmpresaUpdateFromAccepted({
+      extraccion: extraccionAnsa,
+      accepted: ['domicilio_calle', 'fecha_emision'],
+    });
+    expect(update).toEqual({
+      domicilio_calle: 'CALLE HIDALGO NORTE',
+      csf_fecha_emision: '2026-04-01',
+    });
+  });
+
+  it('renombra num_ext / num_int en el update', () => {
+    const update = buildEmpresaUpdateFromAccepted({
+      extraccion: extraccionAnsa,
+      accepted: ['domicilio_num_ext', 'domicilio_num_int'],
+    });
+    expect(Object.keys(update)).toEqual(['domicilio_numero_ext', 'domicilio_numero_int']);
+  });
+
+  it('aplica id_cif y estatus_sat (extras de empresa)', () => {
+    const update = buildEmpresaUpdateFromAccepted({
+      extraccion: extraccionAnsa,
+      accepted: ['id_cif', 'estatus_sat', 'regimen_capital'],
+    });
+    expect(update.id_cif).toBe('14110980997');
+    expect(update.estatus_sat).toBe('ACTIVO');
+    expect(update.regimen_capital).toBe('SOCIEDAD ANONIMA DE CAPITAL VARIABLE');
+  });
+
+  it('aplica actividades_economicas como array transformado', () => {
+    const update = buildEmpresaUpdateFromAccepted({
+      extraccion: extraccionAnsa,
+      accepted: ['actividades_economicas'],
+    });
+    expect(update.actividades_economicas).toHaveLength(2);
+    expect(update.actividades_economicas?.[0]).toMatchObject({
+      orden: 1,
+      porcentaje: '90%',
+    });
+  });
+
+  it('ignora campos de personas físicas (nombre/apellido_*) sin romper', () => {
+    const update = buildEmpresaUpdateFromAccepted({
+      extraccion: extraccionAnsa,
+      accepted: ['nombre', 'apellido_paterno', 'apellido_materno', 'tipo_persona', 'razon_social'],
+    });
+    expect(update).toEqual({ razon_social: 'AUTOS DEL NORTE' });
+  });
+
+  it('normaliza RFC a uppercase + trim al actualizar', () => {
+    const update = buildEmpresaUpdateFromAccepted({
+      extraccion: extraccionAnsa,
+      accepted: ['rfc'],
+    });
+    expect(update.rfc).toBe('ANO8509243H3');
+  });
+
+  it('regresa objeto vacío si no se aceptó nada', () => {
+    const update = buildEmpresaUpdateFromAccepted({
+      extraccion: extraccionAnsa,
+      accepted: [],
+    });
+    expect(update).toEqual({});
+  });
+});
+
+describe('EMPRESA_DIFFABLE_FIELDS', () => {
+  it('incluye los 4 campos extra de empresa', () => {
+    expect(EMPRESA_DIFFABLE_FIELDS).toContain('id_cif');
+    expect(EMPRESA_DIFFABLE_FIELDS).toContain('estatus_sat');
+    expect(EMPRESA_DIFFABLE_FIELDS).toContain('regimen_capital');
+    expect(EMPRESA_DIFFABLE_FIELDS).toContain('actividades_economicas');
+  });
+
+  it('no incluye campos de personas físicas (no aplican a empresa)', () => {
+    expect(EMPRESA_DIFFABLE_FIELDS).not.toContain('nombre');
+    expect(EMPRESA_DIFFABLE_FIELDS).not.toContain('apellido_paterno');
+    expect(EMPRESA_DIFFABLE_FIELDS).not.toContain('tipo_persona');
+  });
+
+  it('todos los keys mapeables del extractor que sí aplican aparecen', () => {
+    const mapeables = (Object.entries(EMPRESA_FIELD_MAP) as [string, { column: string | null }][])
+      .filter(([, v]) => v.column !== null)
+      .map(([k]) => k);
+    for (const k of mapeables) {
+      expect(EMPRESA_DIFFABLE_FIELDS).toContain(k);
+    }
+  });
+});

--- a/lib/empresas/csf-mapping.ts
+++ b/lib/empresas/csf-mapping.ts
@@ -1,0 +1,327 @@
+/**
+ * Mapping `CsfExtraccion` (lib/proveedores/extract-csf.ts) ⇄ `core.empresas`.
+ *
+ * El extractor CSF se reutiliza directamente desde proveedores (decisión
+ * cerrada en `docs/planning/empresas-csf-config.md`). Este módulo encapsula
+ * la traducción entre el shape "neutro" del extractor y el shape de
+ * `core.empresas`, que tiene nombres ligeramente distintos (ej.
+ * `domicilio_num_ext` → `domicilio_numero_ext`) y formato propio de
+ * `actividades_economicas` y `obligaciones_fiscales`.
+ *
+ * Funciones puras — no tocan DB. Las consume el endpoint en `/api/empresas`.
+ */
+
+import type { CsfExtraccion, CsfUpdatableField } from '@/lib/proveedores/extract-csf';
+
+// ─── Shape de actividades / obligaciones en core.empresas (jsonb) ───────────
+
+/**
+ * Forma de cada elemento de `core.empresas.actividades_economicas` (jsonb).
+ * Coincide con lo que se cargó manualmente para ANSA/RDB/DILESA/COAGAN al
+ * inicio. Las fechas se serializan como string YYYY-MM-DD para conservar el
+ * formato del SAT.
+ */
+export type EmpresaActividadEconomica = {
+  orden: number;
+  actividad: string;
+  porcentaje: string;
+  fecha_inicio: string;
+  fecha_fin: string | null;
+};
+
+/**
+ * Forma de cada elemento de `core.empresas.obligaciones_fiscales` (jsonb).
+ * Compatible con el shape pre-existente: incluye `vencimiento` (texto libre
+ * del SAT). El extractor no provee `vencimiento` directamente — se deja como
+ * cadena vacía cuando la CSF no lo expone explícitamente; el operador puede
+ * editarlo a mano si hace falta.
+ */
+export type EmpresaObligacionFiscal = {
+  descripcion: string;
+  vencimiento: string;
+  fecha_inicio: string;
+  fecha_fin: string | null;
+};
+
+// ─── Mapeo de keys de extracción a columnas de core.empresas ────────────────
+
+/**
+ * Para cada `CsfUpdatableField` definido por el extractor, indica cómo se
+ * proyecta sobre `core.empresas`. Algunos campos no aplican a empresas (los
+ * típicos de personas físicas: `nombre`, `apellido_paterno`, etc.) — esos se
+ * mapean a `null` (= ignorar).
+ *
+ * El export sirve también a la UI del diff: la columna `column` se usa para
+ * leer el valor actual de la empresa al renderizar el diff side-by-side.
+ */
+export type EmpresaFieldMapping = {
+  /** Columna en `core.empresas`. `null` si el campo no aplica. */
+  column: keyof EmpresaCsfUpdate | null;
+  /** Cómo extraer el valor del shape del extractor para esa columna. */
+  extract: (extraccion: CsfExtraccion) => unknown;
+};
+
+export const EMPRESA_FIELD_MAP: Record<CsfUpdatableField, EmpresaFieldMapping> = {
+  // Identidad — para morales solo se lee razón social. CURP solo si es física.
+  tipo_persona: { column: null, extract: () => null },
+  rfc: { column: 'rfc', extract: (e) => e.rfc },
+  curp: { column: 'curp', extract: (e) => e.curp },
+  nombre: { column: null, extract: () => null },
+  apellido_paterno: { column: null, extract: () => null },
+  apellido_materno: { column: null, extract: () => null },
+  razon_social: { column: 'razon_social', extract: (e) => e.razon_social },
+  nombre_comercial: {
+    column: 'nombre_comercial',
+    extract: (e) => e.nombre_comercial,
+  },
+
+  // Régimen fiscal: empresas usa string libre derivado de
+  // `regimen_fiscal_nombre`. La lista completa de regímenes adicionales no
+  // se persiste a v1 (sería una columna nueva). El código y nombre del
+  // régimen principal sí.
+  regimen_fiscal_codigo: { column: null, extract: () => null },
+  regimen_fiscal_nombre: {
+    column: 'regimen_fiscal',
+    extract: (e) => e.regimen_fiscal_nombre,
+  },
+  regimenes_adicionales: { column: null, extract: () => null },
+
+  // Domicilio — rename de `num_ext`/`num_int` a `numero_ext`/`numero_int`.
+  domicilio_calle: {
+    column: 'domicilio_calle',
+    extract: (e) => e.domicilio_calle,
+  },
+  domicilio_num_ext: {
+    column: 'domicilio_numero_ext',
+    extract: (e) => e.domicilio_num_ext,
+  },
+  domicilio_num_int: {
+    column: 'domicilio_numero_int',
+    extract: (e) => e.domicilio_num_int,
+  },
+  domicilio_colonia: {
+    column: 'domicilio_colonia',
+    extract: (e) => e.domicilio_colonia,
+  },
+  domicilio_cp: { column: 'domicilio_cp', extract: (e) => e.domicilio_cp },
+  domicilio_municipio: {
+    column: 'domicilio_municipio',
+    extract: (e) => e.domicilio_municipio,
+  },
+  domicilio_estado: {
+    column: 'domicilio_estado',
+    extract: (e) => e.domicilio_estado,
+  },
+
+  obligaciones: {
+    column: 'obligaciones_fiscales',
+    extract: (e) => extractObligacionesParaEmpresa(e),
+  },
+
+  fecha_inicio_operaciones: {
+    column: 'fecha_inicio_operaciones',
+    extract: (e) => e.fecha_inicio_operaciones,
+  },
+  fecha_emision: {
+    column: 'csf_fecha_emision',
+    extract: (e) => e.fecha_emision,
+  },
+};
+
+/**
+ * Campos extra del extractor que no son `CsfUpdatableField` pero sí relevantes
+ * para empresas (extendidos en Sprint 1). Se aplican siempre que estén
+ * presentes en la extracción y aceptados por el operador.
+ */
+export const EMPRESA_EXTRA_FIELDS = [
+  'id_cif',
+  'estatus_sat',
+  'regimen_capital',
+  'actividades_economicas',
+] as const;
+
+export type EmpresaExtraField = (typeof EMPRESA_EXTRA_FIELDS)[number];
+
+/**
+ * Conjunto canónico de keys que el modal de diff puede ofrecer al operador
+ * en el flujo de update. Es la unión de los `CsfUpdatableField` que sí mapean
+ * a una columna real + los `EmpresaExtraField`.
+ */
+export const EMPRESA_DIFFABLE_FIELDS: ReadonlyArray<CsfUpdatableField | EmpresaExtraField> = [
+  // CsfUpdatableField que sí aplican a empresas
+  'rfc',
+  'curp',
+  'razon_social',
+  'nombre_comercial',
+  'regimen_fiscal_nombre',
+  'domicilio_calle',
+  'domicilio_num_ext',
+  'domicilio_num_int',
+  'domicilio_colonia',
+  'domicilio_cp',
+  'domicilio_municipio',
+  'domicilio_estado',
+  'obligaciones',
+  'fecha_inicio_operaciones',
+  'fecha_emision',
+  // Extras
+  'id_cif',
+  'estatus_sat',
+  'regimen_capital',
+  'actividades_economicas',
+];
+
+// ─── Tipo de update parcial sobre core.empresas ─────────────────────────────
+
+/**
+ * Subset de columnas de `core.empresas` que pueden modificarse por el flujo
+ * de CSF. Otros campos (branding, slug, activa) viven fuera de este flujo.
+ */
+export type EmpresaCsfUpdate = {
+  rfc?: string | null;
+  curp?: string | null;
+  razon_social?: string | null;
+  regimen_capital?: string | null;
+  nombre_comercial?: string | null;
+  fecha_inicio_operaciones?: string | null;
+  estatus_sat?: string | null;
+  id_cif?: string | null;
+  regimen_fiscal?: string | null;
+  domicilio_cp?: string | null;
+  domicilio_calle?: string | null;
+  domicilio_numero_ext?: string | null;
+  domicilio_numero_int?: string | null;
+  domicilio_colonia?: string | null;
+  domicilio_localidad?: string | null;
+  domicilio_municipio?: string | null;
+  domicilio_estado?: string | null;
+  actividades_economicas?: EmpresaActividadEconomica[] | null;
+  obligaciones_fiscales?: EmpresaObligacionFiscal[] | null;
+  csf_fecha_emision?: string | null;
+};
+
+/**
+ * Tipo del INSERT inicial para `core.empresas` durante alta nueva. Toma el
+ * subset CSF + los campos requeridos del alta (slug, nombre, tipo_contribuyente).
+ */
+export type EmpresaCsfInsert = EmpresaCsfUpdate & {
+  slug: string;
+  nombre: string;
+  tipo_contribuyente: 'persona_moral' | 'persona_fisica';
+};
+
+// ─── Helpers internos ───────────────────────────────────────────────────────
+
+function extractObligacionesParaEmpresa(extraccion: CsfExtraccion): EmpresaObligacionFiscal[] {
+  return extraccion.obligaciones.map((o) => ({
+    descripcion: o.descripcion,
+    vencimiento: '', // El extractor no expone vencimiento. Operador puede editarlo a mano.
+    fecha_inicio: o.fecha_inicio ?? '',
+    fecha_fin: o.fecha_fin,
+  }));
+}
+
+function extractActividadesParaEmpresa(extraccion: CsfExtraccion): EmpresaActividadEconomica[] {
+  return extraccion.actividades_economicas.map((a) => ({
+    orden: a.orden,
+    actividad: a.actividad,
+    porcentaje: a.porcentaje ?? '',
+    fecha_inicio: a.fecha_inicio ?? '',
+    fecha_fin: a.fecha_fin,
+  }));
+}
+
+// ─── Builders ───────────────────────────────────────────────────────────────
+
+/**
+ * Construye el row de INSERT para `core.empresas` a partir de la extracción
+ * más los campos requeridos del alta (slug, nombre, tipo_contribuyente).
+ * Usado por `POST /api/empresas/create-with-csf`.
+ */
+export function buildEmpresaInsertFromExtraccion(args: {
+  extraccion: CsfExtraccion;
+  slug: string;
+  nombre: string;
+  tipo_contribuyente?: 'persona_moral' | 'persona_fisica';
+}): EmpresaCsfInsert {
+  const { extraccion, slug, nombre, tipo_contribuyente } = args;
+  const tipoContribuyente =
+    tipo_contribuyente ??
+    (extraccion.tipo_persona === 'fisica' ? 'persona_fisica' : 'persona_moral');
+
+  return {
+    slug,
+    nombre,
+    tipo_contribuyente: tipoContribuyente,
+    rfc: extraccion.rfc.trim().toUpperCase(),
+    curp: extraccion.curp,
+    razon_social: extraccion.razon_social,
+    regimen_capital: extraccion.regimen_capital,
+    nombre_comercial: extraccion.nombre_comercial,
+    fecha_inicio_operaciones: extraccion.fecha_inicio_operaciones,
+    estatus_sat: extraccion.estatus_sat,
+    id_cif: extraccion.id_cif,
+    regimen_fiscal: extraccion.regimen_fiscal_nombre,
+    domicilio_cp: extraccion.domicilio_cp,
+    domicilio_calle: extraccion.domicilio_calle,
+    domicilio_numero_ext: extraccion.domicilio_num_ext,
+    domicilio_numero_int: extraccion.domicilio_num_int,
+    domicilio_colonia: extraccion.domicilio_colonia,
+    domicilio_municipio: extraccion.domicilio_municipio,
+    domicilio_estado: extraccion.domicilio_estado,
+    actividades_economicas: extractActividadesParaEmpresa(extraccion),
+    obligaciones_fiscales: extractObligacionesParaEmpresa(extraccion),
+    csf_fecha_emision: extraccion.fecha_emision,
+  };
+}
+
+/**
+ * Construye el patch para UPDATE sobre `core.empresas` a partir de los campos
+ * aceptados por el operador. Se aplica selectivamente — solo los campos
+ * presentes en `accepted_fields`.
+ *
+ * Acepta tanto keys de `CsfUpdatableField` (provienen del extractor neutro)
+ * como `EmpresaExtraField` (extras específicos de empresa). Si la lista está
+ * vacía, devuelve un objeto vacío — el caller decide qué hacer (típicamente
+ * solo archiva el PDF y termina).
+ */
+export function buildEmpresaUpdateFromAccepted(args: {
+  extraccion: CsfExtraccion;
+  accepted: ReadonlyArray<CsfUpdatableField | EmpresaExtraField>;
+}): EmpresaCsfUpdate {
+  const { extraccion, accepted } = args;
+  const update: EmpresaCsfUpdate = {};
+
+  for (const key of accepted) {
+    // Extras específicos de empresa
+    if (key === 'id_cif') {
+      update.id_cif = extraccion.id_cif;
+      continue;
+    }
+    if (key === 'estatus_sat') {
+      update.estatus_sat = extraccion.estatus_sat;
+      continue;
+    }
+    if (key === 'regimen_capital') {
+      update.regimen_capital = extraccion.regimen_capital;
+      continue;
+    }
+    if (key === 'actividades_economicas') {
+      update.actividades_economicas = extractActividadesParaEmpresa(extraccion);
+      continue;
+    }
+
+    // Campos del extractor neutro
+    const mapping = EMPRESA_FIELD_MAP[key];
+    if (!mapping || !mapping.column) continue;
+    const value = mapping.extract(extraccion);
+    (update as Record<string, unknown>)[mapping.column] = value;
+  }
+
+  // Normalizaciones finales
+  if (typeof update.rfc === 'string') {
+    update.rfc = update.rfc.trim().toUpperCase();
+  }
+
+  return update;
+}

--- a/lib/proveedores/extract-csf.test.ts
+++ b/lib/proveedores/extract-csf.test.ts
@@ -6,6 +6,7 @@ import {
   UpdateCsfPayloadSchema,
   RegimenSchema,
   ObligacionSchema,
+  ActividadEconomicaSchema,
 } from './extract-csf';
 
 /**
@@ -282,6 +283,120 @@ describe('CsfExtraccionSchema — rechazos', () => {
       fecha_emision: null,
     };
     expect(() => CsfExtraccionSchema.parse(input)).toThrow();
+  });
+});
+
+describe('CsfExtraccionSchema — campos extendidos (consumidos por empresas)', () => {
+  const baseInput = {
+    tipo_persona: 'moral',
+    rfc: 'ANO8509243H3',
+    curp: null,
+    nombre: null,
+    apellido_paterno: null,
+    apellido_materno: null,
+    razon_social: 'AUTOS DEL NORTE',
+    nombre_comercial: null,
+    regimen_fiscal_codigo: '601',
+    regimen_fiscal_nombre: 'General de Ley Personas Morales',
+    regimenes_adicionales: [
+      {
+        codigo: '601',
+        nombre: 'General de Ley Personas Morales',
+        fecha_inicio: '1958-12-01',
+        fecha_fin: null,
+      },
+    ],
+    domicilio_calle: null,
+    domicilio_num_ext: null,
+    domicilio_num_int: null,
+    domicilio_colonia: null,
+    domicilio_cp: null,
+    domicilio_municipio: null,
+    domicilio_estado: null,
+    obligaciones: [],
+    fecha_inicio_operaciones: '1958-12-01',
+    fecha_emision: '2026-04-01',
+  };
+
+  it('los campos extendidos son opcionales y default a null/[]', () => {
+    const parsed = CsfExtraccionSchema.parse(baseInput);
+    expect(parsed.id_cif).toBeNull();
+    expect(parsed.estatus_sat).toBeNull();
+    expect(parsed.regimen_capital).toBeNull();
+    expect(parsed.actividades_economicas).toEqual([]);
+  });
+
+  it('parsea CSF de empresa moral con id_cif, estatus_sat, regimen_capital y actividades', () => {
+    const input = {
+      ...baseInput,
+      id_cif: '14110980997',
+      estatus_sat: 'ACTIVO',
+      regimen_capital: 'SOCIEDAD ANONIMA DE CAPITAL VARIABLE',
+      actividades_economicas: [
+        {
+          orden: 1,
+          actividad: 'Comercio al por menor de automóviles y camionetas nuevos',
+          porcentaje: '90%',
+          fecha_inicio: '1999-04-09',
+          fecha_fin: null,
+        },
+        {
+          orden: 2,
+          actividad: 'Reparación mecánica en general de automóviles y camiones',
+          porcentaje: '2%',
+          fecha_inicio: '2023-05-24',
+          fecha_fin: null,
+        },
+      ],
+    };
+    const parsed = CsfExtraccionSchema.parse(input);
+    expect(parsed.id_cif).toBe('14110980997');
+    expect(parsed.estatus_sat).toBe('ACTIVO');
+    expect(parsed.regimen_capital).toBe('SOCIEDAD ANONIMA DE CAPITAL VARIABLE');
+    expect(parsed.actividades_economicas).toHaveLength(2);
+    expect(parsed.actividades_economicas[0]?.orden).toBe(1);
+    expect(parsed.actividades_economicas[0]?.porcentaje).toBe('90%');
+  });
+
+  it('rechaza una actividad económica sin "orden" (campo obligatorio)', () => {
+    const input = {
+      ...baseInput,
+      actividades_economicas: [
+        {
+          actividad: 'Sin orden',
+          porcentaje: '100%',
+          fecha_inicio: null,
+          fecha_fin: null,
+        },
+      ],
+    };
+    expect(() => CsfExtraccionSchema.parse(input)).toThrow();
+  });
+});
+
+describe('ActividadEconomicaSchema standalone', () => {
+  it('parsea actividad con todos los campos', () => {
+    expect(
+      ActividadEconomicaSchema.parse({
+        orden: 1,
+        actividad: 'Comercio al por menor',
+        porcentaje: '90%',
+        fecha_inicio: '2020-01-01',
+        fecha_fin: null,
+      })
+    ).toMatchObject({ orden: 1, porcentaje: '90%' });
+  });
+
+  it('acepta porcentaje null cuando la CSF no lo muestra', () => {
+    expect(
+      ActividadEconomicaSchema.parse({
+        orden: 1,
+        actividad: 'X',
+        porcentaje: null,
+        fecha_inicio: null,
+        fecha_fin: null,
+      })
+    ).toMatchObject({ porcentaje: null });
   });
 });
 

--- a/lib/proveedores/extract-csf.ts
+++ b/lib/proveedores/extract-csf.ts
@@ -55,6 +55,25 @@ export const ObligacionSchema = z.object({
     .describe('Fecha en que dejó de aplicar, formato YYYY-MM-DD. null si sigue vigente.'),
 });
 
+export const ActividadEconomicaSchema = z.object({
+  orden: z.number().int().describe('Número de orden tal como aparece en la CSF (1, 2, 3...).'),
+  actividad: z
+    .string()
+    .describe('Texto literal de la actividad económica tal como aparece en la CSF.'),
+  porcentaje: z
+    .string()
+    .nullable()
+    .describe('Porcentaje atribuido a la actividad (ej. "90%"). null si no aparece.'),
+  fecha_inicio: z
+    .string()
+    .nullable()
+    .describe('Fecha desde cuando aplica, formato YYYY-MM-DD. null si no aparece.'),
+  fecha_fin: z
+    .string()
+    .nullable()
+    .describe('Fecha en que dejó de aplicar, formato YYYY-MM-DD. null si sigue vigente.'),
+});
+
 export const CsfExtraccionSchema = z.object({
   // ─── Identidad fiscal ───────────────────────────────────────────────────
   tipo_persona: z
@@ -142,6 +161,38 @@ export const CsfExtraccionSchema = z.object({
     .string()
     .nullable()
     .describe('Fecha de emisión / generación de la CSF, formato YYYY-MM-DD. null si no aparece.'),
+
+  // ─── Campos extendidos (consumidos por empresas, opcionales) ────────────
+  // Los siguientes campos son opcionales — null por default para no romper
+  // consumidores existentes (proveedores). Empresas los lee cuando la CSF
+  // del SAT los expone (caso típico de personas morales del grupo).
+  id_cif: z
+    .string()
+    .nullable()
+    .default(null)
+    .describe(
+      'Identificador de Cédula de Identificación Fiscal (idCIF), 11 dígitos. null si no aparece.'
+    ),
+  estatus_sat: z
+    .string()
+    .nullable()
+    .default(null)
+    .describe('Estatus en el padrón del SAT (ej. "ACTIVO"). null si no aparece.'),
+  regimen_capital: z
+    .string()
+    .nullable()
+    .default(null)
+    .describe(
+      'Régimen de capital de personas morales (ej. "SOCIEDAD ANONIMA DE CAPITAL VARIABLE"). ' +
+        'null si es persona física o no aparece.'
+    ),
+  actividades_economicas: z
+    .array(ActividadEconomicaSchema)
+    .default([])
+    .describe(
+      'Lista de actividades económicas de la sección "Actividades Económicas" de la CSF, ' +
+        'con orden, descripción literal, porcentaje y fechas. Vacío si no aparece la sección.'
+    ),
 });
 
 export type CsfExtraccion = z.infer<typeof CsfExtraccionSchema>;
@@ -246,6 +297,10 @@ Reglas:
 - Para personas morales: razon_social se llena; nombre/apellidos quedan null; curp null.
 - En "regimenes_adicionales" pon TODOS los regímenes que veas en la sección "Regímenes" de la CSF (uno o varios). El "regimen_fiscal_codigo/nombre" debe ser el principal vigente (el más reciente sin fecha_fin, o si solo hay uno, ese).
 - "obligaciones" debe listar TODAS las que aparezcan, con su descripción literal y fechas si las hay.
+- "actividades_economicas" debe listar TODAS las actividades de la sección "Actividades Económicas" de la CSF, con orden, descripción literal, porcentaje y fechas. Si la CSF no expone esa sección, devuelve un array vacío.
+- "id_cif" es el "idCIF" o "Identificador de Cédula de Identificación Fiscal" (11 dígitos). Aparece en CSF de personas morales y de algunas físicas. null si no está.
+- "estatus_sat" es el estatus en el padrón ("ACTIVO" o equivalente). null si no aparece.
+- "regimen_capital" solo aplica a personas morales (ej. "SOCIEDAD ANONIMA DE CAPITAL VARIABLE"). Si la denominación social ya lo trae, extrae solo la parte de régimen de capital (sin la razón social). null si es física o no aparece.
 - Fechas siempre en formato YYYY-MM-DD (convierte si la CSF las muestra en otro formato).
 - Si un campo no se puede leer con certeza, devuelve null. NO inventes valores.
 - Si el RFC viene con guiones o espacios, devuélvelo limpio (solo letras y números, mayúsculas).


### PR DESCRIPTION
## Summary

Sprint 1 de la iniciativa **`empresas-csf-config`** — backend completo:

- Extractor CSF compartido extendido con `id_cif`, `estatus_sat`, `regimen_capital`, `actividades_economicas[]` (opcionales, backwards-compatible con proveedores).
- `lib/empresas/csf-mapping.ts`: traduce shape neutro del extractor → `core.empresas` (rename `num_ext`→`numero_ext`, `obligaciones`→`obligaciones_fiscales` con `vencimiento` libre, `actividades_economicas[]` con porcentaje string).
- 4 endpoints **admin-only** en `/api/empresas/`:
  - `POST extract-csf` — wrapper sobre extractor compartido, sin persistir.
  - `POST create-with-csf` — alta con dedup RFC + slug, archive PDF en `erp.adjuntos`.
  - `POST [id]/update-csf` — diff selectivo (`accepted_fields[]`); archive siempre.
  - `PATCH [id]` — `registro_patronal_imss` (regex `A0000000000`), extensible.
- `lib/empresas/admin-guard.ts` — gate compartido (`core.usuarios.rol === 'admin'`).

**Sin migración DB** (verificado): `core.empresas.rfc` ya tiene `UNIQUE`, `erp.adjuntos.entidad_tipo` es `TEXT NOT NULL` libre.

+70 tests (24 schema, 15 mapper, 31 endpoints). Suite total 273 verdes.

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓
- [x] `npm run format:check` ✓
- [x] `npm run test:run` (273 verdes, 14 archivos) ✓
- [ ] Sprint 2 conecta UI drawer "Actualizar CSF" + campo `registro_patronal_imss` en `/settings/empresas/[slug]`.
- [ ] Sprint 3 conecta UI alta nueva en `/settings/empresas` + agrupa lista por tipo (Morales/Físicas/Otros).
- [ ] Sprint 4 (operativo) — Beto sube los CSF al día de RDB/DILESA/COAGAN/ANSA por la UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)