### PR TITLE
feat(rdb/playtomic/conciliacion): S2-Waitry-write — asignar/quitar pagos en cancha

### DIFF
--- a/app/rdb/playtomic/conciliacion/actions.ts
+++ b/app/rdb/playtomic/conciliacion/actions.ts
@@ -1,0 +1,131 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { assertNotInPreview } from '@/lib/auth/preview-guard';
+import { isCanchaProduct } from '@/lib/playtomic/conciliacion';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+
+export type AssignPaymentInput = {
+  booking_id: string;
+  waitry_order_id: string;
+  assigned_amount: number;
+  note?: string | null;
+};
+
+export type AssignPaymentResult = { ok: true; id: string } | { ok: false; error: string };
+export type UnassignPaymentResult = { ok: true } | { ok: false; error: string };
+
+function revalidateConciliacion() {
+  revalidatePath('/rdb/playtomic/conciliacion');
+  revalidatePath('/rdb/playtomic');
+}
+
+export async function assignPaymentAction(input: AssignPaymentInput): Promise<AssignPaymentResult> {
+  await assertNotInPreview();
+
+  const bookingId = input.booking_id?.trim();
+  const waitryOrderId = input.waitry_order_id?.trim();
+  const assignedAmount = Number(input.assigned_amount);
+  const note = typeof input.note === 'string' && input.note.trim().length > 0 ? input.note : null;
+
+  if (!bookingId) return { ok: false, error: 'booking_id requerido' };
+  if (!waitryOrderId) return { ok: false, error: 'waitry_order_id requerido' };
+  if (!Number.isFinite(assignedAmount) || assignedAmount <= 0) {
+    return { ok: false, error: 'El monto asignado debe ser mayor que 0.' };
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: 'No autenticado. Vuelve a iniciar sesión.' };
+
+  const playtomic = supabase.schema('playtomic');
+  const rdb = supabase.schema('rdb');
+
+  const { data: booking, error: bookingErr } = await playtomic
+    .from('bookings')
+    .select('booking_id,is_canceled')
+    .eq('booking_id', bookingId)
+    .maybeSingle();
+  if (bookingErr) return { ok: false, error: `Error consultando reserva: ${bookingErr.message}` };
+  if (!booking) return { ok: false, error: 'La reserva no existe.' };
+  if (booking.is_canceled) {
+    return { ok: false, error: 'La reserva está cancelada — no se puede asignar pago.' };
+  }
+
+  const { data: pedido, error: pedidoErr } = await rdb
+    .from('waitry_pedidos')
+    .select('order_id,paid')
+    .eq('order_id', waitryOrderId)
+    .maybeSingle();
+  if (pedidoErr) return { ok: false, error: `Error consultando pedido: ${pedidoErr.message}` };
+  if (!pedido) return { ok: false, error: 'El pedido Waitry no existe.' };
+  if (!pedido.paid) {
+    return { ok: false, error: 'El pedido Waitry no está marcado como pagado.' };
+  }
+
+  const { data: productos, error: productosErr } = await rdb
+    .from('waitry_productos')
+    .select('product_name')
+    .eq('order_id', waitryOrderId);
+  if (productosErr) {
+    return { ok: false, error: `Error consultando productos: ${productosErr.message}` };
+  }
+  const hasCanchaProduct = (productos ?? []).some((p) => isCanchaProduct(p.product_name));
+  if (!hasCanchaProduct) {
+    return {
+      ok: false,
+      error:
+        'El pedido Waitry no contiene un producto de cancha (padel/tenis/pickleball/coach) — no es elegible.',
+    };
+  }
+
+  const { data: inserted, error: insertErr } = await playtomic
+    .from('payment_assignments')
+    .insert({
+      booking_id: bookingId,
+      waitry_order_id: waitryOrderId,
+      assigned_amount: assignedAmount,
+      assigned_by: user.id,
+      note,
+    })
+    .select('id')
+    .single();
+
+  if (insertErr) {
+    if (insertErr.code === '23505') {
+      return { ok: false, error: 'Este pedido Waitry ya está asignado a otra reserva.' };
+    }
+    return { ok: false, error: `Error al guardar la asignación: ${insertErr.message}` };
+  }
+
+  revalidateConciliacion();
+  return { ok: true, id: inserted.id };
+}
+
+export async function unassignPaymentAction(assignmentId: string): Promise<UnassignPaymentResult> {
+  await assertNotInPreview();
+
+  const id = assignmentId?.trim();
+  if (!id) return { ok: false, error: 'assignmentId requerido' };
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: 'No autenticado. Vuelve a iniciar sesión.' };
+
+  const { error } = await supabase
+    .schema('playtomic')
+    .from('payment_assignments')
+    .delete()
+    .eq('id', id);
+
+  if (error) {
+    return { ok: false, error: `Error al quitar la asignación: ${error.message}` };
+  }
+
+  revalidateConciliacion();
+  return { ok: true };
+}

--- a/components/playtomic/conciliacion/assignment-panel.tsx
+++ b/components/playtomic/conciliacion/assignment-panel.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useTransition } from 'react';
+import {
+  assignPaymentAction,
+  unassignPaymentAction,
+} from '@/app/rdb/playtomic/conciliacion/actions';
 import { Button } from '@/components/ui/button';
 import { formatMoney } from '@/components/playtomic/utils';
 import type { PendingBookingWithCoverage, RankedCandidate } from '@/lib/playtomic/conciliacion';
+import type { AssignmentDetail } from './use-conciliacion-data';
 
 const TIMESTAMP_FMT = new Intl.DateTimeFormat('es-MX', {
   timeZone: 'America/Matamoros',
@@ -14,18 +19,31 @@ const TIMESTAMP_FMT = new Intl.DateTimeFormat('es-MX', {
   hour12: false,
 });
 
+type ActionFeedback =
+  | { kind: 'success'; message: string }
+  | { kind: 'partial'; message: string }
+  | { kind: 'error'; message: string };
+
 export function AssignmentPanel({
   booking,
   candidates,
+  existingAssignments,
   tolerancePresetLabel,
   onWidenWindow,
+  onAfterChange,
 }: {
   booking: PendingBookingWithCoverage | null;
   candidates: RankedCandidate[];
+  existingAssignments: AssignmentDetail[];
   tolerancePresetLabel: string;
   onWidenWindow?: () => void;
+  onAfterChange: () => void;
 }) {
   const [selectedOrderIds, setSelectedOrderIds] = useState<Set<string>>(new Set());
+  const [isPending, startTransition] = useTransition();
+  const [feedback, setFeedback] = useState<ActionFeedback | null>(null);
+  // El padre pasa `key={selectedBookingId}` al panel para que React
+  // remonte y reinicie selectedOrderIds/feedback al cambiar de reserva.
 
   const totalSelected = useMemo(
     () =>
@@ -54,6 +72,63 @@ export function AssignmentPanel({
       if (next.has(orderId)) next.delete(orderId);
       else next.add(orderId);
       return next;
+    });
+  }
+
+  function handleConciliar() {
+    if (!booking || selectedOrderIds.size === 0) return;
+    const toAssign = candidates.filter((c) => selectedOrderIds.has(c.order_id));
+    setFeedback(null);
+    startTransition(async () => {
+      let successes = 0;
+      const errors: string[] = [];
+      for (const c of toAssign) {
+        const res = await assignPaymentAction({
+          booking_id: booking.booking_id,
+          waitry_order_id: c.order_id,
+          assigned_amount: c.total_amount,
+        });
+        if (res.ok) {
+          successes += 1;
+        } else {
+          errors.push(`#${c.order_id}: ${res.error}`);
+        }
+      }
+
+      if (errors.length === 0) {
+        setFeedback({
+          kind: 'success',
+          message: `${successes} ${successes === 1 ? 'pedido asignado' : 'pedidos asignados'}.`,
+        });
+      } else if (successes > 0) {
+        setFeedback({
+          kind: 'partial',
+          message: `${successes} asignados, ${errors.length} fallaron: ${errors.join(' · ')}`,
+        });
+      } else {
+        setFeedback({
+          kind: 'error',
+          message: errors.join(' · '),
+        });
+      }
+
+      if (successes > 0) {
+        setSelectedOrderIds(new Set());
+        onAfterChange();
+      }
+    });
+  }
+
+  function handleQuitar(assignmentId: string) {
+    setFeedback(null);
+    startTransition(async () => {
+      const res = await unassignPaymentAction(assignmentId);
+      if (res.ok) {
+        setFeedback({ kind: 'success', message: 'Asignación quitada.' });
+        onAfterChange();
+      } else {
+        setFeedback({ kind: 'error', message: res.error });
+      }
     });
   }
 
@@ -113,6 +188,67 @@ export function AssignmentPanel({
           />
         </div>
       </div>
+
+      {feedback ? (
+        <div
+          role="status"
+          className={`rounded-xl border p-3 text-sm ${
+            feedback.kind === 'success'
+              ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+              : feedback.kind === 'partial'
+                ? 'border-amber-500/40 bg-amber-500/10 text-amber-200'
+                : 'border-red-500/40 bg-red-500/10 text-red-200'
+          }`}
+        >
+          {feedback.message}
+        </div>
+      ) : null}
+
+      {existingAssignments.length > 0 ? (
+        <div className="space-y-2">
+          <h4 className="text-sm font-semibold text-[var(--text)]">
+            Asignaciones actuales ({existingAssignments.length})
+          </h4>
+          <ul className="space-y-2">
+            {existingAssignments.map((a) => {
+              const ts = new Date(a.assigned_at);
+              const tsLabel = Number.isNaN(ts.getTime()) ? '—' : TIMESTAMP_FMT.format(ts);
+              return (
+                <li
+                  key={a.id}
+                  className="flex items-start justify-between gap-3 rounded-xl border border-emerald-500/30 bg-emerald-500/5 p-3 text-sm"
+                >
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2 font-medium text-[var(--text)]">
+                      <span>{formatMoney(a.assigned_amount)}</span>
+                      <span
+                        className="rounded-full border border-[var(--border)] bg-[var(--panel)]/60 px-2 py-0.5 font-mono text-xs text-[var(--text-muted)]"
+                        title={a.waitry_order_id}
+                      >
+                        #{a.waitry_order_id}
+                      </span>
+                      <span className="text-xs text-[var(--text-muted)]">{tsLabel}</span>
+                    </div>
+                    {a.note ? (
+                      <div className="text-xs text-[var(--text)]/80">
+                        <span className="text-[var(--text-muted)]">nota:</span> {a.note}
+                      </div>
+                    ) : null}
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleQuitar(a.id)}
+                    disabled={isPending}
+                  >
+                    Quitar
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
 
       <div className="space-y-2">
         <div className="flex items-center justify-between">
@@ -208,6 +344,7 @@ export function AssignmentPanel({
                     variant={isSelected ? 'default' : 'outline'}
                     size="sm"
                     onClick={() => toggle(candidate.order_id)}
+                    disabled={isPending}
                   >
                     {isSelected ? 'Quitar' : 'Agregar'}
                   </Button>
@@ -222,8 +359,17 @@ export function AssignmentPanel({
         <span className="text-[var(--text-muted)]">
           Selección actual: {selectedOrderIds.size} pedidos · {formatMoney(totalSelected)}
         </span>
-        <Button variant="default" size="sm" disabled title="Disponible en S2">
-          Conciliar (S2)
+        <Button
+          variant="default"
+          size="sm"
+          disabled={selectedOrderIds.size === 0 || isPending}
+          onClick={handleConciliar}
+        >
+          {isPending
+            ? 'Guardando…'
+            : selectedOrderIds.size > 0
+              ? `Conciliar (${selectedOrderIds.size})`
+              : 'Conciliar'}
         </Button>
       </footer>
     </div>

--- a/components/playtomic/conciliacion/conciliacion-view.tsx
+++ b/components/playtomic/conciliacion/conciliacion-view.tsx
@@ -31,6 +31,11 @@ export function ConciliacionView() {
     [data.bookings, selectedBookingId]
   );
 
+  const existingAssignments = useMemo(
+    () => (selectedBookingId ? (data.assignmentsByBooking.get(selectedBookingId) ?? []) : []),
+    [data.assignmentsByBooking, selectedBookingId]
+  );
+
   const rankedCandidates = useMemo(() => {
     if (!selectedBooking) return [];
     const available = data.candidates.filter((c) => !data.assignedOrderIds.has(c.order_id));
@@ -78,12 +83,6 @@ export function ConciliacionView() {
           {refreshing ? 'Refrescando…' : 'Refrescar'}
         </Button>
       </header>
-
-      <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-[var(--text)]">
-        <strong>Sprint 1 — read-only:</strong> esta vista propone candidatos de Waitry para cada
-        reserva pero <em>todavía no guarda asignaciones</em>. Sirve para validar que la heurística
-        de matching es buena antes de habilitar la persistencia en S2.
-      </div>
 
       <div className="flex flex-col gap-3 rounded-xl border border-[var(--border)] bg-[var(--panel)]/30 p-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
@@ -133,8 +132,10 @@ export function ConciliacionView() {
           onSelect={setSelectedBookingId}
         />
         <AssignmentPanel
+          key={selectedBookingId ?? 'none'}
           booking={selectedBooking}
           candidates={rankedCandidates}
+          existingAssignments={existingAssignments}
           tolerancePresetLabel={TOLERANCE_LABELS[tolerancePreset]}
           onWidenWindow={
             tolerancePreset !== '30d'
@@ -145,6 +146,7 @@ export function ConciliacionView() {
                 }
               : undefined
           }
+          onAfterChange={refetch}
         />
       </div>
     </div>

--- a/components/playtomic/conciliacion/use-conciliacion-data.ts
+++ b/components/playtomic/conciliacion/use-conciliacion-data.ts
@@ -49,10 +49,28 @@ type WaitryProductoRow = {
   total_price: number | null;
 };
 
+type AssignmentRow = {
+  id: string;
+  booking_id: string;
+  waitry_order_id: string;
+  assigned_amount: number;
+  assigned_at: string;
+  note: string | null;
+};
+
+export type AssignmentDetail = {
+  id: string;
+  waitry_order_id: string;
+  assigned_amount: number;
+  assigned_at: string;
+  note: string | null;
+};
+
 export type ConciliacionData = {
   bookings: PendingBookingWithCoverage[];
   candidates: WaitryCandidate[];
   assignedOrderIds: Set<string>;
+  assignmentsByBooking: Map<string, AssignmentDetail[]>;
 };
 
 // PostgREST `.or()` con patterns ilike. Cubre padel, tenis, pickleball y "Uso cancha coach...".
@@ -63,6 +81,7 @@ export function useConciliacionData() {
     bookings: [],
     candidates: [],
     assignedOrderIds: new Set(),
+    assignmentsByBooking: new Map(),
   });
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -234,12 +253,26 @@ export function useConciliacionData() {
         }
       >();
       const assignedOrderIds = new Set<string>();
+      const assignmentsByBooking = new Map<string, AssignmentDetail[]>();
       if (bookingIds.length > 0) {
-        const { data: coverageRows, error: coverageErr } = await playtomic
-          .from('v_bookings_total_coverage')
-          .select('booking_id,coverage_status,coverage_pct,combined_total,waitry_order_ids')
-          .in('booking_id', bookingIds);
+        const [
+          { data: coverageRows, error: coverageErr },
+          { data: assignmentRows, error: assignmentsErr },
+        ] = await Promise.all([
+          playtomic
+            .from('v_bookings_total_coverage')
+            .select('booking_id,coverage_status,coverage_pct,combined_total,waitry_order_ids')
+            .in('booking_id', bookingIds),
+          playtomic
+            .from('payment_assignments')
+            .select('id,booking_id,waitry_order_id,assigned_amount,assigned_at,note')
+            .in('booking_id', bookingIds)
+            .order('assigned_at', { ascending: true })
+            .returns<AssignmentRow[]>(),
+        ]);
         if (coverageErr) throw coverageErr;
+        if (assignmentsErr) throw assignmentsErr;
+
         for (const row of coverageRows ?? []) {
           if (!row.booking_id) continue;
           coverageByBooking.set(row.booking_id, {
@@ -249,6 +282,24 @@ export function useConciliacionData() {
             waitry_order_ids: row.waitry_order_ids ?? [],
           });
           for (const oid of row.waitry_order_ids ?? []) assignedOrderIds.add(oid);
+        }
+
+        for (const row of assignmentRows ?? []) {
+          // Defensa-en-profundidad: la vista `v_bookings_total_coverage`
+          // ya incluye los waitry_order_ids asignados, pero solo para los
+          // bookings consultados. Aquí poblamos también desde la tabla
+          // directa para asegurar que cualquier order asignada (visible
+          // o no en el listado) quede excluida de los candidatos.
+          assignedOrderIds.add(row.waitry_order_id);
+          const list = assignmentsByBooking.get(row.booking_id) ?? [];
+          list.push({
+            id: row.id,
+            waitry_order_id: row.waitry_order_id,
+            assigned_amount: Number(row.assigned_amount ?? 0),
+            assigned_at: row.assigned_at,
+            note: row.note,
+          });
+          assignmentsByBooking.set(row.booking_id, list);
         }
       }
 
@@ -293,7 +344,7 @@ export function useConciliacionData() {
           };
         });
 
-      setData({ bookings, candidates, assignedOrderIds });
+      setData({ bookings, candidates, assignedOrderIds, assignmentsByBooking });
     } catch (err) {
       setError(getSupabaseErrorMessage(err, 'No se pudo cargar la conciliación.'));
     } finally {

--- a/docs/planning/rdb-pagos-cancha-conciliacion.md
+++ b/docs/planning/rdb-pagos-cancha-conciliacion.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-05-04
-**Última actualización:** 2026-05-04 (handoff — S2-CSV + iteraciones live en producción; arrancar S2-Waitry-write en sesión nueva siguiendo el plan más abajo)
+**Última actualización:** 2026-05-04 (S2-Waitry-write abierto en [#423](https://github.com/beto-sudo/BSOP/pull/423) — server actions + UI funcional; pendiente smoke en preview + merge)
 
 ## Problema
 
@@ -154,6 +154,7 @@ KPIs visibles en el dashboard:
 - **2026-05-04** — Bug detectado en `/rdb/playtomic/conciliacion`: la página seguía mostrando 457 pendientes con todas marcadas "Sin cobertura" porque el hook `use-conciliacion-data.ts` tenía hardcoded `coverage_status='none'` y nunca consumió la vista `v_bookings_total_coverage`. **Fix [#418](https://github.com/beto-sudo/BSOP/pull/418)**: el hook ahora lee la vista combinada, excluye los `full` (bajan los 106 cubiertos del listado) y propaga el coverage_status real para que el badge muestre `none/partial/full`.
 - **2026-05-04** — **Boost de coaches** ([#419](https://github.com/beto-sudo/BSOP/pull/419)). De los 457 pendientes en ventana 90d, 307 (67%) tienen un coach (Omar/Anibal/Manuel/Paco/Hugo) como owner o participante. 83 pedidos coach existen en Waitry pero solo 17 con nombre (66 son genéricos `Uso cancha coach`). Auto-match estricto solo agarra 2; en cambio el ranker ahora promueve cualquier ticket coach al top cuando la reserva tiene coach (+30 score) y bonus extra (+20) si el nombre del producto coincide con el del booking.
 - **2026-05-04** — Bug "no aparecen pedidos del 30-mar en adelante". Causa: PostgREST default de Supabase capa a ~1000 rows ignorando `.limit(8000)`. Con 5732 pedidos pagados en 120d, la query con `.order(ascending)` traía los más antiguos y dejaba fuera los recientes. **Fix paliativo [#420](https://github.com/beto-sudo/BSOP/pull/420)**: descending. **Fix de raíz [#421](https://github.com/beto-sudo/BSOP/pull/421)**: `ALTER ROLE authenticator SET pgrst.db_max_rows = '50000'` aplicado en producción — todas las queries del repo se benefician.
+- **2026-05-04** — **S2-Waitry-write abierto** ([#423](https://github.com/beto-sudo/BSOP/pull/423)). Server actions `assignPaymentAction` / `unassignPaymentAction` sobre `playtomic.payment_assignments` (validación de booking no cancelada, pedido `paid=true` con producto cancha, monto > 0, manejo de unique violation `23505`). UI funcional en `/rdb/playtomic/conciliacion`: lista de asignaciones actuales con botón Quitar, botón Conciliar wireado a iterar `selectedOrderIds` vía `useTransition`, feedback de éxito/parcial/error inline, banner "S1 read-only" retirado. Hook devuelve `assignmentsByBooking: Map<string, AssignmentDetail[]>`. CI verde, pendiente smoke en preview + merge por Beto.
 
 ## Estado tras S2-CSV (snapshot 2026-05-04 noche)
 


### PR DESCRIPTION
## Summary

- Server actions `assignPaymentAction` / `unassignPaymentAction` sobre `playtomic.payment_assignments` con validaciones completas (auth, preview-guard, booking no cancelada, pedido `paid=true`, producto cancha en `lib/playtomic/conciliacion.ts`, monto > 0) y manejo de unique violation `23505` con mensaje claro.
- UI funcional en `/rdb/playtomic/conciliacion`: lista de asignaciones actuales con botón Quitar, botón Conciliar wireado a iterar `selectedOrderIds` vía `useTransition`, feedback de éxito/parcial/error inline, banner "S1 read-only" retirado. `key={bookingId}` en el padre para reset idiomático al cambiar de reserva.
- Hook `use-conciliacion-data.ts` ahora devuelve `assignmentsByBooking: Map<string, AssignmentDetail[]>` leyendo `playtomic.payment_assignments` por los `bookingIds` visibles, además de seguir poblando `assignedOrderIds` desde la vista combinada Waitry+CSV.

Cierra el último pendiente de la iniciativa `rdb-pagos-cancha-conciliacion` para que el operador pueda conciliar manualmente las ~351 reservas que el CSV de Playtomic Manager no cubrió (efectivo en cancha sin registrar en manager).

Plan seguido al pie de la letra desde la sección **Handoff a S2-Waitry-write** del planning doc ([docs/planning/rdb-pagos-cancha-conciliacion.md](https://github.com/beto-sudo/BSOP/blob/main/docs/planning/rdb-pagos-cancha-conciliacion.md)). Decisiones cerradas que apliqué sin re-preguntar:
- Hard-delete en unassign (no soft-delete).
- `assigned_amount` default = `candidate.total_amount` (no `unit_price`).
- Asignación 1-a-la-vez (no bulk insert), iterando en el cliente — match con la API de la action.
- Audit trail nativo via `assigned_by` + `assigned_at` (ya en la tabla desde S1).

## Test plan

- [x] `npm run typecheck` verde
- [x] `npm run test:run` verde (679 tests)
- [x] `npm run lint` verde (0 errors, 96 warnings preexistentes)
- [x] `npm run format:check` verde
- [ ] Smoke en preview: seleccionar una reserva pendiente, escoger 1+ candidatos, click Conciliar → confirmar que la reserva sale del listado si Σ ≥ total, o que sigue como `partial`.
- [ ] Smoke en preview: en una reserva ya conciliada, click Quitar en una asignación → confirmar que vuelve al pool de candidatos y la cobertura baja.
- [ ] Smoke en preview: intentar asignar un pedido ya asignado a otra reserva (forzando manualmente desde otra pestaña) → confirmar mensaje "Este pedido Waitry ya está asignado a otra reserva."

🤖 Generated with [Claude Code](https://claude.com/claude-code)