### PR TITLE
fix(empresas-csf-config): quitar z.number().int() — Anthropic rechaza el schema

### DIFF
--- a/lib/proveedores/extract-csf.ts
+++ b/lib/proveedores/extract-csf.ts
@@ -56,7 +56,12 @@ export const ObligacionSchema = z.object({
 });
 
 export const ActividadEconomicaSchema = z.object({
-  orden: z.number().int().describe('Número de orden tal como aparece en la CSF (1, 2, 3...).'),
+  // NOTA: usamos `z.number()` sin `.int()` porque la API de Anthropic rechaza
+  // schemas `integer` con `minimum`/`maximum` que zod inyecta automáticamente
+  // (error: "output_config.format.schema: For 'integer' type, properties
+  // maximum, minimum are not supported"). El prompt instruye al modelo a
+  // devolver enteros 1, 2, 3...; en la práctica nunca llegan decimales.
+  orden: z.number().describe('Número de orden tal como aparece en la CSF (1, 2, 3...). Entero.'),
   actividad: z
     .string()
     .describe('Texto literal de la actividad económica tal como aparece en la CSF.'),


### PR DESCRIPTION
## Summary

Fix al schema del extractor CSF — Beto reportó al subir CSF de RDB:

> `output_config.format.schema: For 'integer' type, properties maximum, minimum are not supported`

**Causa raíz**: en Sprint 1 ([#269](https://github.com/beto-sudo/BSOP/pull/269)) agregué `orden: z.number().int()` al `ActividadEconomicaSchema`. Cuando AI SDK convierte zod → JSON Schema para enviar a Anthropic, `.int()` produce `type: 'integer'` con `minimum`/`maximum` (defaults internos de zod) que la API rechaza.

**Fix**: usar `z.number()` sin `.int()`. El prompt sigue instruyendo al modelo a devolver enteros (1, 2, 3...), y en la práctica el LLM no genera decimales para "orden de actividad". Comentario explicativo en el schema para que no se reintroduzca.

Tests existentes pasan tal cual (los fixtures usan números enteros).

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npx vitest run lib/proveedores/extract-csf.test.ts lib/empresas/csf-mapping.test.ts` (58 verdes) ✓
- [ ] **Beto re-prueba subir el CSF de RDB** una vez que el deploy de prod termine (~1-2 min). Debería avanzar a "Procesando con Claude..." y mostrar el diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)