### PR TITLE
feat(health): sleep efficiency + HRV/RHR recovery flags

### DIFF
--- a/components/health/health-dashboard-view.tsx
+++ b/components/health/health-dashboard-view.tsx
@@ -10,6 +10,7 @@ import { CardiacFitnessSection } from './cardiac-fitness-section';
 import {
   buildDeltaHelper,
   formatDaysAgo,
+  getRecoveryFlag,
   groupDailyAverage,
   groupDailySleep,
   isStaleSince,
@@ -25,6 +26,8 @@ import type { HealthDashboardViewProps, HeroCard } from './types';
 export function HealthDashboardView({
   latest,
   heroSleepStages,
+  heroHrv,
+  heroRestingHr,
   sleepStages,
   hrv,
   restingHr,
@@ -60,6 +63,18 @@ export function HealthDashboardView({
   const hrvDaily = useMemo(() => groupDailyAverage(hrv), [hrv]);
   const restingHrDaily = useMemo(() => groupDailyAverage(restingHr), [restingHr]);
   const wristTempDaily = useMemo(() => groupDailyAverage(wristTemp), [wristTemp]);
+  // 14-day windows feed the recovery-flag computation regardless of the
+  // active range, so the flag fires even when the user is looking at "today".
+  const heroHrvDaily = useMemo(() => groupDailyAverage(heroHrv), [heroHrv]);
+  const heroRestingHrDaily = useMemo(() => groupDailyAverage(heroRestingHr), [heroRestingHr]);
+  const hrvFlag = useMemo(
+    () => getRecoveryFlag(heroHrvDaily, { type: 'drop', threshold: 0.1 }),
+    [heroHrvDaily]
+  );
+  const rhrFlag = useMemo(
+    () => getRecoveryFlag(heroRestingHrDaily, { type: 'rise', thresholdAbs: 5 }),
+    [heroRestingHrDaily]
+  );
   const workoutSummary = useMemo(() => {
     const mixMap = new Map<string, number>();
     workouts.forEach((w) => mixMap.set(w.name, (mixMap.get(w.name) ?? 0) + 1));
@@ -104,6 +119,7 @@ export function HealthDashboardView({
       icon: Activity,
       stale: hrvStale.stale,
       staleLabel: formatDaysAgo(hrvStale.daysAgo),
+      flag: hrvFlag ?? undefined,
     },
     {
       key: 'rhr',
@@ -120,6 +136,7 @@ export function HealthDashboardView({
       icon: HeartPulse,
       stale: restHrStale.stale,
       staleLabel: formatDaysAgo(restHrStale.daysAgo),
+      flag: rhrFlag ?? undefined,
     },
     {
       key: 'temp',

--- a/components/health/helpers.test.ts
+++ b/components/health/helpers.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { HealthMetricRow } from '@/lib/health';
+import { getRecoveryFlag, groupDailySleepEfficiency } from './helpers';
+import type { Point } from './types';
+
+function row(
+  metric_name: string,
+  date: string,
+  value: number,
+  source = 'Sleeptracker®'
+): HealthMetricRow {
+  return { id: 1, metric_name, date, value, unit: 'hr', source };
+}
+
+describe('groupDailySleepEfficiency', () => {
+  it('returns (asleep / inBed) × 100 per day, capped at 100', () => {
+    const points = groupDailySleepEfficiency([
+      row('Sleep Core', '2026-04-23T23:16:00.000Z', 5.6),
+      row('Sleep Deep', '2026-04-23T23:16:00.000Z', 0.85),
+      row('Sleep REM', '2026-04-23T23:16:00.000Z', 2.13),
+      row('Sleep In Bed', '2026-04-23T23:16:00.000Z', 8.75),
+      row('Sleep Awake', '2026-04-23T23:16:00.000Z', 0.12), // ignored — not asleep
+    ]);
+    expect(points).toHaveLength(1);
+    // (5.6 + 0.85 + 2.13) / 8.75 × 100 ≈ 98.06
+    expect(points[0]!.value).toBeCloseTo(98.06, 1);
+  });
+
+  it('skips days that have asleep but no In Bed (Apple Watch nap)', () => {
+    const points = groupDailySleepEfficiency([
+      row('Sleep Core', '2026-04-29T18:00:00.000Z', 0.5, "Adalberto's Apple Watch"),
+    ]);
+    expect(points).toEqual([]);
+  });
+
+  it('takes the larger of Sleeptracker® and Apple Watch per day for each side', () => {
+    const points = groupDailySleepEfficiency([
+      row('Sleep Core', '2026-04-23T23:16:00.000Z', 5, 'Sleeptracker®'),
+      row('Sleep Core', '2026-04-23T23:16:00.000Z', 4.5, "Adalberto's Apple Watch"),
+      row('Sleep Deep', '2026-04-23T23:16:00.000Z', 1, 'Sleeptracker®'),
+      row('Sleep REM', '2026-04-23T23:16:00.000Z', 2, 'Sleeptracker®'),
+      row('Sleep In Bed', '2026-04-23T23:16:00.000Z', 8, 'Sleeptracker®'),
+    ]);
+    // Use Sleeptracker® totals (larger asleep): (5+1+2)/8 = 100%
+    expect(points[0]!.value).toBe(100);
+  });
+
+  it('caps efficiency at 100 even if asleep > inBed (data quirk)', () => {
+    const points = groupDailySleepEfficiency([
+      row('Sleep Core', '2026-04-23T23:16:00.000Z', 9),
+      row('Sleep In Bed', '2026-04-23T23:16:00.000Z', 8),
+    ]);
+    expect(points[0]!.value).toBe(100);
+  });
+});
+
+// Build N daily Points centered on today, with values supplied via callback.
+// Index 0 = oldest day; index N-1 = today.
+function buildSeries(days: number, valueFor: (idx: number) => number): Point[] {
+  const points: Point[] = [];
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setDate(today.getDate() - (days - 1 - i));
+    points.push({ date: d.toISOString().slice(0, 10), value: valueFor(i) });
+  }
+  return points;
+}
+
+describe('getRecoveryFlag', () => {
+  it('returns null when there are < 14 days of data', () => {
+    const points = buildSeries(7, () => 50);
+    expect(getRecoveryFlag(points, { type: 'drop', threshold: 0.1 })).toBeNull();
+  });
+
+  it('flags HRV drop > 10% vs previous 7d baseline', () => {
+    // First 7 days: HRV 50, last 7 days: HRV 40 → 20% drop
+    const points = buildSeries(14, (i) => (i < 7 ? 50 : 40));
+    const flag = getRecoveryFlag(points, { type: 'drop', threshold: 0.1 });
+    expect(flag).toEqual({ tone: 'warning', label: '↓ 20%' });
+  });
+
+  it('does not flag HRV drop within 10%', () => {
+    // Only 5% drop
+    const points = buildSeries(14, (i) => (i < 7 ? 50 : 47.5));
+    expect(getRecoveryFlag(points, { type: 'drop', threshold: 0.1 })).toBeNull();
+  });
+
+  it('flags RHR rise > 5 bpm vs previous 7d baseline', () => {
+    // First 7 days: RHR 60, last 7 days: RHR 67 → +7 bpm
+    const points = buildSeries(14, (i) => (i < 7 ? 60 : 67));
+    const flag = getRecoveryFlag(points, { type: 'rise', thresholdAbs: 5 });
+    expect(flag).toEqual({ tone: 'warning', label: '↑ 7 bpm' });
+  });
+
+  it('does not flag RHR rise within 5 bpm', () => {
+    const points = buildSeries(14, (i) => (i < 7 ? 60 : 63));
+    expect(getRecoveryFlag(points, { type: 'rise', thresholdAbs: 5 })).toBeNull();
+  });
+
+  it('returns null when previous baseline is 0 (avoid divide-by-zero)', () => {
+    const points = buildSeries(14, (i) => (i < 7 ? 0 : 50));
+    expect(getRecoveryFlag(points, { type: 'drop', threshold: 0.1 })).toBeNull();
+  });
+});

--- a/components/health/helpers.ts
+++ b/components/health/helpers.ts
@@ -182,6 +182,90 @@ export function isStaleSince(latestIso: string | null | undefined, maxDaysStale:
 }
 
 /**
+ * Daily sleep efficiency = (Core + Deep + REM) / In Bed × 100. Clinical
+ * benchmark: > 85% is considered restorative; sub-80% suggests fragmented
+ * sleep. Sleep In Bed is taken from the larger of the two devices that
+ * report it (Sleeptracker® primary; Apple Watch sometimes reports 0 → it's
+ * skipped at the normalizer level so won't override the bed value here).
+ *
+ * Returns one Point per day where both inBed > 0 and asleep > 0 — days
+ * with only one component (e.g. nap recorded on Apple Watch without an
+ * In Bed sample) are skipped to avoid 0% / >100% noise.
+ */
+export function groupDailySleepEfficiency(rows: HealthMetricRow[]): Point[] {
+  type Bucket = {
+    asleepSt: number;
+    asleepOther: number;
+    inBedSt: number;
+    inBedOther: number;
+  };
+  const buckets = new Map<string, Bucket>();
+  rows.forEach((row) => {
+    const key = row.date.slice(0, 10);
+    const existing = buckets.get(key) ?? { asleepSt: 0, asleepOther: 0, inBedSt: 0, inBedOther: 0 };
+    const isSleeptracker = (row.source ?? '').toLowerCase().includes('sleeptracker');
+    if (row.metric_name === 'Sleep In Bed') {
+      if (isSleeptracker) existing.inBedSt += row.value;
+      else existing.inBedOther += row.value;
+    } else if (
+      row.metric_name === 'Sleep Core' ||
+      row.metric_name === 'Sleep Deep' ||
+      row.metric_name === 'Sleep REM'
+    ) {
+      if (isSleeptracker) existing.asleepSt += row.value;
+      else existing.asleepOther += row.value;
+    }
+    buckets.set(key, existing);
+  });
+  const points: Point[] = [];
+  for (const [date, b] of buckets.entries()) {
+    const asleep = Math.max(b.asleepSt, b.asleepOther);
+    const inBed = Math.max(b.inBedSt, b.inBedOther);
+    if (asleep <= 0 || inBed <= 0) continue;
+    points.push({ date, value: Math.min(100, (asleep / inBed) * 100) });
+  }
+  return points.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Compute a recovery flag for a vital that has shifted unfavorably vs the
+ * previous 7-day baseline. For HRV (where lower = worse) pass type='drop'
+ * and a relative threshold (0.10 = 10% drop). For resting HR (where higher
+ * = worse) pass type='rise' and an absolute threshold (e.g. 5 bpm). Uses
+ * the existing computeSymmetricDelta helper so it requires at least 14
+ * days of data — returns null otherwise.
+ *
+ * Clinical context: post-bypass cardiac rehab. A sustained HRV drop or RHR
+ * rise without a workout / illness explanation is a warning sign worth
+ * surfacing on the hero card so it doesn't get lost in the trend chart.
+ */
+export function getRecoveryFlag(
+  points: Point[],
+  options: { type: 'drop'; threshold: number } | { type: 'rise'; thresholdAbs: number }
+): { tone: 'warning'; label: string } | null {
+  const delta = computeSymmetricDelta(points, 7);
+  if (!delta || delta.previous <= 0) return null;
+
+  if (options.type === 'drop') {
+    const ratio = delta.delta / delta.previous;
+    if (ratio <= -options.threshold) {
+      return {
+        tone: 'warning',
+        label: `↓ ${Math.round(Math.abs(ratio) * 100)}%`,
+      };
+    }
+  } else {
+    if (delta.delta >= options.thresholdAbs) {
+      return {
+        tone: 'warning',
+        label: `↑ ${Math.round(delta.delta)} bpm`,
+      };
+    }
+  }
+  return null;
+}
+
+/**
  * Group sleep-stage rows into per-stage daily totals, de-duplicated across
  * Sleeptracker®/Apple Watch by taking the larger value per stage per day.
  * Returns averages keyed by stage name for breakdown charts.

--- a/components/health/hero-vitals.tsx
+++ b/components/health/hero-vitals.tsx
@@ -27,6 +27,14 @@ export function HeroVitals({ heroCards }: { heroCards: HeroCard[] }) {
                     <Icon className="h-5 w-5" />
                   </div>
                   <div className="flex items-center gap-2">
+                    {card.flag ? (
+                      <span
+                        className="rounded-full border border-amber-400/50 bg-amber-200/60 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-800 dark:border-amber-300/30 dark:bg-amber-300/15 dark:text-amber-100"
+                        title={`${card.label} se movió contra ti vs la base 7d previa.`}
+                      >
+                        {card.flag.label}
+                      </span>
+                    ) : null}
                     {card.stale ? (
                       <span className="rounded-full border border-amber-300/40 bg-amber-100/60 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-700 dark:border-amber-300/25 dark:bg-amber-300/10 dark:text-amber-200">
                         {card.staleLabel ?? 'Sin datos'}

--- a/components/health/sleep-section.tsx
+++ b/components/health/sleep-section.tsx
@@ -9,6 +9,7 @@ import {
   countDaysAtOrAbove,
   filterRecentRows,
   groupDailySleep,
+  groupDailySleepEfficiency,
   groupDailySum,
   groupSleepStages,
   summarizeDailyWindow,
@@ -47,6 +48,9 @@ export function SleepSection({
   const sleepDaily = groupDailySleep(sleepStages);
   const sleepSeries = sleepDaily.slice(-trendDays);
   const breathingSeries = groupDailySum(breathing).slice(-trendDays);
+
+  const efficiencyDaily = groupDailySleepEfficiency(sleepStages);
+  const efficiency7dAvg = summarizeDailyWindow(efficiencyDaily, 7, 0);
 
   const latestSleep = sleepDaily.at(-1) ?? null;
   const sleep7dAvg = summarizeDailyWindow(sleepDaily, 7, 0);
@@ -106,7 +110,7 @@ export function SleepSection({
           </div>
         </div>
 
-        <div className="mb-6 grid gap-3 md:grid-cols-4">
+        <div className="mb-6 grid gap-3 md:grid-cols-3 xl:grid-cols-5">
           <StatPill
             label="Anoche"
             value={`${latestSleep ? formatDurationHours(latestSleep.value) : '—'} hr`}
@@ -118,6 +122,10 @@ export function SleepSection({
           <StatPill
             label="30d avg"
             value={`${sleep30dAvg == null ? '—' : formatDurationHours(sleep30dAvg)} hr`}
+          />
+          <StatPill
+            label="Eficiencia 7d"
+            value={efficiency7dAvg == null ? '—' : `${formatMetricValue(efficiency7dAvg, 0)}%`}
           />
           <StatPill
             label="Noches ≥7h (7d)"

--- a/components/health/types.ts
+++ b/components/health/types.ts
@@ -16,6 +16,10 @@ export type HeroCard = {
   icon: typeof HeartPulse;
   stale?: boolean;
   staleLabel?: string;
+  // Recovery warning surfaced next to the label when the vital has shifted
+  // unfavorably vs its 7-day baseline (e.g. HRV drop > 10%, RHR rise > 5
+  // bpm). Set by getRecoveryFlag in helpers.
+  flag?: { tone: 'warning'; label: string };
 };
 
 export type ChartConfig = {

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -288,10 +288,15 @@ function metricSeriesIn(
 export type HealthDashboardData = {
   range: HealthDashboardRange;
   latest: Record<string, HealthMetricRow | null>;
-  // Recovery hero: pulls last 14 days of sleep stages regardless of the
-  // active range so "Sleep" card always reflects last night even if the
-  // user selected "today" or a custom range with no sleep data.
+  // Recovery hero: pulls last 14 days regardless of the active range so
+  // "Sleep / HRV / RHR" cards always reflect last night even if the user
+  // selected "today" or a custom range with no recent data. The 14-day
+  // window also gives current-vs-previous deltas a stable base so the
+  // recovery flag (HRV drop > 10%, RHR rise > 5 bpm) can fire on any
+  // active range.
   heroSleepStages: HealthMetricRow[];
+  heroHrv: HealthMetricRow[];
+  heroRestingHr: HealthMetricRow[];
   // Recovery
   sleepStages: HealthMetricRow[];
   hrv: HealthMetricRow[];
@@ -333,6 +338,8 @@ export type HealthDashboardData = {
 const EMPTY_DATA_SUFFIX: Omit<HealthDashboardData, 'range' | 'errors'> = {
   latest: {},
   heroSleepStages: [],
+  heroHrv: [],
+  heroRestingHr: [],
   sleepStages: [],
   hrv: [],
   restingHr: [],
@@ -392,6 +399,8 @@ export async function getHealthDashboardData(
   const [
     latestResult,
     heroSleepRes,
+    heroHrvRes,
+    heroRestingHrRes,
     sleepStagesRes,
     hrvRes,
     restingHrRes,
@@ -432,6 +441,8 @@ export async function getHealthDashboardData(
       p_names: LATEST_METRIC_NAMES,
     }),
     metricSeriesIn(supabase, SLEEP_STAGE_METRICS, heroSleepFrom, new Date().toISOString()),
+    metricSeries(supabase, 'Heart Rate Variability', heroSleepFrom, new Date().toISOString()),
+    metricSeries(supabase, 'Resting Heart Rate', heroSleepFrom, new Date().toISOString()),
     metricSeriesIn(supabase, SLEEP_STAGE_METRICS, from, to),
     metricSeries(supabase, 'Heart Rate Variability', from, to),
     metricSeries(supabase, 'Resting Heart Rate', from, to),
@@ -499,6 +510,8 @@ export async function getHealthDashboardData(
   const errors = [
     latestResult.error?.message,
     heroSleepRes.error?.message,
+    heroHrvRes.error?.message,
+    heroRestingHrRes.error?.message,
     sleepStagesRes.error?.message,
     hrvRes.error?.message,
     restingHrRes.error?.message,
@@ -534,6 +547,8 @@ export async function getHealthDashboardData(
     range,
     latest,
     heroSleepStages: heroSleepRes.data ?? [],
+    heroHrv: heroHrvRes.data ?? [],
+    heroRestingHr: heroRestingHrRes.data ?? [],
     sleepStages: sleepStagesRes.data ?? [],
     hrv: hrvRes.data ?? [],
     restingHr: restingHrRes.data ?? [],


### PR DESCRIPTION
## Summary

Two derived analyses on top of the existing /health dashboard. No new tables or RPCs.

### 1. Sleep efficiency

`(Core + Deep + REM) / In Bed × 100`. Clinical benchmark — >85% restorative, <80% fragmented. Surfaced as a 5th StatPill ("Eficiencia 7d") in the Sleep section.

### 2. HRV / RHR recovery flags on hero

Amber badge next to the metric label when the vital has shifted unfavorably vs the prior 7-day baseline:

- **HRV**: drop > 10%
- **RHR**: rise > 5 bpm

Catches under-recovery / inflammation signals (post-bypass cardiac rehab context) without firing on day-to-day variance. The flag needs 14 days of data — to keep it firing on the default 7-day range, hero now pulls `heroHrv` and `heroRestingHr` (last 14d) alongside the existing `heroSleepStages`. Active-range `hrv` / `restingHr` arrays are untouched for the rest of the dashboard.

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓ (no new errors)
- [x] `npm run format:check` ✓
- [x] `npm run test:run` — 1006 tests pass; 10 new in `components/health/helpers.test.ts` covering:
  - `groupDailySleepEfficiency`: dual-source resolution, cap-at-100, skip days missing one component
  - `getRecoveryFlag`: drop / rise / under-threshold / insufficient data / divide-by-zero
- [ ] Post-merge verify on `/health`: hero HRV/RHR show ↓%/↑bpm badge if applicable; Sleep section shows 5 StatPills with "Eficiencia 7d" populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)