### PR TITLE
feat(empresas-csf-config): editor de representante legal + escrituras (desbloquea alta de empleados)

### DIFF
--- a/app/api/empresas/[id]/route.test.ts
+++ b/app/api/empresas/[id]/route.test.ts
@@ -150,4 +150,62 @@ describe('PATCH /api/empresas/[id]', () => {
     const res = await PATCH(req, ctx);
     expect(res.status).toBe(400);
   });
+
+  it('200 con representante_legal capturado a mano', async () => {
+    const { req, ctx } = makeReq({
+      representante_legal: 'BETO SANTOS',
+    });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.fields_updated).toContain('representante_legal');
+  });
+
+  it('200 con escritura_constitutiva como jsonb completo', async () => {
+    const { req, ctx } = makeReq({
+      escritura_constitutiva: {
+        numero: '12345',
+        fecha: '2010-05-15',
+        fecha_texto: 'quince de mayo del dos mil diez',
+        notario: 'JUAN PÉREZ',
+        notaria_numero: '5',
+        distrito: 'PIEDRAS NEGRAS',
+      },
+    });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.fields_updated).toContain('escritura_constitutiva');
+  });
+
+  it('200 con escritura_poder parcial (campos opcionales)', async () => {
+    const { req, ctx } = makeReq({
+      escritura_poder: {
+        numero: '6789',
+        notario: 'MARÍA LÓPEZ',
+        notaria_numero: '12',
+        distrito: 'COAHUILA',
+        fecha_texto: 'tres de marzo del dos mil veintiuno',
+      },
+    });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it('200 con escritura como null limpia el jsonb completo', async () => {
+    const { req, ctx } = makeReq({ escritura_constitutiva: null });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it('400 si la escritura trae llaves desconocidas (strict)', async () => {
+    const { req, ctx } = makeReq({
+      escritura_constitutiva: {
+        numero: '1',
+        campo_random: 'x',
+      },
+    });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+  });
 });

--- a/app/api/empresas/[id]/route.ts
+++ b/app/api/empresas/[id]/route.ts
@@ -48,6 +48,35 @@ const editableText = z
   .union([z.string(), z.null()])
   .transform((v) => (v === '' || v == null ? null : v));
 
+// Escritura (constitutiva o poder): jsonb con 5 campos básicos requeridos por
+// `lib/rh/datos-fiscales-empresa.ts` para alta de empleados y contratos LFT.
+// Acepta objeto literal o `null` para limpiar la escritura completa.
+const escrituraJsonbSchema = z
+  .union([
+    z
+      .object({
+        numero: z.union([z.string(), z.null()]).optional(),
+        fecha: z.union([z.string(), z.null()]).optional(),
+        fecha_texto: z.union([z.string(), z.null()]).optional(),
+        notario: z.union([z.string(), z.null()]).optional(),
+        notaria_numero: z.union([z.string(), z.null()]).optional(),
+        distrito: z.union([z.string(), z.null()]).optional(),
+      })
+      .strict(),
+    z.null(),
+  ])
+  .transform((obj) => {
+    if (obj == null) return null;
+    // Normaliza '' → null en cada campo y descarta la escritura completa si
+    // todos los campos quedaron vacíos (mejor null que jsonb con todo blank).
+    const norm: Record<string, string | null> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      norm[k] = v == null || v === '' ? null : v;
+    }
+    const allBlank = Object.values(norm).every((v) => v == null);
+    return allBlank ? null : norm;
+  });
+
 const PayloadSchema = z
   .object({
     registro_patronal_imss: RegistroPatronalSchema.optional(),
@@ -71,6 +100,11 @@ const PayloadSchema = z
     domicilio_municipio: editableText.optional(),
     domicilio_estado: editableText.optional(),
     domicilio_cp: editableText.optional(),
+    // Datos legales para alta de empleados (validados por
+    // `lib/rh/datos-fiscales-empresa.ts`).
+    representante_legal: editableText.optional(),
+    escritura_constitutiva: escrituraJsonbSchema.optional(),
+    escritura_poder: escrituraJsonbSchema.optional(),
   })
   .strict();
 

--- a/app/settings/empresas/[slug]/page.tsx
+++ b/app/settings/empresas/[slug]/page.tsx
@@ -37,6 +37,7 @@ const SELECT_COLS = [
   'domicilio_localidad, domicilio_municipio, domicilio_estado, actividades_economicas,',
   'obligaciones_fiscales, csf_fecha_emision, csf_url,',
   'tipo_contribuyente, curp, registro_patronal_imss,',
+  'representante_legal, escritura_constitutiva, escritura_poder,',
   'color_primario, color_primario_dark, color_secundario, color_texto_titulo,',
   'color_fondo_brand, color_inverso, logo_master_url, logo_horizontal_light_url,',
   'logo_horizontal_dark_url, logo_vertical_url, isotipo_url, favicon_url,',

--- a/app/settings/empresas/_components/empresa-detail.tsx
+++ b/app/settings/empresas/_components/empresa-detail.tsx
@@ -38,6 +38,19 @@ export type ObligacionFiscal = {
   fecha_fin: string | null;
 };
 
+/**
+ * Forma de `core.empresas.escritura_constitutiva` y `escritura_poder` (jsonb).
+ * Validado por `lib/rh/datos-fiscales-empresa.ts` para alta de empleados.
+ */
+export type EscrituraJsonb = {
+  numero?: string | null;
+  fecha?: string | null;
+  fecha_texto?: string | null;
+  notario?: string | null;
+  notaria_numero?: string | null;
+  distrito?: string | null;
+};
+
 export type Empresa = {
   id: string;
   nombre: string;
@@ -68,6 +81,34 @@ export type Empresa = {
   tipo_contribuyente: 'persona_moral' | 'persona_fisica' | null;
   curp: string | null;
   registro_patronal_imss: string | null;
+  representante_legal: string | null;
+  escritura_constitutiva: EscrituraJsonb | null;
+  escritura_poder: EscrituraJsonb | null;
+};
+
+const ESCRITURA_FIELD_KEYS = [
+  'numero',
+  'fecha_texto',
+  'notario',
+  'notaria_numero',
+  'distrito',
+] as const;
+type EscrituraFieldKey = (typeof ESCRITURA_FIELD_KEYS)[number];
+
+const ESCRITURA_LABELS: Record<EscrituraFieldKey, string> = {
+  numero: 'Número de escritura',
+  fecha_texto: 'Fecha (texto legible)',
+  notario: 'Notario',
+  notaria_numero: 'Número de notaría',
+  distrito: 'Distrito notarial',
+};
+
+const ESCRITURA_PLACEHOLDERS: Record<EscrituraFieldKey, string> = {
+  numero: '12345',
+  fecha_texto: 'quince de mayo del dos mil diez',
+  notario: 'JUAN PÉREZ',
+  notaria_numero: '5',
+  distrito: 'PIEDRAS NEGRAS',
 };
 
 // ─── Diff helpers (espejados del patrón de proveedores) ───────────────────
@@ -313,11 +354,25 @@ const EDITABLE_FIELDS = [
   'domicilio_estado',
   'domicilio_cp',
   'registro_patronal_imss',
+  'representante_legal',
 ] as const;
 
 type EditableField = (typeof EDITABLE_FIELDS)[number];
 
-type EditableValues = Record<EditableField, string>;
+type EditableValues = Record<EditableField, string> & {
+  escritura_constitutiva: Record<EscrituraFieldKey, string>;
+  escritura_poder: Record<EscrituraFieldKey, string>;
+};
+
+function buildEscrituraEditValues(src: EscrituraJsonb | null): Record<EscrituraFieldKey, string> {
+  return {
+    numero: src?.numero ?? '',
+    fecha_texto: src?.fecha_texto ?? src?.fecha ?? '',
+    notario: src?.notario ?? '',
+    notaria_numero: src?.notaria_numero ?? '',
+    distrito: src?.distrito ?? '',
+  };
+}
 
 function buildInitialEditValues(empresa: Empresa): EditableValues {
   return {
@@ -340,7 +395,52 @@ function buildInitialEditValues(empresa: Empresa): EditableValues {
     domicilio_estado: empresa.domicilio_estado ?? '',
     domicilio_cp: empresa.domicilio_cp ?? '',
     registro_patronal_imss: empresa.registro_patronal_imss ?? '',
+    representante_legal: empresa.representante_legal ?? '',
+    escritura_constitutiva: buildEscrituraEditValues(empresa.escritura_constitutiva),
+    escritura_poder: buildEscrituraEditValues(empresa.escritura_poder),
   };
+}
+
+function EscrituraCard({
+  title,
+  values,
+  editing,
+  onChange,
+  original,
+}: {
+  title: string;
+  values: Record<EscrituraFieldKey, string>;
+  editing: boolean;
+  onChange: (field: EscrituraFieldKey, value: string) => void;
+  original: EscrituraJsonb | null;
+}) {
+  const isEmpty = !original || Object.values(original).every((v) => v == null || v === '');
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--panel)]/30 p-4 space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <h5 className="text-sm font-semibold text-[var(--text)]">{title}</h5>
+        {!editing && isEmpty && (
+          <span className="text-[10px] uppercase tracking-wider text-amber-400 bg-amber-500/10 border border-amber-500/30 rounded px-2 py-0.5">
+            Sin capturar
+          </span>
+        )}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {ESCRITURA_FIELD_KEYS.map((field) => (
+          <div key={field} className={field === 'fecha_texto' ? 'sm:col-span-2' : ''}>
+            <EditableTextField
+              label={ESCRITURA_LABELS[field]}
+              value={values[field]}
+              editing={editing}
+              onChange={(v) => onChange(field, v)}
+              placeholder={ESCRITURA_PLACEHOLDERS[field]}
+              monospace={field === 'numero' || field === 'notaria_numero'}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function EditableTextField({
@@ -467,6 +567,17 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
     setEditValues((prev) => ({ ...prev, [key]: value }));
   };
 
+  const setEscrituraField = (
+    which: 'escritura_constitutiva' | 'escritura_poder',
+    field: EscrituraFieldKey,
+    value: string
+  ) => {
+    setEditValues((prev) => ({
+      ...prev,
+      [which]: { ...prev[which], [field]: value },
+    }));
+  };
+
   const handleStartEdit = () => {
     setEditValues(buildInitialEditValues(empresa));
     setEditError(null);
@@ -480,8 +591,11 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
   };
 
   // Diff entre edición y empresa original. Solo manda al server lo que cambió.
-  const editPatch = useMemo<Partial<Record<EditableField, string | null>>>(() => {
-    const patch: Partial<Record<EditableField, string | null>> = {};
+  // Para los jsonb de escrituras, comparamos los 5 campos contra el original
+  // y mandamos el objeto entero si algo cambió (más simple y suficiente para
+  // este uso — son metadatos pequeños).
+  const editPatch = useMemo<Record<string, string | null | Record<string, string | null>>>(() => {
+    const patch: Record<string, string | null | Record<string, string | null>> = {};
     for (const key of EDITABLE_FIELDS) {
       const current = (empresa[key as keyof Empresa] ?? '') as string;
       const next = editValues[key];
@@ -489,6 +603,25 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
         patch[key] = next.trim() === '' ? null : next.trim();
       }
     }
+
+    const escriturasFromEmpresa = {
+      escritura_constitutiva: buildEscrituraEditValues(empresa.escritura_constitutiva),
+      escritura_poder: buildEscrituraEditValues(empresa.escritura_poder),
+    } as const;
+
+    for (const which of ['escritura_constitutiva', 'escritura_poder'] as const) {
+      const original = escriturasFromEmpresa[which];
+      const edited = editValues[which];
+      const changed = ESCRITURA_FIELD_KEYS.some((f) => (original[f] ?? '') !== (edited[f] ?? ''));
+      if (changed) {
+        const obj: Record<string, string | null> = {};
+        for (const f of ESCRITURA_FIELD_KEYS) {
+          obj[f] = edited[f].trim() === '' ? null : edited[f].trim();
+        }
+        patch[which] = obj;
+      }
+    }
+
     return patch;
   }, [editValues, empresa]);
 
@@ -824,6 +957,35 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
               maxLength={11}
               errorMessage={rpInputInvalid ? 'Formato: 1 letra + 10 dígitos.' : null}
             />
+            <div className="sm:col-span-2">
+              <EditableTextField
+                label="Representante Legal"
+                value={editValues.representante_legal}
+                editing={editing}
+                onChange={(v) => setEditField('representante_legal', v)}
+                placeholder="Nombre completo del representante legal"
+              />
+            </div>
+          </div>
+        )}
+        {/* Si solo hay registro_patronal o representante_legal en read-only sin
+            CURP (caso típico para personas morales del grupo), mostrarlos. */}
+        {!editing && empresa.tipo_contribuyente !== 'persona_fisica' && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <EditableTextField
+              label="Registro Patronal IMSS"
+              value={editValues.registro_patronal_imss}
+              editing={false}
+              onChange={() => undefined}
+            />
+            <div className="sm:col-span-2">
+              <EditableTextField
+                label="Representante Legal"
+                value={editValues.representante_legal}
+                editing={false}
+                onChange={() => undefined}
+              />
+            </div>
           </div>
         )}
       </div>
@@ -890,6 +1052,32 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
             maxLength={5}
           />
         </div>
+      </div>
+
+      {/* Documentos legales (alta de empleados) */}
+      <div className="space-y-4">
+        <SectionTitle>Documentos legales — alta de empleados</SectionTitle>
+        <p className="text-xs text-[var(--text-muted)] -mt-2">
+          Requeridos por <code>lib/rh/datos-fiscales-empresa.ts</code> para dar de alta empleados,
+          generar contratos LFT y finiquitos. Los datos viven como JSON en{' '}
+          <code>core.empresas.escritura_constitutiva</code> y <code>escritura_poder</code>.
+        </p>
+
+        <EscrituraCard
+          title="Escritura constitutiva"
+          values={editValues.escritura_constitutiva}
+          editing={editing}
+          onChange={(field, v) => setEscrituraField('escritura_constitutiva', field, v)}
+          original={empresa.escritura_constitutiva}
+        />
+
+        <EscrituraCard
+          title="Poder del representante"
+          values={editValues.escritura_poder}
+          editing={editing}
+          onChange={(field, v) => setEscrituraField('escritura_poder', field, v)}
+          original={empresa.escritura_poder}
+        />
       </div>
 
       {/* Actividades económicas */}


### PR DESCRIPTION
## Summary

Beto reportó al hacer Sprint 4 que `/rdb/rh/personal` sigue bloqueando "Nuevo empleado" con leyenda:

> No se pueden crear empleados todavía. La empresa tiene datos fiscales incompletos en BSOP. Faltan: Representante legal, Domicilio: colonia, Escritura constitutiva, Poder del representante.

La validación vive en [`lib/rh/datos-fiscales-empresa.ts`](https://github.com/beto-sudo/BSOP/blob/main/lib/rh/datos-fiscales-empresa.ts) y exige 3 campos que no estaban en el editor de [/settings/empresas/[slug]](https://github.com/beto-sudo/BSOP/blob/main/app/settings/empresas/%5Bslug%5D/page.tsx). Este PR los agrega.

### Endpoint

`PATCH /api/empresas/[id]` ahora también acepta:
- `representante_legal` — `editableText` (string libre).
- `escritura_constitutiva` — jsonb strict con `{numero, fecha, fecha_texto, notario, notaria_numero, distrito}`. Cadena vacía → `null` por campo; si todos quedan blank, la escritura se persiste como `null`.
- `escritura_poder` — idéntico shape.

### UI

- **Modo edit**: nuevo campo "Representante Legal" debajo de CURP / registro patronal (2 columnas).
- **Modo read-only para personas morales**: ahora muestra registro patronal + representante legal aunque no tengan CURP.
- **Sección nueva "Documentos legales — alta de empleados"** con dos cards (`<EscrituraCard>`): Escritura constitutiva y Poder del representante. Cada una con los 5 campos requeridos. Badge `Sin capturar` cuando la escritura está vacía.

`domicilio_colonia` ya era editable; se llena con el botón Editar.

### Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓ (0 errors)
- [x] `npm run format:check` ✓
- [x] `npm run test:run` (521 verdes, +5 casos para PATCH) ✓
- [ ] Beto: en RDB, click "Editar" → captura representante legal + colonia + las dos escrituras → "Guardar". Después ir a `/rdb/rh/personal` y verificar que el botón "Nuevo empleado" se habilita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)