### PR TITLE
fix(rdb/playtomic/conciliacion): ordenar pedidos Waitry descending para no perder recientes en cap PostgREST

### DIFF
--- a/components/playtomic/conciliacion/use-conciliacion-data.ts
+++ b/components/playtomic/conciliacion/use-conciliacion-data.ts
@@ -113,7 +113,12 @@ export function useConciliacionData() {
           .select('order_id,timestamp,notes,total_amount,paid')
           .eq('paid', true)
           .gte('timestamp', waitryLookbackIso)
-          .order('timestamp', { ascending: true })
+          // Descending: PostgREST capa a ~1000 rows por query independiente del
+          // .limit() que pidamos. Con 5K+ pedidos en 120d, ascending dejaba los
+          // más recientes (los que el operador necesita ver) FUERA del cap. Al
+          // ordenar descending, los recientes llegan primero — exactamente los
+          // que matchean con bookings que aún están abiertos para conciliar.
+          .order('timestamp', { ascending: false })
           .limit(8000)
           .returns<WaitryPedidoRow[]>(),
         rdb
@@ -121,6 +126,7 @@ export function useConciliacionData() {
           .select('order_id,product_name,unit_price,quantity,total_price')
           .or(CANCHA_OR_FILTER)
           .gte('created_at', waitryLookbackIso)
+          .order('created_at', { ascending: false })
           .limit(8000)
           .returns<WaitryProductoRow[]>(),
       ]);


### PR DESCRIPTION
Beto reportó: del 30-mar en adelante no aparecen candidatos en el
dropdown de conciliación.

Causa: 5732 pedidos pagados en 120d. PostgREST capa a ~1000 rows
ignorando el `.limit(8000)` (mismo bug del PR #411 con productos).
El query usaba `.order('timestamp', ascending: true)` → traía los
1000 más antiguos. Los del 30-mar en adelante quedaban fuera.

Fix: invertir orden a descending. Ahora llegan los más recientes
primero — que son justo los que matchean con bookings recientes que
el operador necesita conciliar. Aplico el mismo fix a `waitry_productos`
del Paso 1 por consistencia (el Paso 2 con `.in()` ya está bien).

Trade-off: si el operador busca matches de un booking muy antiguo
(>~3 meses con muchos cobros en medio), los pedidos del periodo
podrían no llegar al cliente. Pero el caso primario es conciliar
recientes, no históricos. Si necesitamos cubrir histórico, agregamos
filtro por booking_start específico al fetch.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
