### PR TITLE
feat(rdb-ventas-por-categoria): columna categoría + drill-down (Sprint 3)

### DIFF
--- a/components/ventas/categoria-badge.tsx
+++ b/components/ventas/categoria-badge.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+
+// Badge de categoría con el color hex del catálogo. Sin color (incluida la
+// fila "Sin categoría") cae a un badge outline neutro.
+export function CategoriaBadge({ nombre, color }: { nombre: string; color: string | null }) {
+  if (!color)
+    return (
+      <Badge variant="outline" className="text-xs">
+        {nombre}
+      </Badge>
+    );
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium"
+      style={{
+        borderColor: `${color}40`,
+        backgroundColor: `${color}10`,
+        color,
+      }}
+    >
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: color }} />
+      {nombre}
+    </span>
+  );
+}

--- a/components/ventas/types.ts
+++ b/components/ventas/types.ts
@@ -62,3 +62,7 @@ export const STATUS_OPTIONS: StatusOption[] = [
   { value: 'pending', label: 'Pendiente' },
   { value: 'cancelled', label: 'Cancelado' },
 ];
+
+// Filtro de categoría que viaja del tab "Por categoría" al tab "Por
+// producto" en el drill-down. id null = fila "Sin categoría".
+export type CategoriaFilter = { id: string | null; nombre: string; color: string | null };

--- a/components/ventas/ventas-por-categoria.tsx
+++ b/components/ventas/ventas-por-categoria.tsx
@@ -5,11 +5,12 @@ import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getLocalDayBoundsUtc } from '@/lib/timezone';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { DataTable, type Column } from '@/components/module-page';
 import { formatCurrency } from '@/lib/format';
 import { Download, Search, Tags } from 'lucide-react';
 import { TZ } from './utils';
+import { CategoriaBadge } from './categoria-badge';
+import type { CategoriaFilter } from './types';
 
 // Las líneas de venta cuyo producto no resuelve a una categoría del
 // catálogo (product_id sin match en erp.productos.codigo, o producto sin
@@ -43,6 +44,7 @@ export type VentasPorCategoriaProps = {
   corteFilter: string;
   search: string;
   onSearchChange: (value: string) => void;
+  onCategoriaClick: (categoria: CategoriaFilter) => void;
 };
 
 export function VentasPorCategoria({
@@ -51,6 +53,7 @@ export function VentasPorCategoria({
   corteFilter,
   search,
   onSearchChange,
+  onCategoriaClick,
 }: VentasPorCategoriaProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -261,36 +264,19 @@ export function VentasPorCategoria({
         loading={loading}
         error={error}
         onRetry={() => void fetchData()}
+        onRowClick={(r) =>
+          onCategoriaClick({
+            id: r.categoria_id === SIN_CATEGORIA_KEY ? null : r.categoria_id,
+            nombre: r.categoria_nombre,
+            color: r.categoria_color,
+          })
+        }
         initialSort={{ key: 'importe', dir: 'desc' }}
         emptyIcon={<Tags className="h-8 w-8 opacity-50" />}
         emptyTitle="Sin ventas en el rango seleccionado"
         showDensityToggle={false}
       />
     </div>
-  );
-}
-
-// Badge de categoría con color hex del catálogo. Sin color (incluida la
-// fila "Sin categoría") cae a un badge outline neutro.
-function CategoriaBadge({ nombre, color }: { nombre: string; color: string | null }) {
-  if (!color)
-    return (
-      <Badge variant="outline" className="text-xs">
-        {nombre}
-      </Badge>
-    );
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium"
-      style={{
-        borderColor: `${color}40`,
-        backgroundColor: `${color}10`,
-        color,
-      }}
-    >
-      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: color }} />
-      {nombre}
-    </span>
   );
 }
 

--- a/components/ventas/ventas-por-producto.tsx
+++ b/components/ventas/ventas-por-producto.tsx
@@ -7,12 +7,17 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { DataTable, type Column } from '@/components/module-page';
 import { formatCurrency } from '@/lib/format';
-import { Download, Package, Search } from 'lucide-react';
+import { Download, Package, Search, X } from 'lucide-react';
 import { TZ } from './utils';
+import { CategoriaBadge } from './categoria-badge';
+import type { CategoriaFilter } from './types';
 
 type ProductoAgg = {
   product_id: string;
   product_name: string;
+  categoria_id: string | null;
+  categoria_nombre: string | null;
+  categoria_color: string | null;
   unidades: number;
   importe: number;
   pedidos: number;
@@ -20,10 +25,13 @@ type ProductoAgg = {
   pct_total: number;
 };
 
-type WaitryItemRow = {
+type CategoriaItemRow = {
   order_id: string;
   product_id: string | null;
   product_name: string;
+  categoria_id: string | null;
+  categoria_nombre: string | null;
+  categoria_color: string | null;
   quantity: number | null;
   total_price: number | null;
 };
@@ -34,6 +42,8 @@ export type VentasPorProductoProps = {
   corteFilter: string;
   search: string;
   onSearchChange: (value: string) => void;
+  categoriaFilter: CategoriaFilter | null;
+  onClearCategoriaFilter: () => void;
 };
 
 export function VentasPorProducto({
@@ -42,6 +52,8 @@ export function VentasPorProducto({
   corteFilter,
   search,
   onSearchChange,
+  categoriaFilter,
+  onClearCategoriaFilter,
 }: VentasPorProductoProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -82,17 +94,21 @@ export function VentasPorProducto({
         return;
       }
 
+      // v_waitry_productos_categoria enriquece cada línea con su categoría
+      // del catálogo (rdb-ventas-por-categoria Sprint 1).
       const CHUNK = 500;
-      const allItems: WaitryItemRow[] = [];
+      const allItems: CategoriaItemRow[] = [];
       for (let i = 0; i < validOrderIds.length; i += CHUNK) {
         const chunk = validOrderIds.slice(i, i + CHUNK);
         const { data: items, error: itemsErr } = await supabase
           .schema('rdb')
-          .from('waitry_productos')
-          .select('order_id, product_id, product_name, quantity, total_price')
+          .from('v_waitry_productos_categoria')
+          .select(
+            'order_id, product_id, product_name, categoria_id, categoria_nombre, categoria_color, quantity, total_price'
+          )
           .in('order_id', chunk);
         if (itemsErr) throw itemsErr;
-        allItems.push(...((items ?? []) as WaitryItemRow[]));
+        allItems.push(...((items ?? []) as CategoriaItemRow[]));
       }
 
       const agg = new Map<
@@ -100,6 +116,9 @@ export function VentasPorProducto({
         {
           product_id: string;
           product_name: string;
+          categoria_id: string | null;
+          categoria_nombre: string | null;
+          categoria_color: string | null;
           unidades: number;
           importe: number;
           ordersSet: Set<string>;
@@ -119,6 +138,11 @@ export function VentasPorProducto({
           agg.set(key, {
             product_id: it.product_id ?? key,
             product_name: it.product_name,
+            // Un product_id resuelve siempre a la misma categoría vía la
+            // vista, así que la primera línea define la del producto.
+            categoria_id: it.categoria_id,
+            categoria_nombre: it.categoria_nombre,
+            categoria_color: it.categoria_color,
             unidades,
             importe,
             ordersSet: new Set([it.order_id]),
@@ -130,6 +154,9 @@ export function VentasPorProducto({
       const result: ProductoAgg[] = Array.from(agg.values()).map((a) => ({
         product_id: a.product_id,
         product_name: a.product_name,
+        categoria_id: a.categoria_id,
+        categoria_nombre: a.categoria_nombre,
+        categoria_color: a.categoria_color,
         unidades: a.unidades,
         importe: a.importe,
         pedidos: a.ordersSet.size,
@@ -150,10 +177,21 @@ export function VentasPorProducto({
   }, [fetchData]);
 
   const filtered = useMemo(() => {
-    if (!search) return rows;
-    const q = search.toLowerCase();
-    return rows.filter((r) => r.product_name.toLowerCase().includes(q));
-  }, [rows, search]);
+    let r = rows;
+    // Filtro de categoría — llega del drill-down desde el tab "Por
+    // categoría". id null = fila "Sin categoría".
+    if (categoriaFilter) {
+      r =
+        categoriaFilter.id === null
+          ? r.filter((x) => x.categoria_id == null)
+          : r.filter((x) => x.categoria_id === categoriaFilter.id);
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      r = r.filter((x) => x.product_name.toLowerCase().includes(q));
+    }
+    return r;
+  }, [rows, search, categoriaFilter]);
 
   const totals = useMemo(
     () => ({
@@ -165,7 +203,15 @@ export function VentasPorProducto({
   );
 
   const exportCsv = () => {
-    const header = ['Producto', 'Unidades', 'Importe', 'Pedidos', 'Ticket prom.', '% del total'];
+    const header = [
+      'Producto',
+      'Categoría',
+      'Unidades',
+      'Importe',
+      'Pedidos',
+      'Ticket prom.',
+      '% del total',
+    ];
     const lines = [header.join(',')];
     // Sort by importe desc to match the visible table default sort.
     const sorted = [...filtered].sort((a, b) => b.importe - a.importe);
@@ -173,6 +219,7 @@ export function VentasPorProducto({
       lines.push(
         [
           `"${r.product_name.replace(/"/g, '""')}"`,
+          `"${(r.categoria_nombre ?? 'Sin categoría').replace(/"/g, '""')}"`,
           r.unidades.toString(),
           r.importe.toFixed(2),
           r.pedidos.toString(),
@@ -227,6 +274,20 @@ export function VentasPorProducto({
             className="pl-9"
           />
         </div>
+        {categoriaFilter && (
+          <div className="flex items-center gap-1.5 rounded-lg border bg-muted/40 py-1 pl-2 pr-1">
+            <span className="text-xs text-muted-foreground">Categoría:</span>
+            <CategoriaBadge nombre={categoriaFilter.nombre} color={categoriaFilter.color} />
+            <button
+              type="button"
+              onClick={onClearCategoriaFilter}
+              className="rounded p-0.5 text-muted-foreground transition hover:bg-muted hover:text-foreground"
+              aria-label="Quitar filtro de categoría"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
         <Button
           variant="outline"
           size="sm"
@@ -247,7 +308,11 @@ export function VentasPorProducto({
         onRetry={() => void fetchData()}
         initialSort={{ key: 'importe', dir: 'desc' }}
         emptyIcon={<Package className="h-8 w-8 opacity-50" />}
-        emptyTitle="Sin ventas en el rango seleccionado"
+        emptyTitle={
+          categoriaFilter
+            ? `Sin ventas de ${categoriaFilter.nombre} en el rango seleccionado`
+            : 'Sin ventas en el rango seleccionado'
+        }
         showDensityToggle={false}
       />
     </div>
@@ -259,6 +324,13 @@ const productoColumns: Column<ProductoAgg>[] = [
     key: 'product_name',
     label: 'Producto',
     cellClassName: 'font-medium',
+  },
+  {
+    key: 'categoria_nombre',
+    label: 'Categoría',
+    render: (r) => (
+      <CategoriaBadge nombre={r.categoria_nombre ?? 'Sin categoría'} color={r.categoria_color} />
+    ),
   },
   {
     key: 'unidades',

--- a/components/ventas/ventas-view.tsx
+++ b/components/ventas/ventas-view.tsx
@@ -27,7 +27,7 @@ import { VentasFilters } from './ventas-filters';
 import { VentasTable } from './ventas-table';
 import { VentasPorProducto } from './ventas-por-producto';
 import { VentasPorCategoria } from './ventas-por-categoria';
-import type { CorteOption, Pedido } from './types';
+import type { CategoriaFilter, CorteOption, Pedido } from './types';
 import { TZ, rangeForPreset, todayRange } from './utils';
 
 type VentasTab = 'pedidos' | 'por-producto' | 'por-categoria';
@@ -40,6 +40,7 @@ export function VentasView() {
   const [error, setError] = useState<string | null>(null);
   const [productoSearch, setProductoSearch] = useState('');
   const [categoriaSearch, setCategoriaSearch] = useState('');
+  const [categoriaFilter, setCategoriaFilter] = useState<CategoriaFilter | null>(null);
   const [cortes, setCortes] = useState<CorteOption[]>([]);
 
   // URL-synced filter defaults are captured once at mount (today's date range).
@@ -72,6 +73,15 @@ export function VentasView() {
       setFilter('presetKey', preset);
     }
   };
+
+  // Drill-down: hacer click en una categoría del tab "Por categoría" abre
+  // el tab "Por producto" filtrado a esa categoría. Las fechas y el corte
+  // son globales a VentasView, así que el rango seleccionado se preserva.
+  const handleCategoriaClick = (cat: CategoriaFilter) => {
+    setCategoriaFilter(cat);
+    setTab('por-producto');
+  };
+
   const [selected, setSelected] = useState<Pedido | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -300,6 +310,8 @@ export function VentasView() {
           corteFilter={corteFilter}
           search={productoSearch}
           onSearchChange={setProductoSearch}
+          categoriaFilter={categoriaFilter}
+          onClearCategoriaFilter={() => setCategoriaFilter(null)}
         />
       )}
       {tab === 'por-categoria' && (
@@ -309,6 +321,7 @@ export function VentasView() {
           corteFilter={corteFilter}
           search={categoriaSearch}
           onSearchChange={setCategoriaSearch}
+          onCategoriaClick={handleCategoriaClick}
         />
       )}
     </div>

--- a/docs/planning/rdb-ventas-por-categoria.md
+++ b/docs/planning/rdb-ventas-por-categoria.md
@@ -163,7 +163,8 @@ Datos de catálogo relevantes para el diseño de la vista:
 
 - **Sprint 1 — Vista DB + tab "Por categoría".** ✅ Entregado.
 - **Sprint 2 — Limpieza del catálogo (servicios deportivos).** ✅ Entregado.
-- **Sprint 3 — Cierre.** Pendiente verificación visual de Beto en preview.
+- **Sprint 3 — Mejoras de UX: columna categoría + drill-down.** ✅ Entregado.
+- **Sprint 4 — Cierre.** Pendiente verificación visual de Beto en preview.
 
 ## Decisiones registradas
 
@@ -237,3 +238,24 @@ Torneos quedó en 19.4% (~$575k), Academias y Uso de cancha en 1.6% c/u.
 Supera la meta de ≥95%.
 
 Próximo: Sprint 3 — verificación visual de Beto en preview y cierre.
+
+### 2026-05-21 · Sprint 3 — columna categoría + drill-down (este PR)
+
+Mejoras pedidas por Beto tras revisar el tab en preview:
+
+- **Columna "Categoría"** en el tab "Por producto". El componente ahora
+  lee de `rdb.v_waitry_productos_categoria` (en vez de `waitry_productos`)
+  y muestra la categoría de cada producto con su badge de color; también
+  va al CSV exportado.
+- **Drill-down**: hacer click en una fila del tab "Por categoría" abre el
+  tab "Por producto" filtrado a esa categoría, preservando el rango de
+  fechas/corte (ya son globales a `VentasView`). El filtro se muestra
+  como un chip removible. La fila "Sin categoría" también es navegable.
+- `CategoriaBadge` extraído a `components/ventas/categoria-badge.tsx`
+  (lo comparten los tabs "Por producto" y "Por categoría").
+- Tipo `CategoriaFilter` en `components/ventas/types.ts`. Smoke test
+  extendido con el caso del drill-down.
+
+Sin cambios de schema ni DB — todo es capa de UI sobre la vista de
+Sprint 1. Próximo: Sprint 4 — verificación visual de Beto en preview y
+cierre de la iniciativa.

--- a/tests/e2e/smoke/auth-rdb-ventas.spec.ts
+++ b/tests/e2e/smoke/auth-rdb-ventas.spec.ts
@@ -113,4 +113,26 @@ test.describe('RDB › Ventas', () => {
     expect(bodyText).toContain('Importe total');
     expect(bodyText).toContain('Categorías con venta');
   });
+
+  test('drill-down de categoría abre "Por producto" filtrado', async ({ page }) => {
+    await page.waitForTimeout(2500);
+
+    const tab = page.getByRole('button', { name: 'Por categoría' });
+    const isVisible = await tab.isVisible().catch(() => false);
+    if (!isVisible) return; // access denied for this user — skip interaction
+
+    await tab.click();
+    await page.waitForTimeout(1800);
+
+    const rows = page.locator('table tbody tr');
+    if ((await rows.count()) === 0) return; // no data in range
+
+    // Click en una categoría → cambia al tab "Por producto" con el filtro
+    // de categoría activo (el chip trae un botón para quitarlo).
+    await rows.first().click();
+    await page.waitForTimeout(1200);
+
+    const clearBtn = page.getByRole('button', { name: 'Quitar filtro de categoría' });
+    await expect(clearBtn).toBeVisible({ timeout: 4000 });
+  });
 });


### PR DESCRIPTION
## Summary

**Sprint 3** de la iniciativa `rdb-ventas-por-categoria` — mejoras de UX al módulo de ventas de RDB pedidas por Beto tras revisar el tab en preview.

- **Columna "Categoría"** en el tab **Por producto**. El componente ahora lee de `rdb.v_waitry_productos_categoria` (en vez de `waitry_productos`) y muestra la categoría de cada producto con su badge de color. También se exporta al CSV.
- **Drill-down**: hacer click en una fila del tab **Por categoría** abre el tab **Por producto** filtrado a esa categoría, **preservando el rango de fechas/corte** seleccionado. El filtro activo se muestra como un chip removible. La fila "Sin categoría" también es navegable.
- `CategoriaBadge` extraído a `components/ventas/categoria-badge.tsx`, compartido por ambos tabs. Tipo `CategoriaFilter` en `components/ventas/types.ts`.
- Smoke test `auth-rdb-ventas.spec.ts` extendido con el caso del drill-down.

Sin cambios de schema ni DB — todo es capa de UI sobre la vista `v_waitry_productos_categoria` de Sprint 1.

## Test plan

- [x] typecheck · test (3562 pasan) · lint · format — verificados localmente.
- [ ] Verificación visual en preview (Beto): columna categoría visible en "Por producto"; click en una categoría lleva a "Por producto" filtrado con las mismas fechas + chip removible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)