### PR TITLE
fix(documentos-legales): schema IA bajo el límite de 16 unions de Anthropic

### DIFF
--- a/app/api/documentos/[id]/extract/route.ts
+++ b/app/api/documentos/[id]/extract/route.ts
@@ -34,6 +34,7 @@ import {
   ensurePdfFitsForClaude,
   embedContent,
   extractWithClaude,
+  extraccionToDocumentoUpdates,
   MODELO_CLAUDE,
 } from '@/lib/documentos/extraction-core';
 import {
@@ -186,25 +187,16 @@ export async function POST(_req: NextRequest, { params }: Params) {
       numero: extraccion.numero_documento,
     });
 
+    // `extraccionToDocumentoUpdates` aplana `predio.*` a columnas top-level
+    // y normaliza "" → null y 0 → null para `superficie_m2`. El sync_trigger
+    // de core.empresa_documentos depende de `null = ausente` en
+    // `subtipo_meta`. Centralizado en lib/documentos/extraction-core.ts para
+    // que API route y script batch no diverjan.
+    const documentoUpdates = extraccionToDocumentoUpdates(extraccion);
+
     const updates: Record<string, unknown> = {
-      descripcion: extraccion.descripcion,
-      contenido_texto: extraccion.contenido_texto,
+      ...documentoUpdates,
       contenido_embedding: embedding,
-      tipo_operacion: extraccion.tipo_operacion,
-      monto: extraccion.monto,
-      moneda: extraccion.moneda,
-      superficie_m2: extraccion.superficie_m2,
-      ubicacion_predio: extraccion.ubicacion_predio,
-      municipio: extraccion.municipio,
-      estado: extraccion.estado,
-      folio_real: extraccion.folio_real,
-      libro_tomo: extraccion.libro_tomo,
-      partes: extraccion.partes,
-      // subtipo_meta: solo se llena si el doc es escritura/poder/acta. Para
-      // otros tipos (factura, contrato laboral, comprobante) la IA pone null.
-      // Consumido por el sync_trigger de core.empresa_documentos para llenar
-      // el caché jsonb en core.empresas.escritura_*.
-      subtipo_meta: extraccion.subtipo_meta,
       extraccion_status: 'completado',
       extraccion_fecha: new Date().toISOString(),
       extraccion_modelo: MODELO_CLAUDE,
@@ -212,8 +204,10 @@ export async function POST(_req: NextRequest, { params }: Params) {
       updated_at: new Date().toISOString(),
     };
 
-    if (extraccion.fecha_emision) updates.fecha_emision = extraccion.fecha_emision;
-    if (extraccion.numero_documento) updates.numero_documento = extraccion.numero_documento;
+    // `fecha_emision` y `numero_documento` solo se sobrescriben si la IA los
+    // determinó (no null) — preservamos el valor humano si existía.
+    if (!documentoUpdates.fecha_emision) delete updates.fecha_emision;
+    if (!documentoUpdates.numero_documento) delete updates.numero_documento;
     // Solo sobrescribimos el título si podemos generar uno estándar nuevo y
     // el actual no está ya en formato estándar (respetamos ediciones humanas).
     const titleIsStandard = isStandardTitulo(docRow.titulo);

--- a/lib/documentos/extraction-core.test.ts
+++ b/lib/documentos/extraction-core.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 
-import { ExtraccionSchema, ParteSchema, SubtipoMetaEscrituraSchema } from './extraction-core';
+import {
+  ExtraccionSchema,
+  ParteSchema,
+  PredioSchema,
+  SubtipoMetaEscrituraSchema,
+  extraccionToDocumentoUpdates,
+  type Extraccion,
+} from './extraction-core';
 
 /**
  * Tests del schema Zod del extractor de documentos legales.
@@ -8,8 +15,12 @@ import { ExtraccionSchema, ParteSchema, SubtipoMetaEscrituraSchema } from './ext
  * No prueban la llamada a Claude (eso vive como integration test fuera de
  * la suite unitaria) — solo el shape de los datos que entran/salen.
  *
- * Sprint 2 — empresa-documentos-legales agregó `subtipo_meta`. Estos
- * tests cubren el shape nuevo.
+ * Convención del schema (post-fix 21 unions, 2026-04-29):
+ * - Top-level nullables: tipo_operacion, monto, fecha_emision, numero_documento.
+ * - Sub-objetos nullables como BLOQUE: predio, subtipo_meta. Sus campos
+ *   internos NO son nullable (la IA emite "" o 0 en ausencia).
+ * - `extraccionToDocumentoUpdates()` normaliza "" → null y 0 → null antes
+ *   de persistir, para mantener `null = ausente` en DB.
  */
 
 const baseExtraccionPayload = {
@@ -18,12 +29,7 @@ const baseExtraccionPayload = {
   tipo_operacion: 'compraventa',
   monto: 1500000,
   moneda: 'MXN',
-  superficie_m2: null,
-  ubicacion_predio: null,
-  municipio: 'Piedras Negras',
-  estado: 'Coahuila',
-  folio_real: null,
-  libro_tomo: null,
+  predio: null,
   partes: [],
   fecha_emision: '2024-03-15',
   numero_documento: '12345',
@@ -47,15 +53,15 @@ describe('ExtraccionSchema — subtipo_meta opcional', () => {
         notario_nombre: 'JUAN PÉREZ',
         notaria_numero: '5',
         distrito_notarial: 'PIEDRAS NEGRAS',
-        tipo_poder: null,
-        alcance: null,
+        tipo_poder: '',
+        alcance: '',
       },
     };
     const parsed = ExtraccionSchema.parse(input);
     expect(parsed.subtipo_meta?.numero_escritura).toBe('12345');
     expect(parsed.subtipo_meta?.fecha_escritura).toBe('2010-05-15');
     expect(parsed.subtipo_meta?.notario_nombre).toBe('JUAN PÉREZ');
-    expect(parsed.subtipo_meta?.tipo_poder).toBeNull();
+    expect(parsed.subtipo_meta?.tipo_poder).toBe('');
   });
 
   it('parsea subtipo_meta de un poder con tipo_poder + alcance', () => {
@@ -65,7 +71,7 @@ describe('ExtraccionSchema — subtipo_meta opcional', () => {
       subtipo_meta: {
         numero_escritura: '6789',
         fecha_escritura: '2021-03-03',
-        fecha_texto: null,
+        fecha_texto: '',
         notario_nombre: 'MARÍA LÓPEZ',
         notaria_numero: '12',
         distrito_notarial: 'COAHUILA',
@@ -78,12 +84,29 @@ describe('ExtraccionSchema — subtipo_meta opcional', () => {
     expect(parsed.subtipo_meta?.alcance).toContain('IMSS');
   });
 
-  it('rechaza si subtipo_meta omite un campo del shape (debe ser explícito null)', () => {
+  it('rechaza si subtipo_meta omite un campo del shape', () => {
     const input = {
       ...baseExtraccionPayload,
       subtipo_meta: {
         // falta numero_escritura, fecha_escritura, fecha_texto, etc.
         notario_nombre: 'X',
+      },
+    };
+    expect(() => ExtraccionSchema.parse(input)).toThrow();
+  });
+
+  it('rechaza si un campo interno de subtipo_meta es null (no nullable)', () => {
+    const input = {
+      ...baseExtraccionPayload,
+      subtipo_meta: {
+        numero_escritura: null,
+        fecha_escritura: '',
+        fecha_texto: '',
+        notario_nombre: '',
+        notaria_numero: '',
+        distrito_notarial: '',
+        tipo_poder: '',
+        alcance: '',
       },
     };
     expect(() => ExtraccionSchema.parse(input)).toThrow();
@@ -95,37 +118,70 @@ describe('SubtipoMetaEscrituraSchema standalone', () => {
     expect(SubtipoMetaEscrituraSchema.parse(null)).toBeNull();
   });
 
-  it('todos los campos pueden ser null individualmente', () => {
-    const allNull = {
-      numero_escritura: null,
-      fecha_escritura: null,
-      fecha_texto: null,
-      notario_nombre: null,
-      notaria_numero: null,
-      distrito_notarial: null,
-      tipo_poder: null,
-      alcance: null,
+  it('todos los campos son string no-nullable (la IA usa "" para ausencia)', () => {
+    const empty = {
+      numero_escritura: '',
+      fecha_escritura: '',
+      fecha_texto: '',
+      notario_nombre: '',
+      notaria_numero: '',
+      distrito_notarial: '',
+      tipo_poder: '',
+      alcance: '',
     };
-    const parsed = SubtipoMetaEscrituraSchema.parse(allNull);
-    expect(parsed).toEqual(allNull);
+    const parsed = SubtipoMetaEscrituraSchema.parse(empty);
+    expect(parsed).toEqual(empty);
   });
 
-  it('todos los campos son string-or-null (no number, no boolean)', () => {
+  it('rechaza valores no-string en cualquier campo', () => {
     const input = {
       numero_escritura: 12345 as unknown as string,
-      fecha_escritura: null,
-      fecha_texto: null,
-      notario_nombre: null,
-      notaria_numero: null,
-      distrito_notarial: null,
-      tipo_poder: null,
-      alcance: null,
+      fecha_escritura: '',
+      fecha_texto: '',
+      notario_nombre: '',
+      notaria_numero: '',
+      distrito_notarial: '',
+      tipo_poder: '',
+      alcance: '',
     };
     expect(() => SubtipoMetaEscrituraSchema.parse(input)).toThrow();
   });
 });
 
-describe('ParteSchema — sigue intacto tras Sprint 2', () => {
+describe('PredioSchema standalone', () => {
+  it('null es válido (doc no involucra predio)', () => {
+    expect(PredioSchema.parse(null)).toBeNull();
+  });
+
+  it('parsea un predio completo', () => {
+    const input = {
+      ubicacion: 'Carretera 57 km 3',
+      municipio: 'Piedras Negras',
+      estado: 'Coahuila',
+      folio_real: '123456',
+      libro_tomo: 'Libro 12, Tomo 3',
+      superficie_m2: 5000,
+    };
+    const parsed = PredioSchema.parse(input);
+    expect(parsed?.superficie_m2).toBe(5000);
+  });
+
+  it('acepta strings vacíos y 0 como ausencia', () => {
+    const input = {
+      ubicacion: '',
+      municipio: '',
+      estado: '',
+      folio_real: '',
+      libro_tomo: '',
+      superficie_m2: 0,
+    };
+    const parsed = PredioSchema.parse(input);
+    expect(parsed?.superficie_m2).toBe(0);
+    expect(parsed?.ubicacion).toBe('');
+  });
+});
+
+describe('ParteSchema', () => {
   it('parsea una parte moral con representante', () => {
     const parsed = ParteSchema.parse({
       rol: 'vendedor',
@@ -136,13 +192,129 @@ describe('ParteSchema — sigue intacto tras Sprint 2', () => {
     expect(parsed.representante).toBe('ADALBERTO SANTOS');
   });
 
-  it('parsea una parte física sin RFC', () => {
+  it('parsea una parte física sin RFC ("" en lugar de null)', () => {
     const parsed = ParteSchema.parse({
       rol: 'comprador',
       nombre: 'JUAN PÉREZ',
-      rfc: null,
-      representante: null,
+      rfc: '',
+      representante: '',
     });
-    expect(parsed.rfc).toBeNull();
+    expect(parsed.rfc).toBe('');
+  });
+});
+
+describe('extraccionToDocumentoUpdates — normalización para persistir', () => {
+  const baseExtraccion: Extraccion = {
+    descripcion: 'doc',
+    contenido_texto: 'texto',
+    tipo_operacion: 'compraventa',
+    monto: 100000,
+    moneda: 'MXN',
+    predio: null,
+    partes: [],
+    fecha_emision: '2024-03-15',
+    numero_documento: '12345',
+    subtipo_meta: null,
+  };
+
+  it('predio null se aplana a columnas null', () => {
+    const out = extraccionToDocumentoUpdates({ ...baseExtraccion, predio: null });
+    expect(out.superficie_m2).toBeNull();
+    expect(out.ubicacion_predio).toBeNull();
+    expect(out.municipio).toBeNull();
+    expect(out.estado).toBeNull();
+    expect(out.folio_real).toBeNull();
+    expect(out.libro_tomo).toBeNull();
+  });
+
+  it('predio con campos vacíos normaliza "" → null y 0 → null', () => {
+    const out = extraccionToDocumentoUpdates({
+      ...baseExtraccion,
+      predio: {
+        ubicacion: '',
+        municipio: 'Piedras Negras',
+        estado: '',
+        folio_real: '   ',
+        libro_tomo: '',
+        superficie_m2: 0,
+      },
+    });
+    expect(out.superficie_m2).toBeNull();
+    expect(out.ubicacion_predio).toBeNull();
+    expect(out.municipio).toBe('Piedras Negras');
+    expect(out.estado).toBeNull();
+    expect(out.folio_real).toBeNull(); // whitespace-only también
+    expect(out.libro_tomo).toBeNull();
+  });
+
+  it('predio con superficie > 0 se preserva', () => {
+    const out = extraccionToDocumentoUpdates({
+      ...baseExtraccion,
+      predio: {
+        ubicacion: 'Carretera 57',
+        municipio: 'PN',
+        estado: 'Coahuila',
+        folio_real: '123',
+        libro_tomo: '',
+        superficie_m2: 5000,
+      },
+    });
+    expect(out.superficie_m2).toBe(5000);
+    expect(out.ubicacion_predio).toBe('Carretera 57');
+    expect(out.libro_tomo).toBeNull();
+  });
+
+  it('subtipo_meta null se preserva como null', () => {
+    const out = extraccionToDocumentoUpdates({ ...baseExtraccion, subtipo_meta: null });
+    expect(out.subtipo_meta).toBeNull();
+  });
+
+  it('subtipo_meta normaliza campos "" → null preservando los poblados', () => {
+    const out = extraccionToDocumentoUpdates({
+      ...baseExtraccion,
+      subtipo_meta: {
+        numero_escritura: '12345',
+        fecha_escritura: '2024-03-15',
+        fecha_texto: '',
+        notario_nombre: 'JUAN PÉREZ',
+        notaria_numero: '5',
+        distrito_notarial: '',
+        tipo_poder: '',
+        alcance: '',
+      },
+    });
+    expect(out.subtipo_meta).not.toBeNull();
+    expect(out.subtipo_meta?.numero_escritura).toBe('12345');
+    expect(out.subtipo_meta?.fecha_texto).toBeNull();
+    expect(out.subtipo_meta?.distrito_notarial).toBeNull();
+    expect(out.subtipo_meta?.tipo_poder).toBeNull();
+  });
+
+  it('partes normaliza rfc/representante "" → null', () => {
+    const out = extraccionToDocumentoUpdates({
+      ...baseExtraccion,
+      partes: [
+        { rol: 'vendedor', nombre: 'X SA', rfc: 'XXX850101AAA', representante: 'Juan' },
+        { rol: 'comprador', nombre: 'María', rfc: '', representante: '' },
+      ],
+    });
+    expect(out.partes[0].rfc).toBe('XXX850101AAA');
+    expect(out.partes[0].representante).toBe('Juan');
+    expect(out.partes[1].rfc).toBeNull();
+    expect(out.partes[1].representante).toBeNull();
+  });
+
+  it('top-level nullables se preservan', () => {
+    const out = extraccionToDocumentoUpdates({
+      ...baseExtraccion,
+      tipo_operacion: null,
+      monto: null,
+      fecha_emision: null,
+      numero_documento: null,
+    });
+    expect(out.tipo_operacion).toBeNull();
+    expect(out.monto).toBeNull();
+    expect(out.fecha_emision).toBeNull();
+    expect(out.numero_documento).toBeNull();
   });
 });

--- a/lib/documentos/extraction-core.ts
+++ b/lib/documentos/extraction-core.ts
@@ -42,6 +42,24 @@ export const PDF_MAX_AFTER_COMPRESS_BYTES = 28 * 1024 * 1024;
 export const anthropic = createAnthropic({ baseURL: 'https://api.anthropic.com/v1' });
 
 // ─── Zod schema compartido ───────────────────────────────────────────────────
+//
+// IMPORTANTE — convención del schema:
+//
+// La Anthropic API limita los tool/object schemas a 16 parámetros con tipo
+// union (nullable, anyOf). Antes esto era 21+ y rompía con
+//   "Schemas contains too many parameters with union types"
+// (cuando `tipo_operacion` + 6 campos de predio + 8 de subtipo_meta + 2 de
+// `partes` sumaban 21 nullables individuales). Por eso ahora sub-objetos
+// opcionales (`predio`, `subtipo_meta`) son nullable como bloque pero sus
+// campos internos NO. La IA emite "" para strings ausentes y 0 para números
+// ausentes; `extraccionToDocumentoUpdates()` (al final de este archivo)
+// normaliza "" → null y 0 → null antes de persistir, así la DB sigue con
+// la convención `null = ausente` que esperan el sync_trigger y los
+// consumidores legacy (validador RH, printable de contrato laboral).
+//
+// Conteo actual de parámetros union (todos top-level):
+//   tipo_operacion, monto, fecha_emision, numero_documento (4)
+//   + predio (1, objeto entero) + subtipo_meta (1, objeto entero) = 6 ≤ 16 ✓
 
 export const ParteSchema = z.object({
   rol: z
@@ -52,12 +70,36 @@ export const ParteSchema = z.object({
         'arrendatario, otorgante, beneficiario, donante, donatario, etc. Usar minúsculas.'
     ),
   nombre: z.string().describe('Nombre completo de la persona física o moral.'),
-  rfc: z.string().nullable().describe('RFC si aparece en el documento, si no null.'),
+  rfc: z.string().describe('RFC si aparece en el documento, "" si no aparece.'),
   representante: z
     .string()
-    .nullable()
-    .describe('Nombre del representante legal si la parte es una persona moral, si no null.'),
+    .describe('Nombre del representante legal si la parte es persona moral, "" en otro caso.'),
 });
+
+/**
+ * Datos del predio / inmueble cuando el documento toca un bien raíz
+ * (compraventa, hipoteca, donación, permuta, fideicomiso inmobiliario, etc.).
+ * Si el documento no toca un bien raíz → `predio: null`.
+ */
+export const PredioSchema = z
+  .object({
+    ubicacion: z.string().describe('Ubicación / domicilio del predio. "" si no aparece.'),
+    municipio: z.string().describe('Municipio donde está el predio. "" si no aparece.'),
+    estado: z.string().describe('Estado donde está el predio. "" si no aparece.'),
+    folio_real: z
+      .string()
+      .describe('Folio real del Registro Público de la Propiedad. "" si no aparece.'),
+    libro_tomo: z.string().describe('Referencia catastral / libro / tomo. "" si no aparece.'),
+    superficie_m2: z
+      .number()
+      .describe('Superficie en m² (1 ha = 10,000 m²). 0 si no aparece o no aplica.'),
+  })
+  .nullable()
+  .describe(
+    'Datos del bien raíz si el documento toca un predio (compraventa, hipoteca, donación, ' +
+      'permuta, fideicomiso inmobiliario, escritura constitutiva con aportación de inmueble, ' +
+      'etc.). Si el documento no involucra un bien raíz → null.'
+  );
 
 /**
  * Metadata específica para escrituras notariales mexicanas (constitutivas,
@@ -77,53 +119,43 @@ export const SubtipoMetaEscrituraSchema = z
   .object({
     numero_escritura: z
       .string()
-      .nullable()
-      .describe('Número de la escritura tal como aparece (ej. "12,345" o "12345"). null si no.'),
+      .describe('Número de la escritura tal como aparece (ej. "12,345" o "12345"). "" si no.'),
     fecha_escritura: z
       .string()
-      .nullable()
-      .describe('Fecha de otorgamiento en formato YYYY-MM-DD. null si no se puede determinar.'),
+      .describe('Fecha de otorgamiento en formato YYYY-MM-DD. "" si no se puede determinar.'),
     fecha_texto: z
       .string()
-      .nullable()
       .describe(
         'Fecha en texto legible tal como aparece en el cuerpo del instrumento ' +
-          '(ej. "quince de mayo del dos mil diez"). Útil para reproducir literal en contratos. null si no.'
+          '(ej. "quince de mayo del dos mil diez"). "" si no.'
       ),
     notario_nombre: z
       .string()
-      .nullable()
-      .describe(
-        'Nombre completo del notario público que da fe (ej. "JUAN PÉREZ LÓPEZ"). null si no.'
-      ),
+      .describe('Nombre completo del notario público (ej. "JUAN PÉREZ LÓPEZ"). "" si no.'),
     notaria_numero: z
       .string()
-      .nullable()
-      .describe('Número de la notaría (texto, ej. "5" o "Cinco"). null si no aparece.'),
+      .describe('Número de la notaría (texto, ej. "5" o "Cinco"). "" si no aparece.'),
     distrito_notarial: z
       .string()
-      .nullable()
       .describe(
         'Distrito notarial / municipio donde ejerce el notario ' +
-          '(ej. "PIEDRAS NEGRAS", "DISTRITO FEDERAL"). null si no aparece.'
+          '(ej. "PIEDRAS NEGRAS", "DISTRITO FEDERAL"). "" si no aparece.'
       ),
     // Campos extras útiles para poderes (auto-sugerir rol al asignar en UI)
     tipo_poder: z
       .string()
-      .nullable()
       .describe(
         'Solo para poderes: clase de poder otorgado, en minúsculas y sin acentos: ' +
           '"general para actos de administracion", "general para actos de dominio", ' +
           '"general para pleitos y cobranzas", "especial para actos bancarios", etc. ' +
-          'null si no es poder o no se puede determinar.'
+          '"" si no es poder o no se puede determinar.'
       ),
     alcance: z
       .string()
-      .nullable()
       .describe(
         'Solo para poderes: resumen breve del alcance/facultades otorgadas ' +
           '(ej. "contratación laboral, IMSS, SAT, contratos comerciales generales"). ' +
-          'null si no es poder.'
+          '"" si no es poder.'
       ),
   })
   .nullable()
@@ -165,15 +197,7 @@ export const ExtraccionSchema = z.object({
     .nullable()
     .describe('Valor económico de la operación si aplica y está explícito. null si no aplica.'),
   moneda: z.string().describe('Moneda de la operación: MXN, USD, EUR. Default MXN si hay monto.'),
-  superficie_m2: z
-    .number()
-    .nullable()
-    .describe('Superficie en m² (convierte hectáreas con 1 ha = 10,000 m²). null si no aplica.'),
-  ubicacion_predio: z.string().nullable(),
-  municipio: z.string().nullable(),
-  estado: z.string().nullable(),
-  folio_real: z.string().nullable(),
-  libro_tomo: z.string().nullable(),
+  predio: PredioSchema,
   partes: z.array(ParteSchema),
   // Datos adicionales necesarios para estandarizar el título del documento.
   fecha_emision: z
@@ -190,6 +214,96 @@ export const ExtraccionSchema = z.object({
 });
 
 export type Extraccion = z.infer<typeof ExtraccionSchema>;
+export type Parte = z.infer<typeof ParteSchema>;
+export type Predio = z.infer<typeof PredioSchema>;
+export type SubtipoMetaEscritura = z.infer<typeof SubtipoMetaEscrituraSchema>;
+
+// ─── Normalización para persistir ────────────────────────────────────────────
+//
+// La IA emite "" para strings ausentes y 0 para números ausentes (porque el
+// schema los hace no-nullable para mantenerse bajo el límite de 16 unions).
+// Antes de escribir a `erp.documentos`, los normalizamos a `null` para que
+// el sync_trigger de `core.empresa_documentos` y los consumidores legacy
+// (validador RH, printable de contrato laboral) sigan recibiendo la
+// convención esperada de `null = ausente`.
+
+const trim = (v: string | null | undefined): string | null => {
+  if (v == null) return null;
+  const t = v.trim();
+  return t === '' ? null : t;
+};
+
+function normalizeParte(p: Parte): {
+  rol: string;
+  nombre: string;
+  rfc: string | null;
+  representante: string | null;
+} {
+  return {
+    rol: p.rol,
+    nombre: p.nombre,
+    rfc: trim(p.rfc),
+    representante: trim(p.representante),
+  };
+}
+
+function normalizeSubtipoMeta(s: SubtipoMetaEscritura): Record<string, string | null> | null {
+  if (s == null) return null;
+  return {
+    numero_escritura: trim(s.numero_escritura),
+    fecha_escritura: trim(s.fecha_escritura),
+    fecha_texto: trim(s.fecha_texto),
+    notario_nombre: trim(s.notario_nombre),
+    notaria_numero: trim(s.notaria_numero),
+    distrito_notarial: trim(s.distrito_notarial),
+    tipo_poder: trim(s.tipo_poder),
+    alcance: trim(s.alcance),
+  };
+}
+
+/**
+ * Convierte el resultado de `extractWithClaude` al shape exacto que el
+ * UPDATE de `erp.documentos` espera: campos planos en columnas top-level,
+ * jsonb para `partes` y `subtipo_meta`, y `null` (no `""` ni `0`) para
+ * ausencias. Centralizado aquí para que el API route y el script batch no
+ * diverjan en la normalización.
+ */
+export function extraccionToDocumentoUpdates(e: Extraccion): {
+  descripcion: string;
+  contenido_texto: string;
+  tipo_operacion: string | null;
+  monto: number | null;
+  moneda: string;
+  superficie_m2: number | null;
+  ubicacion_predio: string | null;
+  municipio: string | null;
+  estado: string | null;
+  folio_real: string | null;
+  libro_tomo: string | null;
+  partes: ReturnType<typeof normalizeParte>[];
+  fecha_emision: string | null;
+  numero_documento: string | null;
+  subtipo_meta: Record<string, string | null> | null;
+} {
+  const predio = e.predio;
+  return {
+    descripcion: e.descripcion,
+    contenido_texto: e.contenido_texto,
+    tipo_operacion: trim(e.tipo_operacion),
+    monto: e.monto,
+    moneda: e.moneda,
+    superficie_m2: predio && predio.superficie_m2 > 0 ? predio.superficie_m2 : null,
+    ubicacion_predio: predio ? trim(predio.ubicacion) : null,
+    municipio: predio ? trim(predio.municipio) : null,
+    estado: predio ? trim(predio.estado) : null,
+    folio_real: predio ? trim(predio.folio_real) : null,
+    libro_tomo: predio ? trim(predio.libro_tomo) : null,
+    partes: e.partes.map(normalizeParte),
+    fecha_emision: trim(e.fecha_emision),
+    numero_documento: trim(e.numero_documento),
+    subtipo_meta: normalizeSubtipoMeta(e.subtipo_meta),
+  };
+}
 
 // ─── Compresión con Ghostscript (WASM) ───────────────────────────────────────
 
@@ -340,21 +454,30 @@ export async function extractWithClaude(pdfBytes: Uint8Array, titulo: string): P
               `Analiza el siguiente PDF y extrae la información solicitada. ` +
               `El título del documento en nuestro sistema es: "${titulo}". ` +
               `Si el PDF es un escaneado, transcribe el texto lo mejor posible. ` +
-              `Para campos numéricos (monto, superficie_m2), si el valor aparece ` +
-              `en letra o con formato raro, conviértelo a número o usa null si no es claro. ` +
-              `Usa null para cualquier campo estructurado que no puedas determinar con ` +
-              `certeza, en vez de inventar o poner strings genéricas. ` +
-              `\n\nIMPORTANTE — campo "subtipo_meta": ` +
-              `Si el documento es una escritura notarial mexicana (constitutiva, reforma, ` +
-              `poder, compraventa, hipoteca, fideicomiso, donación, permuta, acta), llena los ` +
-              `campos del subtipo_meta con los datos del notario y de la escritura: número de ` +
-              `escritura, fecha (en formato YYYY-MM-DD y también en texto legible cuando aparezca ` +
-              `en el cuerpo del instrumento), nombre del notario, número de notaría, distrito ` +
-              `notarial. Si es un PODER, además llena tipo_poder (en minúsculas, sin acentos: ` +
-              `"general para actos de administracion", "general para actos de dominio", ` +
-              `"general para pleitos y cobranzas", "especial para actos bancarios", etc.) y ` +
-              `alcance (resumen breve de facultades). Para documentos NO notariales (facturas, ` +
-              `contratos laborales, comprobantes, declaraciones, etc.), subtipo_meta debe ser null.`,
+              `\n\nCONVENCIÓN para campos ausentes (importante por límites del schema): ` +
+              `\n- Top-level nullables: tipo_operacion, monto, fecha_emision, numero_documento. ` +
+              `Si no puedes determinarlos, usa null (no inventes). ` +
+              `\n- Sub-objetos nullables como BLOQUE: predio, subtipo_meta. Si el documento ` +
+              `no aplica al sub-objeto entero, devuelve el bloque como null. ` +
+              `\n- Campos DENTRO de sub-objetos (predio.*, subtipo_meta.*) y dentro de items ` +
+              `de "partes" (rfc, representante): NO son nullable. Si decides llenar el bloque, ` +
+              `usa "" para strings ausentes y 0 para números ausentes (NO null). El backend ` +
+              `los convierte a null al persistir. ` +
+              `\n\nCampo "predio": llénalo SOLO si el documento toca un bien raíz ` +
+              `(compraventa, hipoteca, donación, permuta, fideicomiso inmobiliario, escritura ` +
+              `constitutiva con aportación de inmueble, etc.). Si el documento no involucra ` +
+              `un predio (poder simple, contrato laboral, factura, acta sin inmueble), ` +
+              `devuelve predio: null. ` +
+              `\n\nCampo "subtipo_meta": llénalo SOLO si el documento es una escritura ` +
+              `notarial mexicana (constitutiva, reforma, poder, compraventa, hipoteca, ` +
+              `fideicomiso, donación, permuta, acta). Llena número de escritura, fecha ` +
+              `(YYYY-MM-DD y texto legible cuando aparezca en el cuerpo), nombre del notario, ` +
+              `número de notaría, distrito notarial. Si es un PODER, además llena tipo_poder ` +
+              `(en minúsculas, sin acentos: "general para actos de administracion", ` +
+              `"general para actos de dominio", "general para pleitos y cobranzas", ` +
+              `"especial para actos bancarios", etc.) y alcance (resumen breve de facultades). ` +
+              `Para documentos NO notariales (facturas, contratos laborales, comprobantes, ` +
+              `declaraciones, etc.) → subtipo_meta: null.`,
           },
           {
             type: 'file',

--- a/scripts/extract-documento-contents.ts
+++ b/scripts/extract-documento-contents.ts
@@ -56,6 +56,7 @@ import {
   ensurePdfFitsForClaude,
   embedContent,
   extractWithClaude,
+  extraccionToDocumentoUpdates,
   formatMB,
   MODELO_CLAUDE,
   MODELO_EMBEDDING,
@@ -224,19 +225,8 @@ async function writeResult(id: string, extraccion: Extraccion, embedding: number
   const { error } = await (supabase.schema('erp') as any)
     .from('documentos')
     .update({
-      descripcion: extraccion.descripcion,
-      contenido_texto: extraccion.contenido_texto,
+      ...extraccionToDocumentoUpdates(extraccion),
       contenido_embedding: embedding as any,
-      tipo_operacion: extraccion.tipo_operacion,
-      monto: extraccion.monto,
-      moneda: extraccion.moneda,
-      superficie_m2: extraccion.superficie_m2,
-      ubicacion_predio: extraccion.ubicacion_predio,
-      municipio: extraccion.municipio,
-      estado: extraccion.estado,
-      folio_real: extraccion.folio_real,
-      libro_tomo: extraccion.libro_tomo,
-      partes: extraccion.partes,
       extraccion_status: 'completado',
       extraccion_fecha: new Date().toISOString(),
       extraccion_modelo: MODELO_CLAUDE,


### PR DESCRIPTION
## El bug

`Procesar con IA` fallaba al cargar escrituras de RDB con:

> Schemas contains too many parameters with union types (21 parameters with type arrays or anyOf). This causes exponential compilation cost. Reduce the number of nullable or union-typed parameters (limit: 16 parameters with unions).

## Causa raíz

El schema unificado para todos los tipos de documentos tenía **21 parámetros nullable individuales**:

- 6 de predio (`superficie_m2`, `ubicacion_predio`, `municipio`, `estado`, `folio_real`, `libro_tomo`)
- 8 de `subtipo_meta` (`numero_escritura`, `fecha_escritura`, `fecha_texto`, `notario_nombre`, `notaria_numero`, `distrito_notarial`, `tipo_poder`, `alcance`)
- 4 top-level (`tipo_operacion`, `monto`, `fecha_emision`, `numero_documento`)
- 2 de partes (`rfc`, `representante`)
- 1 del bloque `subtipo_meta` mismo

En DILESA el feature ya estaba estable porque sus escrituras procesadas tenían `subtipo_meta = null`. En RDB explotó porque llegan más escrituras que disparan la lógica de `subtipo_meta` (Sprint 2 reciente).

## Refactor

- **Sub-objetos opcionales** (`predio`, `subtipo_meta`) ahora son nullable como **bloque**, sus campos internos NO. La IA emite `""` para strings y `0` para números cuando no encuentra el dato.
- **`ParteSchema`**: `rfc`/`representante` también no-nullable (la IA usa `""`).
- **Top-level nullables** solo: `tipo_operacion`, `monto`, `fecha_emision`, `numero_documento`.
- **Total: 6 unions** ≤ 16 ✓

Nuevo `PredioSchema` agrupa los 6 campos de inmueble en un sub-objeto.

## Persistencia

Para mantener `null = ausente` en la DB (lo que esperan el sync_trigger de `core.empresa_documentos`, validador RH y printable de contrato laboral), el nuevo helper `extraccionToDocumentoUpdates()` aplana `predio.*` a columnas top-level y normaliza `""` → `null` y `0` → `null`. Centralizado para que API route y script batch no diverjan.

## Cambios

- **lib/documentos/extraction-core.ts**: schema refactorizado, prompt actualizado para enseñar la convención a la IA, helper de normalización.
- **app/api/documentos/[id]/extract/route.ts** y **scripts/extract-documento-contents.ts**: usan el helper en vez de copiar campos uno por uno.
- **lib/documentos/extraction-core.test.ts**: tests actualizados al nuevo shape + 7 tests nuevos del helper de normalización (20 tests total, todos pasan).

## Test plan
- [ ] En preview: subir la escritura constitutiva de RDB que falló (`ACTA CONSTITUTIVA RINCON DEL BOSQUE.pdf`) y verificar que IA procesa sin error
- [ ] Verificar que el documento queda con `subtipo_meta` poblado (notario, número de escritura, fecha)
- [ ] Verificar que columnas `ubicacion_predio`, `municipio`, `estado`, `folio_real`, `libro_tomo`, `superficie_m2` se llenan correctamente para una escritura con predio
- [ ] Verificar que para una factura/contrato laboral, `predio` y `subtipo_meta` quedan en `null` (no `""` strings vacíos)
- [ ] Verificar que el sync_trigger sigue alimentando `core.empresas.escritura_constitutiva` / `escritura_poder` correctamente
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)