### PR TITLE
fix(rdb-tasks): tabla de tareas RDB con variant=rich igual que DILESA

### DIFF
--- a/app/rdb/admin/tasks/page.tsx
+++ b/app/rdb/admin/tasks/page.tsx
@@ -8,7 +8,12 @@ const EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 export default function Page() {
   return (
     <RequireAccess empresa="rdb">
-      <TasksModule empresaId={EMPRESA_ID} empresaSlug="rdb" title="Tareas — Rincón del Bosque" />
+      <TasksModule
+        empresaId={EMPRESA_ID}
+        empresaSlug="rdb"
+        title="Tareas — Rincón del Bosque"
+        variant="rich"
+      />
     </RequireAccess>
   );
 }


### PR DESCRIPTION
## Summary

- La página del sidebar `/rdb/admin/tasks` usaba `<TasksModule>` sin el flag `variant="rich"`, por lo que la tabla de RDB renderizaba la variante simple (5 columnas, sin toggle de completadas, sin edición inline, sin sheet de avances) en lugar de la variante rich que ya usa DILESA.
- Beto confirmó que la versión de DILESA es la canónica. Diff mínimo: solo agregar `variant="rich"` a la prop, una línea efectiva.
- Con el flag, RDB hereda filtros (estado, prioridad, asignado, departamento), toggle "Ocultar completadas", edición inline de estado y % avance, role gating, y sheet de avances con auto-link a junta en curso.

## Test plan

- [x] `npm run typecheck` verde
- [x] `npm run lint` verde (warnings preexistentes, 0 errors)
- [x] `npm run format:check` verde
- [x] `npm run test:run` verde (364 tests)
- [ ] Verificación visual: `/rdb/admin/tasks` muestra los mismos filtros, columnas, toggle de completadas y sheet de avances que `/dilesa/admin/tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)