### PR TITLE
fix(cortes): cerrarCaja detecta UPDATE silencioso por RLS

### DIFF
--- a/app/rdb/cortes/actions.test.ts
+++ b/app/rdb/cortes/actions.test.ts
@@ -40,7 +40,10 @@ let insertCorteResult: { data: { id: string } | null; error: { message: string }
 };
 
 // cerrarCaja state.
-let updateCorteError: { message: string } | null = null;
+let updateCorteResult: { data: { id: string }[]; error: { message: string } | null } = {
+  data: [{ id: 'corte-1' }],
+  error: null,
+};
 let upsertDenomError: { message: string } | null = null;
 
 // registrarMovimiento state.
@@ -194,7 +197,8 @@ function buildSupabaseMock(): any {
                 );
               }
               if (schemaName === 'erp' && tableName === 'cortes_caja' && _op === 'update') {
-                return Promise.resolve({ data: null, error: updateCorteError }).then(onFulfilled);
+                // .update().eq().eq().select('id') — devuelve array.
+                return Promise.resolve(updateCorteResult).then(onFulfilled);
               }
               if (
                 schemaName === 'erp' &&
@@ -283,7 +287,7 @@ beforeEach(() => {
   ultimoCorte = null;
   ultimoCorteError = null;
   insertCorteResult = { data: { id: 'corte-new' }, error: null };
-  updateCorteError = null;
+  updateCorteResult = { data: [{ id: 'corte-1' }], error: null };
   upsertDenomError = null;
   insertMovimientoResult = { data: { id: 'mov-1' }, error: null };
   previewData = null;
@@ -402,13 +406,23 @@ describe('cerrarCaja', () => {
   });
 
   it('throws si update del corte falla', async () => {
-    updateCorteError = { message: 'rls violation' };
+    updateCorteResult = { data: [], error: { message: 'rls violation' } };
     await expect(
       cerrarCaja({
         corte_id: 'corte-1',
         denominaciones: [{ denominacion: 100, tipo: 'billete', cantidad: 5 }],
       })
     ).rejects.toThrow(/rls violation/);
+  });
+
+  it('throws si update no afecta filas (RLS bloqueando o corte inexistente)', async () => {
+    updateCorteResult = { data: [], error: null };
+    await expect(
+      cerrarCaja({
+        corte_id: 'corte-1',
+        denominaciones: [{ denominacion: 100, tipo: 'billete', cantidad: 5 }],
+      })
+    ).rejects.toThrow(/RLS bloqueando|inexistente/i);
   });
 
   it('throws si upsert de denominaciones falla', async () => {

--- a/app/rdb/cortes/actions.ts
+++ b/app/rdb/cortes/actions.ts
@@ -191,8 +191,12 @@ export async function cerrarCaja(input: CerrarCajaInput): Promise<void> {
 
   const now = new Date().toISOString();
 
-  // Actualizar corte
-  const { error } = await supabase
+  // Actualizar corte. `.select('id')` fuerza a PostgREST a devolver las filas
+  // afectadas: sin esto, un UPDATE bloqueado por RLS o sobre un corte
+  // inexistente devuelve `error: null, data: null` y el cliente recibe
+  // success silencioso mientras el corte sigue abierto. Mismo patrón que
+  // `confirmarVoucher` / `actualizarCategoriaVoucher` más abajo.
+  const { data: updated, error } = await supabase
     .schema('erp')
     .from('cortes_caja')
     .update({
@@ -203,9 +207,15 @@ export async function cerrarCaja(input: CerrarCajaInput): Promise<void> {
       updated_at: now,
     })
     .eq('empresa_id', RDB_EMPRESA_ID)
-    .eq('id', input.corte_id);
+    .eq('id', input.corte_id)
+    .select('id');
 
   if (error) throw new Error(error.message);
+  if (!updated || updated.length === 0) {
+    throw new Error(
+      'No se pudo cerrar el corte (posible RLS bloqueando UPDATE o corte inexistente).'
+    );
+  }
 
   // Guardar denominaciones (solo las que tienen cantidad > 0)
   const rows = input.denominaciones


### PR DESCRIPTION
## Summary

- `cerrarCaja` hacía `.update()` sin `.select('id')` — un UPDATE bloqueado por RLS o sobre un corte inexistente devolvía `{error: null, data: null}` y el cliente recibía success silencioso mientras el corte seguía abierto.
- Aplicado el mismo patrón anti-silent-fail que ya usaban `confirmarVoucher` / `actualizarCategoriaVoucher` en este mismo archivo.
- Mensaje de error explícito: `"No se pudo cerrar el corte (posible RLS bloqueando UPDATE o corte inexistente)."`
- Test cubre el caso `data: []` (RLS bloqueando con error null).

## Contexto

Detectado durante diagnóstico de un incidente reportado: una hostess en RDB (Caja Leslie, 2026-05-02) no pudo cerrar su corte. La investigación descartó RLS y permisos como causa raíz para *ese* incidente — la caja sigue abierta sin movimiento. Pero el patrón de UPDATE sin `.select('id')` es exactamente el síntoma que vimos: el corte queda abierto mientras el UI da éxito. Cerramos ese hueco antes de que se manifieste.

## Test plan

- [x] `npm run typecheck` — limpio
- [x] `npm run test:run` — 639 tests pass (incluye nuevo test "throws si update no afecta filas")
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — limpio

🤖 Generated with [Claude Code](https://claude.com/claude-code)