### PR TITLE
feat(badge-system): Sprint 1 — foundation + ADR-017 + golden tasks-shared

### DIFF
--- a/components/tasks/tasks-shared.tsx
+++ b/components/tasks/tasks-shared.tsx
@@ -10,6 +10,8 @@
 // (Combobox local eliminado — usar @/components/ui/combobox para form fields y
 // @/components/ui/filter-combobox para filtros de tabla).
 
+import { Badge, type BadgeTone } from '@/components/ui/badge';
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type TaskEstado = 'pendiente' | 'en_progreso' | 'bloqueado' | 'completado' | 'cancelado';
@@ -80,13 +82,30 @@ export type TaskFormValues = {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-export const ESTADO_CONFIG: Record<TaskEstado, { label: string; cls: string }> = {
-  pendiente: { label: 'Pendiente', cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20' },
-  en_progreso: { label: 'En progreso', cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20' },
-  bloqueado: { label: 'Bloqueado', cls: 'bg-red-500/15 text-red-400 border-red-500/20' },
-  completado: { label: 'Completado', cls: 'bg-green-500/15 text-green-400 border-green-500/20' },
+export const ESTADO_CONFIG: Record<TaskEstado, { label: string; tone: BadgeTone; cls: string }> = {
+  pendiente: {
+    label: 'Pendiente',
+    tone: 'warning',
+    cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  },
+  en_progreso: {
+    label: 'En progreso',
+    tone: 'info',
+    cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+  },
+  bloqueado: {
+    label: 'Bloqueado',
+    tone: 'danger',
+    cls: 'bg-red-500/15 text-red-400 border-red-500/20',
+  },
+  completado: {
+    label: 'Completado',
+    tone: 'success',
+    cls: 'bg-green-500/15 text-green-400 border-green-500/20',
+  },
   cancelado: {
     label: 'Cancelado',
+    tone: 'neutral',
     cls: 'bg-[var(--border)]/60 text-[var(--text-subtle)] border-[var(--border)]',
   },
 };
@@ -99,25 +118,55 @@ export const ESTADO_ORDER: TaskEstado[] = [
   'cancelado',
 ];
 
-export const PRIORIDAD_CONFIG: Record<string, { label: string; cls: string }> = {
-  Urgente: { label: 'Urgente', cls: 'bg-red-500/15 text-red-400 border-red-500/20' },
-  Alta: { label: 'Alta', cls: 'bg-orange-500/15 text-orange-400 border-orange-500/20' },
-  Media: { label: 'Media', cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20' },
-  Baja: { label: 'Baja', cls: 'bg-green-500/15 text-green-400 border-green-500/20' },
+export const PRIORIDAD_CONFIG: Record<string, { label: string; tone: BadgeTone; cls: string }> = {
+  Urgente: {
+    label: 'Urgente',
+    tone: 'danger',
+    cls: 'bg-red-500/15 text-red-400 border-red-500/20',
+  },
+  Alta: {
+    label: 'Alta',
+    tone: 'warning',
+    cls: 'bg-orange-500/15 text-orange-400 border-orange-500/20',
+  },
+  Media: {
+    label: 'Media',
+    tone: 'warning',
+    cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  },
+  Baja: {
+    label: 'Baja',
+    tone: 'success',
+    cls: 'bg-green-500/15 text-green-400 border-green-500/20',
+  },
 };
 
 export const PRIORIDAD_OPTIONS = ['Urgente', 'Alta', 'Media', 'Baja'] as const;
 
-export const UPDATE_TIPO_CONFIG: Record<string, { label: string; cls: string }> = {
-  avance: { label: 'Avance', cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20' },
-  cambio_estado: { label: 'Estado', cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20' },
-  cambio_fecha: { label: 'Fecha', cls: 'bg-purple-500/15 text-purple-400 border-purple-500/20' },
+export const UPDATE_TIPO_CONFIG: Record<string, { label: string; tone: BadgeTone; cls: string }> = {
+  avance: {
+    label: 'Avance',
+    tone: 'info',
+    cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+  },
+  cambio_estado: {
+    label: 'Estado',
+    tone: 'warning',
+    cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  },
+  cambio_fecha: {
+    label: 'Fecha',
+    tone: 'accent',
+    cls: 'bg-purple-500/15 text-purple-400 border-purple-500/20',
+  },
   nota: {
     label: 'Nota',
+    tone: 'neutral',
     cls: 'bg-[var(--border)]/60 text-[var(--text)]/60 border-[var(--border)]',
   },
   cambio_responsable: {
     label: 'Responsable',
+    tone: 'success',
     cls: 'bg-teal-500/15 text-teal-400 border-teal-500/20',
   },
 };
@@ -143,30 +192,20 @@ export function formatDateTime(dateStr: string | null | undefined) {
 // ─── Small presentational pieces ─────────────────────────────────────────────
 
 export function EstadoBadge({ estado }: { estado: TaskEstado }) {
-  const cfg = ESTADO_CONFIG[estado] ?? { label: estado, cls: '' };
-  return (
-    <span
-      className={`inline-flex items-center rounded-lg border px-2 py-0.5 text-xs font-medium ${cfg.cls}`}
-    >
-      {cfg.label}
-    </span>
-  );
+  const cfg = ESTADO_CONFIG[estado];
+  if (!cfg) return <Badge tone="neutral">{estado}</Badge>;
+  return <Badge tone={cfg.tone}>{cfg.label}</Badge>;
 }
 
 /**
- * Classic prioridad badge (used by simpler variants). Looks up a class by
+ * Classic prioridad badge (used by simpler variants). Looks up a tone by
  * exact prioridad value (e.g. "Urgente", "Alta").
  */
 export function PrioridadBadge({ prioridad }: { prioridad: string | null }) {
   if (!prioridad) return <span className="text-[var(--text-subtle)]">—</span>;
-  const cfg = PRIORIDAD_CONFIG[prioridad] ?? { label: prioridad, cls: '' };
-  return (
-    <span
-      className={`inline-flex items-center rounded-lg border px-2 py-0.5 text-xs font-medium ${cfg.cls}`}
-    >
-      {cfg.label}
-    </span>
-  );
+  const cfg = PRIORIDAD_CONFIG[prioridad];
+  if (!cfg) return <Badge tone="neutral">{prioridad}</Badge>;
+  return <Badge tone={cfg.tone}>{cfg.label}</Badge>;
 }
 
 /**

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,6 +4,23 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * `<Badge>` — display-only label for status, count, or category. Builds on
+ * shadcn's badge with semantic `tone` variants on top of the original layout
+ * variants.
+ *
+ * Use `tone` for status-like badges across the app (estado, prioridad, etapa).
+ * The legacy `default` / `secondary` / `destructive` / `outline` / `ghost` /
+ * `link` variants stay for non-semantic uses (counts, links, etc.).
+ *
+ * Tone palette (background tinted at 15% with matching text and border):
+ *   - `neutral` — informational, no opinion (e.g. "Borrador", "En análisis")
+ *   - `info`    — in-progress, observational (e.g. "En curso", "En trámite")
+ *   - `success` — positive completion (e.g. "Completado", "Aprobado")
+ *   - `warning` — needs attention (e.g. "Pausado", "En revisión")
+ *   - `danger`  — error, blocked, descartado (e.g. "Bloqueado", "Cancelado")
+ *   - `accent`  — special / featured (e.g. "Urgente", "Convertido")
+ */
 const badgeVariants = cva(
   'group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!',
   {
@@ -17,6 +34,14 @@ const badgeVariants = cva(
         ghost: 'hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50',
         link: 'text-primary underline-offset-4 hover:underline',
       },
+      tone: {
+        neutral: 'bg-[var(--border)]/60 text-[var(--text)]/70 border-[var(--border)]',
+        info: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
+        success: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+        warning: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+        danger: 'bg-red-500/15 text-red-400 border-red-500/20',
+        accent: 'bg-violet-500/15 text-violet-400 border-violet-500/20',
+      },
     },
     defaultVariants: {
       variant: 'default',
@@ -24,24 +49,31 @@ const badgeVariants = cva(
   }
 );
 
+export type BadgeTone = NonNullable<VariantProps<typeof badgeVariants>['tone']>;
+
 function Badge({
   className,
-  variant = 'default',
+  variant,
+  tone,
   render,
   ...props
 }: useRender.ComponentProps<'span'> & VariantProps<typeof badgeVariants>) {
+  // When `tone` is set, drop the default `variant` so Tailwind classes don't
+  // fight (the tone classes own background/text/border on their own).
+  const resolvedVariant = tone ? undefined : (variant ?? 'default');
   return useRender({
     defaultTagName: 'span',
     props: mergeProps<'span'>(
       {
-        className: cn(badgeVariants({ variant }), className),
+        className: cn(badgeVariants({ variant: resolvedVariant, tone }), className),
       },
       props
     ),
     render,
     state: {
       slot: 'badge',
-      variant,
+      variant: resolvedVariant,
+      tone,
     },
   });
 }

--- a/docs/adr/017_badge_system.md
+++ b/docs/adr/017_badge_system.md
@@ -1,0 +1,209 @@
+# ADR-017 — Badge tones (semántica de status badges)
+
+- **Status**: Accepted
+- **Date**: 2026-04-29
+- **Authors**: Beto, Claude Code (iniciativa `badge-system`)
+- **Related**: [ADR-006](./006_module_states.md), [ADR-008](./008_action_feedback.md), [ADR-010](./010_data_table.md)
+
+---
+
+## Contexto
+
+Las status badges del repo (`EstadoBadge`, `PrioridadBadge`,
+`AnteproyectoEstadoBadge`, etc.) duplican la misma paleta de Tailwind
+una y otra vez:
+
+```tsx
+'bg-blue-500/15 text-blue-400 border-blue-500/20';
+'bg-emerald-500/15 text-emerald-400 border-emerald-500/20';
+'bg-amber-500/15 text-amber-400 border-amber-500/20';
+'bg-red-500/15 text-red-400 border-red-500/20';
+```
+
+11 archivos las llevan literales. Cada nuevo módulo que necesita un
+status badge inventa su propia variación: `green` vs `emerald`, `orange`
+vs `amber`, `purple` vs `violet`, `cyan` vs `sky`. Cuando llega el
+momento de cambiar el "azul de info" a un tono más oscuro o agregar
+hover states, hay que tocar N lugares.
+
+`lib/status-tokens.ts` ya centraliza los configs de status (junta,
+prioridad, etapa, etc.) — pero cada uno expone un `cls` literal que el
+caller pega en un `<span>`. La abstracción "esto es un estado de tipo
+success/warning/danger" no existe; cada slug elige sus colores ad-hoc.
+
+shadcn `<Badge>` ya está en el repo con variants `default`, `secondary`,
+`destructive`, `outline`, `ghost`, `link`. Cubre uses no-semánticos
+(counts, links) pero no tiene tones de status para el patrón dominante.
+
+## Decisión
+
+Agregar **6 tones semánticos** al `<Badge>` shadcn, cada uno con paleta
+fija (background tinted al 15%, texto y borde matching):
+
+```tsx
+<Badge tone="success">Aprobado</Badge>
+<Badge tone="warning">Pausado</Badge>
+<Badge tone="danger">Cancelado</Badge>
+<Badge tone="info">En curso</Badge>
+<Badge tone="accent">Convertido</Badge>
+<Badge tone="neutral">Borrador</Badge>
+```
+
+`lib/status-tokens.ts` mapea cada slug de status a su `tone` semántico.
+Callers leen `cfg.tone` y lo pasan al `<Badge>`:
+
+```tsx
+const cfg = JUNTA_ESTADO_CONFIG[junta.estado];
+return <Badge tone={cfg.tone}>{cfg.label}</Badge>;
+```
+
+### Las 6 reglas (B1–B6)
+
+#### B1 — 6 tones semánticos canónicos
+
+```ts
+type BadgeTone = 'neutral' | 'info' | 'success' | 'warning' | 'danger' | 'accent';
+```
+
+- **`neutral`** — informational, sin opinión. Ej: "Borrador", "En análisis", "Cancelado/Cerrado".
+- **`info`** — in-progress, observacional. Ej: "En curso", "En trámite", "Programada".
+- **`success`** — positive completion. Ej: "Completado", "Aprobado", "Adquirido".
+- **`warning`** — needs attention. Ej: "Pausado", "Pendiente", "Due diligence".
+- **`danger`** — error, blocked, descartado. Ej: "Bloqueado", "No viable", "Cancelada".
+- **`accent`** — special / featured. Ej: "Urgente", "En negociación", "Construcción".
+
+> **Por qué 6 (no más, no menos)**: cubrir todo el repo con menos pierde
+> matiz visual entre estados; con más, el equipo invoca colores ad-hoc
+> ("¿uso `info` o `progress`?"). 6 es suficiente para distinguir los
+> 8-10 estados que un módulo típicamente expone, mapeando varios
+> slugs al mismo tone si comparten significado.
+
+#### B2 — Cada slug del repo mapea a un tone exactamente
+
+`lib/status-tokens.ts` ya tiene los configs centralizados; ahora cada
+entry expone `tone: BadgeTone` además del legacy `cls`. Aliases de color
+(green/emerald, orange/amber, sky/blue/cyan) colapsan al mismo tone.
+
+```ts
+PRIORIDAD_CONFIG = {
+  alta: { label: 'Alta', tone: 'danger', cls: '...' },
+  media: { label: 'Media', tone: 'warning', cls: '...' },
+  baja: { label: 'Baja', tone: 'success', cls: '...' },
+};
+```
+
+> **Por qué**: status-tokens.ts ya es la single source of truth de los
+> configs; agregar `tone` ahí evita que cada caller tenga que decidir
+> "¿este estado es success o info?" — la decisión se toma una vez.
+
+#### B3 — `<Badge tone>` reemplaza `<span className="bg-X/15 text-X border-X/20">` en TODO el repo
+
+Los `<span>` inline con la paleta literal son deuda. Cualquier badge nuevo
+usa `<Badge tone>`. Los existentes se migran cuando se toquen — no hay
+sweep masivo, pero PRs nuevos no se aprueban con el patrón viejo.
+
+`badge.tsx` ahora exporta `BadgeTone` para callers que necesiten tipar
+sus configs.
+
+> **Por qué**: el sweep masivo (11 archivos × 4-9 estados cada uno) es
+> churn sin valor inmediato. Migración incremental al tocar el código
+> es lo que hizo `<DataTable>` (ADR-010 DT8) y funcionó.
+
+#### B4 — `cls` legacy queda como derivado, no canónico
+
+Durante la transición, los configs exponen ambos `tone` y `cls`. El
+campo `cls` queda **deprecado** — los callsites que lo usan se migran
+a `tone` cuando se toquen. Cuando todos los callsites estén migrados,
+`cls` se elimina del shape (Sprint 2+ de `badge-system`).
+
+> **Por qué**: backwards-compat sin breaking changes. La iniciativa cierra
+> cuando el último `cls` desaparece, no cuando se introduce `tone`.
+
+#### B5 — Variants legacy (`default`, `secondary`, etc.) coexisten con `tone`
+
+`<Badge variant="outline">Count</Badge>` sigue funcionando para usos
+no-semánticos (count badges, link badges, etc.). Si se pasan ambos
+`variant` y `tone`, **`tone` gana** — los styles de variant se descartan
+para no pelear con los de tone.
+
+> **Por qué**: el `<Badge>` shadcn cubre más casos que solo status;
+> mantener variants permite usos no-semánticos sin contaminar.
+
+#### B6 — `<Badge tone="neutral">` para fallback de slugs desconocidos
+
+Cuando el config no tiene un slug registrado (e.g. estado nuevo en DB
+no propagado a la UI), el componente rendea `<Badge tone="neutral">`
+con el slug crudo como label. Así nunca crashea ni queda sin estilo.
+
+```tsx
+const cfg = ESTADO_CONFIG[estado];
+if (!cfg) return <Badge tone="neutral">{estado}</Badge>;
+return <Badge tone={cfg.tone}>{cfg.label}</Badge>;
+```
+
+> **Por qué**: defensivo contra drift DB↔UI sin romper la página. Si el
+> slug no está mapeado, el usuario lo ve raw + neutral; un PR siguiente
+> agrega el mapping correcto.
+
+### A11y mínimo
+
+- `<Badge>` es display-only (`<span>`); no necesita aria-role explícito.
+- Color contrast: cada tone tiene background `15%` + text `400` que
+  cumple WCAG AA contra fondos típicos del app (verificado en `bg-card`
+  y `bg-panel`).
+- No depender de color solo: el `label` siempre se renderea como texto.
+  Filtros de color (daltónicos) leen el label, no el tone.
+
+## Implementación
+
+- **Sprint 1** (este PR): foundation — extender `<Badge>` con 6 tones +
+  `BadgeTone` export. Refactor de `lib/status-tokens.ts` agregando
+  `tone` a cada config (junta, prioridad DILESA, anteproyecto, terreno
+  etapa, prototipo etapa, proyecto fase). Refactor de
+  `components/tasks/tasks-shared.tsx` agregando `tone` a `ESTADO_CONFIG`,
+  `PRIORIDAD_CONFIG`, `UPDATE_TIPO_CONFIG`. Migrar `EstadoBadge` +
+  `PrioridadBadge` de tasks como golden path. ADR-017.
+- **Sprint 2+**: migrar callsites que rendean `<span className={cfg.cls}>`
+  a `<Badge tone={cfg.tone}>` (≈11 archivos). Eliminar `cls` de los
+  configs.
+- **Sprint final**: cerrar la iniciativa cuando el último `cls` desaparezca.
+
+## Consecuencias
+
+### Positivas
+
+- **Single source of truth de la paleta**: cambiar el "azul de info" se
+  hace en `<Badge>` una vez, no en 11 archivos.
+- **Decisión semántica una vez por slug**: en `status-tokens.ts`. El
+  caller no decide colores.
+- **Type-safe**: `BadgeTone` es enum exportado; configs nuevos lo importan.
+- **Code review más simple**: ¿tone correcto? ¿label correcto? Stop.
+- **Migración incremental** sin breaking changes (cls legacy preservado).
+
+### Negativas
+
+- **Coexistencia temporal de `tone` + `cls`** en los configs hasta que
+  cierre la iniciativa. Los configs son ~80 líneas más largos.
+- **6 tones es opinión**: alguien podría argumentar que "cyan/sky" merece
+  su propio tone. Por ahora se mapean a `info`. Si surge necesidad real
+  (ej. distinguir "informational" vs "in-progress"), se agrega.
+
+### Cosas que NO cambian
+
+- `<Badge>` variants (`default`, `secondary`, etc.) — siguen para usos no-semánticos.
+- `lib/status-tokens.ts` shape — solo se agrega `tone`; los slugs y labels existentes no cambian.
+- Cómo los configs se consumen — los callsites mantienen `cfg.label`.
+
+## Fuera de alcance v1
+
+- **Tones para callouts grandes** (banners, alerts). Esos viven en `<ErrorBanner>` (ADR-006) y se tratan distinto.
+- **Tones con dot indicator** (e.g. `<Badge tone="danger" dot />`). El `<PrioridadTextBadge>` de tasks tiene un dot custom; si se quiere generalizar, sale en una iteración futura.
+- **Hover/clickable badges** (badges como links). Las variants legacy ya cubren `link` y `ghost`; tones se mantienen display-only.
+- **Iconos integrados** (`<Badge tone="success" icon={Check}>`). Útil pero no necesario para v1.
+
+## Referencias
+
+- Componente: [components/ui/badge.tsx](../../components/ui/badge.tsx)
+- Tokens: [lib/status-tokens.ts](../../lib/status-tokens.ts)
+- Iniciativa: [docs/planning/badge-system.md](../planning/badge-system.md)
+- ADR-010 — modelo de migración incremental (DT8 deprecation pattern).

--- a/docs/planning/badge-system.md
+++ b/docs/planning/badge-system.md
@@ -3,13 +3,10 @@
 **Slug:** `badge-system`
 **Empresas:** todas
 **Schemas afectados:** n/a (UI)
-**Estado:** proposed
+**Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-04-27
-**Última actualización:** 2026-04-27
-
-> **Bloqueada hasta cierre de `forms-pattern`.** Alcance v1 detallado se
-> cierra cuando arranque su turno.
+**Última actualización:** 2026-04-29
 
 ## Problema
 
@@ -53,21 +50,36 @@ pending | active`. Cada uno con color de fondo, texto y borde
   se preserva.
 - ADR documentando los tonos y cuándo usar cada uno.
 
-## Alcance v1 (tentativo — refinar al arrancar)
+## Alcance v1 (cerrado 2026-04-29 — ver ADR-017)
 
-- [ ] Definir los 7 tonos canónicos + paleta (alineada con tokens
-      `--color-*` existentes en el sistema).
-- [ ] `<Badge>` actualizado con prop `tone` (preservar `variant` de
-      shadcn para compat, deprecar a futuro).
-- [ ] `<BadgeIcon>` opcional (algunos badges llevan ícono — visible
-      en `EstadoBadge` y `EtapaBadgeLarge`).
-- [ ] Helpers de mapping en `lib/badges/` o equivalente:
-      `taskEstadoTone`, `tareaPrioridadTone`, `corteEstadoTone`,
-      `etapaTerrenoTone`, `documentoTipoTone`.
-- [ ] Migrar wrappers existentes a usar `<Badge tone>` internamente.
-- [ ] Auditar usos directos de `<Badge variant="...">` en módulos
-      y migrar a `tone` semántico.
-- [ ] ADR (probable ADR-012).
+- [x] Definir 6 tonos canónicos: `neutral`, `info`, `success`, `warning`, `danger`, `accent`.
+- [x] `<Badge>` extendido con prop `tone` + export `BadgeTone` type.
+      Variants legacy (`default`, `secondary`, etc.) preservadas para usos
+      no-semánticos (counts, links). `tone` gana cuando se pasan ambos.
+- [x] `lib/status-tokens.ts` refactor: cada config expone `tone: BadgeTone`
+      al lado del legacy `cls`. 6 configs migrados (junta, prioridad
+      DILESA, anteproyecto, terreno etapa, prototipo etapa, proyecto fase).
+- [x] `components/tasks/tasks-shared.tsx`: `ESTADO_CONFIG`,
+      `PRIORIDAD_CONFIG`, `UPDATE_TIPO_CONFIG` con `tone` agregado.
+      `EstadoBadge` y `PrioridadBadge` migrados a `<Badge tone>`.
+- [x] ADR-017 con 6 reglas (B1-B6).
+- [ ] Migración del resto de callsites — Sprints 2+ (≈11 archivos).
+- [ ] Eliminar `cls` de los configs cuando todos los callsites migren.
+
+## Decisiones tomadas al cerrar alcance
+
+- **6 tones (no 7)**: agrupar `pending`+`active` bajo `info` y `success`
+  según contexto. Sin granularity loss porque el `label` siempre se
+  muestra. 7+ invita a debate "¿uso `pending` o `info`?".
+- **Sin `<BadgeIcon>` en v1**: los íconos custom en badges son raros
+  (1 caso real: `PrioridadTextBadge` con dot). No vale agregar API; si
+  surge, se itera.
+- **Sin helpers `mapEstadoToTone(estado)`**: el config ya provee
+  `cfg.tone`. Helper sería redundante.
+- **`tone` como naming** (vs `intent`/`kind`/`status`): consistente con
+  shadcn/Radix/MUI design system convention.
+- **Sin `size` prop**: el `<Badge>` actual tiene un solo size; si surge
+  necesidad de "hero badges" (ej. `EtapaBadgeLarge`), se evalúa aparte.
 
 ## Fuera de alcance
 
@@ -85,27 +97,38 @@ pending | active`. Cada uno con color de fondo, texto y borde
 - Visual audit: pasar por las 25 tablas migradas y confirmar que los
   badges del mismo tono se ven idénticos en todas.
 
-## Riesgos / preguntas abiertas
-
-- [ ] **¿Cuántos tonos son suficientes?** Más tonos = más decisiones
-      del caller. Menos tonos = menos expresividad. Mi voto previo:
-      7 (success, warning, error, info, neutral, pending, active).
-      Cerrar al arrancar.
-- [ ] **Coexistencia con `<Badge variant>` shadcn** — deprecar como
-      en `useSortableTable` (mantener exportado, marcar `@deprecated`).
-- [ ] **Naming**: `tone` vs `intent` vs `kind` vs `status`. `tone` es
-      común en design systems modernos.
-- [ ] **Tamaños**: `sm | md | lg` o solo uno. v1 probable 2 tamaños
-      (`md` default, `lg` para badges hero como `EtapaBadgeLarge`).
-
 ## Sprints / hitos
 
-_(se llena cuando arranque ejecución, vía Claude Code)_
+| #   | Sprint                                     | Estado  | PR  |
+| --- | ------------------------------------------ | ------- | --- |
+| 1   | Foundation + ADR-017 + golden tasks        | done    | TBD |
+| 2   | Migrar callsites de `cls` a `<Badge tone>` | pending | —   |
+| 3   | Eliminar `cls` de configs + cierre         | pending | —   |
 
 ## Decisiones registradas
 
-_(append-only, fechadas — escrito por Claude Code)_
+### 2026-04-29 · ADR-017 — Badge tones (Sprint 1)
+
+Codificado en [ADR-017](../adr/017_badge_system.md). Las 6 reglas:
+
+- **B1** — 6 tones canónicos: `neutral`/`info`/`success`/`warning`/`danger`/`accent`.
+- **B2** — Cada slug del repo mapea a un tone exactamente (en `status-tokens.ts`).
+- **B3** — `<Badge tone>` reemplaza `<span className="bg-X/15 text-X border-X/20">` en TODO el repo.
+- **B4** — `cls` legacy queda como derivado, no canónico (deprecación incremental tipo ADR-010 DT8).
+- **B5** — Variants legacy (`default`, `secondary`, etc.) coexisten con `tone`; `tone` gana cuando se pasan ambos.
+- **B6** — `<Badge tone="neutral">` para fallback de slugs desconocidos (defensivo contra drift DB↔UI).
 
 ## Bitácora
 
-_(append-only, escrita por Claude Code al ejecutar)_
+### 2026-04-29 — Sprint 1 mergeado
+
+Foundation:
+
+- `components/ui/badge.tsx` extendido con 6 tones (`neutral`/`info`/`success`/`warning`/`danger`/`accent`) + export `BadgeTone`.
+- `lib/status-tokens.ts` refactor — cada config (junta, prioridad DILESA, anteproyecto, terreno etapa, prototipo etapa, proyecto fase) expone `tone: BadgeTone` al lado del legacy `cls`.
+- `components/tasks/tasks-shared.tsx` — `ESTADO_CONFIG`, `PRIORIDAD_CONFIG`, `UPDATE_TIPO_CONFIG` con `tone`. `EstadoBadge` + `PrioridadBadge` golden migration a `<Badge tone>`.
+- ADR-017 con 6 reglas (B1-B6).
+
+Sprint 2 migrará los ≈11 callsites que aún rendean `<span className={cfg.cls}>`. Sprint 3 elimina `cls` cuando todos migren.
+
+PR: pendiente.

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -30,7 +30,7 @@
 | Access Denied UX (UI)       | `access-denied-ux`           | todas    | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (cola UI — orden en §Roadmap UI)                                                                                                                                                                 | 2026-04-27           |
 | Activity Log pattern (UI)   | `activity-log-pattern`       | todas    | n/a (UI; consume audit_log) | proposed    | Cerrar alcance v1 al arrancar (cola UI — orden en §Roadmap UI)                                                                                                                                                                 | 2026-04-27           |
 | Analytics (BI externo)      | `analytics`                  | todas    | analytics, erp, dilesa, rdb | blocked     | Sprint 0 — desbloquear export del bootstrap (Metabase + Caddy + Postgres) desde Cowork al repo Analytics                                                                                                                       | 2026-04-25           |
-| Badge system (UI)           | `badge-system`               | todas    | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (cola UI — orden en §Roadmap UI)                                                                                                                                                                 | 2026-04-27           |
+| Badge system (UI)           | `badge-system`               | todas    | n/a (UI)                    | in_progress | Sprint 2 — migrar ≈11 callsites de `<span className={cfg.cls}>` a `<Badge tone={cfg.tone}>`                                                                                                                                    | 2026-04-29           |
 | Cuentas por Pagar           | `cxp`                        | todas    | erp                         | planned     | Sprint 1 — schema (extender `erp.facturas` + crear `cxp_pagos` + `cxp_pago_aplicaciones`) + RPCs (alta/alta_xml/cancelar/programar/aprobar/marcar_pagado) + helper `es_comite_ejecutivo` + backfill + regenerar SCHEMA_REF     | 2026-04-28           |
 | Drawer anatomy (UI)         | `drawer-anatomy`             | todas    | n/a (UI)                    | proposed    | Cerrar alcance v1 al arrancar (cola UI — orden en §Roadmap UI)                                                                                                                                                                 | 2026-04-27           |
 | Empresa Docs Legales        | `empresa-documentos-legales` | todas    | core, erp                   | in_progress | Sprint 5 (operativo, **lo hace Beto**) — DILESA asigna sus docs ya cargados en `/settings/empresas/dilesa`; RDB/ANSA/COAGAN suben sus PDFs en `/<empresa>/admin/documentos` y luego los asignan; cierra iniciativa al terminar | 2026-04-28           |
@@ -74,7 +74,7 @@
 > vez de N veces.
 
 6. ~~`forms-pattern`~~ — **DONE** (6 PRs, `<Form>` + zod + RHF; `wizard-pattern` spinned out).
-7. `badge-system` — tokens semánticos para badges; deuda dispersa. **Próximo en cola UI.**
+7. ~~`badge-system`~~ — **`in_progress`** (Sprint 1 foundation listo + ADR-017, Sprint 2+ migración).
 8. `drawer-anatomy` — `<DetailDrawer>` paralelo a `<DetailPage>` (ADR-009).
 9. `responsive-policy` — mobile-first vs desktop-only por módulo.
 10. `a11y-baseline` — WCAG 2.1 AA mínimo. Después de forms + badges para que el audit cubra los componentes ya estandarizados.

--- a/lib/status-tokens.ts
+++ b/lib/status-tokens.ts
@@ -4,25 +4,40 @@
  * Keeping these in one place avoids the drift we had when the same config
  * was copy-pasted across DILESA/RDB/Inicio listing and detail pages.
  * If you need a new status, add it here (not inline in a page).
+ *
+ * **Migración a tonos semánticos (badge-system Sprint 1, 2026-04-29)**:
+ * cada config ahora expone `tone: BadgeTone` además del legacy `cls`.
+ * Nuevos call-sites usan `<Badge tone={cfg.tone}>{cfg.label}</Badge>`.
+ * `cls` queda deprecado y se eliminará cuando todos los callsites
+ * migren (Sprint 2).
  */
+
+import type { BadgeTone } from '@/components/ui/badge';
 
 export type JuntaEstado = 'programada' | 'en_curso' | 'completada' | 'cancelada';
 
-export const JUNTA_ESTADO_CONFIG: Record<JuntaEstado, { label: string; cls: string }> = {
+export const JUNTA_ESTADO_CONFIG: Record<
+  JuntaEstado,
+  { label: string; tone: BadgeTone; cls: string }
+> = {
   programada: {
     label: 'Programada',
+    tone: 'info',
     cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
   },
   en_curso: {
     label: 'En curso',
+    tone: 'success',
     cls: 'bg-green-500/15 text-green-400 border-green-500/20',
   },
   completada: {
     label: 'Completada',
+    tone: 'neutral',
     cls: 'bg-[var(--border)]/60 text-[var(--text)]/50 border-[var(--border)]',
   },
   cancelada: {
     label: 'Cancelada',
+    tone: 'danger',
     cls: 'bg-red-500/15 text-red-400 border-red-500/20',
   },
 };
@@ -33,24 +48,29 @@ export const JUNTA_ESTADO_CONFIG: Record<JuntaEstado, { label: string; cls: stri
 
 export type PrioridadNivel = 'alta' | 'media' | 'baja';
 
-export const PRIORIDAD_CONFIG: Record<PrioridadNivel, { label: string; dot: string; cls: string }> =
-  {
-    alta: {
-      label: 'Alta',
-      dot: 'bg-red-500',
-      cls: 'bg-red-500/15 text-red-400 border-red-500/20',
-    },
-    media: {
-      label: 'Media',
-      dot: 'bg-amber-500',
-      cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
-    },
-    baja: {
-      label: 'Baja',
-      dot: 'bg-emerald-500',
-      cls: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
-    },
-  };
+export const PRIORIDAD_CONFIG: Record<
+  PrioridadNivel,
+  { label: string; tone: BadgeTone; dot: string; cls: string }
+> = {
+  alta: {
+    label: 'Alta',
+    tone: 'danger',
+    dot: 'bg-red-500',
+    cls: 'bg-red-500/15 text-red-400 border-red-500/20',
+  },
+  media: {
+    label: 'Media',
+    tone: 'warning',
+    dot: 'bg-amber-500',
+    cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+  },
+  baja: {
+    label: 'Baja',
+    tone: 'success',
+    dot: 'bg-emerald-500',
+    cls: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+  },
+};
 
 /**
  * Estados del anteproyecto. Coinciden con el CHECK constraint en
@@ -72,30 +92,36 @@ export type AnteproyectoEstado =
 
 export const ANTEPROYECTO_ESTADO_CONFIG: Record<
   AnteproyectoEstado,
-  { label: string; cls: string }
+  { label: string; tone: BadgeTone; cls: string }
 > = {
   en_analisis: {
     label: 'En análisis',
+    tone: 'neutral',
     cls: 'bg-[var(--border)]/60 text-[var(--text)]/70 border-[var(--border)]',
   },
   en_tramite: {
     label: 'En trámite',
+    tone: 'info',
     cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
   },
   en_due_diligence: {
     label: 'Due diligence',
+    tone: 'warning',
     cls: 'bg-orange-500/15 text-orange-400 border-orange-500/20',
   },
   pausado: {
     label: 'Pausado',
+    tone: 'warning',
     cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
   },
   no_viable: {
     label: 'No viable',
+    tone: 'danger',
     cls: 'bg-red-500/15 text-red-400 border-red-500/20',
   },
   convertido_a_proyecto: {
     label: 'Convertido a proyecto',
+    tone: 'success',
     cls: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
   },
 };
@@ -117,41 +143,53 @@ export const TERRENO_ETAPA_OPTIONS = [
 ] as const;
 export type TerrenoEtapa = (typeof TERRENO_ETAPA_OPTIONS)[number];
 
-export const TERRENO_ETAPA_CONFIG: Record<TerrenoEtapa, { label: string; cls: string }> = {
+export const TERRENO_ETAPA_CONFIG: Record<
+  TerrenoEtapa,
+  { label: string; tone: BadgeTone; cls: string }
+> = {
   detectado: {
     label: 'Detectado',
+    tone: 'neutral',
     cls: 'bg-[var(--border)]/60 text-[var(--text)]/70 border-[var(--border)]',
   },
   en_revision: {
     label: 'En revisión',
+    tone: 'info',
     cls: 'bg-sky-500/15 text-sky-400 border-sky-500/20',
   },
   en_analisis: {
     label: 'En análisis',
+    tone: 'info',
     cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
   },
   en_negociacion: {
     label: 'En negociación',
+    tone: 'accent',
     cls: 'bg-violet-500/15 text-violet-400 border-violet-500/20',
   },
   en_due_diligence: {
     label: 'Due diligence',
+    tone: 'warning',
     cls: 'bg-orange-500/15 text-orange-400 border-orange-500/20',
   },
   aprobado_compra: {
     label: 'Aprobado compra',
+    tone: 'info',
     cls: 'bg-cyan-500/15 text-cyan-400 border-cyan-500/20',
   },
   adquirido: {
     label: 'Adquirido',
+    tone: 'success',
     cls: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
   },
   pausado: {
     label: 'Pausado',
+    tone: 'warning',
     cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
   },
   descartado: {
     label: 'Descartado',
+    tone: 'danger',
     cls: 'bg-red-500/15 text-red-400 border-red-500/20',
   },
 };
@@ -195,33 +233,43 @@ export const PROTOTIPO_ETAPA_OPTIONS = [
 ] as const;
 export type PrototipoEtapa = (typeof PROTOTIPO_ETAPA_OPTIONS)[number];
 
-export const PROTOTIPO_ETAPA_CONFIG: Record<PrototipoEtapa, { label: string; cls: string }> = {
+export const PROTOTIPO_ETAPA_CONFIG: Record<
+  PrototipoEtapa,
+  { label: string; tone: BadgeTone; cls: string }
+> = {
   borrador: {
     label: 'Borrador',
+    tone: 'neutral',
     cls: 'bg-[var(--border)]/60 text-[var(--text)]/70 border-[var(--border)]',
   },
   en_diseno: {
     label: 'En diseño',
+    tone: 'info',
     cls: 'bg-sky-500/15 text-sky-400 border-sky-500/20',
   },
   en_costeo: {
     label: 'En costeo',
+    tone: 'info',
     cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
   },
   aprobado: {
     label: 'Aprobado',
+    tone: 'info',
     cls: 'bg-cyan-500/15 text-cyan-400 border-cyan-500/20',
   },
   activo: {
     label: 'Activo',
+    tone: 'success',
     cls: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
   },
   pausado: {
     label: 'Pausado',
+    tone: 'warning',
     cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
   },
   obsoleto: {
     label: 'Obsoleto',
+    tone: 'danger',
     cls: 'bg-red-500/15 text-red-400 border-red-500/20',
   },
 };
@@ -245,33 +293,43 @@ export const PROYECTO_FASE_OPTIONS = [
 ] as const;
 export type ProyectoFase = (typeof PROYECTO_FASE_OPTIONS)[number];
 
-export const PROYECTO_FASE_CONFIG: Record<ProyectoFase, { label: string; cls: string }> = {
+export const PROYECTO_FASE_CONFIG: Record<
+  ProyectoFase,
+  { label: string; tone: BadgeTone; cls: string }
+> = {
   planeacion: {
     label: 'Planeación',
+    tone: 'info',
     cls: 'bg-sky-500/15 text-sky-400 border-sky-500/20',
   },
   urbanizacion: {
     label: 'Urbanización',
+    tone: 'info',
     cls: 'bg-blue-500/15 text-blue-400 border-blue-500/20',
   },
   construccion: {
     label: 'Construcción',
+    tone: 'accent',
     cls: 'bg-violet-500/15 text-violet-400 border-violet-500/20',
   },
   comercializacion: {
     label: 'Comercialización',
+    tone: 'info',
     cls: 'bg-cyan-500/15 text-cyan-400 border-cyan-500/20',
   },
   entrega: {
     label: 'Entrega',
+    tone: 'success',
     cls: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
   },
   cerrado: {
     label: 'Cerrado',
+    tone: 'neutral',
     cls: 'bg-[var(--border)]/60 text-[var(--text)]/50 border-[var(--border)]',
   },
   pausado: {
     label: 'Pausado',
+    tone: 'warning',
     cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
   },
 };


### PR DESCRIPTION
## Summary

Sprint 1 de **`badge-system`** — promueve la iniciativa de `proposed` → `in_progress` con foundation completa + ADR-017 + golden migration.

- **`components/ui/badge.tsx`**: 6 tones canónicos (`neutral`/`info`/`success`/`warning`/`danger`/`accent`) + export `BadgeTone`. Variants legacy (`default`, `secondary`, etc.) preservados; `tone` gana cuando se pasan ambos.
- **`lib/status-tokens.ts`**: cada config (junta/prioridad DILESA/anteproyecto/terreno etapa/prototipo etapa/proyecto fase) expone `tone: BadgeTone` al lado del legacy `cls`. Backwards compat total.
- **`components/tasks/tasks-shared.tsx`**: `ESTADO_CONFIG`, `PRIORIDAD_CONFIG`, `UPDATE_TIPO_CONFIG` con `tone`. `EstadoBadge` + `PrioridadBadge` golden migrados a `<Badge tone={cfg.tone}>{cfg.label}</Badge>`.
- **ADR-017** codifica 6 reglas (B1-B6).
- **INITIATIVES.md**: badge-system `proposed` → `in_progress`.

## Decisiones registradas (ADR-017)

| ID  | Regla                                                                                       |
| --- | ------------------------------------------------------------------------------------------- |
| B1  | 6 tones canónicos: `neutral`/`info`/`success`/`warning`/`danger`/`accent`                  |
| B2  | Cada slug del repo mapea a un tone exactamente (en `status-tokens.ts`)                     |
| B3  | `<Badge tone>` reemplaza `<span className="bg-X/15 ...">` en TODO el repo                  |
| B4  | `cls` legacy queda como derivado, no canónico (deprecación incremental tipo ADR-010 DT8)   |
| B5  | Variants legacy coexisten con `tone`; `tone` gana cuando ambos se pasan                    |
| B6  | `<Badge tone="neutral">` para fallback de slugs desconocidos (defensivo contra drift)      |

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — sin errores nuevos
- [x] `npm run format:check` — passes
- [x] `npm run test:run` — 364/364 pasan
- [ ] Smoke manual:
  - `/rdb/admin/tasks`, `/dilesa/admin/tasks`: badges de Estado y Prioridad visibles e idénticos al before.
  - Cualquier vista con `JUNTA_ESTADO_CONFIG`/`ANTEPROYECTO_ESTADO_CONFIG`/`TERRENO_ETAPA_CONFIG`/`PROTOTIPO_ETAPA_CONFIG`/`PROYECTO_FASE_CONFIG`/`PRIORIDAD_CONFIG`: legacy `cfg.cls` sigue funcionando (backwards compat preservado).

## Próximo

Sprint 2: migrar ≈11 callsites que aún rendean `<span className={cfg.cls}>` a `<Badge tone={cfg.tone}>`. Sprint 3: eliminar `cls` de configs y cerrar la iniciativa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)