### PR TITLE
fix(playtomic-sync): convertir booking_start de America/Chicago a UTC (DRAFT — review antes de mergear)

### DIFF
--- a/supabase/functions/playtomic-sync/index.ts
+++ b/supabase/functions/playtomic-sync/index.ts
@@ -55,22 +55,9 @@ function parsePrice(priceStr?: string) {
  * Central) hay una hora ambigua. Para nuestro caso operativo (reservas
  * de cancha) ese 1 día/año con bookings raros a esa hora es aceptable.
  */
-function naiveChicagoIsoToUtc(naiveIso: string | null | undefined): string | null {
-  if (!naiveIso) return null;
-  // Si por algún motivo el API empieza a mandar con offset (Z o ±HH:MM), no tocamos.
-  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(naiveIso)) return naiveIso;
-
-  // Truco para descubrir el offset de America/Chicago en este instante:
-  // 1) Tomamos el naive como si fuera UTC (asIfUtc).
-  // 2) Formatemos asIfUtc en zona Chicago — el resultado es la hora wall-clock
-  //    de Chicago para ese instante UTC.
-  // 3) La diferencia entre el formato Chicago y asIfUtc nos da el offset Chicago
-  //    en milisegundos (negativo: Chicago va detrás de UTC).
-  // 4) Como el naive ES la hora wall-clock de Chicago, real UTC = asIfUtc - offset.
-  //    (offset es negativo, restar el valor negativo equivale a sumar la diferencia.)
-  const asIfUtc = new Date(naiveIso + 'Z');
-  if (Number.isNaN(asIfUtc.getTime())) return naiveIso;
-
+function chicagoOffsetMsAt(instant: Date): number {
+  // Devuelve cuántos ms está Chicago detrás de UTC en `instant`.
+  // CST = -21600000 ms (6h), CDT = -18000000 ms (5h).
   const fmt = new Intl.DateTimeFormat('en-CA', {
     timeZone: 'America/Chicago',
     year: 'numeric',
@@ -81,9 +68,31 @@ function naiveChicagoIsoToUtc(naiveIso: string | null | undefined): string | nul
     second: '2-digit',
     hour12: false,
   });
-  const parts = Object.fromEntries(fmt.formatToParts(asIfUtc).map((p) => [p.type, p.value]));
+  const parts = Object.fromEntries(fmt.formatToParts(instant).map((p) => [p.type, p.value]));
   const chicagoIso = `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}Z`;
-  const offsetMs = new Date(chicagoIso).getTime() - asIfUtc.getTime();
+  return new Date(chicagoIso).getTime() - instant.getTime();
+}
+
+function naiveChicagoIsoToUtc(naiveIso: string | null | undefined): string | null {
+  if (!naiveIso) return null;
+  // Si por algún motivo el API empieza a mandar con offset (Z o ±HH:MM), no tocamos.
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(naiveIso)) return naiveIso;
+
+  // El naive ISO representa el wall-clock de Chicago. Para convertirlo a UTC,
+  // necesitamos el offset de Chicago EN EL INSTANTE UTC equivalente — pero no
+  // lo sabemos antes de convertir. Resolvemos con dos iteraciones que convergen
+  // en los 2 días/año de transición DST (segundo domingo de marzo y primer
+  // domingo de noviembre).
+  const asIfUtc = new Date(naiveIso + 'Z');
+  if (Number.isNaN(asIfUtc.getTime())) return naiveIso;
+
+  // Iteración 1: usamos el naive-as-UTC como punto de partida.
+  let offsetMs = chicagoOffsetMsAt(asIfUtc);
+  // Iteración 2: usamos el UTC estimado (más preciso) para confirmar el offset.
+  // En días de transición DST, el offset puede cambiar entre asIfUtc y el real
+  // UTC, y esta segunda pasada lo corrige.
+  const estimatedUtc = new Date(asIfUtc.getTime() - offsetMs);
+  offsetMs = chicagoOffsetMsAt(estimatedUtc);
 
   return new Date(asIfUtc.getTime() - offsetMs).toISOString();
 }

--- a/supabase/functions/playtomic-sync/index.ts
+++ b/supabase/functions/playtomic-sync/index.ts
@@ -32,6 +32,62 @@ function parsePrice(priceStr?: string) {
   return { amount: parseFloat(match[1]), currency: match[2] || null };
 }
 
+/**
+ * Convierte un ISO string SIN offset (formato "YYYY-MM-DDTHH:MM:SS"),
+ * asumido en zona "America/Chicago" (Central Time con DST EE.UU.), a un
+ * ISO UTC con sufijo Z.
+ *
+ * Empíricamente, el third-party API de Playtomic devuelve los campos
+ * `booking_start_date` y `booking_end_date` en esa zona. Verificado vía
+ * cross-check contra `payments_import.service_date` que tiene UTC
+ * correcto (parseado del CSV con offset explícito):
+ *
+ *   - feb 2026 (sin DST EE.UU.): drift promedio = 0.00h.
+ *   - mar 2026 (post-8mar, DST EE.UU. activo): drift promedio = ~0.85h.
+ *   - abr/may 2026 (DST EE.UU.): drift promedio = ~0.90-1.00h.
+ *
+ * El club Matamoros opera en CST puro (UTC-6, sin DST), así que NO basta
+ * con un offset constante: la conversión debe respetar las reglas DST
+ * de America/Chicago para que en mayo el cálculo aplique -5h y en enero
+ * aplique -6h.
+ *
+ * Edge case: durante la transición DST (segundo domingo de marzo, 2-3 AM
+ * Central) hay una hora ambigua. Para nuestro caso operativo (reservas
+ * de cancha) ese 1 día/año con bookings raros a esa hora es aceptable.
+ */
+function naiveChicagoIsoToUtc(naiveIso: string | null | undefined): string | null {
+  if (!naiveIso) return null;
+  // Si por algún motivo el API empieza a mandar con offset (Z o ±HH:MM), no tocamos.
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(naiveIso)) return naiveIso;
+
+  // Truco para descubrir el offset de America/Chicago en este instante:
+  // 1) Tomamos el naive como si fuera UTC (asIfUtc).
+  // 2) Formatemos asIfUtc en zona Chicago — el resultado es la hora wall-clock
+  //    de Chicago para ese instante UTC.
+  // 3) La diferencia entre el formato Chicago y asIfUtc nos da el offset Chicago
+  //    en milisegundos (negativo: Chicago va detrás de UTC).
+  // 4) Como el naive ES la hora wall-clock de Chicago, real UTC = asIfUtc - offset.
+  //    (offset es negativo, restar el valor negativo equivale a sumar la diferencia.)
+  const asIfUtc = new Date(naiveIso + 'Z');
+  if (Number.isNaN(asIfUtc.getTime())) return naiveIso;
+
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = Object.fromEntries(fmt.formatToParts(asIfUtc).map((p) => [p.type, p.value]));
+  const chicagoIso = `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}Z`;
+  const offsetMs = new Date(chicagoIso).getTime() - asIfUtc.getTime();
+
+  return new Date(asIfUtc.getTime() - offsetMs).toISOString();
+}
+
 serve(async (req) => {
   const syncLogId = crypto.randomUUID();
   const startTime = new Date();
@@ -107,8 +163,20 @@ serve(async (req) => {
 
     for (const raw of allBookings) {
       const { amount, currency } = parsePrice(raw.price);
-      const bStart = raw.booking_start_date; // These come in UTC with Z or without, let's assume they are ISO UTC
-      const bEnd = raw.booking_end_date;
+      // El third-party API de Playtomic devuelve `booking_start_date` /
+      // `booking_end_date` SIN offset (formato "YYYY-MM-DDTHH:MM:SS").
+      // Empíricamente (verificado contra payments_import.service_date que
+      // tiene UTC correcto) los timestamps están en zona "America/Chicago"
+      // con DST EE.UU. automático. El club Matamoros opera en CST puro
+      // (UTC-6, sin DST). Resultado: en periodo DST EE.UU. (~mar-nov) hay
+      // 1h de drift; fuera de DST, drift = 0.
+      //
+      // Convertimos a UTC verdadero antes de guardar para que
+      // `bookings.booking_start` quede consistente con
+      // `payments_import.service_date` y la conciliación pueda usar una
+      // ventana ±15min en lugar de ±90min (TODO en otro PR).
+      const bStart = naiveChicagoIsoToUtc(raw.booking_start_date);
+      const bEnd = naiveChicagoIsoToUtc(raw.booking_end_date);
 
       const durationMin = raw.duration != null ? Math.floor(raw.duration / 60000) : null;
       const ownerId = raw.participant_info?.owner_id ? String(raw.participant_info.owner_id) : null;


### PR DESCRIPTION
## ⚠️ DRAFT

**No mergear sin validación previa.** Este PR cambia cómo el edge function `playtomic-sync` interpreta los timestamps del API. Requiere re-deploy de la edge function + plan de backfill controlado.

## Problema confirmado con datos

El third-party API de Playtomic devuelve `booking_start_date` y `booking_end_date` SIN offset (formato `"YYYY-MM-DDTHH:MM:SS"`). El sync los guardaba tal cual asumiéndolos como UTC. Empíricamente NO están en UTC sino en **zona "America/Chicago" con DST automático**.

Evidencia (cross-check vs `payments_import.service_date` que tiene UTC correcto del CSV con offset explícito):

| Periodo | Drift promedio | Samples |
|---|---:|---:|
| feb 2026 (sin DST EE.UU.) | 0.00 h | 562 |
| 9-mar 2026 (DST inicia 8-mar) | +0.84 h | 163 |
| mar/abr/may 2026 (DST activo) | +0.85 a +1.00h | ~1000 |

El club Matamoros opera en CST puro (UTC-6, sin DST), así que el sync dejaba bookings con 1h de drift durante el periodo DST EE.UU. Eso obligó a ampliar la ventana de match en `v_bookings_total_coverage` de ±15min a ±90min.

## Fix

Helper `naiveChicagoIsoToUtc()` que usa `Intl.DateTimeFormat` con `timeZone: 'America/Chicago'` para descubrir el offset correcto en cada instante (respeta DST automático), y convierte el naive ISO a UTC verdadero.

## Plan de validación (Beto, mañana)

1. **Test del helper standalone** (Deno o Node):
   - `feb 15 23:30` → `2026-02-16T05:30:00Z` (CST = UTC-6)
   - `may 5 00:30` → `2026-05-05T05:30:00Z` (CDT = UTC-5)
   - Booking de Hector (5-may 00:30 raw) debe quedar como `01:30 UTC` post-conversion, igualando el `service_date` del CSV.

2. **Deploy a staging si existe.** Trigger manual con `curl -X POST .../functions/v1/playtomic-sync`. Verificar que un par de bookings recientes ahora tienen `booking_start` correcto.

3. **Solo si validación pasa**: deploy a prod + trigger manual.

## Plan de backfill después del merge

4. Como el sync hace UPSERT, una ejecución manual con lookback 60d reescribe todos los bookings afectados. El cron normal (cada 30 min) también lo hace, pero forzar uno inmediato cierra el periodo de transición sin esperar.

5. PR de cleanup posterior (otro PR):
   - Cambia la ventana de match en `v_bookings_total_coverage` de ±90min a ±15min.
   - Refresca la vista (`CREATE OR REPLACE`).
   - Valida que el booking de Hector y otros de mayo siguen matchando.

## Riesgos

- **Transición DST** (segundo domingo de marzo, 2-3 AM Central): 1h ambigua. Aceptable para reservas de cancha (raro a esa hora).
- **Defensivo**: si Playtomic empieza a mandar offset (Z o ±HH:MM), el helper detecta el patrón y NO toca, asumiendo que ya viene correcto.
- **Bookings históricos > 60d** quedan con drift. Ya no aparecen en el dashboard (filtro 90d). Si surge necesidad, SQL UPDATE quirúrgico en otro PR.

Cierra TODO en migración `20260506010513_playtomic_coverage_effective.sql` (ventana ±90min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)