### PR TITLE
feat(rh): navegación Puestos/Departamentos → Personal filtrado

### DIFF
--- a/components/rh/departamentos-module.tsx
+++ b/components/rh/departamentos-module.tsx
@@ -27,6 +27,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Plus, RefreshCw, Loader2, Network } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
@@ -110,12 +111,13 @@ const EMPTY_FORM = { nombre: '', codigo: '', padre_id: '' };
 export function DepartamentosModule({
   empresaId,
   scope = 'empresa',
-  empresaSlug: _empresaSlug,
+  empresaSlug,
   title,
   subtitle = 'Estructura organizacional',
   createVariant = 'sheet',
   showEmpleadosCount = false,
 }: DepartamentosModuleProps) {
+  const router = useRouter();
   const supabase = createSupabaseERPClient();
   const toast = useToast();
 
@@ -429,6 +431,10 @@ export function DepartamentosModule({
         ) : (
           <DataTable<Departamento>
             data={departamentos}
+            onRowClick={(d) => {
+              const target = empresaSlug ? `/${empresaSlug}/rh/personal` : '/rh/personal';
+              router.push(`${target}?departamento_id=${d.id}`);
+            }}
             columns={[
               {
                 key: 'nombre',

--- a/components/rh/personal-module.tsx
+++ b/components/rh/personal-module.tsx
@@ -26,7 +26,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { AlertCircle, Plus, Search, RefreshCw, Settings, Users } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
@@ -223,6 +223,7 @@ export function EmpleadosModule({
   subtitle = 'Directorio de personal',
 }: EmpleadosModuleProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const supabase = createSupabaseERPClient();
   const toast = useToast();
 
@@ -241,6 +242,9 @@ export function EmpleadosModule({
   const [estadoFilter, setEstadoFilter] = useState<EstadoFilter>('activos');
   const [search, setSearch] = useState('');
   const [filterDepto, setFilterDepto] = useState('all');
+  const [filterPuestoId, setFilterPuestoId] = useState<string>(
+    () => searchParams?.get('puesto_id') ?? 'all'
+  );
   const [filterAntiguedad, setFilterAntiguedad] = useState<AntiguedadFilter>('all');
 
   const [showCreate, setShowCreate] = useState(false);
@@ -346,6 +350,17 @@ export function EmpleadosModule({
     };
   }, [fetchEmpresaIds, fetchAll]);
 
+  // Entrada por URL: ?departamento_id=Y desde Departamentos. El catálogo se
+  // carga async, así que el mapeo id → nombre tiene que esperar al fetch.
+  // (puesto_id se aplica vía lazy useState arriba — no requiere effect.)
+  useEffect(() => {
+    const dId = searchParams?.get('departamento_id');
+    if (!dId || departamentos.length === 0) return;
+    const d = departamentos.find((x) => x.id === dId);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- URL → state one-shot tras fetch async
+    if (d) setFilterDepto(d.nombre);
+  }, [searchParams, departamentos]);
+
   const insertEmpresaId = empresaId ?? empresaIds[0] ?? null;
 
   // Política (Beto, 2026-04-27): no hay alta de empleado sin que la empresa
@@ -432,6 +447,12 @@ export function EmpleadosModule({
     // Filtro departamento
     if (filterDepto !== 'all' && e.departamento?.nombre !== filterDepto) {
       return false;
+    }
+
+    // Filtro puesto (por id, vía empleados_puestos vigentes)
+    if (filterPuestoId !== 'all') {
+      const tienePuesto = (e.puestos ?? []).some((p) => p.puesto_id === filterPuestoId);
+      if (!tienePuesto) return false;
     }
 
     // Filtro antigüedad por rangos
@@ -565,6 +586,15 @@ export function EmpleadosModule({
             placeholder="Departamento"
             searchPlaceholder="Buscar departamento..."
             clearLabel="Todos los deptos"
+            className="w-44"
+          />
+          <FilterCombobox
+            value={filterPuestoId}
+            onChange={setFilterPuestoId}
+            options={puestos.map((p) => ({ id: p.id, label: p.nombre }))}
+            placeholder="Puesto"
+            searchPlaceholder="Buscar puesto..."
+            clearLabel="Todos los puestos"
             className="w-44"
           />
           <FilterCombobox

--- a/components/rh/puestos-module.tsx
+++ b/components/rh/puestos-module.tsx
@@ -26,6 +26,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Plus, RefreshCw, Loader2, Briefcase } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
@@ -136,7 +137,7 @@ const EMPTY_FORM = {
 export function PuestosModule({
   empresaId,
   scope = 'empresa',
-  empresaSlug: _empresaSlug,
+  empresaSlug,
   title,
   subtitle = 'Catálogo de puestos y perfiles de puesto',
   createVariant = 'sheet',
@@ -144,6 +145,7 @@ export function PuestosModule({
   showEmpleadoCountColumn = false,
   showDeptoFilter = false,
 }: PuestosModuleProps) {
+  const router = useRouter();
   const supabase = createSupabaseERPClient();
   const toast = useToast();
 
@@ -557,6 +559,10 @@ export function PuestosModule({
         ) : (
           <DataTable<Puesto>
             data={visible}
+            onRowClick={(p) => {
+              const target = empresaSlug ? `/${empresaSlug}/rh/personal` : '/rh/personal';
+              router.push(`${target}?puesto_id=${p.id}`);
+            }}
             columns={[
               {
                 key: 'nombre',


### PR DESCRIPTION
## Summary

- Click en fila de **Puestos** o **Departamentos** ahora navega a `Personal` con el filtro pre-aplicado vía URL param (`?puesto_id=X` o `?departamento_id=Y`). Antes no hacía nada.
- `personal-module` lee los params en mount: `puesto_id` se aplica vía lazy `useState`, `departamento_id` se mapea a nombre cuando carga el catálogo.
- Nuevo `FilterCombobox` de **Puesto** al lado del de Departamento — también permite filtrar manualmente sin pasar por el módulo de Puestos.

## Cómo funciona

| Origen | URL destino | Comportamiento |
|---|---|---|
| Click puesto en `/dilesa/rh/puestos` | `/dilesa/rh/personal?puesto_id=<uuid>` | Tabla pre-filtrada por ese puesto (vía `empleados_puestos` vigentes) |
| Click depto en `/dilesa/rh/departamentos` | `/dilesa/rh/personal?departamento_id=<uuid>` | Tabla pre-filtrada por ese departamento |
| Idem para `/rdb/*` y `/rh/*` (los 3 comparten los módulos) | | |

`RowActions` (editar, toggle, borrar) sigue funcionando porque las cells ya estaban envueltas en `DataTable.InteractiveCell` que hace `stopPropagation`.

## Limitación conocida

URL no se sincroniza en sentido inverso: si limpias el filtro vía UI y recargas, el param queda y se vuelve a aplicar. Si molesta, agregamos `router.replace` en una iteración siguiente.

## Test plan

- [ ] `/dilesa/rh/puestos` → click "Oficial Albañil" → llega a `/dilesa/rh/personal?puesto_id=…` con la tabla filtrada a las 3 personas con ese puesto.
- [ ] `/dilesa/rh/departamentos` → click un depto → tabla en `/dilesa/rh/personal` filtrada por ese depto.
- [ ] En `/dilesa/rh/personal` el FilterCombobox de Puesto funciona sin venir de URL (filtrado manual).
- [ ] Click en RowActions de Puestos (editar/borrar) NO dispara navegación (stopPropagation).
- [ ] Idem en `/rdb/rh/*` y `/rh/*` (módulos compartidos).

## Validación local

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errores)
- `npm run format:check` ✓
- `npm run test:run` ✓ 28 files / 469 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)