### PR TITLE
feat(import-empleados-contpaqi): Sprint 5B — page detail expandido (read-only)

### DIFF
--- a/app/rh/personal/[id]/page.tsx
+++ b/app/rh/personal/[id]/page.tsx
@@ -38,6 +38,20 @@ type EmpleadoDetail = {
   fecha_nacimiento: string | null;
   telefono_empresa: string | null;
   extension: string | null;
+  email_empresa: string | null;
+  tipo_contrato: string | null;
+  horario: string | null;
+  lugar_trabajo: string | null;
+  dia_pago: string | null;
+  funciones: string | null;
+  periodo_prueba_dias: number | null;
+  // Sprint 1 schema delta — campos IMSS y SAT
+  umf: string | null;
+  zona_salario: string | null;
+  regimen_imss: string | null;
+  tipo_prestacion: string | null;
+  sindicalizado: string | null;
+  metodo_pago_sat: string | null;
   activo: boolean;
   persona: {
     id: string;
@@ -46,11 +60,61 @@ type EmpleadoDetail = {
     apellido_materno: string | null;
     email: string | null;
     telefono: string | null;
+    telefono_casa: string | null;
     rfc: string | null;
     curp: string | null;
+    sexo: string | null;
+    estado_civil: string | null;
+    lugar_nacimiento: string | null;
+    domicilio: string | null;
+    nacionalidad: string | null;
+    contacto_emergencia_nombre: string | null;
+    contacto_emergencia_telefono: string | null;
+    contacto_emergencia_parentesco: string | null;
   } | null;
   departamento: { id: string; nombre: string } | null;
   puesto: { id: string; nombre: string } | null;
+};
+
+type EmpleadoCompensacion = {
+  id: string;
+  sueldo_diario: number | null;
+  sueldo_mensual: number | null;
+  sdi: number | null;
+  tipo_contrato: string | null;
+  frecuencia_pago: string | null;
+  comisiones_mensuales: number | null;
+  bonificaciones_mensuales: number | null;
+  compensaciones_mensuales: number | null;
+  fecha_inicio: string | null;
+};
+
+type EmpleadoPago = {
+  id: string;
+  banco_codigo: string | null;
+  banco_nombre: string | null;
+  numero_cuenta: string | null;
+  clabe: string | null;
+  sucursal: string | null;
+  fecha_inicio: string | null;
+};
+
+type PuestoAsignado = {
+  id: string;
+  principal: boolean;
+  fecha_inicio: string | null;
+  fecha_fin: string | null;
+  puesto: { id: string; nombre: string } | null;
+};
+
+type ImportLogEntry = {
+  id: string;
+  snapshot_fecha: string;
+  origen: string;
+  accion: string;
+  match_metodo: string | null;
+  diff: Record<string, unknown> | null;
+  created_at: string;
 };
 
 type Departamento = { id: string; nombre: string };
@@ -82,14 +146,55 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   );
 }
 
-function InfoRow({ label, value }: { label: string; value: string | null }) {
+function InfoRow({ label, value }: { label: string; value: string | null | number }) {
   return (
     <div>
       <FieldLabel>{label}</FieldLabel>
-      <p className="text-sm text-[var(--text)]">{value || '—'}</p>
+      <p className="text-sm text-[var(--text)]">
+        {value === null || value === undefined || value === '' ? '—' : String(value)}
+      </p>
     </div>
   );
 }
+
+function formatMoney(n: number | null | undefined): string {
+  if (n === null || n === undefined) return '—';
+  return new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+    minimumFractionDigits: 2,
+  }).format(n);
+}
+
+const REGIMEN_IMSS_LABELS: Record<string, string> = {
+  '02': '02 — Sueldos y Salarios',
+  '03': '03 — Jubilados',
+  '04': '04 — Pensionados',
+  '05': '05 — Asimilados a comisionistas',
+  '06': '06 — Asimilados honorarios',
+  '07': '07 — Asimilados acciones',
+};
+
+const METODO_PAGO_SAT_LABELS: Record<string, string> = {
+  '01': '01 — Efectivo',
+  '02': '02 — Cheque nominativo',
+  '03': '03 — Transferencia electrónica',
+  '28': '28 — Tarjeta de débito',
+};
+
+const SINDICALIZADO_LABELS: Record<string, string> = {
+  C: 'Confianza',
+  S: 'Sindicalizado',
+};
+
+const SEXO_LABELS: Record<string, string> = { M: 'Masculino', F: 'Femenino' };
+const ESTADO_CIVIL_LABELS: Record<string, string> = {
+  S: 'Soltero(a)',
+  C: 'Casado(a)',
+  U: 'Unión libre',
+  V: 'Viudo(a)',
+  D: 'Divorciado(a)',
+};
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
@@ -100,6 +205,10 @@ function EmpleadoDetailInner() {
   const supabase = createSupabaseERPClient();
 
   const [empleado, setEmpleado] = useState<EmpleadoDetail | null>(null);
+  const [compensacion, setCompensacion] = useState<EmpleadoCompensacion | null>(null);
+  const [pago, setPago] = useState<EmpleadoPago | null>(null);
+  const [puestosAsignados, setPuestosAsignados] = useState<PuestoAsignado[]>([]);
+  const [auditLog, setAuditLog] = useState<ImportLogEntry[]>([]);
   const [departamentos, setDepartamentos] = useState<Departamento[]>([]);
   const [puestos, setPuestos] = useState<Puesto[]>([]);
 
@@ -146,7 +255,7 @@ function EmpleadoDetailInner() {
       .schema('erp')
       .from('empleados')
       .select(
-        'id, empresa_id, numero_empleado, fecha_ingreso, fecha_baja, motivo_baja, nss, fecha_nacimiento, telefono_empresa, extension, activo, persona:persona_id(id, nombre, apellido_paterno, apellido_materno, email, telefono, rfc, curp), departamento:departamento_id(id, nombre), puesto:puesto_id(id, nombre)'
+        'id, empresa_id, numero_empleado, fecha_ingreso, fecha_baja, motivo_baja, nss, fecha_nacimiento, telefono_empresa, extension, email_empresa, tipo_contrato, horario, lugar_trabajo, dia_pago, funciones, periodo_prueba_dias, umf, zona_salario, regimen_imss, tipo_prestacion, sindicalizado, metodo_pago_sat, activo, persona:persona_id(id, nombre, apellido_paterno, apellido_materno, email, telefono, telefono_casa, rfc, curp, sexo, estado_civil, lugar_nacimiento, domicilio, nacionalidad, contacto_emergencia_nombre, contacto_emergencia_telefono, contacto_emergencia_parentesco), departamento:departamento_id(id, nombre), puesto:puesto_id(id, nombre)'
       )
       .eq('id', id)
       .single();
@@ -175,7 +284,7 @@ function EmpleadoDetailInner() {
     setTelefonoEmpresa(emp.telefono_empresa ?? '');
     setExtension(emp.extension ?? '');
 
-    const [deptRes, puestosRes] = await Promise.all([
+    const [deptRes, puestosRes, compRes, pagoRes, puestosAsigRes, logRes] = await Promise.all([
       supabase
         .schema('erp')
         .from('departamentos')
@@ -190,9 +299,47 @@ function EmpleadoDetailInner() {
         .eq('empresa_id', emp.empresa_id)
         .eq('activo', true)
         .order('nombre'),
+      supabase
+        .schema('erp')
+        .from('empleados_compensacion')
+        .select(
+          'id, sueldo_diario, sueldo_mensual, sdi, tipo_contrato, frecuencia_pago, comisiones_mensuales, bonificaciones_mensuales, compensaciones_mensuales, fecha_inicio'
+        )
+        .eq('empleado_id', emp.id)
+        .eq('vigente', true)
+        .maybeSingle(),
+      supabase
+        .schema('erp')
+        .from('empleados_pago')
+        .select('id, banco_codigo, banco_nombre, numero_cuenta, clabe, sucursal, fecha_inicio')
+        .eq('empleado_id', emp.id)
+        .eq('vigente', true)
+        .maybeSingle(),
+      supabase
+        .schema('erp')
+        .from('empleados_puestos')
+        .select('id, principal, fecha_inicio, fecha_fin, puesto:puesto_id(id, nombre)')
+        .eq('empleado_id', emp.id)
+        .order('principal', { ascending: false }),
+      supabase
+        .schema('erp')
+        .from('empleados_import_log')
+        .select('id, snapshot_fecha, origen, accion, match_metodo, diff, created_at')
+        .eq('empleado_id', emp.id)
+        .order('created_at', { ascending: false })
+        .limit(20),
     ]);
+
     setDepartamentos(deptRes.data ?? []);
     setPuestos(puestosRes.data ?? []);
+    setCompensacion((compRes.data ?? null) as EmpleadoCompensacion | null);
+    setPago((pagoRes.data ?? null) as EmpleadoPago | null);
+    const puestosNormalized = (puestosAsigRes.data ?? []).map((p: Record<string, unknown>) => ({
+      ...p,
+      puesto: Array.isArray(p.puesto) ? (p.puesto[0] ?? null) : p.puesto,
+    })) as PuestoAsignado[];
+    setPuestosAsignados(puestosNormalized);
+    setAuditLog((logRes.data ?? []) as ImportLogEntry[]);
 
     setLoading(false);
   }, [id, supabase]);
@@ -420,8 +567,206 @@ function EmpleadoDetailInner() {
               className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
             />
           </div>
+          <InfoRow
+            label="Sexo"
+            value={SEXO_LABELS[empleado.persona?.sexo ?? ''] ?? empleado.persona?.sexo ?? null}
+          />
+          <InfoRow
+            label="Estado civil"
+            value={
+              ESTADO_CIVIL_LABELS[empleado.persona?.estado_civil ?? ''] ??
+              empleado.persona?.estado_civil ??
+              null
+            }
+          />
+          <InfoRow label="Nacionalidad" value={empleado.persona?.nacionalidad ?? null} />
+          <InfoRow label="Lugar de nacimiento" value={empleado.persona?.lugar_nacimiento ?? null} />
+          <InfoRow label="Teléfono casa" value={empleado.persona?.telefono_casa ?? null} />
+          <div className="sm:col-span-2 lg:col-span-3">
+            <InfoRow label="Domicilio" value={empleado.persona?.domicilio ?? null} />
+          </div>
         </div>
       </div>
+
+      {/* IMSS */}
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 space-y-4">
+        <SectionTitle>IMSS y régimen fiscal</SectionTitle>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <InfoRow label="UMF (Unidad Médica Familiar)" value={empleado.umf ?? null} />
+          <InfoRow label="Zona de salario mínimo" value={empleado.zona_salario ?? null} />
+          <InfoRow
+            label="Régimen IMSS"
+            value={
+              REGIMEN_IMSS_LABELS[empleado.regimen_imss ?? ''] ?? empleado.regimen_imss ?? null
+            }
+          />
+          <InfoRow label="Tipo de prestación" value={empleado.tipo_prestacion ?? null} />
+          <InfoRow
+            label="Categoría laboral"
+            value={
+              SINDICALIZADO_LABELS[empleado.sindicalizado ?? ''] ?? empleado.sindicalizado ?? null
+            }
+          />
+          <InfoRow
+            label="Método de pago SAT"
+            value={
+              METODO_PAGO_SAT_LABELS[empleado.metodo_pago_sat ?? ''] ??
+              empleado.metodo_pago_sat ??
+              null
+            }
+          />
+          <InfoRow label="Tipo contrato" value={empleado.tipo_contrato ?? null} />
+          <InfoRow label="Horario / turno" value={empleado.horario ?? null} />
+          <InfoRow label="Lugar de trabajo" value={empleado.lugar_trabajo ?? null} />
+          <InfoRow label="Día de pago" value={empleado.dia_pago ?? null} />
+          <InfoRow label="Periodo de prueba (días)" value={empleado.periodo_prueba_dias ?? null} />
+        </div>
+        {empleado.funciones && (
+          <div className="pt-2">
+            <FieldLabel>Funciones</FieldLabel>
+            <p className="text-sm text-[var(--text)] whitespace-pre-wrap">{empleado.funciones}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Compensación vigente */}
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 space-y-4">
+        <SectionTitle>Compensación vigente</SectionTitle>
+        {compensacion ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <InfoRow label="Sueldo diario" value={formatMoney(compensacion.sueldo_diario)} />
+            <InfoRow label="Sueldo mensual" value={formatMoney(compensacion.sueldo_mensual)} />
+            <InfoRow label="SDI" value={formatMoney(compensacion.sdi)} />
+            <InfoRow label="Tipo contrato" value={compensacion.tipo_contrato ?? null} />
+            <InfoRow label="Frecuencia de pago" value={compensacion.frecuencia_pago ?? null} />
+            <InfoRow label="Vigente desde" value={formatDate(compensacion.fecha_inicio)} />
+            <InfoRow
+              label="Comisiones mensuales"
+              value={formatMoney(compensacion.comisiones_mensuales)}
+            />
+            <InfoRow
+              label="Bonificaciones mensuales"
+              value={formatMoney(compensacion.bonificaciones_mensuales)}
+            />
+            <InfoRow
+              label="Compensaciones mensuales"
+              value={formatMoney(compensacion.compensaciones_mensuales)}
+            />
+          </div>
+        ) : (
+          <p className="text-sm text-[var(--text-muted)]">Sin compensación vigente registrada.</p>
+        )}
+      </div>
+
+      {/* Banco / Pago vigente */}
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 space-y-4">
+        <SectionTitle>Cuenta bancaria de nómina</SectionTitle>
+        {pago ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <InfoRow
+              label="Banco"
+              value={
+                pago.banco_nombre ?? (pago.banco_codigo ? `Código ${pago.banco_codigo}` : null)
+              }
+            />
+            <InfoRow label="Código de banco" value={pago.banco_codigo ?? null} />
+            <InfoRow label="Número de cuenta" value={pago.numero_cuenta ?? null} />
+            <InfoRow label="CLABE interbancaria" value={pago.clabe ?? null} />
+            <InfoRow label="Sucursal" value={pago.sucursal ?? null} />
+            <InfoRow label="Vigente desde" value={formatDate(pago.fecha_inicio)} />
+          </div>
+        ) : (
+          <p className="text-sm text-[var(--text-muted)]">Sin cuenta bancaria registrada.</p>
+        )}
+      </div>
+
+      {/* Puestos asignados (multi via empleados_puestos) */}
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 space-y-4">
+        <SectionTitle>Puestos asignados</SectionTitle>
+        {puestosAsignados.length === 0 ? (
+          <p className="text-sm text-[var(--text-muted)]">
+            Sin puestos asignados en empleados_puestos.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {puestosAsignados.map((pa) => (
+              <div
+                key={pa.id}
+                className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--panel)] p-3"
+              >
+                <span className="text-sm font-medium text-[var(--text)]">
+                  {pa.puesto?.nombre ?? '—'}
+                </span>
+                {pa.principal && (
+                  <span className="rounded-md border border-[var(--accent)]/30 bg-[var(--accent)]/10 px-1.5 py-0.5 text-[10px] font-medium text-[var(--accent)]">
+                    Principal
+                  </span>
+                )}
+                {pa.fecha_fin && (
+                  <span className="rounded-md border border-[var(--border)] bg-[var(--card)] px-1.5 py-0.5 text-[10px] text-[var(--text-subtle)]">
+                    Vencido {formatDate(pa.fecha_fin)}
+                  </span>
+                )}
+                <span className="ml-auto text-xs text-[var(--text-subtle)]">
+                  desde {formatDate(pa.fecha_inicio)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Contacto de emergencia */}
+      <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 space-y-4">
+        <SectionTitle>Contacto de emergencia</SectionTitle>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <InfoRow label="Nombre" value={empleado.persona?.contacto_emergencia_nombre ?? null} />
+          <InfoRow
+            label="Teléfono"
+            value={empleado.persona?.contacto_emergencia_telefono ?? null}
+          />
+          <InfoRow
+            label="Parentesco"
+            value={empleado.persona?.contacto_emergencia_parentesco ?? null}
+          />
+        </div>
+      </div>
+
+      {/* Audit log */}
+      {auditLog.length > 0 && (
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 space-y-4">
+          <SectionTitle>Historial de cambios (audit)</SectionTitle>
+          <div className="space-y-2">
+            {auditLog.map((entry) => (
+              <div
+                key={entry.id}
+                className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--panel)] p-3 text-xs"
+              >
+                <span
+                  className={`inline-flex items-center rounded-md border px-1.5 py-0.5 font-medium ${
+                    entry.accion === 'insert'
+                      ? 'border-green-500/20 bg-green-500/10 text-green-400'
+                      : entry.accion === 'update'
+                        ? 'border-blue-500/20 bg-blue-500/10 text-blue-400'
+                        : entry.accion === 'baja'
+                          ? 'border-red-500/20 bg-red-500/10 text-red-400'
+                          : 'border-[var(--border)] bg-[var(--card)] text-[var(--text-subtle)]'
+                  }`}
+                >
+                  {entry.accion}
+                </span>
+                <span className="text-[var(--text)]/70">{entry.origen}</span>
+                {entry.match_metodo && (
+                  <span className="text-[var(--text-subtle)]">via {entry.match_metodo}</span>
+                )}
+                <span className="ml-auto text-[var(--text-subtle)]">
+                  {formatDate(entry.created_at.split('T')[0])}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Baja info (read-only) */}
       {isBaja && (


### PR DESCRIPTION
## Summary

Sprint 5B de [import-empleados-contpaqi](docs/planning/import-empleados-contpaqi.md). Expande `app/rh/personal/[id]/page.tsx` para mostrar toda la información del empleado (read-only). Edición de los nuevos campos viene en Sprint 5C.

## Secciones nuevas

- **Datos personales** mejorado — sexo, estado civil, nacionalidad, lugar nacimiento, teléfono casa, domicilio.
- **IMSS y régimen fiscal** — UMF, zona salario, régimen IMSS, tipo prestación, sindicalizado, método pago SAT, tipo contrato, horario, funciones, etc.
- **Compensación vigente** — sueldo diario/mensual, SDI, frecuencia, comisiones, bonificaciones (de `empleados_compensacion` vigente).
- **Cuenta bancaria de nómina** — banco, código, número de cuenta, CLABE, sucursal (de `empleados_pago` vigente).
- **Puestos asignados** — lista multi via `empleados_puestos` con marcador Principal.
- **Contacto de emergencia** — nombre, teléfono, parentesco.
- **Historial de cambios (audit)** — últimas 20 entradas de `empleados_import_log` con badges por acción.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run test:run` — 1355/1355 pass
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — pass
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)