### PR TITLE
feat(rdb-proveedores-data-completion): Sprint 2 — UI captura contactos/cuentas/direcciones en drawer RDB

### DIFF
--- a/components/proveedores/personas-contactos-section.tsx
+++ b/components/proveedores/personas-contactos-section.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+/**
+ * Sección de contactos operativos de una persona.
+ * Sub-componente del drawer de proveedor (RDB Sprint 2 de
+ * `rdb-proveedores-data-completion`).
+ *
+ * Lee/escribe `erp.personas_contactos`. Multi-contacto, uno marcado
+ * como principal (constraint partial unique en DB lo enforce).
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Plus, Star, X, Save, Trash2, RotateCcw, Pencil } from 'lucide-react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import type { PersonaContacto, PersonaContactoInsert } from '@/lib/personas/satellites';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Props = {
+  personaId: string;
+  empresaId: string;
+};
+
+type FormState = {
+  nombre: string;
+  puesto: string;
+  telefono: string;
+  email: string;
+  notas: string;
+  principal: boolean;
+};
+
+const EMPTY_FORM: FormState = {
+  nombre: '',
+  puesto: '',
+  telefono: '',
+  email: '',
+  notas: '',
+  principal: false,
+};
+
+export function PersonasContactosSection({ personaId, empresaId }: Props) {
+  const [contactos, setContactos] = useState<PersonaContacto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [showAdd, setShowAdd] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+
+  const fetchContactos = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data, error: err } = await supabase
+        .schema('erp')
+        .from('personas_contactos')
+        .select('*')
+        .eq('persona_id', personaId)
+        .order('principal', { ascending: false })
+        .order('activo', { ascending: false })
+        .order('created_at', { ascending: true });
+      if (err) throw err;
+      setContactos((data ?? []) as PersonaContacto[]);
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con contactos'));
+    } finally {
+      setLoading(false);
+    }
+  }, [personaId]);
+
+  useEffect(() => {
+    void fetchContactos();
+  }, [fetchContactos]);
+
+  const startAdd = () => {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setShowAdd(true);
+  };
+
+  const startEdit = (c: PersonaContacto) => {
+    setEditingId(c.id);
+    setForm({
+      nombre: c.nombre,
+      puesto: c.puesto ?? '',
+      telefono: c.telefono ?? '',
+      email: c.email ?? '',
+      notas: c.notas ?? '',
+      principal: c.principal,
+    });
+    setShowAdd(true);
+  };
+
+  const cancelForm = () => {
+    setShowAdd(false);
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+  };
+
+  const handleSave = async () => {
+    if (!form.nombre.trim()) {
+      setError('El nombre es obligatorio');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+
+      // Si se marca como principal, primero desmarcar el otro principal activo
+      // (la partial unique de DB lo rechazaría si no).
+      if (form.principal) {
+        await supabase
+          .schema('erp')
+          .from('personas_contactos')
+          .update({ principal: false })
+          .eq('persona_id', personaId)
+          .eq('principal', true)
+          .eq('activo', true);
+      }
+
+      if (editingId) {
+        const { error: err } = await supabase
+          .schema('erp')
+          .from('personas_contactos')
+          .update({
+            nombre: form.nombre.trim(),
+            puesto: form.puesto.trim() || null,
+            telefono: form.telefono.trim() || null,
+            email: form.email.trim() || null,
+            notas: form.notas.trim() || null,
+            principal: form.principal,
+          })
+          .eq('id', editingId);
+        if (err) throw err;
+      } else {
+        const insert: PersonaContactoInsert = {
+          persona_id: personaId,
+          empresa_id: empresaId,
+          nombre: form.nombre.trim(),
+          puesto: form.puesto.trim() || null,
+          telefono: form.telefono.trim() || null,
+          email: form.email.trim() || null,
+          notas: form.notas.trim() || null,
+          principal: form.principal,
+        };
+        const { error: err } = await supabase
+          .schema('erp')
+          .from('personas_contactos')
+          .insert(insert);
+        if (err) throw err;
+      }
+
+      cancelForm();
+      await fetchContactos();
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con contactos'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleActivo = async (c: PersonaContacto) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      // Si se reactiva un principal, hay que desmarcar otros principales activos.
+      const reactivatingPrincipal = !c.activo && c.principal;
+      if (reactivatingPrincipal) {
+        await supabase
+          .schema('erp')
+          .from('personas_contactos')
+          .update({ principal: false })
+          .eq('persona_id', personaId)
+          .eq('principal', true)
+          .eq('activo', true)
+          .neq('id', c.id);
+      }
+      const { error: err } = await supabase
+        .schema('erp')
+        .from('personas_contactos')
+        .update({ activo: !c.activo })
+        .eq('id', c.id);
+      if (err) throw err;
+      await fetchContactos();
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con contactos'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <Separator className="my-4" />
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Contactos
+        </div>
+        {!showAdd && (
+          <Button variant="ghost" size="sm" onClick={startAdd}>
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            Agregar
+          </Button>
+        )}
+      </div>
+
+      {loading ? (
+        <p className="text-xs text-muted-foreground">Cargando…</p>
+      ) : (
+        <>
+          {contactos.length === 0 && !showAdd && (
+            <p className="text-xs text-muted-foreground">Sin contactos capturados</p>
+          )}
+
+          <ul className="space-y-2">
+            {contactos.map((c) => (
+              <li
+                key={c.id}
+                className={`rounded-md border p-2 text-sm ${c.activo ? '' : 'opacity-50'}`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <span className="font-medium">{c.nombre}</span>
+                      {c.principal && c.activo && (
+                        <Badge variant="default" className="text-[10px]">
+                          <Star className="mr-0.5 h-2.5 w-2.5" />
+                          Principal
+                        </Badge>
+                      )}
+                      {!c.activo && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          Inactivo
+                        </Badge>
+                      )}
+                    </div>
+                    {c.puesto && <div className="text-xs text-muted-foreground">{c.puesto}</div>}
+                    {(c.telefono || c.email) && (
+                      <div className="mt-0.5 flex flex-wrap gap-x-3 text-xs text-muted-foreground">
+                        {c.telefono && <span className="font-mono">{c.telefono}</span>}
+                        {c.email && <span>{c.email}</span>}
+                      </div>
+                    )}
+                    {c.notas && (
+                      <div className="mt-0.5 text-xs italic text-muted-foreground">{c.notas}</div>
+                    )}
+                  </div>
+                  <div className="flex flex-shrink-0 gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => startEdit(c)}
+                      disabled={saving}
+                      aria-label="Editar"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => toggleActivo(c)}
+                      disabled={saving}
+                      aria-label={c.activo ? 'Inactivar' : 'Reactivar'}
+                    >
+                      {c.activo ? (
+                        <Trash2 className="h-3.5 w-3.5" />
+                      ) : (
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          {showAdd && (
+            <div className="mt-3 rounded-md border bg-muted/30 p-3 space-y-2">
+              <div className="text-xs font-semibold">
+                {editingId ? 'Editar contacto' : 'Nuevo contacto'}
+              </div>
+              <Input
+                placeholder="Nombre *"
+                value={form.nombre}
+                onChange={(e) => setForm((f) => ({ ...f, nombre: e.target.value }))}
+              />
+              <Input
+                placeholder="Puesto / rol"
+                value={form.puesto}
+                onChange={(e) => setForm((f) => ({ ...f, puesto: e.target.value }))}
+              />
+              <div className="grid grid-cols-2 gap-2">
+                <Input
+                  placeholder="Teléfono"
+                  value={form.telefono}
+                  onChange={(e) => setForm((f) => ({ ...f, telefono: e.target.value }))}
+                />
+                <Input
+                  type="email"
+                  placeholder="Email"
+                  value={form.email}
+                  onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
+                />
+              </div>
+              <Input
+                placeholder="Notas"
+                value={form.notas}
+                onChange={(e) => setForm((f) => ({ ...f, notas: e.target.value }))}
+              />
+              <label className="flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={form.principal}
+                  onChange={(e) => setForm((f) => ({ ...f, principal: e.target.checked }))}
+                />
+                Marcar como contacto principal
+              </label>
+              <div className="flex justify-end gap-2 pt-1">
+                <Button variant="ghost" size="sm" onClick={cancelForm} disabled={saving}>
+                  <X className="mr-1 h-3.5 w-3.5" />
+                  Cancelar
+                </Button>
+                <Button size="sm" onClick={handleSave} disabled={saving}>
+                  <Save className="mr-1 h-3.5 w-3.5" />
+                  Guardar
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/components/proveedores/personas-cuentas-bancarias-section.tsx
+++ b/components/proveedores/personas-cuentas-bancarias-section.tsx
@@ -1,0 +1,435 @@
+'use client';
+
+/**
+ * Sección de cuentas bancarias de una persona (proveedor).
+ * Sub-componente del drawer (RDB Sprint 2 de `rdb-proveedores-data-completion`).
+ *
+ * Lee/escribe `erp.personas_cuentas_bancarias`. FK opcional a `core.bancos`,
+ * fallback `banco_nombre` libre. Multi-cuenta, una vigente.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Plus, X, Save, Trash2, RotateCcw, Pencil, CheckCircle2 } from 'lucide-react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import {
+  TIPO_CUENTA_BANCARIA,
+  TIPO_CUENTA_BANCARIA_LABEL,
+  formatCuentaCompact,
+  validateCuentaBancaria,
+  type PersonaCuentaBancaria,
+  type PersonaCuentaBancariaInsert,
+  type TipoCuentaBancaria,
+} from '@/lib/personas/satellites';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Props = {
+  personaId: string;
+  empresaId: string;
+};
+
+type Banco = { id: string; codigo: string; nombre: string };
+
+type FormState = {
+  banco_id: string; // '' = sin selección, usa banco_nombre
+  banco_nombre: string;
+  numero_cuenta: string;
+  clabe: string;
+  tipo: TipoCuentaBancaria | '';
+  moneda: string;
+  notas: string;
+  vigente: boolean;
+};
+
+const EMPTY_FORM: FormState = {
+  banco_id: '',
+  banco_nombre: '',
+  numero_cuenta: '',
+  clabe: '',
+  tipo: '',
+  moneda: 'MXN',
+  notas: '',
+  vigente: false,
+};
+
+export function PersonasCuentasBancariasSection({ personaId, empresaId }: Props) {
+  const [cuentas, setCuentas] = useState<PersonaCuentaBancaria[]>([]);
+  const [bancos, setBancos] = useState<Banco[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [showAdd, setShowAdd] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+
+  const bancoLabelMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const b of bancos) m.set(b.id, b.nombre);
+    return m;
+  }, [bancos]);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const [ctasRes, bancosRes] = await Promise.all([
+        supabase
+          .schema('erp')
+          .from('personas_cuentas_bancarias')
+          .select('*')
+          .eq('persona_id', personaId)
+          .order('vigente', { ascending: false })
+          .order('created_at', { ascending: true }),
+        supabase
+          .schema('core')
+          .from('bancos')
+          .select('id, codigo, nombre')
+          .eq('activo', true)
+          .order('nombre', { ascending: true }),
+      ]);
+      if (ctasRes.error) throw ctasRes.error;
+      if (bancosRes.error) throw bancosRes.error;
+      setCuentas((ctasRes.data ?? []) as PersonaCuentaBancaria[]);
+      setBancos((bancosRes.data ?? []) as Banco[]);
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con cuentas bancarias'));
+    } finally {
+      setLoading(false);
+    }
+  }, [personaId]);
+
+  useEffect(() => {
+    void fetchAll();
+  }, [fetchAll]);
+
+  const startAdd = () => {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setShowAdd(true);
+  };
+
+  const startEdit = (c: PersonaCuentaBancaria) => {
+    setEditingId(c.id);
+    setForm({
+      banco_id: c.banco_id ?? '',
+      banco_nombre: c.banco_nombre ?? '',
+      numero_cuenta: c.numero_cuenta ?? '',
+      clabe: c.clabe ?? '',
+      tipo: (c.tipo as TipoCuentaBancaria | null) ?? '',
+      moneda: c.moneda,
+      notas: c.notas ?? '',
+      vigente: c.vigente,
+    });
+    setShowAdd(true);
+  };
+
+  const cancelForm = () => {
+    setShowAdd(false);
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+  };
+
+  const handleSave = async () => {
+    const validationError = validateCuentaBancaria({
+      banco_id: form.banco_id || null,
+      banco_nombre: form.banco_nombre || null,
+      numero_cuenta: form.numero_cuenta || null,
+      clabe: form.clabe || null,
+    });
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+
+      // Si se marca como vigente, desmarcar las otras vigentes
+      // (DB tiene partial unique, lo rechazaría).
+      if (form.vigente) {
+        await supabase
+          .schema('erp')
+          .from('personas_cuentas_bancarias')
+          .update({ vigente: false })
+          .eq('persona_id', personaId)
+          .eq('vigente', true);
+      }
+
+      const payload = {
+        banco_id: form.banco_id || null,
+        // Si banco_id está, banco_nombre se omite (banco real viene del catálogo).
+        banco_nombre: form.banco_id ? null : form.banco_nombre.trim() || null,
+        numero_cuenta: form.numero_cuenta.trim() || null,
+        clabe: form.clabe.trim() || null,
+        tipo: form.tipo || null,
+        moneda: form.moneda || 'MXN',
+        notas: form.notas.trim() || null,
+        vigente: form.vigente,
+      };
+
+      if (editingId) {
+        const { error: err } = await supabase
+          .schema('erp')
+          .from('personas_cuentas_bancarias')
+          .update(payload)
+          .eq('id', editingId);
+        if (err) throw err;
+      } else {
+        const insert: PersonaCuentaBancariaInsert = {
+          ...payload,
+          persona_id: personaId,
+          empresa_id: empresaId,
+        };
+        const { error: err } = await supabase
+          .schema('erp')
+          .from('personas_cuentas_bancarias')
+          .insert(insert);
+        if (err) throw err;
+      }
+
+      cancelForm();
+      await fetchAll();
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con cuentas bancarias'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleVigente = async (c: PersonaCuentaBancaria) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      // Soft-delete por vigente=false; al reactivar otras, el partial unique se respeta.
+      const newVigente = !c.vigente;
+      if (newVigente) {
+        await supabase
+          .schema('erp')
+          .from('personas_cuentas_bancarias')
+          .update({ vigente: false })
+          .eq('persona_id', personaId)
+          .eq('vigente', true)
+          .neq('id', c.id);
+      }
+      const { error: err } = await supabase
+        .schema('erp')
+        .from('personas_cuentas_bancarias')
+        .update({ vigente: newVigente })
+        .eq('id', c.id);
+      if (err) throw err;
+      await fetchAll();
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con cuentas bancarias'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <Separator className="my-4" />
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Cuentas bancarias
+        </div>
+        {!showAdd && (
+          <Button variant="ghost" size="sm" onClick={startAdd}>
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            Agregar
+          </Button>
+        )}
+      </div>
+
+      {loading ? (
+        <p className="text-xs text-muted-foreground">Cargando…</p>
+      ) : (
+        <>
+          {cuentas.length === 0 && !showAdd && (
+            <p className="text-xs text-muted-foreground">Sin cuentas capturadas</p>
+          )}
+
+          <ul className="space-y-2">
+            {cuentas.map((c) => {
+              const bancoLabel = c.banco_id
+                ? (bancoLabelMap.get(c.banco_id) ?? '(banco no encontrado)')
+                : c.banco_nombre;
+              return (
+                <li
+                  key={c.id}
+                  className={`rounded-md border p-2 text-sm ${c.vigente ? '' : 'opacity-60'}`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="font-mono text-xs">
+                          {formatCuentaCompact({
+                            banco_label: bancoLabel,
+                            numero_cuenta: c.numero_cuenta,
+                            clabe: c.clabe,
+                          })}
+                        </span>
+                        {c.vigente && (
+                          <Badge variant="default" className="text-[10px]">
+                            <CheckCircle2 className="mr-0.5 h-2.5 w-2.5" />
+                            Vigente
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="mt-0.5 flex flex-wrap gap-x-3 text-xs text-muted-foreground">
+                        {c.tipo && (
+                          <span>
+                            {TIPO_CUENTA_BANCARIA_LABEL[c.tipo as TipoCuentaBancaria] ?? c.tipo}
+                          </span>
+                        )}
+                        <span>{c.moneda}</span>
+                      </div>
+                      {c.notas && (
+                        <div className="mt-0.5 text-xs italic text-muted-foreground">{c.notas}</div>
+                      )}
+                    </div>
+                    <div className="flex flex-shrink-0 gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => startEdit(c)}
+                        disabled={saving}
+                        aria-label="Editar"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => toggleVigente(c)}
+                        disabled={saving}
+                        aria-label={c.vigente ? 'Marcar no vigente' : 'Marcar vigente'}
+                      >
+                        {c.vigente ? (
+                          <Trash2 className="h-3.5 w-3.5" />
+                        ) : (
+                          <RotateCcw className="h-3.5 w-3.5" />
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+
+          {showAdd && (
+            <div className="mt-3 rounded-md border bg-muted/30 p-3 space-y-2">
+              <div className="text-xs font-semibold">
+                {editingId ? 'Editar cuenta' : 'Nueva cuenta'}
+              </div>
+
+              <div>
+                <label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                  Banco
+                </label>
+                <select
+                  className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+                  value={form.banco_id}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      banco_id: e.target.value,
+                      // Si elige catálogo, limpia banco_nombre libre
+                      banco_nombre: e.target.value ? '' : f.banco_nombre,
+                    }))
+                  }
+                >
+                  <option value="">— Banco no catalogado —</option>
+                  {bancos.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {b.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {!form.banco_id && (
+                <Input
+                  placeholder="Nombre del banco (libre)"
+                  value={form.banco_nombre}
+                  onChange={(e) => setForm((f) => ({ ...f, banco_nombre: e.target.value }))}
+                />
+              )}
+
+              <div className="grid grid-cols-2 gap-2">
+                <Input
+                  placeholder="Número de cuenta"
+                  value={form.numero_cuenta}
+                  onChange={(e) => setForm((f) => ({ ...f, numero_cuenta: e.target.value }))}
+                />
+                <Input
+                  placeholder="CLABE (18 dígitos)"
+                  value={form.clabe}
+                  onChange={(e) => setForm((f) => ({ ...f, clabe: e.target.value }))}
+                  maxLength={18}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                <select
+                  className="rounded-md border bg-background px-2 py-1.5 text-sm"
+                  value={form.tipo}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, tipo: e.target.value as TipoCuentaBancaria | '' }))
+                  }
+                >
+                  <option value="">— Tipo —</option>
+                  {TIPO_CUENTA_BANCARIA.map((t) => (
+                    <option key={t} value={t}>
+                      {TIPO_CUENTA_BANCARIA_LABEL[t]}
+                    </option>
+                  ))}
+                </select>
+                <Input
+                  placeholder="Moneda (MXN)"
+                  value={form.moneda}
+                  onChange={(e) => setForm((f) => ({ ...f, moneda: e.target.value }))}
+                />
+              </div>
+
+              <Input
+                placeholder="Notas"
+                value={form.notas}
+                onChange={(e) => setForm((f) => ({ ...f, notas: e.target.value }))}
+              />
+
+              <label className="flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={form.vigente}
+                  onChange={(e) => setForm((f) => ({ ...f, vigente: e.target.checked }))}
+                />
+                Marcar como cuenta vigente para pagos
+              </label>
+
+              <div className="flex justify-end gap-2 pt-1">
+                <Button variant="ghost" size="sm" onClick={cancelForm} disabled={saving}>
+                  <X className="mr-1 h-3.5 w-3.5" />
+                  Cancelar
+                </Button>
+                <Button size="sm" onClick={handleSave} disabled={saving}>
+                  <Save className="mr-1 h-3.5 w-3.5" />
+                  Guardar
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/components/proveedores/personas-direcciones-section.tsx
+++ b/components/proveedores/personas-direcciones-section.tsx
@@ -1,0 +1,413 @@
+'use client';
+
+/**
+ * Sección de direcciones operativas de una persona (proveedor).
+ * Sub-componente del drawer (RDB Sprint 2 de `rdb-proveedores-data-completion`).
+ *
+ * Lee/escribe `erp.personas_direcciones`. El domicilio fiscal vive en
+ * `erp.personas_datos_fiscales` (no se mezcla aquí). Multi-dirección, una principal.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Plus, Star, X, Save, Trash2, RotateCcw, Pencil } from 'lucide-react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import {
+  TIPO_DIRECCION,
+  TIPO_DIRECCION_LABEL,
+  formatDireccionLine,
+  type PersonaDireccion,
+  type PersonaDireccionInsert,
+  type TipoDireccion,
+} from '@/lib/personas/satellites';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Props = {
+  personaId: string;
+  empresaId: string;
+};
+
+type FormState = {
+  tipo: TipoDireccion;
+  calle: string;
+  num_ext: string;
+  num_int: string;
+  colonia: string;
+  cp: string;
+  municipio: string;
+  estado: string;
+  pais: string;
+  referencia: string;
+  principal: boolean;
+};
+
+const EMPTY_FORM: FormState = {
+  tipo: 'operativo',
+  calle: '',
+  num_ext: '',
+  num_int: '',
+  colonia: '',
+  cp: '',
+  municipio: '',
+  estado: '',
+  pais: 'México',
+  referencia: '',
+  principal: false,
+};
+
+export function PersonasDireccionesSection({ personaId, empresaId }: Props) {
+  const [direcciones, setDirecciones] = useState<PersonaDireccion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [showAdd, setShowAdd] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+
+  const fetchDirecciones = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const { data, error: err } = await supabase
+        .schema('erp')
+        .from('personas_direcciones')
+        .select('*')
+        .eq('persona_id', personaId)
+        .order('principal', { ascending: false })
+        .order('activo', { ascending: false })
+        .order('created_at', { ascending: true });
+      if (err) throw err;
+      setDirecciones((data ?? []) as PersonaDireccion[]);
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con direcciones'));
+    } finally {
+      setLoading(false);
+    }
+  }, [personaId]);
+
+  useEffect(() => {
+    void fetchDirecciones();
+  }, [fetchDirecciones]);
+
+  const startAdd = () => {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setShowAdd(true);
+  };
+
+  const startEdit = (d: PersonaDireccion) => {
+    setEditingId(d.id);
+    setForm({
+      tipo: (d.tipo as TipoDireccion) ?? 'operativo',
+      calle: d.calle ?? '',
+      num_ext: d.num_ext ?? '',
+      num_int: d.num_int ?? '',
+      colonia: d.colonia ?? '',
+      cp: d.cp ?? '',
+      municipio: d.municipio ?? '',
+      estado: d.estado ?? '',
+      pais: d.pais,
+      referencia: d.referencia ?? '',
+      principal: d.principal,
+    });
+    setShowAdd(true);
+  };
+
+  const cancelForm = () => {
+    setShowAdd(false);
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+  };
+
+  const handleSave = async () => {
+    // Al menos un campo de localización debe estar
+    const hasContent =
+      form.calle.trim() ||
+      form.colonia.trim() ||
+      form.cp.trim() ||
+      form.municipio.trim() ||
+      form.estado.trim();
+    if (!hasContent) {
+      setError('Captura al menos calle, colonia, CP, municipio o estado');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+
+      if (form.principal) {
+        await supabase
+          .schema('erp')
+          .from('personas_direcciones')
+          .update({ principal: false })
+          .eq('persona_id', personaId)
+          .eq('principal', true)
+          .eq('activo', true);
+      }
+
+      const payload = {
+        tipo: form.tipo,
+        calle: form.calle.trim() || null,
+        num_ext: form.num_ext.trim() || null,
+        num_int: form.num_int.trim() || null,
+        colonia: form.colonia.trim() || null,
+        cp: form.cp.trim() || null,
+        municipio: form.municipio.trim() || null,
+        estado: form.estado.trim() || null,
+        pais: form.pais.trim() || 'México',
+        referencia: form.referencia.trim() || null,
+        principal: form.principal,
+      };
+
+      if (editingId) {
+        const { error: err } = await supabase
+          .schema('erp')
+          .from('personas_direcciones')
+          .update(payload)
+          .eq('id', editingId);
+        if (err) throw err;
+      } else {
+        const insert: PersonaDireccionInsert = {
+          ...payload,
+          persona_id: personaId,
+          empresa_id: empresaId,
+        };
+        const { error: err } = await supabase
+          .schema('erp')
+          .from('personas_direcciones')
+          .insert(insert);
+        if (err) throw err;
+      }
+
+      cancelForm();
+      await fetchDirecciones();
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con direcciones'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleActivo = async (d: PersonaDireccion) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const reactivatingPrincipal = !d.activo && d.principal;
+      if (reactivatingPrincipal) {
+        await supabase
+          .schema('erp')
+          .from('personas_direcciones')
+          .update({ principal: false })
+          .eq('persona_id', personaId)
+          .eq('principal', true)
+          .eq('activo', true)
+          .neq('id', d.id);
+      }
+      const { error: err } = await supabase
+        .schema('erp')
+        .from('personas_direcciones')
+        .update({ activo: !d.activo })
+        .eq('id', d.id);
+      if (err) throw err;
+      await fetchDirecciones();
+    } catch (e: unknown) {
+      setError(getSupabaseErrorMessage(e, 'Error con direcciones'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <Separator className="my-4" />
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Direcciones (operativas)
+        </div>
+        {!showAdd && (
+          <Button variant="ghost" size="sm" onClick={startAdd}>
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            Agregar
+          </Button>
+        )}
+      </div>
+
+      {loading ? (
+        <p className="text-xs text-muted-foreground">Cargando…</p>
+      ) : (
+        <>
+          {direcciones.length === 0 && !showAdd && (
+            <p className="text-xs text-muted-foreground">
+              Sin direcciones operativas. El domicilio fiscal vive en CSF.
+            </p>
+          )}
+
+          <ul className="space-y-2">
+            {direcciones.map((d) => (
+              <li
+                key={d.id}
+                className={`rounded-md border p-2 text-sm ${d.activo ? '' : 'opacity-50'}`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <Badge variant="outline" className="text-[10px]">
+                        {TIPO_DIRECCION_LABEL[d.tipo as TipoDireccion] ?? d.tipo}
+                      </Badge>
+                      {d.principal && d.activo && (
+                        <Badge variant="default" className="text-[10px]">
+                          <Star className="mr-0.5 h-2.5 w-2.5" />
+                          Principal
+                        </Badge>
+                      )}
+                      {!d.activo && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          Inactiva
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="mt-0.5 text-xs">{formatDireccionLine(d)}</div>
+                    {d.referencia && (
+                      <div className="mt-0.5 text-xs italic text-muted-foreground">
+                        Ref: {d.referencia}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-shrink-0 gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => startEdit(d)}
+                      disabled={saving}
+                      aria-label="Editar"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => toggleActivo(d)}
+                      disabled={saving}
+                      aria-label={d.activo ? 'Inactivar' : 'Reactivar'}
+                    >
+                      {d.activo ? (
+                        <Trash2 className="h-3.5 w-3.5" />
+                      ) : (
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          {showAdd && (
+            <div className="mt-3 rounded-md border bg-muted/30 p-3 space-y-2">
+              <div className="text-xs font-semibold">
+                {editingId ? 'Editar dirección' : 'Nueva dirección'}
+              </div>
+
+              <div>
+                <label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                  Tipo
+                </label>
+                <select
+                  className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+                  value={form.tipo}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, tipo: e.target.value as TipoDireccion }))
+                  }
+                >
+                  {TIPO_DIRECCION.map((t) => (
+                    <option key={t} value={t}>
+                      {TIPO_DIRECCION_LABEL[t]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <Input
+                placeholder="Calle"
+                value={form.calle}
+                onChange={(e) => setForm((f) => ({ ...f, calle: e.target.value }))}
+              />
+              <div className="grid grid-cols-2 gap-2">
+                <Input
+                  placeholder="Núm. ext."
+                  value={form.num_ext}
+                  onChange={(e) => setForm((f) => ({ ...f, num_ext: e.target.value }))}
+                />
+                <Input
+                  placeholder="Núm. int."
+                  value={form.num_int}
+                  onChange={(e) => setForm((f) => ({ ...f, num_int: e.target.value }))}
+                />
+              </div>
+              <Input
+                placeholder="Colonia"
+                value={form.colonia}
+                onChange={(e) => setForm((f) => ({ ...f, colonia: e.target.value }))}
+              />
+              <div className="grid grid-cols-3 gap-2">
+                <Input
+                  placeholder="CP"
+                  value={form.cp}
+                  onChange={(e) => setForm((f) => ({ ...f, cp: e.target.value }))}
+                />
+                <Input
+                  placeholder="Municipio"
+                  value={form.municipio}
+                  onChange={(e) => setForm((f) => ({ ...f, municipio: e.target.value }))}
+                />
+                <Input
+                  placeholder="Estado"
+                  value={form.estado}
+                  onChange={(e) => setForm((f) => ({ ...f, estado: e.target.value }))}
+                />
+              </div>
+              <Input
+                placeholder="País"
+                value={form.pais}
+                onChange={(e) => setForm((f) => ({ ...f, pais: e.target.value }))}
+              />
+              <Input
+                placeholder="Referencia (entre calles, etc.)"
+                value={form.referencia}
+                onChange={(e) => setForm((f) => ({ ...f, referencia: e.target.value }))}
+              />
+
+              <label className="flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={form.principal}
+                  onChange={(e) => setForm((f) => ({ ...f, principal: e.target.checked }))}
+                />
+                Marcar como dirección principal
+              </label>
+
+              <div className="flex justify-end gap-2 pt-1">
+                <Button variant="ghost" size="sm" onClick={cancelForm} disabled={saving}>
+                  <X className="mr-1 h-3.5 w-3.5" />
+                  Cancelar
+                </Button>
+                <Button size="sm" onClick={handleSave} disabled={saving}>
+                  <Save className="mr-1 h-3.5 w-3.5" />
+                  Guardar
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/components/proveedores/proveedores-module.tsx
+++ b/components/proveedores/proveedores-module.tsx
@@ -39,6 +39,9 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import type { CsfExtraccion } from '@/lib/proveedores/extract-csf';
+import { PersonasContactosSection } from './personas-contactos-section';
+import { PersonasCuentasBancariasSection } from './personas-cuentas-bancarias-section';
+import { PersonasDireccionesSection } from './personas-direcciones-section';
 
 // ─── CSF diff helpers (Sprint 3.B) ───────────────────────────────────────────
 
@@ -191,6 +194,7 @@ const proveedorColumns: Column<Proveedor>[] = [
 
 function ProveedorDetail({
   proveedor,
+  empresaId,
   open,
   onClose,
   onEdit,
@@ -201,6 +205,7 @@ function ProveedorDetail({
   membreteAlt,
 }: {
   proveedor: Proveedor | null;
+  empresaId: string;
   open: boolean;
   onClose: () => void;
   onEdit: (p: Proveedor) => void;
@@ -289,6 +294,19 @@ function ProveedorDetail({
           </div>
         ) : (
           <p className="text-sm text-muted-foreground">Sin información de contacto</p>
+        )}
+
+        {/* Sprint 2 — secciones satélite (contactos / cuentas / direcciones).
+             Solo cuando hay persona_id (siempre debería para proveedor activo). */}
+        {proveedor.persona_id && (
+          <>
+            <PersonasContactosSection personaId={proveedor.persona_id} empresaId={empresaId} />
+            <PersonasCuentasBancariasSection
+              personaId={proveedor.persona_id}
+              empresaId={empresaId}
+            />
+            <PersonasDireccionesSection personaId={proveedor.persona_id} empresaId={empresaId} />
+          </>
         )}
 
         {proveedor.notas && (
@@ -939,6 +957,7 @@ export function ProveedoresModule({
       {/* Detail drawer */}
       <ProveedorDetail
         proveedor={selected}
+        empresaId={empresaId}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         onEdit={openEdit}

--- a/lib/personas/satellites.test.ts
+++ b/lib/personas/satellites.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidClabe,
+  hasCuentaIdentificador,
+  hasBancoIdentificado,
+  validateCuentaBancaria,
+  formatCuentaCompact,
+  formatDireccionLine,
+} from './satellites';
+
+describe('isValidClabe', () => {
+  it('acepta NULL y string vacío (campo opcional)', () => {
+    expect(isValidClabe(null)).toBe(true);
+    expect(isValidClabe(undefined)).toBe(true);
+    expect(isValidClabe('')).toBe(true);
+    expect(isValidClabe('   ')).toBe(true);
+  });
+
+  it('acepta exactamente 18 dígitos', () => {
+    expect(isValidClabe('012345678901234567')).toBe(true);
+    expect(isValidClabe('072075004205176879')).toBe(true);
+  });
+
+  it('rechaza longitudes distintas a 18', () => {
+    expect(isValidClabe('1234567890123456')).toBe(false); // 16
+    expect(isValidClabe('1234567890123456789')).toBe(false); // 19
+  });
+
+  it('rechaza no dígitos', () => {
+    expect(isValidClabe('01234567890123456a')).toBe(false);
+    expect(isValidClabe('012-456-789-012-345')).toBe(false);
+  });
+});
+
+describe('hasCuentaIdentificador', () => {
+  it('rechaza ambos vacíos', () => {
+    expect(hasCuentaIdentificador(null, null)).toBe(false);
+    expect(hasCuentaIdentificador('', '')).toBe(false);
+    expect(hasCuentaIdentificador('   ', '   ')).toBe(false);
+  });
+
+  it('acepta solo número de cuenta', () => {
+    expect(hasCuentaIdentificador('472056674', null)).toBe(true);
+  });
+
+  it('acepta solo CLABE', () => {
+    expect(hasCuentaIdentificador(null, '012345678901234567')).toBe(true);
+  });
+
+  it('acepta ambos', () => {
+    expect(hasCuentaIdentificador('472056674', '012345678901234567')).toBe(true);
+  });
+});
+
+describe('hasBancoIdentificado', () => {
+  it('rechaza ambos vacíos', () => {
+    expect(hasBancoIdentificado(null, null)).toBe(false);
+    expect(hasBancoIdentificado('', '')).toBe(false);
+  });
+
+  it('acepta banco_id solo', () => {
+    expect(hasBancoIdentificado('uuid-banorte', null)).toBe(true);
+  });
+
+  it('acepta banco_nombre solo', () => {
+    expect(hasBancoIdentificado(null, 'Banco Extranjero')).toBe(true);
+  });
+});
+
+describe('validateCuentaBancaria', () => {
+  it('rechaza falta de banco', () => {
+    expect(
+      validateCuentaBancaria({
+        banco_id: null,
+        banco_nombre: null,
+        numero_cuenta: '472056674',
+        clabe: null,
+      })
+    ).toMatch(/Falta banco/);
+  });
+
+  it('rechaza falta de identificador', () => {
+    expect(
+      validateCuentaBancaria({
+        banco_id: 'uuid-x',
+        banco_nombre: null,
+        numero_cuenta: null,
+        clabe: null,
+      })
+    ).toMatch(/Falta identificador/);
+  });
+
+  it('rechaza CLABE inválida', () => {
+    expect(
+      validateCuentaBancaria({
+        banco_id: 'uuid-x',
+        banco_nombre: null,
+        numero_cuenta: null,
+        clabe: '12345',
+      })
+    ).toMatch(/CLABE inválida/);
+  });
+
+  it('acepta entrada válida con catálogo + cuenta', () => {
+    expect(
+      validateCuentaBancaria({
+        banco_id: 'uuid-banorte',
+        banco_nombre: null,
+        numero_cuenta: '472056674',
+        clabe: null,
+      })
+    ).toBeNull();
+  });
+
+  it('acepta entrada válida con nombre libre + CLABE', () => {
+    expect(
+      validateCuentaBancaria({
+        banco_id: null,
+        banco_nombre: 'Banco Extranjero',
+        numero_cuenta: null,
+        clabe: '072075004205176879',
+      })
+    ).toBeNull();
+  });
+});
+
+describe('formatCuentaCompact', () => {
+  it('muestra banco + cuenta enmascarada + CLABE truncada', () => {
+    expect(
+      formatCuentaCompact({
+        banco_label: 'BANORTE',
+        numero_cuenta: '11391018105',
+        clabe: '072075004205176879',
+      })
+    ).toBe('BANORTE · ****8105 · CLABE …6879');
+  });
+
+  it('omite partes vacías', () => {
+    expect(
+      formatCuentaCompact({
+        banco_label: 'BBVA',
+        numero_cuenta: '472056674',
+        clabe: null,
+      })
+    ).toBe('BBVA · ****6674');
+  });
+
+  it('devuelve em-dash si nada', () => {
+    expect(
+      formatCuentaCompact({
+        banco_label: null,
+        numero_cuenta: null,
+        clabe: null,
+      })
+    ).toBe('—');
+  });
+});
+
+describe('formatDireccionLine', () => {
+  it('formato canónico completo', () => {
+    expect(
+      formatDireccionLine({
+        calle: 'Calle Saltillo',
+        num_ext: '202',
+        num_int: 'A',
+        colonia: 'Nísperos',
+        cp: '26020',
+        municipio: 'Piedras Negras',
+        estado: 'Coahuila',
+        pais: 'México',
+      })
+    ).toBe('Calle Saltillo #202 int A · Col. Nísperos · CP 26020 · Piedras Negras, Coahuila');
+  });
+
+  it('omite partes nulas', () => {
+    expect(
+      formatDireccionLine({
+        calle: 'Calle X',
+        num_ext: null,
+        num_int: null,
+        colonia: null,
+        cp: '26000',
+        municipio: 'PN',
+        estado: null,
+        pais: 'México',
+      })
+    ).toBe('Calle X · CP 26000 · PN');
+  });
+
+  it('em-dash si todo nulo (excepto pais que tiene default)', () => {
+    expect(
+      formatDireccionLine({
+        calle: null,
+        num_ext: null,
+        num_int: null,
+        colonia: null,
+        cp: null,
+        municipio: null,
+        estado: null,
+        pais: 'México',
+      })
+    ).toBe('—');
+  });
+});

--- a/lib/personas/satellites.ts
+++ b/lib/personas/satellites.ts
@@ -1,0 +1,146 @@
+/**
+ * Helpers para tablas satélite de `erp.personas`:
+ *   - personas_contactos
+ *   - personas_cuentas_bancarias
+ *   - personas_direcciones
+ *
+ * Ver ADR-028 (`docs/adr/028_personas_satellites.md`) para contexto y reglas
+ * PS1-PS6. Iniciativa: `rdb-proveedores-data-completion` (Sprint 2).
+ */
+
+import type { Database } from '@/types/supabase';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type PersonaContacto = Database['erp']['Tables']['personas_contactos']['Row'];
+export type PersonaContactoInsert = Database['erp']['Tables']['personas_contactos']['Insert'];
+
+export type PersonaCuentaBancaria = Database['erp']['Tables']['personas_cuentas_bancarias']['Row'];
+export type PersonaCuentaBancariaInsert =
+  Database['erp']['Tables']['personas_cuentas_bancarias']['Insert'];
+
+export type PersonaDireccion = Database['erp']['Tables']['personas_direcciones']['Row'];
+export type PersonaDireccionInsert = Database['erp']['Tables']['personas_direcciones']['Insert'];
+
+export const TIPO_DIRECCION = ['operativo', 'entrega', 'cobro', 'oficina', 'otro'] as const;
+export type TipoDireccion = (typeof TIPO_DIRECCION)[number];
+
+export const TIPO_DIRECCION_LABEL: Record<TipoDireccion, string> = {
+  operativo: 'Operativo',
+  entrega: 'Entrega',
+  cobro: 'Cobro',
+  oficina: 'Oficina',
+  otro: 'Otro',
+};
+
+export const TIPO_CUENTA_BANCARIA = ['cheques', 'debito', 'credito', 'inversion', 'otro'] as const;
+export type TipoCuentaBancaria = (typeof TIPO_CUENTA_BANCARIA)[number];
+
+export const TIPO_CUENTA_BANCARIA_LABEL: Record<TipoCuentaBancaria, string> = {
+  cheques: 'Cheques',
+  debito: 'Débito',
+  credito: 'Crédito',
+  inversion: 'Inversión',
+  otro: 'Otro',
+};
+
+// ─── Validators ───────────────────────────────────────────────────────────────
+
+/** CLABE mexicana = 18 dígitos exactos. NULL/vacío válido (campo opcional). */
+export function isValidClabe(clabe: string | null | undefined): boolean {
+  if (clabe == null) return true;
+  const trimmed = clabe.trim();
+  if (trimmed === '') return true;
+  return /^[0-9]{18}$/.test(trimmed);
+}
+
+/**
+ * Una cuenta bancaria debe tener al menos uno de `numero_cuenta` o `clabe`.
+ * Esto refleja el constraint `chk_pers_ctas_identificador_present` en DB.
+ */
+export function hasCuentaIdentificador(
+  numeroCuenta: string | null | undefined,
+  clabe: string | null | undefined
+): boolean {
+  const nc = numeroCuenta?.trim() ?? '';
+  const cl = clabe?.trim() ?? '';
+  return nc.length > 0 || cl.length > 0;
+}
+
+/**
+ * Una cuenta bancaria debe tener un banco identificado (FK al catálogo o nombre libre).
+ * Refleja el constraint `chk_pers_ctas_banco_present` en DB.
+ */
+export function hasBancoIdentificado(
+  bancoId: string | null | undefined,
+  bancoNombre: string | null | undefined
+): boolean {
+  if (bancoId != null && bancoId.length > 0) return true;
+  return (bancoNombre?.trim().length ?? 0) > 0;
+}
+
+/**
+ * Validación completa de una cuenta bancaria antes de insertar/actualizar.
+ * Devuelve error legible o `null` si todo OK.
+ */
+export function validateCuentaBancaria(input: {
+  banco_id: string | null;
+  banco_nombre: string | null;
+  numero_cuenta: string | null;
+  clabe: string | null;
+}): string | null {
+  if (!hasBancoIdentificado(input.banco_id, input.banco_nombre)) {
+    return 'Falta banco: selecciónalo del catálogo o escribe un nombre.';
+  }
+  if (!hasCuentaIdentificador(input.numero_cuenta, input.clabe)) {
+    return 'Falta identificador: ingresa al menos número de cuenta o CLABE.';
+  }
+  if (!isValidClabe(input.clabe)) {
+    return 'CLABE inválida: deben ser exactamente 18 dígitos.';
+  }
+  return null;
+}
+
+// ─── Display helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Formato compacto para mostrar una cuenta bancaria en una lista:
+ *   "BANORTE · ****6710 · CLABE 058 010 ********** 36"
+ * Si no hay banco_id, usa banco_nombre. Cuenta y CLABE se muestran enmascaradas.
+ */
+export function formatCuentaCompact(
+  cuenta: Pick<PersonaCuentaBancaria, 'numero_cuenta' | 'clabe'> & {
+    banco_label: string | null;
+  }
+): string {
+  const parts: string[] = [];
+  if (cuenta.banco_label) parts.push(cuenta.banco_label);
+  if (cuenta.numero_cuenta) {
+    const last4 = cuenta.numero_cuenta.slice(-4);
+    parts.push(`****${last4}`);
+  }
+  if (cuenta.clabe) {
+    parts.push(`CLABE …${cuenta.clabe.slice(-4)}`);
+  }
+  return parts.join(' · ') || '—';
+}
+
+/**
+ * Compone el domicilio en una sola línea legible.
+ *   "Calle 123 ext 45 int A · Col. Centro · CP 26000 · Piedras Negras, Coahuila"
+ */
+export function formatDireccionLine(
+  d: Pick<
+    PersonaDireccion,
+    'calle' | 'num_ext' | 'num_int' | 'colonia' | 'cp' | 'municipio' | 'estado' | 'pais'
+  >
+): string {
+  const calle = [d.calle, d.num_ext && `#${d.num_ext}`, d.num_int && `int ${d.num_int}`]
+    .filter(Boolean)
+    .join(' ');
+  const colCp = [d.colonia && `Col. ${d.colonia}`, d.cp && `CP ${d.cp}`]
+    .filter(Boolean)
+    .join(' · ');
+  const lugar = [d.municipio, d.estado].filter(Boolean).join(', ');
+  return [calle, colCp, lugar].filter(Boolean).join(' · ') || '—';
+}


### PR DESCRIPTION
## Summary

3 sub-componentes nuevos en el drawer de proveedor RDB que capturan la información que el schema actual antes no podía guardar:

- **`<PersonasContactosSection>`** — multi-contacto operativo, marcar principal (partial unique en DB lo enforce).
- **`<PersonasCuentasBancariasSection>`** — multi-cuenta con FK a `core.bancos` o `banco_nombre` libre, validación CLABE 18 dígitos, flag vigente.
- **`<PersonasDireccionesSection>`** — multi-dirección operativa (el fiscal sigue en `personas_datos_fiscales`), select de tipo (operativo/entrega/cobro/oficina/otro), marcar principal.

Las 3 secciones cargan independientemente contra las tablas satélite creadas en Sprint 1 (PR #375). No se acoplan al `Proveedor` type del módulo padre — son reusables para clientes/empleados cuando lleguemos a esos módulos.

`lib/personas/satellites.ts` encapsula tipos `Database['erp']['Tables'][...]`, validators (CLABE, identificadores) y formatters compactos. Tests unit cubren casos válidos/inválidos sin tocar DB.

Detalle de schema y reglas: [ADR-028](docs/adr/028_personas_satellites.md). Planning: [docs/planning/rdb-proveedores-data-completion.md](docs/planning/rdb-proveedores-data-completion.md).

## Test plan

- [x] `npm run typecheck` — verde
- [x] `npm run test:run` — 1333 tests verde (incluye 18 tests nuevos en `lib/personas/satellites.test.ts`)
- [x] `npm run lint` — verde
- [x] `npm run format:check` — verde
- [ ] Smoke en preview: abrir un proveedor RDB → ver las 3 secciones vacías → agregar 1 contacto + 1 cuenta + 1 dirección → marcarlos como principal/vigente → editar uno → inactivar/reactivar
- [ ] Smoke RLS: verificar que un usuario sin acceso a empresa RDB no ve los datos
- [ ] CI verde

## Próximo (después de merge)

- **Sprint 3 (operativo, lo hace Beto + ops)** — captura manual desde `PROVEEDORES RDB.csv` para los 12 RDB activos: cuentas bancarias para los 4 que las traen, contacto principal para los que tienen "Contacto" en CSV, direcciones operativas para los 12. Saneamiento de los 3 RFCs inválidos del CSV original. Resolver duplicado #4 (Jorge Amin / Abastecedora Industrial).
- **Sprint 4 (closeout)** — cierre formal de iniciativa cuando los 12 estén capturados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)