### PR TITLE
fix(cortes-rdb): mostrar diferencia parcial cuando hay vouchers capturados

### DIFF
--- a/components/cortes/corte-conciliacion.tsx
+++ b/components/cortes/corte-conciliacion.tsx
@@ -233,8 +233,12 @@ function formatDiferencia(value: number) {
 
 function CardTarjeta({ tarjeta }: { tarjeta: ConciliacionTarjeta }) {
   const pendientes = tarjeta.evidencia_pendiente;
+  const capturados = tarjeta.evidencia_count - pendientes;
   const sumaPendienteLabel = pendientes > 0 ? ` +${pendientes} s/cap` : '';
-  const difLabel = pendientes > 0 ? '—' : formatDiferencia(tarjeta.diferencia);
+  // Cuando hay >=1 capturado, mostrar la diferencia parcial aunque queden pendientes —
+  // así el operador detecta discrepancias temprano sin esperar a capturar todo.
+  const difEsParcial = pendientes > 0 && capturados > 0;
+  const difLabel = pendientes > 0 && capturados === 0 ? '—' : formatDiferencia(tarjeta.diferencia);
 
   return (
     <div className="rounded-lg border bg-card p-4 print:p-2" style={{ pageBreakInside: 'avoid' }}>
@@ -271,7 +275,14 @@ function CardTarjeta({ tarjeta }: { tarjeta: ConciliacionTarjeta }) {
         <hr className="my-1 border-muted print:my-0.5" />
         <div className="flex justify-between text-sm font-semibold print:text-[10px]">
           <dt>Diferencia</dt>
-          <dd className={`tabular-nums ${diferenciaColor(tarjeta.estado)}`}>{difLabel}</dd>
+          <dd className={`tabular-nums ${diferenciaColor(tarjeta.estado)}`}>
+            {difLabel}
+            {difEsParcial && (
+              <span className="ml-1 text-[10px] font-normal text-muted-foreground print:text-[8px]">
+                parcial
+              </span>
+            )}
+          </dd>
         </div>
       </dl>
 

--- a/components/cortes/marbete-conciliacion.tsx
+++ b/components/cortes/marbete-conciliacion.tsx
@@ -93,11 +93,25 @@ export function MarbeteConciliacion({
               {SIMBOLO[tarjeta.estado]}
             </td>
             <td className="text-right tabular-nums">
-              {tarjeta.evidencia_pendiente > 0
-                ? '—'
-                : tarjeta.diferencia === 0
-                  ? '$0.00'
-                  : (tarjeta.diferencia > 0 ? '+' : '') + formatCurrency(tarjeta.diferencia)}
+              {(() => {
+                const capturados = tarjeta.evidencia_count - tarjeta.evidencia_pendiente;
+                const sinCapturados = tarjeta.evidencia_pendiente > 0 && capturados === 0;
+                if (sinCapturados) return '—';
+                const valor =
+                  tarjeta.diferencia === 0
+                    ? '$0.00'
+                    : (tarjeta.diferencia > 0 ? '+' : '') + formatCurrency(tarjeta.diferencia);
+                const sufijoParcial =
+                  tarjeta.evidencia_pendiente > 0 ? (
+                    <span className="ml-0.5 text-[8px] text-gray-500">parcial</span>
+                  ) : null;
+                return (
+                  <>
+                    {valor}
+                    {sufijoParcial}
+                  </>
+                );
+              })()}
             </td>
           </tr>
           <tr className="border-t border-gray-300">


### PR DESCRIPTION
## Summary
- Antes: si quedaba aunque sea 1 voucher pendiente de captura, la diferencia se ocultaba como "—" — bloqueaba detectar discrepancias temprano.
- Ahora: con ≥1 voucher capturado, se muestra la diferencia parcial con sufijo "parcial". Solo cuando no hay ninguno capturado se mantiene "—" (porque sumar 0 no es informativo).
- El estado `pendiente_captura` no cambia: el sistema sigue avisando que falta confirmación antes de validar el cuadre.
- Aplica al detalle del corte ([components/cortes/corte-conciliacion.tsx](components/cortes/corte-conciliacion.tsx)) y al marbete impreso ([components/cortes/marbete-conciliacion.tsx](components/cortes/marbete-conciliacion.tsx)).

## Por qué
Reportado en operación de RDB: la sumatoria de vouchers no estaba "agregando info para detectar diferencias". El problema no era el cálculo (la diferencia se calculaba bien internamente) sino que el render la suprimía hasta tener todo capturado.

## Test plan
- [ ] Abrir un corte con 0 vouchers capturados → diferencia muestra "—"
- [ ] Capturar 1 de 3 vouchers → diferencia muestra el delta con sufijo "parcial" en gris
- [ ] Capturar los 3 vouchers → diferencia muestra el delta sin sufijo (final)
- [ ] Imprimir marbete con vouchers parcialmente capturados → mismo comportamiento
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)