### PR TITLE
fix(playtomic): extender lookback del sync de 48h a 60d

### DIFF
--- a/supabase/functions/playtomic-sync/index.ts
+++ b/supabase/functions/playtomic-sync/index.ts
@@ -36,8 +36,11 @@ serve(async (req) => {
   const syncLogId = crypto.randomUUID();
   const startTime = new Date();
 
-  // We look back 48 hours and forward 14 days to catch updates and new bookings
-  const startUtc = new Date(startTime.getTime() - 48 * 60 * 60 * 1000);
+  // Lookback de 60 días: pagos en club se registran días/semanas después de la
+  // reserva (manager marca PAID en Playtomic post-juego), una ventana corta
+  // dejaba el `payment_status` congelado en PENDING aunque ya estuvieran cobradas.
+  // Lookahead de 14 días para reservas futuras nuevas o modificadas.
+  const startUtc = new Date(startTime.getTime() - 60 * 24 * 60 * 60 * 1000);
   const endUtc = new Date(startTime.getTime() + 14 * 24 * 60 * 60 * 1000);
 
   try {


### PR DESCRIPTION
## Problema

Reservas con \`payment_status = 'PENDING'\` se quedaban congeladas en BSOP aunque en Playtomic ya hubieran sido marcadas como pagadas. Caso reportado: Jose Luis Paz Zablah, 07-abr 20:30, Padel 8, $800 — aparecía como pendiente en BSOP pero estaba pagada en club según Playtomic.

## Causa raíz

[supabase/functions/playtomic-sync/index.ts:39-41](supabase/functions/playtomic-sync/index.ts) consultaba el API de Playtomic con ventana de \`-48h → +14d\`. Los pagos en club se registran días/semanas después de la reserva (el manager marca PAID post-juego), pero para entonces la reserva ya había salido de la ventana de sync y su \`payment_status\` quedaba congelado.

## Alcance

| Pendientes | Cantidad | Monto |
|---|---:|---:|
| Fuera de ventana (datos posiblemente stale) | 564 | $207,100 |
| Dentro de ventana activa | 5 | — |

99% de las "reservas pendientes" en BSOP eran datos congelados.

## Fix

Extender lookback a 60 días. Cubre la práctica totalidad de los pagos en club rezagados con costo extra trivial (~10s de sync vs ~3s previos, y el sync corre cada 30 min).

## Acciones post-merge

1. Redeploy del Edge Function: \`supabase functions deploy playtomic-sync\`
2. Trigger manual una vez para refrescar los 564 huérfanos
3. Verificar que la lista de pendientes se reduce drásticamente

## Test plan

- [ ] CI verde (typecheck + lint + format:check + test:run)
- [ ] Post-merge: redeploy del edge function manualmente
- [ ] Post-deploy: verificar que el sync siguiente fetcha ~2000 bookings (vs ~70 antes)
- [ ] Verificar que la reserva del Sr. Paz pasa a \`PAID\` (o lo que tenga en Playtomic) después del sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)