### PR TITLE
fix(ui): scroll en sheets se rompía sin min-h-0 en flex-1 ScrollArea

### DIFF
--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -432,7 +432,7 @@ function OrdenDetail({
           </div>
         </SheetHeader>
 
-        <ScrollArea className="flex-1 pr-1 print:h-auto print:overflow-visible">
+        <ScrollArea className="flex-1 min-h-0 pr-1 print:h-auto print:overflow-visible">
           <div className="space-y-6 pb-6 pt-6 print:space-y-4 print:pt-0">
             {/* ── Screen: Status + meta ── */}
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between print:hidden">

--- a/app/settings/acceso/acceso-client.tsx
+++ b/app/settings/acceso/acceso-client.tsx
@@ -718,7 +718,7 @@ export function AccesoClient({
                 </div>
               </SheetHeader>
 
-              <ScrollArea className="flex-1">
+              <ScrollArea className="flex-1 min-h-0">
                 <div className="space-y-8 px-6 py-5">
                   {/* ── Empresas section ── */}
                   <section>

--- a/components/documentos/documento-create-sheet.tsx
+++ b/components/documentos/documento-create-sheet.tsx
@@ -108,7 +108,7 @@ export function DocumentoCreateSheet({
         <SheetHeader>
           <SheetTitle>Nuevo Documento</SheetTitle>
         </SheetHeader>
-        <ScrollArea className="flex-1 pr-1">
+        <ScrollArea className="flex-1 min-h-0 pr-1">
           <div className="mt-4 pb-6 space-y-4">
             <div className="flex items-start gap-2 rounded-xl border border-[var(--accent)]/20 bg-[var(--accent)]/5 px-3 py-2.5 text-xs text-[var(--text)]/70">
               <Sparkles className="h-4 w-4 shrink-0 mt-0.5 text-[var(--accent)]" />

--- a/components/documentos/documento-detail-sheet.tsx
+++ b/components/documentos/documento-detail-sheet.tsx
@@ -245,7 +245,11 @@ export function DocumentoDetailSheet({
           </div>
         </SheetHeader>
 
-        <ScrollArea className="flex-1 pr-1 print:h-auto">
+        {/* `min-h-0` permite que este flex item shrinke debajo de la altura
+            natural de su contenido — sin esto, los flex items tienen
+            `min-height: auto` y el ScrollArea nunca llega a overflow, así
+            que el contenido se sale del viewport y no scrollea. */}
+        <ScrollArea className="flex-1 min-h-0 pr-1 print:h-auto">
           <div className="mt-4 space-y-5 pb-6">
             {extractError && (
               <div className="flex items-start gap-2 rounded-xl border border-red-500/25 bg-red-500/10 px-4 py-3 text-xs text-red-400">

--- a/components/proveedores/proveedores-module.tsx
+++ b/components/proveedores/proveedores-module.tsx
@@ -264,7 +264,7 @@ function ProveedorDetail({
           </div>
         </SheetHeader>
 
-        <ScrollArea className="flex-1 pr-1 print:h-auto">
+        <ScrollArea className="flex-1 min-h-0 pr-1 print:h-auto">
           <div className="mt-6 space-y-6 pb-6">
             <Badge variant={proveedor.activo ? 'default' : 'secondary'}>
               {proveedor.activo ? 'Activo' : 'Inactivo'}

--- a/components/ventas/order-detail.tsx
+++ b/components/ventas/order-detail.tsx
@@ -73,7 +73,7 @@ export function OrderDetail({
           </div>
         </SheetHeader>
 
-        <ScrollArea className="flex-1 pr-1 print:h-auto">
+        <ScrollArea className="flex-1 min-h-0 pr-1 print:h-auto">
           <div className="mt-6 space-y-6 pb-6">
             {/* Status + total */}
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## El bug

Reportado por Beto en el detail sheet de documentos legales: al abrir una escritura procesada con IA, el contenido excedía el viewport pero el scroll no funcionaba — el contenido quedaba cortado al fondo del sheet sin acceso a las secciones inferiores (DOCUMENTO PRINCIPAL, IMAGEN/PLANO, ANEXOS, etc.).

## Causa

Bug clásico de flexbox + Radix ScrollArea. Cuando un ScrollArea con `flex-1` vive dentro de un flex column container (como `SheetContent`), el flex item tiene `min-height: auto` por default, lo que le **impide shrinkear debajo de la altura natural de su contenido**. El ScrollArea nunca llega a overflow y el contenido se sale del viewport sin scroll.

## Fix

Agregar `min-h-0` al ScrollArea — permite al flex item shrinkear y deja que el viewport interno tome control del overflow.

```tsx
<ScrollArea className="flex-1 min-h-0 ..."> {/* min-h-0 nuevo */}
```

Comentario explicativo solo en `documento-detail-sheet.tsx` (el más visible para futuros lectores); los otros 5 son one-liners idénticos.

## Sweep

El mismo patrón estaba latente en otros 5 sheets — aplicado el fix a todos para consistencia:

- [components/documentos/documento-detail-sheet.tsx](components/documentos/documento-detail-sheet.tsx) — el reportado
- [components/documentos/documento-create-sheet.tsx](components/documentos/documento-create-sheet.tsx)
- [components/ventas/order-detail.tsx](components/ventas/order-detail.tsx)
- [components/proveedores/proveedores-module.tsx](components/proveedores/proveedores-module.tsx)
- [app/settings/acceso/acceso-client.tsx](app/settings/acceso/acceso-client.tsx)
- [app/rdb/ordenes-compra/page.tsx](app/rdb/ordenes-compra/page.tsx)

## Test plan
- [ ] Abrir el detail sheet de la escritura constitutiva de RDB que ya está procesada — verificar que se puede scrollear hasta el final (DOCUMENTO PRINCIPAL, IMAGEN/PLANO, ANEXOS visibles)
- [ ] Abrir un documento corto — verificar que el sheet sigue funcionando bien (no se rompe nada por agregar `min-h-0`)
- [ ] Abrir el sheet de "Nuevo Documento" — formulario scrollea bien
- [ ] Abrir un detalle de venta/order, proveedor, OC RDB — todos scrollean
- [ ] Abrir el sheet de acceso de un usuario — scrollea
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)