### PR TITLE
feat(drawer-anatomy-polish): aplica DD10/DD11 a drawers core (Sprint 2)

### DIFF
--- a/app/rdb/ordenes-compra/page.tsx
+++ b/app/rdb/ordenes-compra/page.tsx
@@ -555,8 +555,7 @@ function OrdenDetail({
     <DetailDrawer
       open={open}
       onOpenChange={(value) => !value && onClose()}
-      size="md"
-      className="sm:max-w-[700px]"
+      size="lg"
       title={orden?.folio ?? 'Orden de compra'}
       description={`${proveedorObj?.nombre ?? 'Sin proveedor'} · ${formatDate(orden?.fecha_emision)}${reqFolio ? ` · Req: ${reqFolio}` : ''}`}
       actions={

--- a/components/cortes/corte-detail.tsx
+++ b/components/cortes/corte-detail.tsx
@@ -3,8 +3,12 @@ import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { Skeleton } from '@/components/ui/skeleton';
-import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
+import {
+  DetailDrawer,
+  DetailDrawerContent,
+  DetailDrawerSection,
+  DetailDrawerSkeleton,
+} from '@/components/detail-page';
 import { useTriggerPrint } from '@/components/print';
 import { conciliarEfectivo, conciliarTarjeta } from './conciliacion';
 import { CorteConciliacion } from './corte-conciliacion';
@@ -13,19 +17,6 @@ import { MarbeteConciliacion } from './marbete-conciliacion';
 import { RegistrarMovimientoDialog } from './registrar-movimiento-dialog';
 import type { Banco, Corte, CorteTotales, Movimiento, Voucher } from './types';
 import { VoucherLightbox } from './voucher-lightbox';
-
-function DetailSkeleton() {
-  return (
-    <div className="space-y-3">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="flex justify-between gap-4">
-          <Skeleton className="h-4 w-36" />
-          <Skeleton className="h-4 w-24" />
-        </div>
-      ))}
-    </div>
-  );
-}
 
 export function CorteDetail({
   corte,
@@ -173,15 +164,9 @@ export function CorteDetail({
             </>
           )}
 
-          <Separator className="print:my-1" />
-
-          {/* Resumen Financiero */}
-          <div>
-            <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground print:mb-1 print:text-[9px] print:text-gray-500">
-              Resumen Financiero
-            </div>
+          <DetailDrawerSection title="Resumen Financiero" className="print:mt-1 print:pt-1">
             {loadingDetail ? (
-              <DetailSkeleton />
+              <DetailDrawerSkeleton showStats={false} lines={0} sectionRows={6} />
             ) : totales ? (
               <div className="space-y-2 text-sm print:space-y-0 print:text-[10px]">
                 <div className="flex justify-between">
@@ -245,31 +230,30 @@ export function CorteDetail({
             ) : (
               <p className="text-sm text-muted-foreground">Sin datos de totales.</p>
             )}
-          </div>
+          </DetailDrawerSection>
 
-          <Separator className="print:my-1" />
-
-          {/* Movimientos */}
-          <div>
-            <div className="mb-3 flex items-center justify-between print:mb-1">
-              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground print:text-[9px] print:text-gray-500">
-                Movimientos
+          <DetailDrawerSection
+            title={
+              <span className="flex items-center justify-between gap-3">
+                <span>Movimientos</span>
+                {estaAbierto && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setRegistrarOpen(true)}
+                    aria-label="Registrar movimiento de caja"
+                    className="print:hidden"
+                  >
+                    <Plus className="mr-1.5 h-3.5 w-3.5" />
+                    Registrar
+                  </Button>
+                )}
               </span>
-              {estaAbierto && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setRegistrarOpen(true)}
-                  aria-label="Registrar movimiento de caja"
-                  className="print:hidden"
-                >
-                  <Plus className="mr-1.5 h-3.5 w-3.5" />
-                  Registrar
-                </Button>
-              )}
-            </div>
+            }
+            className="print:mt-1 print:pt-1"
+          >
             {loadingDetail ? (
-              <DetailSkeleton />
+              <DetailDrawerSkeleton showStats={false} lines={0} sectionRows={5} />
             ) : movimientos.length === 0 ? (
               <p className="text-sm text-muted-foreground print:text-[10px]">
                 Sin movimientos registrados.
@@ -321,7 +305,7 @@ export function CorteDetail({
                 })}
               </div>
             )}
-          </div>
+          </DetailDrawerSection>
 
           {(() => {
             // Fallback `?? 'voucher_tarjeta'` por compat con vouchers viejos cuyo

--- a/components/documentos/documento-create-sheet.tsx
+++ b/components/documentos/documento-create-sheet.tsx
@@ -120,7 +120,6 @@ export function DocumentoCreateSheet({
         if (!v) onClose();
       }}
       size="md"
-      className="sm:max-w-[640px]"
       title="Nuevo Documento"
     >
       <DetailDrawerContent>

--- a/components/tasks/tasks-updates-sheet.tsx
+++ b/components/tasks/tasks-updates-sheet.tsx
@@ -5,7 +5,7 @@
  * button in the rich table's actions cell.
  */
 
-import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
+import { DetailDrawer, DetailDrawerContent, DetailDrawerSection } from '@/components/detail-page';
 import type { ErpTask, TaskUpdateRow } from './tasks-shared';
 import { UpdateComposer, UpdatesList } from './tasks-updates';
 
@@ -39,22 +39,17 @@ export function TasksUpdatesSheet({
       description={task?.titulo ?? ''}
     >
       <DetailDrawerContent>
-        <div className="space-y-4">
-          <UpdateComposer
-            value={updateContent}
-            onChange={onUpdateContentChange}
-            onSubmit={onSaveUpdate}
-            saving={savingUpdate}
-            size="lg"
-          />
+        <UpdateComposer
+          value={updateContent}
+          onChange={onUpdateContentChange}
+          onSubmit={onSaveUpdate}
+          saving={savingUpdate}
+          size="lg"
+        />
 
-          <div className="border-t border-[var(--border)] pt-4">
-            <div className="text-[10px] font-semibold uppercase tracking-widest text-[var(--text)]/50 mb-3">
-              Historial
-            </div>
-            <UpdatesList updates={updates} loading={loadingUpdates} variant="sheet" />
-          </div>
-        </div>
+        <DetailDrawerSection title="Historial">
+          <UpdatesList updates={updates} loading={loadingUpdates} variant="sheet" />
+        </DetailDrawerSection>
       </DetailDrawerContent>
     </DetailDrawer>
   );

--- a/components/ventas/order-detail.tsx
+++ b/components/ventas/order-detail.tsx
@@ -2,26 +2,16 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Separator } from '@/components/ui/separator';
-import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
+import {
+  DetailDrawer,
+  DetailDrawerContent,
+  DetailDrawerSection,
+  DetailDrawerSkeleton,
+} from '@/components/detail-page';
 import { useTriggerPrint } from '@/components/print';
 
 import type { Pedido } from './types';
 import { formatCurrency, formatDate, statusVariant } from './utils';
-
-function DetailSkeleton() {
-  return (
-    <div className="space-y-3">
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="flex justify-between gap-4">
-          <Skeleton className="h-4 w-40" />
-          <Skeleton className="h-4 w-24" />
-        </div>
-      ))}
-    </div>
-  );
-}
 
 export function OrderDetail({
   pedido,
@@ -62,147 +52,129 @@ export function OrderDetail({
       />
 
       <DetailDrawerContent>
-        <div className="space-y-6">
-          {/* Status + total */}
-          <div className="flex items-center justify-between">
-            <Badge variant={statusVariant(pedido.status)}>{pedido.status ?? 'Sin estado'}</Badge>
-            <span className="text-lg font-semibold">{formatCurrency(pedido.total_amount)}</span>
-          </div>
+        <div className="flex items-center justify-between">
+          <Badge variant={statusVariant(pedido.status)}>{pedido.status ?? 'Sin estado'}</Badge>
+          <span className="text-lg font-semibold">{formatCurrency(pedido.total_amount)}</span>
+        </div>
 
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            {pedido.place_name && (
-              <div>
-                <span className="text-muted-foreground block text-xs">Ubicación</span>
-                <span className="font-medium">{pedido.place_name}</span>
-              </div>
-            )}
-            {pedido.layout_name && (
-              <div>
-                <span className="text-muted-foreground block text-xs">Área</span>
-                <span className="font-medium">{pedido.layout_name}</span>
-              </div>
-            )}
-            {pedido.table_name && (
-              <div>
-                <span className="text-muted-foreground block text-xs">Mesa</span>
-                <span className="font-medium">{pedido.table_name}</span>
-              </div>
-            )}
-            {pedido.external_delivery_id && (
-              <div>
-                <span className="text-muted-foreground block text-xs">Delivery ID</span>
-                <span className="font-medium">{pedido.external_delivery_id}</span>
-              </div>
-            )}
-          </div>
-          {(() => {
-            const realDiscount =
-              (pedido.total_amount ?? 0) - (pedido.total_discount ?? pedido.total_amount ?? 0);
-            const hasDiscount = realDiscount > 0.01;
-            const hasService = (pedido.service_charge ?? 0) > 0;
-            const hasTax = (pedido.tax ?? 0) > 0;
-
-            if (!hasDiscount && !hasService && !hasTax) return null;
-
-            return (
-              <div className="bg-muted/30 rounded-lg p-3 space-y-1 text-sm">
-                {hasDiscount && (
-                  <div className="flex justify-between text-destructive">
-                    <span>Descuento</span>
-                    <span>-{formatCurrency(realDiscount)}</span>
-                  </div>
-                )}
-                {hasService && (
-                  <div className="flex justify-between">
-                    <span>Servicio</span>
-                    <span>{formatCurrency(pedido.service_charge)}</span>
-                  </div>
-                )}
-                {hasTax && (
-                  <div className="flex justify-between text-muted-foreground">
-                    <span>Impuestos</span>
-                    <span>{pedido.tax}%</span>
-                  </div>
-                )}
-              </div>
-            );
-          })()}
-          {pedido.notes && (
-            <div className="bg-yellow-500/10 border border-yellow-500/20 text-yellow-600 dark:text-yellow-400 p-3 rounded-lg text-sm">
-              <span className="font-semibold block mb-1">Notas del Pedido</span>
-              {pedido.notes}
+        <div className="mt-4 grid grid-cols-2 gap-4 text-sm">
+          {pedido.place_name && (
+            <div>
+              <span className="text-muted-foreground block text-xs">Ubicación</span>
+              <span className="font-medium">{pedido.place_name}</span>
             </div>
           )}
-
-          <Separator />
-
-          {/* Items */}
-          <div>
-            <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              Productos
+          {pedido.layout_name && (
+            <div>
+              <span className="text-muted-foreground block text-xs">Área</span>
+              <span className="font-medium">{pedido.layout_name}</span>
             </div>
-            {loadingDetail ? (
-              <DetailSkeleton />
-            ) : items.length === 0 ? (
-              <p className="text-sm text-muted-foreground">Sin detalle de productos</p>
-            ) : (
-              <div className="space-y-2.5">
-                {items.map((item) => {
-                  const nombre = item.product_name ?? item.nombre ?? item.name ?? 'Producto';
-                  const qty = item.cantidad ?? item.quantity ?? 1;
-                  const price = item.unit_price ?? item.precio ?? item.price;
-                  const sub =
-                    item.total_price ?? item.subtotal ?? (price != null ? price * qty : null);
-                  return (
-                    <div
-                      key={String(item.id)}
-                      className="flex items-start justify-between gap-4 text-sm"
-                    >
-                      <span className="text-foreground">{nombre}</span>
-                      <span className="shrink-0 text-right text-muted-foreground">
-                        {qty} × {price != null ? formatCurrency(price) : '—'}
-                        <br />
-                        <span className="font-medium text-foreground">
-                          {sub != null ? formatCurrency(sub) : '—'}
-                        </span>
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-
-          <Separator />
-
-          {/* Payments */}
-          <div>
-            <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              Pagos
+          )}
+          {pedido.table_name && (
+            <div>
+              <span className="text-muted-foreground block text-xs">Mesa</span>
+              <span className="font-medium">{pedido.table_name}</span>
             </div>
-            {loadingDetail ? (
-              <DetailSkeleton />
-            ) : pagos.length === 0 ? (
-              <p className="text-sm text-muted-foreground">Sin registros de pago</p>
-            ) : (
-              <div className="space-y-1.5">
-                {pagos.map((pago) => {
-                  const metodo = pago.metodo ?? pago.payment_method ?? 'Desconocido';
-                  const monto = pago.monto ?? pago.amount;
-                  return (
-                    <div
-                      key={String(pago.id)}
-                      className="flex items-center justify-between text-sm"
-                    >
-                      <span className="capitalize text-foreground">{metodo}</span>
-                      <span className="font-medium">{formatCurrency(monto)}</span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+          )}
+          {pedido.external_delivery_id && (
+            <div>
+              <span className="text-muted-foreground block text-xs">Delivery ID</span>
+              <span className="font-medium">{pedido.external_delivery_id}</span>
+            </div>
+          )}
         </div>
+        {(() => {
+          const realDiscount =
+            (pedido.total_amount ?? 0) - (pedido.total_discount ?? pedido.total_amount ?? 0);
+          const hasDiscount = realDiscount > 0.01;
+          const hasService = (pedido.service_charge ?? 0) > 0;
+          const hasTax = (pedido.tax ?? 0) > 0;
+
+          if (!hasDiscount && !hasService && !hasTax) return null;
+
+          return (
+            <div className="bg-muted/30 mt-4 rounded-lg p-3 space-y-1 text-sm">
+              {hasDiscount && (
+                <div className="flex justify-between text-destructive">
+                  <span>Descuento</span>
+                  <span>-{formatCurrency(realDiscount)}</span>
+                </div>
+              )}
+              {hasService && (
+                <div className="flex justify-between">
+                  <span>Servicio</span>
+                  <span>{formatCurrency(pedido.service_charge)}</span>
+                </div>
+              )}
+              {hasTax && (
+                <div className="flex justify-between text-muted-foreground">
+                  <span>Impuestos</span>
+                  <span>{pedido.tax}%</span>
+                </div>
+              )}
+            </div>
+          );
+        })()}
+        {pedido.notes && (
+          <div className="mt-4 bg-yellow-500/10 border border-yellow-500/20 text-yellow-600 dark:text-yellow-400 p-3 rounded-lg text-sm">
+            <span className="font-semibold block mb-1">Notas del Pedido</span>
+            {pedido.notes}
+          </div>
+        )}
+
+        <DetailDrawerSection title="Productos">
+          {loadingDetail ? (
+            <DetailDrawerSkeleton showStats={false} lines={0} sectionRows={4} />
+          ) : items.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Sin detalle de productos</p>
+          ) : (
+            <div className="space-y-2.5">
+              {items.map((item) => {
+                const nombre = item.product_name ?? item.nombre ?? item.name ?? 'Producto';
+                const qty = item.cantidad ?? item.quantity ?? 1;
+                const price = item.unit_price ?? item.precio ?? item.price;
+                const sub =
+                  item.total_price ?? item.subtotal ?? (price != null ? price * qty : null);
+                return (
+                  <div
+                    key={String(item.id)}
+                    className="flex items-start justify-between gap-4 text-sm"
+                  >
+                    <span className="text-foreground">{nombre}</span>
+                    <span className="shrink-0 text-right text-muted-foreground">
+                      {qty} × {price != null ? formatCurrency(price) : '—'}
+                      <br />
+                      <span className="font-medium text-foreground">
+                        {sub != null ? formatCurrency(sub) : '—'}
+                      </span>
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </DetailDrawerSection>
+
+        <DetailDrawerSection title="Pagos">
+          {loadingDetail ? (
+            <DetailDrawerSkeleton showStats={false} lines={0} sectionRows={3} />
+          ) : pagos.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Sin registros de pago</p>
+          ) : (
+            <div className="space-y-1.5">
+              {pagos.map((pago) => {
+                const metodo = pago.metodo ?? pago.payment_method ?? 'Desconocido';
+                const monto = pago.monto ?? pago.amount;
+                return (
+                  <div key={String(pago.id)} className="flex items-center justify-between text-sm">
+                    <span className="capitalize text-foreground">{metodo}</span>
+                    <span className="font-medium">{formatCurrency(monto)}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </DetailDrawerSection>
       </DetailDrawerContent>
     </DetailDrawer>
   );


### PR DESCRIPTION
## Summary

Sprint 2 de `drawer-anatomy-polish`. Adopta `<DetailDrawerSection>` (DD10) y `<DetailDrawerSkeleton>` (DD11) en los 7 drawers core ya migrados en `drawer-anatomy` v1. El fix DD7-DD9 (header collision X/título/actions + mobile-friendly) lo heredan TODOS automáticamente del componente base mergeado en [Sprint 1 #346](https://github.com/beto-sudo/BSOP/pull/346).

### Migrados explícitamente

- **`<OrderDetail>`** (Ventas): "Productos" + "Pagos" como `<DetailDrawerSection>`. Skeleton canónico para `loadingDetail`. Separators manuales eliminados.
- **`<CorteDetail>`** (Cortes): "Resumen Financiero" + "Movimientos" como Section con `className="print:mt-1 print:pt-1"` para preservar el marbete impreso. `DetailSkeleton` local eliminado en favor de `<DetailDrawerSkeleton>`. Vouchers/otras evidencias mantienen su `print:hidden` inline (caso justificado).
- **`<TasksUpdatesSheet>`**: "Historial" como Section.
- **`<DocumentoCreateSheet>`**: cleanup de `className="sm:max-w-[640px]"` override (no es token canónico DD1).
- **OC drawer** (`app/rdb/ordenes-compra/page.tsx`): cambia de `className="sm:max-w-[700px]"` a `size="lg"` (canónico, 800px). Body interno con printlayout crítico (oc-cierre-ciclo cerrada ayer) intacto.

### Heredan DD7-DD9 sin re-escritura

- **`<DocumentoDetailSheet>`**: patrón `<Separator>` + `FLabel` funcional, convertirlo no aporta; el header se cura automáticamente.
- **`<NuevaEmpresaDrawer>`**: state-machine (drop/processing/preview/creating), tocar sus secciones internas arriesga el flow.

Sprint 3 (próximo) migra ~13 excepciones documentadas en `drawer-anatomy` v1 (DILESA list pages, Settings, Productos, Requisiciones, Proveedores, RH, Tasks create/edit, Juntas).

## Test plan

- [x] `npm run typecheck` (verde)
- [x] `npm run lint` (75 warnings preexistentes, 0 errors)
- [x] `npm run format:check` (verde)
- [x] `npm run test:run` (401 tests verde)
- [ ] Smoke en preview: abrir drawer de pedido en `/rdb/ventas`, drawer de corte en `/rdb/cortes`, drawer de OC en `/rdb/ordenes-compra` y verificar que header no se solapa con la X y que las acciones se ven en mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)