### PR TITLE
feat(oc-cierre-ciclo): Sprint 3 — handoff CxP via view + indicador en drawer

### DIFF
--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -754,6 +754,30 @@ function OrdenDetail({
             </div>
           )}
 
+          {orden?.estatus === 'cerrada' &&
+            orden?.total_a_pagar != null &&
+            orden.total_a_pagar > 0 && (
+              <div className="flex items-start gap-2 rounded-xl border-2 border-emerald-300 bg-emerald-50/80 p-4 text-sm print:hidden">
+                <span
+                  className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-xs font-bold text-white"
+                  aria-hidden
+                >
+                  ✓
+                </span>
+                <div>
+                  <div className="font-semibold text-emerald-900">
+                    Listo para Cuentas por Pagar ·{' '}
+                    <span className="tabular-nums">{formatCurrency(orden.total_a_pagar)}</span>
+                  </div>
+                  <div className="mt-0.5 text-xs text-emerald-800/80">
+                    Pendiente de factura y pago al proveedor. Cuando el módulo CxP esté construido,
+                    esta OC aparecerá automáticamente en su bandeja
+                    (`erp.v_oc_cerradas_pendientes_pago`).
+                  </div>
+                </div>
+              </div>
+            )}
+
           <Separator className="print:hidden" />
 
           {/* ═══ Items (both screen and print) ═══ */}

--- a/supabase/SCHEMA_REF.md
+++ b/supabase/SCHEMA_REF.md
@@ -2242,6 +2242,7 @@ _(sin columnas)_
 - **workouts_count** `integer` DEFAULT `0`
 - **source_ip** `text`
 - **status** `text` DEFAULT `'ok'::text`
+- **metrics_by_name** `jsonb` NOT NULL DEFAULT `'{}'::jsonb`
 
 ### `health.health_medications`
 
@@ -2435,6 +2436,7 @@ _(sin tablas ni vistas)_
 - **workouts_count** `integer`
 - **source_ip** `text`
 - **status** `text`
+- **metrics_by_name** `jsonb`
 
 ### `public.health_medications` _(view)_
 

--- a/supabase/migrations/20260429100000_oc_v_cerradas_pendientes_pago.sql
+++ b/supabase/migrations/20260429100000_oc_v_cerradas_pendientes_pago.sql
@@ -1,0 +1,33 @@
+-- oc-cierre-ciclo Sprint 3 — view de OCs cerradas pendientes de pago
+--
+-- View read-only que expone OCs en estado 'cerrada' con total_a_pagar > 0,
+-- para que el módulo CxP futuro consulte sin retrabajo cuando exista.
+-- Hoy la UI consulta erp.ordenes_compra directamente; la view queda como
+-- contrato listo. Cuando CxP arranque (iniciativa `cxp`, planned), su
+-- Sprint 1 reemplaza esta view por tabla materializada o lógica más rica
+-- — sin afectar a OC porque la view es throwaway.
+
+CREATE OR REPLACE VIEW erp.v_oc_cerradas_pendientes_pago AS
+SELECT
+  oc.id                    AS oc_id,
+  oc.codigo                AS folio,
+  oc.empresa_id,
+  oc.proveedor_id,
+  oc.total_a_pagar,
+  oc.cerrada_at,
+  oc.cerrada_por,
+  EXTRACT(DAY FROM (now() - oc.cerrada_at))::int AS dias_desde_cierre
+FROM erp.ordenes_compra AS oc
+WHERE oc.estado = 'cerrada'
+  AND oc.total_a_pagar IS NOT NULL
+  AND oc.total_a_pagar > 0
+  AND oc.deleted_at IS NULL;
+
+COMMENT ON VIEW erp.v_oc_cerradas_pendientes_pago IS
+  'OCs cerradas con total_a_pagar > 0 — handoff a CxP futuro. Throwaway: cuando módulo CxP exista, replazar por su modelo propio.';
+
+-- Asegurar que PostgREST puede listar la view en el schema 'erp' (que ya
+-- está en pgrst.db_schemas). No se requieren GRANTs adicionales: roles
+-- authenticated/service_role heredan SELECT por convención del schema.
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Sprint 3 de [`oc-cierre-ciclo`](docs/planning/oc-cierre-ciclo.md). Cierra el gap #5: cuando una OC se cierra, no había forma operativa de avisar a CxP que ya se puede pagar.

**Opción D2 elegida** (sin schema rígido futuro): expone los datos via view read-only para que CxP enchufe sin retrabajo cuando exista. Cuando el módulo CxP (iniciativa [`cxp`](docs/planning/cxp.md), `planned`) arranque, su Sprint 1 reemplaza la view por su modelo propio.

## Cambios

- **Migración** `supabase/migrations/20260429100000_oc_v_cerradas_pendientes_pago.sql` — nueva view `erp.v_oc_cerradas_pendientes_pago` con columnas `oc_id`, `folio`, `empresa_id`, `proveedor_id`, `total_a_pagar`, `cerrada_at`, `cerrada_por`, `dias_desde_cierre`. Filtra por `estado='cerrada' AND total_a_pagar > 0 AND deleted_at IS NULL`.
- **UI** — banner verde nuevo en el drawer cuando OC está cerrada con `total_a_pagar > 0`: "Listo para Cuentas por Pagar · \$X" + subtítulo explicativo.

## ⚠️ Migración pendiente de aplicar

Esta migración crea solo una **view read-only** (DDL no destructivo). **Beto aplica con psql antes de mergear**:

```bash
psql "$SUPABASE_DB_URL" -f supabase/migrations/20260429100000_oc_v_cerradas_pendientes_pago.sql
```

Después: regenerar `SCHEMA_REF.md` con `npm run schema:ref` + `types/supabase.ts` con `npm run db:types`. El workflow `db-types.yml` lo hace automáticamente al mergear si está configurado.

**La UI no depende de la view en este sprint** (el banner se muestra con state local `orden.estatus` + `orden.total_a_pagar`). La view es contrato listo para CxP.

## Test plan

- [x] `npm run typecheck` — verde
- [x] `npm run lint` — verde (74 warnings preexistentes, 0 errors)
- [x] `npm run test:run` — verde (382 tests)
- [x] `npm run format:check` — verde
- [ ] CI verde post-push
- [ ] Beto aplica migración con `psql` antes de mergear
- [ ] Smoke: abrir OC cerrada → ver banner verde "Listo para CxP · $X"
- [ ] Smoke: query directa a `erp.v_oc_cerradas_pendientes_pago` retorna las OCs cerradas con total_a_pagar > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)