### PR TITLE
docs(claude-md): barrer Reminders al cerrar iniciativa

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,16 @@ Reflejá el cambio de estado en `docs/strategy/INITIATIVES.md` también
 iniciativa quedó completa, movela a la sección `## Done` con fecha de
 cierre y outcome — no borres su doc de planning, queda como referencia.
 
+**Barrido de Reminders al cerrar (`* → done`):** antes de cerrar la
+iniciativa, listá los pendientes vivos en la lista `Claude: BSOP` con
+`remindctl list "Claude: BSOP" --json` y completá los que sean
+sub-tareas de la iniciativa que cierra (referencias a sus PRs, su
+slug, sub-PRs, sprints, smoke tests, closeouts). Las sub-tareas
+históricas mueren con la iniciativa — no quedan vivas para confundir
+sesiones futuras. Ver regla global "Pendientes y calendario" en
+`~/.claude/CLAUDE.md` para el filtro de qué SÍ va a Reminders desde el
+inicio.
+
 ### Roles
 
 - **Claude Code (yo)** soy dueño de planeación + ejecución end-to-end:


### PR DESCRIPTION
## Summary

- Agrega paso obligatorio al protocolo de cierre de iniciativa: antes de moverla a `## Done`, barrer pendientes vivos en `Claude: BSOP` y completar las sub-tareas asociadas.
- Cierra el ciclo abierto con la regla global recién actualizada en `~/.claude/CLAUDE.md` (Reminders ≠ TodoWrite). Las sub-tareas de proceso ya no se crean — y las históricas mueren cuando cierra su iniciativa madre.
- Detonante: `Claude: BSOP` tenía 67 pendientes vivos (todas sub-tareas de iniciativas ya `done`: forms-pattern, data-table, shared-modules-refactor, separación DILESA↔RDB, cortes-conciliacion, etc.). Limpiados en sesión.

## Test plan

- [x] typecheck verde
- [x] tests verdes (375/375)
- [x] lint sin errores
- [x] format:check verde
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)