### PR TITLE
feat(viendo-como-readonly): Sprint 2 — override de userId en widgets /inicio

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/ssr';
+import { getEffectiveUser } from '@/lib/auth/effective-user';
+
+/**
+ * Returns the effective user for "personal" widgets (`/inicio`, "mis tareas",
+ * etc). Resolves to the impersonated user when an admin is in preview mode,
+ * otherwise to the caller.
+ *
+ * Used by the `useEffectiveUser()` hook. Must NOT be called as a substitute
+ * for `auth.getUser()` for permission decisions — it only swaps identity for
+ * personal-data reads.
+ */
+export async function GET() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options));
+        },
+      },
+    }
+  );
+
+  const effective = await getEffectiveUser(supabase);
+  if (!effective) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  return NextResponse.json(effective);
+}

--- a/app/inicio/juntas/page.tsx
+++ b/app/inicio/juntas/page.tsx
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { useEffectiveUser, useReadOnlyMode } from '@/components/providers';
 import { DataTable, type Column } from '@/components/module-page';
 import {
   Dialog,
@@ -85,6 +86,8 @@ function EstadoBadge({ estado }: { estado: Junta['estado'] }) {
 function JuntasInner() {
   const router = useRouter();
   const supabase = createSupabaseERPClient();
+  const { data: effective, loading: effectiveLoading } = useEffectiveUser();
+  const readOnly = useReadOnlyMode();
 
   const [empresaIds, setEmpresaIds] = useState<string[]>([]);
   const [juntas, setJuntas] = useState<Junta[]>([]);
@@ -106,31 +109,19 @@ function JuntasInner() {
   });
 
   const fetchEmpresaIds = useCallback(async (): Promise<string[]> => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return [];
-
-    const { data: coreUser } = await supabase
-      .schema('core')
-      .from('usuarios')
-      .select('id')
-      .eq('email', (user.email ?? '').toLowerCase())
-      .maybeSingle();
-
-    if (!coreUser) return [];
+    if (!effective?.id) return [];
 
     const { data: ueData } = await supabase
       .schema('core')
       .from('usuarios_empresas')
       .select('empresa_id')
-      .eq('usuario_id', coreUser.id)
+      .eq('usuario_id', effective.id)
       .eq('activo', true);
 
     const ids = (ueData ?? []).map((r: any) => r.empresa_id as string);
     setEmpresaIds(ids);
     return ids;
-  }, [supabase]);
+  }, [supabase, effective]);
 
   const fetchJuntas = useCallback(
     async (ids: string[]) => {
@@ -155,6 +146,7 @@ function JuntasInner() {
   );
 
   useEffect(() => {
+    if (effectiveLoading) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -170,7 +162,7 @@ function JuntasInner() {
     return () => {
       cancelled = true;
     };
-  }, [fetchEmpresaIds, fetchJuntas]);
+  }, [fetchEmpresaIds, fetchJuntas, effectiveLoading]);
 
   const handleCreate = async () => {
     if (!createForm.titulo.trim() || !createForm.fecha_hora || empresaIds.length === 0) return;
@@ -302,7 +294,9 @@ function JuntasInner() {
           <Button
             size="sm"
             onClick={() => setShowCreate(true)}
-            className="rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90 gap-1.5"
+            disabled={readOnly}
+            title={readOnly ? 'Salí del modo vista previa para crear juntas' : undefined}
+            className="rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90 gap-1.5 disabled:opacity-50"
           >
             <Plus className="h-4 w-4" />
             Crear nueva junta

--- a/app/inicio/page.tsx
+++ b/app/inicio/page.tsx
@@ -16,6 +16,7 @@ import { ContentShell } from '@/components/ui/content-shell';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { MisTareasWidget } from '@/components/inicio/mis-tareas-widget';
 import { FechasImportantesWidget } from '@/components/inicio/fechas-importantes-widget';
+import { useEffectiveUser } from '@/components/providers';
 import { useLocale } from '@/lib/i18n';
 import { getGreeting, formatLongDate } from '@/lib/datetime/greeting';
 
@@ -25,23 +26,28 @@ import { getGreeting, formatLongDate } from '@/lib/datetime/greeting';
  */
 export default function InicioPage() {
   const { t, locale } = useLocale();
-  const [userName, setUserName] = useState<string>('');
+  const { data: effective } = useEffectiveUser();
+  const [callerName, setCallerName] = useState<string>('');
 
   useEffect(() => {
+    // Fallback to auth metadata only when there's no effective user yet
+    // (e.g. /api/me hasn't returned). Once effective is available, that wins.
     const supabase = createSupabaseBrowserClient();
     supabase.auth.getUser().then(({ data }) => {
       const meta = data?.user?.user_metadata as
         | { first_name?: string; full_name?: string }
         | undefined;
       if (meta?.first_name) {
-        setUserName(meta.first_name);
+        setCallerName(meta.first_name);
       } else if (meta?.full_name) {
-        setUserName(meta.full_name.split(' ')[0]);
+        setCallerName(meta.full_name.split(' ')[0]);
       } else if (data?.user?.email) {
-        setUserName(data.user.email.split('@')[0]);
+        setCallerName(data.user.email.split('@')[0]);
       }
     });
   }, []);
+
+  const userName = effective?.email ? effective.email.split('@')[0] : callerName;
 
   return (
     <ContentShell>

--- a/components/inicio/fechas-importantes-widget.tsx
+++ b/components/inicio/fechas-importantes-widget.tsx
@@ -13,6 +13,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { CalendarHeart, Cake, PartyPopper, Flag } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { useEffectiveUser } from '@/components/providers';
 import { Surface } from '@/components/ui/surface';
 import { Skeleton } from '@/components/ui/skeleton';
 import { festivosEnRango, type DiaFestivo } from '@/lib/inicio/dias-festivos';
@@ -82,35 +83,19 @@ function formatFechaCorta(d: Date): string {
 
 export function FechasImportantesWidget() {
   const supabase = useMemo(() => createSupabaseERPClient(), []);
+  const { data: effective, loading: effectiveLoading } = useEffectiveUser();
   const [cumples, setCumples] = useState<Cumpleanero[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (effectiveLoading) return;
     let cancelled = false;
     (async () => {
       setLoading(true);
       setError(null);
       try {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        if (!user?.email) {
-          if (!cancelled) {
-            setCumples([]);
-            setLoading(false);
-          }
-          return;
-        }
-
-        const { data: coreUser } = await supabase
-          .schema('core')
-          .from('usuarios')
-          .select('id')
-          .eq('email', user.email.toLowerCase())
-          .maybeSingle();
-
-        if (!coreUser) {
+        if (!effective?.id) {
           if (!cancelled) {
             setCumples([]);
             setLoading(false);
@@ -122,7 +107,7 @@ export function FechasImportantesWidget() {
           .schema('core')
           .from('usuarios_empresas')
           .select('empresa_id')
-          .eq('usuario_id', coreUser.id)
+          .eq('usuario_id', effective.id)
           .eq('activo', true);
 
         const empresaIds = (ue ?? []).map((r: { empresa_id: string }) => r.empresa_id);
@@ -183,7 +168,7 @@ export function FechasImportantesWidget() {
     return () => {
       cancelled = true;
     };
-  }, [supabase]);
+  }, [supabase, effective, effectiveLoading]);
 
   const eventos = useMemo<EventoItem[]>(() => {
     const today = startOfDay(new Date());

--- a/components/inicio/mis-tareas-widget.tsx
+++ b/components/inicio/mis-tareas-widget.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { useEffectiveUser } from '@/components/providers';
 import { Surface } from '@/components/ui/surface';
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -96,43 +97,28 @@ function formatRelative(iso: string | null, todayIso: string): string {
 
 export function MisTareasWidget() {
   const supabase = useMemo(() => createSupabaseERPClient(), []);
+  const { data: effective, loading: effectiveLoading } = useEffectiveUser();
   const [tasks, setTasks] = useState<TaskRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const loadTasks = useCallback(async () => {
+    if (effectiveLoading) return;
     setLoading(true);
     setError(null);
     try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user?.email) {
+      if (!effective?.email) {
         setTasks([]);
         setLoading(false);
         return;
       }
 
-      // core.usuarios por email
-      const { data: coreUser } = await supabase
-        .schema('core')
-        .from('usuarios')
-        .select('id')
-        .eq('email', user.email.toLowerCase())
-        .maybeSingle();
-
-      if (!coreUser) {
-        setTasks([]);
-        setLoading(false);
-        return;
-      }
-
-      // empresas del usuario
+      // empresas del usuario efectivo
       const { data: ue } = await supabase
         .schema('core')
         .from('usuarios_empresas')
         .select('empresa_id')
-        .eq('usuario_id', coreUser.id)
+        .eq('usuario_id', effective.id)
         .eq('activo', true);
 
       const empresaIds = (ue ?? []).map((r: { empresa_id: string }) => r.empresa_id);
@@ -142,8 +128,8 @@ export function MisTareasWidget() {
         return;
       }
 
-      // empleados del usuario en esas empresas (match por email empresa o personal)
-      const emailLower = user.email.toLowerCase();
+      // empleados del usuario efectivo en esas empresas (match por email empresa o personal)
+      const emailLower = effective.email.toLowerCase();
       const { data: empleados } = await supabase
         .schema('erp')
         .from('v_empleados_full')
@@ -185,7 +171,7 @@ export function MisTareasWidget() {
       setError('No pudimos cargar tus tareas. Intenta recargar la página.');
       setLoading(false);
     }
-  }, [supabase]);
+  }, [supabase, effective, effectiveLoading]);
 
   useEffect(() => {
     void loadTasks();

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -64,6 +64,58 @@ export function useReadOnlyMode(): boolean {
   return impersonating !== null;
 }
 
+export type EffectiveUserData = {
+  id: string;
+  email: string;
+  isAdmin: boolean;
+  isPreviewing: boolean;
+};
+
+/**
+ * Returns the effective user for personal-data widgets (`/inicio` greeting,
+ * "mis tareas", "mis juntas", etc).
+ *
+ * When an admin is previewing another user, returns the impersonated user.
+ * Otherwise returns the real caller.
+ *
+ * Refetches whenever the impersonate state changes so widgets re-render with
+ * the right identity.
+ */
+export function useEffectiveUser(): { data: EffectiveUserData | null; loading: boolean } {
+  const { impersonating } = usePermissions();
+  const [data, setData] = useState<EffectiveUserData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    // setLoading(true) is intentional here — we want to flip to loading
+    // whenever `impersonating` changes so widgets can show a skeleton until
+    // /api/me returns. eslint-disable for the initial flip; subsequent
+    // setStates live in async callbacks (already lint-clean).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLoading(true);
+    fetch('/api/me')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (!cancelled) {
+          setData(json);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setData(null);
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [impersonating]);
+
+  return { data, loading };
+}
+
 function PermissionsProvider({ children }: { children: ReactNode }) {
   const [permissions, setPermissions] = useState<UserPermissions>(DEFAULT_PERMISSIONS);
   const [realPermissions, setRealPermissions] = useState<UserPermissions>(DEFAULT_PERMISSIONS);

--- a/components/tasks/tasks-module.tsx
+++ b/components/tasks/tasks-module.tsx
@@ -32,6 +32,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Plus, RefreshCw, Eye, EyeOff } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
+import { useEffectiveUser } from '@/components/providers';
 import type { TablesInsert, TablesUpdate } from '@/types/supabase';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
@@ -108,6 +109,11 @@ export function TasksModule({
   const supabase = createSupabaseERPClient();
   const isRich = variant === 'rich';
 
+  // Effective user override: when an admin previews another user, "mis tareas"
+  // (onlyMine) should show the impersonated user's tasks. For empresa-level
+  // queries we still use the real caller. See viendo-como-readonly Sprint 2.
+  const { data: effective } = useEffectiveUser();
+
   // ── Empresa scope ──────────────────────────────────────────────────────────
   const [empresaIds, setEmpresaIds] = useState<string[]>(
     scope === 'empresa' && empresaId ? [empresaId] : []
@@ -160,27 +166,39 @@ export function TasksModule({
 
   const fetchEmpresaIds = useCallback(async (): Promise<string[]> => {
     if (scope === 'empresa') return empresaId ? [empresaId] : [];
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return [];
-    const { data: coreUser } = await supabase
-      .schema('core')
-      .from('usuarios')
-      .select('id')
-      .eq('email', (user.email ?? '').toLowerCase())
-      .maybeSingle();
-    if (!coreUser) return [];
+
+    // For onlyMine, resolve via the effective user (respects "Viendo como").
+    // For other user-empresas scopes (e.g. cross-empresa overview) use the
+    // real caller — those views are admin-side.
+    let userId: string | null = null;
+    if (onlyMine && effective?.id) {
+      userId = effective.id;
+    } else {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return [];
+      const { data: coreUser } = await supabase
+        .schema('core')
+        .from('usuarios')
+        .select('id')
+        .eq('email', (user.email ?? '').toLowerCase())
+        .maybeSingle();
+      if (!coreUser) return [];
+      userId = coreUser.id;
+    }
+    if (!userId) return [];
+
     const { data: ueData } = await supabase
       .schema('core')
       .from('usuarios_empresas')
       .select('empresa_id')
-      .eq('usuario_id', coreUser.id)
+      .eq('usuario_id', userId)
       .eq('activo', true);
     const ids = (ueData ?? []).map((r: { empresa_id: string }) => r.empresa_id);
     setEmpresaIds(ids);
     return ids;
-  }, [scope, empresaId, supabase]);
+  }, [scope, empresaId, supabase, onlyMine, effective]);
 
   const fetchRefData = useCallback(
     async (ids: string[]) => {
@@ -213,8 +231,10 @@ export function TasksModule({
       setEmpleados(mapped);
 
       // Personal view: resolve my empleado_ids across all empresas in scope.
+      // When previewing another user, the effective email is theirs.
       if (onlyMine) {
-        if (!email) {
+        const personalEmail = (effective?.email ?? email).toLowerCase();
+        if (!personalEmail) {
           setMyEmpleadoIds([]);
         } else {
           const { data: mineRows } = await supabase
@@ -222,7 +242,7 @@ export function TasksModule({
             .from('v_empleados_full')
             .select('empleado_id, empresa_id, email_empresa, email_personal')
             .in('empresa_id', ids)
-            .or(`email_empresa.eq.${email},email_personal.eq.${email}`);
+            .or(`email_empresa.eq.${personalEmail},email_personal.eq.${personalEmail}`);
           const mineIds = (mineRows ?? [])
             .map((r: { empleado_id: string | null }) => r.empleado_id)
             .filter((x: string | null): x is string => Boolean(x));
@@ -290,7 +310,7 @@ export function TasksModule({
         }
       }
     },
-    [supabase, isRich, onlyMine]
+    [supabase, isRich, onlyMine, effective]
   );
 
   const fetchTasks = useCallback(

--- a/lib/auth/effective-user.test.ts
+++ b/lib/auth/effective-user.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let cookieStoreState: { value: string | null };
+
+vi.mock('next/headers', () => ({
+  cookies: async () => ({
+    get: (name: string) => {
+      if (name === 'bsop_preview_as' && cookieStoreState.value) {
+        return { name, value: cookieStoreState.value };
+      }
+      return undefined;
+    },
+  }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let adminClient: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let adminClientOverride: any;
+let adminClientOverrideActive = false;
+
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdminClient: () => (adminClientOverrideActive ? adminClientOverride : adminClient),
+}));
+
+type Script = {
+  caller?: { id: string; email: string; rol: string; activo: boolean } | null;
+  target?: { id: string; email: string; rol: string; activo: boolean } | null;
+};
+
+function installAdmin(script: Script) {
+  adminClient = {
+    schema() {
+      return {
+        from() {
+          const ctx: { filterCols: string[] } = { filterCols: [] };
+          const chain = {
+            select: () => chain,
+            eq: (col: string) => {
+              ctx.filterCols.push(col);
+              return chain;
+            },
+            maybeSingle: async () => {
+              if (ctx.filterCols.includes('email')) {
+                return { data: script.caller ?? null, error: null };
+              }
+              if (ctx.filterCols.includes('id')) {
+                return { data: script.target ?? null, error: null };
+              }
+              return { data: null, error: null };
+            },
+          };
+          return chain;
+        },
+      };
+    },
+  };
+}
+
+const CALLER_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const TARGET_UUID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fakeSupabase = (email: string | null): any => ({
+  auth: {
+    getUser: async () => ({ data: { user: email ? { email } : null } }),
+  },
+});
+
+beforeEach(() => {
+  cookieStoreState = { value: null };
+  adminClientOverrideActive = false;
+  adminClientOverride = null;
+  installAdmin({
+    caller: { id: CALLER_UUID, email: 'caller@bsop.test', rol: 'user', activo: true },
+  });
+});
+
+describe('getEffectiveUser', () => {
+  it('returns null when caller is not authenticated', async () => {
+    const { getEffectiveUser } = await import('./effective-user');
+    const result = await getEffectiveUser(fakeSupabase(null));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when caller is not in core.usuarios', async () => {
+    installAdmin({ caller: null });
+    const { getEffectiveUser } = await import('./effective-user');
+    const result = await getEffectiveUser(fakeSupabase('orphan@bsop.test'));
+    expect(result).toBeNull();
+  });
+
+  it('returns the caller when not admin and no cookie', async () => {
+    const { getEffectiveUser } = await import('./effective-user');
+    const result = await getEffectiveUser(fakeSupabase('caller@bsop.test'));
+    expect(result).toEqual({
+      id: CALLER_UUID,
+      email: 'caller@bsop.test',
+      isAdmin: false,
+      isPreviewing: false,
+    });
+  });
+
+  it('ignores cookie when caller is not admin', async () => {
+    cookieStoreState.value = TARGET_UUID;
+    const { getEffectiveUser } = await import('./effective-user');
+    const result = await getEffectiveUser(fakeSupabase('caller@bsop.test'));
+    expect(result?.id).toBe(CALLER_UUID);
+    expect(result?.isPreviewing).toBe(false);
+  });
+
+  it('returns the caller when admin and no cookie', async () => {
+    installAdmin({
+      caller: { id: CALLER_UUID, email: 'admin@bsop.test', rol: 'admin', activo: true },
+    });
+    const { getEffectiveUser } = await import('./effective-user');
+    const result = await getEffectiveUser(fakeSupabase('admin@bsop.test'));
+    expect(result).toEqual({
+      id: CALLER_UUID,
+      email: 'admin@bsop.test',
+      isAdmin: true,
+      isPreviewing: false,
+    });
+  });
+
+  it('returns the target when admin with valid cookie', async () => {
+    cookieStoreState.value = TARGET_UUID;
+    installAdmin({
+      caller: { id: CALLER_UUID, email: 'admin@bsop.test', rol: 'admin', activo: true },
+      target: { id: TARGET_UUID, email: 'target@bsop.test', rol: 'user', activo: true },
+    });
+    const { getEffectiveUser } = await import('./effective-user');
+    const result = await getEffectiveUser(fakeSupabase('admin@bsop.test'));
+    expect(result).toEqual({
+      id: TARGET_UUID,
+      email: 'target@bsop.test',
+      isAdmin: false,
+      isPreviewing: true,
+    });
+  });
+
+  it('falls back to caller when admin and cookie target is not found', async () => {
+    cookieStoreState.value = TARGET_UUID;
+    installAdmin({
+      caller: { id: CALLER_UUID, email: 'admin@bsop.test', rol: 'admin', activo: true },
+      target: null,
+    });
+    const { getEffectiveUser } = await import('./effective-user');
+    const result = await getEffectiveUser(fakeSupabase('admin@bsop.test'));
+    expect(result?.id).toBe(CALLER_UUID);
+    expect(result?.isPreviewing).toBe(false);
+  });
+
+  it('returns null when admin client is unavailable', async () => {
+    adminClientOverrideActive = true;
+    adminClientOverride = null;
+    const { getEffectiveUser } = await import('./effective-user');
+    const result = await getEffectiveUser(fakeSupabase('caller@bsop.test'));
+    expect(result).toBeNull();
+  });
+});

--- a/lib/auth/effective-user.ts
+++ b/lib/auth/effective-user.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabase';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { getPreviewUserId } from './preview-guard';
+
+export type EffectiveUser = {
+  /** `core.usuarios.id` of the effective user (real or impersonated). */
+  id: string;
+  email: string;
+  isAdmin: boolean;
+  /** True only when the caller is admin AND a preview cookie is active. */
+  isPreviewing: boolean;
+};
+
+/**
+ * Resolves who the request should "act as" for personal data widgets
+ * (`/inicio`, "mis tareas", "mis juntas", etc.).
+ *
+ * Rules:
+ *   - Caller is not admin → effective user IS the caller, regardless of cookie.
+ *   - Caller is admin without preview cookie → effective user IS the caller.
+ *   - Caller is admin with preview cookie → effective user is the cookie target,
+ *     validated against `core.usuarios.activo = true`. If the target is no
+ *     longer active (or doesn't exist), falls back to the caller.
+ *
+ * Read-only enforcement is enforced separately in proxy.ts and server actions.
+ * This helper only swaps identity for *reads* of personal data.
+ *
+ * Returns `null` when the caller is not authenticated.
+ */
+export async function getEffectiveUser(
+  supabase: SupabaseClient<Database>
+): Promise<EffectiveUser | null> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return null;
+
+  const callerEmail = user.email.toLowerCase();
+
+  const admin = getSupabaseAdminClient();
+  if (!admin) return null;
+
+  const { data: caller } = await admin
+    .schema('core')
+    .from('usuarios')
+    .select('id, email, rol, activo')
+    .eq('email', callerEmail)
+    .eq('activo', true)
+    .maybeSingle();
+
+  if (!caller) return null;
+
+  const callerSelf: EffectiveUser = {
+    id: caller.id,
+    email: caller.email,
+    isAdmin: caller.rol === 'admin',
+    isPreviewing: false,
+  };
+
+  if (caller.rol !== 'admin') return callerSelf;
+
+  const previewUserId = await getPreviewUserId();
+  if (!previewUserId) return callerSelf;
+
+  const { data: target } = await admin
+    .schema('core')
+    .from('usuarios')
+    .select('id, email, rol, activo')
+    .eq('id', previewUserId)
+    .eq('activo', true)
+    .maybeSingle();
+
+  if (!target) return callerSelf;
+
+  return {
+    id: target.id,
+    email: target.email,
+    isAdmin: target.rol === 'admin',
+    isPreviewing: true,
+  };
+}


### PR DESCRIPTION
## Resumen

Sprint 2 de [`viendo-como-readonly`](docs/planning/viendo-como-readonly.md). Cierra el bug que reportó Beto: cuando admin está "Viendo como" otro usuario, `/inicio` ahora muestra **los datos del usuario impersonado**, no del admin real.

## Cómo funciona

1. **`lib/auth/effective-user.ts`** (server-side): `getEffectiveUser(supabase)` resuelve la identidad efectiva.
   - Caller no admin → siempre devuelve al caller (cookie ignorada).
   - Caller admin sin cookie → devuelve al caller.
   - Caller admin con cookie → devuelve el target validado (`core.usuarios.activo = true`).
   - Si el target no existe / está inactivo, fallback al caller.

2. **`GET /api/me`** route handler que expone `effective` al cliente.

3. **`useEffectiveUser()`** hook (en `components/providers.tsx`) llama `/api/me` y refetcha cuando cambia `impersonating`.

4. **Widgets refactorizados** para usar el hook en lugar de `supabase.auth.getUser()`:
   - `MisTareasWidget` — filtra empleado_ids por el email efectivo.
   - `FechasImportantesWidget` — empresas y cumpleaños del usuario efectivo.
   - `app/inicio/page.tsx` — greeting con nombre derivado del email efectivo.
   - `app/inicio/juntas/page.tsx` — fetchEmpresaIds usa `effective.id`. Botón Crear deshabilitado vía `useReadOnlyMode()`.
   - `TasksModule` — solo aplica el override cuando `onlyMine` (vistas personales). Las listas a nivel empresa siguen con el caller real.

## Lo que NO cambia

- **Header / displayName**: sigue mostrando el nombre del actor real. El banner naranja "Viendo como X — solo lectura" ya comunica el contexto, y el admin sigue siendo el que opera.
- **Vistas no-personales** (catálogos, ventas, OC, etc.): siguen mostrando los datos reales de la empresa, no la vista de Maribel. Eso requeriría camino A (suplantación honesta de sesión), explícitamente fuera de alcance.
- **Mutations**: ya bloqueadas por Sprint 1. Sprint 2 solo cambia identidad para reads.

## Tests

- `lib/auth/effective-user.test.ts` (8 tests nuevos) cubre: no-auth, no-core-user, caller no admin sin cookie, caller no admin con cookie (ignorada), caller admin sin cookie, caller admin con cookie válida, caller admin con cookie inválida (fallback), admin client unavailable.
- **850 tests pass** (842 + 8 nuevos).

## Plan de prueba

- [x] `npm run typecheck` verde
- [x] `npm run test:run` verde (850 tests)
- [x] `npm run lint` verde (0 errors, 75 warnings preexistentes)
- [x] `npm run format:check` verde
- [ ] CI verde

## Próximo

Sprint 3: ADR-027 documentando la decisión + closeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)