### PR TITLE
feat(tech-debt-h1-2026): Sprint 3C — cortes + levantamientos (unit tests + integration scaffold)

### DIFF
--- a/app/rdb/cortes/actions.test.ts
+++ b/app/rdb/cortes/actions.test.ts
@@ -1,0 +1,756 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests para `app/rdb/cortes/actions.ts` (Server Actions).
+ *
+ * Sprint 3C de tech-debt-h1-2026 — fortifica el flujo financiero de
+ * Cortes (efectivo en caja, vouchers de terminal, conciliación). Este
+ * es el archivo MÁS hot del repo (9 cambios en 6 meses) y maneja dinero
+ * real. Sin tests, regresiones podrían:
+ *
+ *   - Permitir 2 turnos abiertos simultáneos en la misma caja.
+ *   - Insertar movimientos en cortes cerrados (audit trail roto).
+ *   - Aceptar vouchers >10MB o mime types no permitidos.
+ *   - Pasar silenciosamente cuando RLS bloquea un UPDATE
+ *     (regresión histórica de cuando se agregaron columnas editables
+ *     sin policy).
+ *
+ * Estos son **unit tests con mocks** — cubren validaciones que viven
+ * en TS. Los integration tests (Sprint 3C parte 2, en este mismo PR)
+ * cubren el flujo end-to-end contra DB real.
+ */
+
+// ── State del test ─────────────────────────────────────────────────────
+
+let session: { user: { id: string; email: string; user_metadata?: { full_name?: string } } } | null;
+let preventInPreview = false;
+
+// Cortes lookup — reused by registrarMovimiento, subirVoucher.
+let corteLookup: { id: string; estado?: string } | null = null;
+let corteLookupError: { message: string } | null = null;
+
+// abrirCaja state.
+let existingOpenCorte: { id: string } | null = null;
+let existingOpenError: { message: string } | null = null;
+let ultimoCorte: { id: string; efectivo_contado: number | null; cerrado_at: string } | null = null;
+let ultimoCorteError: { message: string } | null = null;
+let insertCorteResult: { data: { id: string } | null; error: { message: string } | null } = {
+  data: { id: 'corte-new' },
+  error: null,
+};
+
+// cerrarCaja state.
+let updateCorteError: { message: string } | null = null;
+let upsertDenomError: { message: string } | null = null;
+
+// registrarMovimiento state.
+let insertMovimientoResult: { data: { id: string } | null; error: { message: string } | null } = {
+  data: { id: 'mov-1' },
+  error: null,
+};
+
+// previewEfectivoInicial state.
+let previewData: { efectivo_contado: number | null; cerrado_at: string } | null = null;
+let previewError: { message: string } | null = null;
+
+// Voucher state.
+let voucherLookup: { storage_path: string } | null = null;
+let voucherLookupError: { message: string } | null = null;
+let storageUploadError: { message: string } | null = null;
+let insertVoucherResult: { data: { id: string } | null; error: { message: string } | null } = {
+  data: { id: 'voucher-1' },
+  error: null,
+};
+let signedUrlResult: { data: { signedUrl: string } | null; error: { message: string } | null } = {
+  data: { signedUrl: 'https://signed.url/voucher-1' },
+  error: null,
+};
+let removeStorageCalled: string[][] = [];
+let updateVoucherResult: { data: { id: string }[]; error: { message: string } | null } = {
+  data: [{ id: 'voucher-1' }],
+  error: null,
+};
+let deleteVoucherError: { message: string } | null = null;
+let vouchersListResult: { data: unknown[]; error: { message: string } | null } = {
+  data: [],
+  error: null,
+};
+let bancosListResult: { data: unknown[]; error: { message: string } | null } = {
+  data: [],
+  error: null,
+};
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/preview-guard', () => ({
+  assertNotInPreview: async () => {
+    if (preventInPreview) throw new Error('Mutation bloqueada en preview');
+  },
+}));
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- test doubles */
+function buildSupabaseMock(): any {
+  return {
+    auth: {
+      getSession: async () => ({ data: { session } }),
+    },
+    schema(schemaName: string) {
+      return {
+        from(tableName: string) {
+          let _op = '';
+          const _filters: Record<string, unknown> = {};
+          let _payload: unknown = null;
+
+          const builder: any = {
+            select(_cols: string) {
+              _op = _op || 'select';
+              return builder;
+            },
+            insert(payload: unknown) {
+              _op = 'insert';
+              _payload = payload;
+              return builder;
+            },
+            update(payload: unknown) {
+              _op = 'update';
+              _payload = payload;
+              return builder;
+            },
+            upsert(payload: unknown, _opts?: unknown) {
+              _op = 'upsert';
+              _payload = payload;
+              return builder;
+            },
+            delete() {
+              _op = 'delete';
+              return builder;
+            },
+            eq(col: string, val: unknown) {
+              _filters[col] = val;
+              return builder;
+            },
+            in(col: string, vals: unknown[]) {
+              _filters[col] = vals;
+              return builder;
+            },
+            order(_col: string, _opts?: unknown) {
+              return builder;
+            },
+            limit(_n: number) {
+              return builder;
+            },
+            async maybeSingle() {
+              if (
+                schemaName === 'erp' &&
+                tableName === 'cortes_caja' &&
+                _filters.estado === 'abierto'
+              ) {
+                return { data: existingOpenCorte, error: existingOpenError };
+              }
+              if (
+                schemaName === 'erp' &&
+                tableName === 'cortes_caja' &&
+                _filters.estado === 'cerrado'
+              ) {
+                return { data: ultimoCorte, error: ultimoCorteError };
+              }
+              if (schemaName === 'erp' && tableName === 'cortes_caja') {
+                return { data: corteLookup, error: corteLookupError };
+              }
+              if (schemaName === 'erp' && tableName === 'cortes_vouchers') {
+                return { data: voucherLookup, error: voucherLookupError };
+              }
+              return { data: null, error: null };
+            },
+            async single() {
+              if (schemaName === 'erp' && tableName === 'cortes_caja' && _op === 'insert') {
+                return insertCorteResult;
+              }
+              if (schemaName === 'erp' && tableName === 'movimientos_caja' && _op === 'insert') {
+                return insertMovimientoResult;
+              }
+              if (schemaName === 'erp' && tableName === 'cortes_vouchers' && _op === 'insert') {
+                return insertVoucherResult;
+              }
+              return { data: null, error: null };
+            },
+            then(onFulfilled: (r: { data: unknown; error: unknown }) => unknown) {
+              // Resolver lecturas terminales (.eq().eq().order().limit().maybeSingle())
+              // o updates / deletes / upserts via await directo.
+              if (
+                schemaName === 'erp' &&
+                tableName === 'cortes_caja' &&
+                _op === 'select' &&
+                _filters.estado === 'cerrado'
+              ) {
+                // previewEfectivoInicial usa .limit(1).maybeSingle() — ya cubierto arriba,
+                // pero por si acaso la chain remata aquí.
+                return Promise.resolve({ data: previewData, error: previewError }).then(
+                  onFulfilled
+                );
+              }
+              if (schemaName === 'erp' && tableName === 'cortes_caja' && _op === 'update') {
+                return Promise.resolve({ data: null, error: updateCorteError }).then(onFulfilled);
+              }
+              if (
+                schemaName === 'erp' &&
+                tableName === 'corte_conteo_denominaciones' &&
+                _op === 'upsert'
+              ) {
+                return Promise.resolve({ data: null, error: upsertDenomError }).then(onFulfilled);
+              }
+              if (schemaName === 'erp' && tableName === 'cortes_vouchers' && _op === 'update') {
+                // .update().eq().select('id') — devuelve array.
+                return Promise.resolve(updateVoucherResult).then(onFulfilled);
+              }
+              if (schemaName === 'erp' && tableName === 'cortes_vouchers' && _op === 'delete') {
+                return Promise.resolve({ data: null, error: deleteVoucherError }).then(onFulfilled);
+              }
+              if (schemaName === 'erp' && tableName === 'cortes_vouchers' && _op === 'select') {
+                return Promise.resolve(vouchersListResult).then(onFulfilled);
+              }
+              if (schemaName === 'core' && tableName === 'bancos' && _op === 'select') {
+                return Promise.resolve(bancosListResult).then(onFulfilled);
+              }
+              return Promise.resolve({ data: null, error: null }).then(onFulfilled);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+    storage: {
+      from(_bucket: string) {
+        return {
+          async upload(_path: string, _file: unknown, _opts: unknown) {
+            return { data: null, error: storageUploadError };
+          },
+          async remove(paths: string[]) {
+            removeStorageCalled.push(paths);
+            return { data: null, error: null };
+          },
+          async createSignedUrl(_path: string, _expiresIn: number) {
+            return signedUrlResult;
+          },
+          async createSignedUrls(paths: string[], _expiresIn: number) {
+            return {
+              data: paths.map((p) => ({ path: p, signedUrl: `https://signed.url/${p}` })),
+              error: null,
+            };
+          },
+        };
+      },
+    },
+  };
+}
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => buildSupabaseMock(),
+}));
+
+// ── Test ───────────────────────────────────────────────────────────────
+
+import {
+  abrirCaja,
+  previewEfectivoInicial,
+  cerrarCaja,
+  registrarMovimiento,
+  subirVoucher,
+  eliminarVoucher,
+  obtenerVouchersDelCorte,
+  cargarBancos,
+  confirmarVoucher,
+  actualizarCategoriaVoucher,
+} from './actions';
+
+beforeEach(() => {
+  session = {
+    user: {
+      id: 'user-uuid',
+      email: 'beto@anorte.com',
+      user_metadata: { full_name: 'Beto Santos' },
+    },
+  };
+  preventInPreview = false;
+  corteLookup = { id: 'corte-1', estado: 'abierto' };
+  corteLookupError = null;
+  existingOpenCorte = null;
+  existingOpenError = null;
+  ultimoCorte = null;
+  ultimoCorteError = null;
+  insertCorteResult = { data: { id: 'corte-new' }, error: null };
+  updateCorteError = null;
+  upsertDenomError = null;
+  insertMovimientoResult = { data: { id: 'mov-1' }, error: null };
+  previewData = null;
+  previewError = null;
+  voucherLookup = { storage_path: 'rdb/corte-1/abc.jpg' };
+  voucherLookupError = null;
+  storageUploadError = null;
+  insertVoucherResult = { data: { id: 'voucher-1' }, error: null };
+  signedUrlResult = { data: { signedUrl: 'https://signed.url/voucher-1' }, error: null };
+  removeStorageCalled = [];
+  updateVoucherResult = { data: [{ id: 'voucher-1' }], error: null };
+  deleteVoucherError = null;
+  vouchersListResult = { data: [], error: null };
+  bancosListResult = { data: [], error: null };
+});
+
+const ABRIR_INPUT = {
+  caja_id: 'caja-1',
+  caja_nombre: 'Caja Principal',
+  responsable_apertura: 'Beto Santos',
+  fecha_operativa: '2026-05-02',
+};
+
+// ─────────────────────────────────────────────────────────────────────
+// abrirCaja
+// ─────────────────────────────────────────────────────────────────────
+
+describe('abrirCaja', () => {
+  it('falla sin auth', async () => {
+    session = null;
+    const res = await abrirCaja(ABRIR_INPUT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/No autenticado/i);
+  });
+
+  it('falla si error al verificar turno existente', async () => {
+    existingOpenError = { message: 'connection lost' };
+    const res = await abrirCaja(ABRIR_INPUT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/verificar turno/i);
+  });
+
+  it('falla si ya hay turno abierto en la misma caja', async () => {
+    existingOpenCorte = { id: 'corte-existing' };
+    const res = await abrirCaja(ABRIR_INPUT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/turno abierto.*Ci[ée]rralo/i);
+  });
+
+  it('falla si error consultando último corte cerrado', async () => {
+    ultimoCorteError = { message: 'rls violation' };
+    const res = await abrirCaja(ABRIR_INPUT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/último corte/i);
+  });
+
+  it('success heredando efectivo del último corte cerrado', async () => {
+    ultimoCorte = { id: 'corte-prev', efectivo_contado: 5000, cerrado_at: '2026-05-01' };
+    const res = await abrirCaja(ABRIR_INPUT);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.efectivo_inicial).toBe(5000);
+      expect(res.heredado).toBe(true);
+      expect(res.previo_sin_contar).toBe(false);
+    }
+  });
+
+  it('success con previo_sin_contar=true cuando último corte no tenía conteo', async () => {
+    ultimoCorte = { id: 'corte-prev', efectivo_contado: null, cerrado_at: '2026-05-01' };
+    const res = await abrirCaja(ABRIR_INPUT);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.efectivo_inicial).toBe(0);
+      expect(res.heredado).toBe(true);
+      expect(res.previo_sin_contar).toBe(true);
+    }
+  });
+
+  it('success en primer turno (sin corte previo)', async () => {
+    ultimoCorte = null;
+    const res = await abrirCaja(ABRIR_INPUT);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.efectivo_inicial).toBe(0);
+      expect(res.heredado).toBe(false);
+      expect(res.previo_sin_contar).toBe(false);
+    }
+  });
+
+  it('falla si error al insertar', async () => {
+    insertCorteResult = { data: null, error: { message: 'check constraint violation' } };
+    const res = await abrirCaja(ABRIR_INPUT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/abrir turno/i);
+  });
+
+  it('lanza si está en preview', async () => {
+    preventInPreview = true;
+    await expect(abrirCaja(ABRIR_INPUT)).rejects.toThrow(/preview/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// cerrarCaja
+// ─────────────────────────────────────────────────────────────────────
+
+describe('cerrarCaja', () => {
+  it('throws sin auth', async () => {
+    session = null;
+    await expect(
+      cerrarCaja({
+        corte_id: 'corte-1',
+        denominaciones: [{ denominacion: 100, tipo: 'billete', cantidad: 5 }],
+      })
+    ).rejects.toThrow(/No autenticado/i);
+  });
+
+  it('throws si update del corte falla', async () => {
+    updateCorteError = { message: 'rls violation' };
+    await expect(
+      cerrarCaja({
+        corte_id: 'corte-1',
+        denominaciones: [{ denominacion: 100, tipo: 'billete', cantidad: 5 }],
+      })
+    ).rejects.toThrow(/rls violation/);
+  });
+
+  it('throws si upsert de denominaciones falla', async () => {
+    upsertDenomError = { message: 'unique constraint' };
+    await expect(
+      cerrarCaja({
+        corte_id: 'corte-1',
+        denominaciones: [{ denominacion: 100, tipo: 'billete', cantidad: 5 }],
+      })
+    ).rejects.toThrow(/unique constraint/);
+  });
+
+  it('success calculando total desde denominaciones', async () => {
+    await expect(
+      cerrarCaja({
+        corte_id: 'corte-1',
+        denominaciones: [
+          { denominacion: 100, tipo: 'billete', cantidad: 10 }, // 1000
+          { denominacion: 50, tipo: 'billete', cantidad: 4 }, // 200
+          { denominacion: 0, tipo: 'moneda', cantidad: 0 }, // 0 (filter)
+        ],
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('omite upsert si todas las denominaciones tienen cantidad 0', async () => {
+    upsertDenomError = { message: 'should not be called' };
+    await expect(
+      cerrarCaja({
+        corte_id: 'corte-1',
+        denominaciones: [{ denominacion: 100, tipo: 'billete', cantidad: 0 }],
+      })
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// registrarMovimiento
+// ─────────────────────────────────────────────────────────────────────
+
+describe('registrarMovimiento', () => {
+  const VALID = {
+    corte_id: 'corte-1',
+    tipo: 'entrada' as const,
+    tipo_detalle: 'efectivo',
+    monto: 100,
+    concepto: 'Pago en efectivo',
+  };
+
+  it('throws sin auth', async () => {
+    session = null;
+    await expect(registrarMovimiento(VALID)).rejects.toThrow(/No autenticado/);
+  });
+
+  it('throws si user no tiene full_name ni email', async () => {
+    session = { user: { id: 'u', email: '', user_metadata: {} } };
+    await expect(registrarMovimiento(VALID)).rejects.toThrow(/sin nombre ni email/i);
+  });
+
+  it('throws si corte_id falta', async () => {
+    await expect(registrarMovimiento({ ...VALID, corte_id: '' })).rejects.toThrow(/corte_id/);
+  });
+
+  it('throws si monto ≤ 0', async () => {
+    await expect(registrarMovimiento({ ...VALID, monto: 0 })).rejects.toThrow(/mayor a 0/);
+    await expect(registrarMovimiento({ ...VALID, monto: -10 })).rejects.toThrow(/mayor a 0/);
+  });
+
+  it('throws si concepto vacío', async () => {
+    await expect(registrarMovimiento({ ...VALID, concepto: '   ' })).rejects.toThrow(/Concepto/);
+  });
+
+  it('throws si tipo no es entrada ni salida', async () => {
+    await expect(registrarMovimiento({ ...VALID, tipo: 'invalido' as 'entrada' })).rejects.toThrow(
+      /tipo inv[áa]lido/i
+    );
+  });
+
+  it('throws si corte no existe', async () => {
+    corteLookup = null;
+    await expect(registrarMovimiento(VALID)).rejects.toThrow(/Corte no encontrado/);
+  });
+
+  it('throws si corte está cerrado', async () => {
+    corteLookup = { id: 'corte-1', estado: 'cerrado' };
+    await expect(registrarMovimiento(VALID)).rejects.toThrow(/Solo cortes abiertos|cerrado/i);
+  });
+
+  it('throws si insert falla', async () => {
+    insertMovimientoResult = { data: null, error: { message: 'fk violation' } };
+    await expect(registrarMovimiento(VALID)).rejects.toThrow(/fk violation/);
+  });
+
+  it('success retorna {id} con realizado_por_nombre del JWT', async () => {
+    const result = await registrarMovimiento(VALID);
+    expect(result).toEqual({ id: 'mov-1' });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// subirVoucher
+// ─────────────────────────────────────────────────────────────────────
+
+describe('subirVoucher', () => {
+  function makeFile(opts: { size?: number; type?: string; name?: string } = {}): File {
+    const size = opts.size ?? 1024;
+    const type = opts.type ?? 'image/jpeg';
+    return new File([new Uint8Array(size)], opts.name ?? 'voucher.jpg', { type });
+  }
+
+  it('throws sin auth', async () => {
+    session = null;
+    await expect(subirVoucher({ corte_id: 'corte-1', file: makeFile() })).rejects.toThrow(
+      /No autenticado/
+    );
+  });
+
+  it('throws si archivo > 10 MB', async () => {
+    await expect(
+      subirVoucher({ corte_id: 'corte-1', file: makeFile({ size: 11 * 1024 * 1024 }) })
+    ).rejects.toThrow(/10 MB/i);
+  });
+
+  it('throws si mime type no permitido (PDF)', async () => {
+    await expect(
+      subirVoucher({
+        corte_id: 'corte-1',
+        file: makeFile({ type: 'application/pdf' }),
+      })
+    ).rejects.toThrow(/Tipo no permitido/);
+  });
+
+  it('throws si corte no existe', async () => {
+    corteLookup = null;
+    await expect(subirVoucher({ corte_id: 'corte-1', file: makeFile() })).rejects.toThrow(
+      /Corte no encontrado/
+    );
+  });
+
+  it('rollback de archivo si insert falla', async () => {
+    insertVoucherResult = { data: null, error: { message: 'rls violation' } };
+    await expect(subirVoucher({ corte_id: 'corte-1', file: makeFile() })).rejects.toThrow(
+      /rls violation/
+    );
+    // Storage remove se llamó para limpiar el archivo huérfano.
+    expect(removeStorageCalled.length).toBeGreaterThan(0);
+  });
+
+  it('success retorna {id, signed_url}', async () => {
+    const res = await subirVoucher({ corte_id: 'corte-1', file: makeFile() });
+    expect(res.id).toBe('voucher-1');
+    expect(res.signed_url).toBe('https://signed.url/voucher-1');
+  });
+
+  it('acepta image/png, image/webp, image/heic', async () => {
+    for (const type of ['image/png', 'image/webp', 'image/heic']) {
+      const res = await subirVoucher({ corte_id: 'corte-1', file: makeFile({ type }) });
+      expect(res.id).toBe('voucher-1');
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// eliminarVoucher
+// ─────────────────────────────────────────────────────────────────────
+
+describe('eliminarVoucher', () => {
+  it('throws sin auth', async () => {
+    session = null;
+    await expect(eliminarVoucher('voucher-1')).rejects.toThrow(/No autenticado/);
+  });
+
+  it('throws si voucher no existe (o sin permisos)', async () => {
+    voucherLookup = null;
+    await expect(eliminarVoucher('voucher-1')).rejects.toThrow(/no encontrado.*permisos/i);
+  });
+
+  it('throws si delete row falla', async () => {
+    deleteVoucherError = { message: 'rls violation' };
+    await expect(eliminarVoucher('voucher-1')).rejects.toThrow(/rls violation/);
+  });
+
+  it('success: borra row e intenta remover archivo (best-effort)', async () => {
+    await expect(eliminarVoucher('voucher-1')).resolves.toBeUndefined();
+    // Storage remove se invocó con el path correcto.
+    expect(removeStorageCalled).toEqual([['rdb/corte-1/abc.jpg']]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// confirmarVoucher
+// ─────────────────────────────────────────────────────────────────────
+
+describe('confirmarVoucher', () => {
+  const VALID = { voucher_id: 'voucher-1', banco_id: 'banco-1', monto: 1000, afiliacion: '12345' };
+
+  it('throws sin auth', async () => {
+    session = null;
+    await expect(confirmarVoucher(VALID)).rejects.toThrow(/No autenticado/);
+  });
+
+  it('throws si monto null', async () => {
+    await expect(confirmarVoucher({ ...VALID, monto: null as unknown as number })).rejects.toThrow(
+      /monto es requerido/
+    );
+  });
+
+  it('throws si monto NaN', async () => {
+    await expect(confirmarVoucher({ ...VALID, monto: NaN })).rejects.toThrow(/monto es requerido/);
+  });
+
+  it('throws si monto negativo', async () => {
+    await expect(confirmarVoucher({ ...VALID, monto: -5 })).rejects.toThrow(
+      /no puede ser negativo/
+    );
+  });
+
+  it('throws si update no afecta filas (RLS bloqueando)', async () => {
+    updateVoucherResult = { data: [], error: null };
+    await expect(confirmarVoucher(VALID)).rejects.toThrow(/RLS bloqueando|inexistente/i);
+  });
+
+  it('success', async () => {
+    await expect(confirmarVoucher(VALID)).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// actualizarCategoriaVoucher
+// ─────────────────────────────────────────────────────────────────────
+
+describe('actualizarCategoriaVoucher', () => {
+  it('throws sin auth', async () => {
+    session = null;
+    await expect(
+      actualizarCategoriaVoucher({
+        voucher_id: 'v1',
+        categoria: 'voucher_tarjeta',
+        movimiento_caja_id: null,
+      })
+    ).rejects.toThrow(/No autenticado/);
+  });
+
+  it('throws si comprobante_movimiento sin movimiento_caja_id', async () => {
+    await expect(
+      actualizarCategoriaVoucher({
+        voucher_id: 'v1',
+        categoria: 'comprobante_movimiento',
+        movimiento_caja_id: null,
+      })
+    ).rejects.toThrow(/seleccionar el movimiento/i);
+  });
+
+  it('throws si update no afecta filas (RLS bloqueando)', async () => {
+    updateVoucherResult = { data: [], error: null };
+    await expect(
+      actualizarCategoriaVoucher({
+        voucher_id: 'v1',
+        categoria: 'voucher_tarjeta',
+        movimiento_caja_id: null,
+      })
+    ).rejects.toThrow(/RLS bloqueando|inexistente/i);
+  });
+
+  it('success voucher_tarjeta', async () => {
+    await expect(
+      actualizarCategoriaVoucher({
+        voucher_id: 'v1',
+        categoria: 'voucher_tarjeta',
+        movimiento_caja_id: null,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('success comprobante_movimiento con movimiento_caja_id', async () => {
+    await expect(
+      actualizarCategoriaVoucher({
+        voucher_id: 'v1',
+        categoria: 'comprobante_movimiento',
+        movimiento_caja_id: 'mov-1',
+      })
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// previewEfectivoInicial
+// ─────────────────────────────────────────────────────────────────────
+
+describe('previewEfectivoInicial', () => {
+  it('returns heredado=false cuando no hay corte previo', async () => {
+    ultimoCorte = null;
+    const res = await previewEfectivoInicial('Caja Principal');
+    expect(res).toEqual({ monto: 0, heredado: false, previo_sin_contar: false, cerrado_at: null });
+  });
+
+  it('returns heredado=true con efectivo previo', async () => {
+    ultimoCorte = { id: 'c1', efectivo_contado: 3000, cerrado_at: '2026-05-01' };
+    const res = await previewEfectivoInicial('Caja Principal');
+    expect(res).toEqual({
+      monto: 3000,
+      heredado: true,
+      previo_sin_contar: false,
+      cerrado_at: '2026-05-01',
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// cargarBancos / obtenerVouchersDelCorte (lecturas)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('cargarBancos', () => {
+  it('returns lista vacía si no hay bancos', async () => {
+    bancosListResult = { data: [], error: null };
+    const res = await cargarBancos();
+    expect(res).toEqual([]);
+  });
+
+  it('returns bancos activos', async () => {
+    bancosListResult = {
+      data: [
+        { id: 'b1', codigo: 'BBVA', nombre: 'BBVA México', patron_ocr: '', activo: true },
+        { id: 'b2', codigo: 'BNX', nombre: 'Banamex', patron_ocr: '', activo: true },
+      ],
+      error: null,
+    };
+    const res = await cargarBancos();
+    expect(res.length).toBe(2);
+    expect(res[0].codigo).toBe('BBVA');
+  });
+});
+
+describe('obtenerVouchersDelCorte', () => {
+  it('returns vacío si el corte no tiene vouchers', async () => {
+    vouchersListResult = { data: [], error: null };
+    const res = await obtenerVouchersDelCorte('corte-1');
+    expect(res).toEqual([]);
+  });
+
+  it('throws si error en query', async () => {
+    vouchersListResult = { data: [], error: { message: 'connection' } };
+    await expect(obtenerVouchersDelCorte('corte-1')).rejects.toThrow(/connection/);
+  });
+});

--- a/app/rdb/inventario/levantamientos/actions.test.ts
+++ b/app/rdb/inventario/levantamientos/actions.test.ts
@@ -1,0 +1,548 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests para `app/rdb/inventario/levantamientos/actions.ts`.
+ *
+ * Sprint 3C de tech-debt-h1-2026 — fortifica el flujo de levantamientos
+ * de inventario (firma, transiciones de estado, aplicación a stock).
+ *
+ * **8 de 9 funciones delegan a RPCs PL/pgSQL** (`fn_iniciar_captura`,
+ * `fn_guardar_conteo`, `fn_cerrar_captura`, `fn_firmar_levantamiento`,
+ * `fn_cancelar_levantamiento`, `fn_get_lineas_*`). Estos unit tests
+ * cubren:
+ *
+ *   - La capa TS (validaciones que viven en `actions.ts`).
+ *   - Que las RPCs se invoquen con los argumentos correctos.
+ *   - Propagación de errores RPC al caller.
+ *   - El parser de `fn_firmar_levantamiento` (`parseFirmarPasoResult`).
+ *
+ * La lógica DENTRO de las RPCs (transiciones de estado, conteo de
+ * firmas, aplicación a movimientos) se cubre en los integration tests
+ * (parte 2 de este PR, contra DB real con `supabase start`).
+ *
+ * `actualizarNotaDiferencia` es la única función con lógica TS rica
+ * (state guards, lookup de línea + levantamiento, validación de
+ * contador) — recibe el grueso de los tests aquí.
+ */
+
+// ── State del test ─────────────────────────────────────────────────────
+
+let session: { user: { id: string } } | null;
+let preventInPreview = false;
+let adminAvailable = true;
+
+// crearLevantamiento.
+let insertLevantamientoResult: {
+  data: { id: string; folio: string | null } | null;
+  error: { message: string } | null;
+} = { data: { id: 'lev-1', folio: 'LEV-2026-001' }, error: null };
+
+// RPCs.
+let rpcResults: Record<string, { data: unknown; error: { message: string } | null }> = {};
+
+// actualizarNotaDiferencia: admin lookups.
+let lineaLookup: { id: string; levantamiento_id: string } | null = null;
+let lineaLookupError: { message: string } | null = null;
+let levLookup: { id: string; estado: string; contador_id: string } | null = null;
+let levLookupError: { message: string } | null = null;
+let updateNotaError: { message: string } | null = null;
+let lastNotaWritten: string | null | undefined;
+
+// Captura de las RPCs llamadas, para verificación.
+let rpcCallLog: Array<{ fn: string; args: Record<string, unknown> }> = [];
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  headers: async () => ({
+    get: (key: string) => {
+      if (key === 'x-forwarded-for') return '192.168.1.1';
+      if (key === 'user-agent') return 'TestAgent/1.0';
+      return null;
+    },
+  }),
+}));
+
+vi.mock('@/lib/auth/preview-guard', () => ({
+  assertNotInPreview: async () => {
+    if (preventInPreview) throw new Error('Mutation bloqueada en preview');
+  },
+}));
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- test doubles */
+function buildSupabaseUserMock(): any {
+  return {
+    auth: {
+      getSession: async () => ({ data: { session } }),
+    },
+    schema(schemaName: string) {
+      return {
+        from(tableName: string) {
+          let _payload: unknown = null;
+          const builder: any = {
+            insert(payload: unknown) {
+              _payload = payload;
+              return builder;
+            },
+            select(_cols: string) {
+              return builder;
+            },
+            async single() {
+              if (schemaName === 'erp' && tableName === 'inventario_levantamientos' && _payload) {
+                return insertLevantamientoResult;
+              }
+              return { data: null, error: null };
+            },
+          };
+          return builder;
+        },
+        rpc(fn: string, args: Record<string, unknown>) {
+          rpcCallLog.push({ fn, args });
+          const result = rpcResults[fn] ?? { data: null, error: null };
+          return Promise.resolve(result);
+        },
+      };
+    },
+  };
+}
+
+function buildSupabaseAdminMock(): any {
+  return {
+    schema(_schemaName: string) {
+      return {
+        from(tableName: string) {
+          const _filters: Record<string, unknown> = {};
+          let _op = '';
+          let _payload: unknown = null;
+
+          const builder: any = {
+            select(_cols: string) {
+              _op = 'select';
+              return builder;
+            },
+            update(payload: unknown) {
+              _op = 'update';
+              _payload = payload;
+              return builder;
+            },
+            eq(col: string, val: unknown) {
+              _filters[col] = val;
+              return builder;
+            },
+            async maybeSingle() {
+              if (tableName === 'inventario_levantamiento_lineas') {
+                return { data: lineaLookup, error: lineaLookupError };
+              }
+              if (tableName === 'inventario_levantamientos') {
+                return { data: levLookup, error: levLookupError };
+              }
+              return { data: null, error: null };
+            },
+            then(onFulfilled: (r: { data: unknown; error: unknown }) => unknown) {
+              if (_op === 'update' && tableName === 'inventario_levantamiento_lineas') {
+                const p = _payload as { notas_diferencia?: string | null };
+                lastNotaWritten = p?.notas_diferencia;
+                return Promise.resolve({ data: null, error: updateNotaError }).then(onFulfilled);
+              }
+              return Promise.resolve({ data: null, error: null }).then(onFulfilled);
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => buildSupabaseUserMock(),
+}));
+
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdminClient: () => (adminAvailable ? buildSupabaseAdminMock() : null),
+}));
+
+// ── Test ───────────────────────────────────────────────────────────────
+
+import {
+  crearLevantamiento,
+  iniciarCaptura,
+  guardarConteo,
+  cerrarCaptura,
+  firmarPaso,
+  cancelarLevantamiento,
+  getLineasParaCapturar,
+  getLineasParaRevisar,
+  actualizarNotaDiferencia,
+} from './actions';
+
+beforeEach(() => {
+  session = { user: { id: 'user-uuid' } };
+  preventInPreview = false;
+  adminAvailable = true;
+  insertLevantamientoResult = {
+    data: { id: 'lev-1', folio: 'LEV-2026-001' },
+    error: null,
+  };
+  rpcResults = {};
+  lineaLookup = { id: 'linea-1', levantamiento_id: 'lev-1' };
+  lineaLookupError = null;
+  levLookup = { id: 'lev-1', estado: 'capturado', contador_id: 'user-uuid' };
+  levLookupError = null;
+  updateNotaError = null;
+  lastNotaWritten = undefined;
+  rpcCallLog = [];
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// crearLevantamiento
+// ─────────────────────────────────────────────────────────────────────
+
+describe('crearLevantamiento', () => {
+  const VALID = {
+    almacen_id: 'almacen-1',
+    fecha_programada: '2026-05-15',
+    notas: 'Conteo mensual',
+  };
+
+  it('falla sin auth', async () => {
+    session = null;
+    const res = await crearLevantamiento(VALID);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/No autenticado/i);
+  });
+
+  it('falla si insert lanza error', async () => {
+    insertLevantamientoResult = { data: null, error: { message: 'check constraint' } };
+    const res = await crearLevantamiento(VALID);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('check constraint');
+  });
+
+  it('falla si insert no devuelve datos', async () => {
+    insertLevantamientoResult = { data: null, error: null };
+    const res = await crearLevantamiento(VALID);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/Sin datos/i);
+  });
+
+  it('success retorna {id, folio}', async () => {
+    const res = await crearLevantamiento(VALID);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data).toEqual({ id: 'lev-1', folio: 'LEV-2026-001' });
+  });
+
+  it('lanza si está en preview', async () => {
+    preventInPreview = true;
+    await expect(crearLevantamiento(VALID)).rejects.toThrow(/preview/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// RPCs simples (delegación + propagación de error)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('iniciarCaptura', () => {
+  it('llama RPC con el levantamiento_id', async () => {
+    rpcResults['fn_iniciar_captura_levantamiento'] = { data: 42, error: null };
+    const res = await iniciarCaptura('lev-1');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data).toEqual({ lineasSembradas: 42 });
+    expect(rpcCallLog).toContainEqual({
+      fn: 'fn_iniciar_captura_levantamiento',
+      args: { p_levantamiento_id: 'lev-1' },
+    });
+  });
+
+  it('propaga error de RPC', async () => {
+    rpcResults['fn_iniciar_captura_levantamiento'] = {
+      data: null,
+      error: { message: 'estado inválido' },
+    };
+    const res = await iniciarCaptura('lev-1');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('estado inválido');
+  });
+
+  it('retorna lineasSembradas: 0 cuando RPC retorna null', async () => {
+    rpcResults['fn_iniciar_captura_levantamiento'] = { data: null, error: null };
+    const res = await iniciarCaptura('lev-1');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.lineasSembradas).toBe(0);
+  });
+});
+
+describe('guardarConteo', () => {
+  it('llama RPC con los 3 args', async () => {
+    rpcResults['fn_guardar_conteo'] = { data: null, error: null };
+    const res = await guardarConteo('lev-1', 'prod-1', 5.5);
+    expect(res.ok).toBe(true);
+    expect(rpcCallLog).toContainEqual({
+      fn: 'fn_guardar_conteo',
+      args: { p_levantamiento_id: 'lev-1', p_producto_id: 'prod-1', p_cantidad: 5.5 },
+    });
+  });
+
+  it('propaga error de RPC', async () => {
+    rpcResults['fn_guardar_conteo'] = { data: null, error: { message: 'línea bloqueada' } };
+    const res = await guardarConteo('lev-1', 'prod-1', 5);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('línea bloqueada');
+  });
+});
+
+describe('cerrarCaptura', () => {
+  it('llama RPC con el id y propaga success', async () => {
+    rpcResults['fn_cerrar_captura_levantamiento'] = { data: null, error: null };
+    const res = await cerrarCaptura('lev-1');
+    expect(res.ok).toBe(true);
+  });
+
+  it('propaga error de RPC', async () => {
+    rpcResults['fn_cerrar_captura_levantamiento'] = {
+      data: null,
+      error: { message: 'líneas pendientes' },
+    };
+    const res = await cerrarCaptura('lev-1');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('líneas pendientes');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// firmarPaso
+// ─────────────────────────────────────────────────────────────────────
+
+describe('firmarPaso', () => {
+  const VALID_INPUT = {
+    levantamiento_id: 'lev-1',
+    paso: 1,
+    rol: 'operacion',
+    comentario: 'OK',
+  };
+
+  it('llama RPC con args + headers (ip + user-agent)', async () => {
+    rpcResults['fn_firmar_levantamiento'] = {
+      data: {
+        firmas_actuales: 1,
+        firmas_requeridas: 2,
+        aplicado: false,
+        movimientos_generados: 0,
+      },
+      error: null,
+    };
+    const res = await firmarPaso(VALID_INPUT);
+    expect(res.ok).toBe(true);
+    const call = rpcCallLog.find((c) => c.fn === 'fn_firmar_levantamiento');
+    expect(call?.args).toMatchObject({
+      p_levantamiento_id: 'lev-1',
+      p_paso: 1,
+      p_rol: 'operacion',
+      p_comentario: 'OK',
+      p_ip: '192.168.1.1',
+      p_user_agent: 'TestAgent/1.0',
+    });
+  });
+
+  it('parsea correctamente firmas_actuales/requeridas/aplicado', async () => {
+    rpcResults['fn_firmar_levantamiento'] = {
+      data: {
+        firmas_actuales: 2,
+        firmas_requeridas: 2,
+        aplicado: true,
+        movimientos_generados: 15,
+      },
+      error: null,
+    };
+    const res = await firmarPaso(VALID_INPUT);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.data).toEqual({
+        firmas_actuales: 2,
+        firmas_requeridas: 2,
+        aplicado: true,
+        movimientos_generados: 15,
+      });
+    }
+  });
+
+  it('falla si la respuesta de RPC tiene shape inválido', async () => {
+    rpcResults['fn_firmar_levantamiento'] = {
+      data: { firmas_actuales: 'not-a-number' },
+      error: null,
+    };
+    const res = await firmarPaso(VALID_INPUT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/Respuesta inesperada/i);
+  });
+
+  it('falla si la respuesta de RPC es null', async () => {
+    rpcResults['fn_firmar_levantamiento'] = { data: null, error: null };
+    const res = await firmarPaso(VALID_INPUT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/Respuesta inesperada/i);
+  });
+
+  it('propaga error de RPC', async () => {
+    rpcResults['fn_firmar_levantamiento'] = {
+      data: null,
+      error: { message: 'rol no autorizado' },
+    };
+    const res = await firmarPaso(VALID_INPUT);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('rol no autorizado');
+  });
+
+  it('movimientos_generados default 0 si no viene en respuesta', async () => {
+    rpcResults['fn_firmar_levantamiento'] = {
+      data: { firmas_actuales: 1, firmas_requeridas: 2, aplicado: false },
+      error: null,
+    };
+    const res = await firmarPaso(VALID_INPUT);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.movimientos_generados).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// cancelarLevantamiento
+// ─────────────────────────────────────────────────────────────────────
+
+describe('cancelarLevantamiento', () => {
+  it('falla si motivo está vacío', async () => {
+    const res = await cancelarLevantamiento('lev-1', '');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/motivo.*requerido/i);
+  });
+
+  it('falla si motivo es solo whitespace', async () => {
+    const res = await cancelarLevantamiento('lev-1', '   ');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/motivo.*requerido/i);
+  });
+
+  it('llama RPC con motivo trimmed', async () => {
+    rpcResults['fn_cancelar_levantamiento'] = { data: null, error: null };
+    await cancelarLevantamiento('lev-1', '  Cancelado por error  ');
+    const call = rpcCallLog.find((c) => c.fn === 'fn_cancelar_levantamiento');
+    expect(call?.args).toEqual({ p_levantamiento_id: 'lev-1', p_motivo: 'Cancelado por error' });
+  });
+
+  it('propaga error de RPC', async () => {
+    rpcResults['fn_cancelar_levantamiento'] = {
+      data: null,
+      error: { message: 'estado inválido' },
+    };
+    const res = await cancelarLevantamiento('lev-1', 'Motivo');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('estado inválido');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// getLineasPara* (lecturas)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('getLineasParaCapturar / getLineasParaRevisar', () => {
+  it('getLineasParaCapturar retorna data del RPC', async () => {
+    const lineas = [{ producto_id: 'p1', producto_nombre: 'X', cantidad_capturada: 5 }];
+    rpcResults['fn_get_lineas_para_capturar'] = { data: lineas, error: null };
+    const res = await getLineasParaCapturar('lev-1');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.length).toBe(1);
+  });
+
+  it('getLineasParaRevisar retorna data del RPC', async () => {
+    rpcResults['fn_get_lineas_para_revisar'] = { data: [], error: null };
+    const res = await getLineasParaRevisar('lev-1');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data).toEqual([]);
+  });
+
+  it('propaga errores', async () => {
+    rpcResults['fn_get_lineas_para_capturar'] = {
+      data: null,
+      error: { message: 'permission denied' },
+    };
+    const res = await getLineasParaCapturar('lev-1');
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// actualizarNotaDiferencia (lógica TS rica)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('actualizarNotaDiferencia', () => {
+  it('falla sin auth', async () => {
+    session = null;
+    const res = await actualizarNotaDiferencia('linea-1', 'nota');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/No autenticado/i);
+  });
+
+  it('falla si admin client no disponible', async () => {
+    adminAvailable = false;
+    const res = await actualizarNotaDiferencia('linea-1', 'nota');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/service-role no disponible/i);
+  });
+
+  it('falla si línea no existe', async () => {
+    lineaLookup = null;
+    const res = await actualizarNotaDiferencia('linea-1', 'nota');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/L[ií]nea no encontrada/i);
+  });
+
+  it('falla si lookup de línea lanza error', async () => {
+    lineaLookupError = { message: 'db error' };
+    const res = await actualizarNotaDiferencia('linea-1', 'nota');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('db error');
+  });
+
+  it('falla si levantamiento no existe', async () => {
+    levLookup = null;
+    const res = await actualizarNotaDiferencia('linea-1', 'nota');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/Levantamiento no encontrado/i);
+  });
+
+  it('falla si estado del levantamiento no es `capturado`', async () => {
+    levLookup = { id: 'lev-1', estado: 'aplicado', contador_id: 'user-uuid' };
+    const res = await actualizarNotaDiferencia('linea-1', 'nota');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/en revisi[óo]n/i);
+  });
+
+  it('falla si user no es contador del levantamiento', async () => {
+    levLookup = { id: 'lev-1', estado: 'capturado', contador_id: 'otro-user' };
+    const res = await actualizarNotaDiferencia('linea-1', 'nota');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/Solo el contador/i);
+  });
+
+  it('falla si update lanza error', async () => {
+    updateNotaError = { message: 'rls violation' };
+    const res = await actualizarNotaDiferencia('linea-1', 'nota');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toBe('rls violation');
+  });
+
+  it('success con nota válida', async () => {
+    const res = await actualizarNotaDiferencia('linea-1', '  Falto producto  ');
+    expect(res.ok).toBe(true);
+    expect(lastNotaWritten).toBe('Falto producto');
+  });
+
+  it('limpia nota a null cuando viene whitespace solo', async () => {
+    const res = await actualizarNotaDiferencia('linea-1', '   ');
+    expect(res.ok).toBe(true);
+    expect(lastNotaWritten).toBe(null);
+  });
+});

--- a/docs/planning/tech-debt-h1-2026.md
+++ b/docs/planning/tech-debt-h1-2026.md
@@ -333,9 +333,75 @@ iniciativa propia.
 
 ## Bitácora
 
-### 2026-05-02 — Sprint 3B en flight (este PR)
+### 2026-05-02 — Sprint 3C en flight (este PR) — unit tests parte 1
 
-Sprint 3B entrega tests para los 2 archivos del medio del Sprint 3
+Cierre del Sprint 3 con `cortes/actions` y `levantamientos/actions`.
+Estructura: parte 1 = unit tests con mocks (este commit), parte 2 =
+integration tests contra DB real con `supabase start` (commits
+posteriores cuando OrbStack esté listo en local).
+
+**Tests nuevos parte 1** (87 tests, todos pasando):
+
+- `app/rdb/cortes/actions.test.ts` (52 tests) — 9 funciones cubiertas:
+  - `abrirCaja`: validaciones, herencia de efectivo del corte previo,
+    `previo_sin_contar`, primer turno (no hay corte previo), insert
+    error, preview guard.
+  - `cerrarCaja`: cálculo de total desde denominaciones, upsert sólo
+    de las cantidades > 0, errores en update/upsert.
+  - `registrarMovimiento`: validaciones (corte_id, monto, concepto,
+    tipo, `realizadoPorNombre` desde JWT), corte debe estar abierto.
+  - `subirVoucher`: límite 10MB, mime types allowlist (jpeg/png/webp/
+    heic/heif), corte debe existir, **rollback de archivo si insert
+    falla** (regresión que la memoria del usuario menciona).
+  - `eliminarVoucher`: voucher must exist, delete row + best-effort
+    storage remove.
+  - `confirmarVoucher` / `actualizarCategoriaVoucher`: validaciones +
+    `data.length === 0 → throw` (cubre el caso de **RLS bloqueando
+    UPDATE silenciosamente**, regresión histórica documentada).
+  - `previewEfectivoInicial` / `cargarBancos` / `obtenerVouchersDelCorte`:
+    lectores con paths de error.
+
+- `app/rdb/inventario/levantamientos/actions.test.ts` (35 tests):
+  - `crearLevantamiento`: validaciones + insert path.
+  - 5 funciones que delegan a RPCs (`iniciarCaptura`, `guardarConteo`,
+    `cerrarCaptura`, `cancelarLevantamiento`, `getLineasParaCapturar`,
+    `getLineasParaRevisar`): verifica delegación con args correctos +
+    propagación de error.
+  - `firmarPaso`: 6 tests del parser `parseFirmarPasoResult` (shapes
+    inválidos retornan null + propagación de IP/user-agent headers).
+  - `cancelarLevantamiento`: motivo trim + validación de motivo vacío.
+  - `actualizarNotaDiferencia` (lógica TS rica, **10 tests**): state
+    guards (`estado === 'capturado'`), validación de contador, trim
+    a null, lookup de línea/levantamiento via admin client.
+
+**Coverage threshold bump**:
+
+- Coverage tras parte 1: **42.1% lines**, 72.08% functions, 84.21%
+  branches.
+- Threshold subido en `vitest.config.ts`:
+  - lines/statements: 33 → **40**
+  - functions: 67 → **70**
+  - branches: 80 → **82**
+- Buffer ~2% sobre el medido. Cumple el target final del Sprint 3
+  (40-45% lines).
+
+**Pendiente parte 2** — integration tests:
+
+- Setup de Supabase local (`supabase start` con OrbStack/Docker).
+- `seed.sql` con fixtures (RDB, almacén, productos, caja).
+- `vitest.integration.config.ts` separado.
+- ~5 tests críticos: levantamiento full flow (crear → conteo → 2
+  firmas → aplicar), cortes full flow (abrir → mov → cerrar →
+  verificar balance), voucher upload + storage round-trip.
+- Opt-in via `npm run test:integration` (no en CI default).
+
+OrbStack instalado en máquina local, Docker symlinks pendientes
+(requiere abrir la app). Integration tests escritos pero NO validados
+todavía — push se hace tras validación con Docker corriendo.
+
+### 2026-05-02 — Sprint 3B merged (PR #396)
+
+Sprint 3B entregó tests para los 2 archivos del medio del Sprint 3
 (complejidad media). Mock strategy A confirmada por Beto.
 
 **Tests nuevos** (36 tests, todos pasando):

--- a/docs/testing/integration-setup.md
+++ b/docs/testing/integration-setup.md
@@ -1,0 +1,154 @@
+# Integration testing setup
+
+> Establecido en Sprint 3C de `tech-debt-h1-2026`. Pipeline de tests
+> contra una **DB real** (Supabase local stack) que detecta drift de
+> RPCs PL/pgSQL, RLS policies, triggers y constraints. Los unit tests
+> con mocks no detectan estas regresiones — los integration tests sí.
+
+## Cuándo correrlos
+
+- **Antes de mergear PRs** que tocan migrations (`supabase/migrations/`).
+- **Antes de mergear PRs** que tocan código financiero
+  (`app/rdb/cortes/`, `app/rdb/inventario/levantamientos/`,
+  `app/rdb/productos/recetas/`).
+- **Periódicamente** sobre `main` para confirmar que la DB local
+  reproduce el schema de producción.
+
+No corren en CI default (Sprint 3C los dejó opt-in para no penalizar
+el tiempo de CI). Si más adelante decidimos escalar a CI nightly o
+gate por archivo, se documenta el cambio en este archivo.
+
+## Pre-requisitos
+
+1. **Docker** corriendo. Cualquiera funciona:
+   - [OrbStack](https://orbstack.dev/) (recomendado para Mac, más
+     liviano: `brew install --cask orbstack`).
+   - [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+2. **Supabase CLI** ≥ 2.0:
+   ```bash
+   brew install supabase/tap/supabase
+   supabase --version
+   ```
+3. El repo clonado y dependencias instaladas (`npm ci`).
+
+## Cómo correrlos
+
+### Workaround inicial (chicken-egg con schemas)
+
+Hay un detalle del setup: nuestro `supabase/config.toml` declara
+`api.schemas = ["public", "core", "erp", ...]` para que producción
+exponga esos schemas vía PostgREST. Pero localmente, antes de aplicar
+migrations, esos schemas no existen — y `supabase start` falla
+porque PostgREST no puede cargar el schema cache.
+
+**Bootstrap inicial** (una sola vez por máquina o tras `supabase stop --no-backup`):
+
+```bash
+# 1) Edita supabase/config.toml temporalmente: cambia
+#    `schemas = ["public", "core", ...]` a `schemas = ["public"]`.
+
+# 2) Levanta el stack local (primera vez ~5-10 min descargando
+#    ~2GB de imágenes; las siguientes ~10-15 segundos).
+supabase start
+
+# 3) Aplica las 211 migrations — ahora los schemas core/erp/etc
+#    se crean en la DB local.
+supabase db reset
+
+# 4) Restaura supabase/config.toml a la lista completa de schemas.
+
+# 5) Restart de PostgREST para que recoja los schemas nuevos.
+supabase stop  # SIN --no-backup, preserva el DB con migrations
+supabase start
+
+# 6) Ya puedes correr los integration tests.
+npm run test:integration
+```
+
+### Uso normal (después del bootstrap)
+
+```bash
+supabase start          # 10-15s — DB persiste entre stop/start sin --no-backup
+npm run test:integration
+```
+
+### Reset clean
+
+```bash
+supabase stop --no-backup   # destruye el DB volume
+# Después tienes que repetir el bootstrap completo arriba.
+```
+
+Para detener:
+
+```bash
+supabase stop
+# o `supabase stop --no-backup` si no quieres preservar el state.
+```
+
+## Estructura
+
+```
+tests/integration/
+├── smoke.integration.test.ts       # Valida que el pipeline está OK.
+└── (futuros tests aquí)
+```
+
+`vitest.integration.config.ts` usa `singleFork: true` para que los
+tests corran serialmente — la DB es compartida y paralelizar genera
+race conditions con SELECT/INSERT del mismo registro.
+
+## Troubleshooting
+
+### `supabase start` falla con "Cannot connect to Docker daemon"
+
+Docker no está corriendo. Abre OrbStack/Docker Desktop primero.
+
+### `supabase start` cuelga descargando
+
+Primera vez tarda. Si lleva >15 min sin avanzar, `supabase stop` y
+re-intentar.
+
+### Tests fallan con "PGRST202: function does not exist"
+
+Las migrations no se aplicaron al DB local. Corre:
+
+```bash
+supabase db reset
+```
+
+### El smoke test pasa pero un test específico falla
+
+Probable drift del schema entre producción y migrations: alguna RPC
+en producción se modificó sin migration. Investigar con
+`supabase/SCHEMA_REF.md` y comparar con la signature que el RPC tenía
+cuando el test fue escrito.
+
+### Quiero ver el state actual de la DB local
+
+```bash
+# Studio (UI web) en http://localhost:54323
+supabase status
+```
+
+## Cómo agregar tests nuevos
+
+1. Archivo en `tests/integration/{feature}.integration.test.ts`.
+2. Import del cliente desde el archivo (los defaults de `supabase
+start` están en el smoke test como referencia).
+3. **Cleanup obligatorio entre tests**: usa `beforeEach` para
+   resetear el state que tu test necesita. La DB persiste entre
+   tests del mismo run.
+4. **Sin paralelismo**: el config force-a `singleFork`. Si tu test
+   asume serialidad, está bien.
+5. **Usar service role key** para crear fixtures (no necesitas auth
+   real para validar lógica DB). Si tu test específicamente prueba
+   RLS, usa anon key + JWT generado.
+
+## Referencias
+
+- Sprint 3C de `tech-debt-h1-2026` (planning doc).
+- ADR pendiente: documentar este setup en
+  `docs/adr/NNNN_integration_testing.md` cuando el patrón se
+  estabilice tras 2-3 sprints de uso.
+- [Supabase CLI docs](https://supabase.com/docs/guides/cli/local-development).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:anon": "playwright test --project=anon",

--- a/tests/integration/smoke.integration.test.ts
+++ b/tests/integration/smoke.integration.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Smoke test del pipeline de integration testing.
+ *
+ * Valida end-to-end que:
+ *   1. Docker está corriendo (OrbStack o Docker Desktop).
+ *   2. `supabase start` está activo en localhost:54321.
+ *   3. Las 211 migrations del repo se aplicaron correctamente.
+ *   4. El cliente supabase-js puede conectar al stack local con la
+ *      service role key estándar del CLI.
+ *   5. Las tablas críticas del flujo financiero (`erp.cortes_caja`,
+ *      `erp.movimientos_caja`, `erp.cortes_vouchers`,
+ *      `erp.inventario_levantamientos`) existen en el schema.
+ *   6. Las RPCs de levantamientos (`fn_iniciar_captura_levantamiento`,
+ *      `fn_firmar_levantamiento`, etc.) existen y responden a
+ *      llamadas con args inválidos retornando error en lugar de
+ *      crashear silenciosamente.
+ *
+ * Si este test pasa, el pipeline está listo para tests de flujo
+ * end-to-end (cortes/levantamientos full flow). Si falla, indica que
+ * el setup local está incompleto — ver `docs/testing/integration-setup.md`.
+ *
+ * Sprint 3C de `tech-debt-h1-2026`. Tests de flujo end-to-end quedan
+ * para iteraciones futuras dentro de la misma rama (no en este commit
+ * para mantener el PR enfocado en el pipeline).
+ */
+
+// Defaults que `supabase start` usa para el stack local. Estables entre
+// versiones del CLI; documentados en
+// https://supabase.com/docs/guides/cli/local-development.
+const SUPABASE_LOCAL_URL = 'http://127.0.0.1:54321';
+const SUPABASE_LOCAL_SERVICE_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+let client: SupabaseClient;
+
+beforeAll(() => {
+  client = createClient(SUPABASE_LOCAL_URL, SUPABASE_LOCAL_SERVICE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+});
+
+describe('Integration pipeline smoke', () => {
+  it('conecta al stack local de Supabase', async () => {
+    // Una query trivial que cualquier proyecto post-migrations debe
+    // soportar. Si falla, supabase no está corriendo o la URL/key cambiaron.
+    /* eslint-disable @typescript-eslint/no-explicit-any -- ad-hoc query */
+    const { error } = await (client.schema('core') as any).from('empresas').select('id').limit(1);
+    expect(error).toBeNull();
+  });
+
+  it('schema `erp` tiene las tablas del flujo financiero', async () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    for (const table of [
+      'cortes_caja',
+      'movimientos_caja',
+      'cortes_vouchers',
+      'inventario_levantamientos',
+      'inventario_levantamiento_lineas',
+    ]) {
+      const { error } = await (client.schema('erp') as any).from(table).select('*').limit(0);
+      expect(error, `tabla erp.${table} debe existir`).toBeNull();
+    }
+  });
+
+  it('RPC `fn_firmar_levantamiento` existe y responde a args inválidos', async () => {
+    // Llamamos con un UUID inexistente — esperamos error de PG, NO un
+    // 404 o "function does not exist". Eso valida que la RPC está
+    // declarada en el schema local con la signature esperada.
+    const { error } = await client.schema('erp').rpc('fn_firmar_levantamiento', {
+      p_levantamiento_id: '00000000-0000-0000-0000-000000000000',
+      p_paso: 1,
+      p_rol: 'operacion',
+      p_comentario: 'test',
+    });
+    // El error puede ser por not-found, RLS, o validación interna —
+    // todos válidos. Lo que NO queremos: PGRST202 ("function does not
+    // exist") o PGRST204.
+    if (error) {
+      expect(error.code).not.toBe('PGRST202');
+      expect(error.code).not.toBe('PGRST204');
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,11 +13,14 @@ import path from 'node:path';
  *   - **Sprint 3A**: baseline 30% lines/statements, 65% functions,
  *     75% branches. Coverage medido tras 3A: ~32% lines, ~69%
  *     functions, ~84% branches.
- *   - **Sprint 3B** (este PR): bump a 33% lines/statements, 67%
- *     functions, 80% branches. Coverage medido tras 3B: 35.29% lines,
- *     69.27% functions, 83.82% branches — buffer ~2-3%.
- *   - **Sprint 3C**: integration tests para `cortes/actions` y
- *     `levantamientos/actions` → target final 40-45% lines.
+ *   - **Sprint 3B**: bump a 33% lines/statements, 67% functions, 80%
+ *     branches. Coverage medido tras 3B: 35.29% / 69.27% / 83.82%.
+ *   - **Sprint 3C** (este PR): bump a 40% lines/statements, 70%
+ *     functions, 82% branches. Coverage medido tras unit tests 3C:
+ *     42.1% lines, 72.08% functions, 84.21% branches — buffer ~2%.
+ *     Los integration tests (cortes + levantamientos contra DB real)
+ *     corren via `npm run test:integration` (config separado), opt-in
+ *     local — no en CI default.
  *
  * El threshold solo bloquea CI cuando se corre `npm run test:coverage`
  * (lo hace el workflow `.github/workflows/ci.yml`). `npm run test:run`
@@ -41,13 +44,12 @@ export default defineConfig({
         'app/api/**/_test-helpers.ts',
       ],
       thresholds: {
-        // Sprint 3B — sube en 3C. Buffer ~2-3% sobre el medido actual
-        // para tolerar variación natural y bitir si alguien agrega
-        // código sin tests.
-        lines: 33,
-        statements: 33,
-        functions: 67,
-        branches: 80,
+        // Sprint 3C — buffer ~2% sobre el medido (42.1 / 72.08 / 84.21).
+        // Bita si alguien agrega código sin tests.
+        lines: 40,
+        statements: 40,
+        functions: 70,
+        branches: 82,
       },
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,7 +32,16 @@ export default defineConfig({
     environment: 'node',
     globals: false,
     include: ['**/*.test.ts', '**/*.test.tsx'],
-    exclude: ['node_modules/**', '.next/**', 'tests/e2e/**'],
+    // Integration tests viven en `tests/integration/**` y corren via
+    // `npm run test:integration` (config separado). Excluirlos aquí
+    // evita que `test:run` los ejecute sin DB local arriba.
+    exclude: [
+      'node_modules/**',
+      '.next/**',
+      'tests/e2e/**',
+      'tests/integration/**',
+      '**/*.integration.test.ts',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+/**
+ * Vitest configuration for **integration tests** (Sprint 3C de
+ * `tech-debt-h1-2026`).
+ *
+ * Diferencia clave vs `vitest.config.ts`:
+ *   - Apunta a `tests/integration/**` exclusivamente.
+ *   - **Single thread / single fork** — DB compartida entre tests, no
+ *     paralelizar para evitar race conditions.
+ *   - **Sin coverage** — los integration tests cubren paths que ya
+ *     están en el coverage del unit test config; no doble-contamos.
+ *   - **Opt-in**: corre con `npm run test:integration`, NO con
+ *     `npm run test:run`. CI default no los corre.
+ *
+ * Pre-requisitos para correr (ver `docs/testing/integration-setup.md`):
+ *   1. Docker corriendo (OrbStack / Docker Desktop).
+ *   2. `supabase start` levantado en localhost:54321.
+ *   3. `supabase db reset` aplicó las 211 migrations al DB local.
+ *
+ * Las env vars apuntan a la instancia local (no a producción) — los
+ * defaults del CLI de Supabase generan llaves predecibles que se
+ * inyectan en `tests/integration/setup.ts`.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['tests/integration/**/*.integration.test.ts'],
+    exclude: ['node_modules/**', '.next/**', 'tests/e2e/**'],
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        // DB compartida → un solo fork serial, sin tests paralelos.
+        singleFork: true,
+      },
+    },
+    // Tests integration suelen ser más lentos que unit (network + DB).
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Cierre del Sprint 3 de [`tech-debt-h1-2026`](docs/planning/tech-debt-h1-2026.md). Estructura split en 2 commits:

- **Parte 1** (commit `d4a758f`) — Unit tests con mocks para `cortes/actions` y `levantamientos/actions` + bump del coverage threshold a 40%. **Validado completamente.**
- **Parte 2** (commit `83c8920`) — Pipeline de integration tests contra DB real (Supabase local stack). **Scaffold + smoke test + docs**, validación end-to-end pendiente por Beto en local.

## Parte 1 — Unit tests (87 tests, todos pasando)

### `app/rdb/cortes/actions.test.ts` (52 tests) — el archivo más hot del repo
- `abrirCaja` (8): validaciones, herencia de efectivo, `previo_sin_contar`, primer turno, errores.
- `cerrarCaja` (5): cálculo de denominaciones, upsert filtrado por cantidad>0, errores.
- `registrarMovimiento` (10): validaciones (corte_id, monto, concepto, tipo, `realizadoPorNombre`), corte debe estar abierto.
- `subirVoucher` (7): límite 10MB, mime types allowlist (jpeg/png/webp/heic/heif), corte exists, **rollback de archivo si insert falla**.
- `eliminarVoucher` (4), `confirmarVoucher` (6), `actualizarCategoriaVoucher` (5): incluyen test del **caso RLS bloqueando UPDATE silenciosamente** (`data.length === 0 → throw`, regresión histórica documentada).
- `previewEfectivoInicial` / `cargarBancos` / `obtenerVouchersDelCorte` (7): lectores con paths de error.

### `app/rdb/inventario/levantamientos/actions.test.ts` (35 tests)

8 de 9 funciones delegan a RPCs PL/pgSQL. Tests cubren:
- `crearLevantamiento` (5): insert + validaciones.
- 6 RPCs (`iniciarCaptura`, `guardarConteo`, `cerrarCaptura`, `cancelarLevantamiento`, `getLineasPara*`): delegación con args correctos + propagación de errores.
- `firmarPaso` (6): parser `parseFirmarPasoResult` (shapes inválidos → null) + propagación de IP/user-agent headers.
- `cancelarLevantamiento`: trim de motivo, motivo vacío rechazado.
- `actualizarNotaDiferencia` **(10 tests)** — la función con lógica TS más rica: state guards (`estado === 'capturado'`), validación de contador, trim a null, lookups via admin client.

## Coverage threshold bump

| Métrica | Pre Sprint 3C | Post Sprint 3C | Threshold |
|---|---|---|---|
| Lines | 35.29% | **42.10%** | 40% |
| Functions | 69.27% | 72.08% | 70% |
| Branches | 83.82% | 84.21% | 82% |

Buffer ~2% sobre el medido. Cumple target final del Sprint 3 (40-45%).

## Parte 2 — Integration testing scaffold

### Archivos nuevos
- `vitest.integration.config.ts` — config separado, single fork serial, sin coverage.
- `tests/integration/smoke.integration.test.ts` — smoke test del pipeline (3 assertions: conexión + tablas críticas existen + RPC `fn_firmar_levantamiento` con signature correcta).
- `docs/testing/integration-setup.md` — guía completa de bootstrap, uso normal, troubleshooting.
- `package.json` — script `test:integration`.
- `vitest.config.ts` — excluye `tests/integration/**` y `**/*.integration.test.ts` (opt-in, NO corre en CI).

### ⚠️ Validación pendiente

Durante la sesión intenté validar `npm run test:integration` end-to-end, pero hay un **chicken-egg con `[api].schemas` de `config.toml`**:

- `config.toml` declara `schemas = ["public", "core", "erp", ...]` para producción.
- En primer `supabase start` local, esos schemas no existen (la DB está vacía hasta que `supabase db reset` aplique las 211 migrations).
- PostgREST falla health check → `supabase start` rollbackea los containers.

El workaround está documentado en `docs/testing/integration-setup.md`: editar config.toml temporalmente a `schemas = ["public"]`, hacer `supabase start && supabase db reset`, restaurar config.toml, `supabase stop && supabase start`.

**Yo no pude completar la validación porque el permission system bloqueó la edición temporal de `supabase/config.toml`** (correcto — es config sensible). Necesito que tú corras los pasos del bootstrap localmente para validar que el smoke test pasa.

### Lo que NO está en este PR

Tests de flujo end-to-end (levantamiento full flow + cortes flow + voucher storage round-trip). Quedan como follow-up cuando el smoke test esté validado y el bootstrap funcione confiable.

## Test plan

- [x] `npm run typecheck` — limpio.
- [x] `npm run format:check` — limpio.
- [x] `npm run lint` — 0 errores.
- [x] `npm run test:run` — 1189 tests pasando, 2.95s. Integration excluido del run default.
- [x] `npm run test:coverage` — threshold 40% lines pasa con buffer.
- [ ] **Pendiente Beto**: bootstrap inicial de Supabase local + `npm run test:integration` (smoke pasa).

## Cómo validar tú

```bash
# Sigue docs/testing/integration-setup.md sección "Workaround inicial":
# 1. Editar supabase/config.toml: schemas = ["public"]
# 2. supabase start
# 3. supabase db reset
# 4. Restaurar supabase/config.toml a la lista completa
# 5. supabase stop && supabase start
# 6. npm run test:integration
```

Si el smoke test pasa, el pipeline está listo para extenderse con tests end-to-end en sprints futuros. Si falla, ajustamos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)