### PR TITLE
feat(drawer-anatomy-polish): migra 16 archivos con Sheet raw a DetailDrawer (Sprint 3)

### DIFF
--- a/app/dilesa/anteproyectos/page.tsx
+++ b/app/dilesa/anteproyectos/page.tsx
@@ -30,13 +30,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { DataTable, type Column } from '@/components/module-page';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -391,16 +385,15 @@ function AnteproyectosInner() {
         />
       </TabPanel>
 
-      <Sheet open={showCreate} onOpenChange={setShowCreate}>
-        <SheetContent side="right" className="w-full max-w-xl">
-          <SheetHeader>
-            <SheetTitle>Nuevo anteproyecto</SheetTitle>
-            <SheetDescription>
-              Solo campos esenciales — el expediente y los prototipos de referencia se capturan
-              desde el detalle.
-            </SheetDescription>
-          </SheetHeader>
-          <Form form={createForm} onSubmit={handleCreate} className="mt-6 space-y-5">
+      <DetailDrawer
+        open={showCreate}
+        onOpenChange={setShowCreate}
+        size="md"
+        title="Nuevo anteproyecto"
+        description="Solo campos esenciales — el expediente y los prototipos de referencia se capturan desde el detalle."
+      >
+        <DetailDrawerContent>
+          <Form form={createForm} onSubmit={handleCreate} className="space-y-5">
             <FormField name="nombre" label="Nombre del anteproyecto" required>
               {(field) => (
                 <Input
@@ -541,8 +534,8 @@ function AnteproyectosInner() {
               className="border-t-0 pt-2"
             />
           </Form>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
     </div>
   );
 }

--- a/app/dilesa/prototipos/page.tsx
+++ b/app/dilesa/prototipos/page.tsx
@@ -31,13 +31,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { DataTable, type Column } from '@/components/module-page';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -320,16 +314,15 @@ function PrototiposInner() {
         />
       </TabPanel>
 
-      <Sheet open={showCreate} onOpenChange={setShowCreate}>
-        <SheetContent side="right" className="w-full max-w-xl overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle>Nuevo prototipo</SheetTitle>
-            <SheetDescription>
-              Captura identidad, dimensiones, valor comercial y los 6 costos unitarios. El costo
-              total se calcula solo (GENERATED).
-            </SheetDescription>
-          </SheetHeader>
-          <Form form={createForm} onSubmit={handleCreate} className="mt-6 space-y-5">
+      <DetailDrawer
+        open={showCreate}
+        onOpenChange={setShowCreate}
+        size="md"
+        title="Nuevo prototipo"
+        description="Captura identidad, dimensiones, valor comercial y los 6 costos unitarios. El costo total se calcula solo (GENERATED)."
+      >
+        <DetailDrawerContent>
+          <Form form={createForm} onSubmit={handleCreate} className="space-y-5">
             <section className="space-y-3">
               <h3 className="text-xs font-semibold uppercase tracking-widest text-[var(--text)]/50">
                 Identidad
@@ -539,8 +532,8 @@ function PrototiposInner() {
               className="border-t-0 pt-2"
             />
           </Form>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
     </div>
   );
 }

--- a/app/dilesa/proyectos/page.tsx
+++ b/app/dilesa/proyectos/page.tsx
@@ -32,13 +32,7 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { DataTable, type Column } from '@/components/module-page';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -382,17 +376,15 @@ function ProyectosInner() {
         />
       </TabPanel>
 
-      <Sheet open={showCreate} onOpenChange={setShowCreate}>
-        <SheetContent side="right" className="w-full max-w-xl overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle>Nuevo proyecto</SheetTitle>
-            <SheetDescription>
-              Captura manual para proyectos sin anteproyecto de origen (casos legacy). Los proyectos
-              nuevos normalmente nacen del botón &ldquo;Convertir a proyecto&rdquo; dentro de
-              Anteproyectos.
-            </SheetDescription>
-          </SheetHeader>
-          <Form form={createForm} onSubmit={handleCreate} className="mt-6 space-y-5">
+      <DetailDrawer
+        open={showCreate}
+        onOpenChange={setShowCreate}
+        size="md"
+        title="Nuevo proyecto"
+        description="Captura manual para proyectos sin anteproyecto de origen (casos legacy). Los proyectos nuevos normalmente nacen del botón “Convertir a proyecto” dentro de Anteproyectos."
+      >
+        <DetailDrawerContent>
+          <Form form={createForm} onSubmit={handleCreate} className="space-y-5">
             <FormField name="nombre" label="Nombre" required>
               {(field) => (
                 <Input
@@ -479,8 +471,8 @@ function ProyectosInner() {
               className="border-t-0 pt-2"
             />
           </Form>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
     </div>
   );
 }

--- a/app/dilesa/terrenos/page.tsx
+++ b/app/dilesa/terrenos/page.tsx
@@ -40,13 +40,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { DataTable, type Column } from '@/components/module-page';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -442,15 +436,15 @@ function TerrenosInner() {
         />
       </TabPanel>
 
-      <Sheet open={showCreate} onOpenChange={setShowCreate}>
-        <SheetContent side="right" className="w-full max-w-xl">
-          <SheetHeader>
-            <SheetTitle>Nuevo terreno</SheetTitle>
-            <SheetDescription>
-              Solo campos esenciales — el resto del expediente se captura después desde el detalle.
-            </SheetDescription>
-          </SheetHeader>
-          <Form form={createForm} onSubmit={handleCreate} className="mt-6 space-y-5">
+      <DetailDrawer
+        open={showCreate}
+        onOpenChange={setShowCreate}
+        size="md"
+        title="Nuevo terreno"
+        description="Solo campos esenciales — el resto del expediente se captura después desde el detalle."
+      >
+        <DetailDrawerContent>
+          <Form form={createForm} onSubmit={handleCreate} className="space-y-5">
             <FormField name="nombre" label="Nombre del terreno" required>
               {(field) => (
                 <Input
@@ -599,8 +593,8 @@ function TerrenosInner() {
               className="border-t-0 pt-2"
             />
           </Form>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
     </div>
   );
 }

--- a/app/inicio/juntas/[id]/page.tsx
+++ b/app/inicio/juntas/[id]/page.tsx
@@ -27,13 +27,7 @@ import Image from '@tiptap/extension-image';
 import { Table, TableRow, TableHeader, TableCell } from '@tiptap/extension-table';
 import { EditorToolbar, MINUTA_EDITOR_STYLES } from '@/components/juntas/editor-toolbar';
 import { Combobox } from '@/components/ui/combobox';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
@@ -1592,7 +1586,7 @@ function JuntaDetailInner() {
       </div>
 
       {/* Sheet: Agregar avance */}
-      <Sheet
+      <DetailDrawer
         open={!!showAddUpdate}
         onOpenChange={(open) => {
           if (!open) {
@@ -1600,18 +1594,12 @@ function JuntaDetailInner() {
             setUpdateForm({ contenido: '', nuevoEstado: '', nuevaFecha: '' });
           }
         }}
+        size="sm"
+        title="Agregar avance"
+        description={showAddUpdate ? (tasks.find((t) => t.id === showAddUpdate)?.titulo ?? '') : ''}
       >
-        <SheetContent
-          side="right"
-          className="w-full sm:max-w-lg border-[var(--border)] bg-[var(--card)] text-[var(--text)] overflow-y-auto"
-        >
-          <SheetHeader className="pb-2">
-            <SheetTitle className="text-[var(--text)] text-lg">Agregar avance</SheetTitle>
-            <SheetDescription className="text-[var(--text)]/50">
-              {showAddUpdate ? (tasks.find((t) => t.id === showAddUpdate)?.titulo ?? '') : ''}
-            </SheetDescription>
-          </SheetHeader>
-          <div className="space-y-5 py-4">
+        <DetailDrawerContent>
+          <div className="space-y-5">
             <div>
               <FieldLabel>Avance / Comentario *</FieldLabel>
               <Textarea
@@ -1671,8 +1659,8 @@ function JuntaDetailInner() {
               Guardar avance
             </Button>
           </div>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
 
       {/* Add task dialog */}
       <TasksCreateForm

--- a/app/rdb/productos/page.tsx
+++ b/app/rdb/productos/page.tsx
@@ -12,13 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { FilterCombobox } from '@/components/ui/filter-combobox';
 import { Combobox } from '@/components/ui/combobox';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { RefreshCw, Search, Settings2, Save, X, BarChart3 } from 'lucide-react';
 import { upsertReceta, updateCategoria } from './actions';
 
@@ -651,17 +645,16 @@ export default function ProductosPage() {
         />
 
         {/* Detail/Config Drawer */}
-        <Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
-          <SheetContent className="sm:max-w-[600px] overflow-y-auto">
-            <SheetHeader>
-              <SheetTitle>Configurar Producto</SheetTitle>
-              <SheetDescription>
-                Ajusta categoría, tipo, reglas de inventario y receta de insumos.
-              </SheetDescription>
-            </SheetHeader>
-
-            {selectedProducto && (
-              <div className="mt-8 space-y-6">
+        <DetailDrawer
+          open={drawerOpen}
+          onOpenChange={setDrawerOpen}
+          size="md"
+          title="Configurar Producto"
+          description="Ajusta categoría, tipo, reglas de inventario y receta de insumos."
+        >
+          {selectedProducto && (
+            <DetailDrawerContent>
+              <div className="space-y-6">
                 <div className="rounded-lg border bg-muted/30 p-4 space-y-1">
                   <div className="font-semibold text-lg">{selectedProducto.nombre}</div>
                   <div className="text-sm text-muted-foreground">
@@ -835,21 +828,19 @@ export default function ProductosPage() {
                   </Button>
                 </div>
               </div>
-            )}
-          </SheetContent>
-        </Sheet>
+            </DetailDrawerContent>
+          )}
+        </DetailDrawer>
 
         {/* Create Producto Drawer */}
-        <Sheet open={createDrawerOpen} onOpenChange={setCreateDrawerOpen}>
-          <SheetContent className="sm:max-w-[600px] overflow-y-auto">
-            <SheetHeader>
-              <SheetTitle>Nuevo Producto</SheetTitle>
-              <SheetDescription>
-                Da de alta un producto o insumo manualmente (ej. para Órdenes de Compra o almacén
-                interno).
-              </SheetDescription>
-            </SheetHeader>
-
+        <DetailDrawer
+          open={createDrawerOpen}
+          onOpenChange={setCreateDrawerOpen}
+          size="md"
+          title="Nuevo Producto"
+          description="Da de alta un producto o insumo manualmente (ej. para Órdenes de Compra o almacén interno)."
+        >
+          <DetailDrawerContent>
             <div className="mt-8 space-y-6">
               <div className="space-y-4">
                 <div className="space-y-2">
@@ -927,8 +918,8 @@ export default function ProductosPage() {
                 </Button>
               </div>
             </div>
-          </SheetContent>
-        </Sheet>
+          </DetailDrawerContent>
+        </DetailDrawer>
       </div>
     </RequireAccess>
   );

--- a/app/rdb/requisiciones/page.tsx
+++ b/app/rdb/requisiciones/page.tsx
@@ -23,13 +23,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { DataTable, type Column } from '@/components/module-page';
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
+import { DetailDrawer } from '@/components/detail-page';
 import { useTriggerPrint } from '@/components/print';
 import { Combobox } from '@/components/ui/combobox';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -379,190 +373,189 @@ function ExistingRequestSheet({
   }
 
   return (
-    <Sheet open={open} onOpenChange={(value) => !value && onClose()}>
-      <SheetContent className="sm:max-w-[700px] flex min-h-0 flex-col overflow-hidden p-6 print:p-0">
-        {/* Membrete y encabezado solo para impresión */}
-        <div className="hidden print:block mb-8">
-          <img
-            src="/brand/rdb/header-email.png"
-            alt="Membrete Rincón del Bosque"
-            className="w-full object-contain mb-6 max-h-32"
-          />
-          <div className="text-center mb-4">
-            <h2 className="text-xl font-bold uppercase tracking-widest">Requisición Interna</h2>
-            <p className="text-lg font-semibold mt-1">Folio: {requisicion.folio || 'S/N'}</p>
-            {requisicion.oc_folio && (
-              <p className="text-sm mt-1 text-gray-600">Orden de Compra: {requisicion.oc_folio}</p>
-            )}
-          </div>
+    <DetailDrawer
+      open={open}
+      onOpenChange={(value) => !value && onClose()}
+      size="lg"
+      title={requisicion.folio || 'Sin folio'}
+      description={formatDate(requisicion.fecha_solicitud)}
+      actions={
+        <Button variant="outline" size="sm" onClick={triggerPrint}>
+          Imprimir
+        </Button>
+      }
+    >
+      {/* Membrete y encabezado solo para impresión */}
+      <div className="hidden print:block mb-8">
+        <img
+          src="/brand/rdb/header-email.png"
+          alt="Membrete Rincón del Bosque"
+          className="w-full object-contain mb-6 max-h-32"
+        />
+        <div className="text-center mb-4">
+          <h2 className="text-xl font-bold uppercase tracking-widest">Requisición Interna</h2>
+          <p className="text-lg font-semibold mt-1">Folio: {requisicion.folio || 'S/N'}</p>
+          {requisicion.oc_folio && (
+            <p className="text-sm mt-1 text-gray-600">Orden de Compra: {requisicion.oc_folio}</p>
+          )}
         </div>
+      </div>
 
-        <SheetHeader className="print:hidden">
-          <SheetTitle>{requisicion.folio || 'Sin folio'}</SheetTitle>
-          <SheetDescription>{formatDate(requisicion.fecha_solicitud)}</SheetDescription>
-          <div className="absolute right-12 top-4 hidden sm:flex print:hidden">
-            <Button variant="outline" size="sm" onClick={triggerPrint}>
-              Imprimir
-            </Button>
+      <ScrollArea className="min-h-0 flex-1 pr-1 print:h-auto print:overflow-visible">
+        <div className="px-6 py-4 space-y-6 print:space-y-4 print:p-0">
+          <div className="flex items-center justify-between gap-4 print:hidden">
+            <StatusBadge status={status} />
+            <span className="text-sm text-muted-foreground">{safeCountLabel(items.length)}</span>
           </div>
-        </SheetHeader>
 
-        <ScrollArea className="min-h-0 flex-1 pr-1 print:h-auto print:overflow-visible">
-          <div className="mt-6 space-y-6 pb-6 print:space-y-4 print:mt-0 print:pb-0">
-            <div className="flex items-center justify-between gap-4 print:hidden">
-              <StatusBadge status={status} />
-              <span className="text-sm text-muted-foreground">{safeCountLabel(items.length)}</span>
+          <div className="grid gap-4 rounded-xl border bg-muted/20 p-4 text-sm sm:grid-cols-2 print:border-none print:bg-transparent print:p-0 print:grid-cols-2 print:text-xs print:mb-4">
+            <div>
+              <span className="block text-xs uppercase tracking-wider text-muted-foreground print:text-black">
+                Solicitado por
+              </span>
+              <span className="font-medium text-foreground print:text-black">
+                {requesterName(requisicion.solicitado_por_nombre ?? requisicion.solicitado_por)}
+              </span>
             </div>
-
-            <div className="grid gap-4 rounded-xl border bg-muted/20 p-4 text-sm sm:grid-cols-2 print:border-none print:bg-transparent print:p-0 print:grid-cols-2 print:text-xs print:mb-4">
-              <div>
+            <div>
+              <span className="block text-xs uppercase tracking-wider text-muted-foreground print:text-black">
+                Fecha
+              </span>
+              <span className="font-medium text-foreground print:text-black">
+                {formatDate(requisicion.fecha_solicitud)}
+              </span>
+            </div>
+            <div className="print:col-span-2 print:mt-2">
+              <span className="block text-xs uppercase tracking-wider text-muted-foreground print:text-black">
+                Aprobado por
+              </span>
+              <span className="font-medium text-foreground print:text-black">
+                {requisicion.aprobado_por_nombre?.trim() ||
+                  requisicion.aprobado_por?.trim() ||
+                  'Pendiente'}
+              </span>
+            </div>
+            {requisicion.oc_folio && (
+              <div className="print:col-span-2">
                 <span className="block text-xs uppercase tracking-wider text-muted-foreground print:text-black">
-                  Solicitado por
+                  Orden de Compra generada
                 </span>
-                <span className="font-medium text-foreground print:text-black">
-                  {requesterName(requisicion.solicitado_por_nombre ?? requisicion.solicitado_por)}
+                <span className="font-mono font-semibold text-foreground print:text-black">
+                  {requisicion.oc_folio}
                 </span>
-              </div>
-              <div>
-                <span className="block text-xs uppercase tracking-wider text-muted-foreground print:text-black">
-                  Fecha
-                </span>
-                <span className="font-medium text-foreground print:text-black">
-                  {formatDate(requisicion.fecha_solicitud)}
-                </span>
-              </div>
-              <div className="print:col-span-2 print:mt-2">
-                <span className="block text-xs uppercase tracking-wider text-muted-foreground print:text-black">
-                  Aprobado por
-                </span>
-                <span className="font-medium text-foreground print:text-black">
-                  {requisicion.aprobado_por_nombre?.trim() ||
-                    requisicion.aprobado_por?.trim() ||
-                    'Pendiente'}
-                </span>
-              </div>
-              {requisicion.oc_folio && (
-                <div className="print:col-span-2">
-                  <span className="block text-xs uppercase tracking-wider text-muted-foreground print:text-black">
-                    Orden de Compra generada
-                  </span>
-                  <span className="font-mono font-semibold text-foreground print:text-black">
-                    {requisicion.oc_folio}
-                  </span>
-                </div>
-              )}
-            </div>
-
-            <Separator className="print:hidden" />
-
-            <div className="space-y-3 print:space-y-1">
-              <div className="print:hidden">
-                <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                  Artículos solicitados
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  Detalle de lo que pidió el área para surtir o convertir a orden de compra.
-                </p>
-              </div>
-
-              {loadingItems ? (
-                <DetailSkeleton />
-              ) : items.length === 0 ? (
-                <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground print:border-none">
-                  Esta requisición no tiene artículos cargados todavía.
-                </div>
-              ) : (
-                <div className="overflow-hidden rounded-xl border print:rounded-none print:border-black">
-                  <Table className="print:text-xs">
-                    <TableHeader>
-                      <TableRow className="print:border-b-black print:bg-gray-100">
-                        <TableHead className="print:text-black print:font-bold">Artículo</TableHead>
-                        <TableHead className="w-32 text-right print:text-black print:font-bold">
-                          Cantidad
-                        </TableHead>
-                        <TableHead className="w-28 print:text-black print:font-bold">
-                          Unidad
-                        </TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {items.map((item) => (
-                        <TableRow key={item.id} className="print:border-b-gray-300">
-                          <TableCell className="print:py-1">
-                            <div className="font-medium text-foreground print:text-black">
-                              {item.descripcion?.trim() || 'Artículo sin descripción'}
-                            </div>
-                          </TableCell>
-                          <TableCell className="text-right font-medium tabular-nums print:text-black print:py-1">
-                            {item.cantidad ?? '—'}
-                          </TableCell>
-                          <TableCell className="text-muted-foreground print:text-black print:py-1">
-                            {item.unidad || 'pza'}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
-              )}
-            </div>
-
-            {/* Espacio para firmas en impresión */}
-            <div className="hidden print:grid grid-cols-2 gap-8 mt-16 pt-8 text-center text-sm">
-              <div>
-                <div className="w-48 mx-auto border-t border-black pt-2">Firma Solicitante</div>
-              </div>
-              <div>
-                <div className="w-48 mx-auto border-t border-black pt-2">Firma Autorización</div>
-              </div>
-            </div>
-
-            {actionError && (
-              <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive print:hidden">
-                {actionError}
               </div>
             )}
+          </div>
 
-            {(status === 'pendiente' || status === 'autorizada') && (
-              <div className="flex flex-wrap justify-end gap-3">
-                {canDelete && (
+          <Separator className="print:hidden" />
+
+          <div className="space-y-3 print:space-y-1">
+            <div className="print:hidden">
+              <div className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Artículos solicitados
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Detalle de lo que pidió el área para surtir o convertir a orden de compra.
+              </p>
+            </div>
+
+            {loadingItems ? (
+              <DetailSkeleton />
+            ) : items.length === 0 ? (
+              <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground print:border-none">
+                Esta requisición no tiene artículos cargados todavía.
+              </div>
+            ) : (
+              <div className="overflow-hidden rounded-xl border print:rounded-none print:border-black">
+                <Table className="print:text-xs">
+                  <TableHeader>
+                    <TableRow className="print:border-b-black print:bg-gray-100">
+                      <TableHead className="print:text-black print:font-bold">Artículo</TableHead>
+                      <TableHead className="w-32 text-right print:text-black print:font-bold">
+                        Cantidad
+                      </TableHead>
+                      <TableHead className="w-28 print:text-black print:font-bold">
+                        Unidad
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {items.map((item) => (
+                      <TableRow key={item.id} className="print:border-b-gray-300">
+                        <TableCell className="print:py-1">
+                          <div className="font-medium text-foreground print:text-black">
+                            {item.descripcion?.trim() || 'Artículo sin descripción'}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right font-medium tabular-nums print:text-black print:py-1">
+                          {item.cantidad ?? '—'}
+                        </TableCell>
+                        <TableCell className="text-muted-foreground print:text-black print:py-1">
+                          {item.unidad || 'pza'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </div>
+
+          {/* Espacio para firmas en impresión */}
+          <div className="hidden print:grid grid-cols-2 gap-8 mt-16 pt-8 text-center text-sm">
+            <div>
+              <div className="w-48 mx-auto border-t border-black pt-2">Firma Solicitante</div>
+            </div>
+            <div>
+              <div className="w-48 mx-auto border-t border-black pt-2">Firma Autorización</div>
+            </div>
+          </div>
+
+          {actionError && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive print:hidden">
+              {actionError}
+            </div>
+          )}
+
+          {(status === 'pendiente' || status === 'autorizada') && (
+            <div className="flex flex-wrap justify-end gap-3">
+              {canDelete && (
+                <Button
+                  variant="outline"
+                  onClick={handleBorrar}
+                  disabled={isPending}
+                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {isPending ? 'Borrando…' : 'Borrar'}
+                </Button>
+              )}
+              {status === 'pendiente' && (
+                <>
                   <Button
                     variant="outline"
-                    onClick={handleBorrar}
-                    disabled={isPending}
-                    className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    onClick={() => onEdit(requisicion)}
+                    disabled={isPending || loadingItems}
                   >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    {isPending ? 'Borrando…' : 'Borrar'}
+                    Editar
                   </Button>
-                )}
-                {status === 'pendiente' && (
-                  <>
-                    <Button
-                      variant="outline"
-                      onClick={() => onEdit(requisicion)}
-                      disabled={isPending || loadingItems}
-                    >
-                      Editar
-                    </Button>
-                    <Button onClick={handleAprobar} disabled={isPending}>
-                      <CheckCircle2 className="mr-2 h-4 w-4" />
-                      {isPending ? 'Aprobando…' : 'Aprobar'}
-                    </Button>
-                  </>
-                )}
-                {status === 'autorizada' && (
-                  <Button onClick={handleGenerarOC} disabled={isPending}>
-                    <ShoppingBasket className="mr-2 h-4 w-4" />
-                    {isPending ? 'Generando OC…' : 'Generar OC'}
+                  <Button onClick={handleAprobar} disabled={isPending}>
+                    <CheckCircle2 className="mr-2 h-4 w-4" />
+                    {isPending ? 'Aprobando…' : 'Aprobar'}
                   </Button>
-                )}
-              </div>
-            )}
-          </div>
-        </ScrollArea>
-      </SheetContent>
-    </Sheet>
+                </>
+              )}
+              {status === 'autorizada' && (
+                <Button onClick={handleGenerarOC} disabled={isPending}>
+                  <ShoppingBasket className="mr-2 h-4 w-4" />
+                  {isPending ? 'Generando OC…' : 'Generar OC'}
+                </Button>
+              )}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </DetailDrawer>
   );
 }
 
@@ -637,295 +630,287 @@ function NewRequestSheet({
   };
 
   return (
-    <Sheet open={open} onOpenChange={(value) => !value && onClose()}>
-      <SheetContent className="sm:max-w-[700px] flex min-h-0 flex-col overflow-hidden p-6 print:p-0">
-        <div className="hidden print:block mb-8">
-          <img
-            src="/brand/rdb/header-email.png"
-            alt="Membrete Rincón del Bosque"
-            className="w-full object-contain mb-6 max-h-32"
-          />
-          <div className="text-center mb-4">
-            <h2 className="text-xl font-bold uppercase tracking-widest">Requisición Interna</h2>
-            <p className="text-lg font-semibold mt-1">
-              Folio: {editingRequisicion?.folio || 'REQ-BORRADOR'}
-            </p>
-          </div>
+    <DetailDrawer
+      open={open}
+      onOpenChange={(value) => !value && onClose()}
+      size="lg"
+      title={
+        isEditing ? `Editar ${editingRequisicion?.folio || 'requisición'}` : 'Nueva Requisición'
+      }
+      description={
+        isEditing
+          ? 'Ajusta productos o cantidades antes de autorizar la requisición.'
+          : 'Captura los artículos que necesitas y envía la requisición a autorización.'
+      }
+      actions={
+        <Button variant="outline" size="sm" onClick={triggerPrint}>
+          Imprimir
+        </Button>
+      }
+    >
+      <div className="hidden print:block mb-8">
+        <img
+          src="/brand/rdb/header-email.png"
+          alt="Membrete Rincón del Bosque"
+          className="w-full object-contain mb-6 max-h-32"
+        />
+        <div className="text-center mb-4">
+          <h2 className="text-xl font-bold uppercase tracking-widest">Requisición Interna</h2>
+          <p className="text-lg font-semibold mt-1">
+            Folio: {editingRequisicion?.folio || 'REQ-BORRADOR'}
+          </p>
         </div>
+      </div>
 
-        <SheetHeader className="print:hidden">
-          <SheetTitle>
-            {isEditing
-              ? `Editar ${editingRequisicion?.folio || 'requisición'}`
-              : 'Nueva Requisición'}
-          </SheetTitle>
-          <SheetDescription>
-            {isEditing
-              ? 'Ajusta productos o cantidades antes de autorizar la requisición.'
-              : 'Captura los artículos que necesitas y envía la requisición a autorización.'}
-          </SheetDescription>
-          <div className="absolute right-12 top-4 hidden sm:flex print:hidden">
-            <Button variant="outline" size="sm" onClick={triggerPrint}>
-              Imprimir
+      <ScrollArea className="min-h-0 flex-1 pr-1 print:h-auto print:overflow-visible">
+        <div className="px-6 py-4 space-y-6 print:space-y-4 print:p-0">
+          <div className="rounded-2xl border bg-gradient-to-br from-muted/40 to-background p-4 print:hidden">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Vista previa
+                </div>
+                <div className="mt-1 text-lg font-semibold">
+                  {editingRequisicion?.folio || 'REQ-BORRADOR'}
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {isEditing
+                    ? 'Ajusta la requisición antes de autorizarla.'
+                    : 'Así se ve una requisición nueva antes de guardarse en DB.'}
+                </p>
+              </div>
+              <StatusBadge status="borrador" />
+            </div>
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-xl border bg-background p-3">
+                <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  <User2 className="h-3.5 w-3.5" />
+                  Solicitante
+                </div>
+                <div className="mt-1 font-medium">{userName || 'Sistema'}</div>
+              </div>
+              <div className="rounded-xl border bg-background p-3">
+                <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  <CalendarDays className="h-3.5 w-3.5" />
+                  Fecha solicitud
+                </div>
+                <div className="mt-1 font-medium">{formatDate(new Date().toISOString())}</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="hidden print:block space-y-3">
+            <div className="grid gap-4 text-sm grid-cols-2 mb-4">
+              <div>
+                <span className="block text-xs uppercase tracking-wider text-black/70">
+                  Solicitante
+                </span>
+                <span className="font-medium text-black">{userName || 'Sistema'}</span>
+              </div>
+              <div>
+                <span className="block text-xs uppercase tracking-wider text-black/70">Fecha</span>
+                <span className="font-medium text-black">
+                  {formatDate(new Date().toISOString())}
+                </span>
+              </div>
+            </div>
+
+            <div className="overflow-hidden rounded-xl border border-black print:rounded-none">
+              <Table className="text-xs">
+                <TableHeader>
+                  <TableRow className="border-b-black bg-gray-100">
+                    <TableHead className="text-black font-bold">Artículo</TableHead>
+                    <TableHead className="w-32 text-right text-black font-bold">Cantidad</TableHead>
+                    <TableHead className="w-28 text-black font-bold">Unidad</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {(printableItems.length > 0 ? printableItems : draftItems).map((item) => (
+                    <TableRow key={`print-${item.id}`} className="border-b-gray-300">
+                      <TableCell className="py-1 text-black">
+                        {(item.producto || item.descripcion).trim() || 'Artículo pendiente'}
+                      </TableCell>
+                      <TableCell className="py-1 text-right text-black tabular-nums">
+                        {item.cantidad?.trim() || '1'}
+                      </TableCell>
+                      <TableCell className="py-1 text-black">
+                        {item.unidad?.trim() || 'pza'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="grid grid-cols-2 gap-8 mt-16 pt-8 text-center text-sm">
+              <div>
+                <div className="w-48 mx-auto border-t border-black pt-2">Firma Solicitante</div>
+              </div>
+              <div>
+                <div className="w-48 mx-auto border-t border-black pt-2">Firma Autorización</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4 print:hidden">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-semibold">Artículos solicitados</div>
+                <p className="text-sm text-muted-foreground">
+                  El flujo de búsqueda/guardado puede conectarse después, pero la experiencia ya
+                  queda definida.
+                </p>
+              </div>
+              <Button variant="outline" onClick={onAddDraftItem}>
+                <FilePlus2 className="mr-2 h-4 w-4" />
+                Agregar producto
+              </Button>
+            </div>
+
+            <div className="space-y-3">
+              {draftItems.map((item, index) => (
+                <div key={item.id} className="rounded-xl border p-4">
+                  <div className="mb-3 flex items-center justify-between">
+                    <div className="text-sm font-medium">Artículo {index + 1}</div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground"
+                      onClick={() => onRemoveDraftItem(item.id)}
+                      disabled={draftItems.length === 1}
+                    >
+                      Quitar
+                    </Button>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="sm:col-span-2">
+                      <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                        Producto
+                      </label>
+                      <Popover>
+                        <PopoverTrigger
+                          render={
+                            <Button
+                              variant="outline"
+                              role="combobox"
+                              className="w-full justify-between font-normal"
+                            />
+                          }
+                        >
+                          <span className="truncate">
+                            {item.producto || 'Buscar o escribir producto...'}
+                          </span>
+                          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        </PopoverTrigger>
+                        <PopoverContent className="w-[420px] p-0" align="start">
+                          <Command>
+                            <CommandInput
+                              placeholder="Buscar producto..."
+                              onValueChange={(val) => {
+                                // Allow free text if it doesn't match
+                                onDraftItemChange(item.id, 'producto', val);
+                                onDraftItemChange(item.id, 'producto_id', '');
+                              }}
+                            />
+                            <CommandList className="max-h-64">
+                              <CommandEmpty>
+                                No hay resultados. Escribe para usar como texto libre.
+                              </CommandEmpty>
+                              <CommandGroup>
+                                {catalogoProductos.map((p) => (
+                                  <CommandItem
+                                    key={p.id}
+                                    value={p.nombre}
+                                    onSelect={() => {
+                                      onDraftItemChange(item.id, 'producto_id', p.id);
+                                      onDraftItemChange(item.id, 'producto', p.nombre);
+                                      if (p.unidad) onDraftItemChange(item.id, 'unidad', p.unidad);
+                                    }}
+                                  >
+                                    <Check
+                                      className={`mr-2 h-4 w-4 shrink-0 ${item.producto_id === p.id ? 'opacity-100' : 'opacity-0'}`}
+                                    />
+                                    <span className="truncate">{p.nombre}</span>
+                                    {p.categoria && (
+                                      <span className="ml-auto text-xs text-muted-foreground shrink-0">
+                                        {p.categoria}
+                                      </span>
+                                    )}
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            </CommandList>
+                          </Command>
+                        </PopoverContent>
+                      </Popover>
+                    </div>
+
+                    <div>
+                      <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                        Cantidad
+                      </label>
+                      <Input
+                        value={item.cantidad}
+                        onChange={(event) =>
+                          onDraftItemChange(item.id, 'cantidad', event.target.value)
+                        }
+                        placeholder="0"
+                      />
+                    </div>
+
+                    <div>
+                      <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                        Unidad
+                      </label>
+                      <Input
+                        value={item.unidad}
+                        onChange={(event) =>
+                          onDraftItemChange(item.id, 'unidad', event.target.value)
+                        }
+                        placeholder="pza, caja, kg..."
+                      />
+                    </div>
+
+                    <div className="sm:col-span-2">
+                      <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                        Descripción / notas
+                      </label>
+                      <Input
+                        value={item.descripcion}
+                        onChange={(event) =>
+                          onDraftItemChange(item.id, 'descripcion', event.target.value)
+                        }
+                        placeholder="Ej. consumo fin de semana"
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <Separator className="print:hidden" />
+
+          {saveError && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive print:hidden">
+              {saveError}
+            </div>
+          )}
+
+          <div className="flex flex-wrap justify-end gap-3 print:hidden">
+            <Button variant="outline" onClick={onClose} disabled={isPending}>
+              Cancelar
+            </Button>
+            <Button onClick={handleGuardar} disabled={isPending}>
+              <FilePlus2 className="mr-2 h-4 w-4" />
+              {isPending ? 'Guardando…' : isEditing ? 'Guardar cambios' : 'Guardar requisición'}
             </Button>
           </div>
-        </SheetHeader>
-
-        <ScrollArea className="min-h-0 flex-1 pr-1 print:h-auto print:overflow-visible">
-          <div className="mt-6 space-y-6 pb-6 print:space-y-4 print:mt-0 print:pb-0">
-            <div className="rounded-2xl border bg-gradient-to-br from-muted/40 to-background p-4 print:hidden">
-              <div className="flex flex-wrap items-start justify-between gap-4">
-                <div>
-                  <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Vista previa
-                  </div>
-                  <div className="mt-1 text-lg font-semibold">
-                    {editingRequisicion?.folio || 'REQ-BORRADOR'}
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {isEditing
-                      ? 'Ajusta la requisición antes de autorizarla.'
-                      : 'Así se ve una requisición nueva antes de guardarse en DB.'}
-                  </p>
-                </div>
-                <StatusBadge status="borrador" />
-              </div>
-
-              <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                <div className="rounded-xl border bg-background p-3">
-                  <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
-                    <User2 className="h-3.5 w-3.5" />
-                    Solicitante
-                  </div>
-                  <div className="mt-1 font-medium">{userName || 'Sistema'}</div>
-                </div>
-                <div className="rounded-xl border bg-background p-3">
-                  <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
-                    <CalendarDays className="h-3.5 w-3.5" />
-                    Fecha solicitud
-                  </div>
-                  <div className="mt-1 font-medium">{formatDate(new Date().toISOString())}</div>
-                </div>
-              </div>
-            </div>
-
-            <div className="hidden print:block space-y-3">
-              <div className="grid gap-4 text-sm grid-cols-2 mb-4">
-                <div>
-                  <span className="block text-xs uppercase tracking-wider text-black/70">
-                    Solicitante
-                  </span>
-                  <span className="font-medium text-black">{userName || 'Sistema'}</span>
-                </div>
-                <div>
-                  <span className="block text-xs uppercase tracking-wider text-black/70">
-                    Fecha
-                  </span>
-                  <span className="font-medium text-black">
-                    {formatDate(new Date().toISOString())}
-                  </span>
-                </div>
-              </div>
-
-              <div className="overflow-hidden rounded-xl border border-black print:rounded-none">
-                <Table className="text-xs">
-                  <TableHeader>
-                    <TableRow className="border-b-black bg-gray-100">
-                      <TableHead className="text-black font-bold">Artículo</TableHead>
-                      <TableHead className="w-32 text-right text-black font-bold">
-                        Cantidad
-                      </TableHead>
-                      <TableHead className="w-28 text-black font-bold">Unidad</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {(printableItems.length > 0 ? printableItems : draftItems).map((item) => (
-                      <TableRow key={`print-${item.id}`} className="border-b-gray-300">
-                        <TableCell className="py-1 text-black">
-                          {(item.producto || item.descripcion).trim() || 'Artículo pendiente'}
-                        </TableCell>
-                        <TableCell className="py-1 text-right text-black tabular-nums">
-                          {item.cantidad?.trim() || '1'}
-                        </TableCell>
-                        <TableCell className="py-1 text-black">
-                          {item.unidad?.trim() || 'pza'}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-
-              <div className="grid grid-cols-2 gap-8 mt-16 pt-8 text-center text-sm">
-                <div>
-                  <div className="w-48 mx-auto border-t border-black pt-2">Firma Solicitante</div>
-                </div>
-                <div>
-                  <div className="w-48 mx-auto border-t border-black pt-2">Firma Autorización</div>
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-4 print:hidden">
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className="text-sm font-semibold">Artículos solicitados</div>
-                  <p className="text-sm text-muted-foreground">
-                    El flujo de búsqueda/guardado puede conectarse después, pero la experiencia ya
-                    queda definida.
-                  </p>
-                </div>
-                <Button variant="outline" onClick={onAddDraftItem}>
-                  <FilePlus2 className="mr-2 h-4 w-4" />
-                  Agregar producto
-                </Button>
-              </div>
-
-              <div className="space-y-3">
-                {draftItems.map((item, index) => (
-                  <div key={item.id} className="rounded-xl border p-4">
-                    <div className="mb-3 flex items-center justify-between">
-                      <div className="text-sm font-medium">Artículo {index + 1}</div>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="text-muted-foreground"
-                        onClick={() => onRemoveDraftItem(item.id)}
-                        disabled={draftItems.length === 1}
-                      >
-                        Quitar
-                      </Button>
-                    </div>
-
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <div className="sm:col-span-2">
-                        <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                          Producto
-                        </label>
-                        <Popover>
-                          <PopoverTrigger
-                            render={
-                              <Button
-                                variant="outline"
-                                role="combobox"
-                                className="w-full justify-between font-normal"
-                              />
-                            }
-                          >
-                            <span className="truncate">
-                              {item.producto || 'Buscar o escribir producto...'}
-                            </span>
-                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                          </PopoverTrigger>
-                          <PopoverContent className="w-[420px] p-0" align="start">
-                            <Command>
-                              <CommandInput
-                                placeholder="Buscar producto..."
-                                onValueChange={(val) => {
-                                  // Allow free text if it doesn't match
-                                  onDraftItemChange(item.id, 'producto', val);
-                                  onDraftItemChange(item.id, 'producto_id', '');
-                                }}
-                              />
-                              <CommandList className="max-h-64">
-                                <CommandEmpty>
-                                  No hay resultados. Escribe para usar como texto libre.
-                                </CommandEmpty>
-                                <CommandGroup>
-                                  {catalogoProductos.map((p) => (
-                                    <CommandItem
-                                      key={p.id}
-                                      value={p.nombre}
-                                      onSelect={() => {
-                                        onDraftItemChange(item.id, 'producto_id', p.id);
-                                        onDraftItemChange(item.id, 'producto', p.nombre);
-                                        if (p.unidad)
-                                          onDraftItemChange(item.id, 'unidad', p.unidad);
-                                      }}
-                                    >
-                                      <Check
-                                        className={`mr-2 h-4 w-4 shrink-0 ${item.producto_id === p.id ? 'opacity-100' : 'opacity-0'}`}
-                                      />
-                                      <span className="truncate">{p.nombre}</span>
-                                      {p.categoria && (
-                                        <span className="ml-auto text-xs text-muted-foreground shrink-0">
-                                          {p.categoria}
-                                        </span>
-                                      )}
-                                    </CommandItem>
-                                  ))}
-                                </CommandGroup>
-                              </CommandList>
-                            </Command>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-
-                      <div>
-                        <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                          Cantidad
-                        </label>
-                        <Input
-                          value={item.cantidad}
-                          onChange={(event) =>
-                            onDraftItemChange(item.id, 'cantidad', event.target.value)
-                          }
-                          placeholder="0"
-                        />
-                      </div>
-
-                      <div>
-                        <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                          Unidad
-                        </label>
-                        <Input
-                          value={item.unidad}
-                          onChange={(event) =>
-                            onDraftItemChange(item.id, 'unidad', event.target.value)
-                          }
-                          placeholder="pza, caja, kg..."
-                        />
-                      </div>
-
-                      <div className="sm:col-span-2">
-                        <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                          Descripción / notas
-                        </label>
-                        <Input
-                          value={item.descripcion}
-                          onChange={(event) =>
-                            onDraftItemChange(item.id, 'descripcion', event.target.value)
-                          }
-                          placeholder="Ej. consumo fin de semana"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <Separator className="print:hidden" />
-
-            {saveError && (
-              <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive print:hidden">
-                {saveError}
-              </div>
-            )}
-
-            <div className="flex flex-wrap justify-end gap-3 print:hidden">
-              <Button variant="outline" onClick={onClose} disabled={isPending}>
-                Cancelar
-              </Button>
-              <Button onClick={handleGuardar} disabled={isPending}>
-                <FilePlus2 className="mr-2 h-4 w-4" />
-                {isPending ? 'Guardando…' : isEditing ? 'Guardar cambios' : 'Guardar requisición'}
-              </Button>
-            </div>
-          </div>
-        </ScrollArea>
-      </SheetContent>
-    </Sheet>
+        </div>
+      </ScrollArea>
+    </DetailDrawer>
   );
 }
 

--- a/app/settings/acceso/acceso-client.tsx
+++ b/app/settings/acceso/acceso-client.tsx
@@ -39,13 +39,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
+import { DetailDrawer } from '@/components/detail-page';
 import {
   Dialog,
   DialogContent,
@@ -701,400 +695,385 @@ export function AccesoClient({
       )}
 
       {/* ── User Detail Sheet ─────────────────────────────────────────────── */}
-      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent className="sm:max-w-2xl flex flex-col p-0" side="right">
-          {selectedUsuario && (
-            <>
-              <SheetHeader className="border-b border-[var(--border)] px-6 py-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <SheetTitle className="dark:text-white text-[var(--text)]">
-                      {selectedUsuario.first_name ?? selectedUsuario.email}
-                    </SheetTitle>
-                    <SheetDescription className="font-mono text-xs">
-                      {selectedUsuario.email}
-                    </SheetDescription>
-                  </div>
-                </div>
-              </SheetHeader>
+      <DetailDrawer
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        size="lg"
+        title={selectedUsuario?.first_name ?? selectedUsuario?.email ?? ''}
+        description={
+          selectedUsuario ? <span className="font-mono">{selectedUsuario.email}</span> : undefined
+        }
+      >
+        {selectedUsuario && (
+          <>
+            <ScrollArea className="flex-1 min-h-0">
+              <div className="space-y-8 px-6 py-5">
+                {/* ── Empresas section ── */}
+                <section>
+                  <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text-subtle)]">
+                    Acceso a empresas
+                  </h3>
+                  <div className="space-y-3">
+                    {empresas.length === 0 ? (
+                      <p className="text-xs dark:text-white/28 text-[var(--text)]/30">
+                        No hay empresas registradas.
+                      </p>
+                    ) : (
+                      empresas.map((emp) => {
+                        const ue = usuariosEmpresas.find(
+                          (x) => x.usuario_id === selectedUsuario.id && x.empresa_id === emp.id
+                        );
+                        const empRoles = roles.filter((r) => r.empresa_id === emp.id);
 
-              <ScrollArea className="flex-1 min-h-0">
-                <div className="space-y-8 px-6 py-5">
-                  {/* ── Empresas section ── */}
-                  <section>
-                    <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text-subtle)]">
-                      Acceso a empresas
-                    </h3>
-                    <div className="space-y-3">
-                      {empresas.length === 0 ? (
-                        <p className="text-xs dark:text-white/28 text-[var(--text)]/30">
-                          No hay empresas registradas.
-                        </p>
-                      ) : (
-                        empresas.map((emp) => {
-                          const ue = usuariosEmpresas.find(
-                            (x) => x.usuario_id === selectedUsuario.id && x.empresa_id === emp.id
-                          );
-                          const empRoles = roles.filter((r) => r.empresa_id === emp.id);
+                        return (
+                          <div
+                            key={emp.id}
+                            className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4"
+                          >
+                            <label className="flex cursor-pointer items-center gap-3">
+                              <input
+                                type="checkbox"
+                                disabled={isPending}
+                                checked={!!ue}
+                                onChange={(e) => {
+                                  run(() =>
+                                    setUsuarioEmpresaAcceso(
+                                      selectedUsuario.id,
+                                      emp.id,
+                                      e.target.checked
+                                    )
+                                  );
+                                }}
+                                className="h-4 w-4 cursor-pointer rounded accent-[var(--accent)]"
+                              />
+                              <span className="text-sm font-medium dark:text-white/85 text-[var(--text)]/85">
+                                Tiene acceso a {emp.nombre}
+                              </span>
+                            </label>
 
-                          return (
-                            <div
-                              key={emp.id}
-                              className="space-y-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4"
-                            >
-                              <label className="flex cursor-pointer items-center gap-3">
-                                <input
-                                  type="checkbox"
+                            {ue && (
+                              <div className="ml-7 flex items-center gap-2">
+                                <span className="text-xs dark:text-white/50 text-[var(--text)]/50">
+                                  Rol base:
+                                </span>
+                                <Combobox
+                                  value={ue.rol_id ?? ''}
                                   disabled={isPending}
-                                  checked={!!ue}
-                                  onChange={(e) => {
+                                  onChange={(v) => {
                                     run(() =>
-                                      setUsuarioEmpresaAcceso(
-                                        selectedUsuario.id,
-                                        emp.id,
-                                        e.target.checked
-                                      )
+                                      updateUsuarioEmpresaRol(selectedUsuario.id, emp.id, v || null)
                                     );
                                   }}
-                                  className="h-4 w-4 cursor-pointer rounded accent-[var(--accent)]"
+                                  options={empRoles.map((rol) => ({
+                                    value: rol.id,
+                                    label: rol.nombre,
+                                  }))}
+                                  placeholder="Sin rol"
+                                  allowClear
+                                  size="sm"
+                                  className="w-48 text-xs"
                                 />
-                                <span className="text-sm font-medium dark:text-white/85 text-[var(--text)]/85">
-                                  Tiene acceso a {emp.nombre}
-                                </span>
-                              </label>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+                </section>
 
-                              {ue && (
-                                <div className="ml-7 flex items-center gap-2">
-                                  <span className="text-xs dark:text-white/50 text-[var(--text)]/50">
-                                    Rol base:
-                                  </span>
-                                  <Combobox
-                                    value={ue.rol_id ?? ''}
-                                    disabled={isPending}
-                                    onChange={(v) => {
-                                      run(() =>
-                                        updateUsuarioEmpresaRol(
-                                          selectedUsuario.id,
-                                          emp.id,
-                                          v || null
-                                        )
-                                      );
-                                    }}
-                                    options={empRoles.map((rol) => ({
-                                      value: rol.id,
-                                      label: rol.nombre,
-                                    }))}
-                                    placeholder="Sin rol"
-                                    allowClear
-                                    size="sm"
-                                    className="w-48 text-xs"
-                                  />
-                                </div>
-                              )}
-                            </div>
-                          );
-                        })
+                {/* ── Excepciones section ── */}
+                <section>
+                  <div className="mb-3 flex items-center justify-between">
+                    <h3 className="text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text-subtle)]">
+                      Excepciones de módulo
+                    </h3>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        setAddingExcepcion((v) => !v);
+                        setNewExcEmpresaId('');
+                        setNewExcModuloId('');
+                        setNewExcLectura(false);
+                        setNewExcEscritura(false);
+                      }}
+                      className="h-7 gap-1 rounded-lg text-xs"
+                    >
+                      {addingExcepcion ? (
+                        <>
+                          <X className="h-3 w-3" /> Cancelar
+                        </>
+                      ) : (
+                        <>
+                          <Plus className="h-3 w-3" /> Excepción
+                        </>
                       )}
-                    </div>
-                  </section>
+                    </Button>
+                  </div>
 
-                  {/* ── Excepciones section ── */}
-                  <section>
-                    <div className="mb-3 flex items-center justify-between">
-                      <h3 className="text-xs font-semibold uppercase tracking-wide dark:text-white/40 text-[var(--text-subtle)]">
-                        Excepciones de módulo
-                      </h3>
+                  {/* Add exception form */}
+                  {addingExcepcion && (
+                    <div className="mb-4 space-y-3 rounded-xl border border-dashed border-[var(--accent)]/40 bg-[var(--accent)]/5 p-4">
+                      <p className="text-xs dark:text-white/55 text-[var(--text-muted)]">
+                        Sobrescribe un permiso específico para este usuario.
+                      </p>
+                      <div className="grid grid-cols-2 gap-2">
+                        <div className="space-y-1">
+                          <p className="text-xs dark:text-white/45 text-[var(--text)]/45">
+                            Empresa
+                          </p>
+                          <Combobox
+                            value={newExcEmpresaId}
+                            onChange={(v) => {
+                              if (v) {
+                                setNewExcEmpresaId(v);
+                                setNewExcModuloId('');
+                              }
+                            }}
+                            options={empresas.map((emp) => ({
+                              value: emp.id,
+                              label: emp.nombre,
+                            }))}
+                            placeholder="Empresa"
+                            size="sm"
+                            className="text-xs"
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-xs dark:text-white/45 text-[var(--text)]/45">Módulo</p>
+                          <Combobox
+                            value={newExcModuloId}
+                            onChange={(v) => {
+                              if (v) setNewExcModuloId(v);
+                            }}
+                            options={modulosExcepcion.map((mod) => ({
+                              value: mod.id,
+                              label: mod.nombre,
+                            }))}
+                            placeholder={newExcEmpresaId ? 'Módulo' : 'Selecciona empresa primero'}
+                            disabled={!newExcEmpresaId}
+                            size="sm"
+                            className="text-xs"
+                          />
+                        </div>
+                      </div>
+                      <div className="flex gap-4">
+                        <label className="flex cursor-pointer items-center gap-2 text-xs dark:text-white/65 text-[var(--text)]/65">
+                          <input
+                            type="checkbox"
+                            checked={newExcLectura}
+                            onChange={(e) => setNewExcLectura(e.target.checked)}
+                            className="h-3.5 w-3.5 rounded accent-[var(--accent)]"
+                          />
+                          Lectura
+                        </label>
+                        <label className="flex cursor-pointer items-center gap-2 text-xs dark:text-white/65 text-[var(--text)]/65">
+                          <input
+                            type="checkbox"
+                            checked={newExcEscritura}
+                            onChange={(e) => setNewExcEscritura(e.target.checked)}
+                            className="h-3.5 w-3.5 rounded accent-[var(--accent)]"
+                          />
+                          Escritura
+                        </label>
+                      </div>
                       <Button
-                        variant="outline"
                         size="sm"
+                        className="w-full rounded-lg text-xs"
+                        disabled={!newExcEmpresaId || !newExcModuloId || isPending}
                         onClick={() => {
-                          setAddingExcepcion((v) => !v);
-                          setNewExcEmpresaId('');
-                          setNewExcModuloId('');
-                          setNewExcLectura(false);
-                          setNewExcEscritura(false);
+                          run(
+                            () =>
+                              upsertExcepcionUsuario({
+                                usuario_id: selectedUsuario.id,
+                                empresa_id: newExcEmpresaId,
+                                modulo_id: newExcModuloId,
+                                acceso_lectura: newExcLectura,
+                                acceso_escritura: newExcEscritura,
+                              }),
+                            () => {
+                              setAddingExcepcion(false);
+                              setNewExcEmpresaId('');
+                              setNewExcModuloId('');
+                              setNewExcLectura(false);
+                              setNewExcEscritura(false);
+                            }
+                          );
                         }}
-                        className="h-7 gap-1 rounded-lg text-xs"
                       >
-                        {addingExcepcion ? (
-                          <>
-                            <X className="h-3 w-3" /> Cancelar
-                          </>
-                        ) : (
-                          <>
-                            <Plus className="h-3 w-3" /> Excepción
-                          </>
-                        )}
+                        Guardar excepción
                       </Button>
                     </div>
+                  )}
 
-                    {/* Add exception form */}
-                    {addingExcepcion && (
-                      <div className="mb-4 space-y-3 rounded-xl border border-dashed border-[var(--accent)]/40 bg-[var(--accent)]/5 p-4">
-                        <p className="text-xs dark:text-white/55 text-[var(--text-muted)]">
-                          Sobrescribe un permiso específico para este usuario.
-                        </p>
-                        <div className="grid grid-cols-2 gap-2">
-                          <div className="space-y-1">
-                            <p className="text-xs dark:text-white/45 text-[var(--text)]/45">
-                              Empresa
-                            </p>
-                            <Combobox
-                              value={newExcEmpresaId}
-                              onChange={(v) => {
-                                if (v) {
-                                  setNewExcEmpresaId(v);
-                                  setNewExcModuloId('');
-                                }
-                              }}
-                              options={empresas.map((emp) => ({
-                                value: emp.id,
-                                label: emp.nombre,
-                              }))}
-                              placeholder="Empresa"
-                              size="sm"
-                              className="text-xs"
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <p className="text-xs dark:text-white/45 text-[var(--text)]/45">
-                              Módulo
-                            </p>
-                            <Combobox
-                              value={newExcModuloId}
-                              onChange={(v) => {
-                                if (v) setNewExcModuloId(v);
-                              }}
-                              options={modulosExcepcion.map((mod) => ({
-                                value: mod.id,
-                                label: mod.nombre,
-                              }))}
-                              placeholder={
-                                newExcEmpresaId ? 'Módulo' : 'Selecciona empresa primero'
-                              }
-                              disabled={!newExcEmpresaId}
-                              size="sm"
-                              className="text-xs"
-                            />
-                          </div>
-                        </div>
-                        <div className="flex gap-4">
-                          <label className="flex cursor-pointer items-center gap-2 text-xs dark:text-white/65 text-[var(--text)]/65">
-                            <input
-                              type="checkbox"
-                              checked={newExcLectura}
-                              onChange={(e) => setNewExcLectura(e.target.checked)}
-                              className="h-3.5 w-3.5 rounded accent-[var(--accent)]"
-                            />
-                            Lectura
-                          </label>
-                          <label className="flex cursor-pointer items-center gap-2 text-xs dark:text-white/65 text-[var(--text)]/65">
-                            <input
-                              type="checkbox"
-                              checked={newExcEscritura}
-                              onChange={(e) => setNewExcEscritura(e.target.checked)}
-                              className="h-3.5 w-3.5 rounded accent-[var(--accent)]"
-                            />
-                            Escritura
-                          </label>
-                        </div>
-                        <Button
-                          size="sm"
-                          className="w-full rounded-lg text-xs"
-                          disabled={!newExcEmpresaId || !newExcModuloId || isPending}
-                          onClick={() => {
-                            run(
-                              () =>
-                                upsertExcepcionUsuario({
-                                  usuario_id: selectedUsuario.id,
-                                  empresa_id: newExcEmpresaId,
-                                  modulo_id: newExcModuloId,
-                                  acceso_lectura: newExcLectura,
-                                  acceso_escritura: newExcEscritura,
-                                }),
-                              () => {
-                                setAddingExcepcion(false);
-                                setNewExcEmpresaId('');
-                                setNewExcModuloId('');
-                                setNewExcLectura(false);
-                                setNewExcEscritura(false);
-                              }
-                            );
-                          }}
-                        >
-                          Guardar excepción
-                        </Button>
-                      </div>
-                    )}
-
-                    {/* Existing exceptions list */}
-                    {(() => {
-                      const userExcs = getUserExcepciones(selectedUsuario.id);
-                      if (userExcs.length === 0) {
-                        return (
-                          <p className="text-xs dark:text-white/28 text-[var(--text)]/30">
-                            Sin excepciones configuradas.
-                          </p>
-                        );
-                      }
+                  {/* Existing exceptions list */}
+                  {(() => {
+                    const userExcs = getUserExcepciones(selectedUsuario.id);
+                    if (userExcs.length === 0) {
                       return (
-                        <div className="space-y-2">
-                          {userExcs.map((ex) => (
-                            <div
-                              key={`${ex.empresa_id}-${ex.modulo_id}`}
-                              className="flex items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-xs"
-                            >
-                              <div>
-                                <span className="font-medium dark:text-white/80 text-[var(--text)]/80">
-                                  {getModuloNombre(ex.modulo_id)}
-                                </span>
-                                <span className="ml-1.5 dark:text-white/40 text-[var(--text-subtle)]">
-                                  en {getEmpresaNombre(ex.empresa_id)}
-                                </span>
-                              </div>
-                              <div className="flex items-center gap-1.5">
-                                {ex.acceso_lectura && (
-                                  <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-600 dark:text-emerald-400">
-                                    Lectura
-                                  </span>
-                                )}
-                                {ex.acceso_escritura && (
-                                  <span className="rounded-full bg-blue-500/10 px-2 py-0.5 text-blue-600 dark:text-blue-400">
-                                    Escritura
-                                  </span>
-                                )}
-                                {!ex.acceso_lectura && !ex.acceso_escritura && (
-                                  <span className="rounded-full bg-red-500/10 px-2 py-0.5 text-red-500">
-                                    Denegado
-                                  </span>
-                                )}
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  disabled={isPending}
-                                  className="h-6 w-6 text-red-500 hover:text-red-600 hover:bg-red-500/10"
-                                  onClick={() => {
-                                    run(() =>
-                                      deleteExcepcionUsuario(
-                                        ex.usuario_id,
-                                        ex.empresa_id,
-                                        ex.modulo_id
-                                      )
-                                    );
-                                  }}
-                                >
-                                  <X className="h-3 w-3" />
-                                </Button>
-                              </div>
+                        <p className="text-xs dark:text-white/28 text-[var(--text)]/30">
+                          Sin excepciones configuradas.
+                        </p>
+                      );
+                    }
+                    return (
+                      <div className="space-y-2">
+                        {userExcs.map((ex) => (
+                          <div
+                            key={`${ex.empresa_id}-${ex.modulo_id}`}
+                            className="flex items-center justify-between rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-xs"
+                          >
+                            <div>
+                              <span className="font-medium dark:text-white/80 text-[var(--text)]/80">
+                                {getModuloNombre(ex.modulo_id)}
+                              </span>
+                              <span className="ml-1.5 dark:text-white/40 text-[var(--text-subtle)]">
+                                en {getEmpresaNombre(ex.empresa_id)}
+                              </span>
                             </div>
-                          ))}
-                        </div>
-                      );
-                    })()}
-                  </section>
-                </div>
-              </ScrollArea>
-
-              {/* ── Action buttons footer ── */}
-              <div className="border-t border-[var(--border)] px-6 py-4">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="gap-1.5 text-xs text-blue-600 border-blue-500/30 hover:bg-blue-500/10 hover:text-blue-700"
-                    onClick={() => {
-                      startImpersonate(
-                        selectedUsuario.id,
-                        `${selectedUsuario.first_name ?? selectedUsuario.email} (${selectedUsuario.email})`
-                      );
-                      setSheetOpen(false);
-                    }}
-                  >
-                    <Eye className="h-3 w-3" /> Ver como usuario
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={isPending}
-                    className={cn(
-                      'gap-1.5 text-xs',
-                      selectedUsuario.welcome_sent_at
-                        ? 'text-emerald-500 border-emerald-500/30 hover:bg-emerald-500/10 hover:text-emerald-600'
-                        : 'text-amber-600 border-amber-500/30 hover:bg-amber-500/10 hover:text-amber-700'
-                    )}
-                    onClick={() => {
-                      const action = selectedUsuario.welcome_sent_at ? 'Reenviar' : 'Enviar';
-                      if (!confirm(`¿${action} correo de bienvenida a ${selectedUsuario.email}?`))
-                        return;
-                      run(async () => {
-                        const { sendWelcomeEmailAction } = await import('./actions');
-                        const result = await sendWelcomeEmailAction(selectedUsuario.id);
-                        if (!result.success) throw new Error(result.error);
-                      });
-                    }}
-                  >
-                    <Mail className="h-3 w-3" />
-                    {selectedUsuario.welcome_sent_at ? 'Reenviar bienvenida' : 'Enviar bienvenida'}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={isPending}
-                    onClick={() => {
-                      const nuevoEstado = !selectedUsuario.activo;
-                      if (
-                        !confirm(
-                          nuevoEstado
-                            ? '¿Reactivar este usuario?'
-                            : '¿Desactivar este usuario? Perderá acceso al sistema.'
-                        )
-                      )
-                        return;
-                      run(() => toggleActivo(selectedUsuario.id, nuevoEstado));
-                    }}
-                    className={cn(
-                      'gap-1.5 text-xs',
-                      selectedUsuario.activo
-                        ? 'text-red-500 border-red-500/30 hover:bg-red-500/10 hover:text-red-600'
-                        : 'text-emerald-500 border-emerald-500/30 hover:bg-emerald-500/10 hover:text-emerald-600'
-                    )}
-                  >
-                    {selectedUsuario.activo ? (
-                      <>
-                        <X className="h-3 w-3" /> Desactivar
-                      </>
-                    ) : (
-                      <>
-                        <ShieldCheck className="h-3 w-3" /> Reactivar
-                      </>
-                    )}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={isPending}
-                    className="gap-1.5 text-xs text-red-500 border-red-500/30 hover:bg-red-500/10 hover:text-red-600"
-                    onClick={() => {
-                      if (
-                        !confirm(
-                          `¿Eliminar permanentemente a ${selectedUsuario.email}? Esta acción no se puede deshacer.`
-                        )
-                      )
-                        return;
-                      run(
-                        () => removeUsuario(selectedUsuario.id),
-                        () => setSheetOpen(false)
-                      );
-                    }}
-                  >
-                    <Trash2 className="h-3 w-3" /> Eliminar
-                  </Button>
-                </div>
+                            <div className="flex items-center gap-1.5">
+                              {ex.acceso_lectura && (
+                                <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-600 dark:text-emerald-400">
+                                  Lectura
+                                </span>
+                              )}
+                              {ex.acceso_escritura && (
+                                <span className="rounded-full bg-blue-500/10 px-2 py-0.5 text-blue-600 dark:text-blue-400">
+                                  Escritura
+                                </span>
+                              )}
+                              {!ex.acceso_lectura && !ex.acceso_escritura && (
+                                <span className="rounded-full bg-red-500/10 px-2 py-0.5 text-red-500">
+                                  Denegado
+                                </span>
+                              )}
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                disabled={isPending}
+                                className="h-6 w-6 text-red-500 hover:text-red-600 hover:bg-red-500/10"
+                                onClick={() => {
+                                  run(() =>
+                                    deleteExcepcionUsuario(
+                                      ex.usuario_id,
+                                      ex.empresa_id,
+                                      ex.modulo_id
+                                    )
+                                  );
+                                }}
+                              >
+                                <X className="h-3 w-3" />
+                              </Button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  })()}
+                </section>
               </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
+            </ScrollArea>
+
+            {/* ── Action buttons footer ── */}
+            <div className="border-t border-[var(--border)] px-6 py-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5 text-xs text-blue-600 border-blue-500/30 hover:bg-blue-500/10 hover:text-blue-700"
+                  onClick={() => {
+                    startImpersonate(
+                      selectedUsuario.id,
+                      `${selectedUsuario.first_name ?? selectedUsuario.email} (${selectedUsuario.email})`
+                    );
+                    setSheetOpen(false);
+                  }}
+                >
+                  <Eye className="h-3 w-3" /> Ver como usuario
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isPending}
+                  className={cn(
+                    'gap-1.5 text-xs',
+                    selectedUsuario.welcome_sent_at
+                      ? 'text-emerald-500 border-emerald-500/30 hover:bg-emerald-500/10 hover:text-emerald-600'
+                      : 'text-amber-600 border-amber-500/30 hover:bg-amber-500/10 hover:text-amber-700'
+                  )}
+                  onClick={() => {
+                    const action = selectedUsuario.welcome_sent_at ? 'Reenviar' : 'Enviar';
+                    if (!confirm(`¿${action} correo de bienvenida a ${selectedUsuario.email}?`))
+                      return;
+                    run(async () => {
+                      const { sendWelcomeEmailAction } = await import('./actions');
+                      const result = await sendWelcomeEmailAction(selectedUsuario.id);
+                      if (!result.success) throw new Error(result.error);
+                    });
+                  }}
+                >
+                  <Mail className="h-3 w-3" />
+                  {selectedUsuario.welcome_sent_at ? 'Reenviar bienvenida' : 'Enviar bienvenida'}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isPending}
+                  onClick={() => {
+                    const nuevoEstado = !selectedUsuario.activo;
+                    if (
+                      !confirm(
+                        nuevoEstado
+                          ? '¿Reactivar este usuario?'
+                          : '¿Desactivar este usuario? Perderá acceso al sistema.'
+                      )
+                    )
+                      return;
+                    run(() => toggleActivo(selectedUsuario.id, nuevoEstado));
+                  }}
+                  className={cn(
+                    'gap-1.5 text-xs',
+                    selectedUsuario.activo
+                      ? 'text-red-500 border-red-500/30 hover:bg-red-500/10 hover:text-red-600'
+                      : 'text-emerald-500 border-emerald-500/30 hover:bg-emerald-500/10 hover:text-emerald-600'
+                  )}
+                >
+                  {selectedUsuario.activo ? (
+                    <>
+                      <X className="h-3 w-3" /> Desactivar
+                    </>
+                  ) : (
+                    <>
+                      <ShieldCheck className="h-3 w-3" /> Reactivar
+                    </>
+                  )}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={isPending}
+                  className="gap-1.5 text-xs text-red-500 border-red-500/30 hover:bg-red-500/10 hover:text-red-600"
+                  onClick={() => {
+                    if (
+                      !confirm(
+                        `¿Eliminar permanentemente a ${selectedUsuario.email}? Esta acción no se puede deshacer.`
+                      )
+                    )
+                      return;
+                    run(
+                      () => removeUsuario(selectedUsuario.id),
+                      () => setSheetOpen(false)
+                    );
+                  }}
+                >
+                  <Trash2 className="h-3 w-3" /> Eliminar
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </DetailDrawer>
 
       {/* ── Empresa Dialog ────────────────────────────────────────────────── */}
       <Dialog

--- a/app/settings/empresas/_components/empresa-detail.tsx
+++ b/app/settings/empresas/_components/empresa-detail.tsx
@@ -5,7 +5,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
 import { Input } from '@/components/ui/input';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import {
   AlertTriangle,
   CheckCircle,
@@ -1213,7 +1213,7 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
       </div>
 
       {/* Drawer: Actualizar CSF */}
-      <Sheet
+      <DetailDrawer
         open={drawerOpen}
         onOpenChange={(v) => {
           if (!v) {
@@ -1225,20 +1225,17 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
             resetDrawer();
           }
         }}
+        size="lg"
+        title={
+          <span className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-emerald-600" />
+            Actualizar CSF — {empresa.nombre}
+          </span>
+        }
+        description="Sube el PDF de la CSF más reciente. El sistema extrae los campos y te muestra qué cambia. Puedes aplicar todo, parcial, o solo archivar el PDF como histórico."
       >
-        <SheetContent className="sm:max-w-[800px] overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle className="flex items-center gap-2">
-              <Sparkles className="h-5 w-5 text-emerald-600" />
-              Actualizar CSF — {empresa.nombre}
-            </SheetTitle>
-            <p className="text-xs text-muted-foreground">
-              Sube el PDF de la CSF más reciente. El sistema extrae los campos y te muestra qué
-              cambia. Puedes aplicar todo, parcial, o solo archivar el PDF como histórico.
-            </p>
-          </SheetHeader>
-
-          <div className="mt-6 space-y-4">
+        <DetailDrawerContent>
+          <div className="space-y-4">
             {/* ── Estado A: drop PDF ──────────────────────────────────────────── */}
             {!csfFile && !csfProcessing && !csfExtraccion && (
               <div className="space-y-3">
@@ -1408,8 +1405,8 @@ export function EmpresaDetail({ empresa, onSaved }: { empresa: Empresa; onSaved:
               </>
             )}
           </div>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
     </div>
   );
 }

--- a/components/juntas/admin-juntas-list-module.tsx
+++ b/components/juntas/admin-juntas-list-module.tsx
@@ -31,13 +31,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import { DataTable, type Column } from '@/components/module-page';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { FilterCombobox, type FilterComboboxOption } from '@/components/ui/filter-combobox';
 import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
@@ -622,24 +616,17 @@ export function AdminJuntasListModule({
         </p>
       )}
 
-      <Sheet
+      <DetailDrawer
         open={showCreate}
         onOpenChange={(open) => {
           if (!open) setShowCreate(false);
         }}
+        size="sm"
+        title="Nueva Junta"
+        description="Selecciona el tipo de junta para iniciar"
       >
-        <SheetContent
-          side="right"
-          className="w-full sm:max-w-md border-[var(--border)] bg-[var(--card)] text-[var(--text)] overflow-y-auto"
-        >
-          <SheetHeader className="pb-2">
-            <SheetTitle className="text-[var(--text)] text-lg">Nueva Junta</SheetTitle>
-            <SheetDescription className="text-[var(--text)]/50">
-              Selecciona el tipo de junta para iniciar
-            </SheetDescription>
-          </SheetHeader>
-
-          <div className="space-y-5 py-4">
+        <DetailDrawerContent>
+          <div className="space-y-5">
             <div>
               <FieldLabel>Tipo de Junta *</FieldLabel>
               <Combobox
@@ -702,8 +689,8 @@ export function AdminJuntasListModule({
               Iniciar Junta
             </Button>
           </div>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
     </div>
   );
 }

--- a/components/juntas/junta-detail-module.tsx
+++ b/components/juntas/junta-detail-module.tsx
@@ -39,13 +39,7 @@ import Image from '@tiptap/extension-image';
 import { Table, TableRow, TableHeader, TableCell } from '@tiptap/extension-table';
 import { EditorToolbar, MINUTA_EDITOR_STYLES } from '@/components/juntas/editor-toolbar';
 import { Combobox } from '@/components/ui/combobox';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
@@ -1575,7 +1569,7 @@ export function JuntaDetailModule({ empresaSlug }: JuntaDetailModuleProps) {
       </div>
 
       {/* ── Sheet: Agregar avance ──────────────────────────────── */}
-      <Sheet
+      <DetailDrawer
         open={!!showAddUpdate}
         onOpenChange={(open) => {
           if (!open) {
@@ -1583,18 +1577,12 @@ export function JuntaDetailModule({ empresaSlug }: JuntaDetailModuleProps) {
             setUpdateForm({ contenido: '', nuevoEstado: '', nuevaFecha: '' });
           }
         }}
+        size="sm"
+        title="Agregar avance"
+        description={showAddUpdate ? (tasks.find((t) => t.id === showAddUpdate)?.titulo ?? '') : ''}
       >
-        <SheetContent
-          side="right"
-          className="w-full sm:max-w-lg border-[var(--border)] bg-[var(--card)] text-[var(--text)] overflow-y-auto"
-        >
-          <SheetHeader className="pb-2">
-            <SheetTitle className="text-[var(--text)] text-lg">Agregar avance</SheetTitle>
-            <SheetDescription className="text-[var(--text)]/50">
-              {showAddUpdate ? (tasks.find((t) => t.id === showAddUpdate)?.titulo ?? '') : ''}
-            </SheetDescription>
-          </SheetHeader>
-          <div className="space-y-5 py-4">
+        <DetailDrawerContent>
+          <div className="space-y-5">
             <div>
               <FieldLabel required>Avance / Comentario</FieldLabel>
               <Textarea
@@ -1654,8 +1642,8 @@ export function JuntaDetailModule({ empresaSlug }: JuntaDetailModuleProps) {
               Guardar avance
             </Button>
           </div>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
 
       <TasksCreateForm
         variant="rich"

--- a/components/proveedores/proveedores-module.tsx
+++ b/components/proveedores/proveedores-module.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { DataTable, type Column } from '@/components/module-page';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -223,91 +223,88 @@ function ProveedorDetail({
   ].filter((r) => r.value);
 
   return (
-    <Sheet
+    <DetailDrawer
       open={open}
       onOpenChange={(v) => {
         if (!v) onClose();
       }}
-    >
-      <SheetContent className="sm:max-w-[600px]">
-        {/* Membrete solo para impresión */}
-        <img
-          src={logoPath}
-          alt={membreteAlt}
-          className="hidden print:block w-full object-contain mb-6"
-        />
-        <SheetHeader>
-          <SheetTitle>{proveedor.nombre}</SheetTitle>
-          <div className="absolute right-12 top-4 hidden sm:flex gap-2 print:hidden">
-            <Button variant="outline" size="sm" onClick={() => onUpdateCsf(proveedor)}>
-              <Sparkles className="mr-2 h-4 w-4" />
-              Cargar / Actualizar CSF
-            </Button>
-            <Button variant="outline" size="sm" onClick={() => onEdit(proveedor)}>
-              <Pencil className="mr-2 h-4 w-4" />
-              Editar
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onToggleActivo(proveedor)}
-              disabled={saving}
-            >
-              {proveedor.activo ? (
-                <Ban className="mr-2 h-4 w-4" />
-              ) : (
-                <RotateCcw className="mr-2 h-4 w-4" />
-              )}
-              {proveedor.activo ? 'Inactivar' : 'Reactivar'}
-            </Button>
-            <Button variant="outline" size="sm" onClick={triggerPrint}>
-              Imprimir
-            </Button>
-          </div>
-        </SheetHeader>
-
-        <ScrollArea className="flex-1 min-h-0 pr-1 print:h-auto">
-          <div className="mt-6 space-y-6 pb-6">
-            <Badge variant={proveedor.activo ? 'default' : 'secondary'}>
-              {proveedor.activo ? 'Activo' : 'Inactivo'}
-            </Badge>
-
-            <Separator />
-
-            {rows.length > 0 ? (
-              <div className="space-y-4">
-                {rows.map((row) => {
-                  const Icon = row.icon;
-                  return (
-                    <div key={row.label}>
-                      <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                        {Icon && <Icon className="h-3 w-3" />}
-                        {row.label}
-                      </div>
-                      <div className="mt-1 text-sm">{row.value}</div>
-                    </div>
-                  );
-                })}
-              </div>
+      size="md"
+      title={proveedor.nombre}
+      actions={
+        <>
+          <Button variant="outline" size="sm" onClick={() => onUpdateCsf(proveedor)}>
+            <Sparkles className="mr-2 h-4 w-4" />
+            Cargar / Actualizar CSF
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => onEdit(proveedor)}>
+            <Pencil className="mr-2 h-4 w-4" />
+            Editar
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onToggleActivo(proveedor)}
+            disabled={saving}
+          >
+            {proveedor.activo ? (
+              <Ban className="mr-2 h-4 w-4" />
             ) : (
-              <p className="text-sm text-muted-foreground">Sin información de contacto</p>
+              <RotateCcw className="mr-2 h-4 w-4" />
             )}
+            {proveedor.activo ? 'Inactivar' : 'Reactivar'}
+          </Button>
+          <Button variant="outline" size="sm" onClick={triggerPrint}>
+            Imprimir
+          </Button>
+        </>
+      }
+    >
+      {/* Membrete solo para impresión */}
+      <img
+        src={logoPath}
+        alt={membreteAlt}
+        className="hidden print:block w-full object-contain mb-6"
+      />
 
-            {proveedor.notas && (
-              <>
-                <Separator />
-                <div>
-                  <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Notas
+      <DetailDrawerContent>
+        <Badge variant={proveedor.activo ? 'default' : 'secondary'}>
+          {proveedor.activo ? 'Activo' : 'Inactivo'}
+        </Badge>
+
+        <Separator className="my-4" />
+
+        {rows.length > 0 ? (
+          <div className="space-y-4">
+            {rows.map((row) => {
+              const Icon = row.icon;
+              return (
+                <div key={row.label}>
+                  <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    {Icon && <Icon className="h-3 w-3" />}
+                    {row.label}
                   </div>
-                  <p className="text-sm leading-relaxed text-muted-foreground">{proveedor.notas}</p>
+                  <div className="mt-1 text-sm">{row.value}</div>
                 </div>
-              </>
-            )}
+              );
+            })}
           </div>
-        </ScrollArea>
-      </SheetContent>
-    </Sheet>
+        ) : (
+          <p className="text-sm text-muted-foreground">Sin información de contacto</p>
+        )}
+
+        {proveedor.notas && (
+          <>
+            <Separator className="my-4" />
+            <div>
+              <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Notas
+              </div>
+              <p className="text-sm leading-relaxed text-muted-foreground">{proveedor.notas}</p>
+            </div>
+          </>
+        )}
+      </DetailDrawerContent>
+    </DetailDrawer>
   );
 }
 
@@ -953,12 +950,14 @@ export function ProveedoresModule({
         membreteAlt={membreteAlt}
       />
 
-      <Sheet open={editDrawerOpen} onOpenChange={setEditDrawerOpen}>
-        <SheetContent className="sm:max-w-[600px] overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle>Editar Proveedor</SheetTitle>
-          </SheetHeader>
-          <div className="mt-8 space-y-6">
+      <DetailDrawer
+        open={editDrawerOpen}
+        onOpenChange={setEditDrawerOpen}
+        size="md"
+        title="Editar Proveedor"
+      >
+        <DetailDrawerContent>
+          <div className="space-y-6">
             <div className="space-y-4">
               <div className="space-y-2">
                 <label className="text-sm font-medium leading-none">
@@ -1016,23 +1015,21 @@ export function ProveedoresModule({
               </Button>
             </div>
           </div>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
 
       {/* Create Proveedor Drawer */}
-      <Sheet
+      <DetailDrawer
         open={createDrawerOpen}
         onOpenChange={(v) => {
           setCreateDrawerOpen(v);
           if (!v) resetCreateForm();
         }}
+        size="md"
+        title="Nuevo Proveedor"
       >
-        <SheetContent className="sm:max-w-[640px] overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle>Nuevo Proveedor</SheetTitle>
-          </SheetHeader>
-
-          <div className="mt-8 space-y-6">
+        <DetailDrawerContent>
+          <div className="space-y-6">
             {/* ── Sección CSF (Sprint 2.B) ────────────────────────── */}
             <div className="rounded-lg border border-emerald-300/40 bg-emerald-50/40 p-4 dark:bg-emerald-950/20">
               <div className="flex items-start gap-3">
@@ -1364,8 +1361,8 @@ export function ProveedoresModule({
               </Button>
             </div>
           </div>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
 
       {/* Update CSF — overlay de procesamiento (mientras Claude lee el PDF) */}
       {updateCsfProcessing && (
@@ -1405,7 +1402,7 @@ export function ProveedoresModule({
       )}
 
       {/* Modal: diff campo-por-campo (Sprint 3.B) */}
-      <Sheet
+      <DetailDrawer
         open={diffOpen}
         onOpenChange={(v) => {
           if (!v) {
@@ -1415,19 +1412,16 @@ export function ProveedoresModule({
             // aplicar exitosamente o al iniciar un nuevo update.
           }
         }}
+        size="lg"
+        title={
+          <span className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-emerald-600" />
+            Revisar cambios de la CSF
+          </span>
+        }
+        description={`${updateCsfTarget?.nombre ?? ''} — marca los campos que quieras aplicar. La CSF nueva queda archivada como histórico aunque rechaces todos los cambios.`}
       >
-        <SheetContent className="sm:max-w-[800px] overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle className="flex items-center gap-2">
-              <Sparkles className="h-5 w-5 text-emerald-600" />
-              Revisar cambios de la CSF
-            </SheetTitle>
-            <p className="text-xs text-muted-foreground">
-              {updateCsfTarget?.nombre} — marca los campos que quieras aplicar. La CSF nueva queda
-              archivada como histórico aunque rechaces todos los cambios.
-            </p>
-          </SheetHeader>
-
+        <DetailDrawerContent>
           <div className="mt-6 space-y-4">
             {/* Toolbar de selección */}
             <div className="flex flex-wrap items-center gap-2 border-b pb-3">
@@ -1543,19 +1537,23 @@ export function ProveedoresModule({
               </Button>
             </div>
           </div>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
 
       {/* Modal: RFC duplicado */}
-      <Sheet open={duplicadoOpen} onOpenChange={setDuplicadoOpen}>
-        <SheetContent className="sm:max-w-[480px]">
-          <SheetHeader>
-            <SheetTitle className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-amber-500" />
-              RFC ya registrado
-            </SheetTitle>
-          </SheetHeader>
-          <div className="mt-8 space-y-6">
+      <DetailDrawer
+        open={duplicadoOpen}
+        onOpenChange={setDuplicadoOpen}
+        size="sm"
+        title={
+          <span className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-amber-500" />
+            RFC ya registrado
+          </span>
+        }
+      >
+        <DetailDrawerContent>
+          <div className="space-y-6">
             <p className="text-sm">
               El RFC{' '}
               <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
@@ -1601,8 +1599,8 @@ export function ProveedoresModule({
               Actualizar CSF&rdquo; en su detalle.
             </p>
           </div>
-        </SheetContent>
-      </Sheet>
+        </DetailDrawerContent>
+      </DetailDrawer>
     </div>
   );
 }

--- a/components/rh/departamentos-module.tsx
+++ b/components/rh/departamentos-module.tsx
@@ -39,7 +39,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { DataTable } from '@/components/module-page';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import {
   Dialog,
   DialogContent,
@@ -519,18 +519,15 @@ export function DepartamentosModule({
 
       {/* Create / Edit form — Sheet or Dialog */}
       {createVariant === 'sheet' ? (
-        <Sheet open={showDialog} onOpenChange={setShowDialog}>
-          <SheetContent
-            side="right"
-            className="w-full max-w-md border-[var(--border)] bg-[var(--card)] text-[var(--text)]"
-          >
-            <SheetHeader>
-              <SheetTitle>{editingId ? 'Editar departamento' : 'Nuevo departamento'}</SheetTitle>
-            </SheetHeader>
-            {FormBody}
-            <SheetFooter className="gap-2">{FormActions}</SheetFooter>
-          </SheetContent>
-        </Sheet>
+        <DetailDrawer
+          open={showDialog}
+          onOpenChange={setShowDialog}
+          size="sm"
+          title={editingId ? 'Editar departamento' : 'Nuevo departamento'}
+          footer={<div className="flex flex-wrap items-center gap-2">{FormActions}</div>}
+        >
+          <DetailDrawerContent>{FormBody}</DetailDrawerContent>
+        </DetailDrawer>
       ) : (
         <Dialog open={showDialog} onOpenChange={setShowDialog}>
           <DialogContent className="max-w-md rounded-3xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]">

--- a/components/rh/puestos-module.tsx
+++ b/components/rh/puestos-module.tsx
@@ -38,7 +38,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { DataTable } from '@/components/module-page';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import {
   Dialog,
   DialogContent,
@@ -662,18 +662,15 @@ export function PuestosModule({
 
       {/* Create / Edit form — Sheet or Dialog */}
       {createVariant === 'sheet' ? (
-        <Sheet open={showDialog} onOpenChange={setShowDialog}>
-          <SheetContent
-            side="right"
-            className="w-full max-w-lg overflow-y-auto border-[var(--border)] bg-[var(--card)] text-[var(--text)]"
-          >
-            <SheetHeader>
-              <SheetTitle>{editingId ? 'Editar puesto' : 'Nuevo puesto'}</SheetTitle>
-            </SheetHeader>
-            {FormBody}
-            <SheetFooter className="gap-2">{FormActions}</SheetFooter>
-          </SheetContent>
-        </Sheet>
+        <DetailDrawer
+          open={showDialog}
+          onOpenChange={setShowDialog}
+          size="md"
+          title={editingId ? 'Editar puesto' : 'Nuevo puesto'}
+          footer={<div className="flex flex-wrap items-center gap-2">{FormActions}</div>}
+        >
+          <DetailDrawerContent>{FormBody}</DetailDrawerContent>
+        </DetailDrawer>
       ) : (
         <Dialog open={showDialog} onOpenChange={setShowDialog}>
           <DialogContent className="max-h-[90vh] max-w-xl overflow-y-auto rounded-3xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]">

--- a/components/tasks/tasks-create-form.tsx
+++ b/components/tasks/tasks-create-form.tsx
@@ -20,13 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -291,19 +285,15 @@ function RichCreateSheet({ open, onOpenChange, onCreate, empleadoOptions }: Task
   };
 
   return (
-    <Sheet open={open} onOpenChange={handleOpenChange}>
-      <SheetContent
-        side="right"
-        className="w-full sm:max-w-lg border-[var(--border)] bg-[var(--card)] text-[var(--text)] overflow-y-auto"
-      >
-        <SheetHeader className="pb-2">
-          <SheetTitle className="text-[var(--text)] text-lg">Nueva Tarea</SheetTitle>
-          <SheetDescription className="text-[var(--text)]/50">
-            Completa los campos requeridos para crear una tarea
-          </SheetDescription>
-        </SheetHeader>
-
-        <Form form={form} onSubmit={handleSubmit} className="space-y-5 py-4">
+    <DetailDrawer
+      open={open}
+      onOpenChange={handleOpenChange}
+      size="sm"
+      title="Nueva Tarea"
+      description="Completa los campos requeridos para crear una tarea"
+    >
+      <DetailDrawerContent>
+        <Form form={form} onSubmit={handleSubmit} className="space-y-5">
           <FormField name="titulo" label="Título" required>
             {(field) => (
               <Input
@@ -399,7 +389,7 @@ function RichCreateSheet({ open, onOpenChange, onCreate, empleadoOptions }: Task
             stretch
           />
         </Form>
-      </SheetContent>
-    </Sheet>
+      </DetailDrawerContent>
+    </DetailDrawer>
   );
 }

--- a/components/tasks/tasks-edit-form.tsx
+++ b/components/tasks/tasks-edit-form.tsx
@@ -21,13 +21,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -361,20 +355,20 @@ function RichEditSheet({
   };
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent
-        side="right"
-        className="w-full sm:max-w-lg border-[var(--border)] bg-[var(--card)] text-[var(--text)] overflow-y-auto"
-      >
-        <SheetHeader className="pb-2">
-          <SheetTitle className="text-[var(--text)] text-lg">Editar Tarea</SheetTitle>
-          <SheetDescription className="text-[var(--text)]/50">
-            {selectedTask?.departamento_nombre && `${selectedTask.departamento_nombre} · `}
-            Creada {formatDate(selectedTask?.created_at ?? null)}
-          </SheetDescription>
-        </SheetHeader>
-
-        <Form form={form} onSubmit={handleSubmit} className="space-y-5 py-4">
+    <DetailDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      size="sm"
+      title="Editar Tarea"
+      description={
+        <>
+          {selectedTask?.departamento_nombre && `${selectedTask.departamento_nombre} · `}
+          Creada {formatDate(selectedTask?.created_at ?? null)}
+        </>
+      }
+    >
+      <DetailDrawerContent>
+        <Form form={form} onSubmit={handleSubmit} className="space-y-5">
           <FormField name="titulo" label="Título" required>
             {(field) => (
               <Input
@@ -573,8 +567,8 @@ function RichEditSheet({
             />
           </div>
         </Form>
-      </SheetContent>
-    </Sheet>
+      </DetailDrawerContent>
+    </DetailDrawer>
   );
 }
 


### PR DESCRIPTION
## Summary

Sprint 3 de `drawer-anatomy-polish`. Cierra las "excepciones documentadas" de `drawer-anatomy` v1 — Beto autorizó retomar la migración postergada para cerrar el patrón end-to-end.

### Migrados de `<Sheet>` raw a `<DetailDrawer>`

**DILESA list pages** (4 sheets "Nuevo X" → `size="md"`):
- [terrenos](app/dilesa/terrenos/page.tsx) · [prototipos](app/dilesa/prototipos/page.tsx) · [proyectos](app/dilesa/proyectos/page.tsx) · [anteproyectos](app/dilesa/anteproyectos/page.tsx)

**Settings** (2):
- [empresa-detail.tsx](app/settings/empresas/_components/empresa-detail.tsx) — drawer "Actualizar CSF" (`size="lg"` con title compuesto por `Sparkles` + nombre)
- [acceso-client.tsx](app/settings/acceso/acceso-client.tsx) — User Detail Sheet (`size="lg"`, state-machine con tabs + ScrollArea custom preservado)

**RDB** (3):
- [productos/page.tsx](app/rdb/productos/page.tsx) — 2 drawers (Configurar + Nuevo Producto)
- [requisiciones/page.tsx](app/rdb/requisiciones/page.tsx) — 2 drawers (Detalle + Nueva/Editar) con printlayout y action="Imprimir" preservados via `actions` prop
- [inicio/juntas/[id]/page.tsx](app/inicio/juntas/[id]/page.tsx) — Sheet "Agregar avance"

**Componentes shared** (5 archivos, 11 drawers):
- [proveedores-module.tsx](components/proveedores/proveedores-module.tsx) — 5 drawers (Detail + Edit + Create + Diff CSF + RFC duplicado). Detail con `actions` prop (CSF/Editar/Inactivar/Imprimir) sin `absolute right-12 top-4` mágico.
- [rh/puestos-module.tsx](components/rh/puestos-module.tsx) + [rh/departamentos-module.tsx](components/rh/departamentos-module.tsx) — sheets alta/edición con `FormActions` en `footer` prop (form mode idiomático ADR-026)
- [tasks/tasks-create-form.tsx](components/tasks/tasks-create-form.tsx) + [tasks-edit-form.tsx](components/tasks/tasks-edit-form.tsx)
- [juntas/admin-juntas-list-module.tsx](components/juntas/admin-juntas-list-module.tsx) — sheet "Nueva Junta"
- [juntas/junta-detail-module.tsx](components/juntas/junta-detail-module.tsx) — sheet "Agregar avance"

### Resultado

- **Cero `<Sheet>`/`<SheetContent>` directos** en `app/` o `components/` excepto `components/ui/sheet.tsx` (primitivo) y `components/detail-page/detail-drawer.tsx` (wrapper canónico).
- Todos los drawers heredan **DD7-DD9** (header sin colisión + mobile-friendly) automáticamente.
- Tamaños literales (`sm:max-w-[600px]`/`[640px]`/`[700px]`/`[800px]`, `max-w-md`/`lg`/`xl`) reemplazados por sizes canónicos `sm`/`md`/`lg`.

Sprint 4 (próximo) — closeout: smoke en preview + mover iniciativa a Done en `INITIATIVES.md` + bitácora.

## Test plan

- [x] `npm run typecheck` (verde)
- [x] `npm run lint` (76 warnings preexistentes, 0 errors)
- [x] `npm run format:check` (verde)
- [x] `npm run test:run` (401 tests verde)
- [x] Verificación: `grep '@/components/ui/sheet' --include="*.tsx" --include="*.ts"` solo regresa `components/detail-page/detail-drawer.tsx`
- [ ] Smoke en preview: abrir 3 drawers de muestra (DILESA terrenos "Nuevo terreno", Productos "Configurar", Tasks "Nueva tarea") y verificar que el header no se solapa con la X y que las acciones se ven en mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)