### PR TITLE
fix(playtomic/rdb): aclarar que pendientes son solo pagos online

### DIFF
--- a/components/playtomic/pending-payments-section.tsx
+++ b/components/playtomic/pending-payments-section.tsx
@@ -48,9 +48,23 @@ export function PendingPaymentsSection({
 }) {
   return (
     <div className="border-t border-[var(--border)] pt-6">
+      <div className="mb-4 space-y-2">
+        <h3 className="text-base font-semibold text-[var(--text)]">
+          Pagos Pendientes (sin cobro online)
+        </h3>
+        <p className="text-sm text-[var(--text-muted)]">
+          Reservas marcadas como pendientes en Playtomic — no se cobraron por la app online.
+        </p>
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-[var(--text)]">
+          <strong>Nota:</strong> los cobros realizados en cancha (efectivo o tarjeta en recepción)
+          se registran en Waitry, no en Playtomic, así que aquí pueden aparecer reservas que ya
+          están pagadas en el club. Para confirmar si ya entró el pago, cruzar contra los tickets de
+          Waitry del mismo día/jugador.
+        </div>
+      </div>
       <div className="space-y-3">
         <div>
-          <h3 className="text-base font-semibold text-[var(--text)]">Resumen por Jugador</h3>
+          <h4 className="text-sm font-semibold text-[var(--text)]">Resumen por Jugador</h4>
           <p className="text-sm text-[var(--text-muted)]">
             Top 20 jugadores con saldo pendiente acumulado.
           </p>
@@ -70,7 +84,7 @@ export function PendingPaymentsSection({
                 {pendingPayments.playerSummary.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={4} className="py-10 text-center text-[var(--text)]/50">
-                      No hay pagos pendientes en este periodo.
+                      No hay pagos pendientes online en este periodo.
                     </TableCell>
                   </TableRow>
                 ) : (
@@ -108,11 +122,11 @@ export function PendingPaymentsSection({
       <div className="mt-6 space-y-3 rounded-2xl border border-[var(--border)] bg-[var(--panel)]/35 p-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h3 className="text-base font-semibold text-[var(--text)]">
+            <h4 className="text-sm font-semibold text-[var(--text)]">
               Detalle de Reservas Pendientes
-            </h3>
+            </h4>
             <p className="text-sm text-[var(--text-muted)]">
-              Listado individual de reservas pendientes.
+              Listado individual de reservas marcadas como pendientes en Playtomic.
             </p>
           </div>
           <Button variant="outline" size="sm" onClick={onToggleDetails}>


### PR DESCRIPTION
## Cambio

Renombra "Pagos Pendientes" a **"Pagos Pendientes (sin cobro online)"** y agrega un banner amarillo explicando que cobros en cancha viven en Waitry, no en Playtomic.

## Por qué

Hoy la sección decía solo "Pagos Pendientes" y mostraba ~550 reservas / $200K como impagas. La gran mayoría de esas reservas en realidad ya están cobradas en cancha (efectivo/tarjeta en recepción) — el cobro vive en Waitry como producto "Renta Cancha Padel", no en el campo \`payment_status\` de Playtomic.

Verificado: Playtomic third-party API no expone los pagos en club por ningún endpoint (probé \`GET /v1/bookings/{id}\`, \`/payments\`, \`/receipts\`, \`/v2/bookings/{id}\` — todos 404). Solo expone pagos hechos vía la plataforma online.

Caso ejemplo: Sr. Paz Zablah, reserva 7-abr 20:30 Padel 8 $800. Apareció como pendiente en BSOP. Match en \`rdb.waitry_pedidos\`: order_id 16798276, 7-abr 20:17, "Renta Cancha Padel" $200, notes "jose Luis paz efectivo", paid=true.

## Lo que NO hace este PR

No concilia automáticamente. Solo aclara la semántica para que el operador sepa que tiene que cruzar contra Waitry. La conciliación automática contra \`rdb.waitry_pedidos\` es una iniciativa separada (a discutir) que cierra el ciclo.

## Test plan

- [ ] CI verde
- [ ] Preview muestra el banner amarillo y el nuevo título
- [ ] Texto empty cambia a "No hay pagos pendientes online en este periodo."

🤖 Generated with [Claude Code](https://claude.com/claude-code)