### PR TITLE
feat(rdb/playtomic/conciliacion): boost de tickets coach en el ranker

### DIFF
--- a/lib/playtomic/conciliacion.test.ts
+++ b/lib/playtomic/conciliacion.test.ts
@@ -283,4 +283,82 @@ describe('rankCandidates', () => {
     const far2 = candidate({ order_id: 'b', timestamp: '2026-08-01T00:00:00Z' });
     expect(rankCandidates(baseBooking, [far1, far2])).toEqual([]);
   });
+
+  it('boosts coach tickets when the booking has a known coach as participant', () => {
+    const coachBooking = {
+      ...baseBooking,
+      owner_name: 'Cliente Random',
+      participant_names: ['Cliente Random', 'Omar Berlanga'],
+    };
+    const coachTicket = candidate({
+      order_id: 'coach-1',
+      timestamp: '2026-04-08T01:35:00Z',
+      total_amount: 300,
+      unit_price: 300,
+      items: [{ product_name: 'Uso cancha coach', quantity: 1, unit_price: 300, total_price: 300 }],
+    });
+    const otherTicket = candidate({
+      order_id: 'other',
+      timestamp: '2026-04-08T01:35:00Z',
+      total_amount: 200,
+      unit_price: 200,
+      items: [
+        { product_name: 'Renta Cancha Padel', quantity: 1, unit_price: 200, total_price: 200 },
+      ],
+    });
+    const ranked = rankCandidates(coachBooking, [otherTicket, coachTicket]);
+    expect(ranked[0].order_id).toBe('coach-1');
+    expect(ranked[0].reasons).toContain('Reserva con coach + ticket "Uso cancha coach"');
+  });
+
+  it('gives extra bonus when the coach name in the product matches the booking coach', () => {
+    const coachBooking = {
+      ...baseBooking,
+      owner_name: 'Omar Berlanga',
+      participant_names: ['Omar Berlanga', 'Cliente'],
+    };
+    const namedCoach = candidate({
+      order_id: 'named',
+      timestamp: '2026-04-08T01:35:00Z',
+      total_amount: 300,
+      unit_price: 300,
+      items: [
+        {
+          product_name: 'Uso cancha coach Omar',
+          quantity: 1,
+          unit_price: 300,
+          total_price: 300,
+        },
+      ],
+    });
+    const genericCoach = candidate({
+      order_id: 'generic',
+      timestamp: '2026-04-08T01:35:00Z',
+      total_amount: 300,
+      unit_price: 300,
+      items: [{ product_name: 'Uso cancha coach', quantity: 1, unit_price: 300, total_price: 300 }],
+    });
+    const ranked = rankCandidates(coachBooking, [genericCoach, namedCoach]);
+    expect(ranked[0].order_id).toBe('named');
+    expect(ranked[0].reasons.some((r) => r.includes('Nombre del coach'))).toBe(true);
+  });
+
+  it('does not boost coach tickets when the booking has no coach', () => {
+    const regularBooking = {
+      ...baseBooking,
+      owner_name: 'Cliente Sin Coach',
+      participant_names: ['Cliente Sin Coach', 'Otro Cliente'],
+    };
+    const coachTicket = candidate({
+      order_id: 'coach',
+      timestamp: '2026-04-08T01:35:00Z',
+      total_amount: 300,
+      unit_price: 300,
+      items: [
+        { product_name: 'Uso cancha coach Omar', quantity: 1, unit_price: 300, total_price: 300 },
+      ],
+    });
+    const ranked = rankCandidates(regularBooking, [coachTicket]);
+    expect(ranked[0].reasons.some((r) => r.includes('coach'))).toBe(false);
+  });
 });

--- a/lib/playtomic/conciliacion.ts
+++ b/lib/playtomic/conciliacion.ts
@@ -29,6 +29,39 @@ export function isCanchaProduct(productName: string | null | undefined): boolean
   return false;
 }
 
+/**
+ * Coaches conocidos del club. Cuando una reserva tiene a uno de estos como
+ * owner o participante, los pedidos Waitry "Uso cancha coach %" en ventana
+ * temporal se promueven en el ranker — el operador los valida visualmente.
+ *
+ * Nombres en lowercase normalizado (sin tildes). Mantener sincronizado con
+ * los productos de Waitry: ver SQL `SELECT DISTINCT product_name FROM
+ * rdb.waitry_productos WHERE product_name ILIKE 'Uso cancha coach%'`.
+ */
+const KNOWN_COACH_NAMES = ['omar', 'anibal', 'manuel', 'paco', 'hugo'] as const;
+
+function isCoachProduct(productName: string | null | undefined): boolean {
+  if (!productName) return false;
+  return productName.toLowerCase().startsWith('uso cancha coach');
+}
+
+function detectBookingCoaches(booking: {
+  owner_name: string | null;
+  participant_names: string[];
+}): string[] {
+  const allNames = [booking.owner_name, ...(booking.participant_names ?? [])].filter(
+    (n): n is string => Boolean(n)
+  );
+  const found = new Set<string>();
+  for (const name of allNames) {
+    const lower = normalizeForMatch(name);
+    for (const coach of KNOWN_COACH_NAMES) {
+      if (lower.includes(coach)) found.add(coach);
+    }
+  }
+  return Array.from(found);
+}
+
 export type PendingBookingWithCoverage = {
   booking_id: string;
   booking_start: string;
@@ -149,6 +182,9 @@ export function rankCandidates(
   const expectedPerPlayer =
     participantCount > 0 && bookingTotal > 0 ? bookingTotal / participantCount : 0;
 
+  const bookingCoaches = detectBookingCoaches(booking);
+  const isCoachBooking = bookingCoaches.length > 0;
+
   return candidates
     .filter((candidate) =>
       isWithinTimestampWindow(booking.booking_start, candidate.timestamp, tolerance)
@@ -220,6 +256,27 @@ export function rankCandidates(
         if (Math.abs(candidate.total_amount - bookingTotal) <= tolerance) {
           score += 10;
           reasons.push('Total del ticket coincide con el total del booking');
+        }
+      }
+
+      // Boost cuando la reserva involucra a un coach conocido (owner o
+      // participante) y el ticket de Waitry contiene un producto "Uso cancha
+      // coach %". 66 de 83 pedidos coach son genéricos sin nombre, así que
+      // promovemos cualquier coach-ticket en la ventana sin exigir match
+      // exacto del nombre. Si además el nombre del producto incluye un coach
+      // que sí está en el booking, bonus extra.
+      if (isCoachBooking) {
+        const coachItem = candidate.items.find((it) => isCoachProduct(it.product_name));
+        if (coachItem) {
+          score += 30;
+          reasons.push('Reserva con coach + ticket "Uso cancha coach"');
+
+          const coachItemNorm = normalizeForMatch(coachItem.product_name);
+          const exactCoachMatch = bookingCoaches.find((c) => coachItemNorm.includes(c));
+          if (exactCoachMatch) {
+            score += 20;
+            reasons.push(`Nombre del coach (${exactCoachMatch}) coincide con el ticket`);
+          }
         }
       }
 


### PR DESCRIPTION
Cuando una reserva tiene un coach conocido (Omar, Anibal, Manuel, Paco,
Hugo) como owner o participante, el ranker promueve los tickets Waitry
"Uso cancha coach %" al top del dropdown. El operador valida visualmente
con un click — semi-automático, no asignación ciega.

Por qué:
- 307 de 457 reservas pendientes tienen un coach como owner/participante.
- 83 pedidos coach existen en Waitry (90d), pero solo 17 tienen el
  nombre del coach en el product_name. Auto-match estricto solo agarra
  2 reservas.
- El boost trabaja con los 66 pedidos genéricos sin nombre + los 17 con
  nombre, presentándolos al top cuando la reserva tiene un coach.

Score:
- +30 cuando ticket es "Uso cancha coach %" y booking tiene coach.
- +20 extra si el nombre del coach en el producto coincide con el coach
  detectado en el booking (ej. "Uso cancha coach Omar" + booking con
  Omar Berlanga como participante).

3 tests nuevos cubren los casos: boost generic con coach booking,
bonus extra por nombre exacto, no-boost cuando no hay coach.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
