### PR TITLE
feat(viendo-como-readonly): Sprint 1 — read-only + cookie de preview

### DIFF
--- a/app/api/impersonate/route.test.ts
+++ b/app/api/impersonate/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
 /**
- * Unit tests for `app/api/impersonate/route.ts` (GET).
+ * Unit tests for `app/api/impersonate/route.ts` (POST).
  *
  * Security-sensitive, admin-only endpoint: every branch that gates access
  * must fail closed and every branch that builds the permission payload for
@@ -192,7 +192,7 @@ function makeReq(searchParams: Record<string, string> = {}) {
 // module system — dynamic import inside each test keeps the env predictable.
 async function loadHandler() {
   const mod = await import('./route');
-  return mod.GET;
+  return mod.POST;
 }
 
 // ── Defaults ──────────────────────────────────────────────────────────────
@@ -228,31 +228,31 @@ beforeEach(() => {
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
-describe('GET /api/impersonate — rate limit', () => {
+describe('POST /api/impersonate — rate limit', () => {
   it('returns the rate-limiter response unchanged when check fails', async () => {
     const blocked = new Response(JSON.stringify({ error: 'Too many requests' }), {
       status: 429,
     });
     rateLimitResult = { ok: false, response: blocked as unknown as Response };
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
 
     expect(res).toBe(blocked);
   });
 
   it('proceeds past the rate limit when ok', async () => {
     // Default state is ok + admin caller + valid target → 200.
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(200);
   });
 });
 
-describe('GET /api/impersonate — query validation', () => {
+describe('POST /api/impersonate — query validation', () => {
   it('returns 400 when userId is missing', async () => {
-    const GET = await loadHandler();
-    const res = await GET(makeReq({}));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({}));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toBe('Invalid request');
@@ -260,25 +260,25 @@ describe('GET /api/impersonate — query validation', () => {
   });
 
   it('returns 400 when userId is not a valid UUID', async () => {
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: 'not-a-uuid' }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: 'not-a-uuid' }));
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.issues?.[0]?.path).toBe('userId');
   });
 
   it('accepts a valid UUID and continues past validation', async () => {
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(200);
   });
 });
 
-describe('GET /api/impersonate — caller authentication', () => {
+describe('POST /api/impersonate — caller authentication', () => {
   it('returns 401 when the server client has no user', async () => {
     serverGetUserResult = { data: { user: null } };
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.error).toBe('Not authenticated');
@@ -288,23 +288,23 @@ describe('GET /api/impersonate — caller authentication', () => {
     serverGetUserResult = {
       data: { user: { email: '' as unknown as string } },
     };
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(401);
   });
 
   it('returns 500 when the admin client cannot be built', async () => {
     adminClientOverrideActive = true;
     adminClientOverride = null;
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('Server config error');
   });
 });
 
-describe('GET /api/impersonate — caller authorization', () => {
+describe('POST /api/impersonate — caller authorization', () => {
   it('returns 403 when caller is not an admin', async () => {
     installAdminMock({
       callerUser: { rol: 'user' },
@@ -315,8 +315,8 @@ describe('GET /api/impersonate — caller authorization', () => {
         activo: true,
       },
     });
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toBe('Forbidden');
@@ -332,8 +332,8 @@ describe('GET /api/impersonate — caller authorization', () => {
         activo: true,
       },
     });
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(403);
   });
 
@@ -344,20 +344,20 @@ describe('GET /api/impersonate — caller authorization', () => {
     serverGetUserResult = {
       data: { user: { email: 'Admin@BSOP.TEST' } },
     };
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(200);
   });
 });
 
-describe('GET /api/impersonate — target lookup', () => {
+describe('POST /api/impersonate — target lookup', () => {
   it('returns 404 when the target user does not exist', async () => {
     installAdminMock({
       callerUser: { rol: 'admin' },
       targetUser: null,
     });
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toBe('User not found or inactive');
@@ -373,13 +373,13 @@ describe('GET /api/impersonate — target lookup', () => {
         activo: false,
       },
     });
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(404);
   });
 });
 
-describe('GET /api/impersonate — admin target short-circuit', () => {
+describe('POST /api/impersonate — admin target short-circuit', () => {
   it('returns isAdmin=true with empty empresas / modulos when target has rol=admin', async () => {
     installAdminMock({
       callerUser: { rol: 'admin' },
@@ -394,8 +394,8 @@ describe('GET /api/impersonate — admin target short-circuit', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({
@@ -407,7 +407,7 @@ describe('GET /api/impersonate — admin target short-circuit', () => {
   });
 });
 
-describe('GET /api/impersonate — non-admin target payload', () => {
+describe('POST /api/impersonate — non-admin target payload', () => {
   it('returns an empty empresas/modulos payload for a user with no memberships', async () => {
     installAdminMock({
       callerUser: { rol: 'admin' },
@@ -430,8 +430,8 @@ describe('GET /api/impersonate — non-admin target payload', () => {
       userExcepciones: [],
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body).toEqual({
       isAdmin: false,
@@ -467,8 +467,8 @@ describe('GET /api/impersonate — non-admin target payload', () => {
       ],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body.empresas).toEqual({
       rdb: { read: true, write: true },
@@ -517,8 +517,8 @@ describe('GET /api/impersonate — non-admin target payload', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body.modulos).toEqual({
       'rdb.ventas': { read: true, write: true },
@@ -550,8 +550,8 @@ describe('GET /api/impersonate — non-admin target payload', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body.empresas).toEqual({ rdb: { read: true, write: true } });
     expect(body.modulos).toEqual({});
@@ -587,8 +587,8 @@ describe('GET /api/impersonate — non-admin target payload', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body.modulos).toEqual({
       'rdb.ventas': { read: true, write: true },
@@ -619,14 +619,14 @@ describe('GET /api/impersonate — non-admin target payload', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body.modulos['rdb.ventas']).toEqual({ read: false, write: false });
   });
 });
 
-describe('GET /api/impersonate — exception overrides', () => {
+describe('POST /api/impersonate — exception overrides', () => {
   it('overrides role-derived modulo perms with matching exception rows', async () => {
     installAdminMock({
       callerUser: { rol: 'admin' },
@@ -657,8 +657,8 @@ describe('GET /api/impersonate — exception overrides', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body.modulos['rdb.ventas']).toEqual({ read: true, write: false });
   });
@@ -696,8 +696,8 @@ describe('GET /api/impersonate — exception overrides', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body.modulos['rdb.cortes']).toEqual({ read: true, write: false });
     // Role-derived perm still stands.
@@ -734,8 +734,8 @@ describe('GET /api/impersonate — exception overrides', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     expect(body.modulos).toEqual({
       'rdb.ventas': { read: true, write: true },
@@ -772,15 +772,15 @@ describe('GET /api/impersonate — exception overrides', () => {
       allEmpresas: [{ id: 'e-rdb', slug: 'rdb' }],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     const body = await res.json();
     // Exception with nulls fully revokes access (null → false).
     expect(body.modulos['rdb.ventas']).toEqual({ read: false, write: false });
   });
 });
 
-describe('GET /api/impersonate — happy-path shape', () => {
+describe('POST /api/impersonate — happy-path shape', () => {
   it('returns isAdmin=false with the target email and fully-built dicts', async () => {
     installAdminMock({
       callerUser: { rol: 'admin' },
@@ -827,8 +827,8 @@ describe('GET /api/impersonate — happy-path shape', () => {
       ],
     });
 
-    const GET = await loadHandler();
-    const res = await GET(makeReq({ userId: TARGET_UUID }));
+    const POST = await loadHandler();
+    const res = await POST(makeReq({ userId: TARGET_UUID }));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({

--- a/app/api/impersonate/route.ts
+++ b/app/api/impersonate/route.ts
@@ -5,12 +5,24 @@ import { z } from 'zod';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { validateQuery } from '@/lib/validation';
 import { impersonateRateLimiter, extractIdentifier } from '@/lib/ratelimit';
+import { PREVIEW_COOKIE_NAME } from '@/lib/auth/preview-guard';
 
 const ImpersonateQuerySchema = z.object({
   userId: z.string().uuid('userId must be a valid UUID'),
 });
 
-export async function GET(req: NextRequest) {
+/**
+ * Starts a "Viendo como" preview session.
+ *
+ * Validates the caller is admin, computes the target user's effective
+ * permissions and returns them as JSON, then sets the `bsop_preview_as`
+ * cookie (httpOnly, sameSite=lax, path=/). The cookie marks the session
+ * as read-only end-to-end (proxy.ts blocks mutations + server actions
+ * call `assertNotInPreview()`).
+ *
+ * The cookie is cleared by `POST /api/impersonate/stop`.
+ */
+export async function POST(req: NextRequest) {
   const rate = await impersonateRateLimiter.check(extractIdentifier(req));
   if (!rate.ok) return rate.response;
 
@@ -74,6 +86,12 @@ export async function GET(req: NextRequest) {
 
   // If target is admin, return admin permissions
   if (targetUser.rol === 'admin') {
+    cookieStore.set(PREVIEW_COOKIE_NAME, targetUser.id, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      secure: process.env.NODE_ENV === 'production',
+    });
     return NextResponse.json({
       isAdmin: true,
       email: targetUser.email,
@@ -145,6 +163,13 @@ export async function GET(req: NextRequest) {
       write: exc.acceso_escritura ?? false,
     };
   }
+
+  cookieStore.set(PREVIEW_COOKIE_NAME, targetUser.id, {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    secure: process.env.NODE_ENV === 'production',
+  });
 
   return NextResponse.json({
     isAdmin: false,

--- a/app/api/impersonate/stop/route.ts
+++ b/app/api/impersonate/stop/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { PREVIEW_COOKIE_NAME } from '@/lib/auth/preview-guard';
+
+/**
+ * Ends the "Viendo como" preview session by clearing the `bsop_preview_as`
+ * cookie. Idempotent — safe to call when no preview is active.
+ *
+ * Exempt from the read-only mutation block in proxy.ts so admins can always
+ * exit preview, even mid-session.
+ */
+export async function POST() {
+  const cookieStore = await cookies();
+  cookieStore.delete(PREVIEW_COOKIE_NAME);
+  return NextResponse.json({ ok: true });
+}

--- a/app/rdb/cortes/actions.ts
+++ b/app/rdb/cortes/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { assertNotInPreview } from '@/lib/auth/preview-guard';
 import type { Banco, Voucher, VoucherCategoria } from '@/components/cortes/types';
 
 const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
@@ -37,6 +38,7 @@ export type AbrirCajaResult =
   | { ok: false; error: string };
 
 export async function abrirCaja(input: AbrirCajaInput): Promise<AbrirCajaResult> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {
@@ -173,6 +175,7 @@ export type CerrarCajaInput = {
 };
 
 export async function cerrarCaja(input: CerrarCajaInput): Promise<void> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {
@@ -239,6 +242,7 @@ export type RegistrarMovimientoInput = {
 export async function registrarMovimiento(
   input: RegistrarMovimientoInput
 ): Promise<{ id: string }> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {
@@ -315,6 +319,7 @@ export type SubirVoucherInput = {
 export async function subirVoucher(
   input: SubirVoucherInput
 ): Promise<{ id: string; signed_url: string }> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {
@@ -390,6 +395,7 @@ export async function subirVoucher(
 }
 
 export async function eliminarVoucher(voucher_id: string): Promise<void> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {
@@ -509,6 +515,7 @@ export type ConfirmarVoucherInput = {
 };
 
 export async function confirmarVoucher(input: ConfirmarVoucherInput): Promise<void> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {
@@ -555,6 +562,7 @@ export type ActualizarCategoriaVoucherInput = {
 export async function actualizarCategoriaVoucher(
   input: ActualizarCategoriaVoucherInput
 ): Promise<void> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {

--- a/app/rdb/inventario/levantamientos/actions.ts
+++ b/app/rdb/inventario/levantamientos/actions.ts
@@ -7,6 +7,7 @@ import { revalidatePath } from 'next/cache';
 import { headers } from 'next/headers';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { assertNotInPreview } from '@/lib/auth/preview-guard';
 import type { Json } from '@/types/supabase';
 import {
   RDB_EMPRESA_ID,
@@ -23,6 +24,7 @@ import {
 export async function crearLevantamiento(
   input: CrearLevantamientoInput
 ): Promise<ActionResult<{ id: string; folio: string | null }>> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {
@@ -60,6 +62,7 @@ export async function crearLevantamiento(
 export async function iniciarCaptura(
   levantamiento_id: string
 ): Promise<ActionResult<{ lineasSembradas: number }>> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const { data, error } = await supabase
@@ -78,6 +81,7 @@ export async function guardarConteo(
   producto_id: string,
   cantidad: number
 ): Promise<ActionResult> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const { error } = await supabase.schema('erp').rpc('fn_guardar_conteo', {
@@ -91,6 +95,7 @@ export async function guardarConteo(
 }
 
 export async function cerrarCaptura(levantamiento_id: string): Promise<ActionResult> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const { error } = await supabase
@@ -107,6 +112,7 @@ export async function cerrarCaptura(levantamiento_id: string): Promise<ActionRes
 // ─── Firma ────────────────────────────────────────────────────────────────────
 
 export async function firmarPaso(input: FirmarPasoInput): Promise<ActionResult<FirmarPasoData>> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
   const hdrs = await headers();
   const ipHeader =
@@ -153,6 +159,7 @@ export async function cancelarLevantamiento(
   levantamiento_id: string,
   motivo: string
 ): Promise<ActionResult> {
+  await assertNotInPreview();
   const motivoTrim = motivo.trim();
   if (!motivoTrim) {
     return { ok: false, error: 'El motivo de cancelación es requerido.' };
@@ -217,6 +224,7 @@ export async function actualizarNotaDiferencia(
   linea_id: string,
   nota: string
 ): Promise<ActionResult> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {

--- a/app/rdb/productos/actions.ts
+++ b/app/rdb/productos/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { assertNotInPreview } from '@/lib/auth/preview-guard';
 
 const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
@@ -19,6 +20,7 @@ export type UpsertRecetaInput = {
 export type UpsertRecetaResult = { ok: true } | { ok: false; error: string };
 
 export async function upsertReceta(input: UpsertRecetaInput): Promise<UpsertRecetaResult> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {
@@ -91,6 +93,7 @@ export type UpdateCategoriaInput = {
 export type UpdateCategoriaResult = { ok: true } | { ok: false; error: string };
 
 export async function updateCategoria(input: UpdateCategoriaInput): Promise<UpdateCategoriaResult> {
+  await assertNotInPreview();
   const supabase = await createSupabaseServerClient();
 
   const {

--- a/app/rdb/requisiciones/actions.ts
+++ b/app/rdb/requisiciones/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { assertNotInPreview } from '@/lib/auth/preview-guard';
 
 const RDB_EMPRESA_ID = 'e52ac307-9373-4115-b65e-1178f0c4e1aa';
 
@@ -66,6 +67,7 @@ export async function guardarRequisicion(
   items: DraftItemInput[],
   notas?: string | null
 ): Promise<{ id: string; folio: string }> {
+  await assertNotInPreview();
   try {
     const { supabase, user } = await requireAuth();
 
@@ -131,6 +133,7 @@ export async function actualizarRequisicion(
   items: DraftItemInput[],
   notas?: string | null
 ): Promise<void> {
+  await assertNotInPreview();
   const { supabase } = await requireAuth();
 
   const sanitizedItems = items
@@ -198,6 +201,7 @@ export async function actualizarRequisicion(
 }
 
 export async function aprobarRequisicion(id: string): Promise<void> {
+  await assertNotInPreview();
   const { supabase, user } = await requireAuth();
 
   const { error } = await supabase
@@ -215,6 +219,7 @@ export async function aprobarRequisicion(id: string): Promise<void> {
 export async function generarOrdenCompra(
   requisicionId: string
 ): Promise<{ id: string; folio: string }> {
+  await assertNotInPreview();
   const { supabase } = await requireAuth();
 
   // Load requisicion items
@@ -297,6 +302,7 @@ async function requireAdmin() {
 }
 
 export async function borrarRequisicion(id: string): Promise<void> {
+  await assertNotInPreview();
   const { supabase } = await requireAdmin();
 
   const { data: existing, error: existingError } = await supabase

--- a/app/settings/acceso/actions.ts
+++ b/app/settings/acceso/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { assertNotInPreview } from '@/lib/auth/preview-guard';
 import { generateWelcomeHtml, type WelcomeEmpresa } from '@/lib/welcome-email';
 
 // ── Legacy flat-role types (pre-RBAC) ──────────────────────────────────────
@@ -63,6 +64,7 @@ export type ExcepcionUsuario = {
 };
 
 async function requireAdmin(): Promise<void> {
+  await assertNotInPreview();
   const cookieStore = await cookies();
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/components/app-shell/impersonation-banner.tsx
+++ b/components/app-shell/impersonation-banner.tsx
@@ -1,6 +1,12 @@
 /**
  * Amber sticky banner shown while an admin is previewing another user.
- * Clicking "Salir de vista previa" calls the parent-provided handler to stop.
+ *
+ * The session is read-only end-to-end — proxy.ts rejects mutations and
+ * server actions call `assertNotInPreview()`. The banner copy reflects
+ * that contract so the admin knows edits will not go through.
+ *
+ * Clicking "Salir de vista previa" calls the parent-provided handler to
+ * stop, which clears both the in-memory state and the httpOnly cookie.
  */
 export function ImpersonationBanner({ label, onStop }: { label: string; onStop: () => void }) {
   return (
@@ -10,11 +16,12 @@ export function ImpersonationBanner({ label, onStop }: { label: string; onStop: 
       className="sticky top-0 z-50 flex items-center justify-between gap-3 bg-amber-500 px-4 py-2 text-sm font-medium text-white shadow-sm print:hidden"
     >
       <span>
-        👁️ Viendo como: <strong>{label}</strong>
+        👁️ Viendo como: <strong>{label}</strong> — solo lectura, las acciones de edición están
+        deshabilitadas.
       </span>
       <button
         onClick={onStop}
-        className="rounded-md bg-white/20 px-3 py-1 text-xs font-semibold hover:bg-white/30 transition-colors"
+        className="shrink-0 rounded-md bg-white/20 px-3 py-1 text-xs font-semibold hover:bg-white/30 transition-colors"
       >
         Salir de vista previa
       </button>

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -51,6 +51,19 @@ export function usePermissions() {
   return useContext(PermissionsContext);
 }
 
+/**
+ * Returns `true` while an admin is in a "Viendo como" preview session.
+ *
+ * Components rendering forms, edit buttons, or other write CTAs should
+ * disable themselves when this is `true` — the server will reject the
+ * underlying mutation anyway (see proxy.ts and `assertNotInPreview()`),
+ * but a disabled button avoids confusing 403 toasts mid-flow.
+ */
+export function useReadOnlyMode(): boolean {
+  const { impersonating } = usePermissions();
+  return impersonating !== null;
+}
+
 function PermissionsProvider({ children }: { children: ReactNode }) {
   const [permissions, setPermissions] = useState<UserPermissions>(DEFAULT_PERMISSIONS);
   const [realPermissions, setRealPermissions] = useState<UserPermissions>(DEFAULT_PERMISSIONS);
@@ -76,6 +89,15 @@ function PermissionsProvider({ children }: { children: ReactNode }) {
       return realPermissionsRef.current;
     }
   }, [supabase]);
+
+  const clearImpersonateCookie = useCallback(async () => {
+    try {
+      await fetch('/api/impersonate/stop', { method: 'POST' });
+    } catch {
+      // Silently ignore — the cookie is httpOnly so we can't fall back to JS.
+      // Proxy still respects whatever the server sees; user can refresh.
+    }
+  }, []);
 
   // Load initial permissions
   useEffect(() => {
@@ -106,14 +128,17 @@ function PermissionsProvider({ children }: { children: ReactNode }) {
         setRealPermissions(fallback);
         setPermissions(fallback);
         setImpersonating(null);
+        void clearImpersonateCookie();
       }
     });
 
     return () => subscription.unsubscribe();
-  }, [supabase, loadReal, impersonating]);
+  }, [supabase, loadReal, impersonating, clearImpersonateCookie]);
 
   const fetchImpersonatePerms = useCallback(async (userId: string): Promise<UserPermissions> => {
-    const res = await fetch(`/api/impersonate?userId=${encodeURIComponent(userId)}`);
+    const res = await fetch(`/api/impersonate?userId=${encodeURIComponent(userId)}`, {
+      method: 'POST',
+    });
     if (!res.ok) return { ...DEFAULT_PERMISSIONS, loading: false };
     const data = await res.json();
     return {
@@ -166,7 +191,8 @@ function PermissionsProvider({ children }: { children: ReactNode }) {
   const stopImpersonate = useCallback(() => {
     setImpersonating(null);
     setPermissions(realPermissions);
-  }, [realPermissions]);
+    void clearImpersonateCookie();
+  }, [realPermissions, clearImpersonateCookie]);
 
   const value = useMemo(
     () => ({ permissions, refreshPermissions, impersonating, startImpersonate, stopImpersonate }),

--- a/lib/auth/preview-guard.test.ts
+++ b/lib/auth/preview-guard.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let cookieStoreState: { value: string | null };
+
+vi.mock('next/headers', () => ({
+  cookies: async () => ({
+    get: (name: string) => {
+      if (name === 'bsop_preview_as' && cookieStoreState.value) {
+        return { name, value: cookieStoreState.value };
+      }
+      return undefined;
+    },
+  }),
+}));
+
+beforeEach(() => {
+  cookieStoreState = { value: null };
+});
+
+describe('preview-guard', () => {
+  it('isInPreview returns false when no cookie is set', async () => {
+    const { isInPreview } = await import('./preview-guard');
+    expect(await isInPreview()).toBe(false);
+  });
+
+  it('isInPreview returns true when cookie is set', async () => {
+    cookieStoreState.value = '11111111-1111-4111-8111-111111111111';
+    const { isInPreview } = await import('./preview-guard');
+    expect(await isInPreview()).toBe(true);
+  });
+
+  it('getPreviewUserId returns null when no cookie is set', async () => {
+    const { getPreviewUserId } = await import('./preview-guard');
+    expect(await getPreviewUserId()).toBeNull();
+  });
+
+  it('getPreviewUserId returns the cookie value when set', async () => {
+    cookieStoreState.value = '22222222-2222-4222-8222-222222222222';
+    const { getPreviewUserId } = await import('./preview-guard');
+    expect(await getPreviewUserId()).toBe('22222222-2222-4222-8222-222222222222');
+  });
+
+  it('assertNotInPreview resolves when no cookie is set', async () => {
+    const { assertNotInPreview } = await import('./preview-guard');
+    await expect(assertNotInPreview()).resolves.toBeUndefined();
+  });
+
+  it('assertNotInPreview throws PreviewModeError when cookie is set', async () => {
+    cookieStoreState.value = '33333333-3333-4333-8333-333333333333';
+    const { assertNotInPreview, PreviewModeError } = await import('./preview-guard');
+    await expect(assertNotInPreview()).rejects.toBeInstanceOf(PreviewModeError);
+  });
+
+  it('requireNotInPreview returns null when no cookie is set', async () => {
+    const { requireNotInPreview } = await import('./preview-guard');
+    expect(await requireNotInPreview()).toBeNull();
+  });
+
+  it('requireNotInPreview returns 403 NextResponse when cookie is set', async () => {
+    cookieStoreState.value = '44444444-4444-4444-8444-444444444444';
+    const { requireNotInPreview } = await import('./preview-guard');
+    const res = await requireNotInPreview();
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe(403);
+    const body = await res!.json();
+    expect(body.error).toMatch(/vista previa/i);
+  });
+});

--- a/lib/auth/preview-guard.ts
+++ b/lib/auth/preview-guard.ts
@@ -1,0 +1,52 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+/**
+ * Cookie that marks an active "Viendo como" preview session for an admin.
+ *
+ * Set by `POST /api/impersonate` (with the impersonated `userId` as value),
+ * cleared by `POST /api/impersonate/stop`. httpOnly + path=/.
+ *
+ * While set, all mutation traffic is blocked end-to-end:
+ *   - `middleware.ts` rejects POST/PUT/PATCH/DELETE on `/api/**`.
+ *   - Server actions call `assertNotInPreview()` at the top of each mutation.
+ *   - The frontend `useReadOnlyMode()` hook disables CTAs.
+ *
+ * Together this enforces the "preview = read-only" contract from the
+ * `viendo-como-readonly` initiative.
+ */
+export const PREVIEW_COOKIE_NAME = 'bsop_preview_as';
+
+export async function getPreviewUserId(): Promise<string | null> {
+  const c = await cookies();
+  return c.get(PREVIEW_COOKIE_NAME)?.value ?? null;
+}
+
+export async function isInPreview(): Promise<boolean> {
+  return (await getPreviewUserId()) !== null;
+}
+
+export class PreviewModeError extends Error {
+  constructor() {
+    super('Modo vista previa activo: las acciones están deshabilitadas');
+    this.name = 'PreviewModeError';
+  }
+}
+
+/** Throws PreviewModeError if a preview cookie is present. Use in server actions. */
+export async function assertNotInPreview(): Promise<void> {
+  if (await isInPreview()) {
+    throw new PreviewModeError();
+  }
+}
+
+/** Returns a 403 NextResponse if a preview cookie is present, else null. Use in route handlers. */
+export async function requireNotInPreview(): Promise<NextResponse | null> {
+  if (await isInPreview()) {
+    return NextResponse.json(
+      { error: 'Modo vista previa activo: las acciones están deshabilitadas' },
+      { status: 403 }
+    );
+  }
+  return null;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,17 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { createClient } from '@supabase/supabase-js';
+import { PREVIEW_COOKIE_NAME } from '@/lib/auth/preview-guard';
 // NOTE: The 'core' schema must be listed in Supabase Dashboard → Settings → API → Exposed Schemas.
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/**
+ * `/api/**` mutation paths that must work even while a preview session is
+ * active. Without these exemptions an admin in preview mode could not exit
+ * ("stop") and could not switch targets ("impersonate" again).
+ */
+const PREVIEW_EXEMPT_API_PATHS = new Set(['/api/impersonate', '/api/impersonate/stop']);
 
 function isPublicPath(pathname: string) {
   return (
@@ -118,6 +128,25 @@ export default async function proxy(request: NextRequest) {
     appUrl.pathname = '/';
     appUrl.search = '';
     return NextResponse.redirect(appUrl);
+  }
+
+  // Read-only enforcement while "Viendo como" is active. Reject any mutation
+  // request to /api/** when the preview cookie is set, except the management
+  // endpoints (/api/impersonate, /api/impersonate/stop) which must keep
+  // working so admins can switch targets or exit preview.
+  if (
+    MUTATION_METHODS.has(request.method) &&
+    pathname.startsWith('/api/') &&
+    !PREVIEW_EXEMPT_API_PATHS.has(pathname) &&
+    request.cookies.get(PREVIEW_COOKIE_NAME)?.value
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          'Modo vista previa activo: las acciones están deshabilitadas. Salí del preview para continuar.',
+      },
+      { status: 403 }
+    );
   }
 
   return response;


### PR DESCRIPTION
## Resumen

Sprint 1 de [`viendo-como-readonly`](docs/planning/viendo-como-readonly.md). Cierra el primer hueco: durante el preview, **ninguna mutation pasa al server**.

## Defensa en profundidad (3 capas)

1. **Cookie httpOnly `bsop_preview_as`** seteada por `POST /api/impersonate` (con el `userId` impersonado), borrada por `POST /api/impersonate/stop`. Path `/`, sameSite `lax`, `secure` en prod. JS del cliente NO puede leerla — solo los endpoints la manejan.
2. **`proxy.ts`** rechaza POST/PUT/PATCH/DELETE en `/api/**` con 403 cuando la cookie está set. Exempt: `/api/impersonate` y `/api/impersonate/stop` (para que admin pueda cambiar de target o salir).
3. **`assertNotInPreview()`** al inicio de cada mutation en server actions (5 archivos, ~37 mutations). Throws `PreviewModeError`, Next.js lo maneja como server action error normal.

## Cambios principales

- `lib/auth/preview-guard.ts` (nuevo) — `isInPreview`, `getPreviewUserId`, `assertNotInPreview`, `requireNotInPreview`, `PREVIEW_COOKIE_NAME`, `PreviewModeError`.
- `app/api/impersonate/route.ts` — GET → POST, agrega cookie set tras validar admin + permisos del target.
- `app/api/impersonate/stop/route.ts` (nuevo) — borra cookie, idempotente.
- `proxy.ts` — bloqueo de mutations con cookie set.
- `components/providers.tsx` — `startImpersonate` usa POST, `stopImpersonate` llama `/stop`, cookie también se limpia en logout. Nuevo hook `useReadOnlyMode()`.
- `components/app-shell/impersonation-banner.tsx` — copy: "Viendo como X — solo lectura, las acciones de edición están deshabilitadas".
- 5 server actions con guard al inicio:
  - `app/rdb/cortes/actions.ts` (7 mutations: abrir/cerrar caja, registrar mov, voucher x4)
  - `app/rdb/inventario/levantamientos/actions.ts` (7 mutations)
  - `app/rdb/productos/actions.ts` (2 mutations)
  - `app/rdb/requisiciones/actions.ts` (5 mutations)
  - `app/settings/acceso/actions.ts` (16 mutations vía `requireAdmin()`)

## Tests

- `lib/auth/preview-guard.test.ts` (8 tests nuevos): isInPreview, getPreviewUserId, assertNotInPreview throws, requireNotInPreview returns 403.
- `app/api/impersonate/route.test.ts` ajustado de GET a POST.
- **842 tests pass** (834 + 8 nuevos).

## Plan de prueba

- [x] `npm run typecheck` verde
- [x] `npm run test:run` verde (842 tests)
- [x] `npm run lint` verde (0 errors, 75 warnings preexistentes)
- [x] `npm run format:check` verde
- [ ] CI verde

## Próximo

Sprint 2: helper `getEffectiveUserId()` + refactor de `MisTareasWidget` y otros widgets `/inicio/*` para que muestren los datos del usuario impersonado, no del admin real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)