### PR TITLE
feat(cortes-rdb): efectivo inicial se hereda del cierre del turno anterior

### DIFF
--- a/app/rdb/cortes/actions.ts
+++ b/app/rdb/cortes/actions.ts
@@ -19,11 +19,22 @@ export type AbrirCajaInput = {
   caja_id: string;
   caja_nombre: string;
   responsable_apertura: string;
-  efectivo_inicial: number;
   fecha_operativa: string; // YYYY-MM-DD
 };
 
-export type AbrirCajaResult = { ok: true; id: string } | { ok: false; error: string };
+export type AbrirCajaResult =
+  | {
+      ok: true;
+      id: string;
+      efectivo_inicial: number;
+      // true si se heredó del corte cerrado anterior; false si es primer turno o el
+      // anterior no tenía conteo (en cuyo caso `efectivo_inicial` es 0).
+      heredado: boolean;
+      // true si hubo corte previo cerrado pero sin efectivo_contado capturado —
+      // el cliente debe avisar al operador que está abriendo en $0 por falta de conteo.
+      previo_sin_contar: boolean;
+    }
+  | { ok: false; error: string };
 
 export async function abrirCaja(input: AbrirCajaInput): Promise<AbrirCajaResult> {
   const supabase = await createSupabaseServerClient();
@@ -56,6 +67,27 @@ export async function abrirCaja(input: AbrirCajaInput): Promise<AbrirCajaResult>
     };
   }
 
+  // Heredar efectivo_inicial del último corte cerrado de la misma caja. Server-side
+  // es la fuente de verdad — el cliente solo lo previsualiza.
+  const { data: ultimoCorte, error: ultimoErr } = await supabase
+    .schema('erp')
+    .from('cortes_caja')
+    .select('id, efectivo_contado, cerrado_at')
+    .eq('empresa_id', RDB_EMPRESA_ID)
+    .eq('caja_nombre', input.caja_nombre)
+    .eq('estado', 'cerrado')
+    .order('cerrado_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (ultimoErr) {
+    return { ok: false, error: `Error al consultar último corte: ${ultimoErr.message}` };
+  }
+
+  const heredado = !!ultimoCorte;
+  const previo_sin_contar = heredado && ultimoCorte.efectivo_contado == null;
+  const efectivoInicial = ultimoCorte?.efectivo_contado ?? 0;
+
   const now = new Date().toISOString();
 
   const { data: corte, error: insertErr } = await supabase
@@ -65,7 +97,7 @@ export async function abrirCaja(input: AbrirCajaInput): Promise<AbrirCajaResult>
       empresa_id: RDB_EMPRESA_ID,
       caja_nombre: input.caja_nombre,
       estado: 'abierto',
-      efectivo_inicial: input.efectivo_inicial,
+      efectivo_inicial: efectivoInicial,
       fecha_operativa: input.fecha_operativa,
       abierto_at: now,
       observaciones: input.responsable_apertura,
@@ -81,7 +113,51 @@ export async function abrirCaja(input: AbrirCajaInput): Promise<AbrirCajaResult>
   }
 
   revalidatePath('/rdb/cortes');
-  return { ok: true, id: corte.id };
+  return {
+    ok: true,
+    id: corte.id,
+    efectivo_inicial: efectivoInicial,
+    heredado,
+    previo_sin_contar,
+  };
+}
+
+export type EfectivoInicialPreview = {
+  monto: number;
+  heredado: boolean;
+  previo_sin_contar: boolean;
+  cerrado_at: string | null;
+};
+
+/**
+ * Preview del efectivo inicial que heredaría una nueva apertura para la caja
+ * dada. El server action `abrirCaja` recalcula igual al abrir — esto es solo
+ * para mostrar al operador antes de confirmar.
+ */
+export async function previewEfectivoInicial(caja_nombre: string): Promise<EfectivoInicialPreview> {
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .schema('erp')
+    .from('cortes_caja')
+    .select('efectivo_contado, cerrado_at')
+    .eq('empresa_id', RDB_EMPRESA_ID)
+    .eq('caja_nombre', caja_nombre)
+    .eq('estado', 'cerrado')
+    .order('cerrado_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+
+  const heredado = !!data;
+  const previo_sin_contar = heredado && data.efectivo_contado == null;
+  return {
+    monto: data?.efectivo_contado ?? 0,
+    heredado,
+    previo_sin_contar,
+    cerrado_at: data?.cerrado_at ?? null,
+  };
 }
 
 export type Denominacion = {

--- a/components/cortes/abrir-caja-dialog.tsx
+++ b/components/cortes/abrir-caja-dialog.tsx
@@ -1,4 +1,4 @@
-import { Loader2, PlusCircle } from 'lucide-react';
+import { AlertTriangle, Loader2, PlusCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -8,16 +8,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Combobox } from '@/components/ui/combobox';
+import { formatCurrency, formatDateTime } from './helpers';
 import type { Caja } from './types';
 
 export type AbrirForm = {
   caja_id: string;
   responsable_apertura: string;
-  efectivo_inicial: string;
   fecha_operativa: string;
   auto_matched: boolean;
+  // Efectivo inicial heredado del cierre del corte anterior. Es display-only:
+  // el server action `abrirCaja` recalcula al abrir y usa su propio valor.
+  efectivo_heredado_monto: number;
+  efectivo_heredado_es_heredado: boolean;
+  efectivo_heredado_previo_sin_contar: boolean;
+  efectivo_heredado_cerrado_at: string | null;
+  efectivo_heredado_cargando: boolean;
 };
 
 export function AbrirCajaDialog({
@@ -25,7 +31,7 @@ export function AbrirCajaDialog({
   onOpenChange,
   cajas,
   form,
-  onFormChange,
+  onCajaChange,
   onSubmit,
   isPending,
   error,
@@ -34,7 +40,7 @@ export function AbrirCajaDialog({
   onOpenChange: (v: boolean) => void;
   cajas: Caja[];
   form: AbrirForm;
-  onFormChange: (updater: (f: AbrirForm) => AbrirForm) => void;
+  onCajaChange: (cajaId: string) => void;
   onSubmit: () => void;
   isPending: boolean;
   error: string | null;
@@ -80,7 +86,7 @@ export function AbrirCajaDialog({
               ) : (
                 <Combobox
                   value={form.caja_id}
-                  onChange={(v) => onFormChange((f) => ({ ...f, caja_id: v }))}
+                  onChange={(v) => onCajaChange(v)}
                   options={cajas.map((caja) => ({ value: caja.id, label: caja.nombre }))}
                   placeholder="Selecciona tu caja…"
                   allowClear
@@ -94,21 +100,37 @@ export function AbrirCajaDialog({
             <label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Efectivo inicial
             </label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
-                $
-              </span>
-              <Input
-                type="number"
-                min="0"
-                step="0.01"
-                value={form.efectivo_inicial}
-                onChange={(e) => onFormChange((f) => ({ ...f, efectivo_inicial: e.target.value }))}
-                placeholder="0.00"
-                className="pl-7 text-lg font-medium"
-                autoFocus
-              />
+            <div className="rounded-md border bg-muted/40 px-3 py-2.5">
+              {form.efectivo_heredado_cargando ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Calculando…
+                </div>
+              ) : (
+                <div className="text-lg font-semibold tabular-nums text-foreground">
+                  {formatCurrency(form.efectivo_heredado_monto)}
+                </div>
+              )}
             </div>
+            {!form.efectivo_heredado_cargando &&
+              (form.efectivo_heredado_previo_sin_contar ? (
+                <p className="flex items-start gap-1.5 text-[11px] text-yellow-700 dark:text-yellow-400">
+                  <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                  El turno anterior cerró sin contar efectivo. Inicia en $0.00 — confírmalo con el
+                  responsable.
+                </p>
+              ) : form.efectivo_heredado_es_heredado ? (
+                <p className="text-[11px] text-muted-foreground">
+                  Heredado del cierre del turno anterior
+                  {form.efectivo_heredado_cerrado_at
+                    ? ` · ${formatDateTime(form.efectivo_heredado_cerrado_at)}`
+                    : ''}
+                </p>
+              ) : (
+                <p className="text-[11px] text-muted-foreground">
+                  Primer turno registrado para esta caja — inicia en $0.00.
+                </p>
+              ))}
           </div>
 
           {error && (

--- a/components/cortes/cortes-view.tsx
+++ b/components/cortes/cortes-view.tsx
@@ -254,7 +254,7 @@ export function CortesView() {
           onOpenChange={abrir.setOpen}
           cajas={abrir.cajas}
           form={abrir.form}
-          onFormChange={abrir.setForm}
+          onCajaChange={abrir.changeCaja}
           onSubmit={() => abrir.submit(() => void fetchCortes())}
           isPending={abrir.isPending}
           error={abrir.error}

--- a/components/cortes/use-abrir-caja.ts
+++ b/components/cortes/use-abrir-caja.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useTransition } from 'react';
-import { abrirCaja } from '@/app/rdb/cortes/actions';
+import { abrirCaja, previewEfectivoInicial } from '@/app/rdb/cortes/actions';
 import type { AbrirForm } from './abrir-caja-dialog';
 import { fetchAbrirCajaContext } from './data';
 import { todayRange } from './helpers';
@@ -10,15 +10,21 @@ import type { Caja } from './types';
 const EMPTY_FORM: AbrirForm = {
   caja_id: '',
   responsable_apertura: '',
-  efectivo_inicial: '',
   fecha_operativa: todayRange().from,
   auto_matched: false,
+  efectivo_heredado_monto: 0,
+  efectivo_heredado_es_heredado: false,
+  efectivo_heredado_previo_sin_contar: false,
+  efectivo_heredado_cerrado_at: null,
+  efectivo_heredado_cargando: false,
 };
 
 /**
  * Hook wiring all state for the Abrir Caja dialog — opens, loads cajas +
  * current user, auto-matches the user's caja by first-name substring, and
- * submits the apertura. Behavior preserved 1:1 from the original page.
+ * submits the apertura. El efectivo inicial se hereda automáticamente del
+ * cierre del último corte cerrado de la misma caja (server-side es la
+ * fuente de verdad — el cliente solo previsualiza).
  */
 export function useAbrirCaja() {
   const [open, setOpen] = useState(false);
@@ -27,6 +33,31 @@ export function useAbrirCaja() {
   const [form, setForm] = useState<AbrirForm>(EMPTY_FORM);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+
+  async function refetchEfectivoHeredado(cajaNombre: string) {
+    setForm((f) => ({ ...f, efectivo_heredado_cargando: true }));
+    try {
+      const preview = await previewEfectivoInicial(cajaNombre);
+      setForm((f) => ({
+        ...f,
+        efectivo_heredado_monto: preview.monto,
+        efectivo_heredado_es_heredado: preview.heredado,
+        efectivo_heredado_previo_sin_contar: preview.previo_sin_contar,
+        efectivo_heredado_cerrado_at: preview.cerrado_at,
+        efectivo_heredado_cargando: false,
+      }));
+    } catch {
+      // Si falla el preview, el server lo recalcula al abrir; muestra $0 mientras.
+      setForm((f) => ({
+        ...f,
+        efectivo_heredado_monto: 0,
+        efectivo_heredado_es_heredado: false,
+        efectivo_heredado_previo_sin_contar: false,
+        efectivo_heredado_cerrado_at: null,
+        efectivo_heredado_cargando: false,
+      }));
+    }
+  }
 
   async function openDialog() {
     setOpen(true);
@@ -47,10 +78,31 @@ export function useAbrirCaja() {
         fecha_operativa: todayRange().from,
         auto_matched: !!matchedCaja,
       }));
+
+      if (matchedCaja) {
+        void refetchEfectivoHeredado(matchedCaja.nombre);
+      }
     } catch {
       // non-fatal
     } finally {
       setLoadingCajas(false);
+    }
+  }
+
+  function changeCaja(cajaId: string) {
+    setForm((f) => ({ ...f, caja_id: cajaId }));
+    const caja = cajas.find((c) => c.id === cajaId);
+    if (caja) {
+      void refetchEfectivoHeredado(caja.nombre);
+    } else {
+      // Combobox limpiado — resetear el preview.
+      setForm((f) => ({
+        ...f,
+        efectivo_heredado_monto: 0,
+        efectivo_heredado_es_heredado: false,
+        efectivo_heredado_previo_sin_contar: false,
+        efectivo_heredado_cerrado_at: null,
+      }));
     }
   }
 
@@ -72,7 +124,6 @@ export function useAbrirCaja() {
           caja_id: form.caja_id,
           caja_nombre: selectedCaja?.nombre ?? form.caja_id,
           responsable_apertura: form.responsable_apertura.trim(),
-          efectivo_inicial: parseFloat(form.efectivo_inicial) || 0,
           fecha_operativa: form.fecha_operativa || todayRange().from,
         });
 
@@ -98,6 +149,7 @@ export function useAbrirCaja() {
     cajas,
     form,
     setForm,
+    changeCaja,
     error,
     isPending,
     openDialog,


### PR DESCRIPTION
## Summary
- Al abrir una caja, el **efectivo inicial deja de capturarse manualmente**: se toma del `efectivo_contado` del último corte cerrado de la misma caja.
- Si es la primera apertura registrada para esa caja, inicia en \$0.
- Si el corte anterior cerró sin contar efectivo, también inicia en \$0 con warning visible al operador.

## Por qué
Pedido de Beto: el efectivo en caja es continuo entre turnos. Capturar el inicial al abrir era doble trabajo y propenso a divergir del cierre real anterior — ahora la cadena queda automáticamente atada.

## Fuente de verdad
Server-side. `abrirCaja` ([app/rdb/cortes/actions.ts](app/rdb/cortes/actions.ts)) consulta `erp.cortes_caja` y **recalcula al abrir**, ignorando lo que envía el cliente. El nuevo helper `previewEfectivoInicial` se usa solo para que el diálogo muestre al operador el monto antes de confirmar (se refresca cuando cambia la caja seleccionada).

## Cambios
- **`app/rdb/cortes/actions.ts`**: quita `efectivo_inicial` del input de `abrirCaja`, agrega lookup del último cierre cerrado, expone `previewEfectivoInicial`. El resultado de `abrirCaja` ahora informa `heredado` y `previo_sin_contar`.
- **[components/cortes/abrir-caja-dialog.tsx](components/cortes/abrir-caja-dialog.tsx)**: reemplaza el input editable por un display read-only con nota explicativa según el caso (heredado / primer turno / previo sin contar).
- **[components/cortes/use-abrir-caja.ts](components/cortes/use-abrir-caja.ts)**: agrega `changeCaja` que refresca el preview cuando se selecciona otra caja, elimina el campo editable del form.
- **[components/cortes/cortes-view.tsx](components/cortes/cortes-view.tsx)**: pasa `onCajaChange` al diálogo en lugar de `onFormChange`.

## Test plan
- [ ] Abrir caja Laisha tras un cierre con efectivo_contado=\$3,060 → efectivo inicial se muestra en \$3,060 con nota "Heredado del cierre del turno anterior · ⟨fecha⟩"
- [ ] Cambiar caja en el combobox → el preview se refresca al monto de la caja nueva
- [ ] Crear una caja desde DB sin cortes previos y abrir turno → muestra "Primer turno registrado para esta caja — inicia en \$0.00"
- [ ] Forzar un corte cerrado con `efectivo_contado IS NULL` → warning amarillo visible, inicia en \$0
- [ ] Verificar en DB que el `efectivo_inicial` insertado coincide con el `efectivo_contado` del corte cerrado anterior (no con lo que el cliente pudiera enviar)
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)