### PR TITLE
feat(dilesa): Sprint 7b — PDFs de Solicitud de Asignación y Aviso de Privacidad

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -1,0 +1,203 @@
+/**
+ * GET /api/dilesa/ventas/[id]/pdf/[tipo]
+ *
+ * Genera un PDF del expediente para una venta DILESA. Sprint 7b.
+ *
+ * Tipos soportados:
+ *   - solicitud-asignacion
+ *   - aviso-privacidad
+ *
+ * Auth: la sesión de Supabase. La RLS de `dilesa.ventas` decide si el
+ * usuario puede leerla — vendedor solo sus propias ventas; otros roles
+ * todas. Si la venta no se ve (RLS), devolvemos 404.
+ *
+ * Output: application/pdf con Content-Disposition `attachment` para que
+ * el browser descargue (no inline) — el vendedor debe imprimir físico.
+ */
+
+import { NextResponse } from 'next/server';
+import { renderToBuffer } from '@react-pdf/renderer';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { SolicitudAsignacionPDF, type SolicitudData } from '@/lib/dilesa/pdf/solicitud-asignacion';
+import { AvisoPrivacidadPDF, type AvisoPrivacidadData } from '@/lib/dilesa/pdf/aviso-privacidad';
+
+const TIPOS = ['solicitud-asignacion', 'aviso-privacidad'] as const;
+type TipoPdf = (typeof TIPOS)[number];
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string; tipo: string }> }
+) {
+  const { id, tipo } = await params;
+
+  if (!TIPOS.includes(tipo as TipoPdf)) {
+    return NextResponse.json({ error: 'Tipo de PDF desconocido' }, { status: 400 });
+  }
+
+  const sb = await createSupabaseServerClient();
+
+  // Venta + relaciones cross-schema. RLS filtra automáticamente.
+  const { data: venta, error: vErr } = await sb
+    .schema('dilesa')
+    .from('ventas')
+    .select(
+      'id, persona_id, unidad_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, created_at'
+    )
+    .eq('id', id)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (vErr || !venta) {
+    return NextResponse.json({ error: 'Venta no encontrada' }, { status: 404 });
+  }
+
+  // Persona (cliente) cross-schema
+  const { data: persona } = await sb
+    .schema('erp')
+    .from('personas')
+    .select('nombre, apellido_paterno, apellido_materno')
+    .eq('id', venta.persona_id)
+    .maybeSingle();
+  const clienteNombre =
+    [persona?.nombre, persona?.apellido_paterno, persona?.apellido_materno]
+      .filter(Boolean)
+      .join(' ') || '(sin nombre)';
+
+  // Unidad + proyecto + producto (todos en dilesa)
+  let identificacionInventario = '';
+  let pdfDataExtra: Partial<SolicitudData> = {};
+  if (venta.unidad_id) {
+    const { data: unidad } = await sb
+      .schema('dilesa')
+      .from('unidades')
+      .select(
+        'identificador, area_m2, es_esquina, tiene_frente_verde, manzana, numero_lote, calle, numero_oficial, m2_construccion, valor_venta_futuro_snapshot, proyecto_id, producto_id'
+      )
+      .eq('id', venta.unidad_id)
+      .maybeSingle();
+    if (unidad) {
+      const [{ data: proyecto }, { data: producto }] = await Promise.all([
+        sb
+          .schema('dilesa')
+          .from('proyectos')
+          .select('nombre, precio_m2_excedente, tamano_lote_promedio')
+          .eq('id', unidad.proyecto_id)
+          .maybeSingle(),
+        unidad.producto_id
+          ? sb
+              .schema('dilesa')
+              .from('productos')
+              .select('nombre')
+              .eq('id', unidad.producto_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null }),
+      ]);
+      const protoSufijo = producto?.nombre ? producto.nombre.split('-').pop() : '';
+      identificacionInventario = protoSufijo
+        ? `${unidad.identificador}-${protoSufijo}`
+        : unidad.identificador;
+
+      pdfDataExtra = {
+        fraccionamiento: (proyecto?.nombre ?? '').toUpperCase(),
+        manzana: unidad.manzana ?? '',
+        lote: unidad.numero_lote ?? '',
+        prototipo: producto?.nombre ?? '',
+        domicilioOficial: [unidad.calle, unidad.numero_oficial]
+          .filter(Boolean)
+          .join(' #')
+          .toUpperCase(),
+        identificacionInventario,
+        terrenoExcedente: Math.max(
+          0,
+          (unidad.area_m2 ?? 0) - (proyecto?.tamano_lote_promedio ?? 0)
+        ),
+        frenteVerde: unidad.tiene_frente_verde ?? false,
+        esquina: unidad.es_esquina ?? false,
+        precioM2Excedente: Number(proyecto?.precio_m2_excedente ?? 0),
+      };
+    }
+  }
+
+  const fechaCreado = new Date(venta.created_at);
+  const fechaTexto = fechaCreado.toLocaleDateString('es-MX', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+
+  if (tipo === 'aviso-privacidad') {
+    const data: AvisoPrivacidadData = {
+      fechaTexto,
+      clienteNombre,
+      identificacionInventario,
+    };
+    const buf = await renderToBuffer(<AvisoPrivacidadPDF data={data} />);
+    return pdfResponse(buf, `aviso-privacidad-${identificacionInventario || id}.pdf`);
+  }
+
+  // solicitud-asignacion
+  // Calcular precios via RPC
+  const { data: calc } = await sb.schema('dilesa').rpc('fn_calcular_precio_venta', {
+    p_unidad_id: venta.unidad_id ?? '00000000-0000-0000-0000-000000000000',
+    p_monto_credito_titular: Number(venta.monto_credito_titular ?? 0),
+    p_monto_credito_cotitular: Number(venta.monto_credito_cotitular ?? 0),
+  });
+  const c = calc as Record<string, number> | null;
+
+  // Folio Coda-style: iniciales cliente - identificación - fechaHora
+  const iniciales = clienteNombre
+    .split(/\s+/)
+    .map((p) => p[0]?.toUpperCase())
+    .filter(Boolean)
+    .slice(0, 3)
+    .join('');
+  const folio = `${iniciales}-${identificacionInventario}-${fechaCreado.toLocaleString('es-MX')}`;
+
+  const data: SolicitudData = {
+    fechaTexto,
+    asesorVentas: (venta.vendedor ?? '').toUpperCase(),
+    valorComercial: Number(c?.valor_comercial ?? 0),
+    valorExcedenteTerreno: Number(c?.valor_excedente_terreno ?? 0),
+    valorFrenteVerde: Number(c?.valor_frente_verde ?? 0),
+    valorEsquina: Number(c?.valor_esquina ?? 0),
+    valorVentaFuturo: Number(c?.valor_venta_futuro ?? 0),
+    costoCreditoAdicional: Number(c?.costo_credito_adicional ?? 0),
+    precioVenta: Number(c?.precio_venta_total ?? 0),
+    enganche1pct: Number(c?.enganche_1pct ?? 0),
+    isai2pct: Number(c?.isai_2pct ?? 0),
+    gastosNotariales6pct: Number(c?.gastos_notariales_6pct ?? 0),
+    tipoCredito: venta.tipo_credito ?? '',
+    pagoDirecto: Number(c?.pago_directo ?? 0) + Number(c?.apoyo_infonavit ?? 0),
+    montoCreditoTitular: Number(venta.monto_credito_titular ?? 0),
+    montoCreditoCotitular: Number(venta.monto_credito_cotitular ?? 0),
+    totalPagosDisponibles: Number(c?.precio_venta_total ?? 0),
+    clienteNombre: `${clienteNombre} (${identificacionInventario})`,
+    folio,
+    fraccionamiento: '',
+    manzana: '',
+    lote: '',
+    prototipo: '',
+    domicilioOficial: '',
+    identificacionInventario: '',
+    terrenoExcedente: 0,
+    frenteVerde: false,
+    esquina: false,
+    precioM2Excedente: 0,
+    ...pdfDataExtra,
+  };
+
+  const buf = await renderToBuffer(<SolicitudAsignacionPDF data={data} />);
+  return pdfResponse(buf, `solicitud-asignacion-${identificacionInventario || id}.pdf`);
+}
+
+function pdfResponse(buf: Buffer, filename: string): Response {
+  return new Response(new Uint8Array(buf), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export const runtime = 'nodejs';

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -24,7 +24,7 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Check, Circle, ExternalLink, FileText } from 'lucide-react';
+import { ArrowLeft, Check, Circle, Download, ExternalLink, FileText } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Badge } from '@/components/ui/badge';
@@ -539,6 +539,15 @@ function DetailInner() {
         </div>
       </header>
 
+      <div className="flex flex-wrap gap-2">
+        <PdfDownloadLink
+          ventaId={venta.id}
+          tipo="solicitud-asignacion"
+          label="Solicitud de Asignación"
+        />
+        <PdfDownloadLink ventaId={venta.id} tipo="aviso-privacidad" label="Aviso de Privacidad" />
+      </div>
+
       <Section title="Datos del cliente">
         {fichaPersona.length === 0 ? (
           <p className="text-sm text-[var(--text)]/60">Sin datos del cliente.</p>
@@ -759,6 +768,26 @@ function FichaGrid({ rows, cols = 2 }: { rows: { label: string; value: string }[
         </div>
       ))}
     </dl>
+  );
+}
+
+function PdfDownloadLink({
+  ventaId,
+  tipo,
+  label,
+}: {
+  ventaId: string;
+  tipo: 'solicitud-asignacion' | 'aviso-privacidad';
+  label: string;
+}) {
+  return (
+    <a
+      href={`/api/dilesa/ventas/${ventaId}/pdf/${tipo}`}
+      className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-xs font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40 hover:text-[var(--text)]"
+    >
+      <Download className="h-3.5 w-3.5" />
+      {label}
+    </a>
   );
 }
 

--- a/lib/dilesa/pdf/aviso-privacidad.tsx
+++ b/lib/dilesa/pdf/aviso-privacidad.tsx
@@ -1,0 +1,110 @@
+/**
+ * Template PDF: Aviso de Privacidad (Sprint 7b).
+ * Replica el export de Coda. Texto legal fijo + cliente + unidad ID.
+ */
+import { Document, Link, Page, Text, View } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand } from './header-footer';
+
+export type AvisoPrivacidadData = {
+  fechaTexto: string; // "24 de Mayo del 2026"
+  clienteNombre: string;
+  identificacionInventario: string; // M3-L9-LDLE-ISC
+};
+
+export function AvisoPrivacidadPDF({ data }: { data: AvisoPrivacidadData }) {
+  return (
+    <Document title={`Aviso de Privacidad — ${data.identificacionInventario}`}>
+      <Page size="LETTER" style={styles.page}>
+        <HeaderBand title="AVISO DE PRIVACIDAD" fecha={data.fechaTexto} />
+
+        <Text style={paragraphStyle}>
+          DILESA es una empresa respetuosa de los derechos sobre los datos personales de las
+          personas físicas, pone a su disposición el presente aviso de privacidad, con la finalidad
+          de que el titular de los datos personales se encuentre facultado a ejercitar su derecho a
+          la autodeterminación informativa.
+        </Text>
+
+        <Text style={paragraphStyle}>
+          Al realizar cualquier trámite, apartado, compraventa y/o solicitar información para la
+          adquisición de productos de los que comercializa DILESA, usted (el titular) declara que
+          está aceptando los términos y las condiciones contenidos en este aviso y declara y otorga
+          expresamente su aceptación y consentimiento utilizando para tal efecto medios
+          electrónicos, en términos de lo dispuesto por el artículo 1803 del código civil federal.
+        </Text>
+
+        <Text style={paragraphStyle}>
+          Si el titular no acepta en forma absoluta y completa los términos y condiciones de este
+          aviso, deberá abstenerse de compartir cualquier tipo de información a DILESA por cualquier
+          medio.
+        </Text>
+
+        <Text style={paragraphStyle}>
+          El solo compartir datos personales a DILESA, implica para el público titular la plena e
+          incondicional aceptación de todas y cada una de las condiciones generales y particulares
+          incluidas en este aviso de privacidad en la versión publicada por DILESA, en el momento
+          mismo en que el titular inicie cualquier apartado, compraventa y/o solicitar información
+          para la adquisición de productos de los que comercializa DILESA.
+        </Text>
+
+        <Text style={paragraphStyle}>
+          Las partes acuerdan que, al no existir, error, dolo, mala fe o cualquier otro vicio de la
+          voluntad que pudiera nulificar la validez del presente instrumento, ambas acuerdan en
+          sujetarse al tenor de lo estipulado en los siguientes:
+        </Text>
+
+        <Text style={paragraphStyle}>
+          EL TITULAR reconoce y acepta que DILESA, obtendrá directamente los siguientes datos
+          personales y/o patrimoniales, tales como: Nombre completo, correo electrónico, teléfono
+          y/o teléfono móvil, domicilio, fecha y lugar de nacimiento, RFC, Número de Seguro Social
+          (NSS), CURP, Número del INFONAVIT, pagos de pensiones alimenticias, ingresos, pagos de
+          tarjeta de crédito, pagos de vehículos, pagos de créditos hipotecarios.
+        </Text>
+
+        <Text style={{ ...paragraphStyle, textAlign: 'center', marginTop: 8, marginBottom: 16 }}>
+          Conozca nuestro aviso de privacidad en:{' '}
+          <Link src="https://dilesa.mx/aviso-de-privacidad.html" style={linkStyle}>
+            dilesa.mx/aviso-de-privacidad.html
+          </Link>
+        </Text>
+
+        <Text style={[styles.sectionTitle, { marginTop: 16 }]}>AVISOS DE PRIVACIDAD INFONAVIT</Text>
+        <Text style={paragraphStyle}>
+          En esta sección encontrarás los avisos de privacidad integrales y simplificados del
+          Infonavit, con ellos podrás conocer la existencia y características principales del
+          tratamiento al que serán sometidos tus datos personales a fin de que puedas tomar
+          decisiones informadas al respecto.
+        </Text>
+        <Text style={{ ...paragraphStyle, textAlign: 'center', marginTop: 4 }}>
+          <Link
+            src="https://portalmx.infonavit.org.mx/wps/portal/infonavit.web/transparencia/aviso-privacidad"
+            style={linkStyle}
+          >
+            portalmx.infonavit.org.mx/wps/portal/infonavit.web/transparencia/aviso-privacidad
+          </Link>
+        </Text>
+
+        <View style={styles.firmaWrap}>
+          <Text style={styles.firmaCliente}>Firma del Cliente</Text>
+          <Text style={styles.firmaNombre}>
+            {data.clienteNombre} ({data.identificacionInventario})
+          </Text>
+        </View>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+const paragraphStyle = {
+  fontSize: 9,
+  lineHeight: 1.5,
+  marginBottom: 6,
+  textAlign: 'justify' as const,
+};
+
+const linkStyle = {
+  color: colors.primary,
+  textDecoration: 'none' as const,
+};

--- a/lib/dilesa/pdf/header-footer.tsx
+++ b/lib/dilesa/pdf/header-footer.tsx
@@ -1,0 +1,71 @@
+/**
+ * Header + Footer reusables para los PDFs DILESA.
+ *
+ * Replica el branding visual del export de Coda: banda olivo con
+ * isotipo + título grande arriba, banda olivo con "DESARROLLO
+ * INMOBILIARIO LOS ENCINOS" + url + logo abajo.
+ *
+ * Las imágenes (isotipo, logo) viven en `public/brand/dilesa/`. En el
+ * server renderiza el PDF via @react-pdf/renderer, las cargamos con
+ * `path.resolve` + buffer (no funciona el `/brand/...` URL en server).
+ */
+import { Image, Text, View } from '@react-pdf/renderer';
+import { styles } from './styles';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/** Lee imagen del filesystem como base64 data URL (compatible con server-side rendering). */
+function readImageDataUrl(relativePath: string): string {
+  const abs = resolve(process.cwd(), 'public', relativePath);
+  const buf = readFileSync(abs);
+  return `data:image/png;base64,${buf.toString('base64')}`;
+}
+
+// Pre-leer al cargar el módulo (cero overhead por request).
+const ISOTIPO_DATA_URL = (() => {
+  try {
+    return readImageDataUrl('brand/dilesa/isotipo.png');
+  } catch {
+    return null;
+  }
+})();
+
+export function HeaderBand({ title, fecha }: { title: string; fecha: string }) {
+  return (
+    <>
+      <View style={styles.bandTopWrap}>
+        <View style={styles.isotipoWrap}>
+          {ISOTIPO_DATA_URL ? <Image src={ISOTIPO_DATA_URL} style={styles.isotipo} /> : null}
+        </View>
+        <View style={styles.bandTitleBar}>
+          <Text style={styles.bandTitle}>{title}</Text>
+        </View>
+      </View>
+      <Text style={styles.fechaTopRight}>{fecha}</Text>
+    </>
+  );
+}
+
+export function FooterBand() {
+  return (
+    <>
+      <View style={styles.footerBandBg} fixed />
+      <View style={styles.footerBand} fixed>
+        <View>
+          <Text style={styles.footerBandText}>DESARROLLO</Text>
+          <Text style={styles.footerBandText}>INMOBILIARIO LOS ENCINOS</Text>
+          <Text style={styles.footerBandUrl}>dilesa.mx (878) 791-1818</Text>
+        </View>
+        {ISOTIPO_DATA_URL ? <Image src={ISOTIPO_DATA_URL} style={styles.footerBandLogo} /> : null}
+      </View>
+    </>
+  );
+}
+
+export function Folio({ value }: { value: string }) {
+  return (
+    <Text style={styles.folio} fixed>
+      {value}
+    </Text>
+  );
+}

--- a/lib/dilesa/pdf/solicitud-asignacion.tsx
+++ b/lib/dilesa/pdf/solicitud-asignacion.tsx
@@ -1,0 +1,214 @@
+/**
+ * Template PDF: Solicitud de Asignación (Sprint 7b).
+ * Replica el export de Coda para que el vendedor pueda imprimir, firmar
+ * con cliente y subir al expediente.
+ *
+ * Layout: 1 página
+ * - Header band con isotipo + título "SOLICITUD DE ASIGNACIÓN"
+ * - Datos de la vivienda (fraccionamiento, manzana, lote, prototipo,
+ *   domicilio, identificador, terreno excedente, frente verde, esquina,
+ *   precio por m² excedente)
+ * - Asesor de ventas (derecha)
+ * - Detalle de operación: valor comercial + adicionales
+ * - Precio de venta + enganche 1% + ISAI 2% + gastos notariales 6%
+ * - Forma de pago: tipo de crédito + pago directo + crédito titular
+ *   + cotitular + total pagos
+ * - Texto legal de pie + firma cliente
+ * - Footer band con marca
+ */
+import { Document, Page, Text, View } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand, Folio } from './header-footer';
+
+export type SolicitudData = {
+  fechaTexto: string; // "24 de Mayo del 2026"
+  fraccionamiento: string;
+  manzana: string;
+  lote: string;
+  prototipo: string;
+  domicilioOficial: string;
+  identificacionInventario: string; // M3-L9-LDLE-ISC
+  terrenoExcedente: number;
+  frenteVerde: boolean;
+  esquina: boolean;
+  precioM2Excedente: number;
+  asesorVentas: string;
+  // detalle
+  valorComercial: number;
+  valorExcedenteTerreno: number;
+  valorFrenteVerde: number;
+  valorEsquina: number;
+  valorVentaFuturo: number;
+  costoCreditoAdicional: number; // IMSS/Fovissste etc.
+  // precio + cargos
+  precioVenta: number;
+  enganche1pct: number;
+  isai2pct: number;
+  gastosNotariales6pct: number;
+  // forma de pago
+  tipoCredito: string;
+  pagoDirecto: number;
+  montoCreditoTitular: number;
+  montoCreditoCotitular: number;
+  totalPagosDisponibles: number;
+  // firma
+  clienteNombre: string;
+  folio: string; // ej. JHM-M3-L9-LDLE-ISC-5/24/2026 9:34:28 AM
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const money = (n: number) => moneyFmt.format(Number(n) || 0);
+const yesNo = (b: boolean) => (b ? 'SÍ' : 'NO');
+
+export function SolicitudAsignacionPDF({ data }: { data: SolicitudData }) {
+  return (
+    <Document title={`Solicitud de Asignación — ${data.identificacionInventario}`}>
+      <Page size="LETTER" style={styles.page}>
+        <HeaderBand title="SOLICITUD DE ASIGNACIÓN" fecha={data.fechaTexto} />
+
+        {/* ── Datos de la vivienda ── */}
+        <Text style={styles.sectionTitle}>DATOS DE LA VIVIENDA</Text>
+        <DataRow label="FRACCIONAMIENTO:" value={data.fraccionamiento} />
+        <View style={styles.row}>
+          <DataInline label="MANZANA:" value={data.manzana} />
+          <View style={{ width: 20 }} />
+          <DataInline label="LOTE:" value={data.lote} />
+          <View style={{ width: 20 }} />
+          <DataInline label="PROTOTIPO:" value={data.prototipo} />
+        </View>
+        <DataRow label="DOMICILIO OFICIAL:" value={data.domicilioOficial} />
+        <DataRow label="IDENTIFICACIÓN INVENTARIO:" value={data.identificacionInventario} />
+        <View style={styles.row}>
+          <DataInline label="TERRENO EXCEDENTE:" value={`${data.terrenoExcedente} m²`} />
+          <View style={{ width: 20 }} />
+          <DataInline label="FRENTE VERDE:" value={yesNo(data.frenteVerde)} />
+          <View style={{ width: 20 }} />
+          <DataInline label="ESQUINA:" value={yesNo(data.esquina)} />
+        </View>
+        <DataRow label="PRECIO POR M² EXCEDENTE:" value={money(data.precioM2Excedente)} />
+
+        <View style={styles.rightCol}>
+          <Text style={styles.label}>
+            <Text>ASESOR DE VENTAS: </Text>
+            <Text style={styles.labelStrong}>{data.asesorVentas}</Text>
+          </Text>
+        </View>
+
+        {/* ── Detalle de Operación ── */}
+        <Text style={styles.sectionTitle}>DETALLE DE OPERACIÓN</Text>
+        <DataRow label="VALOR COMERCIAL ACTUAL:" value={money(data.valorComercial)} />
+        <DataRow label="VALOR EXCEDENTE DE TERRENO:" value={money(data.valorExcedenteTerreno)} />
+        <DataRow label="VALOR FRENTE VERDE:" value={money(data.valorFrenteVerde)} />
+        <DataRow label="VALOR ESQUINA:" value={money(data.valorEsquina)} />
+        <DataRow label="VALOR VENTA FUTURO:" value={money(data.valorVentaFuturo)} />
+        <DataRow label="IMSS/FOVISSSTE:" value={money(data.costoCreditoAdicional)} />
+        <DataRow label="PRODUCTOS ADICIONALES:" value="$0" />
+
+        <View style={styles.divider} />
+
+        {/* ── Precio + cargos ── */}
+        <View style={styles.rightCol}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+            <Text style={[styles.precioVenta]}>PRECIO DE VENTA: </Text>
+            <Text style={styles.precioVenta}>{money(data.precioVenta)}</Text>
+          </View>
+          <PrecioBreakdownRow
+            label="ENGANCHE REQUERIDO PARA ASIGNACIÓN 1%:"
+            value={money(data.enganche1pct)}
+          />
+          <PrecioBreakdownRow
+            label="ISAI 2% (AL MOMENTO DE ESCRITURACIÓN):"
+            value={money(data.isai2pct)}
+          />
+          <PrecioBreakdownRow
+            label="GASTOS NOTARIALES APROXIMADOS 6% (AL MOMENTO DE ESCRITURACIÓN):"
+            value={money(data.gastosNotariales6pct)}
+          />
+        </View>
+
+        {/* ── Forma de pago ── */}
+        <Text style={styles.sectionTitle}>FORMA DE PAGO</Text>
+        <Text style={styles.labelStrong}>{data.tipoCredito.toUpperCase()}</Text>
+        <View style={{ height: 4 }} />
+        <DataRow label="PAGO DIRECTO:" value={money(data.pagoDirecto)} />
+        <DataRow label="MONTO CREDITO TITULAR:" value={money(data.montoCreditoTitular)} />
+        <DataRow label="MONTO CREDITO CO-TITULAR:" value={money(data.montoCreditoCotitular)} />
+        <DataRow
+          label="TOTAL PAGOS DISPONIBLES:"
+          value={money(data.totalPagosDisponibles)}
+          strong
+        />
+
+        {/* ── Texto legal ── */}
+        <Text style={styles.legalText}>
+          <Text>*</Text>He sido informado que si utilizó alguna institución financiera y el crédito
+          no cubre el total del precio de venta, la diferencia tendrá que ser cubierta con recursos
+          de mi propio peculio.
+        </Text>
+        <Text style={styles.legalText}>
+          <Text>*</Text>Comprendo que el contrato de promesa de compraventa que se generará una vez
+          entregado el enganche y la documentación requerida, así como la presente solicitud,
+          <Text style={styles.legalTextBold}>
+            {' '}
+            tendrá que ser firmado dentro del mismo mes y en un plazo máximo de 2 días naturales
+          </Text>{' '}
+          a partir de la fecha de emisión de este documento, de lo contrario esta solicitud quedará
+          sin validez y sujeta a cambio de precios y disponibilidad de inventario.
+        </Text>
+
+        {/* ── Firma cliente ── */}
+        <View style={styles.firmaWrap}>
+          <Text style={styles.firmaCliente}>Firma del Cliente</Text>
+          <Text style={styles.firmaNombre}>{data.clienteNombre}</Text>
+        </View>
+
+        <View style={styles.firmaRow}>
+          <Text style={styles.firmaLabel}>ASESOR</Text>
+          <Text style={styles.firmaLabel}>COMITÉ</Text>
+        </View>
+
+        <Folio value={data.folio} />
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+function DataRow({
+  label,
+  value,
+  strong = false,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+}) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.label}>{label} </Text>
+      <Text style={strong ? styles.labelStrong : styles.labelStrong}>{value}</Text>
+    </View>
+  );
+}
+
+function DataInline({ label, value }: { label: string; value: string }) {
+  return (
+    <Text>
+      <Text style={styles.label}>{label} </Text>
+      <Text style={styles.labelStrong}>{value}</Text>
+    </Text>
+  );
+}
+
+function PrecioBreakdownRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 2 }}>
+      <Text style={styles.precioBreakdownLabel}>{label}</Text>
+      <Text style={[styles.precioBreakdownValue, { color: colors.primary }]}>{value}</Text>
+    </View>
+  );
+}

--- a/lib/dilesa/pdf/styles.ts
+++ b/lib/dilesa/pdf/styles.ts
@@ -1,0 +1,207 @@
+/**
+ * Estilos compartidos para los PDFs DILESA (Sprint 7b).
+ * Replicamos el look del export de Coda — colores corporativos olivo +
+ * gris, tipografía sans-serif uniforme, márgenes legibles.
+ */
+import { StyleSheet, Font } from '@react-pdf/renderer';
+
+// El default font de @react-pdf/renderer (Helvetica) cubre bien.
+// Si queremos Inter o similar más adelante, se registra con Font.register.
+Font.registerHyphenationCallback((word) => [word]);
+
+export const colors = {
+  primary: '#7d8043', // olivo DILESA
+  text: '#111111',
+  textMuted: '#666666',
+  border: '#d4d4d4',
+  borderSoft: '#ececec',
+  bgSoft: '#f5f5f5',
+  bandTop: '#8a8a4a',
+  bandBottomDark: '#8a8a4a',
+  bandBottomLight: '#bdbd91',
+};
+
+export const styles = StyleSheet.create({
+  page: {
+    paddingTop: 30,
+    paddingBottom: 90, // espacio para el footer band
+    paddingHorizontal: 40,
+    fontSize: 10,
+    color: colors.text,
+    fontFamily: 'Helvetica',
+  },
+  bandTopWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  isotipoWrap: {
+    width: 70,
+    height: 70,
+    backgroundColor: '#fff',
+    borderRadius: 4,
+    marginRight: 12,
+    padding: 6,
+    borderWidth: 1,
+    borderColor: colors.border,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  isotipo: { width: 50, height: 50 },
+  bandTitleBar: {
+    flex: 1,
+    backgroundColor: colors.primary,
+    paddingVertical: 16,
+    paddingHorizontal: 18,
+    borderRadius: 2,
+  },
+  bandTitle: {
+    color: '#fff',
+    fontSize: 22,
+    fontFamily: 'Helvetica-Bold',
+    letterSpacing: 1,
+  },
+  fechaTopRight: {
+    fontSize: 9,
+    color: colors.textMuted,
+    textAlign: 'right',
+    marginBottom: 8,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontFamily: 'Helvetica-Bold',
+    marginTop: 14,
+    marginBottom: 6,
+    letterSpacing: 0.5,
+  },
+  row: {
+    flexDirection: 'row',
+    marginBottom: 3,
+  },
+  label: {
+    fontSize: 9,
+    color: colors.text,
+    fontFamily: 'Helvetica',
+    letterSpacing: 0.3,
+  },
+  labelStrong: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    letterSpacing: 0.3,
+  },
+  valueRight: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'right',
+  },
+  divider: {
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.borderSoft,
+    marginVertical: 10,
+  },
+  rowSplit: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 3,
+  },
+  rightCol: {
+    alignItems: 'flex-end',
+    marginVertical: 6,
+  },
+  precioVenta: {
+    color: colors.primary,
+    fontSize: 13,
+    fontFamily: 'Helvetica-Bold',
+    letterSpacing: 0.5,
+  },
+  precioBreakdownLabel: {
+    fontSize: 9,
+    color: colors.textMuted,
+  },
+  precioBreakdownValue: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+  },
+  legalText: {
+    fontSize: 7,
+    color: colors.textMuted,
+    marginTop: 8,
+    lineHeight: 1.4,
+  },
+  legalTextBold: {
+    fontSize: 7,
+    fontFamily: 'Helvetica-Bold',
+  },
+  firmaWrap: {
+    marginTop: 28,
+    alignItems: 'center',
+  },
+  firmaCliente: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    marginBottom: 4,
+  },
+  firmaNombre: {
+    fontSize: 9,
+  },
+  firmaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginTop: 22,
+  },
+  firmaLabel: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    letterSpacing: 0.5,
+  },
+  folio: {
+    position: 'absolute',
+    bottom: 76,
+    right: 40,
+    fontSize: 7,
+    color: colors.textMuted,
+  },
+  footerBand: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 60,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    paddingRight: 30,
+  },
+  footerBandBg: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 60,
+    backgroundColor: colors.bandBottomDark,
+  },
+  footerBandText: {
+    color: '#fff',
+    fontSize: 10,
+    fontFamily: 'Helvetica-Bold',
+    letterSpacing: 0.5,
+    textAlign: 'right',
+    marginRight: 10,
+    zIndex: 2,
+  },
+  footerBandUrl: {
+    color: '#fff',
+    fontSize: 8,
+    textAlign: 'right',
+    marginRight: 10,
+    zIndex: 2,
+  },
+  footerBandLogo: {
+    width: 38,
+    height: 38,
+    backgroundColor: '#fff',
+    borderRadius: 4,
+    padding: 4,
+    zIndex: 2,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@base-ui/react": "^1.3.0",
         "@hookform/resolvers": "^5.2.2",
         "@jspawn/ghostscript-wasm": "^0.0.2",
+        "@react-pdf/renderer": "^4.5.1",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.100.0",
         "@tanstack/react-table": "^8.21.3",
@@ -3158,6 +3159,183 @@
         }
       }
     },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
+      }
+    },
     "node_modules/@remirror/core-constants": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
@@ -5354,6 +5532,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5784,6 +5968,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
@@ -5794,6 +5998,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bmp-js": {
@@ -5850,6 +6063,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-image-compression": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
@@ -5857,6 +6079,15 @@
       "license": "MIT",
       "dependencies": {
         "uzip": "0.20201231.0"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -6208,6 +6439,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -6256,6 +6496,27 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -6674,6 +6935,12 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -6762,6 +7029,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -7772,6 +8045,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -8009,6 +8291,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -8107,6 +8395,23 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -8644,6 +8949,21 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8708,6 +9028,12 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -9482,6 +9808,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -9506,6 +9841,12 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
       "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -9929,6 +10270,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10224,7 +10584,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10326,6 +10685,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
       "license": "MIT"
     },
     "node_modules/media-typer": {
@@ -10742,6 +11107,15 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -11075,6 +11449,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -11116,6 +11496,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -11368,6 +11754,14 @@
         "node": ">=18"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11418,6 +11812,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -11541,7 +11941,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -11814,6 +12213,15 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11899,7 +12307,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
@@ -12126,6 +12533,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -12289,6 +12702,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -12801,6 +13234,15 @@
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -13146,6 +13588,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -13253,6 +13701,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -13658,6 +14112,32 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -13937,6 +14417,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vite-node": {
@@ -14547,6 +15041,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zlibjs": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@jspawn/ghostscript-wasm": "^0.0.2",
+    "@react-pdf/renderer": "^4.5.1",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.100.0",
     "@tanstack/react-table": "^8.21.3",


### PR DESCRIPTION
## Summary

- Genera server-side los 2 primeros PDFs del expediente con `@react-pdf/renderer`, replicando el export visual de Coda (header band olivo + isotipo, footer band marca + url, firmas, folio).
- API route: `GET /api/dilesa/ventas/[id]/pdf/[tipo]` con `tipo` ∈ {`solicitud-asignacion`, `aviso-privacidad`}. Returns `application/pdf` con `Content-Disposition: attachment` para que el vendedor descargue + imprima.
- Botones de descarga en el detalle de la venta (`app/dilesa/ventas/[id]/page.tsx`), justo bajo el header.

## Alcance

Sprint 7b se reduce a estos 2 PDFs para validar el stack antes de ir a los más complejos:

| PDF | Status | Notas |
|---|---|---|
| Solicitud de Asignación | ✅ este PR | Llama `dilesa.fn_calcular_precio_venta` para el desglose |
| Aviso de Privacidad | ✅ este PR | Texto legal fijo + cliente + identificador |
| FICU | ⏭ siguiente sprint | Tiene pie chart, vale otro spike |
| Promesa de Compraventa | ⏭ siguiente sprint | 5 páginas con tabla de materiales |

## Decisiones

- **Stack:** `@react-pdf/renderer` v4.5.1. Elegido sobre puppeteer (sin chrome headless, ~30MB en function) y pdf-lib (más bajo nivel, no JSX). TS-native, server-side via `renderToBuffer`, runtime nodejs (necesita filesystem para el isotipo).
- **Imágenes:** isotipo en `public/brand/dilesa/isotipo.png` pre-leído al cargar el módulo como base64 data URL (cero overhead por request).
- **Folio Coda-style:** `<iniciales-cliente>-<identificador>-<fechaHora>`.
- **Auth:** RLS de `dilesa.ventas` decide el acceso; vendedor solo sus ventas, otros roles todas. Si la venta no se ve → 404.

## Test plan

- [ ] CI verde (typecheck + lint + format + tests + schema:check)
- [ ] Abrir un detalle de venta, click en "Solicitud de Asignación" → descarga PDF con datos correctos + branding
- [ ] Click en "Aviso de Privacidad" → descarga PDF con texto legal + cliente
- [ ] Comparar visualmente con el export de Coda en preview/prod
- [ ] Verificar que vendedor solo descarga PDFs de sus propias ventas (RLS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)