### PR TITLE
chore: instala path-data-parser como devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
+        "path-data-parser": "^0.1.0",
         "pg": "^8.20.0",
         "prettier": "^3.8.3",
         "tailwindcss": "^4.2.2",
@@ -11129,6 +11130,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "path-data-parser": "^0.1.0",
     "pg": "^8.20.0",
     "prettier": "^3.8.3",
     "tailwindcss": "^4.2.2",


### PR DESCRIPTION
## Summary

- Agrega `path-data-parser@0.1.0` (MIT, 33KB, sin deps) como devDep
- Habilita edición programática de paths SVG en `scripts/branding/` sin recurrir a regex frágil sobre el atributo `d`

## Contexto

En el PR #453 (branding SANREN) se necesitó mover subpaths de la "A" del wordmark del path naranja al path negro. Se hizo con regex+split manual; funcionó pero es frágil. Para futuros logos donde se necesite cirugía similar a nivel subpath, esta lib provee el parser correcto.

## Test plan

- [ ] CI verde (typecheck, tests, lint, format, drift-check)
- [ ] Verificar que `npm install` reproduce desde `package-lock.json`