### PR TITLE
feat(rdb/playtomic): tabs internos Dashboard / Conciliación / Import CSV

### DIFF
--- a/app/rdb/playtomic/conciliacion/page.tsx
+++ b/app/rdb/playtomic/conciliacion/page.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-import { RequireAccess } from '@/components/require-access';
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { ConciliacionView } from '@/components/playtomic/conciliacion/conciliacion-view';
 
 /**
  * @module Conciliación Playtomic ↔ Waitry (RDB)
  * @responsive desktop-only
+ *
+ * Gate de acceso + tabs compartidos viven en `app/rdb/playtomic/layout.tsx`.
  */
 export default function ConciliacionPage() {
   return (
-    <RequireAccess empresa="rdb" modulo="rdb.playtomic">
+    <>
       <DesktopOnlyNotice module="Conciliación Playtomic" />
       <div className="hidden sm:block">
         <ConciliacionView />
       </div>
-    </RequireAccess>
+    </>
   );
 }

--- a/app/rdb/playtomic/import-csv/page.tsx
+++ b/app/rdb/playtomic/import-csv/page.tsx
@@ -1,18 +1,19 @@
-import { RequireAccess } from '@/components/require-access';
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { ImportCsvView } from '@/components/playtomic/import-csv/import-csv-view';
 
 /**
  * @module Import CSV de pagos Playtomic (RDB)
  * @responsive desktop-only
+ *
+ * Gate de acceso + tabs compartidos viven en `app/rdb/playtomic/layout.tsx`.
  */
 export default function ImportCsvPage() {
   return (
-    <RequireAccess empresa="rdb" modulo="rdb.playtomic">
+    <>
       <DesktopOnlyNotice module="Import CSV Playtomic" />
       <div className="hidden sm:block">
         <ImportCsvView />
       </div>
-    </RequireAccess>
+    </>
   );
 }

--- a/app/rdb/playtomic/layout.tsx
+++ b/app/rdb/playtomic/layout.tsx
@@ -1,0 +1,35 @@
+import { type ReactNode } from 'react';
+import { RequireAccess } from '@/components/require-access';
+import { RoutedModuleTabs } from '@/components/module-page';
+
+/**
+ * Layout compartido del módulo Playtomic (RDB).
+ *
+ * Patrón "module with submodules / routed tabs" (ADR-005). Las 3 sub-rutas
+ * comparten gate de acceso + strip de tabs, y cada `page.tsx` aporta solo
+ * su contenido específico (header propio, KPIs, contenido).
+ *
+ * - `/rdb/playtomic`             → tab "Dashboard" (default landing).
+ * - `/rdb/playtomic/conciliacion` → tab "Conciliación".
+ * - `/rdb/playtomic/import-csv`   → tab "Import CSV".
+ *
+ * No se renderiza `<ModuleHeader>` aquí porque el dashboard ya trae su
+ * propio `<HeaderSection>` con range selector + sync. Las sub-páginas
+ * traen sus propios títulos en sus respectivos `<View>`.
+ */
+const TABS = [
+  { label: 'Dashboard', href: '/rdb/playtomic', exact: true },
+  { label: 'Conciliación', href: '/rdb/playtomic/conciliacion' },
+  { label: 'Import CSV', href: '/rdb/playtomic/import-csv' },
+] as const;
+
+export default function PlaytomicLayout({ children }: { children: ReactNode }) {
+  return (
+    <RequireAccess empresa="rdb" modulo="rdb.playtomic">
+      <div className="space-y-4">
+        <RoutedModuleTabs tabs={TABS} />
+        {children}
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/rdb/playtomic/page.tsx
+++ b/app/rdb/playtomic/page.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-import { RequireAccess } from '@/components/require-access';
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { PlaytomicView } from '@/components/playtomic/playtomic-view';
 
 /**
- * @module Playtomic (RDB)
+ * @module Playtomic — Dashboard (RDB)
  * @responsive desktop-only
+ *
+ * Gate de acceso + tabs compartidos viven en `app/rdb/playtomic/layout.tsx`.
  */
 export default function PlaytomicPage() {
   return (
-    <RequireAccess empresa="rdb" modulo="rdb.playtomic">
+    <>
       <DesktopOnlyNotice module="Playtomic" />
       <div className="hidden sm:block">
         <PlaytomicView />
       </div>
-    </RequireAccess>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Nuevo `app/rdb/playtomic/layout.tsx` con `<RequireAccess>` + `<RoutedModuleTabs>` siguiendo el patrón ADR-005 (module with submodules / routed tabs). Las 3 sub-rutas (`/rdb/playtomic`, `/rdb/playtomic/conciliacion`, `/rdb/playtomic/import-csv`) comparten gate de acceso y strip de tabs.
- Las 3 `page.tsx` quedan limpias: dejan el `<RequireAccess>` al layout y solo aportan `<DesktopOnlyNotice>` + su `<View>` específica.
- **Sin cambios de RBAC**: el slug `rdb.playtomic` sigue siendo único. Quien tenga read accede a las 3 vistas, quien tenga write puede asignar pagos en cancha Y subir CSV mensual. Decisión cerrada con Beto: el upsert por `payment_id` hace al import idempotente, así que abrir el módulo al staff es seguro.
- **Sin cambios de sidebar**: el link "Playtomic" del sidebar sigue apuntando a `/rdb/playtomic`. La navegación entre las 3 sub-vistas es interna vía los tabs.

Cierra el último pendiente operativo de la iniciativa `rdb-pagos-cancha-conciliacion`: el operador llega al módulo desde el sidebar y desde ahí descubre Conciliación + Import CSV sin necesidad de conocer las URLs.

## Test plan

- [x] `npm run typecheck` verde
- [x] `npm run test:run` verde (679 tests)
- [x] `npm run lint` verde (0 errors)
- [x] `npm run format:check` verde
- [ ] Smoke en preview: navegar a `/rdb/playtomic`, ver los 3 tabs, hacer click en cada uno y verificar que la pestaña activa coincide con la URL.
- [ ] Smoke en preview: usuario sin acceso a `rdb.playtomic` ve "Acceso denegado" en cualquiera de las 3 sub-rutas (verifica que el layout aplicó el gate al árbol entero).

## Relación con otros PRs

Independiente de [#423](https://github.com/beto-sudo/BSOP/pull/423) (S2-Waitry-write). Pueden mergearse en cualquier orden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)