### PR TITLE
docs(claude-md): refactor regla Reminders — default invertido + lista canónica `Claude 🧭`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,15 +34,31 @@ Reflejá el cambio de estado en `docs/strategy/INITIATIVES.md` también
 iniciativa quedó completa, movela a la sección `## Done` con fecha de
 cierre y outcome — no borres su doc de planning, queda como referencia.
 
-**Barrido de Reminders al cerrar (`* → done`):** antes de cerrar la
-iniciativa, listá los pendientes vivos en la lista `Claude: BSOP` con
-`remindctl list "Claude: BSOP" --json` y completá los que sean
-sub-tareas de la iniciativa que cierra (referencias a sus PRs, su
-slug, sub-PRs, sprints, smoke tests, closeouts). Las sub-tareas
+**Barrido obligatorio de Reminders al cerrar (`* → done`):** antes de
+mover el estado a `done` en `INITIATIVES.md` (o de reportar el cierre
+en chat), correr:
+
+```bash
+remindctl show all --list "Claude 🧭" --json
+```
+
+Y completar todo lo que matchee el slug, PRs, sub-PRs, sprints, smoke
+tests o closeouts de la iniciativa que cierra. Las sub-tareas
 históricas mueren con la iniciativa — no quedan vivas para confundir
-sesiones futuras. Ver regla global "Pendientes y calendario" en
-`~/.claude/CLAUDE.md` para el filtro de qué SÍ va a Reminders desde el
-inicio.
+sesiones futuras.
+
+Si bajo el filtro nuevo (ver regla global "Pendientes y calendario" en
+`~/.claude/CLAUDE.md`) las sub-tareas mías nunca debieron entrar a
+Reminders desde un inicio, este barrido es solo seguridad. Si encuentro
+algo cross-sesión que requiere acción operativa de Beto (ej. backfill
+manual post-merge), no lo borro — lo dejo y lo menciono explícitamente
+en el reporte de cierre.
+
+**Nota histórica:** la lista `Claude: BSOP` quedó deprecada el
+2026-05-02 a favor de `Claude 🧭` (lista global para todos los
+proyectos que manejo end-to-end). Cualquier reminder vivo en
+`Claude: BSOP` se barrió en esa fecha; sesiones futuras no agregan
+ahí.
 
 ### Roles
 


### PR DESCRIPTION
## Summary

- **Default invertido**: pasa de "permitido bajo categorías" a "NO crear Reminder por default; solo si Beto acciona en sesión futura". TodoWrite es el default, Reminders la excepción.
- **Tripwires explícitos**: lista de patrones que NUNCA van a Reminders (`Reportar a Beto`, `Open PR`, `4 checks + commit + push + merge`, `Sprint N closeout`, `Implementar X componente`).
- **Lista canónica**: `Claude: BSOP` queda deprecada; reemplazada por `Claude 🧭` para todos los proyectos end-to-end. Refleja el cambio en `~/.claude/CLAUDE.md` y en este repo.
- **Barrido obligatorio** antes de cerrar iniciativa: correr `remindctl show all --list "Claude 🧭" --json` y completar sub-tareas históricas. La regla existía pero no era vinculante; ahora es paso explícito previo al cierre.

## Por qué

`Claude: BSOP` tenía 31 reminders vivos. 27 eran sub-tareas internas mías que la regla anterior prohibía pero que igual aparecieron — incluyendo 3 `"Reportar a Beto…"` (explícitamente prohibidos). La regla estaba bien escrita pero enterrada y no actuaba como tripwire en el momento de crear.

Los 31 se completaron en el barrido del 2026-05-02 (no perdimos info relevante; los 2 que parecían legítimos los reporto separado a Beto para que decida si recrear en `Claude 🧭`).

## Test plan

- [x] `npm run typecheck` — limpio
- [x] `npm run format:check` — limpio
- [x] `npm run lint` — 0 errors (74 warnings preexistentes)
- [x] `npm run test:run` — 469 passed
- [x] Barrido manual ejecutado: `Claude: BSOP` quedó en 0 vivos; `Claude 🧭` mantiene 5 vivos legítimos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)