### PR TITLE
feat(rdb/playtomic/import-csv): status card del último sync (cron vs manual)

### DIFF
--- a/app/rdb/playtomic/import-csv/page.tsx
+++ b/app/rdb/playtomic/import-csv/page.tsx
@@ -1,18 +1,28 @@
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { ImportCsvView } from '@/components/playtomic/import-csv/import-csv-view';
+import { getPaymentsImportStatusView } from '@/lib/playtomic/import-status';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
 
 /**
  * @module Import CSV de pagos Playtomic (RDB)
  * @responsive desktop-only
  *
  * Gate de acceso + tabs compartidos viven en `app/rdb/playtomic/layout.tsx`.
+ *
+ * Desde PR #470 (cron diario 03:00 CST) esta página queda como respaldo
+ * para uploads especiales / backfills. El status card de arriba muestra
+ * el estado del último sync para que el operador sepa si hace falta
+ * subir algo a mano.
  */
-export default function ImportCsvPage() {
+export default async function ImportCsvPage() {
+  const supabase = await createSupabaseServerClient();
+  const { status, lastSyncRelative, tone } = await getPaymentsImportStatusView(supabase);
+
   return (
     <>
       <DesktopOnlyNotice module="Import CSV Playtomic" />
       <div className="hidden sm:block">
-        <ImportCsvView />
+        <ImportCsvView initialStatus={status} lastSyncRelative={lastSyncRelative} syncTone={tone} />
       </div>
     </>
   );

--- a/components/playtomic/import-csv/import-csv-view.tsx
+++ b/components/playtomic/import-csv/import-csv-view.tsx
@@ -7,6 +7,11 @@ import {
   type ImportPaymentsResult,
 } from '@/app/rdb/playtomic/import-csv/actions';
 import { TZ } from '@/components/playtomic/constants';
+import {
+  classifyImportSource,
+  type PaymentsImportStatus,
+  type SyncTone,
+} from '@/lib/playtomic/import-status';
 
 const DATE_FMT = new Intl.DateTimeFormat('es-MX', {
   timeZone: TZ,
@@ -18,13 +23,34 @@ const DATE_FMT = new Intl.DateTimeFormat('es-MX', {
   hour12: false,
 });
 
+const DATE_ONLY_FMT = new Intl.DateTimeFormat('es-MX', {
+  timeZone: TZ,
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+});
+
 function fmtDate(iso: string | null): string {
   if (!iso) return '—';
   const d = new Date(iso);
   return Number.isNaN(d.getTime()) ? '—' : DATE_FMT.format(d);
 }
 
-export function ImportCsvView() {
+function fmtDateOnly(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? '—' : DATE_ONLY_FMT.format(d);
+}
+
+export function ImportCsvView({
+  initialStatus,
+  lastSyncRelative,
+  syncTone,
+}: {
+  initialStatus: PaymentsImportStatus;
+  lastSyncRelative: string | null;
+  syncTone: SyncTone;
+}) {
   const [file, setFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isPending, startTransition] = useTransition();
@@ -58,66 +84,151 @@ export function ImportCsvView() {
           Import de pagos Playtomic (CSV)
         </h1>
         <p className="text-sm text-[var(--text-muted)]">
-          Sube el reporte de pagos exportado desde Playtomic Manager (rango libre, ej. semanal).
-          UPSERT por payment_id — re-subir el mismo periodo es seguro y solo actualiza filas con
-          cambios.
+          Sincronización automática diaria a las 03:00 CST (cron Vercel). Esta página queda como
+          respaldo para backfills o uploads especiales — el cron ya se encarga de la operación
+          regular.
         </p>
       </header>
 
-      <div
-        className={`flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed p-8 transition-colors ${
-          isDragging
-            ? 'border-emerald-500/60 bg-emerald-500/10'
-            : 'border-[var(--border)] bg-[var(--card)]'
-        }`}
-        onDragEnter={(e) => {
-          e.preventDefault();
-          setIsDragging(true);
-        }}
-        onDragOver={(e) => e.preventDefault()}
-        onDragLeave={() => setIsDragging(false)}
-        onDrop={(e) => {
-          e.preventDefault();
-          setIsDragging(false);
-          const f = e.dataTransfer.files?.[0];
-          if (f) onPickFile(f);
-        }}
-      >
-        {file ? (
-          <div className="space-y-2 text-center">
-            <p className="font-medium text-[var(--text)]">{file.name}</p>
-            <p className="text-xs text-[var(--text-muted)]">{(file.size / 1024).toFixed(1)} KB</p>
+      <SyncStatusCard status={initialStatus} lastSyncRelative={lastSyncRelative} tone={syncTone} />
+
+      <details className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">
+        <summary className="cursor-pointer text-sm font-medium text-[var(--text)]">
+          Subir CSV manualmente (respaldo)
+        </summary>
+        <div className="mt-4 space-y-4">
+          <div
+            className={`flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed p-8 transition-colors ${
+              isDragging
+                ? 'border-emerald-500/60 bg-emerald-500/10'
+                : 'border-[var(--border)] bg-[var(--panel)]/30'
+            }`}
+            onDragEnter={(e) => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragOver={(e) => e.preventDefault()}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setIsDragging(false);
+              const f = e.dataTransfer.files?.[0];
+              if (f) onPickFile(f);
+            }}
+          >
+            {file ? (
+              <div className="space-y-2 text-center">
+                <p className="font-medium text-[var(--text)]">{file.name}</p>
+                <p className="text-xs text-[var(--text-muted)]">
+                  {(file.size / 1024).toFixed(1)} KB
+                </p>
+              </div>
+            ) : (
+              <p className="text-center text-sm text-[var(--text-muted)]">
+                Arrastra el CSV aquí, o pulsa el botón para seleccionarlo.
+              </p>
+            )}
+            <label className="cursor-pointer">
+              <span className="inline-flex items-center rounded-md border border-[var(--border)] bg-[var(--panel)]/40 px-3 py-1.5 text-sm hover:bg-[var(--panel)]/60">
+                Seleccionar archivo
+              </span>
+              <input
+                type="file"
+                accept=".csv,text/csv"
+                className="sr-only"
+                onChange={(e) => onPickFile(e.target.files?.[0] ?? null)}
+              />
+            </label>
           </div>
-        ) : (
-          <p className="text-center text-sm text-[var(--text-muted)]">
-            Arrastra el CSV aquí, o pulsa el botón para seleccionarlo.
-          </p>
-        )}
-        <label className="cursor-pointer">
-          <span className="inline-flex items-center rounded-md border border-[var(--border)] bg-[var(--panel)]/40 px-3 py-1.5 text-sm hover:bg-[var(--panel)]/60">
-            Seleccionar archivo
-          </span>
-          <input
-            type="file"
-            accept=".csv,text/csv"
-            className="sr-only"
-            onChange={(e) => onPickFile(e.target.files?.[0] ?? null)}
-          />
-        </label>
-      </div>
 
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-[var(--text-muted)]">
-          Tamaño máximo: 10 MB. Formato esperado: export Playtomic Manager con delimitador
-          &quot;;&quot; y decimales con coma.
-        </p>
-        <Button onClick={onSubmit} disabled={!file || isPending}>
-          {isPending ? 'Subiendo…' : 'Importar'}
-        </Button>
-      </div>
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-[var(--text-muted)]">
+              Tamaño máximo: 10 MB. Formato esperado: export Playtomic Manager con delimitador
+              &quot;;&quot; y decimales con coma.
+            </p>
+            <Button onClick={onSubmit} disabled={!file || isPending}>
+              {isPending ? 'Subiendo…' : 'Importar'}
+            </Button>
+          </div>
 
-      {result ? <ResultPanel result={result} /> : null}
+          {result ? <ResultPanel result={result} /> : null}
+        </div>
+      </details>
     </div>
+  );
+}
+
+function SyncStatusCard({
+  status,
+  lastSyncRelative,
+  tone,
+}: {
+  status: PaymentsImportStatus;
+  lastSyncRelative: string | null;
+  tone: SyncTone;
+}) {
+  const kind = classifyImportSource(status.lastSyncSource);
+
+  const toneClasses: Record<SyncTone, string> = {
+    ok: 'border-emerald-500/40 bg-emerald-500/5',
+    warn: 'border-amber-500/40 bg-amber-500/5',
+    err: 'border-red-500/40 bg-red-500/5',
+  };
+  const dotClasses: Record<SyncTone, string> = {
+    ok: 'bg-emerald-400',
+    warn: 'bg-amber-400',
+    err: 'bg-red-400',
+  };
+
+  const sourceLabel =
+    kind === 'auto'
+      ? '🤖 Cron automático'
+      : kind === 'manual'
+        ? `📤 Upload manual${status.lastSyncSource ? ` · ${status.lastSyncSource}` : ''}`
+        : '—';
+
+  return (
+    <section
+      className={`rounded-2xl border ${toneClasses[tone]} p-4`}
+      aria-label="Estado del último sync"
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <span className={`h-2 w-2 rounded-full ${dotClasses[tone]}`} aria-hidden />
+        <h2 className="text-sm font-semibold text-[var(--text)]">
+          {tone === 'ok'
+            ? 'Sincronización al día'
+            : tone === 'warn'
+              ? 'Revisar sincronización'
+              : 'Sin datos importados'}
+        </h2>
+      </div>
+
+      <dl className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <dt className="text-xs text-[var(--text-muted)]">Último sync</dt>
+          <dd className="font-medium text-[var(--text)]">{fmtDate(status.lastSyncAt)}</dd>
+          {lastSyncRelative ? (
+            <dd className="text-xs text-[var(--text-muted)]">{lastSyncRelative}</dd>
+          ) : null}
+        </div>
+        <div>
+          <dt className="text-xs text-[var(--text-muted)]">Origen</dt>
+          <dd className="font-medium text-[var(--text)]">{sourceLabel}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-[var(--text-muted)]">Filas totales</dt>
+          <dd className="font-medium text-[var(--text)]">
+            {status.totalRows.toLocaleString('es-MX')}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-[var(--text-muted)]">Pagos cubiertos</dt>
+          <dd className="font-medium text-[var(--text)]">
+            {fmtDateOnly(status.paymentDateMin)} → {fmtDateOnly(status.paymentDateMax)}
+          </dd>
+        </div>
+      </dl>
+    </section>
   );
 }
 
@@ -131,7 +242,7 @@ function ResultPanel({ result }: { result: ImportPaymentsResult }) {
   }
   return (
     <div className="space-y-3 rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4 text-sm">
-      <h2 className="text-base font-semibold text-[var(--text)]">Resumen del upload</h2>
+      <h3 className="text-base font-semibold text-[var(--text)]">Resumen del upload</h3>
       <dl className="grid gap-2 sm:grid-cols-2">
         <div>
           <dt className="text-[var(--text-muted)]">Filas en CSV</dt>
@@ -183,11 +294,6 @@ function ResultPanel({ result }: { result: ImportPaymentsResult }) {
           </ul>
         </details>
       ) : null}
-
-      <p className="text-xs text-[var(--text-muted)]">
-        Tras este upload, las reservas con cobertura completa via CSV salen del listado de
-        &quot;Pendientes online&quot; del dashboard automáticamente (cuando S2-CSV-B mergee).
-      </p>
     </div>
   );
 }

--- a/lib/playtomic/import-status.test.ts
+++ b/lib/playtomic/import-status.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyImportSource,
+  computeSyncTone,
+  formatRelativeFromNow,
+  type PaymentsImportStatus,
+} from './import-status';
+
+describe('classifyImportSource', () => {
+  it('marca como auto si empieza con "auto:cron@"', () => {
+    expect(classifyImportSource('auto:cron@2026-05-20T01:05:47.976Z')).toBe('auto');
+  });
+
+  it('marca como manual si es un filename normal', () => {
+    expect(classifyImportSource('playtomic-payments-202604.csv')).toBe('manual');
+    expect(classifyImportSource('Reporte de pagos.csv')).toBe('manual');
+  });
+
+  it('marca como unknown si es null, undefined o vacío', () => {
+    expect(classifyImportSource(null)).toBe('unknown');
+    expect(classifyImportSource(undefined)).toBe('unknown');
+    expect(classifyImportSource('')).toBe('unknown');
+  });
+});
+
+describe('formatRelativeFromNow', () => {
+  const NOW = new Date('2026-05-20T12:00:00Z').getTime();
+
+  it('devuelve null cuando el ISO es null o inválido', () => {
+    expect(formatRelativeFromNow(NOW, null)).toBeNull();
+    expect(formatRelativeFromNow(NOW, 'no es fecha')).toBeNull();
+  });
+
+  it('< 1 min', () => {
+    expect(formatRelativeFromNow(NOW, '2026-05-20T11:59:59Z')).toBe('hace menos de 1 min');
+  });
+
+  it('minutos (1–59)', () => {
+    expect(formatRelativeFromNow(NOW, '2026-05-20T11:30:00Z')).toBe('hace 30 min');
+    expect(formatRelativeFromNow(NOW, '2026-05-20T11:01:00Z')).toBe('hace 59 min');
+  });
+
+  it('horas (1h–47h)', () => {
+    expect(formatRelativeFromNow(NOW, '2026-05-20T08:00:00Z')).toBe('hace 4h');
+    expect(formatRelativeFromNow(NOW, '2026-05-18T13:00:00Z')).toBe('hace 47h');
+  });
+
+  it('días (≥ 48h)', () => {
+    expect(formatRelativeFromNow(NOW, '2026-05-18T12:00:00Z')).toBe('hace 2d');
+    expect(formatRelativeFromNow(NOW, '2026-05-15T12:00:00Z')).toBe('hace 5d');
+  });
+
+  it('en el futuro (clock skew)', () => {
+    expect(formatRelativeFromNow(NOW, '2026-05-20T13:00:00Z')).toBe('en el futuro');
+  });
+});
+
+describe('computeSyncTone', () => {
+  const NOW = new Date('2026-05-20T12:00:00Z').getTime();
+  const base: PaymentsImportStatus = {
+    lastSyncAt: null,
+    lastSyncSource: null,
+    totalRows: 0,
+    paymentDateMin: null,
+    paymentDateMax: null,
+  };
+
+  it('err si la tabla nunca tuvo sync', () => {
+    expect(computeSyncTone(base, NOW)).toBe('err');
+  });
+
+  it('err si lastSyncAt es inválido', () => {
+    expect(computeSyncTone({ ...base, lastSyncAt: 'no es fecha' }, NOW)).toBe('err');
+  });
+
+  it('ok: cron + < 36h', () => {
+    expect(
+      computeSyncTone(
+        {
+          ...base,
+          lastSyncAt: '2026-05-19T03:00:00Z',
+          lastSyncSource: 'auto:cron@2026-05-19T03:00:00.000Z',
+        },
+        NOW
+      )
+    ).toBe('ok');
+  });
+
+  it('warn: cron pero ≥ 36h (sospecha de cron caído)', () => {
+    expect(
+      computeSyncTone(
+        {
+          ...base,
+          lastSyncAt: '2026-05-18T20:00:00Z', // 40h antes
+          lastSyncSource: 'auto:cron@2026-05-18T20:00:00.000Z',
+        },
+        NOW
+      )
+    ).toBe('warn');
+  });
+
+  it('warn: último sync fue manual aunque sea reciente', () => {
+    expect(
+      computeSyncTone(
+        {
+          ...base,
+          lastSyncAt: '2026-05-20T11:00:00Z',
+          lastSyncSource: 'reporte-mayo.csv',
+        },
+        NOW
+      )
+    ).toBe('warn');
+  });
+});

--- a/lib/playtomic/import-status.ts
+++ b/lib/playtomic/import-status.ts
@@ -1,0 +1,142 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabase';
+
+/**
+ * Snapshot del estado de `playtomic.payments_import`. Consumido por la
+ * página `/rdb/playtomic/import-csv` para mostrar al operador cuándo fue
+ * el último sync (cron o manual) sin que tenga que abrir Supabase.
+ */
+export type PaymentsImportStatus = {
+  /** ISO timestamp del `uploaded_at` más reciente; null si la tabla está vacía. */
+  lastSyncAt: string | null;
+  /** `source_filename` del último upsert: `auto:cron@<iso>` o el nombre del archivo manual. */
+  lastSyncSource: string | null;
+  /** Total de filas en la tabla. */
+  totalRows: number;
+  /** `payment_date` mínimo cubierto (más antiguo). */
+  paymentDateMin: string | null;
+  /** `payment_date` máximo cubierto (más reciente). */
+  paymentDateMax: string | null;
+};
+
+export type ImportSourceKind = 'auto' | 'manual' | 'unknown';
+
+/**
+ * Distingue un upsert del cron (`auto:cron@...`) de uno hecho desde la UI
+ * (nombre del archivo cargado). El cron empezó a poblar este campo en
+ * PR #470 (2026-05-19); filas históricas previas tienen el filename real.
+ */
+export function classifyImportSource(source: string | null | undefined): ImportSourceKind {
+  if (!source) return 'unknown';
+  return source.startsWith('auto:cron@') ? 'auto' : 'manual';
+}
+
+/**
+ * Texto relativo en español ("hace 3h", "hace 2d") computado contra un
+ * `nowMs` explícito para que sea testable y para que la página (Server
+ * Component) lo calcule del lado del server — así evitamos drift de
+ * hidratación con `new Date()` en el cliente.
+ */
+export function formatRelativeFromNow(nowMs: number, iso: string | null): string | null {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return null;
+  const diffMs = nowMs - t;
+  if (diffMs < 0) return 'en el futuro';
+  const min = Math.floor(diffMs / 60_000);
+  if (min < 1) return 'hace menos de 1 min';
+  if (min < 60) return `hace ${min} min`;
+  const h = Math.floor(min / 60);
+  if (h < 48) return `hace ${h}h`;
+  const d = Math.floor(h / 24);
+  return `hace ${d}d`;
+}
+
+export type SyncTone = 'ok' | 'warn' | 'err';
+
+/**
+ * Deriva el tono visual del status card. Se calcula del lado del server
+ * (Server Component) para que la clase Tailwind del borde no haga drift
+ * de hidratación entre `Date.now()` de server y client.
+ *
+ *   - `err`: tabla vacía o `lastSyncAt` null → nunca hubo sync.
+ *   - `ok`: último sync fue del cron Y < 36h → operación normal.
+ *   - `warn`: cualquier otra cosa (sync manual, o cron pero ≥ 36h).
+ *
+ * 36h es la franja de holgura sobre el schedule diario del cron (03:00
+ * CST) — permite una corrida fallida sin disparar la alerta visual.
+ */
+export function computeSyncTone(
+  status: PaymentsImportStatus,
+  nowMs: number,
+  thresholdHours = 36
+): SyncTone {
+  if (!status.lastSyncAt) return 'err';
+  const t = new Date(status.lastSyncAt).getTime();
+  if (Number.isNaN(t)) return 'err';
+  const hoursSince = (nowMs - t) / 3_600_000;
+  const kind = classifyImportSource(status.lastSyncSource);
+  if (kind === 'auto' && hoursSince < thresholdHours) return 'ok';
+  return 'warn';
+}
+
+export type PaymentsImportStatusView = {
+  status: PaymentsImportStatus;
+  lastSyncRelative: string | null;
+  tone: SyncTone;
+};
+
+/**
+ * Wrapper para Server Components: lee el status y deriva los campos de
+ * presentación (`lastSyncRelative`, `tone`) en una sola llamada, evitando
+ * que el page tenga que invocar `Date.now()` durante render (regla del
+ * React Compiler "no impure functions during render"). El `nowMs` es
+ * inyectable para tests.
+ */
+export async function getPaymentsImportStatusView(
+  supabase: SupabaseClient<Database>,
+  nowMs: number = Date.now()
+): Promise<PaymentsImportStatusView> {
+  const status = await getPaymentsImportStatus(supabase);
+  return {
+    status,
+    lastSyncRelative: formatRelativeFromNow(nowMs, status.lastSyncAt),
+    tone: computeSyncTone(status, nowMs),
+  };
+}
+
+export async function getPaymentsImportStatus(
+  supabase: SupabaseClient<Database>
+): Promise<PaymentsImportStatus> {
+  const playtomic = supabase.schema('playtomic');
+
+  const [latestRes, countRes, maxDateRes, minDateRes] = await Promise.all([
+    playtomic
+      .from('payments_import')
+      .select('uploaded_at, source_filename')
+      .order('uploaded_at', { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle(),
+    playtomic.from('payments_import').select('payment_id', { count: 'exact', head: true }),
+    playtomic
+      .from('payments_import')
+      .select('payment_date')
+      .order('payment_date', { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle(),
+    playtomic
+      .from('payments_import')
+      .select('payment_date')
+      .order('payment_date', { ascending: true, nullsFirst: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  return {
+    lastSyncAt: latestRes.data?.uploaded_at ?? null,
+    lastSyncSource: latestRes.data?.source_filename ?? null,
+    totalRows: countRes.count ?? 0,
+    paymentDateMin: minDateRes.data?.payment_date ?? null,
+    paymentDateMax: maxDateRes.data?.payment_date ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Ahora que el cron diario [(PR #470)](https://github.com/beto-sudo/BSOP/pull/470) hace el upload del CSV de pagos solo, esta página queda como **respaldo**. Antes era el flujo principal; ahora muestra:

- **Status card arriba**: último sync (relativo + absoluto en TZ del club), origen (🤖 Cron automático / 📤 Upload manual), filas totales, rango de payment_date cubierto.
- **Tono visual derivado**: 🟢 verde (cron + <36h), 🟡 ámbar (cron viejo o último upload manual), 🔴 rojo (tabla vacía). Computado server-side para evitar drift de hidratación.
- **Dropzone manual** ahora vive dentro de un `<details>` colapsado — disponible para backfills/uploads especiales, pero ya no es el call-to-action principal.

## Files

- `lib/playtomic/import-status.ts` — `getPaymentsImportStatus` (3 queries paralelas), `classifyImportSource`, `formatRelativeFromNow`, `computeSyncTone` (umbral 36h sobre el schedule diario). Wrapper `getPaymentsImportStatusView` que aísla `Date.now()` para no chocar con la regla `react-compiler` "no impure during render" del page Server Component.
- `lib/playtomic/import-status.test.ts` — 14 tests sobre las 3 funciones puras (clasificación, formato relativo, umbrales de tono).
- `app/rdb/playtomic/import-csv/page.tsx` — Server Component async que pre-llena el status.
- `components/playtomic/import-csv/import-csv-view.tsx` — recibe `initialStatus` + `lastSyncRelative` + `syncTone` como props, render del card + reorg del dropzone.

## Test plan

- [x] `npm run typecheck` — verde
- [x] `npm run test:run` — 730/730 (14 nuevos)
- [x] `npm run lint` — 0 errores
- [x] `npm run format:check` — limpio
- [ ] Smoke en preview: abrir `/rdb/playtomic/import-csv` — debería ver el card verde con "🤖 Cron automático · hace Xh" reflejando el último run del cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)