### PR TITLE
fix(rdb/playtomic/conciliacion): tooltip auto-match dice ±120 min (no ±15)

### DIFF
--- a/docs/planning/rdb-pagos-cancha-conciliacion.md
+++ b/docs/planning/rdb-pagos-cancha-conciliacion.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-05-04
-**Última actualización:** 2026-05-07 (refinamiento de cobertura efectiva: ventana temporal simétrica, wallet con `non_applicable_total`, boost por cancha en notes, badge dry-run de auto-conciliación)
+**Última actualización:** 2026-05-08 (fix stale en tooltip auto-match post-review Codex CLI: ±120 min, no ±15)
 
 ## Problema
 
@@ -165,6 +165,7 @@ KPIs visibles en el dashboard:
   - [#444](https://github.com/beto-sudo/BSOP/pull/444) — Ventana temporal simétrica. La asunción "pago siempre post-booking" rompe en pre-pago anticipado (caso Paco Palacios pagó 27-abr para jugar 4-may). Eliminado `PRE_BOOKING_GRACE_MS` fijo de 30min, ahora preset aplica a ambos lados.
   - [#449](https://github.com/beto-sudo/BSOP/pull/449) — Boost por cancha en notes. Las hostes/Pablo copian/pegan el bloque "Pista / Padel N \"Sponsor\" / Fecha / Hora" desde Playtomic Manager. Match exacto del `resource_name` en notes → +80 score. Mismatch ("padel 1" vs "padel 5") → -100. Auto-pick visual cuando la nota está bien.
   - [#450](https://github.com/beto-sudo/BSOP/pull/450) — Badge "🤖 Sugerido auto" (dry-run). `is_auto_match` se marca con criterios duros (cancha exacta + owner en notas + monto coincide + ±15min + saldo). Pablo concilia manual mientras valida tasa de acierto. Si >95% en 1-2 semanas → cron real. Bug fix descubierto: stopword "del" causaba falsos positivos por la palabra "pa**del**" — agregada blacklist `NAME_TOKEN_STOPWORDS`.
+- **2026-05-08** — Stale references catchadas en post-review con Codex CLI (segundo modelo). [#452](https://github.com/beto-sudo/BSOP/pull/452) había expandido la ventana de auto-match a ±120 min (`AUTO_MATCH_TIME_WINDOW_MS = 120 * 60 * 1000`) pero dejó dos sitios desincronizados: el string user-facing del tooltip "🤖 Sugerido auto" (`'Pedido dentro de ±15 min del booking'`, L442 — mentía al usuario en pagos a 16–120 min del booking) y el comentario JSDoc de `RankedCandidate.is_auto_match` (L150). **Fix [#456](https://github.com/beto-sudo/BSOP/pull/456)**: ambas referencias → ±120 min. Cambio mínimo (2 líneas), sin tocar lógica.
 
 ## Estado tras S2-CSV (snapshot 2026-05-04 noche)
 

--- a/lib/playtomic/conciliacion.ts
+++ b/lib/playtomic/conciliacion.ts
@@ -147,7 +147,7 @@ export type RankedCandidate = WaitryCandidate & {
    * Marcado true cuando el candidato cumple criterios duros de
    * "auto-conciliación" (modo dry-run): cancha exacta en notas + nombre
    * de owner/participante en notas + monto coincide con bucket esperado
-   * + timestamp dentro de ±15min + pedido con saldo. Pablo lo ve como
+   * + timestamp dentro de ±120min + pedido con saldo. Pablo lo ve como
    * sugerencia visual mientras concilia manual; en el futuro un cron
    * podría aplicarlo automáticamente.
    */
@@ -439,7 +439,7 @@ export function rankCandidates(
         autoMatchReasons.push('Cancha exacta en nota');
         autoMatchReasons.push('Nombre del owner/participante en nota');
         autoMatchReasons.push('Monto coincide con bucket esperado del booking');
-        autoMatchReasons.push('Pedido dentro de ±15 min del booking');
+        autoMatchReasons.push('Pedido dentro de ±120 min del booking');
       }
 
       const isAutoMatch = autoMatchReasons.length > 0;


### PR DESCRIPTION
## Summary

- **L442 (user-facing P3)**: la razón mostrada en el tooltip del panel "🤖 Sugerido auto" decía `'Pedido dentro de ±15 min del booking'` cuando la ventana real ya es `±120min`. Para pagos a 16–120min del booking, el tooltip mentía al usuario.
- **L150 (comentario stale)**: el JSDoc de `RankedCandidate.is_auto_match` mencionaba `±15min` mientras la constante `AUTO_MATCH_TIME_WINDOW_MS` (L167) ya es `120 * 60 * 1000`.

## Context

[PR #452](https://github.com/beto-sudo/BSOP/pull/452) (`af0b8ef`) expandió la ventana de auto-match de ±15min a ±120min, pero dejó estos dos sitios desincronizados con la nueva constante. Hallazgo de revisión post-merge con Codex CLI (segundo modelo); verificado real, no falso positivo.

Cambio mínimo: solo strings/comentario. La lógica (`AUTO_MATCH_TIME_WINDOW_MS`) ya estaba correcta desde PR #452.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 708/708 verde
- [x] `npm run lint` — 0 errors (warnings preexistentes)
- [x] `npm run format:check` — clean
- [ ] Smoke en preview: abrir un pedido sugerido auto en `/rdb/pagos-cancha/conciliacion`, verificar tooltip de "🤖 Sugerido auto" dice "±120 min"