### PR TITLE
fix(dilesa-panel): filtra cards por permisos del usuario efectivo

### DIFF
--- a/app/dilesa/page.tsx
+++ b/app/dilesa/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { useMemo } from 'react';
 import { RequireAccess } from '@/components/require-access';
+import { usePermissions } from '@/components/providers';
+import { canAccessModulo, ROUTE_TO_MODULE } from '@/lib/permissions';
 import Link from 'next/link';
 import {
   ClipboardList,
@@ -59,8 +62,8 @@ const moduleGroups: ModuleGroup[] = [
     title: 'Recursos Humanos',
     items: [
       {
-        label: 'Empleados',
-        href: '/dilesa/rh/empleados',
+        label: 'Personal',
+        href: '/dilesa/rh/personal',
         icon: Users,
         color: 'bg-emerald-500/10 text-emerald-500',
       },
@@ -118,6 +121,27 @@ const moduleGroups: ModuleGroup[] = [
  * @responsive responsive
  */
 export default function DilesaPage() {
+  const { permissions } = usePermissions();
+
+  // Filter cards by the effective user's permissions. When admin is in
+  // "Viendo como" preview, this hides modules the impersonated user cannot
+  // access — same logic the sidebar uses (canAccessModulo). Modules without
+  // a route mapping or unrecognized are shown by default.
+  const visibleGroups = useMemo(() => {
+    if (permissions.loading) return moduleGroups;
+    if (permissions.isAdmin) return moduleGroups;
+    return moduleGroups
+      .map((group) => ({
+        ...group,
+        items: group.items.filter((item) => {
+          const moduloSlug = ROUTE_TO_MODULE[item.href];
+          if (!moduloSlug) return true;
+          return canAccessModulo(permissions, moduloSlug);
+        }),
+      }))
+      .filter((group) => group.items.length > 0);
+  }, [permissions]);
+
   return (
     <RequireAccess empresa="dilesa">
       <div className="space-y-6">
@@ -144,7 +168,7 @@ export default function DilesaPage() {
           </div>
         </section>
 
-        {moduleGroups.map((group) => (
+        {visibleGroups.map((group) => (
           <section key={group.title} className="space-y-3">
             <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text)]/50">
               {group.title}


### PR DESCRIPTION
## Resumen

Beto reportó que el panel `/dilesa` muestra **todas las cards** de módulos aunque esté "Viendo como" un usuario sin acceso a varios. Hueco menor del Camino B que Sprint 1 ni 2 cubrieron — el sidebar SÍ filtraba, pero el panel no.

## Fix

**`app/dilesa/page.tsx`**:

- Agrega `usePermissions()` + `canAccessModulo` + `ROUTE_TO_MODULE` para filtrar cards. Mismo patrón que el sidebar.
- Admin sigue viendo todo.
- Mientras `permissions.loading`, se muestran todos los grupos (evita flash).
- Si un grupo queda sin items tras filtrar, se oculta entero (no se muestra el header solo).

**Bug colateral arreglado:**

- Card "Empleados" apuntaba a `/dilesa/rh/empleados` — ruta que **no existe físicamente**. La URL canónica es `/dilesa/rh/personal` (ver `ROUTE_TO_MODULE` en [lib/permissions.ts](lib/permissions.ts)). Sin esto, el filtrado fallaría porque el href no encontraría mapping → la card aparecería siempre.
- Label también pasa de "Empleados" → "Personal" para coincidir con el sidebar.

## Lo que NO cubre

Acceder por URL directa (ej. `/dilesa/anteproyectos`) sigue cargando datos reales aunque el impersonado no tenga acceso. Eso es **Camino A** — explícitamente fuera de alcance en ADR-027:

> Vistas no-personales (catálogos, ventas, OC, etc.) siguen mostrando los datos reales de la empresa. Si Beto necesita "ver lo que Maribel ve en X módulo de catálogo", eso requiere camino A — sub-iniciativa propia.

## Plan de prueba

- [x] `npm run typecheck` verde
- [x] `npm run test:run` verde (850 tests)
- [x] `npm run lint` verde (0 errors)
- [x] `npm run format:check` verde
- [ ] CI verde
- [ ] Beto valida en producción: ver como Maribel → panel `/dilesa` solo muestra los módulos que ella tiene en su rol

🤖 Generated with [Claude Code](https://claude.com/claude-code)