### PR TITLE
feat(rdb/playtomic): filtros (cancha/coach/actividad/custom range) + sección Entrenadores

### DIFF
--- a/components/playtomic/coaches-section.tsx
+++ b/components/playtomic/coaches-section.tsx
@@ -1,0 +1,97 @@
+import { Combobox } from '@/components/ui/combobox';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { DAY_FMT } from './constants';
+import type { CoachRow, CoachSortKey } from './types';
+import { formatMoney } from './utils';
+
+function formatLastDate(value: string | null): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return DAY_FMT.format(date);
+}
+
+export function CoachesSection({
+  coaches,
+  sort,
+  onSortChange,
+}: {
+  coaches: CoachRow[];
+  sort: CoachSortKey;
+  onSortChange: (value: CoachSortKey) => void;
+}) {
+  return (
+    <section className="space-y-4 rounded-3xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--text)]">Entrenadores</h2>
+          <p className="text-sm text-[var(--text-muted)]">
+            Ranking de coaches por reservas e ingresos en el periodo. Una reserva con N coaches
+            divide el revenue entre ellos.
+          </p>
+        </div>
+        <Combobox
+          value={sort}
+          onChange={(value) => onSortChange(value as CoachSortKey)}
+          options={[
+            { value: 'revenue', label: 'Ordenar por ingresos' },
+            { value: 'reservas', label: 'Ordenar por reservas' },
+            { value: 'jugadores', label: 'Ordenar por jugadores únicos' },
+            { value: 'name', label: 'Ordenar por nombre' },
+          ]}
+          className="sm:w-56"
+        />
+      </div>
+      <div className="overflow-hidden rounded-2xl border border-[var(--border)]">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Entrenador</TableHead>
+              <TableHead>Reservas</TableHead>
+              <TableHead className="text-right">Ingresos</TableHead>
+              <TableHead>Jugadores únicos</TableHead>
+              <TableHead>Última reserva</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {coaches.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="py-10 text-center text-[var(--text)]/50">
+                  No hay reservas con entrenador en el periodo seleccionado.
+                </TableCell>
+              </TableRow>
+            ) : (
+              coaches.map((coach) => (
+                <TableRow key={coach.coach_id}>
+                  <TableCell>
+                    <div className="font-medium text-[var(--text)]">{coach.display_name}</div>
+                    {coach.display_name.startsWith('coach_') ? (
+                      <div className="text-xs text-[var(--text-muted)]" title={coach.coach_id}>
+                        {coach.coach_id.slice(0, 16)}…
+                      </div>
+                    ) : null}
+                  </TableCell>
+                  <TableCell>{coach.reservas}</TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatMoney(coach.revenue)}
+                  </TableCell>
+                  <TableCell>{coach.jugadores_unicos}</TableCell>
+                  <TableCell className="text-[var(--text-muted)]">
+                    {formatLastDate(coach.ultima_reserva)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  );
+}

--- a/components/playtomic/derivations.test.ts
+++ b/components/playtomic/derivations.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { computeCoaches } from './derivations';
+import type { Booking, PlayerRow } from './types';
+
+const baseBooking: Booking = {
+  booking_id: 'b1',
+  resource_name: 'Padel 1',
+  sport_id: '1',
+  booking_start: '2026-04-15T18:00:00Z',
+  booking_end: '2026-04-15T19:30:00Z',
+  duration_min: 90,
+  price_amount: 800,
+  price_currency: 'MXN',
+  status: 'confirmed',
+  is_canceled: false,
+  owner_id: 'player-1',
+  booking_type: null,
+  origin: 'app',
+  payment_status: 'PAID',
+  synced_at: null,
+  coach_ids: null,
+  course_id: null,
+  course_name: null,
+  activity_id: null,
+  activity_name: null,
+};
+
+describe('computeCoaches', () => {
+  it('ignora bookings sin coach_ids', () => {
+    const rows = computeCoaches([{ ...baseBooking, coach_ids: null }], []);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('ignora bookings cancelados', () => {
+    const rows = computeCoaches(
+      [{ ...baseBooking, coach_ids: ['omar-id'], is_canceled: true }],
+      []
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('asigna revenue completo si solo hay 1 coach', () => {
+    const rows = computeCoaches(
+      [{ ...baseBooking, coach_ids: ['omar-id'], price_amount: 800 }],
+      []
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].coach_id).toBe('omar-id');
+    expect(rows[0].revenue).toBe(800);
+    expect(rows[0].reservas).toBe(1);
+  });
+
+  it('reparte revenue entre N coaches del mismo booking', () => {
+    const rows = computeCoaches(
+      [{ ...baseBooking, coach_ids: ['omar-id', 'paco-id'], price_amount: 400 }],
+      []
+    );
+    const omar = rows.find((r) => r.coach_id === 'omar-id');
+    const paco = rows.find((r) => r.coach_id === 'paco-id');
+    expect(omar?.revenue).toBe(200);
+    expect(paco?.revenue).toBe(200);
+  });
+
+  it('cuenta jugadores únicos por owner_id distinto', () => {
+    const rows = computeCoaches(
+      [
+        { ...baseBooking, booking_id: 'b1', coach_ids: ['omar-id'], owner_id: 'player-1' },
+        { ...baseBooking, booking_id: 'b2', coach_ids: ['omar-id'], owner_id: 'player-2' },
+        { ...baseBooking, booking_id: 'b3', coach_ids: ['omar-id'], owner_id: 'player-1' },
+      ],
+      []
+    );
+    const omar = rows.find((r) => r.coach_id === 'omar-id');
+    expect(omar?.reservas).toBe(3);
+    expect(omar?.jugadores_unicos).toBe(2);
+  });
+
+  it('toma la última reserva (booking_start más reciente)', () => {
+    const rows = computeCoaches(
+      [
+        {
+          ...baseBooking,
+          booking_id: 'b1',
+          coach_ids: ['omar-id'],
+          booking_start: '2026-04-10T18:00:00Z',
+        },
+        {
+          ...baseBooking,
+          booking_id: 'b2',
+          coach_ids: ['omar-id'],
+          booking_start: '2026-04-20T18:00:00Z',
+        },
+        {
+          ...baseBooking,
+          booking_id: 'b3',
+          coach_ids: ['omar-id'],
+          booking_start: '2026-04-15T18:00:00Z',
+        },
+      ],
+      []
+    );
+    const omar = rows.find((r) => r.coach_id === 'omar-id');
+    expect(omar?.ultima_reserva).toBe('2026-04-20T18:00:00Z');
+  });
+
+  it('resuelve display_name desde players cuando matchea coach_id', () => {
+    const players: PlayerRow[] = [
+      {
+        playtomic_id: 'omar-id',
+        name: 'Omar Coach',
+        email: 'omar@club.com',
+        player_type: null,
+        favorite_sport: null,
+      },
+    ];
+    const rows = computeCoaches([{ ...baseBooking, coach_ids: ['omar-id'] }], players);
+    expect(rows[0].display_name).toBe('Omar Coach');
+  });
+
+  it('fallback a coach_<8chars> cuando no hay match en players', () => {
+    const rows = computeCoaches([{ ...baseBooking, coach_ids: ['abc12345xyz999'] }], []);
+    expect(rows[0].display_name).toBe('coach_abc12345');
+  });
+
+  it('ignora coach_ids vacíos en el array', () => {
+    const rows = computeCoaches([{ ...baseBooking, coach_ids: ['omar-id', ''] }], []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].coach_id).toBe('omar-id');
+  });
+});

--- a/components/playtomic/derivations.ts
+++ b/components/playtomic/derivations.ts
@@ -3,6 +3,7 @@ import type {
   Booking,
   BookingParticipant,
   CancelPlayerRow,
+  CoachRow,
   ComputedPlayer,
   DashboardData,
   PlayerRow,
@@ -215,6 +216,73 @@ export function computeComputedPlayers(
       gasto: stats.gasto,
       favorite_sport: favSport,
       player_type: player?.player_type ?? null,
+    };
+  });
+}
+
+/**
+ * Calcula ranking de entrenadores a partir de `bookings.coach_ids[]`.
+ *
+ * El API de Playtomic poblá `coach_ids` cuando una reserva involucra
+ * a uno o más entrenadores. Aquí los expandimos (un booking con N
+ * coaches contribuye N filas) y agregamos por coach_id:
+ *
+ * - reservas: count de bookings no canceladas que mencionan el coach.
+ * - revenue: sum(price_amount / coach_ids.length) — si una reserva
+ *   tiene 2 coaches, cada uno se lleva la mitad. Default 1 si solo
+ *   hay 1 coach (que es el caso típico).
+ * - jugadores_unicos: count distinct de owner_ids que reservaron con
+ *   ese coach.
+ * - ultima_reserva: timestamp del booking_start más reciente.
+ *
+ * Resolución de nombre: el `coach_id` de Playtomic suele coincidir con
+ * un `players.playtomic_id`. Cuando matchea, mostramos el nombre real.
+ * Cuando no, fallback al id truncado (`coach_<8 chars>`).
+ */
+export function computeCoaches(bookings: Booking[], players: PlayerRow[]): CoachRow[] {
+  type Bucket = {
+    reservas: number;
+    revenue: number;
+    owners: Set<string>;
+    last: string | null;
+  };
+  const stats = new Map<string, Bucket>();
+
+  for (const booking of bookings) {
+    if (isCanceledBooking(booking)) continue;
+    const coaches = booking.coach_ids ?? [];
+    if (coaches.length === 0) continue;
+    const split = (booking.price_amount ?? 0) / coaches.length;
+    for (const coachId of coaches) {
+      if (!coachId) continue;
+      const bucket: Bucket = stats.get(coachId) ?? {
+        reservas: 0,
+        revenue: 0,
+        owners: new Set<string>(),
+        last: null,
+      };
+      bucket.reservas += 1;
+      bucket.revenue += split;
+      if (booking.owner_id) bucket.owners.add(booking.owner_id);
+      if (booking.booking_start && (!bucket.last || booking.booking_start > bucket.last)) {
+        bucket.last = booking.booking_start;
+      }
+      stats.set(coachId, bucket);
+    }
+  }
+
+  const playerMap = new Map(players.map((p) => [p.playtomic_id, p]));
+
+  return Array.from(stats.entries()).map(([coachId, bucket]) => {
+    const player = playerMap.get(coachId);
+    const display = player?.name?.trim() || `coach_${coachId.slice(0, 8)}`;
+    return {
+      coach_id: coachId,
+      display_name: display,
+      reservas: bucket.reservas,
+      revenue: bucket.revenue,
+      jugadores_unicos: bucket.owners.size,
+      ultima_reserva: bucket.last,
     };
   });
 }

--- a/components/playtomic/header-section.tsx
+++ b/components/playtomic/header-section.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import { Button } from '@/components/ui/button';
+import { Combobox } from '@/components/ui/combobox';
 import { CalendarRange, RefreshCw } from 'lucide-react';
-import type { RangeKey } from './types';
+import type { BookingFilters, RangeKey, SportFilter } from './types';
 
 const RANGE_OPTIONS = [
   ['7d', '7 días'],
@@ -8,21 +11,41 @@ const RANGE_OPTIONS = [
   ['month', 'Este mes'],
   ['year', 'Este año'],
   ['all', 'Todo'],
+  ['custom', 'Custom'],
 ] as const;
 
 export function HeaderSection({
   range,
   onRangeChange,
   rangeLabel,
+  customFromIso,
+  customToIso,
+  onCustomRangeChange,
+  filters,
+  onFiltersChange,
+  resourceOptions,
+  coachOptions,
+  activityOptions,
   refreshing,
   onRefresh,
 }: {
   range: RangeKey;
   onRangeChange: (value: RangeKey) => void;
   rangeLabel: string;
+  customFromIso: string;
+  customToIso: string;
+  onCustomRangeChange: (from: string, to: string) => void;
+  filters: BookingFilters;
+  onFiltersChange: (next: BookingFilters) => void;
+  resourceOptions: { value: string; label: string }[];
+  coachOptions: { value: string; label: string }[];
+  activityOptions: { value: string; label: string }[];
   refreshing: boolean;
   onRefresh: () => void;
 }) {
+  const showCustom = range === 'custom';
+  const todayIso = new Date().toISOString().slice(0, 10);
+
   return (
     <section className="rounded-3xl border border-[var(--border)] bg-[var(--panel)] p-6">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
@@ -34,7 +57,7 @@ export function HeaderSection({
             Dashboard Playtomic
           </h1>
           <p className="mt-2 max-w-3xl text-sm text-[var(--text)]/60">
-            Reservas, ingresos, ocupación, jugadores y salud de sincronización en una sola vista.
+            Reservas, ingresos, ocupación, jugadores y entrenadores en una sola vista.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -59,9 +82,64 @@ export function HeaderSection({
           </Button>
         </div>
       </div>
-      <div className="mt-4 inline-flex items-center gap-2 rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm text-[var(--text)]/65">
-        <CalendarRange className="h-4 w-4" />
-        {rangeLabel}
+
+      {showCustom ? (
+        <div className="mt-4 flex flex-wrap items-center gap-2 rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm">
+          <span className="text-[var(--text)]/65">Del</span>
+          <input
+            type="date"
+            max={customToIso || todayIso}
+            value={customFromIso}
+            onChange={(e) => onCustomRangeChange(e.target.value, customToIso)}
+            className="rounded-md border border-input bg-transparent px-2 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <span className="text-[var(--text)]/65">al</span>
+          <input
+            type="date"
+            min={customFromIso || undefined}
+            max={todayIso}
+            value={customToIso}
+            onChange={(e) => onCustomRangeChange(customFromIso, e.target.value)}
+            className="rounded-md border border-input bg-transparent px-2 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </div>
+      ) : (
+        <div className="mt-4 inline-flex items-center gap-2 rounded-2xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm text-[var(--text)]/65">
+          <CalendarRange className="h-4 w-4" />
+          {rangeLabel}
+        </div>
+      )}
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+        <Combobox
+          value={filters.sport}
+          onChange={(value) =>
+            onFiltersChange({ ...filters, sport: (value ?? 'all') as SportFilter })
+          }
+          options={[
+            { value: 'all', label: 'Todos los deportes' },
+            { value: 'PADEL', label: 'Padel' },
+            { value: 'TENNIS', label: 'Tenis' },
+          ]}
+        />
+        <Combobox
+          value={filters.resource}
+          onChange={(value) => onFiltersChange({ ...filters, resource: value ?? '' })}
+          options={[{ value: '', label: 'Todas las canchas' }, ...resourceOptions]}
+          allowClear
+        />
+        <Combobox
+          value={filters.coachId}
+          onChange={(value) => onFiltersChange({ ...filters, coachId: value ?? '' })}
+          options={[{ value: '', label: 'Todos los entrenadores' }, ...coachOptions]}
+          allowClear
+        />
+        <Combobox
+          value={filters.activity}
+          onChange={(value) => onFiltersChange({ ...filters, activity: value ?? '' })}
+          options={[{ value: '', label: 'Todas las actividades' }, ...activityOptions]}
+          allowClear
+        />
       </div>
     </section>
   );

--- a/components/playtomic/playtomic-view.tsx
+++ b/components/playtomic/playtomic-view.tsx
@@ -4,7 +4,13 @@ import { useCallback, useMemo, useState } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSortableTable } from '@/hooks/use-sortable-table';
 import { CancellationSection } from './cancellation-section';
-import { computeCancellationAnalysis, computeComputedPlayers, computeKpis } from './derivations';
+import { CoachesSection } from './coaches-section';
+import {
+  computeCancellationAnalysis,
+  computeCoaches,
+  computeComputedPlayers,
+  computeKpis,
+} from './derivations';
 import { computePendingPayments } from './pending-payments';
 import { computeReconciliation } from './reconciliation';
 import { HeaderSection } from './header-section';
@@ -14,15 +20,44 @@ import { PlayersSection } from './players-section';
 import { ReconciliationSection } from './reconciliation-section';
 import { RevenueSection } from './revenue-section';
 import { SyncSection } from './sync-section';
-import type { ChartBucket, PendingBooking, PlayerSortKey, RangeKey, SportFilter } from './types';
+import type {
+  BookingFilters,
+  ChartBucket,
+  CoachSortKey,
+  PendingBooking,
+  PlayerSortKey,
+  RangeKey,
+} from './types';
 import { usePlaytomicData } from './use-playtomic-data';
-import { bucketRevenue, getRangeMeta, normalizeSport, pickBucketMode } from './utils';
+import {
+  applyBookingFilters,
+  bucketRevenue,
+  getRangeMeta,
+  isoDateLocal,
+  normalizeSport,
+  pickBucketMode,
+} from './utils';
+
+const DEFAULT_FILTERS: BookingFilters = {
+  sport: 'all',
+  resource: '',
+  coachId: '',
+  activity: '',
+};
 
 export function PlaytomicView() {
-  const [range, setRange] = useState<RangeKey>('30d');
-  const [sportFilter, setSportFilter] = useState<SportFilter>('all');
+  const [range, setRange] = useState<RangeKey>('month');
+  // Defaults para custom inicializan en el mes actual también — si el user
+  // cambia a "Custom" sin tocar las fechas, no se queda con un rango vacío.
+  const [customFromIso, setCustomFromIso] = useState(() => {
+    const now = new Date();
+    return isoDateLocal(new Date(now.getFullYear(), now.getMonth(), 1));
+  });
+  const [customToIso, setCustomToIso] = useState(() => isoDateLocal(new Date()));
+  const [filters, setFilters] = useState<BookingFilters>(DEFAULT_FILTERS);
   const [playerQuery, setPlayerQuery] = useState('');
   const [playerSort, setPlayerSort] = useState<PlayerSortKey>('gasto');
+  const [coachSort, setCoachSort] = useState<CoachSortKey>('revenue');
   const [showPendingDetails, setShowPendingDetails] = useState(false);
   const {
     sortKey: pendingSortKey,
@@ -31,7 +66,10 @@ export function PlaytomicView() {
     sortData: pendingSortData,
   } = useSortableTable<PendingBooking>('fecha', 'desc');
 
-  const meta = useMemo(() => getRangeMeta(range), [range]);
+  const meta = useMemo(
+    () => getRangeMeta(range, customFromIso, customToIso),
+    [range, customFromIso, customToIso]
+  );
 
   const { data, loading, refreshing, error, fetchData, coveredBookingIds } = usePlaytomicData({
     range,
@@ -39,31 +77,55 @@ export function PlaytomicView() {
     toIso: meta.toIso,
   });
 
+  const filteredBookings = useMemo(
+    () => applyBookingFilters(data.bookings, filters),
+    [data.bookings, filters]
+  );
+
+  const filteredBookingIds = useMemo(
+    () => new Set(filteredBookings.map((b) => b.booking_id)),
+    [filteredBookings]
+  );
+
+  const filteredParticipants = useMemo(
+    () => data.participants.filter((p) => filteredBookingIds.has(p.booking_id)),
+    [data.participants, filteredBookingIds]
+  );
+
   const revenueSeries = useMemo<ChartBucket[]>(() => {
     const mode = pickBucketMode(range);
     return bucketRevenue(data.revenue, meta.from, meta.to, mode);
   }, [data.revenue, meta.from, meta.to, range]);
 
-  const kpis = useMemo(() => computeKpis(data), [data]);
+  // KPIs y demás derivations operan sobre las bookings filtradas. Pasamos
+  // un "DashboardData proxy" con bookings/participants reemplazados — el
+  // resto (revenue, occupancy, players, syncs, resources) sigue siendo el
+  // dataset crudo del periodo.
+  const filteredData = useMemo(
+    () => ({ ...data, bookings: filteredBookings, participants: filteredParticipants }),
+    [data, filteredBookings, filteredParticipants]
+  );
+
+  const kpis = useMemo(() => computeKpis(filteredData), [filteredData]);
 
   const filteredOccupancy = useMemo(() => {
-    if (sportFilter === 'all') return data.occupancy;
+    if (filters.sport === 'all') return data.occupancy;
     const allowed = new Set(
       data.resources
-        .filter((resource) => normalizeSport(resource.sport_id) === sportFilter)
+        .filter((resource) => normalizeSport(resource.sport_id) === filters.sport)
         .map((resource) => resource.resource_name ?? '')
     );
     return data.occupancy.filter((row) => allowed.has(row.resource_name ?? ''));
-  }, [data.occupancy, data.resources, sportFilter]);
+  }, [data.occupancy, data.resources, filters.sport]);
 
   const cancellationAnalysis = useMemo(
-    () => computeCancellationAnalysis(data.bookings, data.players),
-    [data.bookings, data.players]
+    () => computeCancellationAnalysis(filteredBookings, data.players),
+    [filteredBookings, data.players]
   );
 
   const computedPlayers = useMemo(
-    () => computeComputedPlayers(data.bookings, data.participants, data.players),
-    [data.bookings, data.participants, data.players]
+    () => computeComputedPlayers(filteredBookings, filteredParticipants, data.players),
+    [filteredBookings, filteredParticipants, data.players]
   );
 
   const topPlayers = useMemo(() => {
@@ -86,14 +148,69 @@ export function PlaytomicView() {
     });
   }, [computedPlayers, playerQuery, playerSort]);
 
-  const reconciliation = useMemo(() => computeReconciliation(data.bookings), [data.bookings]);
+  const coaches = useMemo(
+    () => computeCoaches(filteredBookings, data.players),
+    [filteredBookings, data.players]
+  );
+
+  const sortedCoaches = useMemo(() => {
+    return [...coaches].sort((a, b) => {
+      if (coachSort === 'name') return a.display_name.localeCompare(b.display_name, 'es');
+      if (coachSort === 'reservas') return b.reservas - a.reservas;
+      if (coachSort === 'jugadores') return b.jugadores_unicos - a.jugadores_unicos;
+      return b.revenue - a.revenue;
+    });
+  }, [coaches, coachSort]);
+
+  // Opciones de los selectores: derivadas del periodo, ordenadas alfa.
+  const resourceOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const resource of data.resources) {
+      if (resource.resource_name) seen.add(resource.resource_name);
+    }
+    for (const booking of data.bookings) {
+      if (booking.resource_name) seen.add(booking.resource_name);
+    }
+    return Array.from(seen)
+      .sort((a, b) => a.localeCompare(b, 'es'))
+      .map((name) => ({ value: name, label: name }));
+  }, [data.resources, data.bookings]);
+
+  const coachOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const booking of data.bookings) {
+      for (const id of booking.coach_ids ?? []) {
+        if (id) seen.add(id);
+      }
+    }
+    const playerMap = new Map(data.players.map((p) => [p.playtomic_id, p.name]));
+    return Array.from(seen)
+      .map((id) => ({
+        value: id,
+        label: playerMap.get(id)?.trim() || `coach_${id.slice(0, 8)}`,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label, 'es'));
+  }, [data.bookings, data.players]);
+
+  const activityOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const booking of data.bookings) {
+      const name = booking.activity_name ?? booking.course_name;
+      if (name) seen.add(name);
+    }
+    return Array.from(seen)
+      .sort((a, b) => a.localeCompare(b, 'es'))
+      .map((name) => ({ value: name, label: name }));
+  }, [data.bookings]);
+
+  const reconciliation = useMemo(() => computeReconciliation(filteredBookings), [filteredBookings]);
 
   const pendingPayments = useMemo(
     () =>
-      computePendingPayments(data.bookings, data.participants, data.players, {
+      computePendingPayments(filteredBookings, filteredParticipants, data.players, {
         coveredBookingIds,
       }),
-    [data.bookings, data.participants, data.players, coveredBookingIds]
+    [filteredBookings, filteredParticipants, data.players, coveredBookingIds]
   );
 
   const exportReconciliationCsv = useCallback(() => {
@@ -144,6 +261,17 @@ export function PlaytomicView() {
         range={range}
         onRangeChange={setRange}
         rangeLabel={meta.label}
+        customFromIso={customFromIso}
+        customToIso={customToIso}
+        onCustomRangeChange={(from, to) => {
+          setCustomFromIso(from);
+          setCustomToIso(to);
+        }}
+        filters={filters}
+        onFiltersChange={setFilters}
+        resourceOptions={resourceOptions}
+        coachOptions={coachOptions}
+        activityOptions={activityOptions}
         refreshing={refreshing}
         onRefresh={() => void fetchData(true)}
       />
@@ -172,8 +300,8 @@ export function PlaytomicView() {
           />
           <RevenueSection revenueSeries={revenueSeries} />
           <OccupancySection
-            sportFilter={sportFilter}
-            onSportFilterChange={setSportFilter}
+            sportFilter={filters.sport}
+            onSportFilterChange={(sport) => setFilters((prev) => ({ ...prev, sport }))}
             filteredOccupancy={filteredOccupancy}
             resources={data.resources}
           />
@@ -185,9 +313,10 @@ export function PlaytomicView() {
             onPlayerSortChange={setPlayerSort}
             cancellationAnalysis={cancellationAnalysis}
           />
+          <CoachesSection coaches={sortedCoaches} sort={coachSort} onSortChange={setCoachSort} />
           <CancellationSection
             analysis={cancellationAnalysis}
-            totalBookings={data.bookings.length}
+            totalBookings={filteredBookings.length}
           />
           <ReconciliationSection
             reconciliation={reconciliation}

--- a/components/playtomic/types.ts
+++ b/components/playtomic/types.ts
@@ -1,6 +1,7 @@
-export type RangeKey = '7d' | '30d' | 'month' | 'year' | 'all';
+export type RangeKey = '7d' | '30d' | 'month' | 'year' | 'all' | 'custom';
 export type SportFilter = 'all' | 'PADEL' | 'TENNIS';
 export type PlayerSortKey = 'name' | 'reservas' | 'gasto' | 'sport';
+export type CoachSortKey = 'name' | 'reservas' | 'revenue' | 'jugadores';
 
 export type Booking = {
   booking_id: string;
@@ -18,6 +19,29 @@ export type Booking = {
   origin: string | null;
   payment_status: string | null;
   synced_at: string | null;
+  coach_ids: string[] | null;
+  course_id: string | null;
+  course_name: string | null;
+  activity_id: string | null;
+  activity_name: string | null;
+};
+
+/**
+ * Filtros que aplica el dashboard sobre el array de `data.bookings`. NO
+ * se mandan al servidor — la query trae el rango de fechas crudo y aquí
+ * en cliente filtramos. Se aplica a KPIs, reconciliación, ocupación,
+ * jugadores, cancelaciones, entrenadores. Revenue chart usa
+ * `v_revenue_diario` directo y no responde a estos filtros (limitación
+ * conocida — la vista no agrupa por cancha/coach/actividad).
+ */
+export type BookingFilters = {
+  sport: SportFilter;
+  /** `resource_name` exacto. `''` = todas. */
+  resource: string;
+  /** Coach id de Playtomic. `''` = todos. */
+  coachId: string;
+  /** `activity_name` o `course_name` (lo que esté presente). `''` = todas. */
+  activity: string;
 };
 
 export type ReconciliationDay = {
@@ -95,6 +119,20 @@ export type ComputedPlayer = {
   gasto: number;
   favorite_sport: string | null;
   player_type: string | null;
+};
+
+export type CoachRow = {
+  /** ID crudo del coach (de `bookings.coach_ids`). Se usa como filterId. */
+  coach_id: string;
+  /** Nombre legible si el coach_id matchea con `players.playtomic_id`. */
+  display_name: string;
+  reservas: number;
+  /** Sum(price_amount) de las reservas; se reparte si hubo varios coaches. */
+  revenue: number;
+  /** Cuenta distinct de owner_ids únicos. */
+  jugadores_unicos: number;
+  /** ISO timestamp del booking más reciente del coach. */
+  ultima_reserva: string | null;
 };
 
 export type CancelPlayerRow = {

--- a/components/playtomic/use-playtomic-data.ts
+++ b/components/playtomic/use-playtomic-data.ts
@@ -64,7 +64,7 @@ export function usePlaytomicData({
         const bookingsQuery = schema
           .from('bookings')
           .select(
-            'booking_id,resource_name,sport_id,booking_start,booking_end,duration_min,price_amount,price_currency,status,is_canceled,owner_id,booking_type,origin,payment_status,synced_at'
+            'booking_id,resource_name,sport_id,booking_start,booking_end,duration_min,price_amount,price_currency,status,is_canceled,owner_id,booking_type,origin,payment_status,synced_at,coach_ids,course_id,course_name,activity_id,activity_name'
           )
           .gte('booking_start', bookingsFromBounds.start)
           .lte('booking_start', bookingsToBounds.end)

--- a/components/playtomic/utils.ts
+++ b/components/playtomic/utils.ts
@@ -1,5 +1,5 @@
 import { DATE_TIME_FMT, DAY_FMT, MONTH_FMT, MXN, MXN_FULL, TZ, WEEK_FMT } from './constants';
-import type { Booking, ChartBucket, RangeKey, RevenueRow } from './types';
+import type { Booking, BookingFilters, ChartBucket, RangeKey, RevenueRow } from './types';
 
 export function nowInTz() {
   return new Date(new Date().toLocaleString('en-US', { timeZone: TZ }));
@@ -18,36 +18,50 @@ export function isoDateLocal(date: Date) {
   return `${y}-${m}-${d}`;
 }
 
-export function getRangeMeta(range: RangeKey) {
-  const to = nowInTz();
+export function getRangeMeta(
+  range: RangeKey,
+  customFromIso?: string | null,
+  customToIso?: string | null
+) {
+  const today = nowInTz();
   let from: Date;
+  let to: Date = today;
   let label: string;
 
   switch (range) {
     case '7d':
-      from = addDays(to, -6);
+      from = addDays(today, -6);
       label = 'Últimos 7 días';
       break;
     case '30d':
-      from = addDays(to, -29);
+      from = addDays(today, -29);
       label = 'Últimos 30 días';
       break;
     case 'month': {
-      from = new Date(to.getFullYear(), to.getMonth(), 1);
-      const monthName = to.toLocaleString('es-MX', { month: 'long' });
-      label = `${monthName.charAt(0).toUpperCase()}${monthName.slice(1)} ${to.getFullYear()}`;
+      from = new Date(today.getFullYear(), today.getMonth(), 1);
+      const monthName = today.toLocaleString('es-MX', { month: 'long' });
+      label = `${monthName.charAt(0).toUpperCase()}${monthName.slice(1)} ${today.getFullYear()}`;
       break;
     }
     case 'year':
-      from = new Date(to.getFullYear(), 0, 1);
-      label = `Año ${to.getFullYear()}`;
+      from = new Date(today.getFullYear(), 0, 1);
+      label = `Año ${today.getFullYear()}`;
       break;
     case 'all':
       from = new Date(2020, 0, 1);
       label = 'Todo el historial';
       break;
+    case 'custom': {
+      const safeFrom =
+        customFromIso && /^\d{4}-\d{2}-\d{2}$/.test(customFromIso) ? customFromIso : null;
+      const safeTo = customToIso && /^\d{4}-\d{2}-\d{2}$/.test(customToIso) ? customToIso : null;
+      from = safeFrom ? new Date(`${safeFrom}T12:00:00`) : addDays(today, -29);
+      to = safeTo ? new Date(`${safeTo}T12:00:00`) : today;
+      label = `${isoDateLocal(from)} → ${isoDateLocal(to)}`;
+      break;
+    }
     default:
-      from = addDays(to, -29);
+      from = addDays(today, -29);
       label = 'Últimos 30 días';
   }
 
@@ -58,6 +72,28 @@ export function getRangeMeta(range: RangeKey) {
     toIso: isoDateLocal(to),
     label,
   };
+}
+
+/**
+ * Filtra bookings en cliente según los selectores del dashboard
+ * (deporte / cancha / entrenador / actividad). El rango de fechas no se
+ * aplica aquí — la query del hook ya trae solo el rango activo. Pure
+ * function: testeable.
+ */
+export function applyBookingFilters(bookings: Booking[], filters: BookingFilters): Booking[] {
+  return bookings.filter((booking) => {
+    if (filters.sport !== 'all' && normalizeSport(booking.sport_id) !== filters.sport) return false;
+    if (filters.resource && booking.resource_name !== filters.resource) return false;
+    if (filters.coachId) {
+      const coachIds = booking.coach_ids ?? [];
+      if (!coachIds.includes(filters.coachId)) return false;
+    }
+    if (filters.activity) {
+      const activity = booking.activity_name ?? booking.course_name ?? '';
+      if (activity !== filters.activity) return false;
+    }
+    return true;
+  });
 }
 
 export function formatMoney(value: number | null | undefined, compact = false) {


### PR DESCRIPTION
## Summary

**Filtros del dashboard:**
- Default range cambia de 30d → **mes actual** (decisión de Beto).
- Nuevo botón **Custom** con date pickers from-to (las fechas inicializan en el mes actual para que clickear "Custom" no dé pantalla vacía).
- Selectores nuevos en el header: **Cancha** (`resource_name`), **Entrenador** (`coach_id` resuelto a nombre vía lookup en `players`) y **Actividad** (`activity_name` o `course_name`).
- Los filtros aplican en cliente sobre `data.bookings`. Afectan KPIs, ocupación, jugadores, cancelaciones, entrenadores y reconciliación.
- **Limitación conocida documentada**: el revenue chart usa `v_revenue_diario` directo, que solo agrupa por deporte+fecha — no responde a filtros de cancha/coach/actividad. Si en el futuro queremos eso, hay que agregar columnas a la vista.

**Sección Entrenadores nueva:**
- Tabla debajo de Jugadores con ranking por **reservas**, **ingresos**, **jugadores únicos** y **última reserva**.
- Ingresos se reparten cuando una reserva tiene N coaches (split = `price_amount / coach_ids.length`).
- Resolución de nombre: `coach_id` → lookup contra `players.playtomic_id`. Fallback a `coach_<id_truncado>` si no matchea.
- 9 tests unitarios para `computeCoaches` cubriendo split, agregación, distinct owners, fallback de nombre, ignorar canceladas, etc.

**Backend:** se agregaron `coach_ids`, `course_id`, `course_name`, `activity_id`, `activity_name` al SELECT del hook. Estos campos ya estaban poblados por el sync edge function pero la UI no los consumía. Sin migración SQL.

Cierra el último pendiente operativo de la iniciativa `rdb-pagos-cancha-conciliacion` (filtros + visibilidad de coaches que tenías en tu lista).

## Test plan

- [x] `npm run typecheck` verde
- [x] `npm run test:run` verde (1326 tests, 9 nuevos)
- [x] `npm run lint` verde (0 errors, 96 warnings preexistentes)
- [x] `npm run format:check` verde
- [ ] Smoke en preview: abrir `/rdb/playtomic`, confirmar que carga el mes actual por default.
- [ ] Smoke en preview: clickear **Custom**, ajustar fechas, verificar que KPIs y tablas reflejan el nuevo rango.
- [ ] Smoke en preview: usar el filtro de **Entrenador** y verificar que la sección Entrenadores baja a 1 fila (la del coach seleccionado) y los KPIs reflejan solo bookings de ese coach.
- [ ] Smoke en preview: ordenar la tabla Entrenadores por las 4 keys (revenue / reservas / jugadores / nombre) y verificar que el orden cambia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)