### PR TITLE
fix(inicio): dedup cumpleaños por persona_id en widget de fechas importantes

### DIFF
--- a/components/inicio/fechas-importantes-widget.tsx
+++ b/components/inicio/fechas-importantes-widget.tsx
@@ -19,8 +19,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { festivosEnRango, type DiaFestivo } from '@/lib/inicio/dias-festivos';
 
 type Cumpleanero = {
-  empleado_id: string;
-  empresa_id: string;
+  persona_id: string;
   nombre_completo: string;
   fecha_nacimiento: string; // YYYY-MM-DD
 };
@@ -120,10 +119,13 @@ export function FechasImportantesWidget() {
         }
 
         // Empleados activos con fecha de nacimiento en esas empresas.
+        // Dedup por persona_id: operadores que son empleado en N empresas
+        // (accionistas con presencia multi-empresa) aparecen N veces en
+        // v_empleados_full pero su cumpleaños es uno solo.
         const { data: emp, error: empErr } = await supabase
           .schema('erp')
           .from('v_empleados_full')
-          .select('empleado_id, empresa_id, nombre_completo, fecha_nacimiento, empleado_activo')
+          .select('persona_id, nombre_completo, fecha_nacimiento, empleado_activo')
           .in('empresa_id', empresaIds)
           .not('fecha_nacimiento', 'is', null)
           .eq('empleado_activo', true);
@@ -132,29 +134,21 @@ export function FechasImportantesWidget() {
 
         if (!cancelled) {
           const rows = (emp ?? []) as Array<{
-            empleado_id: string | null;
-            empresa_id: string | null;
+            persona_id: string | null;
             nombre_completo: string | null;
             fecha_nacimiento: string | null;
           }>;
-          const mapped: Cumpleanero[] = rows
-            .filter(
-              (
-                r
-              ): r is {
-                empleado_id: string;
-                empresa_id: string;
-                nombre_completo: string | null;
-                fecha_nacimiento: string;
-              } => Boolean(r.empleado_id && r.empresa_id && r.fecha_nacimiento)
-            )
-            .map((r) => ({
-              empleado_id: r.empleado_id,
-              empresa_id: r.empresa_id,
+          const byPersona = new Map<string, Cumpleanero>();
+          for (const r of rows) {
+            if (!r.persona_id || !r.fecha_nacimiento) continue;
+            if (byPersona.has(r.persona_id)) continue;
+            byPersona.set(r.persona_id, {
+              persona_id: r.persona_id,
               nombre_completo: r.nombre_completo ?? '—',
               fecha_nacimiento: r.fecha_nacimiento,
-            }));
-          setCumples(mapped);
+            });
+          }
+          setCumples([...byPersona.values()]);
           setLoading(false);
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

- Operadores con presencia multi-empresa (Beto, Alejandra, Michelle — accionistas en 4 empresas) aparecían 4× en el widget de "Próximas fechas importantes" porque `v_empleados_full` devuelve una fila por `(persona, empresa)`.
- Deduplico por `persona_id` antes de mapear: el cumpleaños de la persona es uno solo, no uno por empresa.

## Test plan

- [x] `npm run typecheck` ✅
- [x] `npm run format:check` ✅
- [x] `npm run lint` ✅ (0 errors)
- [x] `npm run test:run` ✅ (638/638)
- [ ] Post-merge: validar en producción que Beto/Alejandra/Michelle aparezcan una sola vez en el widget de inicio

🤖 Generated with [Claude Code](https://claude.com/claude-code)