### PR TITLE
fix(dilesa): cron sync — usar dominio verificado en Resend

### DIFF
--- a/.github/workflows/dilesa-coda-sync.yml
+++ b/.github/workflows/dilesa-coda-sync.yml
@@ -79,7 +79,7 @@ jobs:
             -H "Authorization: Bearer $RESEND_API_KEY" \
             -H "Content-Type: application/json" \
             -d "{
-              \"from\": \"${SYNC_FROM_EMAIL:-BSOP Sync <sync@anorte.com>}\",
+              \"from\": \"${SYNC_FROM_EMAIL:-BSOP Sync <noreply@bsop.io>}\",
               \"to\": [\"$NOTIFY_EMAIL\"],
               \"subject\": \"✗✗ Sync DILESA Coda→BSOP — $STATUS\",
               \"html\": \"<p>El job de sync terminó con estado <b>$STATUS</b> antes de poder generar el reporte normal.</p><p><a href='\\\"$RUN_URL\\\"'>Ver log en GitHub Actions</a></p>\"

--- a/docs/runbooks/dilesa-coda-sync.md
+++ b/docs/runbooks/dilesa-coda-sync.md
@@ -20,7 +20,7 @@ Antes del primer run hay que cargar 5 secrets en GitHub:
    | `RESEND_API_KEY`            | API key de Resend         | `op read "op://Infrastructure/RESEND_API_KEY/credential"`                                                                    |
    | `NOTIFY_EMAIL`              | `beto@anorte.com`         | Hardcoded                                                                                                                    |
 
-2. **Opcional** — `SYNC_FROM_EMAIL` (default `BSOP Sync <sync@anorte.com>`). Si el dominio remitente no está verificado en Resend, el email cae a spam o falla; usa uno que esté verificado.
+2. **Opcional** — `SYNC_FROM_EMAIL` (default `BSOP Sync <noreply@bsop.io>`, dominio ya verificado en Resend). Si quieres override, asegúrate que el dominio esté verificado en Resend o el email falla con 422.
 
 3. Verifica vía CLI:
    ```bash
@@ -69,7 +69,7 @@ Wrapper [`scripts/run-dilesa-sync.ts`](../../scripts/run-dilesa-sync.ts):
 
 - Verifica `gh secret list` — los 5 secrets están seteados.
 - Revisa el log del workflow — la última línea debe decir `✔ Email enviado a ...`.
-- Si dice `✗ Resend error 4xx` — revisa si el dominio del `from:` (default `sync@anorte.com`) está verificado en Resend. Si no, set `SYNC_FROM_EMAIL` a un dominio verificado.
+- Si dice `✗ Resend error 4xx` (típico 422 "The domain is invalid") — el dominio del `from:` no está verificado en Resend. Default es `noreply@bsop.io` que ya está verificado; si overrideaste `SYNC_FROM_EMAIL`, asegúrate que ese dominio también lo esté.
 
 ### El job toma > 45 min
 

--- a/scripts/run-dilesa-sync.ts
+++ b/scripts/run-dilesa-sync.ts
@@ -30,7 +30,7 @@ const RESEND_API_KEY = process.env.RESEND_API_KEY ?? '';
 const NOTIFY_EMAIL = process.env.NOTIFY_EMAIL ?? '';
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
-const FROM_EMAIL = process.env.SYNC_FROM_EMAIL ?? 'BSOP Sync <sync@anorte.com>';
+const FROM_EMAIL = process.env.SYNC_FROM_EMAIL ?? 'BSOP Sync <noreply@bsop.io>';
 
 if (!RESEND_API_KEY) throw new Error('Falta RESEND_API_KEY');
 if (!NOTIFY_EMAIL) throw new Error('Falta NOTIFY_EMAIL');


### PR DESCRIPTION
## Summary
El primer run del cron post-merge corrió perfecto en 1m 53s (0 huérfanos, 1 adjunto nuevo procesado), pero el email falló con `Resend error 422: "The domain is invalid"`.

`sync@anorte.com` no está verificado en Resend. Cambio default a `noreply@bsop.io` que ya usan los demás emails de la app.

## Test plan
- [ ] Tras merge, re-trigger workflow manual
- [ ] Verificar email recibido a beto@anorte.com con asunto `✓ Sync DILESA Coda→BSOP — sábado, 23 de mayo de 2026`

🤖 Generated with [Claude Code](https://claude.com/claude-code)