### PR TITLE
fix(rdb/playtomic): detectar coaches por matching de nombre (no por API coach_ids)

### DIFF
--- a/components/playtomic/coaches-section.tsx
+++ b/components/playtomic/coaches-section.tsx
@@ -33,7 +33,8 @@ export function CoachesSection({
         <div>
           <h2 className="text-lg font-semibold text-[var(--text)]">Entrenadores</h2>
           <p className="text-sm text-[var(--text-muted)]">
-            Ranking de coaches por reservas e ingresos en el periodo. Una reserva con N coaches
+            Identificamos a los coaches (Omar, Aníbal, Manuel, Paco, Hugo) por matching de nombre en
+            owner o participantes — no hay registro formal en Playtomic. Una reserva con N coaches
             divide el revenue entre ellos.
           </p>
         </div>
@@ -72,11 +73,6 @@ export function CoachesSection({
                 <TableRow key={coach.coach_id}>
                   <TableCell>
                     <div className="font-medium text-[var(--text)]">{coach.display_name}</div>
-                    {coach.display_name.startsWith('coach_') ? (
-                      <div className="text-xs text-[var(--text-muted)]" title={coach.coach_id}>
-                        {coach.coach_id.slice(0, 16)}…
-                      </div>
-                    ) : null}
                   </TableCell>
                   <TableCell>{coach.reservas}</TableCell>
                   <TableCell className="text-right font-medium">

--- a/components/playtomic/derivations.test.ts
+++ b/components/playtomic/derivations.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { computeCoaches } from './derivations';
-import type { Booking, PlayerRow } from './types';
+import { buildBookingCoachMap, computeCoaches } from './derivations';
+import type { Booking, BookingParticipant, PlayerRow } from './types';
 
 const baseBooking: Booking = {
   booking_id: 'b1',
@@ -25,106 +25,135 @@ const baseBooking: Booking = {
   activity_name: null,
 };
 
+const omar: PlayerRow = {
+  playtomic_id: 'player-omar',
+  name: 'Omar Treviño',
+  email: 'omar@club.com',
+  player_type: null,
+  favorite_sport: null,
+};
+const cliente: PlayerRow = {
+  playtomic_id: 'player-1',
+  name: 'Juan Pérez',
+  email: 'juan@example.com',
+  player_type: null,
+  favorite_sport: null,
+};
+const aniba: PlayerRow = {
+  playtomic_id: 'player-anibal',
+  name: 'Aníbal González',
+  email: 'anibal@club.com',
+  player_type: null,
+  favorite_sport: null,
+};
+
+describe('buildBookingCoachMap', () => {
+  it('detecta coach cuando es owner del booking', () => {
+    const bookings: Booking[] = [{ ...baseBooking, booking_id: 'b1', owner_id: 'player-omar' }];
+    const map = buildBookingCoachMap(bookings, [], [omar]);
+    expect(map.get('b1')).toEqual(new Set(['omar']));
+  });
+
+  it('detecta coach cuando es participante (no owner)', () => {
+    const bookings: Booking[] = [{ ...baseBooking, booking_id: 'b1', owner_id: 'player-1' }];
+    const participants: BookingParticipant[] = [
+      { booking_id: 'b1', player_id: 'player-1', is_owner: true, family_member_id: null },
+      { booking_id: 'b1', player_id: 'player-omar', is_owner: false, family_member_id: null },
+    ];
+    const map = buildBookingCoachMap(bookings, participants, [cliente, omar]);
+    expect(map.get('b1')).toEqual(new Set(['omar']));
+  });
+
+  it('matchea nombres con tildes (Aníbal → anibal)', () => {
+    const bookings: Booking[] = [{ ...baseBooking, owner_id: 'player-anibal' }];
+    const map = buildBookingCoachMap(bookings, [], [aniba]);
+    expect(map.get('b1')).toEqual(new Set(['anibal']));
+  });
+
+  it('un booking puede tener múltiples coaches (clase con 2)', () => {
+    const bookings: Booking[] = [{ ...baseBooking, owner_id: 'player-omar' }];
+    const participants: BookingParticipant[] = [
+      { booking_id: 'b1', player_id: 'player-omar', is_owner: true, family_member_id: null },
+      { booking_id: 'b1', player_id: 'player-anibal', is_owner: false, family_member_id: null },
+    ];
+    const map = buildBookingCoachMap(bookings, participants, [omar, aniba]);
+    expect(map.get('b1')).toEqual(new Set(['omar', 'anibal']));
+  });
+
+  it('booking sin coach no entra al mapa', () => {
+    const bookings: Booking[] = [{ ...baseBooking, owner_id: 'player-1' }];
+    const map = buildBookingCoachMap(bookings, [], [cliente]);
+    expect(map.has('b1')).toBe(false);
+  });
+});
+
 describe('computeCoaches', () => {
-  it('ignora bookings sin coach_ids', () => {
-    const rows = computeCoaches([{ ...baseBooking, coach_ids: null }], []);
+  it('ranking vacío si el mapa no tiene entradas', () => {
+    const rows = computeCoaches([baseBooking], new Map());
     expect(rows).toHaveLength(0);
   });
 
-  it('ignora bookings cancelados', () => {
-    const rows = computeCoaches(
-      [{ ...baseBooking, coach_ids: ['omar-id'], is_canceled: true }],
-      []
-    );
+  it('ignora bookings cancelados aunque haya coach', () => {
+    const map = new Map([['b1', new Set<'omar'>(['omar'])]]);
+    const rows = computeCoaches([{ ...baseBooking, is_canceled: true }], map);
     expect(rows).toHaveLength(0);
   });
 
-  it('asigna revenue completo si solo hay 1 coach', () => {
-    const rows = computeCoaches(
-      [{ ...baseBooking, coach_ids: ['omar-id'], price_amount: 800 }],
-      []
-    );
+  it('asigna revenue completo si solo hay 1 coach en el booking', () => {
+    const map = new Map([['b1', new Set<'omar'>(['omar'])]]);
+    const rows = computeCoaches([{ ...baseBooking, price_amount: 800 }], map);
     expect(rows).toHaveLength(1);
-    expect(rows[0].coach_id).toBe('omar-id');
+    expect(rows[0].coach_id).toBe('omar');
+    expect(rows[0].display_name).toBe('Omar');
     expect(rows[0].revenue).toBe(800);
     expect(rows[0].reservas).toBe(1);
   });
 
-  it('reparte revenue entre N coaches del mismo booking', () => {
-    const rows = computeCoaches(
-      [{ ...baseBooking, coach_ids: ['omar-id', 'paco-id'], price_amount: 400 }],
-      []
-    );
-    const omar = rows.find((r) => r.coach_id === 'omar-id');
-    const paco = rows.find((r) => r.coach_id === 'paco-id');
-    expect(omar?.revenue).toBe(200);
-    expect(paco?.revenue).toBe(200);
+  it('reparte revenue cuando un booking involucra a 2 coaches', () => {
+    const map = new Map([['b1', new Set<'omar' | 'anibal'>(['omar', 'anibal'])]]);
+    const rows = computeCoaches([{ ...baseBooking, price_amount: 400 }], map);
+    const omarRow = rows.find((r) => r.coach_id === 'omar');
+    const anibalRow = rows.find((r) => r.coach_id === 'anibal');
+    expect(omarRow?.revenue).toBe(200);
+    expect(anibalRow?.revenue).toBe(200);
   });
 
   it('cuenta jugadores únicos por owner_id distinto', () => {
+    const map = new Map([
+      ['b1', new Set<'omar'>(['omar'])],
+      ['b2', new Set<'omar'>(['omar'])],
+      ['b3', new Set<'omar'>(['omar'])],
+    ]);
     const rows = computeCoaches(
       [
-        { ...baseBooking, booking_id: 'b1', coach_ids: ['omar-id'], owner_id: 'player-1' },
-        { ...baseBooking, booking_id: 'b2', coach_ids: ['omar-id'], owner_id: 'player-2' },
-        { ...baseBooking, booking_id: 'b3', coach_ids: ['omar-id'], owner_id: 'player-1' },
+        { ...baseBooking, booking_id: 'b1', owner_id: 'player-1' },
+        { ...baseBooking, booking_id: 'b2', owner_id: 'player-2' },
+        { ...baseBooking, booking_id: 'b3', owner_id: 'player-1' },
       ],
-      []
+      map
     );
-    const omar = rows.find((r) => r.coach_id === 'omar-id');
-    expect(omar?.reservas).toBe(3);
-    expect(omar?.jugadores_unicos).toBe(2);
+    expect(rows[0].reservas).toBe(3);
+    expect(rows[0].jugadores_unicos).toBe(2);
   });
 
-  it('toma la última reserva (booking_start más reciente)', () => {
+  it('toma la última reserva más reciente', () => {
+    const map = new Map([
+      ['b1', new Set<'omar'>(['omar'])],
+      ['b2', new Set<'omar'>(['omar'])],
+    ]);
     const rows = computeCoaches(
       [
-        {
-          ...baseBooking,
-          booking_id: 'b1',
-          coach_ids: ['omar-id'],
-          booking_start: '2026-04-10T18:00:00Z',
-        },
-        {
-          ...baseBooking,
-          booking_id: 'b2',
-          coach_ids: ['omar-id'],
-          booking_start: '2026-04-20T18:00:00Z',
-        },
-        {
-          ...baseBooking,
-          booking_id: 'b3',
-          coach_ids: ['omar-id'],
-          booking_start: '2026-04-15T18:00:00Z',
-        },
+        { ...baseBooking, booking_id: 'b1', booking_start: '2026-04-10T18:00:00Z' },
+        { ...baseBooking, booking_id: 'b2', booking_start: '2026-04-20T18:00:00Z' },
       ],
-      []
+      map
     );
-    const omar = rows.find((r) => r.coach_id === 'omar-id');
-    expect(omar?.ultima_reserva).toBe('2026-04-20T18:00:00Z');
+    expect(rows[0].ultima_reserva).toBe('2026-04-20T18:00:00Z');
   });
 
-  it('resuelve display_name desde players cuando matchea coach_id', () => {
-    const players: PlayerRow[] = [
-      {
-        playtomic_id: 'omar-id',
-        name: 'Omar Coach',
-        email: 'omar@club.com',
-        player_type: null,
-        favorite_sport: null,
-      },
-    ];
-    const rows = computeCoaches([{ ...baseBooking, coach_ids: ['omar-id'] }], players);
-    expect(rows[0].display_name).toBe('Omar Coach');
-  });
-
-  it('fallback a coach_<8chars> cuando no hay match en players', () => {
-    const rows = computeCoaches([{ ...baseBooking, coach_ids: ['abc12345xyz999'] }], []);
-    expect(rows[0].display_name).toBe('coach_abc12345');
-  });
-
-  it('ignora coach_ids vacíos en el array', () => {
-    const rows = computeCoaches([{ ...baseBooking, coach_ids: ['omar-id', ''] }], []);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].coach_id).toBe('omar-id');
+  it('display_name capitaliza el slug correctamente', () => {
+    const map = new Map([['b1', new Set<'anibal'>(['anibal'])]]);
+    const rows = computeCoaches([baseBooking], map);
+    expect(rows[0].display_name).toBe('Aníbal');
   });
 });

--- a/components/playtomic/derivations.ts
+++ b/components/playtomic/derivations.ts
@@ -1,3 +1,4 @@
+import { KNOWN_COACH_NAMES, type CoachSlug } from '@/lib/playtomic/conciliacion';
 import { HOUR_FMT, WEEKDAY_INDEX_MAP, WEEKDAY_KEY_FMT, WEEKDAY_LABELS } from './constants';
 import type {
   Booking,
@@ -10,6 +11,78 @@ import type {
   SyncRow,
 } from './types';
 import { isCanceledBooking, normalizeSport } from './utils';
+
+/**
+ * Capitaliza el slug del coach para mostrarlo en la UI. 'anibal' → 'Aníbal'.
+ */
+const COACH_DISPLAY_NAMES: Record<CoachSlug, string> = {
+  omar: 'Omar',
+  anibal: 'Aníbal',
+  manuel: 'Manuel',
+  paco: 'Paco',
+  hugo: 'Hugo',
+};
+
+function normalizeForCoachMatch(text: string | null | undefined): string {
+  return (text ?? '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').trim();
+}
+
+/**
+ * Detecta qué coaches conocidos están involucrados en cada booking, ya
+ * sea como owner o como participante. La identidad "coach" se infiere
+ * por matching del nombre normalizado contra `KNOWN_COACH_NAMES` (no hay
+ * registro formal en Playtomic — los coaches reservan como cualquier
+ * cliente con un descuento operativo).
+ *
+ * Devuelve: `Map<booking_id, Set<CoachSlug>>`. Bookings sin coach no
+ * aparecen en el mapa (lookup retorna `undefined`).
+ */
+export function buildBookingCoachMap(
+  bookings: Booking[],
+  participants: BookingParticipant[],
+  players: PlayerRow[]
+): Map<string, Set<CoachSlug>> {
+  // Pre-resuelve por player UNA VEZ para no rehacerlo por booking.
+  const coachSlugsByPlayer = new Map<string, Set<CoachSlug>>();
+  for (const player of players) {
+    if (!player.name) continue;
+    const norm = normalizeForCoachMatch(player.name);
+    const slugs = new Set<CoachSlug>();
+    for (const slug of KNOWN_COACH_NAMES) {
+      if (norm.includes(slug)) slugs.add(slug);
+    }
+    if (slugs.size > 0) coachSlugsByPlayer.set(player.playtomic_id, slugs);
+  }
+
+  // Agrupa participants por booking para evitar O(N×M).
+  const participantsByBooking = new Map<string, BookingParticipant[]>();
+  for (const p of participants) {
+    const list = participantsByBooking.get(p.booking_id) ?? [];
+    list.push(p);
+    participantsByBooking.set(p.booking_id, list);
+  }
+
+  const result = new Map<string, Set<CoachSlug>>();
+  for (const booking of bookings) {
+    const slugs = new Set<CoachSlug>();
+
+    if (booking.owner_id) {
+      const ownerSlugs = coachSlugsByPlayer.get(booking.owner_id);
+      if (ownerSlugs) for (const s of ownerSlugs) slugs.add(s);
+    }
+
+    const bookingParticipants = participantsByBooking.get(booking.booking_id) ?? [];
+    for (const part of bookingParticipants) {
+      if (!part.player_id) continue;
+      const partSlugs = coachSlugsByPlayer.get(part.player_id);
+      if (partSlugs) for (const s of partSlugs) slugs.add(s);
+    }
+
+    if (slugs.size > 0) result.set(booking.booking_id, slugs);
+  }
+
+  return result;
+}
 
 export type PlaytomicKpis = {
   totalBookings: number;
@@ -221,41 +294,45 @@ export function computeComputedPlayers(
 }
 
 /**
- * Calcula ranking de entrenadores a partir de `bookings.coach_ids[]`.
+ * Calcula ranking de entrenadores a partir del matching de nombres del
+ * owner/participantes contra `KNOWN_COACH_NAMES`.
  *
- * El API de Playtomic poblá `coach_ids` cuando una reserva involucra
- * a uno o más entrenadores. Aquí los expandimos (un booking con N
- * coaches contribuye N filas) y agregamos por coach_id:
+ * Modelo: en el club NO existen coaches registrados como entidad en
+ * Playtomic. Los coaches reservan como cualquier cliente con un descuento
+ * acordado. Identificamos sus reservas porque su nombre normalizado
+ * matchea uno de los slugs conocidos (omar/anibal/manuel/paco/hugo).
  *
- * - reservas: count de bookings no canceladas que mencionan el coach.
- * - revenue: sum(price_amount / coach_ids.length) — si una reserva
- *   tiene 2 coaches, cada uno se lleva la mitad. Default 1 si solo
- *   hay 1 coach (que es el caso típico).
- * - jugadores_unicos: count distinct de owner_ids que reservaron con
- *   ese coach.
- * - ultima_reserva: timestamp del booking_start más reciente.
+ * Por cada coach detectado, agregamos los bookings que lo involucran:
+ * - reservas: count de bookings no canceladas con ese coach (owner o participante).
+ * - revenue: sum(price_amount / coachesEnElBooking) — split cuando hay
+ *   varios coaches en la misma reserva (ej. clase con 2 instructores).
+ * - jugadores_unicos: count distinct de owner_ids del booking, que en este
+ *   modelo refleja "cuántas distintas dueñas de reserva han involucrado al coach".
+ * - ultima_reserva: ISO timestamp del booking_start más reciente.
  *
- * Resolución de nombre: el `coach_id` de Playtomic suele coincidir con
- * un `players.playtomic_id`. Cuando matchea, mostramos el nombre real.
- * Cuando no, fallback al id truncado (`coach_<8 chars>`).
+ * Solo retorna coaches con al menos 1 reserva en el periodo (los demás
+ * de KNOWN_COACH_NAMES no aparecen en la lista).
  */
-export function computeCoaches(bookings: Booking[], players: PlayerRow[]): CoachRow[] {
+export function computeCoaches(
+  bookings: Booking[],
+  bookingCoachMap: Map<string, Set<CoachSlug>>
+): CoachRow[] {
   type Bucket = {
     reservas: number;
     revenue: number;
     owners: Set<string>;
     last: string | null;
   };
-  const stats = new Map<string, Bucket>();
+  const stats = new Map<CoachSlug, Bucket>();
 
   for (const booking of bookings) {
     if (isCanceledBooking(booking)) continue;
-    const coaches = booking.coach_ids ?? [];
-    if (coaches.length === 0) continue;
-    const split = (booking.price_amount ?? 0) / coaches.length;
-    for (const coachId of coaches) {
-      if (!coachId) continue;
-      const bucket: Bucket = stats.get(coachId) ?? {
+    const coaches = bookingCoachMap.get(booking.booking_id);
+    if (!coaches || coaches.size === 0) continue;
+    const split = (booking.price_amount ?? 0) / coaches.size;
+
+    for (const slug of coaches) {
+      const bucket: Bucket = stats.get(slug) ?? {
         reservas: 0,
         revenue: 0,
         owners: new Set<string>(),
@@ -267,22 +344,16 @@ export function computeCoaches(bookings: Booking[], players: PlayerRow[]): Coach
       if (booking.booking_start && (!bucket.last || booking.booking_start > bucket.last)) {
         bucket.last = booking.booking_start;
       }
-      stats.set(coachId, bucket);
+      stats.set(slug, bucket);
     }
   }
 
-  const playerMap = new Map(players.map((p) => [p.playtomic_id, p]));
-
-  return Array.from(stats.entries()).map(([coachId, bucket]) => {
-    const player = playerMap.get(coachId);
-    const display = player?.name?.trim() || `coach_${coachId.slice(0, 8)}`;
-    return {
-      coach_id: coachId,
-      display_name: display,
-      reservas: bucket.reservas,
-      revenue: bucket.revenue,
-      jugadores_unicos: bucket.owners.size,
-      ultima_reserva: bucket.last,
-    };
-  });
+  return Array.from(stats.entries()).map(([slug, bucket]) => ({
+    coach_id: slug,
+    display_name: COACH_DISPLAY_NAMES[slug],
+    reservas: bucket.reservas,
+    revenue: bucket.revenue,
+    jugadores_unicos: bucket.owners.size,
+    ultima_reserva: bucket.last,
+  }));
 }

--- a/components/playtomic/header-section.tsx
+++ b/components/playtomic/header-section.tsx
@@ -129,8 +129,8 @@ export function HeaderSection({
           allowClear
         />
         <Combobox
-          value={filters.coachId}
-          onChange={(value) => onFiltersChange({ ...filters, coachId: value ?? '' })}
+          value={filters.coachSlug}
+          onChange={(value) => onFiltersChange({ ...filters, coachSlug: value ?? '' })}
           options={[{ value: '', label: 'Todos los entrenadores' }, ...coachOptions]}
           allowClear
         />

--- a/components/playtomic/playtomic-view.tsx
+++ b/components/playtomic/playtomic-view.tsx
@@ -6,11 +6,13 @@ import { useSortableTable } from '@/hooks/use-sortable-table';
 import { CancellationSection } from './cancellation-section';
 import { CoachesSection } from './coaches-section';
 import {
+  buildBookingCoachMap,
   computeCancellationAnalysis,
   computeCoaches,
   computeComputedPlayers,
   computeKpis,
 } from './derivations';
+import { KNOWN_COACH_NAMES } from '@/lib/playtomic/conciliacion';
 import { computePendingPayments } from './pending-payments';
 import { computeReconciliation } from './reconciliation';
 import { HeaderSection } from './header-section';
@@ -41,8 +43,16 @@ import {
 const DEFAULT_FILTERS: BookingFilters = {
   sport: 'all',
   resource: '',
-  coachId: '',
+  coachSlug: '',
   activity: '',
+};
+
+const COACH_LABELS: Record<string, string> = {
+  omar: 'Omar',
+  anibal: 'Aníbal',
+  manuel: 'Manuel',
+  paco: 'Paco',
+  hugo: 'Hugo',
 };
 
 export function PlaytomicView() {
@@ -77,9 +87,17 @@ export function PlaytomicView() {
     toIso: meta.toIso,
   });
 
+  // Mapa booking_id → coaches involucrados (owner o participantes con
+  // nombre que matchea uno de los slugs conocidos). Lo precomputamos UNA
+  // vez por dataset y lo reusamos para filtrar y para ranquear.
+  const bookingCoachMap = useMemo(
+    () => buildBookingCoachMap(data.bookings, data.participants, data.players),
+    [data.bookings, data.participants, data.players]
+  );
+
   const filteredBookings = useMemo(
-    () => applyBookingFilters(data.bookings, filters),
-    [data.bookings, filters]
+    () => applyBookingFilters(data.bookings, filters, bookingCoachMap),
+    [data.bookings, filters, bookingCoachMap]
   );
 
   const filteredBookingIds = useMemo(
@@ -149,8 +167,8 @@ export function PlaytomicView() {
   }, [computedPlayers, playerQuery, playerSort]);
 
   const coaches = useMemo(
-    () => computeCoaches(filteredBookings, data.players),
-    [filteredBookings, data.players]
+    () => computeCoaches(filteredBookings, bookingCoachMap),
+    [filteredBookings, bookingCoachMap]
   );
 
   const sortedCoaches = useMemo(() => {
@@ -176,21 +194,18 @@ export function PlaytomicView() {
       .map((name) => ({ value: name, label: name }));
   }, [data.resources, data.bookings]);
 
+  // Coach options = solo los coaches conocidos que tienen al menos 1
+  // booking detectado en el periodo (filtrar la lista hardcoded contra
+  // el bookingCoachMap evita mostrar opciones vacías).
   const coachOptions = useMemo(() => {
-    const seen = new Set<string>();
-    for (const booking of data.bookings) {
-      for (const id of booking.coach_ids ?? []) {
-        if (id) seen.add(id);
-      }
+    const present = new Set<string>();
+    for (const slugs of bookingCoachMap.values()) {
+      for (const slug of slugs) present.add(slug);
     }
-    const playerMap = new Map(data.players.map((p) => [p.playtomic_id, p.name]));
-    return Array.from(seen)
-      .map((id) => ({
-        value: id,
-        label: playerMap.get(id)?.trim() || `coach_${id.slice(0, 8)}`,
-      }))
+    return KNOWN_COACH_NAMES.filter((slug) => present.has(slug))
+      .map((slug) => ({ value: slug, label: COACH_LABELS[slug] ?? slug }))
       .sort((a, b) => a.label.localeCompare(b.label, 'es'));
-  }, [data.bookings, data.players]);
+  }, [bookingCoachMap]);
 
   const activityOptions = useMemo(() => {
     const seen = new Set<string>();

--- a/components/playtomic/types.ts
+++ b/components/playtomic/types.ts
@@ -38,8 +38,13 @@ export type BookingFilters = {
   sport: SportFilter;
   /** `resource_name` exacto. `''` = todas. */
   resource: string;
-  /** Coach id de Playtomic. `''` = todos. */
-  coachId: string;
+  /**
+   * Slug del coach (omar/anibal/manuel/paco/hugo). `''` = todos.
+   * El matching lo resuelve `applyBookingFilters` contra un
+   * `bookingCoachMap` precomputado a partir de los nombres del owner
+   * y participantes — no hay registro formal de coaches en Playtomic.
+   */
+  coachSlug: string;
   /** `activity_name` o `course_name` (lo que esté presente). `''` = todas. */
   activity: string;
 };

--- a/components/playtomic/utils.ts
+++ b/components/playtomic/utils.ts
@@ -77,16 +77,26 @@ export function getRangeMeta(
 /**
  * Filtra bookings en cliente según los selectores del dashboard
  * (deporte / cancha / entrenador / actividad). El rango de fechas no se
- * aplica aquí — la query del hook ya trae solo el rango activo. Pure
- * function: testeable.
+ * aplica aquí — la query del hook ya trae solo el rango activo.
+ *
+ * Para el filtro de coach pasa `bookingCoachMap` (Map<booking_id, Set<slug>>)
+ * que el view precomputa con `buildBookingCoachMap`. Si no se pasa, el
+ * filtro de coach se ignora (degraded mode) en lugar de retornar 0
+ * resultados.
+ *
+ * Pure function: testeable.
  */
-export function applyBookingFilters(bookings: Booking[], filters: BookingFilters): Booking[] {
+export function applyBookingFilters(
+  bookings: Booking[],
+  filters: BookingFilters,
+  bookingCoachMap?: Map<string, Set<string>>
+): Booking[] {
   return bookings.filter((booking) => {
     if (filters.sport !== 'all' && normalizeSport(booking.sport_id) !== filters.sport) return false;
     if (filters.resource && booking.resource_name !== filters.resource) return false;
-    if (filters.coachId) {
-      const coachIds = booking.coach_ids ?? [];
-      if (!coachIds.includes(filters.coachId)) return false;
+    if (filters.coachSlug && bookingCoachMap) {
+      const slugs = bookingCoachMap.get(booking.booking_id);
+      if (!slugs || !slugs.has(filters.coachSlug)) return false;
     }
     if (filters.activity) {
       const activity = booking.activity_name ?? booking.course_name ?? '';

--- a/lib/playtomic/conciliacion.ts
+++ b/lib/playtomic/conciliacion.ts
@@ -38,7 +38,8 @@ export function isCanchaProduct(productName: string | null | undefined): boolean
  * los productos de Waitry: ver SQL `SELECT DISTINCT product_name FROM
  * rdb.waitry_productos WHERE product_name ILIKE 'Uso cancha coach%'`.
  */
-const KNOWN_COACH_NAMES = ['omar', 'anibal', 'manuel', 'paco', 'hugo'] as const;
+export const KNOWN_COACH_NAMES = ['omar', 'anibal', 'manuel', 'paco', 'hugo'] as const;
+export type CoachSlug = (typeof KNOWN_COACH_NAMES)[number];
 
 function isCoachProduct(productName: string | null | undefined): boolean {
   if (!productName) return false;


### PR DESCRIPTION
## Summary

**Bug que cierra:** después de mergear [#425](https://github.com/beto-sudo/BSOP/pull/425) la sección Entrenadores aparecía en blanco. Causa: yo asumí que `playtomic.bookings.coach_ids[]` venía poblado por el sync, pero el club **no tiene coaches registrados como entidad en Playtomic** — los coaches reservan como cualquier cliente con un descuento operativo, así que ese array está vacío.

**Modelo correcto** (que ya estaba en `lib/playtomic/conciliacion.ts` para el ranker de S2-Waitry-write): identificar al coach por matching del nombre normalizado del owner o de algún participante contra slugs conocidos `omar/anibal/manuel/paco/hugo`.

## Cambios

- `KNOWN_COACH_NAMES` y tipo `CoachSlug` exportados desde [lib/playtomic/conciliacion.ts](lib/playtomic/conciliacion.ts) como single source of truth (antes eran privados).
- Nueva `buildBookingCoachMap(bookings, participants, players)` en [components/playtomic/derivations.ts](components/playtomic/derivations.ts) que pre-resuelve el matching por player UNA vez y devuelve `Map<booking_id, Set<CoachSlug>>`.
- `computeCoaches` ahora consume ese mapa en vez de iterar `coach_ids[]`. Display name = capitalized del slug (`'omar'` → `'Omar'`, `'anibal'` → `'Aníbal'`).
- `applyBookingFilters` recibe el mapa para resolver `filters.coachSlug` contra él (renombre de `coachId` → `coachSlug` en el tipo `BookingFilters`).
- `coachOptions` del header ahora se filtra contra los coaches realmente presentes en el periodo — no muestra opciones vacías.
- Subtítulo de la sección actualizado para reflejar el modelo real ("identificamos por matching de nombre... no hay registro formal en Playtomic").

## Tests

12 tests verdes, reescritos con el nuevo modelo:
- Detección por owner del booking
- Detección por participante (no owner)
- Normalización de tildes (Aníbal → anibal)
- Múltiples coaches en un booking (clase con 2 instructores)
- Booking sin coach no entra al mapa
- Ignorar canceladas
- Split de revenue cuando hay N coaches
- Distinct owners para `jugadores_unicos`
- Última reserva (booking_start más reciente)
- Capitalización del display_name

## Test plan

- [x] `npm run typecheck` verde
- [x] `npm run test:run` verde
- [x] `npm run lint` verde (0 errors)
- [x] `npm run format:check` verde
- [ ] Smoke en preview: confirmar que la sección Entrenadores ahora muestra los 5 coaches conocidos (filtrados a los que tienen reservas en el mes actual).
- [ ] Smoke en preview: filtrar por entrenador en el header → confirmar que KPIs y tablas reflejan solo bookings de ese coach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)