### PR TITLE
feat(rdb/playtomic/conciliacion): deep-link Historial → Conciliación con booking pre-seleccionado

### DIFF
--- a/app/rdb/playtomic/conciliacion/page.tsx
+++ b/app/rdb/playtomic/conciliacion/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { Suspense } from 'react';
 import { DesktopOnlyNotice } from '@/components/responsive';
+import { Skeleton } from '@/components/ui/skeleton';
 import { ConciliacionView } from '@/components/playtomic/conciliacion/conciliacion-view';
 
 /**
@@ -8,13 +10,26 @@ import { ConciliacionView } from '@/components/playtomic/conciliacion/conciliaci
  * @responsive desktop-only
  *
  * Gate de acceso + tabs compartidos viven en `app/rdb/playtomic/layout.tsx`.
+ *
+ * `<Suspense>` boundary: requerido por `useSearchParams()` que usa el view
+ * para leer `?selected=<bookingId>` (deep-link desde el tab Historial).
+ * Sin esto, Next.js bail-out de static rendering con un warning.
  */
 export default function ConciliacionPage() {
   return (
     <>
       <DesktopOnlyNotice module="Conciliación Playtomic" />
       <div className="hidden sm:block">
-        <ConciliacionView />
+        <Suspense
+          fallback={
+            <div className="space-y-4 p-4">
+              <Skeleton className="h-8 w-64" />
+              <Skeleton className="h-96 w-full" />
+            </div>
+          }
+        >
+          <ConciliacionView />
+        </Suspense>
       </div>
     </>
   );

--- a/components/playtomic/conciliacion/assignment-panel.tsx
+++ b/components/playtomic/conciliacion/assignment-panel.tsx
@@ -28,6 +28,7 @@ export function AssignmentPanel({
   booking,
   candidates,
   existingAssignments,
+  isDeepLinkedOutOfFilter,
   tolerancePresetLabel,
   onWidenWindow,
   onAfterChange,
@@ -35,6 +36,13 @@ export function AssignmentPanel({
   booking: PendingBookingWithCoverage | null;
   candidates: RankedCandidate[];
   existingAssignments: AssignmentDetail[];
+  /**
+   * `true` cuando el booking llegó por deep-link `?selected=` desde el
+   * Historial y NO está en la lista filtrada normal (ya está full-cubierto,
+   * fuera de los 90d, etc). Se muestra un banner explicativo arriba del
+   * panel.
+   */
+  isDeepLinkedOutOfFilter?: boolean;
   tolerancePresetLabel: string;
   onWidenWindow?: () => void;
   onAfterChange: () => void;
@@ -137,6 +145,14 @@ export function AssignmentPanel({
 
   return (
     <div className="space-y-4 rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+      {isDeepLinkedOutOfFilter ? (
+        <div className="rounded-xl border border-blue-500/40 bg-blue-500/10 p-3 text-sm text-blue-200">
+          <strong>Llegaste desde el Historial.</strong> Esta reserva ya tiene cobertura completa
+          (Online + Waitry suman el total) o quedó fuera del rango normal del listado, por eso no
+          aparece en la columna izquierda. La mostramos aquí para que puedas revisar/ajustar las
+          asignaciones existentes.
+        </div>
+      ) : null}
       <header className="space-y-1">
         <h3 className="text-sm font-semibold text-[var(--text)]">Detalle de reserva</h3>
         <dl className="grid gap-1 text-sm sm:grid-cols-2">

--- a/components/playtomic/conciliacion/conciliacion-view.tsx
+++ b/components/playtomic/conciliacion/conciliacion-view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -22,7 +23,14 @@ const TOLERANCE_LABELS: Record<TimestampTolerancePreset, string> = {
 
 export function ConciliacionView() {
   const { data, loading, refreshing, error, refetch } = useConciliacionData();
-  const [selectedBookingId, setSelectedBookingId] = useState<string | null>(null);
+  // Deep-link desde el tab Historial: `?selected=<bookingId>` pre-selecciona
+  // la reserva. Se lee solo en mount (pattern recommended: single source of
+  // truth = state local). Si el booking no está en la lista visible (fuera
+  // de los 90d o ya full-cubierto), el panel queda vacío con su placeholder.
+  const searchParams = useSearchParams();
+  const [selectedBookingId, setSelectedBookingId] = useState<string | null>(() =>
+    searchParams.get('selected')
+  );
   const [tolerancePreset, setTolerancePreset] = useState<TimestampTolerancePreset>('2d');
   const [searchQuery, setSearchQuery] = useState('');
 

--- a/components/playtomic/conciliacion/conciliacion-view.tsx
+++ b/components/playtomic/conciliacion/conciliacion-view.tsx
@@ -22,21 +22,32 @@ const TOLERANCE_LABELS: Record<TimestampTolerancePreset, string> = {
 };
 
 export function ConciliacionView() {
-  const { data, loading, refreshing, error, refetch } = useConciliacionData();
   // Deep-link desde el tab Historial: `?selected=<bookingId>` pre-selecciona
   // la reserva. Se lee solo en mount (pattern recommended: single source of
-  // truth = state local). Si el booking no está en la lista visible (fuera
-  // de los 90d o ya full-cubierto), el panel queda vacío con su placeholder.
+  // truth = state local).
+  //
+  // El hook recibe `extraBookingId` (con el valor del query param inicial)
+  // para hacer fetch específico de ese booking si NO está en la lista
+  // filtrada (porque ya está full-cubierto, fuera del rango 90d, etc).
+  // Solo se usa el valor inicial — clicks subsiguientes en otras reservas
+  // de la lista NO disparan re-fetch.
   const searchParams = useSearchParams();
-  const [selectedBookingId, setSelectedBookingId] = useState<string | null>(() =>
-    searchParams.get('selected')
-  );
+  const [initialSelectedId] = useState<string | null>(() => searchParams.get('selected'));
+  const { data, loading, refreshing, error, refetch } = useConciliacionData({
+    extraBookingId: initialSelectedId,
+  });
+  const [selectedBookingId, setSelectedBookingId] = useState<string | null>(initialSelectedId);
   const [tolerancePreset, setTolerancePreset] = useState<TimestampTolerancePreset>('2d');
   const [searchQuery, setSearchQuery] = useState('');
 
   const selectedBooking = useMemo(
     () => data.bookings.find((b) => b.booking_id === selectedBookingId) ?? null,
     [data.bookings, selectedBookingId]
+  );
+
+  const isDeepLinkedOutOfFilter = useMemo(
+    () => Boolean(selectedBookingId && data.outOfFilterBookings.has(selectedBookingId)),
+    [data.outOfFilterBookings, selectedBookingId]
   );
 
   const existingAssignments = useMemo(
@@ -144,6 +155,7 @@ export function ConciliacionView() {
           booking={selectedBooking}
           candidates={rankedCandidates}
           existingAssignments={existingAssignments}
+          isDeepLinkedOutOfFilter={isDeepLinkedOutOfFilter}
           tolerancePresetLabel={TOLERANCE_LABELS[tolerancePreset]}
           onWidenWindow={
             tolerancePreset !== '30d'

--- a/components/playtomic/conciliacion/historial-view.tsx
+++ b/components/playtomic/conciliacion/historial-view.tsx
@@ -186,8 +186,10 @@ export function HistorialView() {
     });
   }
 
-  function handleNavigateToBooking() {
-    router.push('/rdb/playtomic/conciliacion');
+  function handleNavigateToBooking(bookingId: string) {
+    // Deep-link al tab Conciliación con la reserva pre-seleccionada.
+    // ConciliacionView lee `?selected=` en mount.
+    router.push(`/rdb/playtomic/conciliacion?selected=${encodeURIComponent(bookingId)}`);
   }
 
   function handleExportCsv() {
@@ -433,7 +435,7 @@ export function HistorialView() {
                     <TableRow
                       key={`${ev.source}-${ev.row_id}`}
                       className="cursor-pointer transition-colors hover:bg-[var(--panel)]/40"
-                      onClick={handleNavigateToBooking}
+                      onClick={() => handleNavigateToBooking(ev.booking_id)}
                     >
                       <TableCell className="font-medium text-[var(--text)]">
                         {bookingValid ? FECHA_CORTA_FMT.format(bookingDate as Date) : '—'}

--- a/components/playtomic/conciliacion/use-conciliacion-data.ts
+++ b/components/playtomic/conciliacion/use-conciliacion-data.ts
@@ -80,342 +80,390 @@ export type ConciliacionData = {
   candidates: WaitryCandidate[];
   assignedOrderIds: Set<string>;
   assignmentsByBooking: Map<string, AssignmentDetail[]>;
+  /**
+   * Bookings que están en `bookings[]` pero vinieron por fetch extra
+   * (deep-link `?selected=<id>` apuntando a un booking que ya está
+   * full-cubierto, fuera del rango 90d, o de otro modo no estaría en el
+   * listado normal de pendientes). El view muestra un banner explicativo
+   * cuando el booking seleccionado pertenece a este Set.
+   */
+  outOfFilterBookings: Set<string>;
 };
 
 // PostgREST `.or()` con patterns ilike. Cubre padel, tenis, pickleball y "Uso cancha coach...".
 const CANCHA_OR_FILTER = CANCHA_PRODUCT_PATTERNS.map((p) => `product_name.ilike.${p}`).join(',');
 
-export function useConciliacionData() {
+export function useConciliacionData(options?: { extraBookingId?: string | null }) {
+  const extraBookingId = options?.extraBookingId ?? null;
   const [data, setData] = useState<ConciliacionData>({
     bookings: [],
     candidates: [],
     assignedOrderIds: new Set(),
     assignmentsByBooking: new Map(),
+    outOfFilterBookings: new Set(),
   });
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async (isRefresh = false) => {
-    if (isRefresh) setRefreshing(true);
-    else setLoading(true);
-    setError(null);
+  const fetchData = useCallback(
+    async (isRefresh = false) => {
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
+      setError(null);
 
-    try {
-      const supabase = createSupabaseBrowserClient();
-      const playtomic = supabase.schema('playtomic');
-      const rdb = supabase.schema('rdb');
+      try {
+        const supabase = createSupabaseBrowserClient();
+        const playtomic = supabase.schema('playtomic');
+        const rdb = supabase.schema('rdb');
 
-      const nowIso = new Date().toISOString();
-      const bookingsLookbackDays = 90;
-      const ninetyDaysAgoIso = new Date(
-        Date.now() - bookingsLookbackDays * 24 * 60 * 60 * 1000
-      ).toISOString();
-      // Waitry lookback = bookings + max tolerance window (30d) para cubrir
-      // pagos hechos antes del booking_start más antiguo en la lista.
-      const waitryLookbackDays = bookingsLookbackDays + 30;
-      const waitryLookbackIso = new Date(
-        Date.now() - waitryLookbackDays * 24 * 60 * 60 * 1000
-      ).toISOString();
+        const nowIso = new Date().toISOString();
+        const bookingsLookbackDays = 90;
+        const ninetyDaysAgoIso = new Date(
+          Date.now() - bookingsLookbackDays * 24 * 60 * 60 * 1000
+        ).toISOString();
+        // Waitry lookback = bookings + max tolerance window (30d) para cubrir
+        // pagos hechos antes del booking_start más antiguo en la lista.
+        const waitryLookbackDays = bookingsLookbackDays + 30;
+        const waitryLookbackIso = new Date(
+          Date.now() - waitryLookbackDays * 24 * 60 * 60 * 1000
+        ).toISOString();
 
-      // Paso 1: bookings + pedidos Waitry pagados + productos "Renta Cancha
-      // Padel" (filtrado para no chocar con el cap default de PostgREST de
-      // 1000 rows aunque pidamos más).
-      const [
-        { data: pendingBookings, error: pendingErr },
-        { data: waitryPedidos, error: pedidosErr },
-        { data: canchaProductos, error: canchaErr },
-      ] = await Promise.all([
-        playtomic
-          .from('bookings')
-          .select(
-            'booking_id,booking_start,booking_end,resource_name,price_amount,owner_id,payment_status'
-          )
-          // Modelo de cobertura efectiva: incluimos PENDING + PARTIAL_PAID +
-          // PAID (los 3 pueden requerir conciliación) y filtramos en cliente
-          // por `effective_status != 'full'`. NOT_APPLICABLE queda fuera —
-          // son torneos/clases/cuentas internas, otra historia.
-          .in('payment_status', ['PENDING', 'PARTIAL_PAID', 'PAID'])
-          .eq('is_canceled', false)
-          .lte('booking_start', nowIso)
-          .gte('booking_start', ninetyDaysAgoIso)
-          .order('booking_start', { ascending: true })
-          .limit(5000)
-          .returns<BookingRow[]>(),
-        rdb
-          .from('waitry_pedidos')
-          .select('order_id,timestamp,notes,total_amount,paid')
-          .eq('paid', true)
-          .gte('timestamp', waitryLookbackIso)
-          // Descending: PostgREST capa a ~1000 rows por query independiente del
-          // .limit() que pidamos. Con 5K+ pedidos en 120d, ascending dejaba los
-          // más recientes (los que el operador necesita ver) FUERA del cap. Al
-          // ordenar descending, los recientes llegan primero — exactamente los
-          // que matchean con bookings que aún están abiertos para conciliar.
-          .order('timestamp', { ascending: false })
-          .limit(8000)
-          .returns<WaitryPedidoRow[]>(),
-        rdb
-          .from('waitry_productos')
-          .select('order_id,product_name,unit_price,quantity,total_price')
-          .or(CANCHA_OR_FILTER)
-          .gte('created_at', waitryLookbackIso)
-          .order('created_at', { ascending: false })
-          .limit(8000)
-          .returns<WaitryProductoRow[]>(),
-      ]);
-
-      if (pendingErr) throw pendingErr;
-      if (pedidosErr) throw pedidosErr;
-      if (canchaErr) throw canchaErr;
-
-      // Paso 2: con los order_ids que tienen Renta Cancha Padel, fetcheamos
-      // TODOS los items de esos pedidos (incluye F&B, otros productos) — usa
-      // `.in()` con un set acotado, ya no choca con el cap default.
-      const candidateOrderIds = Array.from(new Set((canchaProductos ?? []).map((p) => p.order_id)));
-      let waitryProductos: WaitryProductoRow[] = canchaProductos ?? [];
-      if (candidateOrderIds.length > 0) {
-        const { data: allItems, error: itemsErr } = await rdb
-          .from('waitry_productos')
-          .select('order_id,product_name,unit_price,quantity,total_price')
-          .in('order_id', candidateOrderIds)
-          .limit(20000)
-          .returns<WaitryProductoRow[]>();
-        if (itemsErr) throw itemsErr;
-        if (allItems && allItems.length > 0) waitryProductos = allItems;
-      }
-
-      const bookingsList = pendingBookings ?? [];
-      const bookingIds = bookingsList.map((b) => b.booking_id);
-
-      const participants: ParticipantRow[] = [];
-      const players: PlayerRow[] = [];
-
-      if (bookingIds.length > 0) {
-        // Chunkeamos: con 600+ booking_ids en `.in()` la URL excede 8KB y
-        // Cloudflare/PostgREST devuelven HTTP 400 Bad Request. Mismo patrón
-        // que ya usa `use-playtomic-data.ts` para el dashboard principal.
-        const bookingIdChunks = chunkArray(bookingIds, BOOKING_ID_CHUNK);
-        const participantResponses = await Promise.all(
-          bookingIdChunks.map((chunk) =>
-            playtomic
-              .from('booking_participants')
-              .select('booking_id,player_id,is_owner')
-              .in('booking_id', chunk)
-              .returns<ParticipantRow[]>()
-          )
-        );
-        for (const res of participantResponses) {
-          if (res.error) throw res.error;
-          participants.push(...(res.data ?? []));
-        }
-
-        const playerIds = Array.from(new Set(participants.map((p) => p.player_id)));
-        if (playerIds.length > 0) {
-          const playerIdChunks = chunkArray(playerIds, BOOKING_ID_CHUNK);
-          const playerResponses = await Promise.all(
-            playerIdChunks.map((chunk) =>
-              playtomic
-                .from('players')
-                .select('playtomic_id,name,email')
-                .in('playtomic_id', chunk)
-                .returns<PlayerRow[]>()
+        // Paso 1: bookings + pedidos Waitry pagados + productos "Renta Cancha
+        // Padel" (filtrado para no chocar con el cap default de PostgREST de
+        // 1000 rows aunque pidamos más).
+        const [
+          { data: pendingBookings, error: pendingErr },
+          { data: waitryPedidos, error: pedidosErr },
+          { data: canchaProductos, error: canchaErr },
+        ] = await Promise.all([
+          playtomic
+            .from('bookings')
+            .select(
+              'booking_id,booking_start,booking_end,resource_name,price_amount,owner_id,payment_status'
             )
-          );
-          for (const res of playerResponses) {
-            if (res.error) throw res.error;
-            players.push(...(res.data ?? []));
-          }
-        }
-      }
-
-      const playerMap = new Map(players.map((p) => [p.playtomic_id, p]));
-      const participantsByBooking = new Map<string, ParticipantRow[]>();
-      for (const p of participants) {
-        const list = participantsByBooking.get(p.booking_id) ?? [];
-        list.push(p);
-        participantsByBooking.set(p.booking_id, list);
-      }
-
-      // Agrupa todos los productos por order_id para construir los items[]
-      // del candidato y para localizar el producto "Renta Cancha Padel"
-      // que alimenta unit_price/quantity de la heurística.
-      const productosByOrder = new Map<string, WaitryProductoRow[]>();
-      for (const prod of waitryProductos ?? []) {
-        const list = productosByOrder.get(prod.order_id) ?? [];
-        list.push(prod);
-        productosByOrder.set(prod.order_id, list);
-      }
-
-      const candidates: WaitryCandidate[] = (waitryPedidos ?? [])
-        .map((pedido) => {
-          const prods = productosByOrder.get(pedido.order_id);
-          if (!prods || prods.length === 0) return null;
-          const cancha = prods.find((p) => isCanchaProduct(p.product_name));
-          if (!cancha) return null;
-          const items: WaitryItem[] = prods.map((p) => ({
-            product_name: p.product_name,
-            quantity: Number(p.quantity ?? 0),
-            unit_price: Number(p.unit_price ?? 0),
-            total_price: Number(p.total_price ?? 0),
-          }));
-          return {
-            order_id: pedido.order_id,
-            timestamp: pedido.timestamp,
-            notes: pedido.notes,
-            total_amount: Number(pedido.total_amount ?? 0),
-            unit_price: Number(cancha.unit_price ?? 0),
-            quantity: Number(cancha.quantity ?? 1),
-            items,
-          };
-        })
-        .filter((c): c is WaitryCandidate => c !== null);
-
-      // Coverage efectiva (waitry + online_csv) por booking. Modelo nuevo:
-      // - effective_status='full' → totalmente trazable, sale del listado.
-      // - 'partial' / 'none' → aparecen para conciliar contra Waitry.
-      // - has_unverified_manager=true → flag visual: el manager marcó pagos
-      //   onsite en Playtomic pero no hay pedido equivalente en Waitry. Es
-      //   el caso central que la iniciativa caza (Hector et al).
-      type CoverageEntry = {
-        effective_status: CoverageStatus;
-        effective_pct: number;
-        assigned_total: number;
-        waitry_total: number;
-        online_csv_total: number;
-        manager_csv_total: number;
-        has_unverified_manager: boolean;
-        waitry_order_ids: string[];
-      };
-      const coverageByBooking = new Map<string, CoverageEntry>();
-      const assignedOrderIds = new Set<string>();
-      const assignmentsByBooking = new Map<string, AssignmentDetail[]>();
-      if (bookingIds.length > 0) {
-        // Mismo motivo que arriba: chunkeamos para no exceder el límite de URL.
-        const bookingIdChunks = chunkArray(bookingIds, BOOKING_ID_CHUNK);
-        const [coverageResponses, assignmentResponses] = await Promise.all([
-          Promise.all(
-            bookingIdChunks.map((chunk) =>
-              playtomic
-                .from('v_bookings_total_coverage')
-                .select(
-                  'booking_id,effective_status,effective_pct,effective_total,waitry_total,online_csv_total,manager_csv_total,has_unverified_manager,waitry_order_ids'
-                )
-                .in('booking_id', chunk)
-            )
-          ),
-          Promise.all(
-            bookingIdChunks.map((chunk) =>
-              playtomic
-                .from('payment_assignments')
-                .select('id,booking_id,waitry_order_id,assigned_amount,assigned_at,note')
-                .in('booking_id', chunk)
-                .order('assigned_at', { ascending: true })
-                .returns<AssignmentRow[]>()
-            )
-          ),
+            // Modelo de cobertura efectiva: incluimos PENDING + PARTIAL_PAID +
+            // PAID (los 3 pueden requerir conciliación) y filtramos en cliente
+            // por `effective_status != 'full'`. NOT_APPLICABLE queda fuera —
+            // son torneos/clases/cuentas internas, otra historia.
+            .in('payment_status', ['PENDING', 'PARTIAL_PAID', 'PAID'])
+            .eq('is_canceled', false)
+            .lte('booking_start', nowIso)
+            .gte('booking_start', ninetyDaysAgoIso)
+            .order('booking_start', { ascending: true })
+            .limit(5000)
+            .returns<BookingRow[]>(),
+          rdb
+            .from('waitry_pedidos')
+            .select('order_id,timestamp,notes,total_amount,paid')
+            .eq('paid', true)
+            .gte('timestamp', waitryLookbackIso)
+            // Descending: PostgREST capa a ~1000 rows por query independiente del
+            // .limit() que pidamos. Con 5K+ pedidos en 120d, ascending dejaba los
+            // más recientes (los que el operador necesita ver) FUERA del cap. Al
+            // ordenar descending, los recientes llegan primero — exactamente los
+            // que matchean con bookings que aún están abiertos para conciliar.
+            .order('timestamp', { ascending: false })
+            .limit(8000)
+            .returns<WaitryPedidoRow[]>(),
+          rdb
+            .from('waitry_productos')
+            .select('order_id,product_name,unit_price,quantity,total_price')
+            .or(CANCHA_OR_FILTER)
+            .gte('created_at', waitryLookbackIso)
+            .order('created_at', { ascending: false })
+            .limit(8000)
+            .returns<WaitryProductoRow[]>(),
         ]);
 
-        const coverageRows: NonNullable<(typeof coverageResponses)[number]['data']> = [];
-        for (const res of coverageResponses) {
-          if (res.error) throw res.error;
-          if (res.data) coverageRows.push(...res.data);
-        }
-        const assignmentRows: AssignmentRow[] = [];
-        for (const res of assignmentResponses) {
-          if (res.error) throw res.error;
-          if (res.data) assignmentRows.push(...res.data);
+        if (pendingErr) throw pendingErr;
+        if (pedidosErr) throw pedidosErr;
+        if (canchaErr) throw canchaErr;
+
+        // Paso 2: con los order_ids que tienen Renta Cancha Padel, fetcheamos
+        // TODOS los items de esos pedidos (incluye F&B, otros productos) — usa
+        // `.in()` con un set acotado, ya no choca con el cap default.
+        const candidateOrderIds = Array.from(
+          new Set((canchaProductos ?? []).map((p) => p.order_id))
+        );
+        let waitryProductos: WaitryProductoRow[] = canchaProductos ?? [];
+        if (candidateOrderIds.length > 0) {
+          const { data: allItems, error: itemsErr } = await rdb
+            .from('waitry_productos')
+            .select('order_id,product_name,unit_price,quantity,total_price')
+            .in('order_id', candidateOrderIds)
+            .limit(20000)
+            .returns<WaitryProductoRow[]>();
+          if (itemsErr) throw itemsErr;
+          if (allItems && allItems.length > 0) waitryProductos = allItems;
         }
 
-        for (const row of coverageRows ?? []) {
-          if (!row.booking_id) continue;
-          coverageByBooking.set(row.booking_id, {
-            effective_status: (row.effective_status as CoverageStatus | null) ?? 'none',
-            effective_pct: Number(row.effective_pct ?? 0),
-            assigned_total: Number(row.effective_total ?? 0),
-            waitry_total: Number(row.waitry_total ?? 0),
-            online_csv_total: Number(row.online_csv_total ?? 0),
-            manager_csv_total: Number(row.manager_csv_total ?? 0),
-            has_unverified_manager: Boolean(row.has_unverified_manager),
-            waitry_order_ids: row.waitry_order_ids ?? [],
-          });
-          for (const oid of row.waitry_order_ids ?? []) assignedOrderIds.add(oid);
+        const bookingsList = pendingBookings ?? [];
+        const outOfFilterIds = new Set<string>();
+
+        // Si llega un deep-link `?selected=<id>` apuntando a un booking que
+        // NO está en `bookingsList` (porque ya está full-cubierto, fuera del
+        // rango 90d, cancelado, o NOT_APPLICABLE), hacer un fetch específico
+        // y agregarlo. Lo marcamos en `outOfFilterIds` para que el view
+        // muestre un banner explicativo y NO lo filtre fuera por
+        // `effective_status='full'` al final.
+        if (extraBookingId && !bookingsList.find((b) => b.booking_id === extraBookingId)) {
+          const { data: extraData, error: extraErr } = await playtomic
+            .from('bookings')
+            .select(
+              'booking_id,booking_start,booking_end,resource_name,price_amount,owner_id,payment_status'
+            )
+            .eq('booking_id', extraBookingId)
+            .maybeSingle();
+          if (extraErr) throw extraErr;
+          if (extraData) {
+            bookingsList.push(extraData as BookingRow);
+            outOfFilterIds.add(extraBookingId);
+          }
         }
 
-        for (const row of assignmentRows ?? []) {
-          // Defensa-en-profundidad: la vista `v_bookings_total_coverage`
-          // ya incluye los waitry_order_ids asignados, pero solo para los
-          // bookings consultados. Aquí poblamos también desde la tabla
-          // directa para asegurar que cualquier order asignada (visible
-          // o no en el listado) quede excluida de los candidatos.
-          assignedOrderIds.add(row.waitry_order_id);
-          const list = assignmentsByBooking.get(row.booking_id) ?? [];
-          list.push({
-            id: row.id,
-            waitry_order_id: row.waitry_order_id,
-            assigned_amount: Number(row.assigned_amount ?? 0),
-            assigned_at: row.assigned_at,
-            note: row.note,
-          });
-          assignmentsByBooking.set(row.booking_id, list);
-        }
-      }
+        const bookingIds = bookingsList.map((b) => b.booking_id);
 
-      const bookings: PendingBookingWithCoverage[] = bookingsList
-        // Filtra por cobertura EFECTIVA: si waitry + online_csv ya cubre el
-        // total, el booking sale del listado. Los partial y none aparecen,
-        // incluyendo bookings con `payment_status=PAID` agregado pero sin
-        // cobertura trazable (ahí está el "marcado paid sin Waitry").
-        .filter(
-          (booking) =>
-            (coverageByBooking.get(booking.booking_id)?.effective_status ?? 'none') !== 'full'
-        )
-        .map((booking) => {
-          const bookingParticipants = participantsByBooking.get(booking.booking_id) ?? [];
-          const ownerParticipant = bookingParticipants.find((p) => p.is_owner === true);
-          const ownerPlayer = ownerParticipant
-            ? playerMap.get(ownerParticipant.player_id)
-            : undefined;
-          const participantNames: string[] = [];
-          const participantEmails: string[] = [];
-          for (const p of bookingParticipants) {
-            const player = playerMap.get(p.player_id);
-            if (player?.name) participantNames.push(player.name);
-            if (player?.email) participantEmails.push(player.email);
+        const participants: ParticipantRow[] = [];
+        const players: PlayerRow[] = [];
+
+        if (bookingIds.length > 0) {
+          // Chunkeamos: con 600+ booking_ids en `.in()` la URL excede 8KB y
+          // Cloudflare/PostgREST devuelven HTTP 400 Bad Request. Mismo patrón
+          // que ya usa `use-playtomic-data.ts` para el dashboard principal.
+          const bookingIdChunks = chunkArray(bookingIds, BOOKING_ID_CHUNK);
+          const participantResponses = await Promise.all(
+            bookingIdChunks.map((chunk) =>
+              playtomic
+                .from('booking_participants')
+                .select('booking_id,player_id,is_owner')
+                .in('booking_id', chunk)
+                .returns<ParticipantRow[]>()
+            )
+          );
+          for (const res of participantResponses) {
+            if (res.error) throw res.error;
+            participants.push(...(res.data ?? []));
           }
 
-          const cov = coverageByBooking.get(booking.booking_id);
+          const playerIds = Array.from(new Set(participants.map((p) => p.player_id)));
+          if (playerIds.length > 0) {
+            const playerIdChunks = chunkArray(playerIds, BOOKING_ID_CHUNK);
+            const playerResponses = await Promise.all(
+              playerIdChunks.map((chunk) =>
+                playtomic
+                  .from('players')
+                  .select('playtomic_id,name,email')
+                  .in('playtomic_id', chunk)
+                  .returns<PlayerRow[]>()
+              )
+            );
+            for (const res of playerResponses) {
+              if (res.error) throw res.error;
+              players.push(...(res.data ?? []));
+            }
+          }
+        }
 
-          return {
-            booking_id: booking.booking_id,
-            booking_start: booking.booking_start,
-            booking_end: booking.booking_end,
-            resource_name: booking.resource_name,
-            price_amount: Number(booking.price_amount ?? 0),
-            owner_id: booking.owner_id,
-            owner_name: ownerPlayer?.name ?? null,
-            owner_email: ownerPlayer?.email ?? null,
-            participant_names: participantNames,
-            participant_emails: participantEmails,
-            api_payment_status: booking.payment_status,
-            coverage_status: cov?.effective_status ?? 'none',
-            coverage_pct: cov?.effective_pct ?? 0,
-            assigned_total: cov?.assigned_total ?? 0,
-            assigned_waitry_orders: cov?.waitry_order_ids ?? [],
-            online_csv_total: cov?.online_csv_total ?? 0,
-            manager_csv_total: cov?.manager_csv_total ?? 0,
-            has_unverified_manager: Boolean(cov?.has_unverified_manager),
-          };
+        const playerMap = new Map(players.map((p) => [p.playtomic_id, p]));
+        const participantsByBooking = new Map<string, ParticipantRow[]>();
+        for (const p of participants) {
+          const list = participantsByBooking.get(p.booking_id) ?? [];
+          list.push(p);
+          participantsByBooking.set(p.booking_id, list);
+        }
+
+        // Agrupa todos los productos por order_id para construir los items[]
+        // del candidato y para localizar el producto "Renta Cancha Padel"
+        // que alimenta unit_price/quantity de la heurística.
+        const productosByOrder = new Map<string, WaitryProductoRow[]>();
+        for (const prod of waitryProductos ?? []) {
+          const list = productosByOrder.get(prod.order_id) ?? [];
+          list.push(prod);
+          productosByOrder.set(prod.order_id, list);
+        }
+
+        const candidates: WaitryCandidate[] = (waitryPedidos ?? [])
+          .map((pedido) => {
+            const prods = productosByOrder.get(pedido.order_id);
+            if (!prods || prods.length === 0) return null;
+            const cancha = prods.find((p) => isCanchaProduct(p.product_name));
+            if (!cancha) return null;
+            const items: WaitryItem[] = prods.map((p) => ({
+              product_name: p.product_name,
+              quantity: Number(p.quantity ?? 0),
+              unit_price: Number(p.unit_price ?? 0),
+              total_price: Number(p.total_price ?? 0),
+            }));
+            return {
+              order_id: pedido.order_id,
+              timestamp: pedido.timestamp,
+              notes: pedido.notes,
+              total_amount: Number(pedido.total_amount ?? 0),
+              unit_price: Number(cancha.unit_price ?? 0),
+              quantity: Number(cancha.quantity ?? 1),
+              items,
+            };
+          })
+          .filter((c): c is WaitryCandidate => c !== null);
+
+        // Coverage efectiva (waitry + online_csv) por booking. Modelo nuevo:
+        // - effective_status='full' → totalmente trazable, sale del listado.
+        // - 'partial' / 'none' → aparecen para conciliar contra Waitry.
+        // - has_unverified_manager=true → flag visual: el manager marcó pagos
+        //   onsite en Playtomic pero no hay pedido equivalente en Waitry. Es
+        //   el caso central que la iniciativa caza (Hector et al).
+        type CoverageEntry = {
+          effective_status: CoverageStatus;
+          effective_pct: number;
+          assigned_total: number;
+          waitry_total: number;
+          online_csv_total: number;
+          manager_csv_total: number;
+          has_unverified_manager: boolean;
+          waitry_order_ids: string[];
+        };
+        const coverageByBooking = new Map<string, CoverageEntry>();
+        const assignedOrderIds = new Set<string>();
+        const assignmentsByBooking = new Map<string, AssignmentDetail[]>();
+        if (bookingIds.length > 0) {
+          // Mismo motivo que arriba: chunkeamos para no exceder el límite de URL.
+          const bookingIdChunks = chunkArray(bookingIds, BOOKING_ID_CHUNK);
+          const [coverageResponses, assignmentResponses] = await Promise.all([
+            Promise.all(
+              bookingIdChunks.map((chunk) =>
+                playtomic
+                  .from('v_bookings_total_coverage')
+                  .select(
+                    'booking_id,effective_status,effective_pct,effective_total,waitry_total,online_csv_total,manager_csv_total,has_unverified_manager,waitry_order_ids'
+                  )
+                  .in('booking_id', chunk)
+              )
+            ),
+            Promise.all(
+              bookingIdChunks.map((chunk) =>
+                playtomic
+                  .from('payment_assignments')
+                  .select('id,booking_id,waitry_order_id,assigned_amount,assigned_at,note')
+                  .in('booking_id', chunk)
+                  .order('assigned_at', { ascending: true })
+                  .returns<AssignmentRow[]>()
+              )
+            ),
+          ]);
+
+          const coverageRows: NonNullable<(typeof coverageResponses)[number]['data']> = [];
+          for (const res of coverageResponses) {
+            if (res.error) throw res.error;
+            if (res.data) coverageRows.push(...res.data);
+          }
+          const assignmentRows: AssignmentRow[] = [];
+          for (const res of assignmentResponses) {
+            if (res.error) throw res.error;
+            if (res.data) assignmentRows.push(...res.data);
+          }
+
+          for (const row of coverageRows ?? []) {
+            if (!row.booking_id) continue;
+            coverageByBooking.set(row.booking_id, {
+              effective_status: (row.effective_status as CoverageStatus | null) ?? 'none',
+              effective_pct: Number(row.effective_pct ?? 0),
+              assigned_total: Number(row.effective_total ?? 0),
+              waitry_total: Number(row.waitry_total ?? 0),
+              online_csv_total: Number(row.online_csv_total ?? 0),
+              manager_csv_total: Number(row.manager_csv_total ?? 0),
+              has_unverified_manager: Boolean(row.has_unverified_manager),
+              waitry_order_ids: row.waitry_order_ids ?? [],
+            });
+            for (const oid of row.waitry_order_ids ?? []) assignedOrderIds.add(oid);
+          }
+
+          for (const row of assignmentRows ?? []) {
+            // Defensa-en-profundidad: la vista `v_bookings_total_coverage`
+            // ya incluye los waitry_order_ids asignados, pero solo para los
+            // bookings consultados. Aquí poblamos también desde la tabla
+            // directa para asegurar que cualquier order asignada (visible
+            // o no en el listado) quede excluida de los candidatos.
+            assignedOrderIds.add(row.waitry_order_id);
+            const list = assignmentsByBooking.get(row.booking_id) ?? [];
+            list.push({
+              id: row.id,
+              waitry_order_id: row.waitry_order_id,
+              assigned_amount: Number(row.assigned_amount ?? 0),
+              assigned_at: row.assigned_at,
+              note: row.note,
+            });
+            assignmentsByBooking.set(row.booking_id, list);
+          }
+        }
+
+        const bookings: PendingBookingWithCoverage[] = bookingsList
+          // Filtra por cobertura EFECTIVA: si waitry + online_csv ya cubre el
+          // total, el booking sale del listado. Los partial y none aparecen,
+          // incluyendo bookings con `payment_status=PAID` agregado pero sin
+          // cobertura trazable (ahí está el "marcado paid sin Waitry").
+          // Excepción: bookings del deep-link (outOfFilterIds) siempre pasan
+          // — el operador llegó con un click explícito desde Historial y
+          // espera ver ese booking aunque ya esté full-cubierto.
+          .filter(
+            (booking) =>
+              outOfFilterIds.has(booking.booking_id) ||
+              (coverageByBooking.get(booking.booking_id)?.effective_status ?? 'none') !== 'full'
+          )
+          .map((booking) => {
+            const bookingParticipants = participantsByBooking.get(booking.booking_id) ?? [];
+            const ownerParticipant = bookingParticipants.find((p) => p.is_owner === true);
+            const ownerPlayer = ownerParticipant
+              ? playerMap.get(ownerParticipant.player_id)
+              : undefined;
+            const participantNames: string[] = [];
+            const participantEmails: string[] = [];
+            for (const p of bookingParticipants) {
+              const player = playerMap.get(p.player_id);
+              if (player?.name) participantNames.push(player.name);
+              if (player?.email) participantEmails.push(player.email);
+            }
+
+            const cov = coverageByBooking.get(booking.booking_id);
+
+            return {
+              booking_id: booking.booking_id,
+              booking_start: booking.booking_start,
+              booking_end: booking.booking_end,
+              resource_name: booking.resource_name,
+              price_amount: Number(booking.price_amount ?? 0),
+              owner_id: booking.owner_id,
+              owner_name: ownerPlayer?.name ?? null,
+              owner_email: ownerPlayer?.email ?? null,
+              participant_names: participantNames,
+              participant_emails: participantEmails,
+              api_payment_status: booking.payment_status,
+              coverage_status: cov?.effective_status ?? 'none',
+              coverage_pct: cov?.effective_pct ?? 0,
+              assigned_total: cov?.assigned_total ?? 0,
+              assigned_waitry_orders: cov?.waitry_order_ids ?? [],
+              online_csv_total: cov?.online_csv_total ?? 0,
+              manager_csv_total: cov?.manager_csv_total ?? 0,
+              has_unverified_manager: Boolean(cov?.has_unverified_manager),
+            };
+          });
+
+        setData({
+          bookings,
+          candidates,
+          assignedOrderIds,
+          assignmentsByBooking,
+          outOfFilterBookings: outOfFilterIds,
         });
-
-      setData({ bookings, candidates, assignedOrderIds, assignmentsByBooking });
-    } catch (err) {
-      setError(getSupabaseErrorMessage(err, 'No se pudo cargar la conciliación.'));
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  }, []);
+      } catch (err) {
+        setError(getSupabaseErrorMessage(err, 'No se pudo cargar la conciliación.'));
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [extraBookingId]
+  );
 
   useEffect(() => {
     void fetchData(false);


### PR DESCRIPTION
## Summary

Click en una fila del tab Historial → \`/rdb/playtomic/conciliacion?selected=<bookingId>\` y la vista Conciliación **pre-selecciona ese booking automáticamente** — incluso si ya está full-cubierto, fuera del rango 90d, etc.

Cierra el flujo operativo:
1. Estás auditando en el tab Historial.
2. Ves un evento sospechoso (ej. ⚠ Manager onsite sin Waitry equivalente, o una asignación que quieres revertir).
3. Click → te lleva a Conciliación con la reserva ya abierta.
4. Si el booking ya está conciliado, ves un banner azul explicativo y puedes ajustar/quitar asignaciones.

## Implementación

**Commit 1 — Deep-link inicial:**
- \`ConciliacionView\`: \`useSearchParams()\` lee \`selected\` en mount como state inicial.
- \`HistorialView\`: \`handleNavigateToBooking\` recibe el \`bookingId\` y lo pasa como query param.
- \`ConciliacionPage\`: \`<Suspense>\` boundary requerido por \`useSearchParams()\`.

**Commit 2 — Fix bookings full-cubiertos (post-feedback de Beto):**
- Hook \`useConciliacionData\` acepta \`extraBookingId\`. Si ese ID NO está en los pendientes filtrados, hace fetch específico y lo agrega al listado, marcándolo en \`outOfFilterBookings: Set<string>\`.
- El filter final excluye \`effective_status='full'\` SALVO los IDs en outOfFilterBookings.
- Banner azul al inicio del panel cuando el booking llegó por deep-link fuera del filtro normal.
- \`extraBookingId\` se captura en mount (state inicial). Clicks subsiguientes en otras reservas NO disparan re-fetch del hook.

## Edge cases manejados

- ✅ Booking en lista visible → comportamiento normal.
- ✅ Booking ya full-cubierto → fetch extra + banner.
- ✅ Booking fuera del rango 90d → fetch extra + banner.
- ✅ Booking que NO existe en BD → panel queda con placeholder (no crash).
- ✅ Link compartido (\`?selected=\`) funciona desde cualquier punto de entrada.

## Test plan

- [x] \`npm run typecheck\` verde
- [x] \`npm run test:run\` verde
- [x] \`npm run lint\` verde (0 errors)
- [x] \`npm run format:check\` verde
- [ ] Smoke en preview con un booking ya conciliado: confirmar banner azul + posibilidad de Quitar asignaciones existentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)