### PR TITLE
fix(empresa-documentos-legales): trigger sync usaba updated_at inexistente + permitir re-extraer

### DIFF
--- a/components/documentos/documento-detail-sheet.tsx
+++ b/components/documentos/documento-detail-sheet.tsx
@@ -185,11 +185,12 @@ export function DocumentoDetailSheet({
   if (!doc) return null;
 
   const metaEntries = Object.entries(doc.subtipo_meta ?? {}).filter(([, v]) => v);
-  const canExtract =
-    !!doc.id &&
-    (doc.extraccion_status === 'pendiente' ||
-      doc.extraccion_status === 'error' ||
-      !doc.extraccion_status);
+  // Permitimos re-extraer también docs ya 'completado' — útil cuando el schema
+  // del extractor cambia (ej. Sprint 2 de empresa-documentos-legales agregó
+  // `subtipo_meta` para escrituras y los docs viejos no lo tienen poblado).
+  // El único estado que bloquea es 'procesando' (otro request lo tiene).
+  const canExtract = !!doc.id && doc.extraccion_status !== 'procesando';
+  const isReExtract = doc.extraccion_status === 'completado';
 
   const hasPrincipalPdf = adjuntos.some((a) => a.rol === 'documento_principal');
   const needsPdf = doc.tipo && doc.tipo !== 'Otro';
@@ -212,14 +213,22 @@ export function DocumentoDetailSheet({
                 onClick={handleExtract}
                 disabled={extracting}
                 className="border-[var(--accent)]/30 bg-[var(--accent)]/5 text-[var(--accent)] hover:bg-[var(--accent)]/10"
-                title="Extraer datos del PDF con IA (60-120s)"
+                title={
+                  isReExtract
+                    ? 'Volver a extraer datos del PDF con IA (60-120s) — sobrescribe la extracción actual.'
+                    : 'Extraer datos del PDF con IA (60-120s)'
+                }
               >
                 {extracting ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 ) : (
                   <Wand2 className="mr-2 h-4 w-4" />
                 )}
-                {extracting ? 'Procesando...' : 'Procesar con IA'}
+                {extracting
+                  ? 'Procesando...'
+                  : isReExtract
+                    ? 'Re-extraer con IA'
+                    : 'Procesar con IA'}
               </Button>
             )}
             {!editing && (

--- a/supabase/migrations/20260428241000_fix_empresa_documentos_trigger_updated_at.sql
+++ b/supabase/migrations/20260428241000_fix_empresa_documentos_trigger_updated_at.sql
@@ -1,0 +1,75 @@
+-- Fix urgente — `core.empresas` no tiene columna `updated_at`. La función
+-- de sync del trigger creada en migración 20260428235000 incluía
+-- `, updated_at = now()` en el UPDATE — eso producía el error:
+--
+--   "column \"updated_at\" of relation \"empresas\" does not exist"
+--
+-- al asignar cualquier documento default (los triggers AFTER
+-- INSERT/UPDATE/DELETE invocan la función de sync, que falla y
+-- propaga el error al INSERT del row de empresa_documentos).
+--
+-- Reemplazamos la función con CREATE OR REPLACE quitando la cláusula
+-- problemática. Los triggers no cambian (siguen apuntando a esta función).
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION core.fn_empresa_documentos_sync_escrituras_cache(
+  p_empresa_id uuid,
+  p_rol text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_meta jsonb;
+  v_cache jsonb;
+  v_target_col text;
+BEGIN
+  IF p_rol = 'acta_constitutiva' THEN
+    v_target_col := 'escritura_constitutiva';
+  ELSIF p_rol = 'poder_general_administracion' THEN
+    v_target_col := 'escritura_poder';
+  ELSE
+    RETURN;
+  END IF;
+
+  SELECT d.subtipo_meta
+    INTO v_meta
+    FROM core.empresa_documentos ed
+    JOIN erp.documentos d ON d.id = ed.documento_id
+   WHERE ed.empresa_id = p_empresa_id
+     AND ed.rol = p_rol
+     AND ed.es_default = true
+   LIMIT 1;
+
+  IF v_meta IS NULL THEN
+    -- Sin default → caché limpio. Sin updated_at (la columna no existe
+    -- en core.empresas).
+    EXECUTE format(
+      'UPDATE core.empresas SET %I = NULL WHERE id = $1',
+      v_target_col
+    ) USING p_empresa_id;
+    RETURN;
+  END IF;
+
+  v_cache := jsonb_strip_nulls(jsonb_build_object(
+    'numero',         COALESCE(v_meta->>'numero_escritura', v_meta->>'numero'),
+    'fecha',          COALESCE(v_meta->>'fecha_escritura', v_meta->>'fecha'),
+    'fecha_texto',    v_meta->>'fecha_texto',
+    'notario',        COALESCE(v_meta->>'notario_nombre', v_meta->>'notario'),
+    'notaria_numero', v_meta->>'notaria_numero',
+    'distrito',       COALESCE(v_meta->>'distrito_notarial', v_meta->>'distrito')
+  ));
+
+  EXECUTE format(
+    'UPDATE core.empresas SET %I = $1 WHERE id = $2',
+    v_target_col
+  ) USING v_cache, p_empresa_id;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Beto reportó al hacer Sprint 5 operativo (asignar acta constitutiva en DILESA):

> `insert asignacion: column "updated_at" of relation "empresas" does not exist`

**Causa raíz**: la función `core.fn_empresa_documentos_sync_escrituras_cache` (creada en migración `20260428235000_*` del Sprint 1) incluía `, updated_at = now()` en los `UPDATE core.empresas SET ...` — pero esa tabla **no tiene** columna `updated_at`. Cualquier asignación con `es_default=true` disparaba el trigger, que llamaba a la función, que fallaba, y la falla se propagaba al INSERT del row de `empresa_documentos`.

**Fix DB**: migración `20260428240000_*` con `CREATE OR REPLACE FUNCTION` que quita la cláusula problemática. Los triggers no cambian.

**Bonus — botón re-extraer**: los docs ya `completado` no exponían botón para re-extraer en `documento-detail-sheet.tsx`. Bloqueaba el rollout: los docs cargados antes del Sprint 2 (#288) no tienen `subtipo_meta` poblado, y para que el sync_trigger los procese al asignar, hay que re-extraerlos. Ahora `canExtract` cubre todos los estados excepto `'procesando'`, y el label cambia a **"Re-extraer con IA"** cuando hay extracción previa.

## Pendiente operativo (Beto)

1. `psql "$SUPABASE_DB_URL" -f supabase/migrations/20260428240000_fix_empresa_documentos_trigger_updated_at.sql`
2. SCHEMA_REF NO necesita regenerarse (la firma de la función no cambia).
3. En `/dilesa/admin/documentos` abrir cada escritura/poder → **"Re-extraer con IA"** para poblar `subtipo_meta`.
4. En `/settings/empresas/dilesa` asignar — ahora sí debe llenar el caché jsonb sin error.

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓ (0 errors)
- [x] `npm run format:check` ✓
- [x] `npm run test:run` (586 verdes) ✓
- [ ] Beto re-prueba asignar acta constitutiva tras aplicar la migración

🤖 Generated with [Claude Code](https://claude.com/claude-code)