### PR TITLE
fix(health): doble conteo de sueño (24.4h anoche)

### DIFF
--- a/components/health/helpers.test.ts
+++ b/components/health/helpers.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { HealthMetricRow } from '@/lib/health';
-import { classifyBand, getRecoveryFlag, groupDailySleepEfficiency, type Band } from './helpers';
+import {
+  classifyBand,
+  getRecoveryFlag,
+  groupDailySleep,
+  groupDailySleepEfficiency,
+  groupSleepStages,
+  type Band,
+} from './helpers';
 import type { Point } from './types';
 
 function row(
@@ -51,6 +58,94 @@ describe('groupDailySleepEfficiency', () => {
       row('Sleep In Bed', '2026-04-23T23:16:00.000Z', 8),
     ]);
     expect(points[0]!.value).toBe(100);
+  });
+
+  it('collapses fragmented samples per source/stage via MAX, not SUM', () => {
+    // HAE Time Grouping = Minute splits one night into N samples, each
+    // carrying the cumulative session total. Naive sum would inflate.
+    const aw = "Adalberto's Apple Watch";
+    const points = groupDailySleepEfficiency([
+      row('Sleep Core', '2026-05-05T03:37:00.000Z', 5.74, aw),
+      row('Sleep Core', '2026-05-05T06:29:00.000Z', 4.35, aw),
+      row('Sleep Core', '2026-05-05T07:49:00.000Z', 3.02, aw),
+      row('Sleep Deep', '2026-05-05T03:37:00.000Z', 0.74, aw),
+      row('Sleep Deep', '2026-05-05T06:29:00.000Z', 0.09, aw),
+      row('Sleep REM', '2026-05-05T03:37:00.000Z', 2.8, aw),
+      row('Sleep In Bed', '2026-05-05T03:37:00.000Z', 9.5, 'Sleeptracker®'),
+    ]);
+    // asleep = max stages: Core 5.74 + Deep 0.74 + REM 2.8 = 9.28
+    // inBed = 9.5
+    // efficiency = 9.28 / 9.5 ≈ 97.7 (NOT >100 from a 24h sum)
+    expect(points[0]!.value).toBeCloseTo(97.68, 1);
+  });
+});
+
+describe('groupDailySleep', () => {
+  const aw = "Adalberto's Apple Watch";
+
+  it('skips Awake and In Bed; sums Core + Deep + REM per source', () => {
+    const points = groupDailySleep([
+      row('Sleep Core', '2026-04-23T23:16:00.000Z', 5, 'Sleeptracker®'),
+      row('Sleep Deep', '2026-04-23T23:16:00.000Z', 1, 'Sleeptracker®'),
+      row('Sleep REM', '2026-04-23T23:16:00.000Z', 2, 'Sleeptracker®'),
+      row('Sleep Awake', '2026-04-23T23:16:00.000Z', 0.2, 'Sleeptracker®'), // skipped
+      row('Sleep In Bed', '2026-04-23T23:16:00.000Z', 8.8, 'Sleeptracker®'), // skipped
+    ]);
+    expect(points).toHaveLength(1);
+    expect(points[0]!.value).toBeCloseTo(8, 5);
+  });
+
+  it('collapses HAE-fragmented samples via MAX per (source, stage), not SUM', () => {
+    // Real shape from 4-5 may: Apple Watch wrote 4 samples for one night,
+    // each carrying the full session total (not segments). Sum = 24.4h
+    // (impossible). MAX per stage = ~9h (correct).
+    const points = groupDailySleep([
+      row('Sleep Core', '2026-05-05T03:37:00.000Z', 5.74, aw),
+      row('Sleep Core', '2026-05-05T06:29:00.000Z', 4.35, aw),
+      row('Sleep Core', '2026-05-05T07:49:00.000Z', 3.02, aw),
+      row('Sleep Core', '2026-05-05T09:18:00.000Z', 1.93, aw),
+      row('Sleep Deep', '2026-05-05T03:37:00.000Z', 0.74, aw),
+      row('Sleep Deep', '2026-05-05T06:29:00.000Z', 0.09, aw),
+      row('Sleep REM', '2026-05-05T03:37:00.000Z', 2.8, aw),
+      row('Sleep REM', '2026-05-05T06:29:00.000Z', 1.97, aw),
+      row('Sleep REM', '2026-05-05T07:49:00.000Z', 1.97, aw),
+      row('Sleep REM', '2026-05-05T09:18:00.000Z', 1.67, aw),
+    ]);
+    expect(points).toHaveLength(1);
+    // max Core 5.74 + max Deep 0.74 + max REM 2.8 = 9.28
+    expect(points[0]!.value).toBeCloseTo(9.28, 2);
+  });
+
+  it('takes the larger of Sleeptracker® and Apple Watch when both report', () => {
+    const points = groupDailySleep([
+      row('Sleep Core', '2026-04-23T23:16:00.000Z', 5, 'Sleeptracker®'),
+      row('Sleep Deep', '2026-04-23T23:16:00.000Z', 1, 'Sleeptracker®'),
+      row('Sleep REM', '2026-04-23T23:16:00.000Z', 2, 'Sleeptracker®'),
+      row('Sleep Core', '2026-04-23T23:16:00.000Z', 4, aw),
+      row('Sleep Deep', '2026-04-23T23:16:00.000Z', 0.3, aw),
+      row('Sleep REM', '2026-04-23T23:16:00.000Z', 1.7, aw),
+    ]);
+    // Sleeptracker total 8 vs Apple Watch total 6 → 8
+    expect(points[0]!.value).toBeCloseTo(8, 5);
+  });
+});
+
+describe('groupSleepStages', () => {
+  it('returns per-stage averages collapsed via MAX across fragmented samples', () => {
+    const aw = "Adalberto's Apple Watch";
+    const averages = groupSleepStages([
+      // Night 1: fragmented Apple Watch
+      row('Sleep Core', '2026-05-05T03:37:00.000Z', 5.74, aw),
+      row('Sleep Core', '2026-05-05T06:29:00.000Z', 4.35, aw),
+      row('Sleep Deep', '2026-05-05T03:37:00.000Z', 0.74, aw),
+      row('Sleep REM', '2026-05-05T03:37:00.000Z', 2.8, aw),
+      row('Sleep Awake', '2026-05-05T03:37:00.000Z', 0.05, aw),
+    ]);
+    // 1 night, MAX per stage (not sum across the 2 Core fragments)
+    expect(averages['Sleep Core']).toBeCloseTo(5.74, 2);
+    expect(averages['Sleep Deep']).toBeCloseTo(0.74, 2);
+    expect(averages['Sleep REM']).toBeCloseTo(2.8, 2);
+    expect(averages['Sleep Awake']).toBeCloseTo(0.05, 2);
   });
 });
 

--- a/components/health/helpers.ts
+++ b/components/health/helpers.ts
@@ -45,27 +45,44 @@ export function groupDailySum(rows: HealthMetricRow[]): Point[] {
 
 /**
  * Sleep comes in as one row per stage/segment, from two devices (Sleeptracker®
- * bed and Apple Watch). A plain average is nonsense — it ends up averaging
- * 15-min stage slivers. Correct daily total is SUM per source per day, then
- * GREATEST across sources (never double-count the two devices).
+ * bed and Apple Watch). HAE with Time Grouping = Minute fragments a single
+ * night into multiple samples whose `value` is each session's accumulated
+ * total — so naively summing them multiplies the night by N.
  *
- * `stageMetrics` controls which metric_name rows are summed — pass the sleep
- * stages that count as "asleep" (Core + Deep + REM) or all stages including
- * Awake if you want total in-bed coverage.
+ * Daily total = MAX per (source, stage) per day (collapses fragmentation),
+ * then SUM stages within a source, then MAX across sources (never double-
+ * count the two devices). Awake and In Bed are excluded: Awake is the gap
+ * between asleep stages, and In Bed is the wrap of the whole session, both
+ * would inflate the total.
  */
 export function groupDailySleep(rows: HealthMetricRow[]): Point[] {
-  const buckets = new Map<string, { sleeptracker: number; other: number }>();
+  type Stage = 'Core' | 'Deep' | 'REM';
+  type SourceBucket = Record<Stage, number>;
+  const emptySource = (): SourceBucket => ({ Core: 0, Deep: 0, REM: 0 });
+  const buckets = new Map<string, { sleeptracker: SourceBucket; other: SourceBucket }>();
   rows.forEach((row) => {
-    if (row.metric_name === 'Sleep Awake') return;
+    const stage: Stage | null =
+      row.metric_name === 'Sleep Core'
+        ? 'Core'
+        : row.metric_name === 'Sleep Deep'
+          ? 'Deep'
+          : row.metric_name === 'Sleep REM'
+            ? 'REM'
+            : null;
+    if (!stage) return;
     const key = row.date.slice(0, 10);
-    const existing = buckets.get(key) ?? { sleeptracker: 0, other: 0 };
+    const existing = buckets.get(key) ?? { sleeptracker: emptySource(), other: emptySource() };
     const isSleeptracker = (row.source ?? '').toLowerCase().includes('sleeptracker');
-    if (isSleeptracker) existing.sleeptracker += row.value;
-    else existing.other += row.value;
+    const target = isSleeptracker ? existing.sleeptracker : existing.other;
+    target[stage] = Math.max(target[stage], row.value);
     buckets.set(key, existing);
   });
   return Array.from(buckets.entries())
-    .map(([date, b]) => ({ date, value: Math.max(b.sleeptracker, b.other) }))
+    .map(([date, b]) => {
+      const st = b.sleeptracker.Core + b.sleeptracker.Deep + b.sleeptracker.REM;
+      const other = b.other.Core + b.other.Deep + b.other.REM;
+      return { date, value: Math.max(st, other) };
+    })
     .sort((a, b) => a.date.localeCompare(b.date));
 }
 
@@ -193,33 +210,54 @@ export function isStaleSince(latestIso: string | null | undefined, maxDaysStale:
  * In Bed sample) are skipped to avoid 0% / >100% noise.
  */
 export function groupDailySleepEfficiency(rows: HealthMetricRow[]): Point[] {
+  type Stage = 'Core' | 'Deep' | 'REM';
+  type AsleepBucket = Record<Stage, number>;
   type Bucket = {
-    asleepSt: number;
-    asleepOther: number;
+    asleepSt: AsleepBucket;
+    asleepOther: AsleepBucket;
     inBedSt: number;
     inBedOther: number;
   };
+  const emptyAsleep = (): AsleepBucket => ({ Core: 0, Deep: 0, REM: 0 });
   const buckets = new Map<string, Bucket>();
   rows.forEach((row) => {
     const key = row.date.slice(0, 10);
-    const existing = buckets.get(key) ?? { asleepSt: 0, asleepOther: 0, inBedSt: 0, inBedOther: 0 };
+    const existing =
+      buckets.get(key) ??
+      ({
+        asleepSt: emptyAsleep(),
+        asleepOther: emptyAsleep(),
+        inBedSt: 0,
+        inBedOther: 0,
+      } satisfies Bucket);
     const isSleeptracker = (row.source ?? '').toLowerCase().includes('sleeptracker');
     if (row.metric_name === 'Sleep In Bed') {
-      if (isSleeptracker) existing.inBedSt += row.value;
-      else existing.inBedOther += row.value;
-    } else if (
-      row.metric_name === 'Sleep Core' ||
-      row.metric_name === 'Sleep Deep' ||
-      row.metric_name === 'Sleep REM'
-    ) {
-      if (isSleeptracker) existing.asleepSt += row.value;
-      else existing.asleepOther += row.value;
+      // MAX (not SUM) — fragmented samples carry the cumulative session value.
+      if (isSleeptracker) existing.inBedSt = Math.max(existing.inBedSt, row.value);
+      else existing.inBedOther = Math.max(existing.inBedOther, row.value);
+    } else {
+      const stage: Stage | null =
+        row.metric_name === 'Sleep Core'
+          ? 'Core'
+          : row.metric_name === 'Sleep Deep'
+            ? 'Deep'
+            : row.metric_name === 'Sleep REM'
+              ? 'REM'
+              : null;
+      if (!stage) {
+        buckets.set(key, existing);
+        return;
+      }
+      const target = isSleeptracker ? existing.asleepSt : existing.asleepOther;
+      target[stage] = Math.max(target[stage], row.value);
     }
     buckets.set(key, existing);
   });
   const points: Point[] = [];
   for (const [date, b] of buckets.entries()) {
-    const asleep = Math.max(b.asleepSt, b.asleepOther);
+    const stAsleep = b.asleepSt.Core + b.asleepSt.Deep + b.asleepSt.REM;
+    const otherAsleep = b.asleepOther.Core + b.asleepOther.Deep + b.asleepOther.REM;
+    const asleep = Math.max(stAsleep, otherAsleep);
     const inBed = Math.max(b.inBedSt, b.inBedOther);
     if (asleep <= 0 || inBed <= 0) continue;
     points.push({ date, value: Math.min(100, (asleep / inBed) * 100) });
@@ -315,8 +353,12 @@ export function groupSleepStages(rows: HealthMetricRow[]) {
         { sleeptracker: number; other: number }
       >);
     const isSleeptracker = (row.source ?? '').toLowerCase().includes('sleeptracker');
-    if (isSleeptracker) existing[stage].sleeptracker += row.value;
-    else existing[stage].other += row.value;
+    // MAX, not SUM — see groupDailySleep comment on HAE Time Grouping = Minute
+    // fragmentation. Each fragment carries the full session total to date,
+    // so summing inflates the day by N.
+    if (isSleeptracker)
+      existing[stage].sleeptracker = Math.max(existing[stage].sleeptracker, row.value);
+    else existing[stage].other = Math.max(existing[stage].other, row.value);
     buckets.set(key, existing);
   });
   const entries = Array.from(buckets.entries()).sort((a, b) => a[0].localeCompare(b[0]));


### PR DESCRIPTION
## Summary

- Anoche el dashboard reportaba **24.4hr de sueño** — bug. Causa raíz: HAE con `Time Grouping = Minute` fragmenta una noche en N samples (cada uno con el total acumulado de la sesión), y el helper sumaba todos los fragmentos. Apple Watch con 4 samples para anoche → 4× double-count.
- Bug secundario: `groupDailySleep` incluía `Sleep In Bed` (envoltura de la sesión completa) además de Core+Deep+REM → otra capa de doble conteo.
- Fix: por `(date, source, stage)` tomar MAX (no SUM), y excluir Awake e In Bed del total asleep. Mismo principio aplicado a `groupSleepStages` y `groupDailySleepEfficiency`.

Verificado con datos reales del 4-5 may: con MAX da ~9.28h (correcto), antes daba 24.37h.

## Test plan

- [x] Tests nuevos cubren: fragmentación Apple Watch (4 Core samples → max), exclusión Awake/In Bed, MAX entre sources cuando ambas reportan
- [x] `npm run typecheck` pasa
- [x] `npm run test:run components/health/helpers.test.ts` — 19 tests pasan
- [ ] Validar en `/health` que ANOCHE muestra valor realista (no 24.4hr) tras el merge
- [ ] Validar que 7D AVG y NOCHES ≥7H bajan a valores reales (eran 16.4h promedio per noche, irreal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)