### PR TITLE
test(drawer-anatomy): regression guard + nota en CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,33 @@ Hasta entonces, Reglas 1+2 deberían ser suficientes.
 
 ---
 
+## Reglas UI
+
+### Drawers — scroll y anatomía (ADR-018, ADR-026)
+
+`<DetailDrawer>` (en [components/detail-page/detail-drawer.tsx](components/detail-page/detail-drawer.tsx))
+es el wrapper canónico para drawers laterales. Hay 2 patrones que se confunden
+y rompen el scroll cuando se mezclan; ambos son válidos por separado:
+
+- **Idiomático**: usar `<DetailDrawerContent>` como hijo directo. Ya hace
+  `<ScrollArea h-full>` internamente — scrollea solo. **Default recomendado.**
+- **Custom**: meter `<ScrollArea className="flex-1 min-h-0">` raw (sin
+  `<DetailDrawerContent>`) cuando se necesita padding/print stylesheet
+  diferente al default. Funciona porque el body del drawer es flex-col
+  container (commit 3c96b45).
+
+Lo que **NO** funciona: meter `<div>` con contenido directo sin scroll
+wrapper. El body del drawer es `flex-1 min-h-0` con altura constreñida —
+el contenido se corta sin scroll. Si el contenido puede crecer (lista
+de items, form largo), siempre envolver en uno de los dos patrones.
+
+Test de regresión en [components/detail-page/detail-drawer.test.ts](components/detail-page/detail-drawer.test.ts)
+guarda los invariantes del componente base (DD7-DD11). Si CI rompe ahí,
+es porque alguien quitó `flex flex-col` del body o `pr-14` del header u
+otro contrato del DetailDrawer — restaurar antes de mergear.
+
+---
+
 ## Reglas DB
 
 - Always refer to `supabase/SCHEMA_REF.md` for exact table and column names to prevent mapping errors. Date/timestamp columns are returned in UTC, so parse them with a proper timezone.

--- a/components/detail-page/detail-drawer.test.ts
+++ b/components/detail-page/detail-drawer.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Source-level invariants for `<DetailDrawer>` (ADR-018, ADR-026).
+ *
+ * Why source-level instead of render-based: this repo's test setup is
+ * env=node with no jsdom or @testing-library/react. Adding those for a
+ * single regression guard isn't worth it. Reading the source string and
+ * asserting on critical strings is a pragmatic compromise that catches
+ * the specific bugs we want to prevent (PR #350, see CLAUDE.md "Reglas UI").
+ *
+ * If these tests start being noisy (flaky on whitespace changes, etc.) it's
+ * a signal to invest in proper component testing.
+ */
+
+const drawerPath = path.resolve(__dirname, 'detail-drawer.tsx');
+const source = readFileSync(drawerPath, 'utf8');
+
+describe('<DetailDrawer> source invariants', () => {
+  it('body wrapper is a flex-col container so children with flex-1 inherit constrained height', () => {
+    // Regression guard for PR #350: dropping `flex flex-col` here breaks
+    // <ScrollArea flex-1> raw inside the drawer body — it loses its height
+    // context and the drawer stops scrolling when content overflows.
+    expect(source).toMatch(/flex-1 min-h-0 flex flex-col/);
+  });
+
+  it('header reserves padding-right for the native X close button (DD7)', () => {
+    // ADR-026 DD7: the SheetContent ships with an absolute X at top-3 right-3
+    // (28×28). The header must keep `pr-14` on the SheetHeader so neither
+    // the title nor the actions collide with it.
+    expect(source).toMatch(/pr-14/);
+  });
+
+  it('title clamps to 2 lines and breaks long words (DD8)', () => {
+    // ADR-026 DD8: prevents the title from invading the X area or growing
+    // unbounded when given a long string like "Editar Documento Legal · Acta Constitutiva".
+    expect(source).toMatch(/line-clamp-2 break-words/);
+  });
+
+  it('actions are visible on mobile (no `hidden sm:flex`) — DD9', () => {
+    // ADR-026 DD9: actions stack vertically on mobile, never disappear.
+    // If `hidden sm:flex` reappears here, mobile users lose primary actions.
+    expect(source).not.toMatch(/hidden sm:flex/);
+  });
+
+  it('exports DetailDrawerSection (DD10)', () => {
+    expect(source).toMatch(/export function DetailDrawerSection/);
+  });
+
+  it('exports DetailDrawerSkeleton (DD11)', () => {
+    expect(source).toMatch(/export function DetailDrawerSkeleton/);
+  });
+
+  it('print stylesheet by construction (DD5): no max-w + no padding when printing', () => {
+    expect(source).toMatch(/print:max-w-full/);
+    expect(source).toMatch(/print:p-0/);
+  });
+});


### PR DESCRIPTION
## Summary

Bloquea futuras regresiones del bug del scroll que cerró [PR #350](https://github.com/beto-sudo/BSOP/pull/350). Sigue la sugerencia de Beto de hacer **(1) test de regresión + (3) nota en CLAUDE.md** (descartamos DD12 en ADR-018 — la iniciativa `drawer-anatomy-polish` ya cerró y tocar el ADR ahora es ceremonia).

### `components/detail-page/detail-drawer.test.ts`

Test source-level (sin `@testing-library/react` — el repo no lo tiene y agregarlo solo para esto no vale). Lee el archivo del componente con `readFileSync` y verifica con regex los 7 invariantes críticos:

1. Body wrapper contiene `flex-1 min-h-0 flex flex-col` (DD3 + fix del scroll).
2. Header contiene `pr-14` (DD7 — espacio para X de cierre).
3. Title con `line-clamp-2 break-words` (DD8).
4. **NO** contiene `hidden sm:flex` (DD9 — actions visibles en mobile).
5-6. Exporta `DetailDrawerSection` y `DetailDrawerSkeleton` (DD10-DD11).
7. Print stylesheet por construcción (DD5).

Verificado manualmente: si alguien quita `flex flex-col` del body, el test falla con el mensaje exacto del invariante.

### `CLAUDE.md`

Nueva sección "Reglas UI" → "Drawers — scroll y anatomía" antes de "Reglas DB". Documenta:

- Los 2 patrones válidos: `<DetailDrawerContent>` idiomático vs `<ScrollArea flex-1 min-h-0>` raw.
- El patrón roto: `<div>` sin scroll wrapper (contenido se corta).
- Apunta al test de regresión como red de seguridad.

Cubre el caso donde una sesión futura de Claude Code hace una migración similar a Sprint 3 de `drawer-anatomy-polish` — la regla queda visible al inicio sin tener que abrir ADR-018/ADR-026.

## Test plan

- [x] `npm run typecheck` (verde)
- [x] `npm run test:run` (1210 tests verde, +7 nuevos)
- [x] `npm run lint` (75 warnings preexistentes, 0 errors)
- [x] `npm run format:check` (verde)
- [x] Verificación manual de la regresión: quité `flex flex-col` del body con sed → test falló como esperado → restauré.

🤖 Generated with [Claude Code](https://claude.com/claude-code)