### PR TITLE
feat(rdb/playtomic): cobertura combinada + filtro dashboard + whitelist productos cancha (S2-CSV-B)

### DIFF
--- a/components/playtomic/conciliacion/assignment-panel.tsx
+++ b/components/playtomic/conciliacion/assignment-panel.tsx
@@ -120,8 +120,8 @@ export function AssignmentPanel({
             Candidatos en Waitry ({candidates.length})
           </h4>
           <span className="text-xs text-[var(--text-muted)]">
-            hasta {tolerancePresetLabel} después del booking · incluye &quot;Renta Cancha
-            Padel&quot; · pagados · no asignados
+            hasta {tolerancePresetLabel} después del booking · cancha (padel/tenis/pickleball/coach)
+            · pagados · no asignados
           </span>
         </div>
         {candidates.length === 0 ? (
@@ -136,8 +136,8 @@ export function AssignmentPanel({
               </li>
               <li>La búsqueda en notes está activa y no hay coincidencias.</li>
               <li>
-                El pedido en Waitry no tiene producto &quot;Renta Cancha Padel&quot; — el operador
-                lo registró con otro nombre.
+                El pedido en Waitry no tiene un producto de cancha reconocido (padel, tenis,
+                pickleball, uso de coach) — el operador lo registró con otro nombre.
               </li>
               <li>Realmente no hay pago en club registrado — pendiente real.</li>
             </ul>

--- a/components/playtomic/conciliacion/conciliacion-view.tsx
+++ b/components/playtomic/conciliacion/conciliacion-view.tsx
@@ -70,8 +70,8 @@ export function ConciliacionView() {
             Conciliación Playtomic ↔ Waitry
           </h1>
           <p className="text-sm text-[var(--text-muted)]">
-            Cruza reservas marcadas como pendientes en Playtomic con cobros registrados en Waitry
-            como &quot;Renta Cancha Padel&quot;. {data.bookings.length} reservas a revisar.
+            Cruza reservas pendientes en Playtomic con cobros de cancha en Waitry (padel, tenis,
+            pickleball, uso de coach). {data.bookings.length} reservas a revisar.
           </p>
         </div>
         <Button variant="outline" size="sm" onClick={refetch} disabled={refreshing}>

--- a/components/playtomic/conciliacion/use-conciliacion-data.ts
+++ b/components/playtomic/conciliacion/use-conciliacion-data.ts
@@ -3,11 +3,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
-import type {
-  CoverageStatus,
-  PendingBookingWithCoverage,
-  WaitryCandidate,
-  WaitryItem,
+import {
+  CANCHA_PRODUCT_PATTERNS,
+  isCanchaProduct,
+  type CoverageStatus,
+  type PendingBookingWithCoverage,
+  type WaitryCandidate,
+  type WaitryItem,
 } from '@/lib/playtomic/conciliacion';
 
 type BookingRow = {
@@ -53,7 +55,8 @@ export type ConciliacionData = {
   assignedOrderIds: Set<string>;
 };
 
-const RENTA_CANCHA_PRODUCT = 'Renta Cancha Padel';
+// PostgREST `.or()` con patterns ilike. Cubre padel, tenis, pickleball y "Uso cancha coach...".
+const CANCHA_OR_FILTER = CANCHA_PRODUCT_PATTERNS.map((p) => `product_name.ilike.${p}`).join(',');
 
 export function useConciliacionData() {
   const [data, setData] = useState<ConciliacionData>({
@@ -116,7 +119,7 @@ export function useConciliacionData() {
         rdb
           .from('waitry_productos')
           .select('order_id,product_name,unit_price,quantity,total_price')
-          .eq('product_name', RENTA_CANCHA_PRODUCT)
+          .or(CANCHA_OR_FILTER)
           .gte('created_at', waitryLookbackIso)
           .limit(8000)
           .returns<WaitryProductoRow[]>(),
@@ -191,7 +194,7 @@ export function useConciliacionData() {
         .map((pedido) => {
           const prods = productosByOrder.get(pedido.order_id);
           if (!prods || prods.length === 0) return null;
-          const cancha = prods.find((p) => p.product_name === RENTA_CANCHA_PRODUCT);
+          const cancha = prods.find((p) => isCanchaProduct(p.product_name));
           if (!cancha) return null;
           const items: WaitryItem[] = prods.map((p) => ({
             product_name: p.product_name,

--- a/components/playtomic/pending-payments.ts
+++ b/components/playtomic/pending-payments.ts
@@ -20,10 +20,12 @@ export type PendingPaymentsResult = {
 export function computePendingPayments(
   bookings: Booking[],
   participants: BookingParticipant[],
-  players: PlayerRow[]
+  players: PlayerRow[],
+  options: { coveredBookingIds?: ReadonlySet<string> } = {}
 ): PendingPaymentsResult {
   const playerMap = new Map(players.map((player) => [player.playtomic_id, player]));
   const ownerParticipantMap = new Map<string, BookingParticipant>();
+  const coveredBookingIds = options.coveredBookingIds ?? new Set<string>();
 
   participants.forEach((participant) => {
     if (participant.booking_id && participant.is_owner) {
@@ -34,7 +36,9 @@ export function computePendingPayments(
   const rowsWithSort = bookings
     .filter(
       (booking) =>
-        !isCanceledBooking(booking) && (booking.payment_status ?? '').toUpperCase() === 'PENDING'
+        !isCanceledBooking(booking) &&
+        (booking.payment_status ?? '').toUpperCase() === 'PENDING' &&
+        !coveredBookingIds.has(booking.booking_id)
     )
     .map((booking) => {
       const bookingDate = booking.booking_start ? new Date(booking.booking_start) : null;

--- a/components/playtomic/playtomic-view.tsx
+++ b/components/playtomic/playtomic-view.tsx
@@ -33,7 +33,7 @@ export function PlaytomicView() {
 
   const meta = useMemo(() => getRangeMeta(range), [range]);
 
-  const { data, loading, refreshing, error, fetchData } = usePlaytomicData({
+  const { data, loading, refreshing, error, fetchData, coveredBookingIds } = usePlaytomicData({
     range,
     fromIso: meta.fromIso,
     toIso: meta.toIso,
@@ -89,8 +89,11 @@ export function PlaytomicView() {
   const reconciliation = useMemo(() => computeReconciliation(data.bookings), [data.bookings]);
 
   const pendingPayments = useMemo(
-    () => computePendingPayments(data.bookings, data.participants, data.players),
-    [data.bookings, data.participants, data.players]
+    () =>
+      computePendingPayments(data.bookings, data.participants, data.players, {
+        coveredBookingIds,
+      }),
+    [data.bookings, data.participants, data.players, coveredBookingIds]
   );
 
   const exportReconciliationCsv = useCallback(() => {

--- a/components/playtomic/use-playtomic-data.ts
+++ b/components/playtomic/use-playtomic-data.ts
@@ -43,6 +43,7 @@ export function usePlaytomicData({
     resources: [],
     syncs: [],
   });
+  const [coveredBookingIds, setCoveredBookingIds] = useState<Set<string>>(new Set());
 
   const fetchData = useCallback(
     async (isRefresh = false) => {
@@ -156,6 +157,38 @@ export function usePlaytomicData({
           resources: (resourcesRes.data ?? []) as ResourceRow[],
           syncs: (syncsRes.data ?? []) as SyncRow[],
         });
+
+        // Fetch cobertura combinada (Waitry + CSV) para todos los bookings
+        // del dashboard. Usado para excluir reservas con cobertura completa
+        // del listado de "Pagos Pendientes (sin cobro online)". Se hace
+        // después del setData principal para no bloquear el render.
+        // `v_bookings_total_coverage` aparece en types tras aplicar
+        // la migración + regen — hasta entonces se usa cast local.
+        if (bookingIds.length > 0) {
+          const coverageBookingChunks = chunkArray(bookingIds, 500);
+          const covered = new Set<string>();
+          const coverageSchema = schema as any;
+          for (const chunk of coverageBookingChunks) {
+            const { data: coverageRows, error: coverageErr } = await coverageSchema
+              .from('v_bookings_total_coverage')
+              .select('booking_id,coverage_status')
+              .in('booking_id', chunk)
+              .eq('coverage_status', 'full');
+            if (coverageErr) {
+              // No bloqueamos el dashboard si la vista falla — solo perdemos
+              // el filtro y el operador ve el listado completo (peor caso:
+              // ruido). Pasa naturalmente si la migración aún no se aplicó.
+              console.warn('coverage query failed', coverageErr);
+              break;
+            }
+            for (const row of (coverageRows ?? []) as { booking_id: string }[]) {
+              covered.add(row.booking_id);
+            }
+          }
+          setCoveredBookingIds(covered);
+        } else {
+          setCoveredBookingIds(new Set());
+        }
       } catch (err: any) {
         setError(err?.message ?? 'No se pudo cargar el dashboard de Playtomic');
       } finally {
@@ -170,5 +203,5 @@ export function usePlaytomicData({
     void fetchData();
   }, [fetchData]);
 
-  return { data, loading, refreshing, error, fetchData };
+  return { data, loading, refreshing, error, fetchData, coveredBookingIds };
 }

--- a/lib/playtomic/conciliacion.test.ts
+++ b/lib/playtomic/conciliacion.test.ts
@@ -1,5 +1,58 @@
 import { describe, expect, it } from 'vitest';
-import { isWithinTimestampWindow, rankCandidates, type WaitryCandidate } from './conciliacion';
+import {
+  isCanchaProduct,
+  isWithinTimestampWindow,
+  rankCandidates,
+  type WaitryCandidate,
+} from './conciliacion';
+
+describe('isCanchaProduct', () => {
+  it('accepts the exact "Renta Cancha Padel"', () => {
+    expect(isCanchaProduct('Renta Cancha Padel')).toBe(true);
+  });
+
+  it('accepts "Renta Tenis ..." variants', () => {
+    expect(isCanchaProduct('Renta Tenis Doub. 90 min')).toBe(true);
+    expect(isCanchaProduct('Renta Tenis Singles 90 min')).toBe(true);
+  });
+
+  it('accepts "Renta Pickleball ..." variants', () => {
+    expect(isCanchaProduct('Renta Pickleball Doub. 90 min')).toBe(true);
+    expect(isCanchaProduct('Renta Pickleball Doub. 60 min')).toBe(true);
+    expect(isCanchaProduct('Renta Pickleball Sing. 60 min')).toBe(true);
+    expect(isCanchaProduct('Renta Pickleball Sing 90 min')).toBe(true);
+  });
+
+  it('accepts "Uso cancha coach" variants (named coaches and PREMIUM)', () => {
+    expect(isCanchaProduct('Uso cancha coach')).toBe(true);
+    expect(isCanchaProduct('Uso cancha coach PREMIUM')).toBe(true);
+    expect(isCanchaProduct('Uso cancha coach Omar')).toBe(true);
+    expect(isCanchaProduct('Uso cancha coach Anibal')).toBe(true);
+    expect(isCanchaProduct('Uso cancha coach Manuel')).toBe(true);
+    expect(isCanchaProduct('Uso cancha coach Paco')).toBe(true);
+    expect(isCanchaProduct('Uso cancha coach PREMIUM Hugo')).toBe(true);
+  });
+
+  it('rejects equipment, academies, tournaments and unrelated products', () => {
+    expect(isCanchaProduct('Palbea Padel Overgrip')).toBe(false);
+    expect(isCanchaProduct('Pelotas Padel Head')).toBe(false);
+    expect(isCanchaProduct('Renta de Pala Adidas')).toBe(false);
+    expect(isCanchaProduct('Academia Padel')).toBe(false);
+    expect(isCanchaProduct('Academia Tenis')).toBe(false);
+    expect(isCanchaProduct('Clase de Academia Padel')).toBe(false);
+    expect(isCanchaProduct('Torneo 2do Tenis Open')).toBe(false);
+    expect(isCanchaProduct('Rey de la Cancha')).toBe(false);
+    expect(isCanchaProduct('Reina de la cancha')).toBe(false);
+    expect(isCanchaProduct('Pickle Juice')).toBe(false);
+    expect(isCanchaProduct('Coca Cola')).toBe(false);
+  });
+
+  it('rejects null/undefined/empty', () => {
+    expect(isCanchaProduct(null)).toBe(false);
+    expect(isCanchaProduct(undefined)).toBe(false);
+    expect(isCanchaProduct('')).toBe(false);
+  });
+});
 
 const baseBooking = {
   booking_start: '2026-04-08T01:30:00Z',

--- a/lib/playtomic/conciliacion.ts
+++ b/lib/playtomic/conciliacion.ts
@@ -1,5 +1,34 @@
 export type CoverageStatus = 'none' | 'partial' | 'full';
 
+/**
+ * Productos de Waitry que amparan renta de cancha y, por tanto, son
+ * candidatos válidos para conciliar contra reservas Playtomic. Lista
+ * confirmada con datos reales del schema rdb.waitry_productos.
+ *
+ * Tres familias:
+ *   - "Renta Cancha Padel" (exacto, ~1834 pedidos / 60d)
+ *   - "Renta Tenis ..." y "Renta Pickleball ..." (variantes Doub./Singles, 60/90 min)
+ *   - "Uso cancha coach ..." (entrenadores con nombres: Omar, Anibal, Manuel, Paco, Hugo, + variante PREMIUM)
+ *
+ * Para PostgREST, los patterns se aplican con `.or('...ilike...,...ilike...')`.
+ * Para validación en cliente/server action se usa `isCanchaProduct()`.
+ */
+export const CANCHA_PRODUCT_PATTERNS = [
+  'Renta Cancha Padel',
+  'Renta Tenis%',
+  'Renta Pickleball%',
+  'Uso cancha coach%',
+] as const;
+
+export function isCanchaProduct(productName: string | null | undefined): boolean {
+  if (!productName) return false;
+  if (productName === 'Renta Cancha Padel') return true;
+  if (productName.startsWith('Renta Tenis ')) return true;
+  if (productName.startsWith('Renta Pickleball ')) return true;
+  if (productName.startsWith('Uso cancha coach')) return true;
+  return false;
+}
+
 export type PendingBookingWithCoverage = {
   booking_id: string;
   booking_start: string;

--- a/supabase/migrations/20260505010000_playtomic_v_bookings_total_coverage.sql
+++ b/supabase/migrations/20260505010000_playtomic_v_bookings_total_coverage.sql
@@ -1,0 +1,79 @@
+-- Iniciativa rdb-pagos-cancha-conciliacion — Sprint 2 (CSV import, parte B)
+--
+-- Vista combinada que para cada booking suma cobertura de AMBAS fuentes:
+--   1. payment_assignments (Waitry manual, S1 + S2-Waitry futuro)
+--   2. payments_import (CSV de Playtomic Manager, S2-CSV-A)
+--
+-- Esta vista reemplaza conceptualmente a v_bookings_payment_coverage para
+-- determinar el estado real de un booking. La vista anterior (S1) sigue
+-- existiendo y solo refleja Waitry.
+--
+-- Match key con CSV: (cualquier participante.player_id == payments_import.user_id)
+-- AND service_date dentro de ±15 min del booking_start AND payment_status='Paid'.
+-- El match por participante (no solo owner) cubre los splits donde cada
+-- jugador paga su parte por separado.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW playtomic.v_bookings_total_coverage
+WITH (security_invoker = true)
+AS
+WITH waitry_agg AS (
+  SELECT
+    booking_id,
+    SUM(assigned_amount) AS waitry_total,
+    ARRAY_AGG(waitry_order_id ORDER BY assigned_at) AS waitry_order_ids
+  FROM playtomic.payment_assignments
+  GROUP BY booking_id
+),
+csv_agg AS (
+  SELECT
+    b.booking_id,
+    SUM(p.total) AS csv_total,
+    COUNT(DISTINCT p.payment_id) AS csv_payments_count,
+    ARRAY_AGG(DISTINCT p.payment_id) AS csv_payment_ids
+  FROM playtomic.bookings b
+  JOIN playtomic.booking_participants bp ON bp.booking_id = b.booking_id
+  JOIN playtomic.payments_import p
+    ON p.user_id = bp.player_id
+   AND p.service_date BETWEEN b.booking_start - INTERVAL '15 minutes'
+                          AND b.booking_start + INTERVAL '15 minutes'
+   AND p.payment_status = 'Paid'
+  GROUP BY b.booking_id
+)
+SELECT
+  b.booking_id,
+  b.price_amount AS booking_total,
+  COALESCE(w.waitry_total, 0) AS waitry_total,
+  COALESCE(c.csv_total, 0)    AS csv_total,
+  COALESCE(w.waitry_total, 0) + COALESCE(c.csv_total, 0) AS combined_total,
+  CASE
+    WHEN COALESCE(w.waitry_total, 0) + COALESCE(c.csv_total, 0) = 0 THEN 'none'
+    WHEN COALESCE(w.waitry_total, 0) + COALESCE(c.csv_total, 0) >= COALESCE(b.price_amount, 0) THEN 'full'
+    ELSE 'partial'
+  END AS coverage_status,
+  CASE
+    WHEN COALESCE(b.price_amount, 0) = 0 THEN 0
+    ELSE LEAST(
+      100,
+      ROUND(
+        (COALESCE(w.waitry_total, 0) + COALESCE(c.csv_total, 0)) / b.price_amount * 100,
+        2
+      )
+    )
+  END AS coverage_pct,
+  COALESCE(w.waitry_order_ids,  ARRAY[]::text[]) AS waitry_order_ids,
+  COALESCE(c.csv_payments_count, 0)              AS csv_payments_count,
+  COALESCE(c.csv_payment_ids,    ARRAY[]::text[]) AS csv_payment_ids
+FROM playtomic.bookings b
+LEFT JOIN waitry_agg w ON w.booking_id = b.booking_id
+LEFT JOIN csv_agg    c ON c.booking_id = b.booking_id;
+
+GRANT SELECT ON playtomic.v_bookings_total_coverage TO authenticated;
+
+COMMENT ON VIEW playtomic.v_bookings_total_coverage IS
+  'Cobertura combinada de un booking: payment_assignments (Waitry) + payments_import (CSV). Match con CSV por participante + service_date ±15min + Paid. Iniciativa rdb-pagos-cancha-conciliacion.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## 3 mejoras en un solo PR

Comparten alcance (todas son ajustes de S2 sobre la conciliación) y dependen de la misma migración.

### 1. Vista combinada \`v_bookings_total_coverage\`

Suma cobertura de \`payment_assignments\` (Waitry) + \`payments_import\` (CSV) por booking. Match con CSV: **cualquier participante** del booking + service_date ±15min + Paid. Match flexible captura los splits donde cada jugador paga su parte por separado.

### 2. Filtro del dashboard principal

El módulo \`/rdb/playtomic\` excluye del listado de "Pagos Pendientes (sin cobro online)" las reservas con cobertura completa via Waitry o CSV. Validado con datos reales:

| | Antes del CSV | Después del CSV upload |
|---|---:|---:|
| Pendientes en BSOP | 551 | **441** (-110) |
| Monto pendiente | $204,800 | **~$174,100** (-$30,700) |

\`pending-payments.ts\` ahora acepta opt \`coveredBookingIds\`. Fail-safe: si la vista falla (e.g. migración no aplicada todavía), el dashboard sigue funcionando sin filtro.

### 3. Whitelist productos cancha (de 1 a 4 patterns)

Antes solo se reconocía \`Renta Cancha Padel\` como candidato para conciliar contra Waitry. Los pendientes de tenis/pickleball nunca tenían matches. Ahora reconoce 4 familias:

| Pattern | Productos cubiertos | Pedidos / 60d |
|---|---|---:|
| \`Renta Cancha Padel\` | Padel exact | 1834 |
| \`Renta Tenis %\` | Doub. 90, Singles 90 | 211 |
| \`Renta Pickleball %\` | Doub./Sing. 60/90 | 12 |
| \`Uso cancha coach %\` | Coaches: Omar, Anibal, Manuel, Paco, Hugo + PREMIUM | 107 |

Centralizado en \`lib/playtomic/conciliacion.ts\` (\`CANCHA_PRODUCT_PATTERNS\` + \`isCanchaProduct()\`). Hook usa \`.or()\` de PostgREST con ilike. Helper reutilizable en S2-Waitry-write futuro.

## Tests

22 unitarios verdes (eran 16). 6 nuevos cubren \`isCanchaProduct\` con todos los casos: padel exact, tenis/pickleball variants, coaches con nombres, equipamiento/torneos/academias rechazados.

## Pasos post-merge (orden estricto)

1. **Aplicar migración** desde la branch:
   \`\`\`bash
   git fetch origin feat/rdb-conciliacion-s2-csv-b:feat/rdb-conciliacion-s2-csv-b
   git checkout feat/rdb-conciliacion-s2-csv-b
   psql "\$SUPABASE_DB_URL" -f supabase/migrations/20260505010000_playtomic_v_bookings_total_coverage.sql
   \`\`\`
2. Verificar: \`psql "\$SUPABASE_DB_URL" -c "\d+ playtomic.v_bookings_total_coverage"\`.
3. Regenerar \`SCHEMA_REF\` + \`types/supabase.ts\`. Tras el regen, retirar el \`as any\` en \`use-playtomic-data.ts\` (un commit chico de cleanup).
4. Smoke en preview: \`/rdb/playtomic\` debe mostrar ~441 pendientes (no 551). \`/rdb/playtomic/conciliacion\` ahora muestra candidatos de tenis/pickleball/coach.

## Test plan

- [ ] CI verde
- [ ] Migración aplicada
- [ ] Dashboard pendientes baja de 551 → ~441
- [ ] Conciliación muestra candidatos de tenis (verificar con una reserva de tenis pendiente)
- [ ] Búsqueda por "coach" en notes funciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)