### PR TITLE
fix(acceso): repair Server Actions in /settings/acceso (use server export)

### DIFF
--- a/app/settings/acceso/actions.ts
+++ b/app/settings/acceso/actions.ts
@@ -18,15 +18,19 @@ export type Usuario = {
 
 // ── RBAC schema types (core.*) ─────────────────────────────────────────────
 export type Empresa = { id: string; nombre: string; slug: string };
-export const MODULO_SECCIONES = [
-  'administracion',
-  'rh',
-  'compras',
-  'inventario',
-  'operaciones',
-  'sistema',
-] as const;
-export type ModuloSeccion = (typeof MODULO_SECCIONES)[number];
+// NOTE: this file is a `'use server'` module — Next.js 16 only allows async
+// function exports from it. Anything else (e.g. `export const ...`) makes
+// EVERY action in the file fail at runtime with:
+//   `Error: A "use server" file can only export async functions`
+// Keep this as a pure type alias. If you need a runtime list of secciones,
+// put it in a sibling non-server file and import from there.
+export type ModuloSeccion =
+  | 'administracion'
+  | 'rh'
+  | 'compras'
+  | 'inventario'
+  | 'operaciones'
+  | 'sistema';
 
 export type Modulo = {
   id: string;

--- a/docs/planning/modulos-catalog.md
+++ b/docs/planning/modulos-catalog.md
@@ -227,3 +227,21 @@ sync` agregado en `lib/permissions.test.ts` con
   `BSOP/CLAUDE.md` sección "Reglas DB" listando los 4 lugares a
   tocar (NAV_ITEMS, ROUTE_TO_MODULE, EXPECTED_DB_MODULE_SLUGS,
   migración SQL) + plantilla de la migración. PR #284 mergeado.
+- **2026-04-29 — Hot-fix post-cierre (PR #326).** Regresión
+  detectada por Beto en `/settings/acceso`: "Crear rol" y toggle de
+  permisos fallaban con `An error occurred in the Server Components
+render`. Causa: el Sprint 1 (PR #282) había agregado
+  `export const MODULO_SECCIONES = [...] as const` a
+  `app/settings/acceso/actions.ts`, que es un archivo `'use server'`.
+  Next.js 16 solo permite exports de funciones async en archivos
+  `'use server'` — cualquier otro export hace fallar **todas** las
+  Server Actions del archivo al primer invoke con
+  `Error: A "use server" file can only export async functions`.
+  Confirmado en runtime logs de prod (deployment
+  `dpl_E8pVPCHTAuiLPJX7AGQrLqYmMMEP`, 20+ POSTs 500 desde 19:49 CST).
+  Fix: el const solo se usaba para derivar el type vía
+  `(typeof MODULO_SECCIONES)[number]`; reemplazado por type union
+  literal directo + comentario explicando la regla. Lección para
+  futuras sesiones: **nunca poner `export const`/`export class` en
+  archivos con `'use server'` — solo `export async function` y
+  `export type`** (los types se borran en compile, son safe).


### PR DESCRIPTION
## Summary

- **Bug:** `/settings/acceso` no permite crear roles ni togglear permisos. El modal "Nuevo rol" muestra `An error occurred in the Server Components render. The specific message is omitted in production builds…` y los checkboxes de la matriz de permisos no responden.
- **Causa:** PR #282 (modulos-catalog Sprint 1) agregó `export const MODULO_SECCIONES = [...] as const` a `app/settings/acceso/actions.ts`, que es un archivo `'use server'`. Next.js 16 solo permite exportar funciones async desde archivos `'use server'`; cualquier otro export hace fallar **todas** las Server Actions del archivo al primer invoke con `Error: A "use server" file can only export async functions`.
- **Fix:** El const solo se usaba dentro del mismo archivo para derivar el type `ModuloSeccion` vía `(typeof MODULO_SECCIONES)[number]`. Nadie lo importaba como valor runtime. Reemplazo por un type union literal directo y agrego comentario explicando la regla.

## Confirmación en prod

Runtime logs del deployment `dpl_E8pVPCHTAuiLPJX7AGQrLqYmMMEP` muestran 20+ errores 500 en `POST /settings/acceso` desde las 19:49 (4/29) con el mismo mensaje truncado `Error: A "use server" file ...`.

## Test plan

- [x] `npm run typecheck` — pasa
- [x] `npm run lint` — pasa (0 errors)
- [x] `npm run format:check` — pasa
- [x] `npm run test:run` — 375/375 pasan
- [ ] Después de merge: en prod, abrir `/settings/acceso` → tab "Roles y Permisos" → seleccionar Rincón del Bosque → "Nuevo rol" → escribir "Nelcy" → "Crear rol" → debe aparecer en la lista sin error
- [ ] Seleccionar el rol nuevo → togglear checkboxes de Lectura/Escritura en cualquier módulo → debe persistir tras refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)