### PR TITLE
fix(playtomic-sync): corregir conversión de drift — fix del fix anterior

### DIFF
--- a/supabase/functions/playtomic-sync/index.ts
+++ b/supabase/functions/playtomic-sync/index.ts
@@ -33,27 +33,31 @@ function parsePrice(priceStr?: string) {
 }
 
 /**
- * Convierte un ISO string SIN offset (formato "YYYY-MM-DDTHH:MM:SS"),
- * asumido en zona "America/Chicago" (Central Time con DST EE.UU.), a un
- * ISO UTC con sufijo Z.
+ * Corrige los timestamps "naive" del third-party API de Playtomic
+ * sumándoles el ajuste DST EE.UU. cuando aplica.
  *
- * Empíricamente, el third-party API de Playtomic devuelve los campos
- * `booking_start_date` y `booking_end_date` en esa zona. Verificado vía
- * cross-check contra `payments_import.service_date` que tiene UTC
- * correcto (parseado del CSV con offset explícito):
+ * Empíricamente (verificado contra `payments_import.service_date` y
+ * `rdb.waitry_pedidos.timestamp`, ambos UTC verdaderos), el campo
+ * `booking_start_date` viene en formato "YYYY-MM-DDTHH:MM:SS" sin offset.
+ * Tratado como UTC, presenta un drift positivo durante DST EE.UU.:
  *
- *   - feb 2026 (sin DST EE.UU.): drift promedio = 0.00h.
- *   - mar 2026 (post-8mar, DST EE.UU. activo): drift promedio = ~0.85h.
- *   - abr/may 2026 (DST EE.UU.): drift promedio = ~0.90-1.00h.
+ *   - Fuera de DST EE.UU. (Chicago en CST = UTC-6): drift = 0.
+ *   - En DST EE.UU. (Chicago en CDT = UTC-5):       drift = +1h.
  *
- * El club Matamoros opera en CST puro (UTC-6, sin DST), así que NO basta
- * con un offset constante: la conversión debe respetar las reglas DST
- * de America/Chicago para que en mayo el cálculo aplique -5h y en enero
- * aplique -6h.
+ * Drift promedio por semana (drift_hrs = csv - booking_start):
+ *   - feb 2026 (pre-DST):           0.00 h
+ *   - 9-mar 2026 (DST inicia 8-mar): +0.84 h
+ *   - mar/abr/may 2026 (DST):       +0.85 a +1.00 h
  *
- * Edge case: durante la transición DST (segundo domingo de marzo, 2-3 AM
- * Central) hay una hora ambigua. Para nuestro caso operativo (reservas
- * de cancha) ese 1 día/año con bookings raros a esa hora es aceptable.
+ * El club Matamoros opera en CST puro (UTC-6, sin DST). Para alinear el
+ * `booking_start` guardado con la realidad operativa del club (que es lo
+ * que también refleja el CSV y los pedidos Waitry), sumamos al naive
+ * la diferencia entre el offset de Chicago en ese instante y el offset
+ * fijo CST. Eso da +1h en DST y 0h fuera.
+ *
+ * Edge case: durante la transición DST (2do domingo marzo, 1er domingo
+ * noviembre, 2-3 AM Central) hay una hora ambigua. Para reservas de
+ * cancha (raras a esas horas) es aceptable.
  */
 function chicagoOffsetMsAt(instant: Date): number {
   // Devuelve cuántos ms está Chicago detrás de UTC en `instant`.
@@ -73,28 +77,22 @@ function chicagoOffsetMsAt(instant: Date): number {
   return new Date(chicagoIso).getTime() - instant.getTime();
 }
 
+const CST_FIXED_OFFSET_MS = -6 * 60 * 60 * 1000; // CST puro = UTC-6 (zona Matamoros, sin DST).
+
 function naiveChicagoIsoToUtc(naiveIso: string | null | undefined): string | null {
   if (!naiveIso) return null;
   // Si por algún motivo el API empieza a mandar con offset (Z o ±HH:MM), no tocamos.
   if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(naiveIso)) return naiveIso;
 
-  // El naive ISO representa el wall-clock de Chicago. Para convertirlo a UTC,
-  // necesitamos el offset de Chicago EN EL INSTANTE UTC equivalente — pero no
-  // lo sabemos antes de convertir. Resolvemos con dos iteraciones que convergen
-  // en los 2 días/año de transición DST (segundo domingo de marzo y primer
-  // domingo de noviembre).
   const asIfUtc = new Date(naiveIso + 'Z');
   if (Number.isNaN(asIfUtc.getTime())) return naiveIso;
 
-  // Iteración 1: usamos el naive-as-UTC como punto de partida.
-  let offsetMs = chicagoOffsetMsAt(asIfUtc);
-  // Iteración 2: usamos el UTC estimado (más preciso) para confirmar el offset.
-  // En días de transición DST, el offset puede cambiar entre asIfUtc y el real
-  // UTC, y esta segunda pasada lo corrige.
-  const estimatedUtc = new Date(asIfUtc.getTime() - offsetMs);
-  offsetMs = chicagoOffsetMsAt(estimatedUtc);
+  // dstAdjustmentMs = cuánto adelanta Chicago respecto a CST puro EN ese
+  // instante. CDT (mayo): chicago=-5h, CST=-6h → diff = +1h. CST (febrero):
+  // chicago=-6h, CST=-6h → diff = 0.
+  const dstAdjustmentMs = chicagoOffsetMsAt(asIfUtc) - CST_FIXED_OFFSET_MS;
 
-  return new Date(asIfUtc.getTime() - offsetMs).toISOString();
+  return new Date(asIfUtc.getTime() + dstAdjustmentMs).toISOString();
 }
 
 serve(async (req) => {


### PR DESCRIPTION
## Summary

**El PR #433 hacía la transformación al revés.** En vez de corregir el drift, lo amplificó: el booking de Hector quedó como \`05:30 UTC\` cuando la verdad operativa es \`01:30 UTC\`.

## Causa del error en #433

El helper interpretaba el naive de Playtomic como **wall-clock de Chicago** y le restaba el offset (5h en CDT, 6h en CST). Pero la realidad empírica (verificada contra \`payments_import.service_date\` y \`rdb.waitry_pedidos.timestamp\`, ambos UTC verdaderos) es:

> El naive de Playtomic NO es wall-clock — **es un timestamp UTC con drift positivo durante DST EE.UU.** (mar-nov).

| Periodo | Drift observado (csv − booking_start) | Causa |
|---|---:|---|
| Fuera DST EE.UU. | **0 h** | Chicago = CST = UTC-6 = mismo que el club |
| En DST EE.UU. | **+1 h** | Chicago = CDT = UTC-5, club sigue en CST = UTC-6 |

## Fix correcto

```ts
const dstAdjustmentMs = chicagoOffsetMsAt(asIfUtc) - CST_FIXED_OFFSET_MS;
return new Date(asIfUtc.getTime() + dstAdjustmentMs).toISOString();
```

- Fuera de DST: \`chicago = -6h\` y \`CST = -6h\` → diff = 0 → no cambia.
- En DST: \`chicago = -5h\` y \`CST = -6h\` → diff = +1h → suma 1h al naive.

## Validación

| Caso | Input naive | Esperado | Por qué |
|---|---|---|---|
| feb 15 23:30 (pre-DST) | \`2026-02-15T23:30:00\` | \`2026-02-15T23:30:00.000Z\` | Sin cambio (CST = CST) |
| may 5 00:30 (DST EE.UU.) | \`2026-05-05T00:30:00\` | \`2026-05-05T01:30:00.000Z\` | +1h por DST |

El segundo caso coincide exactamente con el CSV de Hector (\`service_date = 2026-05-05 01:30+00\`) y la realidad operativa (19:30 CST = 01:30 UTC).

## Plan post-merge

1. **Deploy** la edge function:
   \`\`\`bash
   git checkout main && git pull
   supabase functions deploy playtomic-sync --project-ref ybklderteyhuugzfmxbi
   \`\`\`
2. **Trigger manual** del sync para reescribir los ~1100 bookings con la lógica nueva:
   \`\`\`bash
   ANON=$(grep -E "^NEXT_PUBLIC_SUPABASE_ANON_KEY=" .env.local | cut -d= -f2-)
   curl -X POST -H "Authorization: Bearer $ANON" -H "Content-Type: application/json" \
     https://ybklderteyhuugzfmxbi.supabase.co/functions/v1/playtomic-sync
   \`\`\`
3. **Verificar** que el booking de Hector quedó en \`01:30 UTC\` (no 05:30):
   \`\`\`sql
   SELECT booking_start FROM playtomic.bookings WHERE booking_id='852a871c-33a9-4c85-851c-02886aa9405a';
   \`\`\`

Después de eso (otro PR de cleanup): cambiar la ventana de match en \`v_bookings_total_coverage\` de ±90min a ±15min, ya que el drift desaparece.

## Lección aprendida

Mi script de validación inicial usaba expected values basados en mi interpretación equivocada del modelo. Por eso los 4 casos "pasaban" pero el resultado real era opuesto al correcto. **El verdadero ground truth eran los datos en BD** (\`payments_import.service_date\` y \`waitry_pedidos.timestamp\`), no mi razonamiento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)