### PR TITLE
fix(rh): Title Case en personas + accionistas sin N:M aparecían en Empleados

### DIFF
--- a/components/rh/personal-module.tsx
+++ b/components/rh/personal-module.tsx
@@ -75,12 +75,25 @@ type Empleado = {
   }[];
 };
 
-const ACCIONISTA_PUESTOS = new Set([
-  'Accionista',
-  'Comité Ejecutivo',
-  'Consejo de Administracion',
-  'Consejo de Administración',
+// Nombres de puesto/departamento que clasifican a una persona como accionista
+// (en sentido amplio: socios, miembros del comité, consejeros). Match
+// case-insensitive y normalizado para evitar drift por tildes o casing.
+const ACCIONISTA_LABELS = new Set([
+  'accionista',
+  'accionistas',
+  'comite ejecutivo',
+  'consejo de administracion',
+  'consejero',
 ]);
+
+function normalizeLabel(s: string | null | undefined): string {
+  if (!s) return '';
+  return s.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').trim();
+}
+
+function matchesAccionistaLabel(s: string | null | undefined): boolean {
+  return ACCIONISTA_LABELS.has(normalizeLabel(s));
+}
 
 type TipoTab = 'empleados' | 'accionistas' | 'todos';
 type EstadoFilter = 'activos' | 'inactivos' | 'todos';
@@ -203,9 +216,18 @@ function antiguedadStr(fechaIngreso: string | null): string {
 }
 
 function isAccionista(emp: Empleado): boolean {
-  return (emp.puestos ?? []).some(
-    (p) => p.puesto?.nombre && ACCIONISTA_PUESTOS.has(p.puesto.nombre)
-  );
+  // Departamento "Accionistas" gana sobre cualquier puesto. Cubre el caso de
+  // socios cargados sin puesto formal (o con un puesto legacy/custom que no
+  // matchea ACCIONISTA_LABELS).
+  if (matchesAccionistaLabel(emp.departamento?.nombre)) return true;
+  // N:M actual (modelo desde 2026-04-27).
+  if ((emp.puestos ?? []).some((p) => matchesAccionistaLabel(p.puesto?.nombre))) {
+    return true;
+  }
+  // Campo legacy `empleados.puesto_id` directo, para empleados que aún no
+  // tienen entrada en empleados_puestos (e.g. COAGAN/ANSA pre-migración N:M).
+  if (matchesAccionistaLabel(emp.puesto?.nombre)) return true;
+  return false;
 }
 
 function detailHref(empresaSlug: string, id: string) {

--- a/scripts/import-contpaqi/apply.py
+++ b/scripts/import-contpaqi/apply.py
@@ -65,6 +65,47 @@ def sql_quote(v) -> str:
     return f"'{s}'"
 
 
+# Partículas que quedan en minúscula cuando NO son la primera palabra.
+# Espejo de LOWERCASE_PARTICLES en lib/name-case.ts — mantener en sync.
+_LOWERCASE_PARTICLES = {
+    "de", "del", "la", "las", "los", "y", "e",
+    "da", "das", "do", "dos", "van", "von", "der", "den",
+}
+
+
+def title_case_es(s: Optional[str]) -> Optional[str]:
+    """Title Case en español para nombres propios. Espejo de titleCase()
+    en lib/name-case.ts — los imports deben emitir SQL ya normalizado para
+    no requerir backfill posterior con scripts/normalize-personas.ts.
+    """
+    if s is None:
+        return None
+    raw = re.sub(r"\s+", " ", str(s).strip())
+    if not raw:
+        return None
+
+    def _cap_word(word: str) -> str:
+        # Respeta apóstrofo (O'Connor) y guion (Jean-Luc) capitalizando cada parte.
+        parts = re.split(r"(['’\-])", word)
+        out = []
+        for part in parts:
+            if part in ("'", "’", "-") or not part:
+                out.append(part)
+            else:
+                out.append(part[:1].upper() + part[1:].lower())
+        return "".join(out)
+
+    words = raw.split(" ")
+    result = []
+    for i, w in enumerate(words):
+        lower = w.lower()
+        if i > 0 and lower in _LOWERCASE_PARTICLES:
+            result.append(lower)
+        else:
+            result.append(_cap_word(w))
+    return " ".join(result)
+
+
 def empresa_id_subq(slug: str) -> str:
     return f"(SELECT id FROM core.empresas WHERE slug = '{slug}')"
 
@@ -84,18 +125,21 @@ def puesto_id_subq(slug: str, nombre: Optional[str]) -> str:
 
 
 def excel_to_personas_fields(ex: dict) -> dict:
-    """Mapea campos Excel a columnas de erp.personas."""
+    """Mapea campos Excel a columnas de erp.personas. Aplica Title Case a
+    los campos de nombre propio para mantener convención del wizard de RH
+    (ver lib/name-case.ts) y evitar drift que requiera backfill posterior.
+    """
     return {
-        "nombre": ex.get("nombre"),
-        "apellido_paterno": ex.get("apellido_paterno"),
-        "apellido_materno": ex.get("apellido_materno"),
+        "nombre": title_case_es(ex.get("nombre")),
+        "apellido_paterno": title_case_es(ex.get("apellido_paterno")),
+        "apellido_materno": title_case_es(ex.get("apellido_materno")),
         "rfc": ex.get("rfc"),
         "curp": ex.get("curp"),
         "nss": ex.get("nss"),
         "fecha_nacimiento": ex.get("fecha_nacimiento"),
         "sexo": ex.get("sexo"),
         "estado_civil": ex.get("estado_civil"),
-        "lugar_nacimiento": ex.get("lugar_nacimiento"),
+        "lugar_nacimiento": title_case_es(ex.get("lugar_nacimiento")),
         "domicilio": ex.get("direccion"),
         "telefono": ex.get("telefono"),
         "email": ex.get("email"),

--- a/scripts/normalize-personas.ts
+++ b/scripts/normalize-personas.ts
@@ -1,0 +1,278 @@
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js tipa solo `public`; para leer/escribir en `erp` usamos `as any`
+ * (mismo patrón que el resto de scripts de mantenimiento).
+ */
+/**
+ * normalize-personas.ts
+ *
+ * Script one-shot (idempotente) para normalizar nombres propios en
+ * `erp.personas` aplicando Title Case según convenciones del wizard de RH
+ * (ver `lib/name-case.ts`).
+ *
+ * Contexto: el alta de empleados vía wizard ya normaliza al guardar. Pero
+ * imports masivos (Contpaqi, IMSS, Coda, etc.) escriben los strings tal
+ * cual vienen de la fuente — generalmente TODO EN MAYÚSCULAS. Eso se
+ * arrastra a cualquier módulo que muestre el nombre sin re-normalizar al
+ * render (tasks, juntas, listados varios).
+ *
+ * Este script limpia la fuente de verdad (`erp.personas`) en lugar de
+ * obligar a cada módulo a aplicar `composeFullName` al pintar.
+ *
+ * Campos normalizados:
+ *   - nombre, apellido_paterno, apellido_materno
+ *   - contacto_emergencia_nombre, contacto_emergencia_parentesco
+ *   - nacionalidad
+ *
+ * Campos que NO se tocan:
+ *   - email, rfc, curp, nss, telefono, sexo, estado_civil, tipo,
+ *     tipo_persona, fecha_nacimiento, domicilio (dirección — manejada
+ *     por separado en `erp.personas_direcciones`).
+ *   - lugar_nacimiento: el formato histórico es "CIUDAD, CÓDIGO_ESTADO"
+ *     donde el código (CL=Coahuila, NL=Nuevo León, DF, etc.) viene de
+ *     IMSS y debe quedar en MAYÚSCULAS. titleCase rompería esos códigos.
+ *     Si se quiere normalizar este campo, requiere un script separado
+ *     que parse "ciudad, código" y aplique reglas distintas a cada parte.
+ *
+ * Uso:
+ *   DRY_RUN=1 npx tsx scripts/normalize-personas.ts     # preview
+ *   npx tsx scripts/normalize-personas.ts               # aplica
+ *
+ * Env:
+ *   NEXT_PUBLIC_SUPABASE_URL      (requerido)
+ *   SUPABASE_SERVICE_ROLE_KEY     (requerido — bypassa RLS)
+ *   DRY_RUN=1                     no escribe a DB, solo reporta
+ *   EMPRESA_ID=<uuid>             limita a una empresa
+ *   SHOW_DIFFS=1                  imprime cada cambio (default: solo conteo)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { createClient } from '@supabase/supabase-js';
+
+import { titleCase } from '../lib/name-case';
+
+// Carga `.env.local` buscando hacia arriba desde cwd hasta la raíz del FS.
+// Necesario porque el repo se trabaja también desde worktrees
+// (`.claude/worktrees/<n>/`) donde `.env.local` no se duplica — vive solo en
+// la raíz del repo principal (`/Users/Beto/BSOP/.env.local`).
+// El entorno real gana sobre el archivo (útil para sobrescribir ad-hoc).
+function findEnvLocal(): string | null {
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, '.env.local');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function loadEnvLocal(): void {
+  const envPath = findEnvLocal();
+  if (!envPath) return;
+  const content = fs.readFileSync(envPath, 'utf8');
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eqIndex = line.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = line.slice(0, eqIndex).trim();
+    let value = line.slice(eqIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+loadEnvLocal();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+const EMPRESA_ID = process.env.EMPRESA_ID ?? null;
+const SHOW_DIFFS = process.env.SHOW_DIFFS === '1';
+
+if (!SUPABASE_URL) throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL');
+if (!SUPABASE_KEY) throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY');
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+// Campos sujetos a Title Case. Subset de los que normaliza el wizard de RH
+// al guardar — excluimos lugar_nacimiento porque su formato histórico
+// "CIUDAD, CÓDIGO_ESTADO" (códigos IMSS de 2 letras) requeriría parsing
+// separado para no degradar el código del estado.
+const TITLE_CASE_FIELDS = [
+  'nombre',
+  'apellido_paterno',
+  'apellido_materno',
+  'contacto_emergencia_nombre',
+  'contacto_emergencia_parentesco',
+  'nacionalidad',
+] as const;
+
+type Field = (typeof TITLE_CASE_FIELDS)[number];
+
+type PersonaRow = {
+  id: string;
+  empresa_id: string;
+  nombre: string | null;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
+  contacto_emergencia_nombre: string | null;
+  contacto_emergencia_parentesco: string | null;
+  nacionalidad: string | null;
+};
+
+type Change = {
+  id: string;
+  diffs: Array<{ field: Field; antes: string; despues: string }>;
+};
+
+async function fetchPersonas(): Promise<PersonaRow[]> {
+  // Paginamos para evitar el cap default de 1000 rows. Patrón espejo de
+  // scripts/link-documentos-adjuntos.ts (sin .order — el orden no importa
+  // para este script y .order sobre uuid bloquea queries grandes).
+  const PAGE = 1000;
+  const all: PersonaRow[] = [];
+  let from = 0;
+  const SELECT =
+    'id, empresa_id, nombre, apellido_paterno, apellido_materno, contacto_emergencia_nombre, contacto_emergencia_parentesco, nacionalidad';
+
+  for (;;) {
+    let q = supabase
+      .schema('erp' as any)
+      .from('personas')
+      .select(SELECT)
+      .is('deleted_at', null)
+      .range(from, from + PAGE - 1);
+
+    if (EMPRESA_ID) q = q.eq('empresa_id', EMPRESA_ID);
+
+    const { data, error } = await q;
+    if (error) throw new Error(`fetch personas (offset ${from}): ${error.message}`);
+
+    const rows = (data ?? []) as unknown as PersonaRow[];
+    all.push(...rows);
+    process.stdout.write(`  fetched ${all.length}…\r`);
+    if (rows.length < PAGE) break;
+    from += PAGE;
+  }
+  process.stdout.write('\n');
+
+  return all;
+}
+
+function diffPersona(p: PersonaRow): Change | null {
+  const diffs: Change['diffs'] = [];
+  for (const field of TITLE_CASE_FIELDS) {
+    const current = p[field];
+    if (!current) continue;
+    const normalized = titleCase(current);
+    if (normalized && normalized !== current) {
+      diffs.push({ field, antes: current, despues: normalized });
+    }
+  }
+  if (diffs.length === 0) return null;
+  return { id: p.id, diffs };
+}
+
+function buildUpdatePayload(change: Change): Record<string, string> {
+  const payload: Record<string, string> = {};
+  for (const d of change.diffs) {
+    payload[d.field] = d.despues;
+  }
+  payload.updated_at = new Date().toISOString();
+  return payload;
+}
+
+async function main() {
+  console.log('─────────────────────────────────────────────────────');
+  console.log(' normalize-personas');
+  console.log('─────────────────────────────────────────────────────');
+  console.log(` DRY_RUN     = ${DRY_RUN}`);
+  console.log(` EMPRESA_ID  = ${EMPRESA_ID ?? '(todas)'}`);
+  console.log(` SHOW_DIFFS  = ${SHOW_DIFFS}`);
+  console.log('');
+
+  const personas = await fetchPersonas();
+  console.log(`Total personas activas: ${personas.length}`);
+
+  const changes: Change[] = [];
+  const fieldCounts = new Map<Field, number>();
+
+  for (const p of personas) {
+    const c = diffPersona(p);
+    if (!c) continue;
+    changes.push(c);
+    for (const d of c.diffs) {
+      fieldCounts.set(d.field, (fieldCounts.get(d.field) ?? 0) + 1);
+    }
+  }
+
+  console.log(`Personas con cambios:    ${changes.length}`);
+
+  if (changes.length > 0) {
+    console.log('');
+    console.log('Distribución por campo:');
+    for (const [field, n] of [...fieldCounts.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${n.toString().padStart(4)} × ${field}`);
+    }
+  }
+
+  if (SHOW_DIFFS && changes.length > 0) {
+    console.log('');
+    console.log('Cambios propuestos:');
+    const SAMPLE = SHOW_DIFFS ? changes.length : 20;
+    for (const c of changes.slice(0, SAMPLE)) {
+      console.log(`  ${c.id}`);
+      for (const d of c.diffs) {
+        console.log(`    ${d.field}: "${d.antes}" → "${d.despues}"`);
+      }
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log('');
+    console.log('⚠️  DRY_RUN=1 — no se escribió nada. Re-correr sin DRY_RUN para aplicar.');
+    return;
+  }
+
+  if (changes.length === 0) {
+    console.log('Nada que cambiar.');
+    return;
+  }
+
+  console.log('');
+  console.log(`Aplicando ${changes.length} updates…`);
+
+  let ok = 0;
+  let fail = 0;
+  for (const c of changes) {
+    const { error } = await (supabase.schema('erp') as any)
+      .from('personas')
+      .update(buildUpdatePayload(c))
+      .eq('id', c.id);
+    if (error) {
+      console.error(`  ✗ ${c.id}: ${error.message}`);
+      fail++;
+    } else {
+      ok++;
+    }
+  }
+
+  console.log('');
+  console.log('─── Reporte ─────────────────────────────────────────');
+  console.log(`Updates ok:    ${ok}`);
+  console.log(`Updates fail:  ${fail}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Backfill `erp.personas` a Title Case** ([scripts/normalize-personas.ts](scripts/normalize-personas.ts)): aplica `titleCase` (mismo helper que el wizard de RH al guardar) sobre `nombre`, `apellido_paterno`, `apellido_materno`, `contacto_emergencia_*`, `nacionalidad`. Idempotente, `DRY_RUN=1` para preview. **Ya aplicado en producción: 195 personas actualizadas.**
- **Tapa la fuga en imports Contpaqi** ([scripts/import-contpaqi/apply.py](scripts/import-contpaqi/apply.py)): `title_case_es()` espejo de `lib/name-case.ts` aplicado en `excel_to_personas_fields` para que futuros imports salgan ya normalizados.
- **Fix RH › Empleados** ([components/rh/personal-module.tsx](components/rh/personal-module.tsx)): `isAccionista()` ahora detecta también por `departamento.nombre = "Accionistas"` y el campo legacy `empleados.puesto_id`, no solo por `empleados_puestos` (N:M). Cubre 5 casos en DILESA donde socios estaban en el dept "Accionistas" pero sin entrada en N:M y se colaban al tab "Empleados". Match case-insensitive y sin tildes.

## Contexto

**Origen:** los responsables de tareas aparecían algunos en MAYÚSCULAS aunque RH los muestra normalizados. Causa: el wizard de RH aplica `titleCase` al guardar, pero los imports masivos (Coda/IMSS/Contpaqi) escriben strings tal cual de la fuente. RH lo enmascaraba normalizando al render; tasks (y otros módulos) muestran crudo.

**Decisión:** fix de raíz limpiando el dato en `erp.personas` (no defensa per-render). Así cualquier módulo nuevo queda bien sin tocar.

**Excluido del backfill:** `lugar_nacimiento` (formato histórico "CIUDAD, CÓDIGO_ESTADO" con códigos IMSS de 2 letras que `titleCase` degradaría a `"Cl"`/`"Nl"`/etc.). Si se quiere normalizar, requiere parsing aparte por las dos partes.

**Casos manuales pendientes** (no resueltos por el algoritmo):
- 2 personas con `apellido_paterno = "Usa"` (data sucia, no es apellido).
- 1 persona con `nombre = "J.pas"` (debería ser `"J.Pas"` — punto en medio rompe el algoritmo).
- 1 persona con `nombre = "Notaria 10 Imss"` (siglas IMSS).

## Test plan

- [x] `npm run typecheck` ✅
- [x] `npm run lint` ✅ (0 errors)
- [x] `npm run format:check` ✅
- [x] `npm run test:run` ✅ (638/638)
- [x] DRY_RUN del backfill verificado antes de aplicar a prod (195 cambios)
- [x] Backfill aplicado en producción: 195 personas updated, 0 fail
- [x] Verificado en localhost (worktree dev): los 5 accionistas que estaban mal ahora salen en el tab "Accionistas" y no en "Empleados"
- [ ] Post-merge: refrescar producción y validar visualmente módulos de tasks (responsables) y RH (DILESA › Empleados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)