### PR TITLE
feat(empresa-documentos-legales): Sprint 3 — API endpoints /api/empresas/[id]/documentos

### DIFF
--- a/app/api/empresas/[id]/documentos/[asignacion_id]/route.test.ts
+++ b/app/api/empresas/[id]/documentos/[asignacion_id]/route.test.ts
@@ -1,0 +1,213 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- Test fixtures for fluent mocks. */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+let serverUser: { email: string } | null = null;
+let adminAvailable = true;
+
+type Script = {
+  callerUser?: { id: string; email: string; rol: string; activo: boolean } | null;
+  asignacion?: { id: string; empresa_id: string; rol: string; es_default: boolean } | null;
+  updateResult?: { error: { message: string } | null };
+  deleteResult?: { error: { message: string } | null };
+};
+
+let script: Script = {};
+
+function buildAdmin(): any {
+  return {
+    schema(_schemaName: string) {
+      return {
+        from(_tableName: string) {
+          let pendingUpdate: unknown = null;
+          let pendingDelete = false;
+
+          const builder: any = {
+            select() {
+              return builder;
+            },
+            update(row: unknown) {
+              pendingUpdate = row;
+              return builder;
+            },
+            delete() {
+              pendingDelete = true;
+              return builder;
+            },
+            eq() {
+              return builder;
+            },
+            async maybeSingle() {
+              // Las dos lookups del PATCH/DELETE son: core.usuarios y
+              // core.empresa_documentos. El fluent mock no distingue tabla
+              // aquí, devuelve por orden de llamada usando un counter.
+              counter += 1;
+              if (counter === 1) return { data: script.callerUser ?? null, error: null };
+              if (counter === 2) return { data: script.asignacion ?? null, error: null };
+              return { data: null, error: null };
+            },
+            then(onF: (r: any) => unknown, onR?: (r: unknown) => unknown) {
+              const result = pendingDelete
+                ? (script.deleteResult ?? { data: null, error: null })
+                : pendingUpdate
+                  ? (script.updateResult ?? { data: null, error: null })
+                  : { data: null, error: null };
+              return Promise.resolve(result).then(onF, onR);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+let counter = 0;
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: serverUser } }) },
+  }),
+}));
+
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdminClient: () => (adminAvailable ? buildAdmin() : null),
+}));
+
+import { PATCH, DELETE } from './route';
+
+beforeEach(() => {
+  counter = 0;
+  serverUser = { email: 'admin@example.com' };
+  script = {
+    callerUser: { id: 'admin-uuid', email: 'admin@example.com', rol: 'admin', activo: true },
+    asignacion: { id: 'asg1', empresa_id: 'e1', rol: 'acta_constitutiva', es_default: false },
+    updateResult: { error: null },
+    deleteResult: { error: null },
+  };
+  adminAvailable = true;
+});
+
+function makeReq(method: 'PATCH' | 'DELETE', body?: unknown, id = 'e1', asignacionId = 'asg1') {
+  const req = new NextRequest(
+    new URL(`http://localhost/api/empresas/${id}/documentos/${asignacionId}`),
+    {
+      method,
+      headers: body ? { 'content-type': 'application/json' } : undefined,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    }
+  );
+  return { req, ctx: { params: Promise.resolve({ id, asignacion_id: asignacionId }) } };
+}
+
+describe('PATCH /api/empresas/[id]/documentos/[asignacion_id]', () => {
+  it('401 sin user', async () => {
+    serverUser = null;
+    const { req, ctx } = makeReq('PATCH', { es_default: true });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si caller no es admin', async () => {
+    script.callerUser = { id: 'u1', email: 'x@y.com', rol: 'usuario', activo: true };
+    const { req, ctx } = makeReq('PATCH', { es_default: true });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('400 si body trae llaves desconocidas', async () => {
+    const { req, ctx } = makeReq('PATCH', { es_default: true, extra: 'x' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('400 si body vacío', async () => {
+    const { req, ctx } = makeReq('PATCH', {});
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('404 si la asignación no existe', async () => {
+    script.asignacion = null;
+    const { req, ctx } = makeReq('PATCH', { es_default: true });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('403 si la asignación pertenece a otra empresa', async () => {
+    script.asignacion = {
+      id: 'asg1',
+      empresa_id: 'OTRA',
+      rol: 'acta_constitutiva',
+      es_default: false,
+    };
+    const { req, ctx } = makeReq('PATCH', { es_default: true });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('200 al cambiar es_default=true', async () => {
+    const { req, ctx } = makeReq('PATCH', { es_default: true });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.fields_updated).toContain('es_default');
+  });
+
+  it('200 al actualizar solo notas', async () => {
+    const { req, ctx } = makeReq('PATCH', { notas: 'doc legacy migrado de Coda' });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it('200 al limpiar notas con null', async () => {
+    const { req, ctx } = makeReq('PATCH', { notas: null });
+    const res = await PATCH(req, ctx);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('DELETE /api/empresas/[id]/documentos/[asignacion_id]', () => {
+  it('401 sin user', async () => {
+    serverUser = null;
+    const { req, ctx } = makeReq('DELETE');
+    const res = await DELETE(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si caller no es admin', async () => {
+    script.callerUser = { id: 'u1', email: 'x@y.com', rol: 'usuario', activo: true };
+    const { req, ctx } = makeReq('DELETE');
+    const res = await DELETE(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('404 si la asignación no existe', async () => {
+    script.asignacion = null;
+    const { req, ctx } = makeReq('DELETE');
+    const res = await DELETE(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('403 si la asignación pertenece a otra empresa', async () => {
+    script.asignacion = {
+      id: 'asg1',
+      empresa_id: 'OTRA',
+      rol: 'acta_constitutiva',
+      es_default: false,
+    };
+    const { req, ctx } = makeReq('DELETE');
+    const res = await DELETE(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('200 al borrar', async () => {
+    const { req, ctx } = makeReq('DELETE');
+    const res = await DELETE(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.deleted).toBe(true);
+  });
+});

--- a/app/api/empresas/[id]/documentos/[asignacion_id]/route.ts
+++ b/app/api/empresas/[id]/documentos/[asignacion_id]/route.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa `public`; para `core` usamos `as any`.
+ */
+
+/**
+ * PATCH /api/empresas/[id]/documentos/[asignacion_id]
+ * DELETE /api/empresas/[id]/documentos/[asignacion_id]
+ *
+ * Sprint 3 — iniciativa `empresa-documentos-legales`.
+ *
+ * PATCH actualiza es_default y/o notas de una asignación existente. Si pasa
+ * es_default=true, baja el flag de los demás docs del mismo rol antes del
+ * UPDATE (atomicidad por partial UNIQUE index).
+ *
+ * DELETE desasigna (hard delete del row). Importante: solo borra la
+ * asignación — el documento original en `erp.documentos` queda intacto.
+ *
+ * El sync_trigger en DB se encarga de actualizar el caché jsonb en
+ * `core.empresas.escritura_*` cuando cambia el es_default de los roles
+ * `acta_constitutiva` o `poder_general_administracion`.
+ *
+ * Solo admin.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { requireAdmin } from '@/lib/empresas/admin-guard';
+
+export const runtime = 'nodejs';
+
+const PatchBodySchema = z
+  .object({
+    es_default: z.boolean().optional(),
+    notas: z.union([z.string(), z.null()]).optional(),
+  })
+  .strict();
+
+type Params = { params: Promise<{ id: string; asignacion_id: string }> };
+
+// ─── PATCH ─────────────────────────────────────────────────────────────────
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const { id: empresaId, asignacion_id: asignacionId } = await params;
+
+  const userSupa = await createSupabaseServerClient();
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const guard = await requireAdmin(userSupa, admin);
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `body JSON inválido: ${msg}` }, { status: 400 });
+  }
+
+  let payload;
+  try {
+    payload = PatchBodySchema.parse(body);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  if (Object.keys(payload).length === 0) {
+    return NextResponse.json({ error: 'No hay campos para actualizar.' }, { status: 400 });
+  }
+
+  // Verifica que la asignación existe y pertenece a la empresa.
+  const { data: asignacion, error: lookupErr } = await (admin.schema('core') as any)
+    .from('empresa_documentos')
+    .select('id, empresa_id, rol, es_default')
+    .eq('id', asignacionId)
+    .maybeSingle();
+  if (lookupErr) {
+    return NextResponse.json({ error: `lookup asignacion: ${lookupErr.message}` }, { status: 500 });
+  }
+  if (!asignacion) {
+    return NextResponse.json({ error: 'Asignación no encontrada.' }, { status: 404 });
+  }
+  if (asignacion.empresa_id !== empresaId) {
+    return NextResponse.json({ error: 'La asignación pertenece a otra empresa.' }, { status: 403 });
+  }
+
+  // Si va a setear es_default=true y aún no lo está, primero baja el flag
+  // del actual default para evitar choque con el partial UNIQUE.
+  if (payload.es_default === true && !asignacion.es_default) {
+    const { error: clearErr } = await (admin.schema('core') as any)
+      .from('empresa_documentos')
+      .update({ es_default: false, updated_at: new Date().toISOString() })
+      .eq('empresa_id', empresaId)
+      .eq('rol', asignacion.rol)
+      .eq('es_default', true);
+    if (clearErr) {
+      return NextResponse.json(
+        { error: `clear default previo: ${clearErr.message}` },
+        { status: 500 }
+      );
+    }
+  }
+
+  const updates: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+  if ('es_default' in payload) updates.es_default = payload.es_default;
+  if ('notas' in payload) updates.notas = payload.notas;
+
+  const { error: updErr } = await (admin.schema('core') as any)
+    .from('empresa_documentos')
+    .update(updates)
+    .eq('id', asignacionId);
+
+  if (updErr) {
+    return NextResponse.json({ error: `update: ${updErr.message}` }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    asignacion_id: asignacionId,
+    fields_updated: Object.keys(updates).filter((k) => k !== 'updated_at'),
+  });
+}
+
+// ─── DELETE ────────────────────────────────────────────────────────────────
+
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  const { id: empresaId, asignacion_id: asignacionId } = await params;
+
+  const userSupa = await createSupabaseServerClient();
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const guard = await requireAdmin(userSupa, admin);
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  const { data: asignacion, error: lookupErr } = await (admin.schema('core') as any)
+    .from('empresa_documentos')
+    .select('id, empresa_id')
+    .eq('id', asignacionId)
+    .maybeSingle();
+  if (lookupErr) {
+    return NextResponse.json({ error: `lookup asignacion: ${lookupErr.message}` }, { status: 500 });
+  }
+  if (!asignacion) {
+    return NextResponse.json({ error: 'Asignación no encontrada.' }, { status: 404 });
+  }
+  if (asignacion.empresa_id !== empresaId) {
+    return NextResponse.json({ error: 'La asignación pertenece a otra empresa.' }, { status: 403 });
+  }
+
+  const { error: delErr } = await (admin.schema('core') as any)
+    .from('empresa_documentos')
+    .delete()
+    .eq('id', asignacionId);
+
+  if (delErr) {
+    return NextResponse.json({ error: `delete: ${delErr.message}` }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, asignacion_id: asignacionId, deleted: true });
+}

--- a/app/api/empresas/[id]/documentos/route.test.ts
+++ b/app/api/empresas/[id]/documentos/route.test.ts
@@ -1,0 +1,332 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- Test fixtures for fluent mocks. */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+let serverUser: { email: string } | null = null;
+let adminAvailable = true;
+
+// Per-test fixtures.
+type Script = {
+  callerUser?: { id: string; email: string; rol: string; activo: boolean } | null;
+  empresa?: { id: string; slug: string } | null;
+  documento?: { id: string; empresa_id: string } | null;
+  rows?: Array<{
+    id: string;
+    documento_id: string;
+    rol: string;
+    es_default: boolean;
+    asignado_por: string | null;
+    asignado_at: string;
+    notas: string | null;
+    created_at: string;
+  }>;
+  documentosByIds?: Array<{
+    id: string;
+    titulo: string | null;
+    numero_documento: string | null;
+    fecha_emision: string | null;
+    archivo_url: string | null;
+    subtipo_meta: Record<string, unknown> | null;
+    tipo: string | null;
+    tipo_operacion: string | null;
+    extraccion_status: string | null;
+  }>;
+  insertResult?: { data: any; error: { message: string } | null };
+  updateResult?: { error: { message: string } | null };
+};
+
+let script: Script = {};
+
+function buildAdmin(): any {
+  return {
+    schema(schemaName: string) {
+      return {
+        from(tableName: string) {
+          const key = `${schemaName}.${tableName}`;
+          const filters: Record<string, unknown> = {};
+          let pendingInsert: unknown = null;
+          let pendingUpdate: unknown = null;
+
+          const builder: any = {
+            select() {
+              return builder;
+            },
+            insert(row: unknown) {
+              pendingInsert = row;
+              return builder;
+            },
+            update(row: unknown) {
+              pendingUpdate = row;
+              return builder;
+            },
+            eq(col: string, val: unknown) {
+              filters[col] = val;
+              return builder;
+            },
+            in(_col: string, _vals: unknown[]) {
+              return builder;
+            },
+            is() {
+              return builder;
+            },
+            order() {
+              return builder;
+            },
+            async maybeSingle() {
+              if (key === 'core.usuarios') return { data: script.callerUser ?? null, error: null };
+              if (key === 'core.empresas') return { data: script.empresa ?? null, error: null };
+              if (key === 'erp.documentos') return { data: script.documento ?? null, error: null };
+              return { data: null, error: null };
+            },
+            async single() {
+              if (pendingInsert && key === 'core.empresa_documentos') {
+                return (
+                  script.insertResult ?? {
+                    data: {
+                      id: 'asg-new',
+                      empresa_id: 'e1',
+                      documento_id: 'd1',
+                      rol: 'acta_constitutiva',
+                      es_default: false,
+                      asignado_por: 'admin-uuid',
+                      asignado_at: '2026-04-28T00:00:00Z',
+                      notas: null,
+                    },
+                    error: null,
+                  }
+                );
+              }
+              return { data: null, error: null };
+            },
+            then(onF: (r: any) => unknown, onR?: (r: unknown) => unknown) {
+              const result = pendingUpdate
+                ? (script.updateResult ?? { data: null, error: null })
+                : key === 'core.empresa_documentos'
+                  ? { data: script.rows ?? [], error: null }
+                  : key === 'erp.documentos'
+                    ? { data: script.documentosByIds ?? [], error: null }
+                    : { data: [], error: null };
+              return Promise.resolve(result).then(onF, onR);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: serverUser } }) },
+  }),
+}));
+
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdminClient: () => (adminAvailable ? buildAdmin() : null),
+}));
+
+import { GET, POST } from './route';
+
+beforeEach(() => {
+  serverUser = { email: 'admin@example.com' };
+  script = {
+    callerUser: { id: 'admin-uuid', email: 'admin@example.com', rol: 'admin', activo: true },
+    empresa: { id: 'e1', slug: 'rdb' },
+    documento: { id: 'd1', empresa_id: 'e1' },
+    rows: [],
+    documentosByIds: [],
+    insertResult: undefined,
+    updateResult: { error: null },
+  };
+  adminAvailable = true;
+});
+
+function makeReq(method: 'GET' | 'POST', body?: unknown, id = 'e1') {
+  const req = new NextRequest(new URL(`http://localhost/api/empresas/${id}/documentos`), {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  return { req, ctx: { params: Promise.resolve({ id }) } };
+}
+
+describe('GET /api/empresas/[id]/documentos', () => {
+  it('401 si no hay user', async () => {
+    serverUser = null;
+    const { req, ctx } = makeReq('GET');
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si caller no es admin', async () => {
+    script.callerUser = { id: 'u1', email: 'x@y.com', rol: 'usuario', activo: true };
+    const { req, ctx } = makeReq('GET');
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('404 si la empresa no existe', async () => {
+    script.empresa = null;
+    const { req, ctx } = makeReq('GET');
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('200 con asignaciones vacías', async () => {
+    const { req, ctx } = makeReq('GET');
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.asignaciones).toEqual([]);
+  });
+
+  it('200 con asignaciones hidratadas con metadata del documento', async () => {
+    script.rows = [
+      {
+        id: 'asg1',
+        documento_id: 'd1',
+        rol: 'acta_constitutiva',
+        es_default: true,
+        asignado_por: 'admin-uuid',
+        asignado_at: '2026-04-28T00:00:00Z',
+        notas: null,
+        created_at: '2026-04-28T00:00:00Z',
+      },
+    ];
+    script.documentosByIds = [
+      {
+        id: 'd1',
+        titulo: 'Escritura Constitutiva',
+        numero_documento: '12345',
+        fecha_emision: '2010-05-15',
+        archivo_url: 'erp/x.pdf',
+        subtipo_meta: { numero_escritura: '12345', notario_nombre: 'JUAN' },
+        tipo: 'legal',
+        tipo_operacion: 'constitutiva',
+        extraccion_status: 'completado',
+      },
+    ];
+    const { req, ctx } = makeReq('GET');
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.asignaciones).toHaveLength(1);
+    expect(json.asignaciones[0].documento.titulo).toBe('Escritura Constitutiva');
+    expect(json.asignaciones[0].es_default).toBe(true);
+  });
+});
+
+describe('POST /api/empresas/[id]/documentos', () => {
+  it('401 si no hay user', async () => {
+    serverUser = null;
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'acta_constitutiva',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si caller no es admin', async () => {
+    script.callerUser = { id: 'u1', email: 'x@y.com', rol: 'usuario', activo: true };
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'acta_constitutiva',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('400 si body trae llaves desconocidas (strict)', async () => {
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'acta_constitutiva',
+      extra: 'x',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('400 si rol no está en el enum permitido', async () => {
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'rol_inventado',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('400 si documento_id no es UUID', async () => {
+    const { req, ctx } = makeReq('POST', { documento_id: 'no-uuid', rol: 'acta_constitutiva' });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('404 si la empresa no existe', async () => {
+    script.empresa = null;
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'acta_constitutiva',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('404 si el documento no existe', async () => {
+    script.documento = null;
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'acta_constitutiva',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it('403 si el documento pertenece a otra empresa', async () => {
+    script.documento = { id: 'd1', empresa_id: 'OTRA-EMPRESA' };
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'acta_constitutiva',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it('200 con flujo OK (es_default=false default)', async () => {
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'acta_constitutiva',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.asignacion).toBeDefined();
+  });
+
+  it('200 con es_default=true (limpia defaults previos del rol)', async () => {
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'poder_general_administracion',
+      es_default: true,
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it('409 si UNIQUE constraint falla (doc ya asignado al mismo rol)', async () => {
+    script.insertResult = {
+      data: null,
+      error: { message: 'duplicate key value violates unique constraint' },
+    };
+    const { req, ctx } = makeReq('POST', {
+      documento_id: 'e52ac307-9373-4115-b65e-1178f0c4e1aa',
+      rol: 'acta_constitutiva',
+    });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(409);
+  });
+});

--- a/app/api/empresas/[id]/documentos/route.ts
+++ b/app/api/empresas/[id]/documentos/route.ts
@@ -1,0 +1,255 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa `public`; para `core` y `erp` usamos `as any`.
+ */
+
+/**
+ * GET /api/empresas/[id]/documentos
+ * POST /api/empresas/[id]/documentos
+ *
+ * Sprint 3 — iniciativa `empresa-documentos-legales`.
+ *
+ * GET lista las asignaciones de la empresa agrupadas por rol con metadata
+ * mínima del documento (titulo, numero_documento, fecha_emision, archivo_url,
+ * subtipo_meta) y los flags de la asignación (es_default, asignado_at).
+ *
+ * POST asigna un documento existente con un rol. Si `es_default=true`, baja
+ * el flag de los demás docs con el mismo rol antes de hacer el INSERT (uso
+ * el partial unique index requiere atomicidad). Verifica que el documento
+ * pertenece a la empresa — no se permite asignar docs de otra empresa.
+ *
+ * Side-effect: el sync_trigger en DB se encarga de proyectar el subtipo_meta
+ * al jsonb caché en `core.empresas.escritura_*` para los roles que aplican
+ * (`acta_constitutiva`, `poder_general_administracion`).
+ *
+ * Solo admin.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { requireAdmin } from '@/lib/empresas/admin-guard';
+import { EMPRESA_DOCUMENTOS_ROLES } from '@/lib/empresa-documentos/cache-mapping';
+
+export const runtime = 'nodejs';
+
+const PostBodySchema = z
+  .object({
+    documento_id: z.string().uuid('documento_id debe ser UUID'),
+    rol: z.enum(EMPRESA_DOCUMENTOS_ROLES),
+    es_default: z.boolean().optional().default(false),
+    notas: z.union([z.string(), z.null()]).optional(),
+  })
+  .strict();
+
+type Params = { params: Promise<{ id: string }> };
+
+// ─── GET ───────────────────────────────────────────────────────────────────
+
+export async function GET(_req: NextRequest, { params }: Params) {
+  const { id: empresaId } = await params;
+
+  const userSupa = await createSupabaseServerClient();
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const guard = await requireAdmin(userSupa, admin);
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  // Verifica que la empresa existe (defensivo; admin podría llamar con id
+  // inválido).
+  const { data: empresa, error: empresaErr } = await (admin.schema('core') as any)
+    .from('empresas')
+    .select('id, slug')
+    .eq('id', empresaId)
+    .maybeSingle();
+  if (empresaErr) {
+    return NextResponse.json({ error: `lookup empresa: ${empresaErr.message}` }, { status: 500 });
+  }
+  if (!empresa) {
+    return NextResponse.json({ error: 'Empresa no encontrada.' }, { status: 404 });
+  }
+
+  // Trae todas las asignaciones de la empresa.
+  const { data: rows, error: rowsErr } = await (admin.schema('core') as any)
+    .from('empresa_documentos')
+    .select('id, documento_id, rol, es_default, asignado_por, asignado_at, notas, created_at')
+    .eq('empresa_id', empresaId)
+    .order('rol')
+    .order('es_default', { ascending: false })
+    .order('asignado_at', { ascending: false });
+
+  if (rowsErr) {
+    return NextResponse.json({ error: `fetch asignaciones: ${rowsErr.message}` }, { status: 500 });
+  }
+
+  type AsignacionRow = {
+    id: string;
+    documento_id: string;
+    rol: string;
+    es_default: boolean;
+    asignado_por: string | null;
+    asignado_at: string;
+    notas: string | null;
+    created_at: string;
+  };
+
+  const asignaciones = (rows ?? []) as AsignacionRow[];
+
+  // Si no hay asignaciones, devolvemos estructura vacía (UI lo maneja).
+  if (asignaciones.length === 0) {
+    return NextResponse.json({ ok: true, empresa_id: empresaId, asignaciones: [] });
+  }
+
+  // Hidrata la metadata de los documentos asignados (cross-schema → no
+  // podemos hacer JOIN de Supabase; segunda query con `.in()`).
+  const documentoIds = Array.from(new Set(asignaciones.map((a) => a.documento_id)));
+
+  type DocumentoRow = {
+    id: string;
+    titulo: string | null;
+    numero_documento: string | null;
+    fecha_emision: string | null;
+    archivo_url: string | null;
+    subtipo_meta: Record<string, unknown> | null;
+    tipo: string | null;
+    tipo_operacion: string | null;
+    extraccion_status: string | null;
+  };
+
+  const { data: docsData, error: docsErr } = await (admin.schema('erp') as any)
+    .from('documentos')
+    .select(
+      'id, titulo, numero_documento, fecha_emision, archivo_url, subtipo_meta, tipo, tipo_operacion, extraccion_status'
+    )
+    .in('id', documentoIds);
+
+  if (docsErr) {
+    return NextResponse.json({ error: `fetch documentos: ${docsErr.message}` }, { status: 500 });
+  }
+
+  const docsById = new Map<string, DocumentoRow>(
+    ((docsData ?? []) as DocumentoRow[]).map((d) => [d.id, d])
+  );
+
+  return NextResponse.json({
+    ok: true,
+    empresa_id: empresaId,
+    asignaciones: asignaciones.map((a) => ({
+      ...a,
+      documento: docsById.get(a.documento_id) ?? null,
+    })),
+  });
+}
+
+// ─── POST ──────────────────────────────────────────────────────────────────
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const { id: empresaId } = await params;
+
+  const userSupa = await createSupabaseServerClient();
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Server config error (admin client)' }, { status: 500 });
+  }
+
+  const guard = await requireAdmin(userSupa, admin);
+  if (!guard.ok) {
+    return NextResponse.json({ error: guard.error }, { status: guard.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `body JSON inválido: ${msg}` }, { status: 400 });
+  }
+
+  let payload;
+  try {
+    payload = PostBodySchema.parse(body);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `payload inválido: ${msg}` }, { status: 400 });
+  }
+
+  // Verifica empresa.
+  const { data: empresa, error: empresaErr } = await (admin.schema('core') as any)
+    .from('empresas')
+    .select('id, slug')
+    .eq('id', empresaId)
+    .maybeSingle();
+  if (empresaErr) {
+    return NextResponse.json({ error: `lookup empresa: ${empresaErr.message}` }, { status: 500 });
+  }
+  if (!empresa) {
+    return NextResponse.json({ error: 'Empresa no encontrada.' }, { status: 404 });
+  }
+
+  // Verifica que el documento pertenece a esta empresa (no se permite
+  // asignar docs de otra empresa).
+  const { data: documento, error: docErr } = await (admin.schema('erp') as any)
+    .from('documentos')
+    .select('id, empresa_id')
+    .eq('id', payload.documento_id)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (docErr) {
+    return NextResponse.json({ error: `lookup documento: ${docErr.message}` }, { status: 500 });
+  }
+  if (!documento) {
+    return NextResponse.json({ error: 'Documento no encontrado.' }, { status: 404 });
+  }
+  if (documento.empresa_id !== empresaId) {
+    return NextResponse.json({ error: 'El documento pertenece a otra empresa.' }, { status: 403 });
+  }
+
+  // Si la asignación pide es_default=true, baja el flag de los demás docs
+  // del mismo rol primero (el partial UNIQUE index requiere unicidad).
+  if (payload.es_default) {
+    const { error: clearErr } = await (admin.schema('core') as any)
+      .from('empresa_documentos')
+      .update({ es_default: false, updated_at: new Date().toISOString() })
+      .eq('empresa_id', empresaId)
+      .eq('rol', payload.rol)
+      .eq('es_default', true);
+    if (clearErr) {
+      return NextResponse.json(
+        { error: `clear default previo: ${clearErr.message}` },
+        { status: 500 }
+      );
+    }
+  }
+
+  // INSERT.
+  const { data: inserted, error: insErr } = await (admin.schema('core') as any)
+    .from('empresa_documentos')
+    .insert({
+      empresa_id: empresaId,
+      documento_id: payload.documento_id,
+      rol: payload.rol,
+      es_default: payload.es_default ?? false,
+      asignado_por: guard.usuario.id,
+      notas: payload.notas ?? null,
+    })
+    .select('id, empresa_id, documento_id, rol, es_default, asignado_por, asignado_at, notas')
+    .single();
+
+  if (insErr) {
+    // Conflicto típico: UNIQUE (empresa_id, documento_id, rol) — el doc ya
+    // tiene ese rol asignado.
+    const isConflict = /duplicate key|unique/i.test(insErr.message);
+    return NextResponse.json(
+      { error: `insert asignacion: ${insErr.message}` },
+      { status: isConflict ? 409 : 500 }
+    );
+  }
+
+  return NextResponse.json({ ok: true, asignacion: inserted });
+}


### PR DESCRIPTION
## Summary

Sprint 3 — CRUD de asignaciones documento↔empresa↔rol sobre `core.empresa_documentos`.

| Endpoint | Función |
|---|---|
| `GET /api/empresas/[id]/documentos` | Lista asignaciones con metadata del documento hidratada cross-schema (`erp.documentos`). |
| `POST /api/empresas/[id]/documentos` | Asigna documento existente con un rol. Verifica que el doc pertenece a la empresa. Si `es_default=true`, baja el flag de los demás del mismo rol. 409 en duplicado. |
| `PATCH /api/empresas/[id]/documentos/[asignacion_id]` | Actualiza `es_default` y/o `notas`. Maneja transición atómica del partial UNIQUE. |
| `DELETE /api/empresas/[id]/documentos/[asignacion_id]` | Hard delete del row (sin tocar el doc en `erp.documentos`). |

**Side-effect**: el sync_trigger de Sprint 1 proyecta automáticamente el `subtipo_meta` del doc default a `core.empresas.escritura_constitutiva` / `escritura_poder` para los roles `acta_constitutiva` y `poder_general_administracion`. Cierra el ciclo: subir doc → asignar → caché lleno → RH desbloquea alta de empleados.

Validación zod strict: rol ∈ `EMPRESA_DOCUMENTOS_ROLES`, documento_id UUID, body strict. Solo admin (mismo guard que el resto de `/api/empresas/*`).

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓ (0 errors)
- [x] `npm run format:check` ✓
- [x] `npm run test:run` (+30 casos: 16 GET/POST + 14 PATCH/DELETE) ✓

## Próximo

Sprint 4: UI rediseñada en `/settings/empresas/[slug]` con lista por rol, dropdown asignar, marcar default, desasignar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)