### PR TITLE
fix(dilesa): cron sync — usar onboarding@resend.dev (re-apply)

### DIFF
--- a/.github/workflows/dilesa-coda-sync.yml
+++ b/.github/workflows/dilesa-coda-sync.yml
@@ -79,7 +79,7 @@ jobs:
             -H "Authorization: Bearer $RESEND_API_KEY" \
             -H "Content-Type: application/json" \
             -d "{
-              \"from\": \"${SYNC_FROM_EMAIL:-BSOP Sync <noreply@bsop.io>}\",
+              \"from\": \"${SYNC_FROM_EMAIL:-BSOP Sync <onboarding@resend.dev>}\",
               \"to\": [\"$NOTIFY_EMAIL\"],
               \"subject\": \"✗✗ Sync DILESA Coda→BSOP — $STATUS\",
               \"html\": \"<p>El job de sync terminó con estado <b>$STATUS</b> antes de poder generar el reporte normal.</p><p><a href='\\\"$RUN_URL\\\"'>Ver log en GitHub Actions</a></p>\"

--- a/docs/runbooks/dilesa-coda-sync.md
+++ b/docs/runbooks/dilesa-coda-sync.md
@@ -20,7 +20,9 @@ Antes del primer run hay que cargar 5 secrets en GitHub:
    | `RESEND_API_KEY`            | API key de Resend         | `op read "op://Infrastructure/RESEND_API_KEY/credential"`                                                                    |
    | `NOTIFY_EMAIL`              | `beto@anorte.com`         | Hardcoded                                                                                                                    |
 
-2. **Opcional** — `SYNC_FROM_EMAIL` (default `BSOP Sync <noreply@bsop.io>`, dominio ya verificado en Resend). Si quieres override, asegúrate que el dominio esté verificado en Resend o el email falla con 422.
+2. **Opcional** — `SYNC_FROM_EMAIL`. Default `BSOP Sync <onboarding@resend.dev>` (dominio reservado de Resend que funciona con cualquier API key). Para usar un dominio propio (más pro: `BSOP Sync <sync@anorte.com>` o `noreply@bsop.io`):
+   1. Verifica el dominio en Resend → Domains → Add Domain → agregar los DNS records que Resend te da
+   2. Carga el secret: `printf 'BSOP Sync <sync@tudominio.com>' | gh secret set SYNC_FROM_EMAIL -R beto-sudo/BSOP`
 
 3. Verifica vía CLI:
    ```bash
@@ -69,7 +71,7 @@ Wrapper [`scripts/run-dilesa-sync.ts`](../../scripts/run-dilesa-sync.ts):
 
 - Verifica `gh secret list` — los 5 secrets están seteados.
 - Revisa el log del workflow — la última línea debe decir `✔ Email enviado a ...`.
-- Si dice `✗ Resend error 4xx` (típico 422 "The domain is invalid") — el dominio del `from:` no está verificado en Resend. Default es `noreply@bsop.io` que ya está verificado; si overrideaste `SYNC_FROM_EMAIL`, asegúrate que ese dominio también lo esté.
+- Si dice `✗ Resend error 4xx` (típico 422 "The domain is invalid") — el dominio del `from:` no está verificado en Resend. Default es `onboarding@resend.dev` que siempre funciona. Si overrideaste `SYNC_FROM_EMAIL`, asegúrate que ese dominio esté verificado.
 
 ### El job toma > 45 min
 

--- a/scripts/run-dilesa-sync.ts
+++ b/scripts/run-dilesa-sync.ts
@@ -30,7 +30,10 @@ const RESEND_API_KEY = process.env.RESEND_API_KEY ?? '';
 const NOTIFY_EMAIL = process.env.NOTIFY_EMAIL ?? '';
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
-const FROM_EMAIL = process.env.SYNC_FROM_EMAIL ?? 'BSOP Sync <noreply@bsop.io>';
+// `onboarding@resend.dev` es el dominio reservado de Resend que funciona con
+// cualquier API key. Para usar un dominio propio (más pro), verifícalo en
+// Resend → Domains y override con el secret SYNC_FROM_EMAIL.
+const FROM_EMAIL = process.env.SYNC_FROM_EMAIL ?? 'BSOP Sync <onboarding@resend.dev>';
 
 if (!RESEND_API_KEY) throw new Error('Falta RESEND_API_KEY');
 if (!NOTIFY_EMAIL) throw new Error('Falta NOTIFY_EMAIL');


### PR DESCRIPTION
## Summary
Re-aplico el cambio que cerré en PR #500. La key de Resend rotada y re-cargada en GH Secrets **sigue fallando** con `noreply@bsop.io` → la cuenta Resend del key cargado no tiene ese dominio verificado.

Para desbloquear el cron, fallback a `onboarding@resend.dev` (dominio reservado que funciona con cualquier key Resend). Confirmado: este último run pasó verde en datos (1m 46s, 1,425 UPSERT, 0 huérfanos), solo el email falló al final.

## Test plan
- [ ] Tras merge, re-trigger workflow
- [ ] Email debe llegar de `BSOP Sync <onboarding@resend.dev>` con stats correctas

## Cuando quieras dominio propio
Verifica `anorte.com` o `bsop.io` en https://resend.com/domains (asegurándote estar en la account del key cargado) → cuando esté verificado, `printf 'BSOP Sync <sync@anorte.com>' | gh secret set SYNC_FROM_EMAIL -R beto-sudo/BSOP` y listo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)