### PR TITLE
fix(drawer-anatomy): body wrapper flex-col para que ScrollArea raw scrollee

### DIFF
--- a/components/detail-page/detail-drawer.tsx
+++ b/components/detail-page/detail-drawer.tsx
@@ -33,6 +33,12 @@ import { cn } from '@/lib/utils';
  * Sub-components for body composition:
  * - `<DetailDrawerSection>` — canonical sub-section with title/description/divider (DD10).
  * - `<DetailDrawerSkeleton>` — loading placeholder (DD11).
+ *
+ * The body wrapper is `flex flex-col flex-1 min-h-0`. Children must claim the
+ * available height to scroll: either use `<DetailDrawerContent>` (recommended,
+ * already does it via `<ScrollArea h-full>`) or a custom `<ScrollArea>` with
+ * `flex-1 min-h-0`. Plain `<div>` children won't scroll — they sit at intrinsic
+ * height and overflow gets cut off.
  */
 
 export type DetailDrawerProps = {
@@ -86,7 +92,7 @@ export function DetailDrawer({
       >
         <DetailDrawerHeader title={title} description={description} meta={meta} actions={actions} />
 
-        <div className="flex-1 min-h-0">{children}</div>
+        <div className="flex-1 min-h-0 flex flex-col">{children}</div>
 
         {footer ? (
           <div className="border-t border-[var(--border)] px-6 py-3 print:hidden">{footer}</div>

--- a/components/proveedores/proveedores-module.tsx
+++ b/components/proveedores/proveedores-module.tsx
@@ -17,7 +17,6 @@ import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { DataTable, type Column } from '@/components/module-page';
 import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';


### PR DESCRIPTION
## Summary

Reportado: el drawer "Nueva Requisición" no scrollea cuando hay muchos productos. Después del barrido de `drawer-anatomy-polish` quedaron 2 callers con `<ScrollArea className="min-h-0 flex-1">` raw — patrón válido en intención pero roto en práctica.

### Causa raíz

`<DetailDrawer>` envuelve children en `<div flex-1 min-h-0>` (un div, NO un flex container). Cuando el caller mete `<ScrollArea flex-1>`, el `flex-1` no aplica porque el padre no es flex → el ScrollArea queda con altura intrínseca (= contenido) → no hay scroll.

### Fix

Cambio mínimo en el componente: `<div flex-1 min-h-0>` → `<div flex-1 min-h-0 flex flex-col>`. Ahora tolera ambos patrones:

- `<DetailDrawerContent>` usa `<ScrollArea h-full>` internamente — sigue funcionando (h-full resuelve al alto del flex-1 padre).
- `<ScrollArea flex-1 min-h-0>` raw — **ahora también funciona** porque está en flex-col.

### Beneficiados sin tocar el caller

- [app/rdb/requisiciones/page.tsx](app/rdb/requisiciones/page.tsx) — 2 sheets (Detail + Nueva/Editar) con printlayout custom.
- [app/settings/acceso/acceso-client.tsx](app/settings/acceso/acceso-client.tsx) — User Detail Sheet con state-machine de tabs.

### Cleanup colateral

- [components/proveedores/proveedores-module.tsx](components/proveedores/proveedores-module.tsx): import muerto de `ScrollArea` (quedó del Sprint 3 de `drawer-anatomy-polish`).
- JSDoc del componente extendido para documentar el contrato del body y las dos formas válidas de claim height.

### Por qué no abrir iniciativa nueva

Es un fix de 1 línea al componente base. La iniciativa `drawer-anatomy-polish` cerró ayer pero este caso específico no lo cubría — quedó del Sprint 3 cuando preservé `<ScrollArea>` artesanal en algunos callers en lugar de migrarlos a `<DetailDrawerContent>`. El fix component-level resuelve ambos sin re-tocar callers.

## Test plan

- [x] `npm run typecheck` (verde)
- [x] `npm run lint` (75 warnings preexistentes, 0 errors)
- [x] `npm run format:check` (verde)
- [x] `npm run test:run` (802 tests verde)
- [ ] Smoke en preview: abrir `/rdb/requisiciones` con una requisición de 10+ productos y verificar que scrollea. Repetir con `/settings/acceso` (drawer de usuario con muchas excepciones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)