### PR TITLE
chore(db): drop policies service_role redundantes en playtomic

### DIFF
--- a/supabase/migrations/20260504230000_drop_redundant_service_role_policies_playtomic.sql
+++ b/supabase/migrations/20260504230000_drop_redundant_service_role_policies_playtomic.sql
@@ -1,0 +1,21 @@
+-- Drop policies redundantes detectadas por drift-check.sql:
+-- service_role bypassa RLS automáticamente, así que las policies
+-- `* FOR ALL TO service_role USING (true)` son ruido. Las introdujimos en
+-- las migraciones de S1 (payment_assignments) y S2-CSV (payments_import)
+-- siguiendo el patrón histórico de `20260418020117_rls_rdb_playtomic_cleanup`,
+-- pero el linter actual del repo prefiere no agregarlas en migraciones nuevas.
+--
+-- Net effect: cero cambio funcional. service_role sigue pudiendo escribir/leer
+-- ambas tablas porque bypassa RLS sin policies.
+
+BEGIN;
+
+DROP POLICY IF EXISTS payment_assignments_service_role
+  ON playtomic.payment_assignments;
+
+DROP POLICY IF EXISTS payments_import_service_role
+  ON playtomic.payments_import;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Drift-check

\`\`\`
ALERT 2 redundant service_role policies (service_role bypassa RLS automáticamente).
Detalle:
  playtomic.payment_assignments (payment_assignments_service_role)
  playtomic.payments_import (payments_import_service_role)
\`\`\`

## Causa

\`service_role\` bypassa RLS automáticamente. Las policies con \`FOR ALL TO service_role USING (true)\` son ruido — no agregan nada funcional. Se introdujeron en S1 ([#409](https://github.com/beto-sudo/BSOP/pull/409) ya mergeado) y S2-CSV ([#412](https://github.com/beto-sudo/BSOP/pull/412) abierto) siguiendo el patrón histórico de \`20260418020117_rls_rdb_playtomic_cleanup\`. El linter actual del repo prefiere no agregarlas en migraciones nuevas.

## Fix

Una migración pequeña que hace \`DROP POLICY IF EXISTS\` para ambas. Idempotente.

## Net effect

Cero cambio funcional. \`service_role\` sigue pudiendo escribir y leer ambas tablas porque bypassa RLS sin necesidad de policy explícita. El edge function \`playtomic-sync\` y cualquier otra integración con SERVICE_ROLE_KEY no se ven afectadas.

## Pasos post-merge

1. \`psql "\$SUPABASE_DB_URL" -f supabase/migrations/20260504230000_drop_redundant_service_role_policies_playtomic.sql\`
2. Verificar drift-check limpio:
   \`\`\`sql
   SELECT schemaname, tablename, policyname FROM pg_policies
   WHERE schemaname='playtomic' AND policyname LIKE '%service_role%';
   \`\`\`
   Esperado: 0 filas.
3. Regenerar SCHEMA_REF + types/supabase.ts (no debería haber cambios en types — solo policies).

## Test plan

- [ ] CI verde
- [ ] Migración aplicada en producción
- [ ] drift-check verde sin alerts en §2
- [ ] \`playtomic-sync\` Edge Function sigue corriendo cada 30 min sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)