### PR TITLE
chore(db): subir pgrst.db_max_rows a 50K (fix raíz del cap de 1000)

### DIFF
--- a/supabase/migrations/20260505030000_pgrst_db_max_rows_50k.sql
+++ b/supabase/migrations/20260505030000_pgrst_db_max_rows_50k.sql
@@ -1,0 +1,18 @@
+-- Sube el cap de rows que PostgREST devuelve por query (default Supabase
+-- ~1000 rows). Con 5K+ pedidos Waitry pagados en 120d, el cap de 1000
+-- truncaba los resultados y dejaba fuera los más recientes — fix #420
+-- (descending) era paliativo, este es el fix de raíz.
+--
+-- 50K es un valor conservador: cubre todas las queries actuales del repo
+-- con margen amplio sin abrir la puerta a queries malformados que
+-- pidieran millones de rows. Los queries del cliente siguen filtrando
+-- por ventana temporal y demás predicados, así que en la práctica nunca
+-- se devuelven cantidades grandes.
+
+BEGIN;
+
+ALTER ROLE authenticator SET pgrst.db_max_rows = '50000';
+
+NOTIFY pgrst, 'reload config';
+
+COMMIT;


### PR DESCRIPTION
Fix de raíz: el rol authenticator usaba el default de Supabase (~1000
rows). Con 5K+ pedidos Waitry en 120d, el cap dejaba fuera los más
recientes y la página /rdb/playtomic/conciliacion no mostraba matches
del 30-mar en adelante.

50K cubre todas las queries actuales con margen sin abrir la puerta a
queries malformados (los queries del cliente filtran por ventana
temporal + predicados, en la práctica nunca devolverán millones).

Aplica también a:
- waitry_productos en S2-CSV-A donde el fix #411 dividió en 2 queries
  (antes con limit 30K, ahora 8K es suficiente porque el cap real sube).
- Cualquier query futura que pase el cap.

NOTIFY pgrst 'reload config' después del ALTER.

Aplicar en producción para desbloquear el bug reportado.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
