### PR TITLE
feat(oc-recepciones-modulo): DB migration + RBAC sync para slug rdb.recepciones (Sprint 1)

### DIFF
--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -106,6 +106,7 @@ export const NAV_ITEMS: NavItem[] = [
           { label: 'Proveedores', href: '/rdb/proveedores' },
           { label: 'Requisiciones', href: '/rdb/requisiciones' },
           { label: 'Órdenes de Compra', href: '/rdb/ordenes-compra' },
+          { label: 'Recepciones', href: '/rdb/recepciones' },
         ],
       },
       {

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -197,6 +197,7 @@ const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   'rdb.requisiciones',
   'rdb.playtomic',
   'rdb.ordenes_compra',
+  'rdb.recepciones',
   'rdb.admin.tasks',
   'rdb.admin.juntas',
   'rdb.admin.documentos',

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -50,6 +50,7 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   '/rdb/requisiciones': 'rdb.requisiciones',
   '/rdb/playtomic': 'rdb.playtomic',
   '/rdb/ordenes-compra': 'rdb.ordenes_compra',
+  '/rdb/recepciones': 'rdb.recepciones',
 
   // RDB — administración
   '/rdb/admin/tasks': 'rdb.admin.tasks',

--- a/supabase/migrations/20260430140000_modulo_rdb_recepciones.sql
+++ b/supabase/migrations/20260430140000_modulo_rdb_recepciones.sql
@@ -1,0 +1,60 @@
+-- Crea el módulo `rdb.recepciones` en core.modulos + backfill defensivo de
+-- permisos clonando los permisos actuales de `rdb.ordenes_compra` para
+-- preservar el status quo entre el `apply` de esta migración y el ajuste
+-- fino que Beto hace manualmente por rol.
+--
+-- Contexto: iniciativa `oc-recepciones-modulo` (ver
+-- docs/planning/oc-recepciones-modulo.md). Hoy todo el ciclo OC vive en un
+-- solo módulo RBAC (`rdb.ordenes_compra`) — quien tiene escritura accede
+-- a TODO (crear, enviar, imprimir, cerrar, cancelar, override de precio, Y
+-- recibir mercancía). Esta migración agrega el slug nuevo `rdb.recepciones`
+-- al catálogo, dejando la división fina de permisos por rol en manos de
+-- Beto post-aplicación.
+--
+-- Pasos:
+--   1. INSERT del slug `rdb.recepciones` en core.modulos (sección 'compras').
+--   2. Backfill defensivo: por cada `(rol_id, modulo_id)` existente en
+--      core.permisos_rol para `rdb.ordenes_compra` en RDB, clonar
+--      acceso_lectura y acceso_escritura al `rdb.recepciones` recién creado.
+--      Sin esto, el módulo nuevo quedaría INVISIBLE a no-admin users (regla
+--      de "Liberación de módulo nuevo (RBAC sync)" en BSOP/CLAUDE.md).
+--      Beto luego rebaja Gerente en módulo OC y/o ajusta otros roles según
+--      el modelo operativo final.
+--   3. NOTIFY pgrst para refrescar el cache de schema.
+
+BEGIN;
+
+-- Paso 1: Insertar el módulo en core.modulos.
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT 'rdb.recepciones',
+       'Recepciones',
+       'Captura de recepciones de productos contra OCs enviadas + cancelación de pendiente por línea',
+       e.empresa_id,
+       'compras'
+FROM (SELECT id AS empresa_id FROM core.empresas WHERE slug = 'rdb') AS e
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+-- Paso 2: Backfill defensivo — clonar permisos de `rdb.ordenes_compra` →
+-- `rdb.recepciones` para cada rol existente en RDB. Idempotente vía
+-- ON CONFLICT.
+INSERT INTO core.permisos_rol (rol_id, modulo_id, acceso_lectura, acceso_escritura)
+SELECT pr.rol_id,
+       m_new.id,
+       pr.acceso_lectura,
+       pr.acceso_escritura
+FROM core.permisos_rol pr
+JOIN core.modulos m_oc
+  ON m_oc.id = pr.modulo_id
+JOIN core.empresas e
+  ON e.id = m_oc.empresa_id
+JOIN core.modulos m_new
+  ON m_new.empresa_id = e.id
+ AND m_new.slug = 'rdb.recepciones'
+WHERE e.slug = 'rdb'
+  AND m_oc.slug = 'rdb.ordenes_compra'
+ON CONFLICT (rol_id, modulo_id) DO NOTHING;
+
+-- Reload PostgREST schema cache.
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

- Sprint 1 de [`oc-recepciones-modulo`](https://github.com/beto-sudo/BSOP/blob/main/docs/planning/oc-recepciones-modulo.md). Crea el slug `rdb.recepciones` en `core.modulos` y cierra los 4 lugares del protocolo "Liberación de módulo nuevo (RBAC sync)" del CLAUDE.md.
- **Migración SQL** (no aplicada — Beto la corre con `psql`): INSERT en `core.modulos` con `seccion='compras'` + backfill defensivo que clona los permisos actuales de `rdb.ordenes_compra` → `rdb.recepciones` por cada rol existente en RDB para preservar status quo. Sin el backfill, el módulo nuevo quedaría invisible a no-admin users.
- **Código**: `nav-config.ts` agrega entrada en sidebar bajo "Compras"; `permissions.ts` agrega route mapping; `permissions.test.ts` agrega slug a `EXPECTED_DB_MODULE_SLUGS`.

## ⏸ PAUSA después de mergear

Beto aplica la SQL con `psql` y hace su división fina de permisos por rol (rebajar Gerente en módulo OC, etc.) **antes** de arrancar Sprint 2 (página nueva). El page del Sprint 2 monta `<RequireAccess module="rdb.recepciones">`; sin la migración aplicada, todos reciben "Acceso denegado".

## Test plan

- [ ] CI verde (typecheck + lint + format:check + test:run)
- [ ] Migración SQL revisada antes de aplicar
- [ ] Después del apply: query a `core.modulos WHERE slug='rdb.recepciones'` retorna 1 row
- [ ] Después del apply: query a `core.permisos_rol` para `rdb.recepciones` clona el comportamiento de `rdb.ordenes_compra`
- [ ] Sidebar muestra "Recepciones" bajo "Compras" de RDB (sigue oculto si el usuario no tiene acceso)

🤖 Generated with [Claude Code](https://claude.com/claude-code)