### PR TITLE
feat(dilesa): Sprint 4 — UI del módulo portafolio

### DIFF
--- a/app/dilesa/portafolio/page.tsx
+++ b/app/dilesa/portafolio/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { PortafolioModule } from '@/components/dilesa/portafolio-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Portafolio (DILESA)
+ * @responsive desktop-only
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.portafolio">
+      <DesktopOnlyNotice module="Portafolio" />
+      <div className="hidden sm:block">
+        <PortafolioModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/proyectos/page.tsx
+++ b/app/dilesa/proyectos/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { ProyectosModule } from '@/components/dilesa/proyectos-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Proyectos (DILESA)
+ * @responsive desktop-only
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.proyectos">
+      <DesktopOnlyNotice module="Proyectos" />
+      <div className="hidden sm:block">
+        <ProyectosModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -68,6 +68,13 @@ export const NAV_ITEMS: NavItem[] = [
         label: 'Compras',
         children: [{ label: 'Proveedores', href: '/dilesa/proveedores' }],
       },
+      {
+        label: 'Inmobiliario',
+        children: [
+          { label: 'Portafolio', href: '/dilesa/portafolio' },
+          { label: 'Proyectos', href: '/dilesa/proyectos' },
+        ],
+      },
     ],
   },
   {

--- a/components/dilesa/portafolio-module.tsx
+++ b/components/dilesa/portafolio-module.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+/**
+ * PortafolioModule — lista del portafolio de activos DILESA.
+ *
+ * Iniciativa dilesa-portafolio-activos · Sprint 4. Lectura del schema
+ * `dilesa` v2: tabla `activos` (master). v0 = lista + filtros; el detalle
+ * rico y la captura son entregables posteriores.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, type Column } from '@/components/module-page';
+import { Badge } from '@/components/ui/badge';
+import type { BadgeTone } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Building2, RefreshCw, Search } from 'lucide-react';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Activo = {
+  id: string;
+  tipo: string;
+  nombre: string;
+  estado: string;
+  municipio: string | null;
+  area_m2: number | null;
+  valor_estimado: number | null;
+  activo_padre_id: string | null;
+};
+
+const TIPO_LABEL: Record<string, string> = {
+  terreno: 'Terreno',
+  espectacular: 'Espectacular',
+  unipolar: 'Unipolar',
+  casa: 'Casa',
+  local: 'Local',
+  plaza: 'Plaza',
+  edificio: 'Edificio',
+  nave: 'Nave',
+  departamento: 'Departamento',
+  lote: 'Lote',
+  infraestructura: 'Infraestructura',
+};
+
+const ESTADO_TONE: Record<string, BadgeTone> = {
+  prospecto: 'neutral',
+  adquirido: 'info',
+  operando: 'success',
+  en_intervencion: 'warning',
+  desincorporado: 'danger',
+};
+
+const ESTADO_LABEL: Record<string, string> = {
+  prospecto: 'Prospecto',
+  adquirido: 'Adquirido',
+  operando: 'Operando',
+  en_intervencion: 'En intervención',
+  desincorporado: 'Desincorporado',
+};
+
+export function PortafolioModule({ empresaId }: { empresaId: string }) {
+  const [activos, setActivos] = useState<Activo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [tipoFiltro, setTipoFiltro] = useState<string>('');
+
+  const fetchActivos = useCallback(
+    () =>
+      createSupabaseBrowserClient()
+        .schema('dilesa')
+        .from('activos')
+        .select('id, tipo, nombre, estado, municipio, area_m2, valor_estimado, activo_padre_id')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null)
+        .order('nombre'),
+    [empresaId]
+  );
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: err } = await fetchActivos();
+    if (err) {
+      setError(getSupabaseErrorMessage(err, 'No se pudieron cargar los activos.'));
+      setActivos([]);
+    } else {
+      setActivos((data ?? []) as Activo[]);
+    }
+    setLoading(false);
+  }, [fetchActivos]);
+
+  // La carga inicial no llama cargar() directo: los setState van después del
+  // await para no dispararlos síncronamente dentro del effect.
+  useEffect(() => {
+    let activo = true;
+    void fetchActivos().then(({ data, error: err }) => {
+      if (!activo) return;
+      if (err) {
+        setError(getSupabaseErrorMessage(err, 'No se pudieron cargar los activos.'));
+        setActivos([]);
+      } else {
+        setActivos((data ?? []) as Activo[]);
+      }
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchActivos]);
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return activos.filter((a) => {
+      if (tipoFiltro && a.tipo !== tipoFiltro) return false;
+      if (q && !a.nombre.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [activos, search, tipoFiltro]);
+
+  const columns: Column<Activo>[] = [
+    { key: 'nombre', label: 'Nombre', type: 'text', sticky: true, width: 'min-w-[220px]' },
+    {
+      key: 'tipo',
+      label: 'Tipo',
+      type: 'custom',
+      render: (a) => <Badge tone="neutral">{TIPO_LABEL[a.tipo] ?? a.tipo}</Badge>,
+    },
+    {
+      key: 'estado',
+      label: 'Estado',
+      type: 'custom',
+      render: (a) => (
+        <Badge tone={ESTADO_TONE[a.estado] ?? 'neutral'}>
+          {ESTADO_LABEL[a.estado] ?? a.estado}
+        </Badge>
+      ),
+    },
+    { key: 'municipio', label: 'Municipio', type: 'text' },
+    { key: 'area_m2', label: 'Área (m²)', type: 'number' },
+    { key: 'valor_estimado', label: 'Valor estimado', type: 'currency' },
+  ];
+
+  const tiposPresentes = useMemo(
+    () => Array.from(new Set(activos.map((a) => a.tipo))).sort(),
+    [activos]
+  );
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <Building2 className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Portafolio</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Activos de DILESA — terrenos, lotes, locales, plazas, espectaculares y demás.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar por nombre…"
+            className="w-64 pl-9"
+          />
+        </div>
+        <select
+          value={tipoFiltro}
+          onChange={(e) => setTipoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los tipos</option>
+          {tiposPresentes.map((t) => (
+            <option key={t} value={t}>
+              {TIPO_LABEL[t] ?? t}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        initialSort={{ key: 'nombre', dir: 'asc' }}
+        emptyTitle="Sin activos"
+        emptyDescription="Aún no hay activos en el portafolio. Se llenará al importar los datos de Coda."
+        emptyIcon={<Building2 className="h-6 w-6" />}
+      />
+    </div>
+  );
+}

--- a/components/dilesa/proyectos-module.tsx
+++ b/components/dilesa/proyectos-module.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+/**
+ * ProyectosModule — lista de proyectos DILESA.
+ *
+ * Iniciativa dilesa-portafolio-activos · Sprint 4. Lectura del schema
+ * `dilesa` v2: tabla `proyectos` (master). v0 = lista + filtros; el detalle
+ * (sub-proyectos, activos input/output, modelo financiero) y la captura son
+ * entregables posteriores.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, type Column } from '@/components/module-page';
+import { Badge } from '@/components/ui/badge';
+import type { BadgeTone } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Landmark, RefreshCw, Search } from 'lucide-react';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Proyecto = {
+  id: string;
+  tipo: string;
+  nombre: string;
+  estado: string;
+  fecha_inicio: string | null;
+  presupuesto_estimado: number | null;
+  proyecto_padre_id: string | null;
+};
+
+const TIPO_LABEL: Record<string, string> = {
+  anteproyecto: 'Anteproyecto',
+  desarrollo: 'Desarrollo',
+  remodelacion: 'Remodelación',
+  reconversion: 'Reconversión',
+  subdivision: 'Subdivisión',
+  comercializacion: 'Comercialización',
+  operacion: 'Operación',
+};
+
+const ESTADO_TONE: Record<string, BadgeTone> = {
+  propuesta: 'neutral',
+  analisis: 'info',
+  aprobado: 'info',
+  ejecutando: 'warning',
+  completado: 'success',
+  archivado: 'neutral',
+};
+
+const ESTADO_LABEL: Record<string, string> = {
+  propuesta: 'Propuesta',
+  analisis: 'Análisis',
+  aprobado: 'Aprobado',
+  ejecutando: 'Ejecutando',
+  completado: 'Completado',
+  archivado: 'Archivado',
+};
+
+export function ProyectosModule({ empresaId }: { empresaId: string }) {
+  const [proyectos, setProyectos] = useState<Proyecto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [tipoFiltro, setTipoFiltro] = useState<string>('');
+
+  const fetchProyectos = useCallback(
+    () =>
+      createSupabaseBrowserClient()
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, tipo, nombre, estado, fecha_inicio, presupuesto_estimado, proyecto_padre_id')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null)
+        .order('nombre'),
+    [empresaId]
+  );
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: err } = await fetchProyectos();
+    if (err) {
+      setError(getSupabaseErrorMessage(err, 'No se pudieron cargar los proyectos.'));
+      setProyectos([]);
+    } else {
+      setProyectos((data ?? []) as Proyecto[]);
+    }
+    setLoading(false);
+  }, [fetchProyectos]);
+
+  // La carga inicial no llama cargar() directo: los setState van después del
+  // await para no dispararlos síncronamente dentro del effect.
+  useEffect(() => {
+    let activo = true;
+    void fetchProyectos().then(({ data, error: err }) => {
+      if (!activo) return;
+      if (err) {
+        setError(getSupabaseErrorMessage(err, 'No se pudieron cargar los proyectos.'));
+        setProyectos([]);
+      } else {
+        setProyectos((data ?? []) as Proyecto[]);
+      }
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchProyectos]);
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return proyectos.filter((p) => {
+      if (tipoFiltro && p.tipo !== tipoFiltro) return false;
+      if (q && !p.nombre.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [proyectos, search, tipoFiltro]);
+
+  const columns: Column<Proyecto>[] = [
+    { key: 'nombre', label: 'Nombre', type: 'text', sticky: true, width: 'min-w-[220px]' },
+    {
+      key: 'tipo',
+      label: 'Tipo',
+      type: 'custom',
+      render: (p) => <Badge tone="neutral">{TIPO_LABEL[p.tipo] ?? p.tipo}</Badge>,
+    },
+    {
+      key: 'estado',
+      label: 'Estado',
+      type: 'custom',
+      render: (p) => (
+        <Badge tone={ESTADO_TONE[p.estado] ?? 'neutral'}>
+          {ESTADO_LABEL[p.estado] ?? p.estado}
+        </Badge>
+      ),
+    },
+    { key: 'fecha_inicio', label: 'Inicio', type: 'date' },
+    { key: 'presupuesto_estimado', label: 'Presupuesto', type: 'currency' },
+  ];
+
+  const tiposPresentes = useMemo(
+    () => Array.from(new Set(proyectos.map((p) => p.tipo))).sort(),
+    [proyectos]
+  );
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <Landmark className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Proyectos</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Proyectos de desarrollo e intervención sobre los activos del portafolio.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar por nombre…"
+            className="w-64 pl-9"
+          />
+        </div>
+        <select
+          value={tipoFiltro}
+          onChange={(e) => setTipoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los tipos</option>
+          {tiposPresentes.map((t) => (
+            <option key={t} value={t}>
+              {TIPO_LABEL[t] ?? t}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        initialSort={{ key: 'nombre', dir: 'asc' }}
+        emptyTitle="Sin proyectos"
+        emptyDescription="Aún no hay proyectos. Se llenará al importar los datos de Coda."
+        emptyIcon={<Landmark className="h-6 w-6" />}
+      />
+    </div>
+  );
+}

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -181,6 +181,8 @@ const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   'dilesa.rh.puestos',
   'dilesa.rh.departamentos',
   'dilesa.proveedores',
+  'dilesa.portafolio',
+  'dilesa.proyectos',
 
   // RDB
   'rdb.home',

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -33,6 +33,8 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   '/dilesa/rh/puestos': 'dilesa.rh.puestos',
   '/dilesa/rh/departamentos': 'dilesa.rh.departamentos',
   '/dilesa/proveedores': 'dilesa.proveedores',
+  '/dilesa/portafolio': 'dilesa.portafolio',
+  '/dilesa/proyectos': 'dilesa.proyectos',
 
   // RDB — home + operaciones
   '/rdb/home': 'rdb.home',

--- a/supabase/migrations/20260521225606_modulos_dilesa_portafolio.sql
+++ b/supabase/migrations/20260521225606_modulos_dilesa_portafolio.sql
@@ -1,0 +1,43 @@
+-- ════════════════════════════════════════════════════════════════════════════
+-- Iniciativa dilesa-portafolio-activos · Sprint 4 — RBAC del módulo portafolio
+-- ════════════════════════════════════════════════════════════════════════════
+--
+-- Registra en core.modulos los 2 módulos UI del schema dilesa v2:
+--   • dilesa.portafolio — lista/detalle de activos
+--   • dilesa.proyectos  — lista/detalle de proyectos
+--
+-- Reemplaza a los 4 módulos v1 (terrenos/prototipos/anteproyectos/proyectos)
+-- borrados en el Sprint 1. Patrón: regla "Liberación de módulo nuevo" del
+-- CLAUDE.md — INSERT en core.modulos + backfill defensivo de core.permisos_rol
+-- para que los pages no se escondan a los usuarios no-admin.
+
+BEGIN;
+
+-- Paso 1: Insertar los 2 módulos en core.modulos (sección 'operaciones',
+-- según ADR-014 Inmobiliario plegado en Operaciones para DILESA).
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT m.slug, m.nombre, m.descripcion, e.empresa_id, 'operaciones'
+FROM (
+  VALUES
+    ('dilesa.portafolio', 'Portafolio', 'Portafolio de activos de DILESA — terrenos, lotes, locales, plazas, espectaculares y demás'),
+    ('dilesa.proyectos', 'Proyectos', 'Proyectos de desarrollo e intervención sobre los activos del portafolio')
+) AS m(slug, nombre, descripcion)
+CROSS JOIN (SELECT id AS empresa_id FROM core.empresas WHERE slug = 'dilesa') AS e
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+-- Paso 2: Backfill defensivo de permisos_rol. Por cada rol de DILESA × los 2
+-- módulos nuevos, (lectura=true, escritura=true) para preservar el acceso
+-- esperado. Sin esto, agregar los slugs a EXPECTED_DB_MODULE_SLUGS esconde
+-- los pages a usuarios no-admin (canAccessModulo retorna false). Idempotente.
+INSERT INTO core.permisos_rol (rol_id, modulo_id, acceso_lectura, acceso_escritura)
+SELECT r.id, m.id, true, true
+FROM core.roles r
+JOIN core.empresas e ON e.id = r.empresa_id
+JOIN core.modulos m ON m.empresa_id = r.empresa_id
+WHERE e.slug = 'dilesa'
+  AND m.slug IN ('dilesa.portafolio', 'dilesa.proyectos')
+ON CONFLICT (rol_id, modulo_id) DO NOTHING;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Iniciativa `dilesa-portafolio-activos` · **Sprint 4 — UI del módulo portafolio**. UI de lectura sobre el schema `dilesa` v2.

- **Migración `20260521225606`** — registra los módulos `dilesa.portafolio` y `dilesa.proyectos` en `core.modulos` + backfill defensivo de `permisos_rol`.
- **`nav-config.ts`** — sección "Inmobiliario" en el sidebar de DILESA (Portafolio + Proyectos).
- **`permissions.ts` / `permissions.test.ts`** — rutas y slugs nuevos.
- **`/dilesa/portafolio`** — lista de activos: `DataTable` con columnas (nombre, tipo, estado, municipio, área, valor), filtros de búsqueda y tipo, `RequireAccess`.
- **`/dilesa/proyectos`** — lista de proyectos, mismo patrón.

⚠️ **Checkpoint: la migración RBAC no aplicar en prod hasta OK.** El PR queda con CI verde; el `db push` tras aprobación.

### Alcance — honesto

v0 es **lista de lectura**. El detalle rico (jerarquía, sub-proyectos, modelo financiero proyectado vs comprometido) y la **captura/alta** son entregables posteriores: dependen de **D1** (test de captura <2 min) y **D3** (definición de "binding comprometido"), aún abiertas. Sprint 3 (carga del piloto Lomas del Bosque) sigue diferido hasta tener los datos de Coda.

## Test plan

- [x] `typecheck` / `lint` (0 errors) / `test` (3562) / `format` — verdes
- [ ] Supabase Preview aplica la migración RBAC en branch efímero
- [ ] **Checkpoint Beto** → `db push` de la migración RBAC → verificación en browser → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)