### PR TITLE
fix(viendo-como-readonly): acepta GET en /api/impersonate (back-compat)

### DIFF
--- a/app/api/impersonate/route.ts
+++ b/app/api/impersonate/route.ts
@@ -21,6 +21,11 @@ const ImpersonateQuerySchema = z.object({
  * call `assertNotInPreview()`).
  *
  * The cookie is cleared by `POST /api/impersonate/stop`.
+ *
+ * Accepts both GET and POST for backwards compatibility: clients running
+ * an older bundle from before Sprint 1 still call this with GET. The
+ * behavior is identical — same admin auth, same cookie set. Safe because
+ * cookie setting only happens after the admin check passes.
  */
 export async function POST(req: NextRequest) {
   const rate = await impersonateRateLimiter.check(extractIdentifier(req));
@@ -178,3 +183,9 @@ export async function POST(req: NextRequest) {
     modulos,
   });
 }
+
+// Backwards compatibility: clients on the pre-Sprint-1 bundle still call
+// this endpoint with GET. Aliasing GET to the same handler keeps them
+// working while their browsers warm up to the new bundle. Behavior is
+// identical — admin auth + same cookie set + same payload.
+export const GET = POST;


### PR DESCRIPTION
## Resumen

Hotfix: Beto reportó que el sidebar solo muestra "Inicio" cuando entra a "Viendo como" cualquier usuario.

## Diagnóstico

Runtime logs de producción:

| Time     | Method | Path             | Status |
| -------- | ------ | ---------------- | ------ |
| 20:37:28 | GET    | /api/impersonate | 405    |
| 20:37:20 | GET    | /api/impersonate | 405    |
| 20:36:55 | GET    | /api/impersonate | 405    |

El browser de Beto está corriendo el bundle JS pre-Sprint-1 (cacheado), que llama el endpoint con GET. El server actualizado solo exporta POST → 405 → `fetchImpersonatePerms` cae a `DEFAULT_PERMISSIONS` vacío (`empresas: Map()`, `modulos: Map()`) → el sidebar filtra todo y solo deja "Inicio".

## Fix

`export const GET = POST` — alias para que ambos métodos llamen al mismo handler. Behavior idéntico: misma auth de admin, mismo cookie set, mismo payload.

**Cero impacto en el contrato de read-only**: la cookie `bsop_preview_as` se setea igual sea GET o POST, y `proxy.ts` + `assertNotInPreview()` bloquean mutations independientemente del método con que se inició la sesión.

## Por qué este fix vs "Beto haz hard refresh"

Hard refresh resuelve el caso individual de Beto, pero cualquier otro admin con la app abierta y bundle viejo está roto silenciosamente. El alias GET=POST cura a todos los browsers en cualquier estado, sin pedirles que recarguen.

El alias se puede remover en una sub-iniciativa futura si nadie está corriendo bundle viejo (verificable revisando logs de `/api/impersonate` GET — cuando lleguen a 0 sostenidamente, el alias se quita).

## Plan de prueba

- [x] `npm run typecheck` verde
- [x] `npm run test:run` verde (850 tests)
- [x] `npm run lint` verde (0 errors)
- [x] `npm run format:check` verde
- [ ] CI verde
- [ ] Beto valida en producción tras merge: ver como Maribel → sidebar muestra DILESA con sus módulos

🤖 Generated with [Claude Code](https://claude.com/claude-code)