### PR TITLE
feat(rdb/playtomic/conciliacion): badge "🤖 Sugerido auto" para dry-run de auto-conciliación

### DIFF
--- a/components/playtomic/conciliacion/assignment-panel.tsx
+++ b/components/playtomic/conciliacion/assignment-panel.tsx
@@ -387,13 +387,16 @@ export function AssignmentPanel({
                 (candidate.shared_with_bookings_count ?? 0) > 0 &&
                 (candidate.assigned_to_other_bookings ?? 0) > 0;
               const remaining = candidate.remaining_amount ?? candidate.total_amount;
+              const isAutoMatch = candidate.is_auto_match === true;
               return (
                 <li
                   key={candidate.order_id}
                   className={`flex items-start justify-between gap-3 rounded-xl border p-3 text-sm transition-colors ${
                     isSelected
                       ? 'border-emerald-500/40 bg-emerald-500/10'
-                      : 'border-[var(--border)] bg-[var(--panel)]/20'
+                      : isAutoMatch
+                        ? 'border-cyan-500/50 bg-cyan-500/5 ring-1 ring-cyan-500/40'
+                        : 'border-[var(--border)] bg-[var(--panel)]/20'
                   }`}
                 >
                   <div className="min-w-0 flex-1 space-y-1">
@@ -425,6 +428,14 @@ export function AssignmentPanel({
                           title={`Asignado a ${candidate.shared_with_bookings_count} reserva${candidate.shared_with_bookings_count === 1 ? '' : 's'} previa${candidate.shared_with_bookings_count === 1 ? '' : 's'} por ${formatMoney(candidate.assigned_to_other_bookings ?? 0)}`}
                         >
                           Pago compartido
+                        </span>
+                      ) : null}
+                      {isAutoMatch ? (
+                        <span
+                          className="rounded-full border border-cyan-500/40 bg-cyan-500/10 px-2 py-0.5 text-xs text-cyan-200"
+                          title={`Cumple criterios para auto-conciliación: ${(candidate.auto_match_reasons ?? []).join(' · ')}. Cuando activemos auto-conciliación, este pedido se asignaría automáticamente.`}
+                        >
+                          🤖 Sugerido auto
                         </span>
                       ) : null}
                     </div>

--- a/lib/playtomic/conciliacion.test.ts
+++ b/lib/playtomic/conciliacion.test.ts
@@ -446,4 +446,107 @@ describe('rankCandidates', () => {
       expect(ranked[0].order_id).toBe('court-only');
     });
   });
+
+  // Auto-match eligibility (modo dry-run): el candidato se marca con
+  // is_auto_match=true SOLO cuando cumple TODOS los criterios duros.
+  // Pablo lo ve como sugerencia visual mientras concilia manual.
+  describe('auto-match eligibility (dry-run)', () => {
+    it('marks candidate with is_auto_match=true when all signals align', () => {
+      // Cancha exacta + nombre del owner + monto del booking completo + ±15min + saldo
+      const idealMatch = candidate({
+        order_id: 'ideal',
+        timestamp: '2026-04-08T01:35:00Z',
+        total_amount: 800,
+        unit_price: 200,
+        notes:
+          'Pista\nPadel 5 "Mueblería Guillen"\nFecha\n7 abr 2026\nHora\n08:30 p.m.\njose luis paz',
+        items: [
+          { product_name: 'Renta Cancha Padel', quantity: 4, unit_price: 200, total_price: 800 },
+        ],
+      });
+      const ranked = rankCandidates(baseBooking, [idealMatch]);
+      expect(ranked[0].is_auto_match).toBe(true);
+      expect(ranked[0].auto_match_reasons?.length).toBeGreaterThan(0);
+    });
+
+    it('does NOT mark when court matches but owner/participant is not in notes', () => {
+      const courtNoOwner = candidate({
+        order_id: 'court-no-owner',
+        timestamp: '2026-04-08T01:35:00Z',
+        total_amount: 800,
+        notes: 'Pista\nPadel 5 "Mueblería Guillen"\nFecha\n7 abr 2026',
+      });
+      const ranked = rankCandidates(baseBooking, [courtNoOwner]);
+      expect(ranked[0].is_auto_match).toBe(false);
+    });
+
+    it('does NOT mark when owner is in notes but court is not', () => {
+      const ownerNoCourt = candidate({
+        order_id: 'owner-no-court',
+        timestamp: '2026-04-08T01:35:00Z',
+        total_amount: 800,
+        notes: 'jose luis paz efectivo',
+      });
+      const ranked = rankCandidates(baseBooking, [ownerNoCourt]);
+      expect(ranked[0].is_auto_match).toBe(false);
+    });
+
+    it('does NOT mark when notes mention a different court (penalty active)', () => {
+      const wrongCourt = candidate({
+        order_id: 'wrong-court',
+        timestamp: '2026-04-08T01:35:00Z',
+        total_amount: 800,
+        notes:
+          'Pista\nPadel 1 "Autos del Norte"\nFecha\n7 abr 2026\nHora\n08:30 p.m.\njose luis paz',
+      });
+      const ranked = rankCandidates(baseBooking, [wrongCourt]);
+      expect(ranked[0].is_auto_match).toBe(false);
+    });
+
+    it('does NOT mark when timestamp is outside ±15 min window', () => {
+      // 30 min después: dentro de la ventana ±2d default pero fuera de ±15min
+      const farTimestamp = candidate({
+        order_id: 'far-time',
+        timestamp: '2026-04-08T02:00:00Z',
+        total_amount: 800,
+        notes: 'Pista\nPadel 5 "Mueblería Guillen"\nFecha\n7 abr 2026\njose luis paz',
+        items: [
+          { product_name: 'Renta Cancha Padel', quantity: 4, unit_price: 200, total_price: 800 },
+        ],
+      });
+      const ranked = rankCandidates(baseBooking, [farTimestamp]);
+      expect(ranked[0].is_auto_match).toBe(false);
+    });
+
+    it('does NOT mark when amount does not match any expected bucket', () => {
+      // Monto raro: $500 con 4 jugadores ($200 c/u esperado, ±15%) — no encaja
+      const oddAmount = candidate({
+        order_id: 'odd-amount',
+        timestamp: '2026-04-08T01:35:00Z',
+        total_amount: 500,
+        unit_price: 500,
+        notes: 'Pista\nPadel 5 "Mueblería Guillen"\nFecha\n7 abr 2026\njose luis paz',
+        items: [
+          { product_name: 'Renta Cancha Padel', quantity: 1, unit_price: 500, total_price: 500 },
+        ],
+      });
+      const ranked = rankCandidates(baseBooking, [oddAmount]);
+      expect(ranked[0].is_auto_match).toBe(false);
+    });
+
+    it('does NOT mark when remaining_amount is zero (split-payment fully consumed)', () => {
+      const consumed = candidate({
+        order_id: 'consumed',
+        timestamp: '2026-04-08T01:35:00Z',
+        total_amount: 800,
+        remaining_amount: 0,
+        notes: 'Pista\nPadel 5 "Mueblería Guillen"\nFecha\n7 abr 2026\njose luis paz',
+        items: [
+          { product_name: 'Renta Cancha Padel', quantity: 4, unit_price: 200, total_price: 800 },
+        ],
+      });
+      const ranked = rankCandidates(baseBooking, [consumed]);
+      expect(ranked[0].is_auto_match).toBe(false);
+    });
+  });
 });

--- a/lib/playtomic/conciliacion.ts
+++ b/lib/playtomic/conciliacion.ts
@@ -143,7 +143,23 @@ export type WaitryCandidate = {
 export type RankedCandidate = WaitryCandidate & {
   score: number;
   reasons: string[];
+  /**
+   * Marcado true cuando el candidato cumple criterios duros de
+   * "auto-conciliación" (modo dry-run): cancha exacta en notas + nombre
+   * de owner/participante en notas + monto coincide con bucket esperado
+   * + timestamp dentro de ±15min + pedido con saldo. Pablo lo ve como
+   * sugerencia visual mientras concilia manual; en el futuro un cron
+   * podría aplicarlo automáticamente.
+   */
+  is_auto_match?: boolean;
+  /** Razones específicas que hicieron al candidato elegible para auto-match. */
+  auto_match_reasons?: string[];
 };
+
+// Criterios duros para "auto-conciliación" en modo dry-run. Conservadores
+// a propósito — solo marca un candidato cuando hay match casi-certain por
+// la combinación de señales, no por una sola.
+const AUTO_MATCH_TIME_WINDOW_MS = 15 * 60 * 1000;
 
 // Ventana temporal simétrica. La asunción original "el pago siempre
 // ocurre después del booking_start" no se sostiene: hay clientes que
@@ -174,10 +190,27 @@ function normalizeForMatch(text: string | null | undefined): string {
   return (text ?? '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').trim();
 }
 
+// Stopwords cortos en nombres de personas (español). Filtrarlos evita
+// falsos positivos cuando el token coincide por casualidad con palabras
+// del bloque Playtomic en notas Waitry — ej. "del" (de "Gerardo Del
+// Toro") matchearía siempre con "pa[del]" en la nota estructurada.
+const NAME_TOKEN_STOPWORDS = new Set([
+  'del',
+  'los',
+  'las',
+  'san',
+  'que',
+  'por',
+  'mar',
+  'rey',
+  'sol',
+  'sur',
+]);
+
 function nameTokens(name: string): string[] {
   return normalizeForMatch(name)
     .split(/\s+/)
-    .filter((token) => token.length >= 3);
+    .filter((token) => token.length >= 3 && !NAME_TOKEN_STOPWORDS.has(token));
 }
 
 // Las hostes/Pablo copian/pegan el bloque "Pista / Padel N "Sponsor" /
@@ -366,7 +399,53 @@ export function rankCandidates(
         }
       }
 
-      return { ...candidate, score, reasons };
+      // ─── Elegibilidad para auto-conciliación (modo dry-run) ───────────
+      // Criterios DUROS, no por threshold de score: queremos certeza, no
+      // optimismo. Las cuatro señales abajo deben estar TODAS presentes:
+      const autoMatchReasons: string[] = [];
+      const candidateMsAbs = Math.abs(candidateMs - bookingMs);
+      const withinTightWindow = candidateMsAbs <= AUTO_MATCH_TIME_WINDOW_MS;
+
+      const matchedExactCourt = reasons.some(
+        (r) => r.includes('cancha exacta') || r.includes('copia/pega del booking')
+      );
+      const matchedNamesInNotes = reasons.some((r) => r.toLowerCase().includes('notes coinciden'));
+      const matchedOtherCourt = reasons.some((r) => r.includes('otra cancha'));
+      const matchedAmountBucket = reasons.some(
+        (r) =>
+          r.includes('Total del ticket coincide') ||
+          r.includes('cubre la cancha completa') ||
+          r.includes('Unit price coincide con el monto por jugador')
+      );
+
+      // Saldo del pedido: si el candidato lleva remaining_amount (split-payment
+      // tracking), respetarlo; si no, asumir que `total_amount` está disponible.
+      const candidateRemaining = candidate.remaining_amount ?? candidate.total_amount;
+      const hasUsableRemaining = candidateRemaining > 0.01;
+
+      if (
+        withinTightWindow &&
+        matchedExactCourt &&
+        matchedNamesInNotes &&
+        matchedAmountBucket &&
+        hasUsableRemaining &&
+        !matchedOtherCourt
+      ) {
+        autoMatchReasons.push('Cancha exacta en nota');
+        autoMatchReasons.push('Nombre del owner/participante en nota');
+        autoMatchReasons.push('Monto coincide con bucket esperado del booking');
+        autoMatchReasons.push('Pedido dentro de ±15 min del booking');
+      }
+
+      const isAutoMatch = autoMatchReasons.length > 0;
+
+      return {
+        ...candidate,
+        score,
+        reasons,
+        is_auto_match: isAutoMatch,
+        auto_match_reasons: isAutoMatch ? autoMatchReasons : undefined,
+      };
     })
     .sort((a, b) => b.score - a.score);
 }


### PR DESCRIPTION
## Caso (idea de Beto)

> ¿No se pudiera hacer automática esa conciliación si son match 100%? Mejor solo marcárselo a Pablo como candidato a auto-conciliación y que él siga conciliando manual y después de un tiempo le preguntamos si todos los candidatos aplicaban correctamente.

## Cambios

### Lógica (`lib/playtomic/conciliacion.ts`)

`RankedCandidate` ahora puede llevar `is_auto_match: boolean` y `auto_match_reasons: string[]`.

Criterios **DUROS** (todos deben cumplirse — sin threshold de score):

1. **Cancha exacta** del booking aparece literal en notes
2. **Owner o participante** también mencionado en notes
3. **Monto coincide** con bucket esperado (price, price/N, N×price/M)
4. **Timestamp dentro de ±15 min** del booking_start
5. **Saldo disponible** (`remaining_amount > 0`)
6. NO menciona otra cancha (sin penalty `-100`)

Conservador a propósito — queremos certeza, no optimismo.

### UI (`assignment-panel.tsx`)

- Borde + ring **cyan distintivo** en el card del candidato elegible
- Badge **"🤖 Sugerido auto"** junto a los otros badges, con tooltip de las razones
- No interfiere con selección manual

### Bug latente arreglado

En el camino encontré que `nameTokens` filtraba por `length >= 3` pero no filtraba stopwords. **El token `"del"` (de "Gerardo Del Toro Garibay") matcheaba la palabra `"padel"` en cualquier nota estructurada**, generando falsos positivos en el reason "Notes coinciden con un participante" en TODA reserva.

Fix: agregada blacklist `NAME_TOKEN_STOPWORDS` con `del/los/las/san/que/por/mar/rey/sol/sur`.

## Plan de adopción

| Fase | Acción |
|------|--------|
| **1. Dry-run** (este PR) | Pablo concilia manual + ve el badge. Validamos el match rate. |
| **2. Cron auto** | Si tasa de acierto >95%, agregamos cron que aplica los matches. Auditoría con `is_auto: bool` en `payment_assignments`. |

## Test plan

- [x] `npm run typecheck` (verde)
- [x] `npm run test:run` (38 files, 706 tests verde — +7 nuevos)
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check` (verde)
- [ ] Smoke test post-merge: abrir Conciliación, validar que candidatos con cancha+nombre+monto correctos muestran badge cyan
- [ ] Validar después de 1-2 semanas: pedirle a Pablo confirmación de que los "Sugerido auto" eran 100% correctos

## Tests nuevos (7)

`describe('auto-match eligibility (dry-run)')`:
1. Match ideal → `is_auto_match=true`
2. Cancha sin owner → `false`
3. Owner sin cancha → `false`
4. Cancha distinta (penalty) → `false`
5. Timestamp fuera de ±15min → `false`
6. Monto no encaja en bucket → `false`
7. `remaining_amount=0` → `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)