### PR TITLE
fix(juntas): grabar responsable al crear tarea desde junta abierta

### DIFF
--- a/components/juntas/junta-detail-module.tsx
+++ b/components/juntas/junta-detail-module.tsx
@@ -1031,7 +1031,7 @@ export function JuntaDetailModule({ empresaSlug }: JuntaDetailModuleProps) {
 
   const empleadoMap = new Map(empleados.map((e) => [e.id, e]));
   const empleadoOptions = useMemo(
-    () => empleados.map((e) => ({ value: e.id, label: e.nombre })),
+    () => empleados.map((e) => ({ id: e.id, label: e.nombre })),
     [empleados]
   );
 
@@ -1663,7 +1663,7 @@ export function JuntaDetailModule({ empresaSlug }: JuntaDetailModuleProps) {
         onOpenChange={setShowAddTask}
         onCreate={handleAddTask}
         empleados={empleados}
-        empleadoOptions={empleadoOptions as any}
+        empleadoOptions={empleadoOptions}
       />
 
       <Dialog open={showReenviarDialog} onOpenChange={setShowReenviarDialog}>


### PR DESCRIPTION
## Summary

- En el modal **Nueva Tarea** de juntas (`/dilesa/admin/juntas/[id]` y `/rdb/admin/juntas/[id]`), al seleccionar un responsable el valor no se persistía: el campo seguía vacío y la validación marcaba "Selecciona un responsable" al intentar crear.
- Causa raíz: `junta-detail-module.tsx:1033` construía `empleadoOptions` con shape `{ value, label }`, pero `TasksCreateForm` espera `{ id, label }` (alias `FilterComboboxOption`). El cast `as any` en el call site (línea 1666) ocultaba el typecheck, por lo que `o.id` resolvía a `undefined` dentro de `tasks-create-form.tsx:372`, y el `<Combobox>` recibía `value: undefined` en cada opción del dropdown.
- Fix: corregir el shape al producir `empleadoOptions` y eliminar el `as any` para que el typecheck atrape regresiones futuras.

El bug se introdujo en [#248](https://github.com/beto-sudo/BSOP/pull/248) (`feat(shared-modules-refactor): Sub-PR 3 — extraer <JuntaDetailModule>`) cuando se extrajo el módulo. El cast `as any` permitió que el shape quedara desincronizado con el contrato del componente. Otros call sites (`tasks-module.tsx:671`, `app/inicio/juntas/[id]/page.tsx:1684`) ya usan el shape correcto.

## Test plan

- [ ] En `/dilesa/admin/juntas/<id>` (junta abierta) → "Agregar tarea" → seleccionar responsable → verificar que el nombre queda visible en el campo después de elegir.
- [ ] Crear la tarea con todos los campos requeridos y confirmar que aparece en la lista con el responsable correcto.
- [ ] Mismo flujo en `/rdb/admin/juntas/<id>`.
- [ ] Validar que `app/inicio/juntas/[id]` (que ya estaba bien) sigue funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)