### PR TITLE
fix(cortes-rdb): RLS bloqueaba captura de vouchers (sin policy de UPDATE)

### DIFF
--- a/app/rdb/cortes/actions.ts
+++ b/app/rdb/cortes/actions.ts
@@ -445,7 +445,12 @@ export async function confirmarVoucher(input: ConfirmarVoucherInput): Promise<vo
   }
   if (input.monto < 0) throw new Error('El monto no puede ser negativo');
 
-  const { error } = await supabase
+  // `.select('id')` fuerza a PostgREST a devolver las filas afectadas. Si
+  // RLS bloquea el UPDATE, supabase-js no devuelve `error` — devuelve
+  // `data: []`. Sin esto, el UPDATE puede fallar silenciosamente y el UI
+  // muestra success mientras el dato nunca persiste (regresión histórica
+  // de cuando se agregaron columnas editables sin policy de UPDATE).
+  const { data, error } = await supabase
     .schema('erp')
     .from('cortes_vouchers')
     .update({
@@ -453,9 +458,15 @@ export async function confirmarVoucher(input: ConfirmarVoucherInput): Promise<vo
       monto_reportado: input.monto,
       afiliacion: input.afiliacion?.trim() || null,
     })
-    .eq('id', input.voucher_id);
+    .eq('id', input.voucher_id)
+    .select('id');
 
   if (error) throw new Error(error.message);
+  if (!data || data.length === 0) {
+    throw new Error(
+      'No se pudo guardar el voucher (posible RLS bloqueando UPDATE o voucher inexistente).'
+    );
+  }
   revalidatePath('/rdb/cortes');
 }
 
@@ -479,7 +490,7 @@ export async function actualizarCategoriaVoucher(
     throw new Error('Comprobante de movimiento requiere seleccionar el movimiento ligado');
   }
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .schema('erp')
     .from('cortes_vouchers')
     .update({
@@ -488,8 +499,14 @@ export async function actualizarCategoriaVoucher(
       movimiento_caja_id:
         input.categoria === 'comprobante_movimiento' ? input.movimiento_caja_id : null,
     })
-    .eq('id', input.voucher_id);
+    .eq('id', input.voucher_id)
+    .select('id');
 
   if (error) throw new Error(error.message);
+  if (!data || data.length === 0) {
+    throw new Error(
+      'No se pudo actualizar la categoría (posible RLS bloqueando UPDATE o voucher inexistente).'
+    );
+  }
   revalidatePath('/rdb/cortes');
 }

--- a/supabase/migrations/20260428240000_erp_cortes_vouchers_update_policy.sql
+++ b/supabase/migrations/20260428240000_erp_cortes_vouchers_update_policy.sql
@@ -1,0 +1,50 @@
+-- ────────────────────────────────────────────────────────────────────────────
+-- erp.cortes_vouchers — habilitar UPDATE
+--
+-- La migración original (20260424184855) creó la tabla SIN policy de UPDATE
+-- bajo el supuesto de que los vouchers serían inmutables (audit trail). En
+-- el sprint siguiente (20260425153136) se agregaron columnas editables —
+-- monto_reportado, banco_id, afiliacion, categoria, movimiento_caja_id —
+-- para soportar el flujo de captura post-subida, pero quedó pendiente
+-- crear la policy de UPDATE.
+--
+-- Síntoma: el server action `confirmarVoucher()` corre el UPDATE, RLS lo
+-- bloquea silenciosamente (PostgREST devuelve 200 con 0 filas afectadas
+-- cuando RLS rechaza el UPDATE — no error 4xx), supabase-js retorna sin
+-- error, el toast del UI dice "Voucher actualizado" y el dato nunca se
+-- persiste. Se ve directamente en producción como
+-- `Σ Vouchers (3): $0.00 +3 s/cap` aún después de capturar montos.
+--
+-- Decisión: misma USING que SELECT — cualquier usuario con acceso a la
+-- empresa puede confirmar/corregir un voucher (no se restringe a quien
+-- subió, porque operativamente el manager suele confirmar lo del cajero).
+-- Los campos inmutables (empresa_id, corte_id, uploaded_by, storage_path,
+-- uploaded_at) los protege la app — no los manda en el .update().
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE POLICY erp_cortes_vouchers_update ON erp.cortes_vouchers
+  FOR UPDATE TO authenticated
+  USING (core.fn_has_empresa(empresa_id) OR core.fn_is_admin())
+  WITH CHECK (core.fn_has_empresa(empresa_id) OR core.fn_is_admin());
+
+NOTIFY pgrst, 'reload schema';
+
+-- ═══════════════════════════ VERIFY ═══════════════════════════════════════
+DO $$
+DECLARE
+  has_update_policy boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+      FROM pg_policies
+     WHERE schemaname = 'erp'
+       AND tablename  = 'cortes_vouchers'
+       AND cmd        = 'UPDATE'
+  ) INTO has_update_policy;
+
+  IF NOT has_update_policy THEN
+    RAISE EXCEPTION 'Policy de UPDATE no se creó en erp.cortes_vouchers';
+  END IF;
+
+  RAISE NOTICE 'OK: erp.cortes_vouchers ya admite UPDATE para usuarios con acceso a la empresa.';
+END $$;


### PR DESCRIPTION
## El bug

Beto reportó que el modal del corte mostraba `Σ Vouchers (3): \$0.00 +3 s/cap` **a pesar de que sí había capturado montos**. Diagnóstico:

1. La migración original de `erp.cortes_vouchers` ([20260424184855_erp_cortes_vouchers.sql:109](supabase/migrations/20260424184855_erp_cortes_vouchers.sql:109)) creó la tabla **sin policy de UPDATE** — diseño inicial: vouchers como audit trail inmutable.
2. El sprint siguiente ([20260425153136_cortes_vouchers_bancos_y_categoria.sql](supabase/migrations/20260425153136_cortes_vouchers_bancos_y_categoria.sql)) agregó columnas editables (`monto_reportado`, `banco_id`, `afiliacion`, `categoria`, `movimiento_caja_id`) **sin crear la policy correspondiente**.
3. Cuando `confirmarVoucher()` corre el UPDATE, RLS lo bloquea silenciosamente. PostgREST devuelve 200 con 0 filas afectadas (no error 4xx para UPDATE bloqueado). supabase-js retorna sin `error`, el UI muestra toast de éxito, y el dato **nunca persiste**.

## Cambios

1. **[supabase/migrations/20260428240000_erp_cortes_vouchers_update_policy.sql](supabase/migrations/20260428240000_erp_cortes_vouchers_update_policy.sql)** — agrega policy de UPDATE. Misma USING que SELECT (cualquier usuario con acceso a la empresa puede confirmar/corregir un voucher — operativamente el manager suele confirmar lo del cajero, no se restringe al uploader). Los campos inmutables (`empresa_id`, `corte_id`, `uploaded_by`, `storage_path`, `uploaded_at`) los protege la app: no los manda en el `.update()`.
2. **[app/rdb/cortes/actions.ts](app/rdb/cortes/actions.ts)** — `confirmarVoucher()` y `actualizarCategoriaVoucher()` ahora agregan `.select('id')` para detectar 0 filas afectadas y lanzar un error visible. Defense-in-depth: si en el futuro se introduce otro bug similar de RLS, el toast del UI mostrará el error en vez de silenciar el problema.

## Aplicar la migración

⚠️ **Antes de mergear**: aplicar la migración con psql.

\`\`\`bash
psql \$SUPABASE_DB_URL -f supabase/migrations/20260428240000_erp_cortes_vouchers_update_policy.sql
\`\`\`

Tras aplicar, regenerar:

\`\`\`bash
npm run schema:ref
\`\`\`

(El SCHEMA_REF no debería cambiar — la migración solo agrega policy, no columnas — pero es buena práctica.)

## Test plan
- [ ] Aplicar migración con psql
- [ ] En preview: subir 2-3 vouchers, capturar montos, verificar que `Σ Vouchers` refleja la suma
- [ ] Verificar que la diferencia se calcula correctamente
- [ ] Cambiar la categoría de un voucher a "comprobante_movimiento" y verificar que persiste
- [ ] Verificar que el guard nuevo lanza error visible si se rompe RLS en el futuro (smoke test manual: cambiar temporalmente la policy y intentar capturar)
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)