### PR TITLE
feat(empresas-csf-config): Sprint 3 — alta nueva con CSF + agrupación por tipo

### DIFF
--- a/app/settings/empresas/_components/nueva-empresa-drawer.tsx
+++ b/app/settings/empresas/_components/nueva-empresa-drawer.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { FieldLabel } from '@/components/ui/field-label';
+import { Input } from '@/components/ui/input';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { AlertTriangle, Loader2, RefreshCw, Save, Sparkles, Upload } from 'lucide-react';
+
+import type { CsfExtraccion } from '@/lib/proveedores/extract-csf';
+
+/**
+ * Drawer para alta de empresa nueva con flujo CSF.
+ *
+ * Flujo:
+ *   A. drop: usuario sube PDF de la CSF.
+ *   B. processing: extract-csf con Claude (30-90s).
+ *   C. preview + form: usuario revisa los campos extraídos, captura slug
+ *      (default = slugify del nombre), nombre (default = razón social),
+ *      tipo_contribuyente (default según `extraccion.tipo_persona`).
+ *   D. creating: POST create-with-csf, redirige al detalle.
+ *
+ * Errores comunes manejados friendly:
+ *   - 409 rfc_duplicado: link al detalle de la empresa existente.
+ *   - 409 slug_duplicado: invita a editar el slug.
+ */
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, 40);
+}
+
+export function NuevaEmpresaDrawer({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onCreated: () => void;
+}) {
+  const router = useRouter();
+
+  const [csfFile, setCsfFile] = useState<File | null>(null);
+  const [csfProcessing, setCsfProcessing] = useState(false);
+  const [csfError, setCsfError] = useState<string | null>(null);
+  const [extraccion, setExtraccion] = useState<CsfExtraccion | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [nombre, setNombre] = useState('');
+  const [slug, setSlug] = useState('');
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [tipoContribuyente, setTipoContribuyente] = useState<'persona_moral' | 'persona_fisica'>(
+    'persona_moral'
+  );
+
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<{
+    message: string;
+    duplicateSlug?: string;
+  } | null>(null);
+
+  const reset = () => {
+    setCsfFile(null);
+    setCsfProcessing(false);
+    setCsfError(null);
+    setExtraccion(null);
+    setNombre('');
+    setSlug('');
+    setSlugTouched(false);
+    setTipoContribuyente('persona_moral');
+    setCreating(false);
+    setCreateError(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleClose = (v: boolean) => {
+    if (!v) {
+      reset();
+      onOpenChange(false);
+    }
+  };
+
+  const handleFileChosen = async (file: File | null) => {
+    if (!file) return;
+    setCsfFile(file);
+    setCsfProcessing(true);
+    setCsfError(null);
+    setExtraccion(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await fetch('/api/empresas/extract-csf', { method: 'POST', body: fd });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? 'Error al procesar CSF');
+      const ex = json.extraccion as CsfExtraccion;
+      setExtraccion(ex);
+      const isMoral = ex.tipo_persona === 'moral';
+      setTipoContribuyente(isMoral ? 'persona_moral' : 'persona_fisica');
+      const defaultNombre = isMoral
+        ? ex.nombre_comercial?.trim() || ex.razon_social?.trim() || 'Empresa'
+        : [ex.nombre, ex.apellido_paterno, ex.apellido_materno].filter(Boolean).join(' ').trim() ||
+          'Persona';
+      setNombre(defaultNombre);
+      if (!slugTouched) setSlug(slugify(defaultNombre));
+    } catch (err) {
+      setCsfError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCsfProcessing(false);
+    }
+  };
+
+  const handleNombreChange = (v: string) => {
+    setNombre(v);
+    if (!slugTouched) setSlug(slugify(v));
+  };
+
+  const handleCreate = async () => {
+    if (!csfFile || !extraccion || !nombre.trim() || !slug.trim()) return;
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', csfFile);
+      fd.append(
+        'payload',
+        JSON.stringify({
+          extraccion,
+          slug: slug.trim(),
+          nombre: nombre.trim(),
+          tipo_contribuyente: tipoContribuyente,
+        })
+      );
+      const res = await fetch('/api/empresas/create-with-csf', {
+        method: 'POST',
+        body: fd,
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        if (json.error === 'rfc_duplicado') {
+          setCreateError({
+            message: `Ya existe una empresa con este RFC.`,
+            duplicateSlug: json.existing_slug ?? null,
+          });
+        } else if (json.error === 'slug_duplicado') {
+          setCreateError({ message: 'Ya existe una empresa con ese slug. Edítalo y reintenta.' });
+        } else {
+          setCreateError({ message: json.error ?? 'Error al crear empresa' });
+        }
+        return;
+      }
+      onCreated();
+      handleClose(false);
+      // Navega al detalle de la empresa recién creada.
+      router.push(`/settings/empresas/${json.slug}`);
+    } catch (err) {
+      setCreateError({ message: err instanceof Error ? err.message : String(err) });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const slugValid = /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug);
+  const canSubmit =
+    !!csfFile && !!extraccion && nombre.trim().length > 0 && slug.trim().length > 0 && slugValid;
+
+  return (
+    <Sheet open={open} onOpenChange={handleClose}>
+      <SheetContent className="sm:max-w-[700px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-emerald-600" />
+            Nueva empresa con CSF
+          </SheetTitle>
+          <p className="text-xs text-muted-foreground">
+            Sube el PDF de la CSF y el sistema extrae los datos fiscales. Solo necesitas confirmar
+            slug y nombre.
+          </p>
+        </SheetHeader>
+
+        <div className="mt-6 space-y-4">
+          {/* Estado A: drop */}
+          {!csfFile && !csfProcessing && (
+            <div className="space-y-3">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/pdf"
+                className="hidden"
+                onChange={(e) => {
+                  const f = e.target.files?.[0] ?? null;
+                  void handleFileChosen(f);
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="w-full rounded-xl border-2 border-dashed border-[var(--border)] bg-[var(--panel)]/30 hover:bg-[var(--panel)]/60 px-6 py-12 text-center transition cursor-pointer"
+              >
+                <Upload className="mx-auto h-10 w-10 text-[var(--text)]/40" />
+                <p className="mt-3 text-sm font-medium text-[var(--text)]">Sube el PDF de la CSF</p>
+                <p className="mt-1 text-xs text-[var(--text-muted)]">
+                  Solo .pdf, máximo 50 MB. La extracción tarda 30-90 segundos.
+                </p>
+              </button>
+              {csfError && (
+                <div className="flex items-start gap-2 rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-400">
+                  <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                  {csfError}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Estado B: procesando */}
+          {csfProcessing && (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <Loader2 className="h-10 w-10 animate-spin text-emerald-500" />
+              <p className="mt-4 text-sm font-medium text-[var(--text)]">
+                Procesando con Claude...
+              </p>
+              <p className="mt-1 text-xs text-[var(--text-muted)]">
+                Tarda 30-90 segundos. No cierres este drawer.
+              </p>
+            </div>
+          )}
+
+          {/* Estado C: preview + form */}
+          {extraccion && !csfProcessing && (
+            <>
+              {/* Resumen del extracto */}
+              <div className="rounded-xl border border-emerald-300/40 bg-emerald-50/40 dark:bg-emerald-950/20 p-4 space-y-2">
+                <div className="flex items-center gap-2 text-sm font-medium text-emerald-700 dark:text-emerald-300">
+                  <Sparkles className="h-4 w-4" />
+                  CSF procesada — revisa y confirma
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2 text-xs">
+                  <div>
+                    <span className="text-muted-foreground">Tipo:</span>{' '}
+                    <span className="font-medium">{extraccion.tipo_persona}</span>
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">RFC:</span>{' '}
+                    <span className="font-mono">{extraccion.rfc}</span>
+                  </div>
+                  {extraccion.razon_social && (
+                    <div className="sm:col-span-2">
+                      <span className="text-muted-foreground">Razón social:</span>{' '}
+                      <span className="font-medium">{extraccion.razon_social}</span>
+                    </div>
+                  )}
+                  {extraccion.regimen_fiscal_nombre && (
+                    <div className="sm:col-span-2">
+                      <span className="text-muted-foreground">Régimen:</span>{' '}
+                      {extraccion.regimen_fiscal_nombre}
+                    </div>
+                  )}
+                  {extraccion.id_cif && (
+                    <div>
+                      <span className="text-muted-foreground">idCIF:</span>{' '}
+                      <span className="font-mono">{extraccion.id_cif}</span>
+                    </div>
+                  )}
+                  {extraccion.estatus_sat && (
+                    <div>
+                      <span className="text-muted-foreground">Estatus:</span>{' '}
+                      {extraccion.estatus_sat}
+                    </div>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setExtraccion(null);
+                    setCsfFile(null);
+                    if (fileInputRef.current) fileInputRef.current.value = '';
+                  }}
+                  className="text-xs text-emerald-700 dark:text-emerald-400 hover:underline"
+                >
+                  Cambiar PDF
+                </button>
+              </div>
+
+              {/* Form de alta */}
+              <div className="space-y-4">
+                <div>
+                  <FieldLabel>Nombre interno *</FieldLabel>
+                  <Input
+                    value={nombre}
+                    onChange={(e) => handleNombreChange(e.target.value)}
+                    placeholder="Cómo se llamará en el sistema (ej. RDB, ANSA)"
+                    className="rounded-xl"
+                    maxLength={120}
+                  />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Default: nombre comercial o razón social. Editable.
+                  </p>
+                </div>
+
+                <div>
+                  <FieldLabel>Slug (URL) *</FieldLabel>
+                  <Input
+                    value={slug}
+                    onChange={(e) => {
+                      setSlug(e.target.value);
+                      setSlugTouched(true);
+                    }}
+                    placeholder="kebab-case (ej. rdb, autos-del-norte)"
+                    className="rounded-xl font-mono"
+                    maxLength={40}
+                  />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Solo a-z, 0-9, guiones. Aparece en `/settings/empresas/&lt;slug&gt;`.
+                  </p>
+                  {slug && !slugValid && (
+                    <p className="mt-1 text-xs text-red-400">
+                      Slug inválido. Usa kebab-case (a-z, 0-9, guiones).
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <FieldLabel>Tipo contribuyente</FieldLabel>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant={tipoContribuyente === 'persona_moral' ? 'default' : 'outline'}
+                      onClick={() => setTipoContribuyente('persona_moral')}
+                      className="rounded-xl"
+                    >
+                      Persona moral
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant={tipoContribuyente === 'persona_fisica' ? 'default' : 'outline'}
+                      onClick={() => setTipoContribuyente('persona_fisica')}
+                      className="rounded-xl"
+                    >
+                      Persona física
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              {createError && (
+                <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-400 space-y-2">
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                    <span>{createError.message}</span>
+                  </div>
+                  {createError.duplicateSlug && (
+                    <a
+                      href={`/settings/empresas/${createError.duplicateSlug}`}
+                      className="block text-xs underline hover:no-underline"
+                    >
+                      → Abrir empresa existente
+                    </a>
+                  )}
+                </div>
+              )}
+
+              <div className="flex justify-end gap-2 border-t pt-4">
+                <Button variant="outline" onClick={() => handleClose(false)} disabled={creating}>
+                  Cancelar
+                </Button>
+                <Button onClick={handleCreate} disabled={!canSubmit || creating} className="gap-2">
+                  {creating ? (
+                    <RefreshCw className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Save className="h-4 w-4" />
+                  )}
+                  Crear empresa
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/app/settings/empresas/page.tsx
+++ b/app/settings/empresas/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { RequireAccess } from '@/components/require-access';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Building2, RefreshCw, FileText, ChevronRight, Palette } from 'lucide-react';
+import { Building2, ChevronRight, FileText, Palette, Plus, RefreshCw } from 'lucide-react';
+
+import { NuevaEmpresaDrawer } from './_components/nueva-empresa-drawer';
 
 type EmpresaRow = {
   id: string;
@@ -19,10 +21,21 @@ type EmpresaRow = {
   domicilio_municipio: string | null;
   domicilio_estado: string | null;
   csf_url: string | null;
+  tipo_contribuyente: 'persona_moral' | 'persona_fisica' | null;
   color_primario: string | null;
   logo_horizontal_light_url: string | null;
   branding_updated_at: string | null;
 };
+
+type GrupoKey = 'persona_moral' | 'persona_fisica' | 'otros';
+
+const GRUPO_LABELS: Record<GrupoKey, string> = {
+  persona_moral: 'Personas Morales',
+  persona_fisica: 'Personas Físicas',
+  otros: 'Otros',
+};
+
+const GRUPO_ORDER: ReadonlyArray<GrupoKey> = ['persona_moral', 'persona_fisica', 'otros'];
 
 function EstatusBadge({ estatus }: { estatus: string | null }) {
   if (!estatus) return <span className="text-[var(--text)]/30 text-xs">—</span>;
@@ -41,18 +54,127 @@ function EstatusBadge({ estatus }: { estatus: string | null }) {
 const thClass =
   'px-4 py-3 text-left text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/50';
 
+function EmpresaTableRow({ e }: { e: EmpresaRow }) {
+  const domicilio = [e.domicilio_municipio, e.domicilio_estado].filter(Boolean).join(', ');
+  return (
+    <tr className="border-b border-[var(--border)] last:border-0 group hover:bg-[var(--panel)]/50 transition cursor-pointer">
+      <td colSpan={9} className="p-0">
+        <Link href={`/settings/empresas/${e.slug}`} className="flex items-center w-full">
+          <span className="flex items-center justify-center w-16 px-3 py-3 shrink-0">
+            {e.logo_horizontal_light_url ? (
+              /* eslint-disable-next-line @next/next/no-img-element */
+              <img
+                src={e.logo_horizontal_light_url}
+                alt={e.nombre}
+                className="h-8 w-8 object-contain"
+              />
+            ) : (
+              <div className="h-8 w-8 rounded-lg bg-[var(--panel)] flex items-center justify-center">
+                <Building2 className="h-4 w-4 text-[var(--text)]/30" />
+              </div>
+            )}
+          </span>
+          <span className="flex-1 min-w-0 px-4 py-3.5">
+            <span className="font-medium text-[var(--text)] truncate block">{e.nombre}</span>
+          </span>
+          <span className="hidden sm:block w-36 px-4 py-3.5 text-[var(--text)]/70 font-mono text-xs shrink-0">
+            {e.rfc || '—'}
+          </span>
+          <span className="hidden md:flex w-28 px-4 py-3.5 shrink-0 items-center">
+            <EstatusBadge estatus={e.estatus_sat} />
+          </span>
+          <span className="hidden lg:block w-48 px-4 py-3.5 text-[var(--text)]/60 text-xs truncate shrink-0">
+            {e.regimen_fiscal || '—'}
+          </span>
+          <span className="hidden lg:block w-40 px-4 py-3.5 text-[var(--text)]/60 text-xs truncate shrink-0">
+            {domicilio || '—'}
+          </span>
+          <span className="hidden sm:flex w-20 px-4 py-3.5 items-center justify-center shrink-0">
+            {e.color_primario ? (
+              <span className="flex items-center gap-1">
+                <span
+                  className="h-4 w-4 rounded-full border border-[var(--border)]"
+                  style={{ backgroundColor: e.color_primario }}
+                  title={e.color_primario}
+                />
+              </span>
+            ) : (
+              <Palette className="h-4 w-4 text-[var(--text)]/20" />
+            )}
+          </span>
+          <span className="flex w-12 px-4 py-3.5 items-center justify-center shrink-0">
+            {e.csf_url ? (
+              <FileText className="h-4 w-4 text-[var(--accent)]" />
+            ) : (
+              <span className="text-[var(--text)]/20 text-xs">—</span>
+            )}
+          </span>
+          <span className="flex w-10 px-3 py-3.5 items-center justify-center shrink-0 text-[var(--text)]/30 group-hover:text-[var(--text)]/60 transition">
+            <ChevronRight className="h-4 w-4" />
+          </span>
+        </Link>
+      </td>
+    </tr>
+  );
+}
+
+function EmpresaGroupTable({
+  empresas,
+  grupoLabel,
+}: {
+  empresas: EmpresaRow[];
+  grupoLabel: string;
+}) {
+  if (empresas.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline gap-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-[var(--text)]/70">
+          {grupoLabel}
+        </h2>
+        <span className="text-xs text-[var(--text)]/40">
+          {empresas.length} {empresas.length === 1 ? 'empresa' : 'empresas'}
+        </span>
+      </div>
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[var(--border)] bg-[var(--panel)]">
+              <th className={`${thClass} w-16`}>Logo</th>
+              <th className={thClass}>Nombre</th>
+              <th className={`${thClass} hidden sm:table-cell`}>RFC</th>
+              <th className={`${thClass} hidden md:table-cell`}>Estatus SAT</th>
+              <th className={`${thClass} hidden lg:table-cell`}>Régimen Fiscal</th>
+              <th className={`${thClass} hidden lg:table-cell`}>Domicilio</th>
+              <th className={`${thClass} hidden sm:table-cell w-20 text-center`}>Branding</th>
+              <th className={`${thClass} w-12 text-center`}>CSF</th>
+              <th className={`${thClass} w-10`} />
+            </tr>
+          </thead>
+          <tbody>
+            {empresas.map((e) => (
+              <EmpresaTableRow key={e.id} e={e} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
 function EmpresasSettingsInner() {
   const supabase = createSupabaseBrowserClient();
   const [empresas, setEmpresas] = useState<EmpresaRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const fetchEmpresas = useCallback(async () => {
     const { data, error: err } = await supabase
       .schema('core')
       .from('empresas')
       .select(
-        'id, nombre, slug, activa, rfc, estatus_sat, regimen_fiscal, domicilio_municipio, domicilio_estado, csf_url, color_primario, logo_horizontal_light_url, branding_updated_at'
+        'id, nombre, slug, activa, rfc, estatus_sat, regimen_fiscal, domicilio_municipio, domicilio_estado, csf_url, tipo_contribuyente, color_primario, logo_horizontal_light_url, branding_updated_at'
       )
       .order('nombre');
     if (err) {
@@ -72,6 +194,20 @@ function EmpresasSettingsInner() {
     })();
   }, [fetchEmpresas]);
 
+  const grupos = useMemo<Record<GrupoKey, EmpresaRow[]>>(() => {
+    const out: Record<GrupoKey, EmpresaRow[]> = {
+      persona_moral: [],
+      persona_fisica: [],
+      otros: [],
+    };
+    for (const e of empresas) {
+      if (e.tipo_contribuyente === 'persona_moral') out.persona_moral.push(e);
+      else if (e.tipo_contribuyente === 'persona_fisica') out.persona_fisica.push(e);
+      else out.otros.push(e);
+    }
+    return out;
+  }, [empresas]);
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -81,18 +217,24 @@ function EmpresasSettingsInner() {
             Selecciona una empresa para ver y editar sus datos fiscales y branding
           </p>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            setLoading(true);
-            fetchEmpresas().finally(() => setLoading(false));
-          }}
-          disabled={loading}
-          className="rounded-xl border-[var(--border)] bg-[var(--card)] text-[var(--text)] hover:bg-[var(--panel)]"
-        >
-          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button size="sm" onClick={() => setDrawerOpen(true)} className="gap-1.5 rounded-xl">
+            <Plus className="h-4 w-4" />
+            Nueva empresa
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              setLoading(true);
+              fetchEmpresas().finally(() => setLoading(false));
+            }}
+            disabled={loading}
+            className="rounded-xl border-[var(--border)] bg-[var(--card)] text-[var(--text)] hover:bg-[var(--panel)]"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
       </div>
 
       {error && (
@@ -121,119 +263,26 @@ function EmpresasSettingsInner() {
         <div className="flex flex-col items-center justify-center p-16 text-center rounded-2xl border border-[var(--border)] bg-[var(--card)]">
           <Building2 className="mb-3 h-10 w-10 text-[var(--text)]/20" />
           <p className="text-sm text-[var(--text-muted)]">No hay empresas registradas.</p>
+          <Button size="sm" onClick={() => setDrawerOpen(true)} className="mt-4 gap-1.5 rounded-xl">
+            <Plus className="h-4 w-4" />
+            Dar de alta la primera
+          </Button>
         </div>
       ) : (
-        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-[var(--border)] bg-[var(--panel)]">
-                <th className={`${thClass} w-16`}>Logo</th>
-                <th className={thClass}>Nombre</th>
-                <th className={`${thClass} hidden sm:table-cell`}>RFC</th>
-                <th className={`${thClass} hidden md:table-cell`}>Estatus SAT</th>
-                <th className={`${thClass} hidden lg:table-cell`}>Régimen Fiscal</th>
-                <th className={`${thClass} hidden lg:table-cell`}>Domicilio</th>
-                <th className={`${thClass} hidden sm:table-cell w-20 text-center`}>Branding</th>
-                <th className={`${thClass} w-12 text-center`}>CSF</th>
-                <th className={`${thClass} w-10`} />
-              </tr>
-            </thead>
-            <tbody>
-              {empresas.map((e) => {
-                const domicilio = [e.domicilio_municipio, e.domicilio_estado]
-                  .filter(Boolean)
-                  .join(', ');
-
-                return (
-                  <tr
-                    key={e.id}
-                    className="border-b border-[var(--border)] last:border-0 group hover:bg-[var(--panel)]/50 transition cursor-pointer"
-                  >
-                    <td colSpan={9} className="p-0">
-                      <Link
-                        href={`/settings/empresas/${e.slug}`}
-                        className="flex items-center w-full"
-                      >
-                        {/* Logo */}
-                        <span className="flex items-center justify-center w-16 px-3 py-3 shrink-0">
-                          {e.logo_horizontal_light_url ? (
-                            /* eslint-disable-next-line @next/next/no-img-element */
-                            <img
-                              src={e.logo_horizontal_light_url}
-                              alt={e.nombre}
-                              className="h-8 w-8 object-contain"
-                            />
-                          ) : (
-                            <div className="h-8 w-8 rounded-lg bg-[var(--panel)] flex items-center justify-center">
-                              <Building2 className="h-4 w-4 text-[var(--text)]/30" />
-                            </div>
-                          )}
-                        </span>
-
-                        {/* Nombre */}
-                        <span className="flex-1 min-w-0 px-4 py-3.5">
-                          <span className="font-medium text-[var(--text)] truncate block">
-                            {e.nombre}
-                          </span>
-                        </span>
-
-                        {/* RFC */}
-                        <span className="hidden sm:block w-36 px-4 py-3.5 text-[var(--text)]/70 font-mono text-xs shrink-0">
-                          {e.rfc || '—'}
-                        </span>
-
-                        {/* Estatus SAT */}
-                        <span className="hidden md:flex w-28 px-4 py-3.5 shrink-0 items-center">
-                          <EstatusBadge estatus={e.estatus_sat} />
-                        </span>
-
-                        {/* Régimen Fiscal */}
-                        <span className="hidden lg:block w-48 px-4 py-3.5 text-[var(--text)]/60 text-xs truncate shrink-0">
-                          {e.regimen_fiscal || '—'}
-                        </span>
-
-                        {/* Domicilio */}
-                        <span className="hidden lg:block w-40 px-4 py-3.5 text-[var(--text)]/60 text-xs truncate shrink-0">
-                          {domicilio || '—'}
-                        </span>
-
-                        {/* Branding indicator */}
-                        <span className="hidden sm:flex w-20 px-4 py-3.5 items-center justify-center shrink-0">
-                          {e.color_primario ? (
-                            <span className="flex items-center gap-1">
-                              <span
-                                className="h-4 w-4 rounded-full border border-[var(--border)]"
-                                style={{ backgroundColor: e.color_primario }}
-                                title={e.color_primario}
-                              />
-                            </span>
-                          ) : (
-                            <Palette className="h-4 w-4 text-[var(--text)]/20" />
-                          )}
-                        </span>
-
-                        {/* CSF */}
-                        <span className="flex w-12 px-4 py-3.5 items-center justify-center shrink-0">
-                          {e.csf_url ? (
-                            <FileText className="h-4 w-4 text-[var(--accent)]" />
-                          ) : (
-                            <span className="text-[var(--text)]/20 text-xs">—</span>
-                          )}
-                        </span>
-
-                        {/* Chevron */}
-                        <span className="flex w-10 px-3 py-3.5 items-center justify-center shrink-0 text-[var(--text)]/30 group-hover:text-[var(--text)]/60 transition">
-                          <ChevronRight className="h-4 w-4" />
-                        </span>
-                      </Link>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+        <div className="space-y-8">
+          {GRUPO_ORDER.map((g) => (
+            <EmpresaGroupTable key={g} empresas={grupos[g]} grupoLabel={GRUPO_LABELS[g]} />
+          ))}
         </div>
       )}
+
+      <NuevaEmpresaDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        onCreated={() => {
+          void fetchEmpresas();
+        }}
+      />
     </div>
   );
 }

--- a/docs/planning/empresas-csf-config.md
+++ b/docs/planning/empresas-csf-config.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-04-28
-**Última actualización:** 2026-04-28 (Sprint 2 mergeado: `EmpresaDetail` reescrito con CSF read-only + drawer "Actualizar CSF" inline (estados A→B→C→D + diff selectivo) + campo `registro_patronal_imss` editable con regex; SELECT del page extiende `tipo_contribuyente`, `curp`, `registro_patronal_imss`)
+**Última actualización:** 2026-04-28 (Sprint 3 mergeado: botón "Nueva empresa" + drawer `<NuevaEmpresaDrawer>` con flujo CSF→preview→create + agrupación de la lista por tipo de contribuyente — Morales / Físicas / Otros. Faltan solo Sprint 4 operativo)
 
 ## Problema
 
@@ -103,7 +103,7 @@ Empresa es estructuralmente igual al proveedor moral: mismo PDF de SAT, mismos c
 | 0   | Promoción: este doc + fila en INITIATIVES.md                                                                                           | done    | #267 |
 | 1   | Endpoints `/api/empresas/extract-csf`, `create-with-csf`, `[id]/update-csf`, `PATCH [id]` (registro patronal) + tests con fixtures CSF | done    | #269 |
 | 2   | UI drawer "Actualizar CSF" en `/settings/empresas/[slug]` + campo `registro_patronal_imss` editable + reuso `<CsfDiffModal>`           | done    | TBD  |
-| 3   | Botón "Nueva empresa" + drawer `create-with-csf` en lista `/settings/empresas`                                                         | pending | —    |
+| 3   | Botón "Nueva empresa" + drawer `create-with-csf` en lista `/settings/empresas` + agrupación por tipo (Morales/Físicas/Otros)           | done    | TBD  |
 | 4   | Refresh operativo: subir CSF al día de RDB/DILESA/COAGAN/ANSA + capturar `registro_patronal_imss` faltantes                            | pending | —    |
 
 ## Decisiones registradas
@@ -169,3 +169,30 @@ Empresa es estructuralmente igual al proveedor moral: mismo PDF de SAT, mismos c
 **Links:**
 
 - PR Sprint 2: TBD (se agregará al merge).
+
+### 2026-04-28 — Sprint 3: alta nueva + agrupación por tipo
+
+**Qué se hizo en esta sesión:**
+
+- `app/settings/empresas/_components/nueva-empresa-drawer.tsx` (nuevo componente):
+  - Estado A: drop PDF (dashed border).
+  - Estado B: procesando con loader.
+  - Estado C: preview tipo+RFC+razón social+régimen+idCIF + form para `nombre` (default = nombre comercial / razón social) y `slug` (default = slugify del nombre, editable; deja de auto-tracking si el usuario lo modifica). Toggle persona moral / física.
+  - Estado D: POST `create-with-csf`, redirige a `/settings/empresas/{nuevo-slug}`.
+  - Errores friendly: `409 rfc_duplicado` con link al detalle existente; `409 slug_duplicado` con sugerencia de editar.
+- `app/settings/empresas/page.tsx`:
+  - SELECT extendido con `tipo_contribuyente`.
+  - Botón header "Nueva empresa" abre el drawer.
+  - Lista agrupada: tres tablas (Personas Morales, Personas Físicas, Otros) con header de sección + contador. Empresas con `tipo_contribuyente = null` caen en "Otros". Si una sección no tiene empresas, no se renderiza.
+  - Empty state ahora invita a "Dar de alta la primera" empresa con el mismo botón.
+- Sprint 4 (operativo) queda como pendiente para Beto: subir CSF al día de RDB/DILESA/COAGAN/ANSA + capturar `registro_patronal_imss` faltantes.
+
+**Decisiones tácticas registradas durante implementación:**
+
+- **Slug auto-trackea al nombre solo hasta que el usuario lo edita manualmente** (`slugTouched` flag). Patrón estándar de UX para evitar pisar la edición del usuario.
+- **Tablas separadas por grupo en vez de un solo table con headers de sección**: encabezados de columna repetidos (más visual ruido) pero el costo es bajo con N=4-5 empresas, y mantiene el componente `<EmpresaGroupTable>` simple/reutilizable.
+- **Empresas sin `tipo_contribuyente` van a "Otros"** sin forzar default a moral. Las 4 actuales ya tienen el default `'persona_moral'` por DEFAULT del schema; el grupo "Otros" cubre futuras categorizaciones (fideicomisos, entidades extranjeras) sin romper la UI.
+
+**Links:**
+
+- PR Sprint 3: TBD (se agregará al merge).


### PR DESCRIPTION
## Summary

Sprint 3 de la iniciativa **`empresas-csf-config`** — UI completa de alta nueva en `/settings/empresas`.

- Componente nuevo `<NuevaEmpresaDrawer>` con flujo de 4 estados:
  - **A — drop PDF** (dashed border, solo .pdf, máx 50 MB).
  - **B — processing** con loader (30-90s).
  - **C — preview + form**: campos extraídos visibles + `nombre` (default = nombre comercial / razón social) + `slug` (default = slugify del nombre, auto-track se desactiva al editar) + toggle persona moral / física.
  - **D — creating**: POST `/api/empresas/create-with-csf` → redirect a `/settings/empresas/{slug}`.
- Errores friendly:
  - `409 rfc_duplicado` → muestra link al detalle de la empresa existente.
  - `409 slug_duplicado` → invita a editar el slug.
- Lista de empresas agrupada en 3 tablas: **Personas Morales / Personas Físicas / Otros** con header de sección + contador. Empresas con `tipo_contribuyente = null` caen en "Otros".
- Empty state ahora invita a "Dar de alta la primera" empresa.

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓
- [x] `npm run format:check` ✓
- [x] `npm run test:run` (273 verdes) ✓
- [ ] Smoke en preview: abrir drawer y dropear un PDF de CSF nueva → verificar campos extraídos + redirect tras crear.
- [ ] Sprint 4 (operativo, **lo hace Beto**): subir CSF al día de RDB/DILESA/COAGAN/ANSA + capturar `registro_patronal_imss` faltantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)