### PR TITLE
feat(rdb/playtomic): conciliación pagos cancha — S1 read-only

### DIFF
--- a/app/rdb/playtomic/conciliacion/page.tsx
+++ b/app/rdb/playtomic/conciliacion/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { ConciliacionView } from '@/components/playtomic/conciliacion/conciliacion-view';
+
+/**
+ * @module Conciliación Playtomic ↔ Waitry (RDB)
+ * @responsive desktop-only
+ */
+export default function ConciliacionPage() {
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.playtomic">
+      <DesktopOnlyNotice module="Conciliación Playtomic" />
+      <div className="hidden sm:block">
+        <ConciliacionView />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/components/playtomic/conciliacion/assignment-panel.tsx
+++ b/components/playtomic/conciliacion/assignment-panel.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { formatMoney } from '@/components/playtomic/utils';
+import type { PendingBookingWithCoverage, RankedCandidate } from '@/lib/playtomic/conciliacion';
+
+const TIMESTAMP_FMT = new Intl.DateTimeFormat('es-MX', {
+  timeZone: 'America/Matamoros',
+  day: '2-digit',
+  month: 'short',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+export function AssignmentPanel({
+  booking,
+  candidates,
+}: {
+  booking: PendingBookingWithCoverage | null;
+  candidates: RankedCandidate[];
+}) {
+  const [selectedOrderIds, setSelectedOrderIds] = useState<Set<string>>(new Set());
+
+  const totalSelected = useMemo(
+    () =>
+      candidates
+        .filter((c) => selectedOrderIds.has(c.order_id))
+        .reduce((sum, c) => sum + c.total_amount, 0),
+    [candidates, selectedOrderIds]
+  );
+
+  if (!booking) {
+    return (
+      <div className="flex h-full min-h-[20rem] items-center justify-center rounded-2xl border border-dashed border-[var(--border)] bg-[var(--card)] p-8 text-center text-sm text-[var(--text-muted)]">
+        Selecciona una reserva de la lista para ver candidatos de pago en Waitry.
+      </div>
+    );
+  }
+
+  const totalPlanned = booking.assigned_total + totalSelected;
+  const coveragePct =
+    booking.price_amount > 0 ? Math.round((totalPlanned / booking.price_amount) * 100) : 0;
+  const remaining = Math.max(0, booking.price_amount - totalPlanned);
+
+  function toggle(orderId: string) {
+    setSelectedOrderIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(orderId)) next.delete(orderId);
+      else next.add(orderId);
+      return next;
+    });
+  }
+
+  const date = booking.booking_start ? new Date(booking.booking_start) : null;
+  const dateLabel = date && !Number.isNaN(date.getTime()) ? TIMESTAMP_FMT.format(date) : '—';
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+      <header className="space-y-1">
+        <h3 className="text-sm font-semibold text-[var(--text)]">Detalle de reserva</h3>
+        <dl className="grid gap-1 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-[var(--text-muted)]">Fecha y hora</dt>
+            <dd className="font-medium text-[var(--text)]">{dateLabel}</dd>
+          </div>
+          <div>
+            <dt className="text-[var(--text-muted)]">Cancha</dt>
+            <dd className="font-medium text-[var(--text)]">{booking.resource_name ?? '—'}</dd>
+          </div>
+          <div>
+            <dt className="text-[var(--text-muted)]">Owner</dt>
+            <dd className="font-medium text-[var(--text)]">
+              {booking.owner_name ?? 'Sin registro'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-[var(--text-muted)]">Total reserva</dt>
+            <dd className="font-medium text-[var(--text)]">{formatMoney(booking.price_amount)}</dd>
+          </div>
+          <div className="sm:col-span-2">
+            <dt className="text-[var(--text-muted)]">Participantes</dt>
+            <dd className="text-[var(--text)]/80">
+              {booking.participant_names.length > 0 ? booking.participant_names.join(', ') : '—'}
+            </dd>
+          </div>
+        </dl>
+      </header>
+
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--panel)]/30 p-3">
+        <div className="flex flex-wrap items-baseline justify-between gap-2 text-sm">
+          <div>
+            <span className="font-medium text-[var(--text)]">
+              Cubierto (preview): {formatMoney(totalPlanned)} de {formatMoney(booking.price_amount)}
+            </span>
+            <span className="ml-2 text-[var(--text-muted)]">({coveragePct}%)</span>
+          </div>
+          <div className="text-[var(--text-muted)]">
+            {remaining > 0 ? `Faltan ${formatMoney(remaining)}` : 'Cubre el total'}
+          </div>
+        </div>
+        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--border)]">
+          <div
+            className={`h-full transition-all ${
+              coveragePct >= 100 ? 'bg-emerald-500' : 'bg-amber-500'
+            }`}
+            style={{ width: `${Math.min(100, coveragePct)}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-[var(--text)]">
+            Candidatos en Waitry ({candidates.length})
+          </h4>
+          <span className="text-xs text-[var(--text-muted)]">
+            ±3h del booking · &quot;Renta Cancha Padel&quot; · pagados · no asignados
+          </span>
+        </div>
+        {candidates.length === 0 ? (
+          <p className="rounded-xl border border-dashed border-[var(--border)] p-3 text-sm text-[var(--text-muted)]">
+            Sin candidatos en la ventana temporal. La heurística no encontró pedidos elegibles —
+            puede que no haya pago en club registrado para esta reserva.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {candidates.map((candidate) => {
+              const isSelected = selectedOrderIds.has(candidate.order_id);
+              const tsLabel = TIMESTAMP_FMT.format(new Date(candidate.timestamp));
+              return (
+                <li
+                  key={candidate.order_id}
+                  className={`flex items-start justify-between gap-3 rounded-xl border p-3 text-sm transition-colors ${
+                    isSelected
+                      ? 'border-emerald-500/40 bg-emerald-500/10'
+                      : 'border-[var(--border)] bg-[var(--panel)]/20'
+                  }`}
+                >
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2 font-medium text-[var(--text)]">
+                      <span>{tsLabel}</span>
+                      <span className="text-[var(--text-muted)]">·</span>
+                      <span>{formatMoney(candidate.total_amount)}</span>
+                      <span className="rounded-full border border-[var(--border)] bg-[var(--panel)]/60 px-2 py-0.5 text-xs text-[var(--text-muted)]">
+                        score {Math.round(candidate.score)}
+                      </span>
+                    </div>
+                    {candidate.notes ? (
+                      <div className="text-[var(--text)]/80">
+                        notes: &quot;{candidate.notes}&quot;
+                      </div>
+                    ) : null}
+                    {candidate.reasons.length > 0 ? (
+                      <div className="text-xs text-[var(--text-muted)]">
+                        {candidate.reasons.join(' · ')}
+                      </div>
+                    ) : null}
+                  </div>
+                  <Button
+                    variant={isSelected ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => toggle(candidate.order_id)}
+                  >
+                    {isSelected ? 'Quitar' : 'Agregar'}
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <footer className="flex items-center justify-between gap-3 border-t border-[var(--border)] pt-3 text-sm">
+        <span className="text-[var(--text-muted)]">
+          Selección actual: {selectedOrderIds.size} pedidos · {formatMoney(totalSelected)}
+        </span>
+        <Button variant="default" size="sm" disabled title="Disponible en S2">
+          Conciliar (S2)
+        </Button>
+      </footer>
+    </div>
+  );
+}

--- a/components/playtomic/conciliacion/conciliacion-view.tsx
+++ b/components/playtomic/conciliacion/conciliacion-view.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { rankCandidates } from '@/lib/playtomic/conciliacion';
+import { AssignmentPanel } from './assignment-panel';
+import { PendingList } from './pending-list';
+import { useConciliacionData } from './use-conciliacion-data';
+
+export function ConciliacionView() {
+  const { data, loading, refreshing, error, refetch } = useConciliacionData();
+  const [selectedBookingId, setSelectedBookingId] = useState<string | null>(null);
+
+  const selectedBooking = useMemo(
+    () => data.bookings.find((b) => b.booking_id === selectedBookingId) ?? null,
+    [data.bookings, selectedBookingId]
+  );
+
+  const rankedCandidates = useMemo(() => {
+    if (!selectedBooking) return [];
+    const available = data.candidates.filter((c) => !data.assignedOrderIds.has(c.order_id));
+    return rankCandidates(selectedBooking, available);
+  }, [selectedBooking, data.candidates, data.assignedOrderIds]);
+
+  if (loading) {
+    return (
+      <div className="space-y-4 p-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-3 p-4">
+        <p className="text-sm text-red-500">Error al cargar datos: {error}</p>
+        <Button variant="outline" size="sm" onClick={refetch}>
+          Reintentar
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-[var(--text)]">
+            Conciliación Playtomic ↔ Waitry
+          </h1>
+          <p className="text-sm text-[var(--text-muted)]">
+            Cruza reservas marcadas como pendientes en Playtomic con cobros registrados en Waitry
+            como &quot;Renta Cancha Padel&quot;. {data.bookings.length} reservas a revisar.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={refetch} disabled={refreshing}>
+          {refreshing ? 'Refrescando…' : 'Refrescar'}
+        </Button>
+      </header>
+
+      <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-[var(--text)]">
+        <strong>Sprint 1 — read-only:</strong> esta vista propone candidatos de Waitry para cada
+        reserva pero <em>todavía no guarda asignaciones</em>. Sirve para validar que la heurística
+        de matching es buena antes de habilitar la persistencia en S2.
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+        <PendingList
+          bookings={data.bookings}
+          selectedBookingId={selectedBookingId}
+          onSelect={setSelectedBookingId}
+        />
+        <AssignmentPanel booking={selectedBooking} candidates={rankedCandidates} />
+      </div>
+    </div>
+  );
+}

--- a/components/playtomic/conciliacion/pending-list.tsx
+++ b/components/playtomic/conciliacion/pending-list.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { formatMoney } from '@/components/playtomic/utils';
+import type { PendingBookingWithCoverage } from '@/lib/playtomic/conciliacion';
+
+const FECHA_FMT = new Intl.DateTimeFormat('es-MX', {
+  timeZone: 'America/Matamoros',
+  day: '2-digit',
+  month: 'short',
+});
+const HORA_FMT = new Intl.DateTimeFormat('es-MX', {
+  timeZone: 'America/Matamoros',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+function coverageLabel(status: PendingBookingWithCoverage['coverage_status']): string {
+  switch (status) {
+    case 'full':
+      return 'Cubierta';
+    case 'partial':
+      return 'Parcial';
+    case 'none':
+    default:
+      return 'Sin cobertura';
+  }
+}
+
+function coverageBadgeClass(status: PendingBookingWithCoverage['coverage_status']): string {
+  switch (status) {
+    case 'full':
+      return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
+    case 'partial':
+      return 'bg-amber-500/15 text-amber-300 border-amber-500/30';
+    case 'none':
+    default:
+      return 'bg-[var(--panel)]/60 text-[var(--text-muted)] border-[var(--border)]';
+  }
+}
+
+export function PendingList({
+  bookings,
+  selectedBookingId,
+  onSelect,
+}: {
+  bookings: PendingBookingWithCoverage[];
+  selectedBookingId: string | null;
+  onSelect: (bookingId: string) => void;
+}) {
+  if (bookings.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-2xl border border-[var(--border)] bg-[var(--card)] text-sm text-[var(--text-muted)]">
+        No hay reservas pendientes que conciliar.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)]">
+      <div className="border-b border-[var(--border)] bg-[var(--panel)]/40 px-4 py-2 text-xs font-medium uppercase tracking-wide text-[var(--text-muted)]">
+        Reservas pendientes ({bookings.length})
+      </div>
+      <div className="max-h-[36rem] overflow-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Fecha</TableHead>
+              <TableHead>Hora</TableHead>
+              <TableHead>Cancha</TableHead>
+              <TableHead>Jugador</TableHead>
+              <TableHead className="text-right">Total</TableHead>
+              <TableHead>Cobertura</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bookings.map((booking) => {
+              const date = booking.booking_start ? new Date(booking.booking_start) : null;
+              const isValid = date && !Number.isNaN(date.getTime());
+              const isSelected = booking.booking_id === selectedBookingId;
+              return (
+                <TableRow
+                  key={booking.booking_id}
+                  className={`cursor-pointer transition-colors ${
+                    isSelected ? 'bg-[var(--accent)]/15' : 'hover:bg-[var(--panel)]/40'
+                  }`}
+                  onClick={() => onSelect(booking.booking_id)}
+                >
+                  <TableCell className="font-medium text-[var(--text)]">
+                    {isValid ? FECHA_FMT.format(date as Date) : '—'}
+                  </TableCell>
+                  <TableCell>{isValid ? HORA_FMT.format(date as Date) : '—'}</TableCell>
+                  <TableCell>{booking.resource_name ?? '—'}</TableCell>
+                  <TableCell className="text-[var(--text)]/80">
+                    {booking.owner_name ?? 'Sin registro'}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatMoney(booking.price_amount)}
+                  </TableCell>
+                  <TableCell>
+                    <span
+                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${coverageBadgeClass(
+                        booking.coverage_status
+                      )}`}
+                    >
+                      {coverageLabel(booking.coverage_status)}
+                      {booking.coverage_status === 'partial' ? ` ${booking.coverage_pct}%` : ''}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/components/playtomic/conciliacion/use-conciliacion-data.ts
+++ b/components/playtomic/conciliacion/use-conciliacion-data.ts
@@ -1,0 +1,227 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import type {
+  CoverageStatus,
+  PendingBookingWithCoverage,
+  WaitryCandidate,
+} from '@/lib/playtomic/conciliacion';
+
+type BookingRow = {
+  booking_id: string;
+  booking_start: string;
+  booking_end: string;
+  resource_name: string | null;
+  price_amount: number | null;
+  owner_id: string | null;
+};
+
+type ParticipantRow = {
+  booking_id: string;
+  player_id: string;
+  is_owner: boolean | null;
+};
+
+type PlayerRow = {
+  playtomic_id: string;
+  name: string | null;
+  email: string | null;
+};
+
+type WaitryPedidoRow = {
+  order_id: string;
+  timestamp: string;
+  notes: string | null;
+  total_amount: number | null;
+  paid: boolean | null;
+};
+
+type WaitryProductoRow = {
+  order_id: string;
+  product_name: string;
+  unit_price: number | null;
+  quantity: number | null;
+};
+
+export type ConciliacionData = {
+  bookings: PendingBookingWithCoverage[];
+  candidates: WaitryCandidate[];
+  assignedOrderIds: Set<string>;
+};
+
+const RENTA_CANCHA_PRODUCT = 'Renta Cancha Padel';
+
+export function useConciliacionData() {
+  const [data, setData] = useState<ConciliacionData>({
+    bookings: [],
+    candidates: [],
+    assignedOrderIds: new Set(),
+  });
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+
+    try {
+      const supabase = createSupabaseBrowserClient();
+      const playtomic = supabase.schema('playtomic');
+      const rdb = supabase.schema('rdb');
+
+      const nowIso = new Date().toISOString();
+      const ninetyDaysAgoIso = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+
+      const [
+        { data: pendingBookings, error: pendingErr },
+        { data: waitryPedidos, error: pedidosErr },
+        { data: waitryProductos, error: productosErr },
+      ] = await Promise.all([
+        playtomic
+          .from('bookings')
+          .select('booking_id,booking_start,booking_end,resource_name,price_amount,owner_id')
+          .eq('payment_status', 'PENDING')
+          .eq('is_canceled', false)
+          .lte('booking_start', nowIso)
+          .gte('booking_start', ninetyDaysAgoIso)
+          .order('booking_start', { ascending: true })
+          .limit(2000)
+          .returns<BookingRow[]>(),
+        rdb
+          .from('waitry_pedidos')
+          .select('order_id,timestamp,notes,total_amount,paid')
+          .eq('paid', true)
+          .gte('timestamp', ninetyDaysAgoIso)
+          .order('timestamp', { ascending: true })
+          .limit(5000)
+          .returns<WaitryPedidoRow[]>(),
+        rdb
+          .from('waitry_productos')
+          .select('order_id,product_name,unit_price,quantity')
+          .eq('product_name', RENTA_CANCHA_PRODUCT)
+          .gte('created_at', ninetyDaysAgoIso)
+          .limit(10000)
+          .returns<WaitryProductoRow[]>(),
+      ]);
+
+      if (pendingErr) throw pendingErr;
+      if (pedidosErr) throw pedidosErr;
+      if (productosErr) throw productosErr;
+
+      const bookingsList = pendingBookings ?? [];
+      const bookingIds = bookingsList.map((b) => b.booking_id);
+
+      let participants: ParticipantRow[] = [];
+      let players: PlayerRow[] = [];
+
+      if (bookingIds.length > 0) {
+        const { data: participantRows, error: participantErr } = await playtomic
+          .from('booking_participants')
+          .select('booking_id,player_id,is_owner')
+          .in('booking_id', bookingIds)
+          .returns<ParticipantRow[]>();
+        if (participantErr) throw participantErr;
+        participants = participantRows ?? [];
+
+        const playerIds = Array.from(new Set(participants.map((p) => p.player_id)));
+        if (playerIds.length > 0) {
+          const { data: playerRows, error: playerErr } = await playtomic
+            .from('players')
+            .select('playtomic_id,name,email')
+            .in('playtomic_id', playerIds)
+            .returns<PlayerRow[]>();
+          if (playerErr) throw playerErr;
+          players = playerRows ?? [];
+        }
+      }
+
+      const playerMap = new Map(players.map((p) => [p.playtomic_id, p]));
+      const participantsByBooking = new Map<string, ParticipantRow[]>();
+      for (const p of participants) {
+        const list = participantsByBooking.get(p.booking_id) ?? [];
+        list.push(p);
+        participantsByBooking.set(p.booking_id, list);
+      }
+
+      const productosByOrder = new Map<string, WaitryProductoRow>();
+      for (const prod of waitryProductos ?? []) {
+        if (!productosByOrder.has(prod.order_id)) productosByOrder.set(prod.order_id, prod);
+      }
+
+      const candidates: WaitryCandidate[] = (waitryPedidos ?? [])
+        .map((pedido) => {
+          const prod = productosByOrder.get(pedido.order_id);
+          if (!prod) return null;
+          return {
+            order_id: pedido.order_id,
+            timestamp: pedido.timestamp,
+            notes: pedido.notes,
+            total_amount: Number(pedido.total_amount ?? 0),
+            unit_price: Number(prod.unit_price ?? 0),
+            quantity: Number(prod.quantity ?? 1),
+          };
+        })
+        .filter((c): c is WaitryCandidate => c !== null);
+
+      // S1: la tabla payment_assignments está vacía hasta S2 — sin asignaciones existentes.
+      // Cuando S2 implemente las server actions de write, esto consultará la tabla
+      // (vía la vista `playtomic.v_bookings_payment_coverage` ya creada en la migración).
+      const assignedOrderIds = new Set<string>();
+
+      const bookings: PendingBookingWithCoverage[] = bookingsList.map((booking) => {
+        const bookingParticipants = participantsByBooking.get(booking.booking_id) ?? [];
+        const ownerParticipant = bookingParticipants.find((p) => p.is_owner === true);
+        const ownerPlayer = ownerParticipant
+          ? playerMap.get(ownerParticipant.player_id)
+          : undefined;
+        const participantNames: string[] = [];
+        const participantEmails: string[] = [];
+        for (const p of bookingParticipants) {
+          const player = playerMap.get(p.player_id);
+          if (player?.name) participantNames.push(player.name);
+          if (player?.email) participantEmails.push(player.email);
+        }
+
+        return {
+          booking_id: booking.booking_id,
+          booking_start: booking.booking_start,
+          booking_end: booking.booking_end,
+          resource_name: booking.resource_name,
+          price_amount: Number(booking.price_amount ?? 0),
+          owner_id: booking.owner_id,
+          owner_name: ownerPlayer?.name ?? null,
+          owner_email: ownerPlayer?.email ?? null,
+          participant_names: participantNames,
+          participant_emails: participantEmails,
+          coverage_status: 'none' as CoverageStatus,
+          coverage_pct: 0,
+          assigned_total: 0,
+          assigned_waitry_orders: [] as string[],
+        };
+      });
+
+      setData({ bookings, candidates, assignedOrderIds });
+    } catch (err) {
+      setError(getSupabaseErrorMessage(err, 'No se pudo cargar la conciliación.'));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchData(false);
+  }, [fetchData]);
+
+  return {
+    data,
+    loading,
+    refreshing,
+    error,
+    refetch: () => fetchData(true),
+  };
+}

--- a/docs/planning/rdb-pagos-cancha-conciliacion.md
+++ b/docs/planning/rdb-pagos-cancha-conciliacion.md
@@ -87,7 +87,7 @@ KPIs visibles en el dashboard:
   - **Dropdown/picker** de pedidos Waitry disponibles:
     - Filtrados: `product_name='Renta Cancha Padel'`, `paid=true`, no asignados a ninguna reserva.
     - Ventana temporal: ±3h del `booking_start` (configurable a futuro).
-    - Sugerencias rankeadas: notes contiene nombre del owner/participantes ↑, monto múltiplo de $200 ↑, timestamp más cercano ↑.
+    - Sugerencias rankeadas: notes contiene nombre del owner/participantes ↑, monto compatible con `booking.price_amount / participantes` (no hardcoded — soporta padel $800/4=$200, tenis singles $300/2=$150, tenis dobles $400/4=$100, descuentos por horario, etc.) ↑, timestamp más cercano ↑.
     - Cada item del dropdown muestra: hora, monto, notes, badge si match con jugador.
 - [ ] **Botón "Conciliar"** explícito cuando Σ ≥ total: cierra la asignación. Si Σ < total, queda parcial pero se puede forzar con nota explicativa (descuentos, cortesías).
 - [ ] **Filtro de la lista del dashboard principal**: las reservas con cobertura completa (`v_bookings_payment_coverage.estado = 'full'`) salen del listado de "Pagos Pendientes (sin cobro online)" del PR #406.
@@ -140,7 +140,9 @@ KPIs visibles en el dashboard:
 - **2026-05-04** — Asignación manual obligatoria, no matching ciego. Razón: alto riesgo de falsos positivos sin contexto humano (notes ambiguos, montos atípicos).
 - **2026-05-04** — Solo "Renta Cancha Padel" en scope. Razón: torneos no son canchas reservadas; F&B no aplica.
 - **2026-05-04** — Vista nueva separada (`/rdb/playtomic/conciliacion`), no inline en el dashboard. Razón: la operación de conciliar es un workflow distinto a "ver KPIs", separar concerns.
+- **2026-05-04** — La heurística de matching deriva el monto esperado del propio booking (`price_amount / participantes`), no de un valor hardcoded. Razón: tenis singles ($300/2 = $150), tenis dobles ($400/4 = $100), horarios con descuento, torneos a precios distintos. Hardcodear $200 sólo funcionaba para padel a precio estándar y rompía el resto. Tolerancia ±15% absorbe redondeos del POS.
 
 ## Bitácora
 
 - **2026-05-04** — Iniciativa promovida. Detonante: investigación de [#406](https://github.com/beto-sudo/BSOP/pull/406) (banner aclaratorio sobre pagos online vs club) + descubrimiento de que Waitry ya está integrado en BSOP (schema `rdb`, ~10K pedidos / 14K productos). Match verificado del caso del Sr. Paz Zablah (reserva 7-abr 20:30 ↔ Waitry order 16798276 con notes "jose Luis paz efectivo"). Alcance v1 cerrado tras 5 preguntas con Beto.
+- **2026-05-04** — Sprint 1 abierto en [#409](https://github.com/beto-sudo/BSOP/pull/409): migración SQL + helpers + UI read-only con ranking de candidatos por proximidad temporal + match en notes + compatibilidad de monto. Heurística de monto ajustada tras feedback de Beto para derivarse del booking en vez de hardcodear $200 (soporta tenis singles/dobles, horarios con descuento, torneos a precios distintos).

--- a/lib/playtomic/conciliacion.test.ts
+++ b/lib/playtomic/conciliacion.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { isWithinTimestampWindow, rankCandidates, type WaitryCandidate } from './conciliacion';
+
+const baseBooking = {
+  booking_start: '2026-04-08T01:30:00Z',
+  price_amount: 800,
+  owner_name: 'Jose Luis Paz Zablah',
+  owner_email: 'drjoseluispazz@gmail.com',
+  participant_names: [
+    'Jose Luis Paz Zablah',
+    'Cristofer Canchola',
+    'ARTURO MORALES',
+    'Gerardo Del Toro Garibay',
+  ],
+  participant_emails: [
+    'drjoseluispazz@gmail.com',
+    'grillo1179@yahoo.com',
+    'drmorales@ventrisfertility.com',
+    'gerardo.deltoro@hankat.mx',
+  ],
+};
+
+function candidate(overrides: Partial<WaitryCandidate>): WaitryCandidate {
+  return {
+    order_id: 'o1',
+    timestamp: '2026-04-08T01:25:00Z',
+    notes: null,
+    total_amount: 200,
+    unit_price: 200,
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+describe('isWithinTimestampWindow', () => {
+  it('accepts candidate within ±3h by default', () => {
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T01:25:00Z')).toBe(true);
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-07T22:31:00Z')).toBe(true);
+  });
+
+  it('rejects candidate outside ±3h', () => {
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-07T22:29:00Z')).toBe(false);
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T04:31:00Z')).toBe(false);
+  });
+
+  it('respects custom tolerance', () => {
+    const oneHour = 60 * 60 * 1000;
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T02:00:00Z', oneHour)).toBe(
+      true
+    );
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T02:31:00Z', oneHour)).toBe(
+      false
+    );
+  });
+
+  it('returns false on invalid timestamps', () => {
+    expect(isWithinTimestampWindow('not-a-date', '2026-04-08T01:30:00Z')).toBe(false);
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', 'invalid')).toBe(false);
+  });
+});
+
+describe('rankCandidates', () => {
+  it('filters out candidates outside the timestamp window', () => {
+    const offWindow = candidate({ order_id: 'far', timestamp: '2026-04-07T20:00:00Z' });
+    const inWindow = candidate({ order_id: 'near', timestamp: '2026-04-08T01:25:00Z' });
+    const ranked = rankCandidates(baseBooking, [offWindow, inWindow]);
+    expect(ranked.map((r) => r.order_id)).toEqual(['near']);
+  });
+
+  it('boosts candidate when notes match the owner', () => {
+    const ownerMatch = candidate({
+      order_id: 'owner',
+      timestamp: '2026-04-08T01:17:00Z',
+      notes: 'jose Luis paz efectivo',
+    });
+    const noNotes = candidate({
+      order_id: 'plain',
+      timestamp: '2026-04-08T01:18:00Z',
+      notes: null,
+    });
+    const ranked = rankCandidates(baseBooking, [noNotes, ownerMatch]);
+    expect(ranked[0].order_id).toBe('owner');
+    expect(ranked[0].reasons).toContain('Notes coinciden con owner');
+  });
+
+  it('boosts candidate when notes match a participant if owner does not match', () => {
+    const participantMatch = candidate({
+      order_id: 'participant',
+      timestamp: '2026-04-08T01:25:00Z',
+      notes: 'cristofer canchola tarjeta',
+    });
+    const noMatch = candidate({
+      order_id: 'no-match',
+      timestamp: '2026-04-08T01:25:00Z',
+      notes: 'cancha 7',
+    });
+    const ranked = rankCandidates(baseBooking, [noMatch, participantMatch]);
+    expect(ranked[0].order_id).toBe('participant');
+  });
+
+  it('uses temporal proximity as tiebreaker when notes are absent', () => {
+    const closer = candidate({ order_id: 'closer', timestamp: '2026-04-08T01:30:00Z' });
+    const further = candidate({ order_id: 'further', timestamp: '2026-04-08T03:00:00Z' });
+    const ranked = rankCandidates(baseBooking, [further, closer]);
+    expect(ranked[0].order_id).toBe('closer');
+  });
+
+  it('rewards typical renta-cancha unit price', () => {
+    const typical = candidate({ order_id: 'typical', unit_price: 200 });
+    const atypical = candidate({ order_id: 'atypical', unit_price: 350, total_amount: 350 });
+    const ranked = rankCandidates(baseBooking, [atypical, typical]);
+    expect(ranked[0].order_id).toBe('typical');
+  });
+
+  it('returns empty array when all candidates are out of window', () => {
+    const far1 = candidate({ order_id: 'a', timestamp: '2025-12-01T00:00:00Z' });
+    const far2 = candidate({ order_id: 'b', timestamp: '2026-08-01T00:00:00Z' });
+    expect(rankCandidates(baseBooking, [far1, far2])).toEqual([]);
+  });
+});

--- a/lib/playtomic/conciliacion.test.ts
+++ b/lib/playtomic/conciliacion.test.ts
@@ -105,11 +105,81 @@ describe('rankCandidates', () => {
     expect(ranked[0].order_id).toBe('closer');
   });
 
-  it('rewards typical renta-cancha unit price', () => {
-    const typical = candidate({ order_id: 'typical', unit_price: 200 });
-    const atypical = candidate({ order_id: 'atypical', unit_price: 350, total_amount: 350 });
-    const ranked = rankCandidates(baseBooking, [atypical, typical]);
-    expect(ranked[0].order_id).toBe('typical');
+  it('derives the expected per-player price from the booking, not a hardcoded value', () => {
+    // Padel: $800 / 4 jugadores = $200/jugador
+    const padelBooking = { ...baseBooking, price_amount: 800 };
+    const padelCandidate = candidate({ order_id: 'padel-200', unit_price: 200, total_amount: 200 });
+    const padelOff = candidate({ order_id: 'padel-150', unit_price: 150, total_amount: 150 });
+    const padelRanked = rankCandidates(padelBooking, [padelOff, padelCandidate]);
+    expect(padelRanked[0].order_id).toBe('padel-200');
+
+    // Tenis singles: $300 / 2 jugadores = $150/jugador. Aquí $200 NO debe ganar.
+    const tenisSingles = {
+      ...baseBooking,
+      price_amount: 300,
+      participant_names: ['Player A', 'Player B'],
+    };
+    const tenisCandidate = candidate({ order_id: 'tenis-150', unit_price: 150, total_amount: 150 });
+    const padelPriceOff = candidate({ order_id: 'tenis-200', unit_price: 200, total_amount: 200 });
+    const tenisRanked = rankCandidates(tenisSingles, [padelPriceOff, tenisCandidate]);
+    expect(tenisRanked[0].order_id).toBe('tenis-150');
+
+    // Tenis dobles con descuento: $400 / 4 jugadores = $100/jugador.
+    const tenisDobles = {
+      ...baseBooking,
+      price_amount: 400,
+      participant_names: ['A', 'B', 'C', 'D'],
+    };
+    const dobleMatch = candidate({ order_id: 'doble-100', unit_price: 100, total_amount: 100 });
+    const dobleOff = candidate({ order_id: 'doble-200', unit_price: 200, total_amount: 200 });
+    const dobleRanked = rankCandidates(tenisDobles, [dobleOff, dobleMatch]);
+    expect(dobleRanked[0].order_id).toBe('doble-100');
+  });
+
+  it('rewards tickets that cover whole-court or multi-player payments', () => {
+    // Padel $800/4 = $200. Un ticket de $400 = 2 jugadores en un solo cargo.
+    const wholeCourt = candidate({
+      order_id: 'whole',
+      unit_price: 800,
+      quantity: 1,
+      total_amount: 800,
+    });
+    const halfCourt = candidate({
+      order_id: 'half',
+      unit_price: 200,
+      quantity: 2,
+      total_amount: 400,
+    });
+    const single = candidate({
+      order_id: 'single',
+      unit_price: 200,
+      quantity: 1,
+      total_amount: 200,
+    });
+    const ranked = rankCandidates(
+      baseBooking,
+      [single, halfCourt, wholeCourt].map((c, i) => ({
+        ...c,
+        timestamp: `2026-04-08T01:${20 + i}:00Z`,
+      }))
+    );
+    expect(ranked.map((r) => r.order_id)).toContain('whole');
+    expect(ranked.map((r) => r.order_id)).toContain('half');
+    expect(ranked.map((r) => r.order_id)).toContain('single');
+    // Los tres son matches válidos; la posición exacta depende de proximidad
+    // temporal. Lo importante: ninguno debe quedar fuera por monto.
+  });
+
+  it('falls back to booking total when participants are not captured', () => {
+    const noParticipants = {
+      ...baseBooking,
+      participant_names: [],
+      price_amount: 600,
+    };
+    const fullMatch = candidate({ order_id: 'full', unit_price: 600, total_amount: 600 });
+    const noMatch = candidate({ order_id: 'no', unit_price: 50, total_amount: 50 });
+    const ranked = rankCandidates(noParticipants, [noMatch, fullMatch]);
+    expect(ranked[0].order_id).toBe('full');
   });
 
   it('returns empty array when all candidates are out of window', () => {

--- a/lib/playtomic/conciliacion.ts
+++ b/lib/playtomic/conciliacion.ts
@@ -1,0 +1,125 @@
+export type CoverageStatus = 'none' | 'partial' | 'full';
+
+export type PendingBookingWithCoverage = {
+  booking_id: string;
+  booking_start: string;
+  booking_end: string;
+  resource_name: string | null;
+  price_amount: number;
+  owner_id: string | null;
+  owner_name: string | null;
+  owner_email: string | null;
+  participant_names: string[];
+  participant_emails: string[];
+  coverage_status: CoverageStatus;
+  coverage_pct: number;
+  assigned_total: number;
+  assigned_waitry_orders: string[];
+};
+
+export type WaitryCandidate = {
+  order_id: string;
+  timestamp: string;
+  notes: string | null;
+  total_amount: number;
+  unit_price: number;
+  quantity: number;
+};
+
+export type RankedCandidate = WaitryCandidate & {
+  score: number;
+  reasons: string[];
+};
+
+const DEFAULT_TIMESTAMP_TOLERANCE_MS = 3 * 60 * 60 * 1000;
+
+const ESTIMATED_PRICE_PER_PLAYER = 200;
+
+function normalizeForMatch(text: string | null | undefined): string {
+  return (text ?? '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').trim();
+}
+
+function nameTokens(name: string): string[] {
+  return normalizeForMatch(name)
+    .split(/\s+/)
+    .filter((token) => token.length >= 3);
+}
+
+export function isWithinTimestampWindow(
+  bookingStart: string,
+  candidateTimestamp: string,
+  toleranceMs: number = DEFAULT_TIMESTAMP_TOLERANCE_MS
+): boolean {
+  const bookingMs = new Date(bookingStart).getTime();
+  const candidateMs = new Date(candidateTimestamp).getTime();
+  if (Number.isNaN(bookingMs) || Number.isNaN(candidateMs)) return false;
+  return Math.abs(bookingMs - candidateMs) <= toleranceMs;
+}
+
+export function rankCandidates(
+  booking: Pick<
+    PendingBookingWithCoverage,
+    | 'booking_start'
+    | 'price_amount'
+    | 'owner_name'
+    | 'owner_email'
+    | 'participant_names'
+    | 'participant_emails'
+  >,
+  candidates: WaitryCandidate[],
+  options: { toleranceMs?: number } = {}
+): RankedCandidate[] {
+  const tolerance = options.toleranceMs ?? DEFAULT_TIMESTAMP_TOLERANCE_MS;
+  const bookingMs = new Date(booking.booking_start).getTime();
+
+  const ownerTokens = booking.owner_name ? nameTokens(booking.owner_name) : [];
+  const participantTokens = (booking.participant_names ?? []).flatMap(nameTokens);
+  const ownerEmailLocal = (booking.owner_email ?? '').split('@')[0]?.toLowerCase() ?? '';
+
+  return candidates
+    .filter((candidate) =>
+      isWithinTimestampWindow(booking.booking_start, candidate.timestamp, tolerance)
+    )
+    .map((candidate) => {
+      const reasons: string[] = [];
+      let score = 0;
+
+      const candidateMs = new Date(candidate.timestamp).getTime();
+      const proximityMin = Math.abs(candidateMs - bookingMs) / 60_000;
+      const proximityScore = Math.max(0, 60 - proximityMin) * 0.5;
+      score += proximityScore;
+      if (proximityMin <= 30) reasons.push('Hora muy cercana al booking');
+      else if (proximityMin <= 90) reasons.push('Hora cercana al booking');
+
+      const notesNorm = normalizeForMatch(candidate.notes);
+      if (notesNorm) {
+        const ownerHit = ownerTokens.some((token) => notesNorm.includes(token));
+        if (ownerHit) {
+          score += 50;
+          reasons.push('Notes coinciden con owner');
+        } else if (
+          ownerEmailLocal &&
+          ownerEmailLocal.length >= 3 &&
+          notesNorm.includes(ownerEmailLocal)
+        ) {
+          score += 35;
+          reasons.push('Notes coinciden con email del owner');
+        } else {
+          const participantHit = participantTokens.some((token) => notesNorm.includes(token));
+          if (participantHit) {
+            score += 25;
+            reasons.push('Notes coinciden con un participante');
+          }
+        }
+      }
+
+      const isPlayerSlot = Math.abs(candidate.unit_price - ESTIMATED_PRICE_PER_PLAYER) < 0.01;
+      if (isPlayerSlot) {
+        score += 8;
+        reasons.push('Monto típico de renta por jugador');
+      }
+
+      return { ...candidate, score, reasons };
+    })
+    .sort((a, b) => b.score - a.score);
+}

--- a/lib/playtomic/conciliacion.ts
+++ b/lib/playtomic/conciliacion.ts
@@ -33,7 +33,12 @@ export type RankedCandidate = WaitryCandidate & {
 
 const DEFAULT_TIMESTAMP_TOLERANCE_MS = 3 * 60 * 60 * 1000;
 
-const ESTIMATED_PRICE_PER_PLAYER = 200;
+// Tolerancia relativa al precio esperado del booking. ±15% absorbe
+// redondeos típicos del POS y descuentos chicos sin abrir la puerta a
+// matches arbitrarios. Si el precio esperado no se puede derivar (booking
+// sin participantes capturados), se usa esta misma fracción contra el
+// total del booking como fallback.
+const AMOUNT_MATCH_TOLERANCE = 0.15;
 
 function normalizeForMatch(text: string | null | undefined): string {
   return (text ?? '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').trim();
@@ -76,6 +81,17 @@ export function rankCandidates(
   const participantTokens = (booking.participant_names ?? []).flatMap(nameTokens);
   const ownerEmailLocal = (booking.owner_email ?? '').split('@')[0]?.toLowerCase() ?? '';
 
+  // El monto esperado por jugador se deriva del booking en sí, no de un
+  // valor hardcoded. Padel típico: $800 / 4 = $200. Tenis singles: $300 /
+  // 2 = $150. Tenis dobles, horarios con descuento, torneos, etc, todos
+  // caen naturalmente en este cálculo. Si la reserva no trae
+  // participantes capturados, dejamos `expectedPerPlayer = 0` y caemos
+  // al fallback que compara contra el total completo del booking.
+  const participantCount = booking.participant_names?.length ?? 0;
+  const bookingTotal = booking.price_amount ?? 0;
+  const expectedPerPlayer =
+    participantCount > 0 && bookingTotal > 0 ? bookingTotal / participantCount : 0;
+
   return candidates
     .filter((candidate) =>
       isWithinTimestampWindow(booking.booking_start, candidate.timestamp, tolerance)
@@ -113,10 +129,41 @@ export function rankCandidates(
         }
       }
 
-      const isPlayerSlot = Math.abs(candidate.unit_price - ESTIMATED_PRICE_PER_PLAYER) < 0.01;
-      if (isPlayerSlot) {
-        score += 8;
-        reasons.push('Monto típico de renta por jugador');
+      // Bonus por compatibilidad de monto, derivado del booking — no
+      // hardcoded. Tres niveles, no excluyentes:
+      //  1) unit_price ≈ precio esperado por jugador.
+      //  2) total_amount cubre múltiplo entero N×expectedPerPlayer
+      //     (1, 2, 3, 4… jugadores en un solo ticket).
+      //  3) total_amount ≈ total del booking completo (un jugador pagó
+      //     toda la cancha en un solo ticket).
+      if (expectedPerPlayer > 0) {
+        const tolerancePerPlayer = expectedPerPlayer * AMOUNT_MATCH_TOLERANCE;
+
+        if (Math.abs(candidate.unit_price - expectedPerPlayer) <= tolerancePerPlayer) {
+          score += 12;
+          reasons.push('Unit price coincide con el monto por jugador del booking');
+        }
+
+        for (let n = 1; n <= participantCount; n += 1) {
+          const expected = expectedPerPlayer * n;
+          if (Math.abs(candidate.total_amount - expected) <= tolerancePerPlayer * n) {
+            const reason =
+              n === 1
+                ? 'Total del ticket coincide con 1 jugador'
+                : n === participantCount
+                  ? 'Total del ticket cubre la cancha completa'
+                  : `Total del ticket coincide con ${n} jugadores`;
+            score += 6 + n * 2;
+            reasons.push(reason);
+            break;
+          }
+        }
+      } else if (bookingTotal > 0) {
+        const tolerance = bookingTotal * AMOUNT_MATCH_TOLERANCE;
+        if (Math.abs(candidate.total_amount - bookingTotal) <= tolerance) {
+          score += 10;
+          reasons.push('Total del ticket coincide con el total del booking');
+        }
       }
 
       return { ...candidate, score, reasons };

--- a/supabase/migrations/20260504000000_playtomic_payment_assignments.sql
+++ b/supabase/migrations/20260504000000_playtomic_payment_assignments.sql
@@ -1,0 +1,97 @@
+-- Iniciativa rdb-pagos-cancha-conciliacion — Sprint 1
+--
+-- Crea el modelo de datos para conciliar reservas Playtomic con pagos
+-- "en club" registrados como pedidos en Waitry. El third-party API de
+-- Playtomic no expone los pagos en cancha (efectivo/tarjeta cobrados
+-- en recepción), pero esos cobros sí están en `rdb.waitry_pedidos` con
+-- producto "Renta Cancha Padel". Esta migración define la tabla de
+-- asignaciones (1 reserva ↔ N pedidos Waitry) y la vista derivada de
+-- cobertura.
+--
+-- S1 sólo crea estructura: la UI lee. Las server actions de write
+-- (assign / unassign) llegan en S2.
+
+BEGIN;
+
+-- ══════════════════════════════════════════════════════════════════
+-- Tabla de asignaciones
+-- ══════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS playtomic.payment_assignments (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  booking_id      text        NOT NULL REFERENCES playtomic.bookings(booking_id)   ON DELETE CASCADE,
+  waitry_order_id text        NOT NULL UNIQUE REFERENCES rdb.waitry_pedidos(order_id) ON DELETE RESTRICT,
+  assigned_amount numeric     NOT NULL CHECK (assigned_amount > 0),
+  assigned_by     uuid        NOT NULL REFERENCES auth.users(id),
+  assigned_at     timestamptz NOT NULL DEFAULT now(),
+  note            text        NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_payment_assignments_booking_id
+  ON playtomic.payment_assignments(booking_id);
+
+COMMENT ON TABLE playtomic.payment_assignments IS
+  'Asignación manual: 1 reserva Playtomic ↔ N pedidos de Waitry "Renta Cancha Padel" que la cubren. Audit trail nativo via assigned_by + assigned_at. UNIQUE(waitry_order_id) impide doble asignación. Iniciativa rdb-pagos-cancha-conciliacion.';
+
+-- ══════════════════════════════════════════════════════════════════
+-- RLS — mismo scoping que el resto del schema playtomic (RDB only)
+-- ══════════════════════════════════════════════════════════════════
+
+ALTER TABLE playtomic.payment_assignments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY payment_assignments_select
+  ON playtomic.payment_assignments
+  FOR SELECT TO authenticated
+  USING (core.fn_is_admin() OR core.fn_has_empresa('e52ac307-9373-4115-b65e-1178f0c4e1aa'::uuid));
+
+CREATE POLICY payment_assignments_write
+  ON playtomic.payment_assignments
+  FOR ALL TO authenticated
+  USING      (core.fn_is_admin() OR core.fn_has_empresa('e52ac307-9373-4115-b65e-1178f0c4e1aa'::uuid))
+  WITH CHECK (core.fn_is_admin() OR core.fn_has_empresa('e52ac307-9373-4115-b65e-1178f0c4e1aa'::uuid));
+
+CREATE POLICY payment_assignments_service_role
+  ON playtomic.payment_assignments
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- ══════════════════════════════════════════════════════════════════
+-- Vista de cobertura: por cada booking, cuánto está asignado
+-- ══════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE VIEW playtomic.v_bookings_payment_coverage
+WITH (security_invoker = true)
+AS
+SELECT
+  b.booking_id,
+  b.price_amount AS booking_total,
+  COALESCE(SUM(pa.assigned_amount), 0) AS assigned_total,
+  CASE
+    WHEN COALESCE(SUM(pa.assigned_amount), 0) = 0                        THEN 'none'
+    WHEN COALESCE(SUM(pa.assigned_amount), 0) >= COALESCE(b.price_amount, 0) THEN 'full'
+    ELSE 'partial'
+  END AS coverage_status,
+  CASE
+    WHEN COALESCE(b.price_amount, 0) = 0 THEN 0
+    ELSE LEAST(100, ROUND(COALESCE(SUM(pa.assigned_amount), 0) / b.price_amount * 100, 2))
+  END AS coverage_pct,
+  COALESCE(
+    ARRAY_AGG(pa.waitry_order_id ORDER BY pa.assigned_at) FILTER (WHERE pa.id IS NOT NULL),
+    ARRAY[]::text[]
+  ) AS assigned_waitry_orders
+FROM playtomic.bookings b
+LEFT JOIN playtomic.payment_assignments pa ON pa.booking_id = b.booking_id
+GROUP BY b.booking_id, b.price_amount;
+
+GRANT SELECT ON playtomic.v_bookings_payment_coverage TO authenticated;
+
+COMMENT ON VIEW playtomic.v_bookings_payment_coverage IS
+  'Cobertura derivada por reserva: total reserva, suma de pagos asignados, estado (none/partial/full), %. Vista security_invoker — la RLS de la tabla subyacente aplica. Iniciativa rdb-pagos-cancha-conciliacion.';
+
+-- ══════════════════════════════════════════════════════════════════
+-- Reload PostgREST schema cache
+-- ══════════════════════════════════════════════════════════════════
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Iniciativa: \`rdb-pagos-cancha-conciliacion\` — Sprint 1

Doc de planning: [docs/planning/rdb-pagos-cancha-conciliacion.md](docs/planning/rdb-pagos-cancha-conciliacion.md)

## Qué entrega S1

Vista nueva read-only en \`/rdb/playtomic/conciliacion\` que muestra reservas pendientes y propone candidatos de Waitry por reserva. Sirve para **validar visualmente** que la heurística de matching encuentra los pagos correctos antes de invertir en server actions de write (S2).

**Caso de validación**: cargar la página, seleccionar la reserva del Sr. Paz Zablah (7-abr 20:30 Padel 8 \$800). El panel debería sugerir como candidato top el order #16798276 (notes "jose Luis paz efectivo" \$200, ~13 min antes del booking).

## Componentes

| Archivo | Propósito |
|---|---|
| \`supabase/migrations/20260504000000_playtomic_payment_assignments.sql\` | Tabla \`payment_assignments\` + vista \`v_bookings_payment_coverage\` + RLS RDB-only |
| \`lib/playtomic/conciliacion.ts\` | Helper puro: \`rankCandidates()\`, \`isWithinTimestampWindow()\`. Heurística: proximidad temporal + match en notes (owner/email/participantes) + bonus monto típico (\$200) |
| \`lib/playtomic/conciliacion.test.ts\` | 10 tests unitarios sobre la heurística |
| \`components/playtomic/conciliacion/use-conciliacion-data.ts\` | Hook que combina bookings + participants + players + waitry_pedidos + waitry_productos |
| \`components/playtomic/conciliacion/conciliacion-view.tsx\` | View shell con grid split |
| \`components/playtomic/conciliacion/pending-list.tsx\` | Lista de reservas pendientes con badge de cobertura |
| \`components/playtomic/conciliacion/assignment-panel.tsx\` | Panel con candidatos rankeados, score, reasons, indicador de cobertura preview |
| \`app/rdb/playtomic/conciliacion/page.tsx\` | Entry point con \`<RequireAccess modulo="rdb.playtomic">\` |

## Lo que NO hace S1 (deliberado)

- **No persiste asignaciones** — botón "Conciliar (S2)" está disabled. La selección de candidatos solo afecta la UI.
- **No filtra "Pagos Pendientes" del dashboard principal** — eso entra en S2 cuando ya haya asignaciones reales.
- **No agrega link en sidebar** — acceso por URL directa para validar la heurística antes de exponerla. Si en S2 la usamos, agregamos sub-item.

## Acciones post-merge (orden estricto)

1. **Aplicar migración** desde la branch del PR (regla del repo: aplicar desde la branch, no main):
   \`\`\`bash
   git fetch origin feat/rdb-pagos-cancha-conciliacion-s1:feat/rdb-pagos-cancha-conciliacion-s1
   git checkout feat/rdb-pagos-cancha-conciliacion-s1
   psql "\$SUPABASE_DB_URL" -f supabase/migrations/20260504000000_playtomic_payment_assignments.sql
   \`\`\`
2. Verificar la tabla y vista:
   \`\`\`sql
   \\d playtomic.payment_assignments
   \\d+ playtomic.v_bookings_payment_coverage
   \`\`\`
3. **Regenerar \`SCHEMA_REF.md\` + \`types/supabase.ts\`** (un PR aparte, según workflow estándar).
4. Smoke test en preview: ir a \`/rdb/playtomic/conciliacion\`, seleccionar la reserva del Sr. Paz, verificar que aparece el order de Waitry como candidato top.
5. Mergear.

## Test plan

- [ ] CI verde (typecheck + lint + format + tests, incluyendo los 10 nuevos del helper)
- [ ] Migración aplicada manualmente sin errores
- [ ] \`SCHEMA_REF.md\` regenerado y commiteado
- [ ] Smoke en preview: caso del Sr. Paz Zablah aparece con candidato esperado
- [ ] Cobertura preview funciona: agregar candidato, indicador sube; quitar, baja
- [ ] Botón "Conciliar (S2)" está disabled (intencional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)