### PR TITLE
fix(health/ingest): soporte shape agregado de sleep_analysis (HAE)

### DIFF
--- a/app/api/health/ingest/route.test.ts
+++ b/app/api/health/ingest/route.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMetricRecords } from './route';
+
+describe('normalizeMetricRecords — sleep_analysis', () => {
+  it('handles segmented shape (older Apple Watch: value+qty per stage)', () => {
+    const out = normalizeMetricRecords([
+      {
+        name: 'sleep_analysis',
+        units: 'hr',
+        data: [
+          {
+            date: '2026-04-22 03:32:00 -0500',
+            source: "Adalberto's Apple Watch",
+            value: 'Core',
+            qty: 0.95,
+          },
+          {
+            date: '2026-04-22 04:11:00 -0500',
+            source: "Adalberto's Apple Watch",
+            value: 'Deep',
+            qty: 0.18,
+          },
+        ],
+      },
+    ]);
+
+    expect(out).toEqual([
+      {
+        metric_name: 'Sleep Core',
+        date: new Date('2026-04-22T03:32:00-05:00').toISOString(),
+        value: 0.95,
+        unit: 'hr',
+        source: "Adalberto's Apple Watch",
+      },
+      {
+        metric_name: 'Sleep Deep',
+        date: new Date('2026-04-22T04:11:00-05:00').toISOString(),
+        value: 0.18,
+        unit: 'hr',
+        source: "Adalberto's Apple Watch",
+      },
+    ]);
+  });
+
+  it('handles aggregated shape (current HAE: one row per night with stage props)', () => {
+    const out = normalizeMetricRecords([
+      {
+        name: 'sleep_analysis',
+        units: 'hr',
+        data: [
+          {
+            date: '2026-04-24 00:00:00 -0500',
+            source: 'Sleeptracker®',
+            sleepStart: '2026-04-23 23:16:00 -0500',
+            sleepEnd: '2026-04-24 08:01:00 -0500',
+            core: 5.6,
+            deep: 0.85,
+            rem: 2.13,
+            awake: 0.11,
+            inBed: 8.75,
+            asleep: 0,
+            totalSleep: 8.58,
+          },
+        ],
+      },
+    ]);
+
+    expect(out).toHaveLength(5);
+    const byMetric = Object.fromEntries(out.map((r) => [r.metric_name, r]));
+    expect(byMetric['Sleep Core']?.value).toBe(5.6);
+    expect(byMetric['Sleep Deep']?.value).toBe(0.85);
+    expect(byMetric['Sleep REM']?.value).toBe(2.13);
+    expect(byMetric['Sleep Awake']?.value).toBe(0.11);
+    expect(byMetric['Sleep In Bed']?.value).toBe(8.75);
+    // asleep: 0 must be skipped to keep dashboard averages clean
+    expect(byMetric['Sleep Asleep']).toBeUndefined();
+    // sleepStart wins over date so the timestamp reflects bedtime, not midnight
+    expect(byMetric['Sleep Core']?.date).toBe(new Date('2026-04-23T23:16:00-05:00').toISOString());
+    expect(byMetric['Sleep Core']?.source).toBe('Sleeptracker®');
+    expect(byMetric['Sleep Core']?.unit).toBe('hr');
+  });
+
+  it('skips an aggregated row that has every stage at 0', () => {
+    const out = normalizeMetricRecords([
+      {
+        name: 'sleep_analysis',
+        units: 'hr',
+        data: [
+          {
+            date: '2026-04-29 00:00:00 -0500',
+            source: 'Sleeptracker®',
+            core: 0,
+            deep: 0,
+            rem: 0,
+            awake: 0,
+            inBed: 0,
+            asleep: 0,
+            totalSleep: 0,
+          },
+        ],
+      },
+    ]);
+    expect(out).toEqual([]);
+  });
+
+  it('falls back to date when sleepStart is missing in aggregated shape', () => {
+    const out = normalizeMetricRecords([
+      {
+        name: 'sleep_analysis',
+        units: 'hr',
+        data: [
+          {
+            date: '2026-04-29 00:00:00 -0500',
+            source: 'Sleeptracker®',
+            core: 4.5,
+          },
+        ],
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.date).toBe(new Date('2026-04-29T00:00:00-05:00').toISOString());
+  });
+
+  it('drops sample with no stage data and no value/qty (the silent-drop bug)', () => {
+    const out = normalizeMetricRecords([
+      {
+        name: 'sleep_analysis',
+        units: 'hr',
+        data: [{ date: '2026-04-29 00:00:00 -0500', source: 'X', value: null, qty: null }],
+      },
+    ]);
+    expect(out).toEqual([]);
+  });
+});
+
+describe('normalizeMetricRecords — blood_pressure', () => {
+  it('splits systolic and diastolic into separate metrics', () => {
+    const out = normalizeMetricRecords([
+      {
+        name: 'blood_pressure',
+        units: 'mmHg',
+        data: [
+          {
+            date: '2026-04-23 18:30:00 -0500',
+            source: 'Connect',
+            systolic: 143,
+            diastolic: 97,
+          },
+        ],
+      },
+    ]);
+    expect(out).toHaveLength(2);
+    const systolic = out.find((r) => r.metric_name === 'Blood Pressure Systolic');
+    const diastolic = out.find((r) => r.metric_name === 'Blood Pressure Diastolic');
+    expect(systolic?.value).toBe(143);
+    expect(systolic?.unit).toBe('mmHg');
+    expect(diastolic?.value).toBe(97);
+    expect(diastolic?.unit).toBe('mmHg');
+  });
+});
+
+describe('normalizeMetricRecords — generic qty path', () => {
+  it('uses qty for simple metrics like step_count', () => {
+    const out = normalizeMetricRecords([
+      {
+        name: 'step_count',
+        units: 'steps',
+        data: [{ date: '2026-04-29 12:00:00 -0500', qty: 1234, source: 'iPhone' }],
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.metric_name).toBe('Step Count');
+    expect(out[0]?.value).toBe(1234);
+  });
+
+  it('prefers Avg over qty for heart_rate (segmented stat)', () => {
+    const out = normalizeMetricRecords([
+      {
+        name: 'heart_rate',
+        units: 'count/min',
+        data: [{ date: '2026-04-29 12:00:00 -0500', Avg: 72, Min: 60, Max: 90 }],
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.value).toBe(72);
+  });
+});

--- a/app/api/health/ingest/route.ts
+++ b/app/api/health/ingest/route.ts
@@ -152,7 +152,7 @@ function dedupeByKey<T>(rows: T[], keyOf: (row: T) => string): T[] {
   return Array.from(map.values());
 }
 
-function normalizeMetricRecords(metrics: unknown[]) {
+export function normalizeMetricRecords(metrics: unknown[]) {
   const records: Array<{
     metric_name: string;
     date: string;
@@ -193,16 +193,53 @@ function normalizeMetricRecords(metrics: unknown[]) {
       const sampleSource = rowSource || entrySource || 'Health Auto Export';
 
       if (isSleepAnalysis) {
+        // Two shapes coexist depending on HAE version / source:
+        //   1) Segmented (older Apple Watch): { value: "Core", qty: 0.95 }
+        //   2) Aggregated (current HAE for Sleeptracker® and recent Apple
+        //      Watch): { core: 5.6, deep: 0.85, rem: 2.13, awake: 0.11,
+        //      inBed: 8.75, asleep: 0, totalSleep: 8.58, sleepStart, sleepEnd }
+        // A `value:null, qty:null` sample silently dropped both branches —
+        // that's why 24-29 abr lost every sleep row even though ingest
+        // returned status=ok.
         const stage = typeof row.value === 'string' ? row.value.trim() : null;
         const qty = parseNumber(row.qty);
-        if (!stage || qty == null) return;
-        records.push({
-          metric_name: `Sleep ${stage}`,
-          date,
-          value: qty,
-          unit: unit ?? 'hr',
-          source: sampleSource,
-        });
+        if (stage && qty != null) {
+          records.push({
+            metric_name: `Sleep ${stage}`,
+            date,
+            value: qty,
+            unit: unit ?? 'hr',
+            source: sampleSource,
+          });
+          return;
+        }
+
+        // Aggregated: prefer sleepStart over date (which arrives as
+        // midnight-of-the-day) so the timestamp reflects the actual bedtime.
+        const aggregatedDate =
+          parseDate(row.sleepStart ?? row.start ?? row.startDate ?? row.date) ?? date;
+        const stages: Array<[keyof typeof row | string, string]> = [
+          ['core', 'Sleep Core'],
+          ['deep', 'Sleep Deep'],
+          ['rem', 'Sleep REM'],
+          ['awake', 'Sleep Awake'],
+          ['inBed', 'Sleep In Bed'],
+          ['asleep', 'Sleep Asleep'],
+        ];
+        for (const [key, metricName] of stages) {
+          const val = parseNumber(row[key as string]);
+          // Skip 0 values — Sleeptracker® always sends asleep:0, Apple Watch
+          // sends inBed:0; treating those as real measurements would pollute
+          // the dashboard averages with zero-padded noise.
+          if (val == null || val === 0) continue;
+          records.push({
+            metric_name: metricName,
+            date: aggregatedDate,
+            value: val,
+            unit: unit ?? 'hr',
+            source: sampleSource,
+          });
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

- HAE cambió el shape de `sleep_analysis` ~23-abr: ahora manda **un sample por noche** con `{core, deep, rem, awake, inBed, asleep, totalSleep, sleepStart, sleepEnd}` en lugar de uno por intervalo de stage `{value: "Core", qty: 5.6}`.
- El normalizer en [route.ts:195](app/api/health/ingest/route.ts:195) hacía `if (!stage || qty == null) return;` y descartaba silenciosamente cada sample del shape nuevo. Resultado: 6 días con 0 filas de Sleep en BD (24-29 abr) aunque `health_ingest_log` reportaba `ok` en cada batch — punto ciego de instrumentación.
- Fix: detectar shape agregado y expandir cada stage numérico a su propio record. Skip 0 (Sleeptracker® siempre manda `asleep:0`, Apple Watch `inBed:0`). Preferir `sleepStart` sobre `date` para que el timestamp refleje bedtime, no midnight-of-the-day.
- También exporta `normalizeMetricRecords` y agrega 8 tests cubriendo: shape segmentado (back-compat), shape agregado, all-zeros skip, fallback a `date`, **el silent-drop bug** (test que pinea el bug original), blood_pressure split, generic qty path.

Beto reprodujo el bug con un manual export 23→29 abr — las 7 noches están en el JSON. Backfill por re-POST después del merge.

## Test plan

- [x] `npm run test:run` (382 tests, todos verde)
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors, warnings preexistentes)
- [x] `npm run format:check`
- [ ] Tras merge: re-POSTear el manual export al endpoint y verificar que llegan ≥30 filas Sleep nuevas (5 stages × 7 noches, sin contar all-zeros)
- [ ] Verificar en /health que las noches 23-29 aparezcan en la sección Recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)