### PR TITLE
feat(empresa-documentos-legales): Sprint 2 — extracción IA llena subtipo_meta de escrituras

### DIFF
--- a/app/api/documentos/[id]/extract/route.ts
+++ b/app/api/documentos/[id]/extract/route.ts
@@ -200,6 +200,11 @@ export async function POST(_req: NextRequest, { params }: Params) {
       folio_real: extraccion.folio_real,
       libro_tomo: extraccion.libro_tomo,
       partes: extraccion.partes,
+      // subtipo_meta: solo se llena si el doc es escritura/poder/acta. Para
+      // otros tipos (factura, contrato laboral, comprobante) la IA pone null.
+      // Consumido por el sync_trigger de core.empresa_documentos para llenar
+      // el caché jsonb en core.empresas.escritura_*.
+      subtipo_meta: extraccion.subtipo_meta,
       extraccion_status: 'completado',
       extraccion_fecha: new Date().toISOString(),
       extraccion_modelo: MODELO_CLAUDE,

--- a/lib/documentos/extraction-core.test.ts
+++ b/lib/documentos/extraction-core.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+
+import { ExtraccionSchema, ParteSchema, SubtipoMetaEscrituraSchema } from './extraction-core';
+
+/**
+ * Tests del schema Zod del extractor de documentos legales.
+ *
+ * No prueban la llamada a Claude (eso vive como integration test fuera de
+ * la suite unitaria) — solo el shape de los datos que entran/salen.
+ *
+ * Sprint 2 — empresa-documentos-legales agregó `subtipo_meta`. Estos
+ * tests cubren el shape nuevo.
+ */
+
+const baseExtraccionPayload = {
+  descripcion: 'Resumen del doc',
+  contenido_texto: 'Texto completo del documento.',
+  tipo_operacion: 'compraventa',
+  monto: 1500000,
+  moneda: 'MXN',
+  superficie_m2: null,
+  ubicacion_predio: null,
+  municipio: 'Piedras Negras',
+  estado: 'Coahuila',
+  folio_real: null,
+  libro_tomo: null,
+  partes: [],
+  fecha_emision: '2024-03-15',
+  numero_documento: '12345',
+};
+
+describe('ExtraccionSchema — subtipo_meta opcional', () => {
+  it('parsea con subtipo_meta = null para docs no notariales', () => {
+    const input = { ...baseExtraccionPayload, subtipo_meta: null };
+    const parsed = ExtraccionSchema.parse(input);
+    expect(parsed.subtipo_meta).toBeNull();
+  });
+
+  it('parsea con subtipo_meta poblado para una escritura constitutiva', () => {
+    const input = {
+      ...baseExtraccionPayload,
+      tipo_operacion: 'constitutiva',
+      subtipo_meta: {
+        numero_escritura: '12345',
+        fecha_escritura: '2010-05-15',
+        fecha_texto: 'quince de mayo del dos mil diez',
+        notario_nombre: 'JUAN PÉREZ',
+        notaria_numero: '5',
+        distrito_notarial: 'PIEDRAS NEGRAS',
+        tipo_poder: null,
+        alcance: null,
+      },
+    };
+    const parsed = ExtraccionSchema.parse(input);
+    expect(parsed.subtipo_meta?.numero_escritura).toBe('12345');
+    expect(parsed.subtipo_meta?.fecha_escritura).toBe('2010-05-15');
+    expect(parsed.subtipo_meta?.notario_nombre).toBe('JUAN PÉREZ');
+    expect(parsed.subtipo_meta?.tipo_poder).toBeNull();
+  });
+
+  it('parsea subtipo_meta de un poder con tipo_poder + alcance', () => {
+    const input = {
+      ...baseExtraccionPayload,
+      tipo_operacion: 'poder',
+      subtipo_meta: {
+        numero_escritura: '6789',
+        fecha_escritura: '2021-03-03',
+        fecha_texto: null,
+        notario_nombre: 'MARÍA LÓPEZ',
+        notaria_numero: '12',
+        distrito_notarial: 'COAHUILA',
+        tipo_poder: 'general para actos de administracion',
+        alcance: 'contratación laboral, IMSS, SAT, contratos comerciales generales',
+      },
+    };
+    const parsed = ExtraccionSchema.parse(input);
+    expect(parsed.subtipo_meta?.tipo_poder).toBe('general para actos de administracion');
+    expect(parsed.subtipo_meta?.alcance).toContain('IMSS');
+  });
+
+  it('rechaza si subtipo_meta omite un campo del shape (debe ser explícito null)', () => {
+    const input = {
+      ...baseExtraccionPayload,
+      subtipo_meta: {
+        // falta numero_escritura, fecha_escritura, fecha_texto, etc.
+        notario_nombre: 'X',
+      },
+    };
+    expect(() => ExtraccionSchema.parse(input)).toThrow();
+  });
+});
+
+describe('SubtipoMetaEscrituraSchema standalone', () => {
+  it('null es válido (doc no notarial)', () => {
+    expect(SubtipoMetaEscrituraSchema.parse(null)).toBeNull();
+  });
+
+  it('todos los campos pueden ser null individualmente', () => {
+    const allNull = {
+      numero_escritura: null,
+      fecha_escritura: null,
+      fecha_texto: null,
+      notario_nombre: null,
+      notaria_numero: null,
+      distrito_notarial: null,
+      tipo_poder: null,
+      alcance: null,
+    };
+    const parsed = SubtipoMetaEscrituraSchema.parse(allNull);
+    expect(parsed).toEqual(allNull);
+  });
+
+  it('todos los campos son string-or-null (no number, no boolean)', () => {
+    const input = {
+      numero_escritura: 12345 as unknown as string,
+      fecha_escritura: null,
+      fecha_texto: null,
+      notario_nombre: null,
+      notaria_numero: null,
+      distrito_notarial: null,
+      tipo_poder: null,
+      alcance: null,
+    };
+    expect(() => SubtipoMetaEscrituraSchema.parse(input)).toThrow();
+  });
+});
+
+describe('ParteSchema — sigue intacto tras Sprint 2', () => {
+  it('parsea una parte moral con representante', () => {
+    const parsed = ParteSchema.parse({
+      rol: 'vendedor',
+      nombre: 'AUTOS DEL NORTE, SA DE CV',
+      rfc: 'ANO850924XXX',
+      representante: 'ADALBERTO SANTOS',
+    });
+    expect(parsed.representante).toBe('ADALBERTO SANTOS');
+  });
+
+  it('parsea una parte física sin RFC', () => {
+    const parsed = ParteSchema.parse({
+      rol: 'comprador',
+      nombre: 'JUAN PÉREZ',
+      rfc: null,
+      representante: null,
+    });
+    expect(parsed.rfc).toBeNull();
+  });
+});

--- a/lib/documentos/extraction-core.ts
+++ b/lib/documentos/extraction-core.ts
@@ -59,6 +59,81 @@ export const ParteSchema = z.object({
     .describe('Nombre del representante legal si la parte es una persona moral, si no null.'),
 });
 
+/**
+ * Metadata específica para escrituras notariales mexicanas (constitutivas,
+ * reformas, poderes, compraventas, etc.). Se persiste en
+ * `erp.documentos.subtipo_meta` (jsonb) y la consume:
+ *
+ *   - El sync_trigger de `core.empresa_documentos` (lo proyecta al jsonb
+ *     caché en `core.empresas.escritura_constitutiva` / `escritura_poder`).
+ *   - El validador de RH `lib/rh/datos-fiscales-empresa.ts` (vía caché).
+ *   - El printable de contrato laboral (vía caché).
+ *
+ * Solo se llena cuando el documento es una escritura/acta/poder. Para otros
+ * tipos (factura, contrato laboral, comprobante de domicilio), debe quedar
+ * null. La IA decide en función de `tipo_operacion`.
+ */
+export const SubtipoMetaEscrituraSchema = z
+  .object({
+    numero_escritura: z
+      .string()
+      .nullable()
+      .describe('Número de la escritura tal como aparece (ej. "12,345" o "12345"). null si no.'),
+    fecha_escritura: z
+      .string()
+      .nullable()
+      .describe('Fecha de otorgamiento en formato YYYY-MM-DD. null si no se puede determinar.'),
+    fecha_texto: z
+      .string()
+      .nullable()
+      .describe(
+        'Fecha en texto legible tal como aparece en el cuerpo del instrumento ' +
+          '(ej. "quince de mayo del dos mil diez"). Útil para reproducir literal en contratos. null si no.'
+      ),
+    notario_nombre: z
+      .string()
+      .nullable()
+      .describe(
+        'Nombre completo del notario público que da fe (ej. "JUAN PÉREZ LÓPEZ"). null si no.'
+      ),
+    notaria_numero: z
+      .string()
+      .nullable()
+      .describe('Número de la notaría (texto, ej. "5" o "Cinco"). null si no aparece.'),
+    distrito_notarial: z
+      .string()
+      .nullable()
+      .describe(
+        'Distrito notarial / municipio donde ejerce el notario ' +
+          '(ej. "PIEDRAS NEGRAS", "DISTRITO FEDERAL"). null si no aparece.'
+      ),
+    // Campos extras útiles para poderes (auto-sugerir rol al asignar en UI)
+    tipo_poder: z
+      .string()
+      .nullable()
+      .describe(
+        'Solo para poderes: clase de poder otorgado, en minúsculas y sin acentos: ' +
+          '"general para actos de administracion", "general para actos de dominio", ' +
+          '"general para pleitos y cobranzas", "especial para actos bancarios", etc. ' +
+          'null si no es poder o no se puede determinar.'
+      ),
+    alcance: z
+      .string()
+      .nullable()
+      .describe(
+        'Solo para poderes: resumen breve del alcance/facultades otorgadas ' +
+          '(ej. "contratación laboral, IMSS, SAT, contratos comerciales generales"). ' +
+          'null si no es poder.'
+      ),
+  })
+  .nullable()
+  .describe(
+    'Metadata específica de escrituras notariales (constitutiva, reforma, poder, ' +
+      'compraventa, etc.). Llenar SOLO si tipo_operacion es uno de estos: ' +
+      'escritura, constitutiva, reforma, acta, poder, compraventa, hipoteca, fideicomiso, ' +
+      'donacion, permuta. Para facturas, contratos laborales, comprobantes y demás → null.'
+  );
+
 export const ExtraccionSchema = z.object({
   descripcion: z
     .string()
@@ -111,6 +186,7 @@ export const ExtraccionSchema = z.object({
     .string()
     .nullable()
     .describe('Número del documento (escritura, acta, póliza, etc.) tal cual aparece. null si no.'),
+  subtipo_meta: SubtipoMetaEscrituraSchema,
 });
 
 export type Extraccion = z.infer<typeof ExtraccionSchema>;
@@ -267,7 +343,18 @@ export async function extractWithClaude(pdfBytes: Uint8Array, titulo: string): P
               `Para campos numéricos (monto, superficie_m2), si el valor aparece ` +
               `en letra o con formato raro, conviértelo a número o usa null si no es claro. ` +
               `Usa null para cualquier campo estructurado que no puedas determinar con ` +
-              `certeza, en vez de inventar o poner strings genéricas.`,
+              `certeza, en vez de inventar o poner strings genéricas. ` +
+              `\n\nIMPORTANTE — campo "subtipo_meta": ` +
+              `Si el documento es una escritura notarial mexicana (constitutiva, reforma, ` +
+              `poder, compraventa, hipoteca, fideicomiso, donación, permuta, acta), llena los ` +
+              `campos del subtipo_meta con los datos del notario y de la escritura: número de ` +
+              `escritura, fecha (en formato YYYY-MM-DD y también en texto legible cuando aparezca ` +
+              `en el cuerpo del instrumento), nombre del notario, número de notaría, distrito ` +
+              `notarial. Si es un PODER, además llena tipo_poder (en minúsculas, sin acentos: ` +
+              `"general para actos de administracion", "general para actos de dominio", ` +
+              `"general para pleitos y cobranzas", "especial para actos bancarios", etc.) y ` +
+              `alcance (resumen breve de facultades). Para documentos NO notariales (facturas, ` +
+              `contratos laborales, comprobantes, declaraciones, etc.), subtipo_meta debe ser null.`,
           },
           {
             type: 'file',


### PR DESCRIPTION
## Summary

Sprint 2 — el extractor de `erp.documentos` ahora puebla `subtipo_meta` con los datos notariales que el sync_trigger de Sprint 1 necesita.

**Antes**: la extracción IA producía metadata genérica (numero_documento, fecha_emision, partes, etc.) pero `subtipo_meta` quedaba `null` para todos los docs. Eso significaba que asignar una escritura al rol `acta_constitutiva` no llenaba el caché jsonb en `core.empresas.escritura_constitutiva` → `lib/rh/datos-fiscales-empresa.ts` seguía bloqueando alta de empleados.

**Ahora**: nuevo `SubtipoMetaEscrituraSchema` con 8 campos:
- `numero_escritura`, `fecha_escritura` (ISO), `fecha_texto` (legible)
- `notario_nombre`, `notaria_numero`, `distrito_notarial`
- `tipo_poder` (solo poderes — auto-sugerir rol al asignar en Sprint 4)
- `alcance` (solo poderes — facultades otorgadas)

El schema es nullable: docs no notariales lo dejan `null`. La IA decide en función de `tipo_operacion`. Prompt extendido con instrucción explícita.

`subtipo_meta` se persiste a `erp.documentos.subtipo_meta` en `app/api/documentos/[id]/extract/route.ts`. El sync_trigger de `core.empresa_documentos` (Sprint 1) lo lee y proyecta al caché → cierra el ciclo end-to-end.

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓ (0 errors)
- [x] `npm run format:check` ✓
- [x] `npm run test:run` (545 verdes; +9 casos para `extraction-core.test.ts`) ✓

## Pendiente operativo (Sprint 5)

Documentos ya extraídos antes de este Sprint NO tienen `subtipo_meta` poblado. Para que el sync_trigger los procese al asignar, hay que re-extraer:
- DILESA: tiene docs cargados; correr `POST /api/documentos/[id]/extract` sobre los legales (Beto desde la UI o vía script).
- RDB/ANSA/COAGAN: subir docs nuevos, la extracción ya genera `subtipo_meta` por defecto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)