### PR TITLE
feat(finiquito-mejoras): Sprint 2 — persistencia + forma de pago (con migración)

### DIFF
--- a/components/rh/empleado-detail-module.tsx
+++ b/components/rh/empleado-detail-module.tsx
@@ -104,6 +104,41 @@ type Beneficiario = {
   orden: number;
 };
 
+type FiniquitoListItem = {
+  id: string;
+  fecha_baja: string;
+  fecha_convenio: string;
+  causa: string;
+  total_general: number;
+  forma_pago: string;
+  referencia_pago: string | null;
+  creado_en: string;
+};
+
+const CAUSA_LABELS_SHORT: Record<string, string> = {
+  renuncia: 'Renuncia voluntaria',
+  mutuo_consentimiento: 'Mutuo consentimiento',
+  termino_contrato: 'Término de contrato',
+  despido_justificado: 'Despido justificado',
+  despido_injustificado: 'Despido injustificado',
+  muerte: 'Muerte del trabajador',
+  incapacidad: 'Incapacidad permanente',
+};
+
+const FORMA_PAGO_LABELS_SHORT: Record<string, string> = {
+  efectivo: 'Efectivo',
+  cheque: 'Cheque',
+  transferencia: 'Transferencia',
+};
+
+function formatMoneda(n: number): string {
+  return new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+    minimumFractionDigits: 2,
+  }).format(n);
+}
+
 const TIPO_CONTRATO_OPTIONS: Array<{ value: string; label: string }> = [
   { value: 'prueba', label: 'Periodo de prueba (Art. 39-A)' },
   { value: 'indefinido', label: 'Tiempo indefinido / Planta' },
@@ -460,6 +495,10 @@ function EmpleadoDetailInner({ empresaSlug }: EmpleadoDetailModuleProps) {
   // Beneficiarios (Art. 501 LFT)
   const [beneficiarios, setBeneficiarios] = useState<Beneficiario[]>([]);
 
+  // Finiquitos generados (Sprint 2 de finiquito-mejoras): historial
+  // read-only de los convenios persistidos en `erp.finiquitos`.
+  const [finiquitos, setFiniquitos] = useState<FiniquitoListItem[]>([]);
+
   // Datos fiscales de la empresa (para habilitar contrato/finiquito)
   const datosFiscales = useDatosFiscalesEmpresa(empleado?.empresa_id ?? null);
 
@@ -610,6 +649,34 @@ function EmpleadoDetailInner({ empresaSlug }: EmpleadoDetailModuleProps) {
   useEffect(() => {
     void fetchAll();
   }, [fetchAll]);
+
+  // Carga el historial de finiquitos generados para este empleado.
+  // La tabla `erp.finiquitos` se agrega en migración
+  // 20260430160000_erp_finiquitos.sql; hasta que se aplique con psql y
+  // se regeneren types/supabase.ts, no aparece en los tipos generados —
+  // de ahí el cast.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const { data, error: fErr } = await (supabase.schema('erp') as any)
+        .from('finiquitos')
+        .select(
+          'id, fecha_baja, fecha_convenio, causa, total_general, forma_pago, referencia_pago, creado_en'
+        )
+        .eq('empleado_id', id)
+        .order('creado_en', { ascending: false });
+      if (cancelled) return;
+      if (fErr) {
+        // Tabla aún no aplicada o sin permisos — no es un error de UI.
+        setFiniquitos([]);
+        return;
+      }
+      setFiniquitos((data ?? []) as FiniquitoListItem[]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id, supabase]);
 
   const handleSave = async () => {
     if (!empleado) return;
@@ -1412,6 +1479,40 @@ function EmpleadoDetailInner({ empresaSlug }: EmpleadoDetailModuleProps) {
           />
         ) : (
           <p className="text-xs text-[var(--text-subtle)]">Sin notas registradas.</p>
+        )}
+      </div>
+
+      {/* Finiquitos generados (audit trail) */}
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5">
+        <SectionTitle>Finiquitos generados</SectionTitle>
+        {finiquitos.length === 0 ? (
+          <p className="text-xs text-[var(--text-subtle)]">
+            Sin finiquitos guardados. Al usar &ldquo;Guardar y descargar&rdquo; desde la pantalla de
+            finiquito, cada convenio queda registrado aquí.
+          </p>
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {finiquitos.map((f) => (
+              <li
+                key={f.id}
+                className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-3"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <div className="font-medium text-[var(--text)]">
+                    {formatDate(f.fecha_convenio)} — {formatMoneda(Number(f.total_general))}
+                  </div>
+                  <div className="text-[10px] uppercase tracking-wide text-[var(--text-subtle)]">
+                    Baja {formatDate(f.fecha_baja)}
+                  </div>
+                </div>
+                <div className="mt-1 text-xs text-[var(--text-muted)]">
+                  {CAUSA_LABELS_SHORT[f.causa] ?? f.causa} ·{' '}
+                  {FORMA_PAGO_LABELS_SHORT[f.forma_pago] ?? f.forma_pago}
+                  {f.referencia_pago ? ` (ref. ${f.referencia_pago})` : ''}
+                </div>
+              </li>
+            ))}
+          </ul>
         )}
       </div>
 

--- a/components/rh/empleado-finiquito-module.tsx
+++ b/components/rh/empleado-finiquito-module.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-/* eslint-disable @typescript-eslint/no-explicit-any, react-hooks/set-state-in-effect --
+/* eslint-disable @typescript-eslint/no-explicit-any --
  * Supabase row mapping is dynamic; data-sync en useEffect es el patrón
  * estándar de la app.
  */
@@ -25,11 +25,13 @@ import { Input } from '@/components/ui/input';
 import { FieldLabel } from '@/components/ui/field-label';
 import { Combobox } from '@/components/ui/combobox';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
 import { useTriggerPrint } from '@/components/print';
-import { ArrowLeft, Printer, AlertCircle, Settings } from 'lucide-react';
+import { ArrowLeft, Printer, AlertCircle, Settings, Save, Loader2 } from 'lucide-react';
 import {
   FiniquitoPrintable,
   type FiniquitoEmpleadoData,
+  type FormaPagoFiniquito,
 } from '@/components/rh/finiquito-printable';
 import type { ContratoPatron } from '@/components/rh/contrato-printable';
 import { useDatosFiscalesEmpresa, buildPatronFromDatos } from '@/lib/rh/datos-fiscales-empresa';
@@ -43,6 +45,19 @@ import {
   labelZona,
   type ZonaSalarioMinimo,
 } from '@/lib/hr/salario-minimo-zona';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+const FORMA_PAGO_LABELS: Record<FormaPagoFiniquito, string> = {
+  efectivo: 'Efectivo',
+  cheque: 'Cheque',
+  transferencia: 'Transferencia bancaria',
+};
+
+function placeholderReferencia(forma: FormaPagoFiniquito): string {
+  if (forma === 'cheque') return 'Nº de cheque (ej. 0001234)';
+  if (forma === 'transferencia') return 'Referencia / SPEI';
+  return 'No aplica para efectivo';
+}
 
 export type EmpleadoFiniquitoModuleProps = {
   empresaSlug: 'rdb' | 'dilesa';
@@ -78,7 +93,14 @@ function Inner({ empresaSlug }: EmpleadoFiniquitoModuleProps) {
   // de auto-set por zona pise un valor ajustado a propósito.
   const [smTouched, setSmTouched] = useState(false);
 
+  // Forma de pago + referencia (Sprint 2): se capturan en el panel y
+  // entran al convenio impreso + al snapshot persistido.
+  const [formaPago, setFormaPago] = useState<FormaPagoFiniquito>('transferencia');
+  const [referenciaPago, setReferenciaPago] = useState<string>('');
+  const [saving, setSaving] = useState(false);
+
   const datosFiscales = useDatosFiscalesEmpresa(empresaId);
+  const toast = useToast();
 
   // Auto-setear SM según municipio fiscal de la empresa, una sola vez
   // cuando los datos fiscales y la fecha de baja están disponibles.
@@ -180,6 +202,92 @@ function Inner({ empresaSlug }: EmpleadoFiniquitoModuleProps) {
     });
   }, [fechaIngreso, fechaBaja, sueldoDiario, sdi, salarioMinimo, causa, diasPend, vacsTomadas]);
 
+  // Construir patron solo cuando datos fiscales completos. Memoizado para
+  // que `handleGuardarYDescargar` pueda referenciarlo en sus deps sin
+  // re-construir en cada render.
+  const patron = useMemo<ContratoPatron | null>(() => {
+    if (!datosFiscales.completo || !datosFiscales.datos) return null;
+    try {
+      return buildPatronFromDatos(datosFiscales.datos);
+    } catch {
+      return null;
+    }
+  }, [datosFiscales.completo, datosFiscales.datos]);
+
+  // Guarda un snapshot inmutable del finiquito en `erp.finiquitos` y
+  // dispara el print dialog. Si el usuario cancela el print, el registro
+  // ya quedó persistido — eso es intencional: el motivo de persistir es
+  // tener audit trail del que se enseñó al trabajador.
+  const handleGuardarYDescargar = useCallback(async () => {
+    if (!calculo || !empleado || !empresaId || !patron) return;
+    setSaving(true);
+    try {
+      const row = {
+        empleado_id: id,
+        empresa_id: empresaId,
+        fecha_baja: calculo.fechaBaja,
+        fecha_convenio: new Date().toISOString().split('T')[0],
+        causa: calculo.causa,
+        motivo_detalle: motivoDetalle || motivoBajaGuardado || null,
+        fecha_ingreso: calculo.fechaIngreso,
+        antiguedad_anios: calculo.antiguedad.anios,
+        antiguedad_meses: calculo.antiguedad.meses,
+        antiguedad_dias: calculo.antiguedad.dias,
+        sueldo_diario: calculo.sueldoDiario,
+        sdi: calculo.sdi !== calculo.sueldoDiario ? calculo.sdi : null,
+        salario_minimo_diario: salarioMinimo,
+        zona_salario_minimo: salarioMinimoZona,
+        total_finiquito: calculo.totalFiniquito,
+        total_indemnizacion: calculo.totalIndemnizacion,
+        total_general: calculo.totalGeneral,
+        conceptos: calculo.conceptos,
+        notas_calculo: calculo.notas,
+        empleado_snapshot: empleado,
+        patron_snapshot: patron,
+        forma_pago: formaPago,
+        referencia_pago: formaPago === 'efectivo' ? null : referenciaPago.trim() || null,
+      };
+      // `erp.finiquitos` se agrega en migración 20260430160000_erp_finiquitos.sql.
+      // Hasta que se aplique con psql + se regeneren types/supabase.ts, la
+      // tabla no aparece en los tipos generados — por eso el cast.
+      const { error: insertErr } = await (supabase.schema('erp') as any)
+        .from('finiquitos')
+        .insert(row);
+      if (insertErr) {
+        toast.add({
+          title: 'No se pudo guardar el finiquito',
+          description: getSupabaseErrorMessage(insertErr, 'Error desconocido al insertar.'),
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({
+        title: 'Finiquito guardado',
+        description: 'El registro queda en histórico del empleado.',
+        type: 'success',
+      });
+      // Pequeña espera para que el toast sea visible antes del print dialog.
+      setTimeout(() => triggerPrint(), 300);
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    calculo,
+    empleado,
+    empresaId,
+    id,
+    patron,
+    motivoDetalle,
+    motivoBajaGuardado,
+    salarioMinimo,
+    salarioMinimoZona,
+    formaPago,
+    referenciaPago,
+    supabase,
+    toast,
+    triggerPrint,
+  ]);
+
   if (loading || datosFiscales.loading) {
     return (
       <div className="space-y-4">
@@ -244,37 +352,53 @@ function Inner({ empresaSlug }: EmpleadoFiniquitoModuleProps) {
     );
   }
 
-  let patron: ContratoPatron;
-  try {
-    patron = buildPatronFromDatos(datosFiscales.datos!);
-  } catch (err) {
+  if (!patron) {
     return (
       <div className="rounded-2xl border border-red-500/30 bg-red-500/5 p-5 text-sm text-red-400">
-        Error construyendo datos del patrón: {err instanceof Error ? err.message : 'desconocido'}
+        Error construyendo datos del patrón. Revisa los datos fiscales en Settings → Empresas.
       </div>
     );
   }
 
   const hayDatosFaltantes = sueldoDiario <= 0 || !fechaIngreso;
+  const referenciaRequerida = formaPago !== 'efectivo' && referenciaPago.trim() === '';
+  const puedeGuardar = !!calculo && !hayDatosFaltantes && !referenciaRequerida && !saving;
 
   return (
     <div className="space-y-4">
-      <div className="no-print flex items-center justify-between">
+      <div className="no-print flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <Button
           variant="outline"
           size="sm"
           onClick={() => router.push(`/${empresaSlug}/rh/personal/${id}`)}
-          className="rounded-xl border-[var(--border)] bg-[var(--card)] text-[var(--text)]"
+          className="rounded-xl border-[var(--border)] bg-[var(--card)] text-[var(--text)] sm:w-auto"
         >
           <ArrowLeft className="h-4 w-4 mr-1" /> Volver al empleado
         </Button>
         {calculo && (
-          <Button
-            onClick={triggerPrint}
-            className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90"
-          >
-            <Printer className="h-4 w-4" /> Imprimir finiquito
-          </Button>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button
+              variant="outline"
+              onClick={triggerPrint}
+              className="gap-1.5 rounded-xl border-[var(--border)] text-[var(--text)]"
+              title="Vista previa sin guardar el registro"
+            >
+              <Printer className="h-4 w-4" /> Vista previa
+            </Button>
+            <Button
+              onClick={handleGuardarYDescargar}
+              disabled={!puedeGuardar}
+              title={
+                referenciaRequerida
+                  ? `Captura la referencia para forma de pago "${FORMA_PAGO_LABELS[formaPago]}"`
+                  : 'Guarda el snapshot en histórico y abre el print dialog'
+              }
+              className="gap-1.5 rounded-xl bg-[var(--accent)] text-white hover:bg-[var(--accent)]/90 disabled:opacity-60"
+            >
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}{' '}
+              Guardar y descargar
+            </Button>
+          </div>
         )}
       </div>
 
@@ -371,6 +495,38 @@ function Inner({ empresaSlug }: EmpleadoFiniquitoModuleProps) {
             />
           </div>
         </div>
+
+        {/* Forma de pago — entra a la cláusula PRIMERA del convenio. */}
+        <div className="grid grid-cols-1 gap-3 pt-2 sm:grid-cols-2">
+          <div>
+            <FieldLabel>Forma de pago</FieldLabel>
+            <Combobox
+              value={formaPago}
+              onChange={(v) => {
+                setFormaPago(v as FormaPagoFiniquito);
+                if (v === 'efectivo') setReferenciaPago('');
+              }}
+              options={(Object.keys(FORMA_PAGO_LABELS) as FormaPagoFiniquito[]).map((k) => ({
+                value: k,
+                label: FORMA_PAGO_LABELS[k],
+              }))}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+            />
+          </div>
+          <div>
+            <FieldLabel>
+              Referencia / nº de cheque {formaPago === 'efectivo' ? '(opcional)' : '(requerida)'}
+            </FieldLabel>
+            <Input
+              value={referenciaPago}
+              onChange={(e) => setReferenciaPago(e.target.value)}
+              disabled={formaPago === 'efectivo'}
+              placeholder={placeholderReferencia(formaPago)}
+              className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)] disabled:opacity-60"
+            />
+          </div>
+        </div>
+
         {fechaBajaGuardada && fechaBaja !== fechaBajaGuardada && (
           <p className="text-[10px] text-amber-400">
             La fecha de baja guardada en BSOP es {fechaBajaGuardada}; estás calculando con{' '}
@@ -387,6 +543,8 @@ function Inner({ empresaSlug }: EmpleadoFiniquitoModuleProps) {
             calculo={calculo}
             motivoDetalle={motivoDetalle || motivoBajaGuardado || undefined}
             patron={patron}
+            formaPago={formaPago}
+            referenciaPago={referenciaPago.trim() || null}
           />
         </div>
       )}

--- a/components/rh/finiquito-printable.tsx
+++ b/components/rh/finiquito-printable.tsx
@@ -32,9 +32,21 @@ export interface FiniquitoEmpleadoData {
   numero_empleado: string | null;
 }
 
+export type FormaPagoFiniquito = 'efectivo' | 'cheque' | 'transferencia';
+
 function formatDateLarga(iso: string): string {
   const d = new Date(iso.includes('T') ? iso : `${iso}T00:00:00`);
   return d.toLocaleDateString('es-MX', { day: 'numeric', month: 'long', year: 'numeric' });
+}
+
+function describeFormaPago(forma: FormaPagoFiniquito, referencia: string | null): string {
+  if (forma === 'efectivo') return 'efectivo';
+  if (forma === 'cheque') {
+    return referencia ? `cheque número ${referencia}` : 'cheque';
+  }
+  return referencia
+    ? `transferencia bancaria con referencia ${referencia}`
+    : 'transferencia bancaria';
 }
 
 export function FiniquitoPrintable({
@@ -43,12 +55,18 @@ export function FiniquitoPrintable({
   motivoDetalle,
   patron,
   fechaConvenio,
+  formaPago,
+  referenciaPago,
 }: {
   empleado: FiniquitoEmpleadoData;
   calculo: FiniquitoCalculado;
   motivoDetalle?: string;
   patron: ContratoPatron;
   fechaConvenio?: string;
+  /** Forma de pago capturada en el panel. Default 'transferencia' para mantener back-compat con renderizados sin captura. */
+  formaPago?: FormaPagoFiniquito;
+  /** Nº de cheque o referencia de transferencia. NULL si forma=efectivo o no se capturó. */
+  referenciaPago?: string | null;
 }) {
   const fechaHoy = fechaConvenio ?? new Date().toISOString().split('T')[0];
   const nombreCompleto = composeFullName(
@@ -248,7 +266,7 @@ export function FiniquitoPrintable({
         <strong>PRIMERA.</strong> EL PATRÓN entrega en este acto a EL TRABAJADOR la cantidad de{' '}
         <strong>{formatMoneda(totalGeneral)}</strong> ({formatMoneda(totalGeneral).replace('$', '')}{' '}
         pesos M.N.), correspondiente al desglose descrito, mediante{' '}
-        <em>[efectivo / cheque / transferencia bancaria nº ________________]</em>.
+        <strong>{describeFormaPago(formaPago ?? 'transferencia', referenciaPago ?? null)}</strong>.
       </p>
 
       <p>

--- a/docs/planning/finiquito-mejoras.md
+++ b/docs/planning/finiquito-mejoras.md
@@ -157,3 +157,13 @@ en `core.empresas`:
   del proceso completo de finiquitos. Tras el explainer, autoriza los
   5 puntos como iniciativa formal. Promovida a `in_progress` en este
   mismo PR (Sprint 1 arranca de inmediato).
+- **2026-04-30**: Sprint 1 mergeado en PR #371 — modal fix + ciudad
+  dinámica + SM por zona. CI verde, 14 tests nuevos.
+- **2026-04-30**: Sprint 2 abierto — migración `erp.finiquitos` con
+  RLS por empresa + `core.fn_has_empresa` + UPDATE/DELETE solo admin
+  (audit trail estricto), captura de forma de pago + referencia,
+  botón "Guardar y descargar" que persiste snapshot inmutable
+  (incluye `empleado_snapshot` y `patron_snapshot` jsonb), sección
+  "Finiquitos generados" en detalle del empleado. La migración la
+  aplica Beto con `psql` post-merge + regenera `SCHEMA_REF.md` y
+  `types/supabase.ts`.

--- a/supabase/migrations/20260430160000_erp_finiquitos.sql
+++ b/supabase/migrations/20260430160000_erp_finiquitos.sql
@@ -1,0 +1,168 @@
+-- ╭──────────────────────────────────────────────────────────────────╮
+-- │  20260430160000_erp_finiquitos                                    │
+-- │                                                                    │
+-- │  Crea `erp.finiquitos` — registro persistente de los convenios     │
+-- │  de terminación laboral generados desde                            │
+-- │  `<EmpleadoFiniquitoModule>`. Cada fila es el snapshot completo    │
+-- │  del cálculo al momento de imprimir, con datos del empleado,       │
+-- │  patrón, conceptos, totales y forma de pago.                       │
+-- │                                                                    │
+-- │  Iniciativa: `finiquito-mejoras` (Sprint 2). Ver                   │
+-- │  `docs/planning/finiquito-mejoras.md`.                             │
+-- │                                                                    │
+-- │  Política de inmutabilidad: una vez insertado, el registro NO se   │
+-- │  edita ni borra (audit trail). Si hay error en un finiquito ya     │
+-- │  generado, se inserta uno nuevo y se referencia desde el           │
+-- │  histórico — `UPDATE`/`DELETE` quedan restringidos a admin para    │
+-- │  emergencias operativas.                                           │
+-- ╰──────────────────────────────────────────────────────────────────╯
+
+BEGIN;
+
+-- ─── Tabla ────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS erp.finiquitos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  empleado_id uuid NOT NULL REFERENCES erp.empleados (id),
+  -- empresa_id se denormaliza para que las policies RLS no tengan que
+  -- hacer JOIN con erp.empleados en cada SELECT.
+  empresa_id uuid NOT NULL REFERENCES core.empresas (id),
+
+  -- ── Convenio ────────────────────────────────────────────────────────
+  fecha_baja date NOT NULL,
+  fecha_convenio date NOT NULL,
+  causa text NOT NULL CHECK (
+    causa IN (
+      'renuncia',
+      'mutuo_consentimiento',
+      'termino_contrato',
+      'despido_justificado',
+      'despido_injustificado',
+      'muerte',
+      'incapacidad'
+    )
+  ),
+  motivo_detalle text,
+
+  -- ── Antigüedad (snapshot) ───────────────────────────────────────────
+  fecha_ingreso date NOT NULL,
+  antiguedad_anios integer NOT NULL,
+  antiguedad_meses integer NOT NULL,
+  antiguedad_dias integer NOT NULL,
+
+  -- ── Sueldos al momento del cálculo ─────────────────────────────────
+  sueldo_diario numeric(12, 2) NOT NULL,
+  sdi numeric(12, 2),
+  salario_minimo_diario numeric(12, 2) NOT NULL,
+  zona_salario_minimo text NOT NULL CHECK (
+    zona_salario_minimo IN ('frontera', 'general')
+  ),
+
+  -- ── Totales ────────────────────────────────────────────────────────
+  total_finiquito numeric(14, 2) NOT NULL,
+  total_indemnizacion numeric(14, 2) NOT NULL DEFAULT 0,
+  total_general numeric(14, 2) NOT NULL,
+
+  -- ── Snapshots inmutables (jsonb) ───────────────────────────────────
+  -- conceptos: array de FiniquitoConcepto[] (concepto/dias/tasa/monto/nota)
+  conceptos jsonb NOT NULL,
+  -- notas_calculo: array de strings que el cálculo emite (ej. "Prima
+  -- de antigüedad NO aplica: …").
+  notas_calculo jsonb NOT NULL DEFAULT '[]'::jsonb,
+  -- empleado_snapshot: { nombre, apellido_paterno, apellido_materno,
+  -- rfc, nss, puesto, departamento, numero_empleado }.
+  empleado_snapshot jsonb NOT NULL,
+  -- patron_snapshot: { razonSocial, rfc, domicilio, municipio, estado,
+  -- representanteLegal, registroPatronalImss, ... } — congelado al
+  -- momento de generación para que cambios futuros en core.empresas
+  -- no alteren el documento histórico.
+  patron_snapshot jsonb NOT NULL,
+
+  -- ── Forma de pago ──────────────────────────────────────────────────
+  forma_pago text NOT NULL CHECK (
+    forma_pago IN ('efectivo', 'cheque', 'transferencia')
+  ),
+  referencia_pago text,
+
+  -- ── Audit ──────────────────────────────────────────────────────────
+  creado_por uuid REFERENCES auth.users (id),
+  creado_en timestamptz NOT NULL DEFAULT now()
+);
+
+-- ─── Comentarios ──────────────────────────────────────────────────────
+
+COMMENT ON TABLE erp.finiquitos IS
+  'Snapshot inmutable de cada convenio de terminación laboral generado en BSOP. Una fila por finiquito firmado/impreso. UPDATE/DELETE solo admin.';
+COMMENT ON COLUMN erp.finiquitos.empresa_id IS
+  'Denormalizado de erp.empleados para evitar JOIN en RLS.';
+COMMENT ON COLUMN erp.finiquitos.fecha_baja IS
+  'Fecha efectiva de terminación de la relación laboral.';
+COMMENT ON COLUMN erp.finiquitos.fecha_convenio IS
+  'Fecha en que se firma/imprime el convenio (puede diferir de fecha_baja).';
+COMMENT ON COLUMN erp.finiquitos.zona_salario_minimo IS
+  'Zona CONASAMI usada para tope de prima de antigüedad: frontera (ZLFN) o general.';
+COMMENT ON COLUMN erp.finiquitos.conceptos IS
+  'Array snapshot de FiniquitoConcepto[]: [{concepto, dias?, tasa?, monto, nota?}, …].';
+COMMENT ON COLUMN erp.finiquitos.empleado_snapshot IS
+  'Snapshot inmutable del empleado al momento de generación.';
+COMMENT ON COLUMN erp.finiquitos.patron_snapshot IS
+  'Snapshot inmutable de la empresa/patrón. Cambios futuros en core.empresas no afectan finiquitos históricos.';
+COMMENT ON COLUMN erp.finiquitos.referencia_pago IS
+  'Número de cheque, referencia de transferencia u otro identificador del pago. NULL si forma_pago=efectivo.';
+
+-- ─── Índices ──────────────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS finiquitos_empleado_id_idx
+  ON erp.finiquitos (empleado_id);
+
+CREATE INDEX IF NOT EXISTS finiquitos_empresa_id_idx
+  ON erp.finiquitos (empresa_id);
+
+CREATE INDEX IF NOT EXISTS finiquitos_creado_en_idx
+  ON erp.finiquitos (creado_en DESC);
+
+-- ─── RLS ──────────────────────────────────────────────────────────────
+
+ALTER TABLE erp.finiquitos ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: cualquier miembro activo de la empresa o admin global.
+DROP POLICY IF EXISTS erp_finiquitos_select ON erp.finiquitos;
+CREATE POLICY erp_finiquitos_select
+  ON erp.finiquitos
+  FOR SELECT
+  TO authenticated
+  USING (core.fn_has_empresa(empresa_id) OR core.fn_is_admin());
+
+-- INSERT: cualquier miembro de la empresa puede crear finiquitos.
+-- (la UI ya gatea el acceso por permisos al módulo RH).
+DROP POLICY IF EXISTS erp_finiquitos_insert ON erp.finiquitos;
+CREATE POLICY erp_finiquitos_insert
+  ON erp.finiquitos
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (core.fn_has_empresa(empresa_id) OR core.fn_is_admin());
+
+-- UPDATE: solo admin (audit trail estricto: los finiquitos ya generados
+-- no se editan, se generan nuevos si hay error).
+DROP POLICY IF EXISTS erp_finiquitos_update ON erp.finiquitos;
+CREATE POLICY erp_finiquitos_update
+  ON erp.finiquitos
+  FOR UPDATE
+  TO authenticated
+  USING (core.fn_is_admin())
+  WITH CHECK (core.fn_is_admin());
+
+-- DELETE: solo admin (mismo razonamiento).
+DROP POLICY IF EXISTS erp_finiquitos_delete ON erp.finiquitos;
+CREATE POLICY erp_finiquitos_delete
+  ON erp.finiquitos
+  FOR DELETE
+  TO authenticated
+  USING (core.fn_is_admin());
+
+-- ─── Reload PostgREST ────────────────────────────────────────────────
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Cierra los 3 puntos restantes de la iniciativa `finiquito-mejoras`. PR con migración SQL — requiere aplicar con \`psql\` post-merge.

- **Migración `erp.finiquitos`**: tabla nueva con FK a `erp.empleados` y `core.empresas`, snapshot inmutable de cada convenio (causa, antigüedad, sueldos, conceptos jsonb, totales, forma de pago, `empleado_snapshot` y `patron_snapshot` jsonb). Índices por empleado/empresa/fecha. RLS canónica (`core.fn_has_empresa OR core.fn_is_admin`) con SELECT/INSERT abiertos a miembros y UPDATE/DELETE solo admin (audit trail estricto). \`NOTIFY pgrst, 'reload schema'\` al final.
- **Captura de forma de pago**: combo (efectivo / cheque / transferencia) + input de referencia (deshabilitado para efectivo, requerido para cheque/transferencia) en el panel del finiquito. Reemplaza el bracket placeholder de la cláusula PRIMERA con texto dinámico.
- **Persistencia inmutable**: nuevo botón "Guardar y descargar" en `<EmpleadoFiniquitoModule>` que insertea snapshot completo y dispara el print dialog. El botón viejo se mantiene como "Vista previa" (sin persistir).
- **Histórico en detalle**: sección nueva "Finiquitos generados" en `<EmpleadoDetailModule>` lista los registros read-only (fecha, total, causa, forma de pago + referencia), ordenado por más reciente.

## Para aplicar tras merge

Beto, post-merge:

\`\`\`bash
psql "\$SUPABASE_DB_URL" -f supabase/migrations/20260430160000_erp_finiquitos.sql
npm run schema:ref      # regenera supabase/SCHEMA_REF.md
npm run db:types        # regenera types/supabase.ts
git add supabase/SCHEMA_REF.md types/supabase.ts
git commit -m "chore(db): regenera SCHEMA_REF + types tras erp.finiquitos"
git push
\`\`\`

El código del PR usa \`(supabase.schema('erp') as any).from('finiquitos')\` porque \`types/supabase.ts\` aún no tiene la tabla. Tras regenerar los types, los casts pueden limpiarse en un PR de seguimiento (no urgente).

## Plan

Iniciativa **`finiquito-mejoras`** — este PR la cierra. Ver [docs/planning/finiquito-mejoras.md](docs/planning/finiquito-mejoras.md):

- ✅ Sprint 1 (#371): modal fix + ciudad/estado dinámicos + SM por zona.
- ✅ **Sprint 2** (este PR): migración + persistencia + forma de pago + listado.

## Test plan

- [x] \`npm run typecheck\` — 0 errores
- [x] \`npm run test:run\` — 447/447
- [x] \`npm run lint\` — 0 warnings nuevos en archivos tocados
- [x] \`npm run format:check\` — clean
- [ ] **Pre-merge**: revisar SQL de la migración (RLS policies, FKs, CHECK constraints)
- [ ] **Post-merge**: aplicar migración con psql + regenerar SCHEMA_REF + types
- [ ] **Smoke**: ir a \`/dilesa/rh/personal/<id>/finiquito\` → completar forma de pago → "Guardar y descargar" → verificar que aparece en sección "Finiquitos generados" del detalle del empleado

🤖 Generated with [Claude Code](https://claude.com/claude-code)