### PR TITLE
fix(rdb/playtomic/conciliacion): ventana temporal simétrica (soporte pre-pago)

### DIFF
--- a/components/playtomic/conciliacion/assignment-panel.tsx
+++ b/components/playtomic/conciliacion/assignment-panel.tsx
@@ -350,19 +350,20 @@ export function AssignmentPanel({
             Candidatos en Waitry ({candidates.length})
           </h4>
           <span className="text-xs text-[var(--text-muted)]">
-            hasta {tolerancePresetLabel} después del booking · cancha (padel/tenis/pickleball/coach)
-            · pagados · no asignados
+            {tolerancePresetLabel} alrededor del booking · cancha (padel/tenis/pickleball/coach) ·
+            pagados · no asignados
           </span>
         </div>
         {candidates.length === 0 ? (
           <div className="space-y-2 rounded-xl border border-dashed border-[var(--border)] p-3 text-sm text-[var(--text-muted)]">
             <p>
-              Sin candidatos dentro de {tolerancePresetLabel} después del booking. Posibles razones:
+              Sin candidatos dentro de {tolerancePresetLabel} alrededor del booking. Posibles
+              razones:
             </p>
             <ul className="ml-4 list-disc space-y-1 text-xs">
               <li>
-                El cliente pagó atrasado (volvió al club días después y se cobró entonces) — ampliar
-                ventana.
+                El cliente pagó días antes (reservó y prepagó) o días después (volvió al club a
+                cobrar) — ampliar ventana temporal.
               </li>
               <li>La búsqueda en notes está activa y no hay coincidencias.</li>
               <li>

--- a/lib/playtomic/conciliacion.test.ts
+++ b/lib/playtomic/conciliacion.test.ts
@@ -96,30 +96,43 @@ describe('isWithinTimestampWindow', () => {
     expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-10T01:29:00Z')).toBe(true);
   });
 
-  it('accepts pre-booking only within 30min grace (pago al llegar)', () => {
+  it('accepts pre-booking candidates within the same tolerance (pago anticipado)', () => {
+    // Caso operativo: el cliente reserva y paga en caja días antes de jugar
+    // (coach Paco Palacios pagó 27-abr para jugar 4-may). La ventana es
+    // simétrica para soportarlo.
     // 5 min antes — paga al registrarse
     expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T01:25:00Z')).toBe(true);
-    // 25 min antes — todavía dentro del grace
+    // 25 min antes — todavía dentro
     expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T01:05:00Z')).toBe(true);
+    // 1 día antes — pago anticipado típico
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-07T01:30:00Z')).toBe(true);
+    // 2 días antes (justo en el límite simétrico)
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-06T01:31:00Z')).toBe(true);
   });
 
-  it('rejects candidates more than 30min before the booking', () => {
-    // 31 min antes — pago en cancha jamás se hace tan temprano
-    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T00:59:00Z')).toBe(false);
-    // Días antes — claramente no es pago en cancha
-    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-07T01:30:00Z')).toBe(false);
-  });
-
-  it('rejects candidates beyond the post-booking tolerance', () => {
+  it('rejects candidates beyond the tolerance on either side', () => {
+    // 2d + 1min después
     expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-10T01:31:00Z')).toBe(false);
+    // 2d + 1min antes
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-06T01:29:00Z')).toBe(false);
   });
 
-  it('respects custom post tolerance', () => {
+  it('respects custom tolerance symmetrically', () => {
     const oneHour = 60 * 60 * 1000;
+    // ±1h: 30min después → dentro
     expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T02:00:00Z', oneHour)).toBe(
       true
     );
+    // ±1h: 1h+1min después → fuera
     expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T02:31:00Z', oneHour)).toBe(
+      false
+    );
+    // ±1h: 30min antes → dentro
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T01:00:00Z', oneHour)).toBe(
+      true
+    );
+    // ±1h: 1h+1min antes → fuera
+    expect(isWithinTimestampWindow('2026-04-08T01:30:00Z', '2026-04-08T00:29:00Z', oneHour)).toBe(
       false
     );
   });
@@ -138,7 +151,9 @@ describe('rankCandidates', () => {
     expect(ranked.map((r) => r.order_id)).toEqual(['near']);
   });
 
-  it('rejects candidates that "paid" days before the booking — pago en cancha es siempre post-booking', () => {
+  it('accepts pre-booking pagos within the symmetric tolerance (pago anticipado)', () => {
+    // Caso operativo (Paco Palacios): cliente reserva y paga en caja
+    // días antes de jugar. La ventana es simétrica para verlo.
     const dayBefore = candidate({
       order_id: 'day-before',
       timestamp: '2026-04-07T15:00:00Z',
@@ -150,11 +165,12 @@ describe('rankCandidates', () => {
       notes: 'jose Luis paz',
     });
     const ranked = rankCandidates(baseBooking, [dayBefore, dayAfter]);
-    expect(ranked.map((r) => r.order_id)).not.toContain('day-before');
+    // Ambos dentro de ±2d default → ambos aparecen
+    expect(ranked.map((r) => r.order_id)).toContain('day-before');
     expect(ranked.map((r) => r.order_id)).toContain('day-after');
   });
 
-  it('accepts pre-booking pagos within the 30min grace (cliente paga al llegar)', () => {
+  it('accepts pre-booking pagos at any distance within tolerance', () => {
     const fiveBefore = candidate({
       order_id: 'just-before',
       timestamp: '2026-04-08T01:25:00Z',

--- a/lib/playtomic/conciliacion.ts
+++ b/lib/playtomic/conciliacion.ts
@@ -145,12 +145,14 @@ export type RankedCandidate = WaitryCandidate & {
   reasons: string[];
 };
 
-// Ventana temporal asimétrica. El pago en cancha SIEMPRE ocurre después
-// del booking_start (el cliente llega a recepción al momento de jugar o
-// días después al volver al club). Pre-grace fijo de 30 minutos para
-// pagos al llegar (cliente paga al registrarse, justo antes de empezar).
-// El preset que ajusta el operador controla solo la cola POST-booking.
-const PRE_BOOKING_GRACE_MS = 30 * 60 * 1000;
+// Ventana temporal simétrica. La asunción original "el pago siempre
+// ocurre después del booking_start" no se sostiene: hay clientes que
+// reservan y pagan en caja días antes del juego (ej. coach Paco
+// Palacios pagó 27-abr para jugar 4-may). Antes la ventana solo tenía
+// 30min de pre-grace y el preset solo aplicaba a la cola post-booking,
+// dejando esos pre-pagos invisibles. Ahora el preset aplica a ambos
+// lados — el ranker pondera por proximidad temporal así que
+// candidatos lejanos quedan abajo del orden.
 const DEFAULT_TIMESTAMP_TOLERANCE_MS = 2 * 24 * 60 * 60 * 1000;
 export const TIMESTAMP_TOLERANCE_PRESETS_MS = {
   '3h': 3 * 60 * 60 * 1000,
@@ -181,13 +183,13 @@ function nameTokens(name: string): string[] {
 export function isWithinTimestampWindow(
   bookingStart: string,
   candidateTimestamp: string,
-  postToleranceMs: number = DEFAULT_TIMESTAMP_TOLERANCE_MS
+  toleranceMs: number = DEFAULT_TIMESTAMP_TOLERANCE_MS
 ): boolean {
   const bookingMs = new Date(bookingStart).getTime();
   const candidateMs = new Date(candidateTimestamp).getTime();
   if (Number.isNaN(bookingMs) || Number.isNaN(candidateMs)) return false;
-  const delta = candidateMs - bookingMs;
-  return delta >= -PRE_BOOKING_GRACE_MS && delta <= postToleranceMs;
+  const delta = Math.abs(candidateMs - bookingMs);
+  return delta <= toleranceMs;
 }
 
 export function rankCandidates(


### PR DESCRIPTION
## Caso operativo (reportado por Beto)

> Esta reserva tiene un pago del día 29 de abril, pero aunque le pongamos 30 días en la ventana temporal no aparecen pagos de antes del 4 de mayo, algo está limitando los pagos que salen.

Booking: 4-may 09:00, Padel 1 "Autos del Norte", $300, owner Paco Palacios.
Pedido Waitry [`17084321`]: 27-abr 21:25, $200, notes="paco palacios cancha".

Diferencia: -6.48 días (pre-pago).

## Causa raíz

`isWithinTimestampWindow` en [lib/playtomic/conciliacion.ts](lib/playtomic/conciliacion.ts) tenía ventana **asimétrica**:

```ts
const PRE_BOOKING_GRACE_MS = 30 * 60 * 1000;   // 30 min pre-booking
const delta = candidateMs - bookingMs;
return delta >= -PRE_BOOKING_GRACE_MS && delta <= postToleranceMs;
```

La asunción original: "el pago en cancha siempre ocurre **después** del booking_start" (cliente llega al club al momento de jugar). El preset (3h/1d/2d/7d/30d) solo extendía la cola **post**, dejando los pre-pagos invisibles aunque el operador subiera la ventana al máximo.

## Fix

Ventana **simétrica** — el preset aplica a ambos lados:

```ts
const delta = Math.abs(candidateMs - bookingMs);
return delta <= toleranceMs;
```

El ranker ya pondera por `proximityScore`, así que candidatos lejanos quedan abajo en el orden — no introduce ruido visible.

## Verificación

| Preset | Caso Paco (-6.48d) |
|--------|--------------------|
| ±3h    | no aparece (correcto) |
| ±1d    | no aparece (correcto) |
| ±2d    | no aparece (correcto) |
| ±7d    | **SÍ aparece** |
| ±30d   | **SÍ aparece** |

Antes: nunca aparecía, sin importar el preset.

## Cambios

- `isWithinTimestampWindow`: ventana simétrica con `|delta| <= toleranceMs`
- `PRE_BOOKING_GRACE_MS` eliminado (innecesario con preset simétrico)
- Tests actualizados en `lib/playtomic/conciliacion.test.ts`
- UI copy: "hasta {preset} después del booking" → "{preset} alrededor del booking"
- Mensaje vacío incluye "pago anticipado" como razón posible

## Test plan

- [x] `npm run typecheck` (verde)
- [x] `npm run test:run` (38 files, 695 tests verde — uno menos por test fusionado)
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check` (verde)
- [x] Verificar caso Paco con simulación local
- [ ] Smoke test post-merge: abrir reserva del 4-may 09:00 con preset ±7d, confirmar que pedido `17084321` aparece como candidato

🤖 Generated with [Claude Code](https://claude.com/claude-code)