### PR TITLE
fix(db): GRANTs faltantes en payment_assignments + payments_import

### DIFF
--- a/supabase/migrations/20260505000000_grant_authenticated_playtomic_payment_tables.sql
+++ b/supabase/migrations/20260505000000_grant_authenticated_playtomic_payment_tables.sql
@@ -1,0 +1,34 @@
+-- Otorga GRANTs faltantes a `authenticated` y `service_role` en las tablas
+-- nuevas de S1 + S2-CSV. Sin estos GRANTs, las queries del cliente
+-- supabase-js fallan con "permission denied for table" ANTES de evaluar RLS.
+--
+-- Confirmado en producción al hacer el primer upload del CSV: el server
+-- action falló con "Error consultando existentes: permission denied for table
+-- payments_import". Las RLS policies estaban definidas pero no se llegaban a
+-- evaluar — Postgres rechaza primero por GRANT a nivel tabla.
+--
+-- Patrón: mismo grant que ya tiene `playtomic.bookings` (verificado via
+-- information_schema.table_privileges). Sin `anon` — estas tablas son
+-- privadas, sin acceso anónimo.
+
+BEGIN;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON playtomic.payment_assignments
+  TO authenticated;
+
+GRANT ALL
+  ON playtomic.payment_assignments
+  TO service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON playtomic.payments_import
+  TO authenticated;
+
+GRANT ALL
+  ON playtomic.payments_import
+  TO service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Bug

Al subir el primer CSV en \`/rdb/playtomic/import-csv\` (#412 mergeado), el server action falla con:

\`\`\`
Error: Error consultando existentes: permission denied for table payments_import
\`\`\`

## Causa

Las migraciones que crearon \`playtomic.payment_assignments\` ([#409](https://github.com/beto-sudo/BSOP/pull/409)) y \`playtomic.payments_import\` ([#412](https://github.com/beto-sudo/BSOP/pull/412)) definieron RLS policies correctamente pero omitieron los GRANTs a nivel tabla. Postgres rechaza el query con "permission denied" ANTES de evaluar RLS, porque el rol \`authenticated\` no tiene SELECT/INSERT/UPDATE/DELETE en absoluto.

## Verificación en producción

\`\`\`sql
SELECT table_name, grantee, privilege_type
FROM information_schema.table_privileges
WHERE table_schema='playtomic' AND grantee IN ('authenticated','service_role');
\`\`\`

| Tabla | Grants para authenticated |
|---|---|
| \`bookings\` | SELECT/INSERT/UPDATE/DELETE ✓ |
| \`payment_assignments\` | **0 grants** ✗ |
| \`payments_import\` | **0 grants** ✗ |

## Fix

Migración que otorga el mismo GRANT que \`bookings\` ya tiene. Sin acceso \`anon\` — estas tablas son privadas RLS-protected.

## Pasos post-merge

\`\`\`bash
psql "\$SUPABASE_DB_URL" -f supabase/migrations/20260505000000_grant_authenticated_playtomic_payment_tables.sql
\`\`\`

Verificar:

\`\`\`sql
SELECT table_name, COUNT(*) AS grants_authenticated
FROM information_schema.table_privileges
WHERE table_schema='playtomic'
  AND grantee='authenticated'
  AND table_name IN ('payment_assignments','payments_import')
GROUP BY table_name;
\`\`\`
Esperado: ambas con 4 grants (SELECT/INSERT/UPDATE/DELETE).

Después: re-ejecutar el smoke test del CSV en \`/rdb/playtomic/import-csv\` — debería funcionar.

## Test plan

- [ ] CI verde
- [ ] Migración aplicada
- [ ] GRANT verificado (4 privilegios authenticated en cada tabla)
- [ ] Smoke test del CSV: 1812 filas insertadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)