### PR TITLE
fix(dilesa): comprimir PDF styles para que Solicitud entre en 1 página

### DIFF
--- a/lib/dilesa/pdf/styles.ts
+++ b/lib/dilesa/pdf/styles.ts
@@ -1,7 +1,11 @@
 /**
  * Estilos compartidos para los PDFs DILESA (Sprint 7b).
  * Replicamos el look del export de Coda — colores corporativos olivo +
- * gris, tipografía sans-serif uniforme, márgenes legibles.
+ * gris, tipografía sans-serif uniforme.
+ *
+ * Diseñado para que Solicitud de Asignación quepa en 1 página letter
+ * (la cantidad de filas exige compresión vertical). Aviso de
+ * Privacidad sobra con esto.
  */
 import { StyleSheet, Font } from '@react-pdf/renderer';
 
@@ -23,9 +27,9 @@ export const colors = {
 
 export const styles = StyleSheet.create({
   page: {
-    paddingTop: 30,
-    paddingBottom: 90, // espacio para el footer band
-    paddingHorizontal: 40,
+    paddingTop: 22,
+    paddingBottom: 60, // espacio para el footer band (45) + margen
+    paddingHorizontal: 36,
     fontSize: 10,
     color: colors.text,
     fontFamily: 'Helvetica',
@@ -33,50 +37,50 @@ export const styles = StyleSheet.create({
   bandTopWrap: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 12,
+    marginBottom: 6,
   },
   isotipoWrap: {
-    width: 70,
-    height: 70,
+    width: 52,
+    height: 52,
     backgroundColor: '#fff',
     borderRadius: 4,
-    marginRight: 12,
-    padding: 6,
+    marginRight: 10,
+    padding: 4,
     borderWidth: 1,
     borderColor: colors.border,
     justifyContent: 'center',
     alignItems: 'center',
   },
-  isotipo: { width: 50, height: 50 },
+  isotipo: { width: 42, height: 42 },
   bandTitleBar: {
     flex: 1,
     backgroundColor: colors.primary,
-    paddingVertical: 16,
-    paddingHorizontal: 18,
+    paddingVertical: 11,
+    paddingHorizontal: 16,
     borderRadius: 2,
   },
   bandTitle: {
     color: '#fff',
-    fontSize: 22,
+    fontSize: 18,
     fontFamily: 'Helvetica-Bold',
     letterSpacing: 1,
   },
   fechaTopRight: {
-    fontSize: 9,
+    fontSize: 8,
     color: colors.textMuted,
     textAlign: 'right',
-    marginBottom: 8,
+    marginBottom: 2,
   },
   sectionTitle: {
-    fontSize: 11,
+    fontSize: 10,
     fontFamily: 'Helvetica-Bold',
-    marginTop: 14,
-    marginBottom: 6,
-    letterSpacing: 0.5,
+    marginTop: 8,
+    marginBottom: 3,
+    letterSpacing: 0.4,
   },
   row: {
     flexDirection: 'row',
-    marginBottom: 3,
+    marginBottom: 1.5,
   },
   label: {
     fontSize: 9,
@@ -97,49 +101,49 @@ export const styles = StyleSheet.create({
   divider: {
     borderBottomWidth: 0.5,
     borderBottomColor: colors.borderSoft,
-    marginVertical: 10,
+    marginVertical: 5,
   },
   rowSplit: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginBottom: 3,
+    marginBottom: 1.5,
   },
   rightCol: {
     alignItems: 'flex-end',
-    marginVertical: 6,
+    marginVertical: 2,
   },
   precioVenta: {
     color: colors.primary,
-    fontSize: 13,
+    fontSize: 12,
     fontFamily: 'Helvetica-Bold',
     letterSpacing: 0.5,
   },
   precioBreakdownLabel: {
-    fontSize: 9,
+    fontSize: 8,
     color: colors.textMuted,
   },
   precioBreakdownValue: {
-    fontSize: 9,
+    fontSize: 8,
     fontFamily: 'Helvetica-Bold',
   },
   legalText: {
-    fontSize: 7,
+    fontSize: 6.5,
     color: colors.textMuted,
-    marginTop: 8,
-    lineHeight: 1.4,
+    marginTop: 4,
+    lineHeight: 1.25,
   },
   legalTextBold: {
-    fontSize: 7,
+    fontSize: 6.5,
     fontFamily: 'Helvetica-Bold',
   },
   firmaWrap: {
-    marginTop: 28,
+    marginTop: 14,
     alignItems: 'center',
   },
   firmaCliente: {
     fontSize: 9,
     fontFamily: 'Helvetica-Bold',
-    marginBottom: 4,
+    marginBottom: 3,
   },
   firmaNombre: {
     fontSize: 9,
@@ -147,7 +151,7 @@ export const styles = StyleSheet.create({
   firmaRow: {
     flexDirection: 'row',
     justifyContent: 'space-around',
-    marginTop: 22,
+    marginTop: 10,
   },
   firmaLabel: {
     fontSize: 9,
@@ -156,9 +160,9 @@ export const styles = StyleSheet.create({
   },
   folio: {
     position: 'absolute',
-    bottom: 76,
-    right: 40,
-    fontSize: 7,
+    bottom: 50,
+    right: 36,
+    fontSize: 6.5,
     color: colors.textMuted,
   },
   footerBand: {
@@ -166,42 +170,42 @@ export const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
-    height: 60,
+    height: 45,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-end',
-    paddingRight: 30,
+    paddingRight: 28,
   },
   footerBandBg: {
     position: 'absolute',
     left: 0,
     right: 0,
     bottom: 0,
-    height: 60,
+    height: 45,
     backgroundColor: colors.bandBottomDark,
   },
   footerBandText: {
     color: '#fff',
-    fontSize: 10,
+    fontSize: 9,
     fontFamily: 'Helvetica-Bold',
-    letterSpacing: 0.5,
+    letterSpacing: 0.4,
     textAlign: 'right',
     marginRight: 10,
     zIndex: 2,
   },
   footerBandUrl: {
     color: '#fff',
-    fontSize: 8,
+    fontSize: 7,
     textAlign: 'right',
     marginRight: 10,
     zIndex: 2,
   },
   footerBandLogo: {
-    width: 38,
-    height: 38,
+    width: 32,
+    height: 32,
     backgroundColor: '#fff',
     borderRadius: 4,
-    padding: 4,
+    padding: 3,
     zIndex: 2,
   },
 });

--- a/scripts/dilesa-pdf-preview.tsx
+++ b/scripts/dilesa-pdf-preview.tsx
@@ -1,0 +1,63 @@
+/**
+ * Render local de los PDFs DILESA con data sintética para verificar
+ * que Solicitud entra en 1 página. Solo se usa durante development —
+ * no se invoca en producción.
+ *
+ * Uso: npx tsx scripts/dilesa-pdf-preview.tsx
+ *      open /tmp/solicitud-preview.pdf
+ *      open /tmp/aviso-preview.pdf
+ */
+import { renderToFile } from '@react-pdf/renderer';
+import { SolicitudAsignacionPDF } from '../lib/dilesa/pdf/solicitud-asignacion';
+import { AvisoPrivacidadPDF } from '../lib/dilesa/pdf/aviso-privacidad';
+
+const solicitudData = {
+  fechaTexto: '24 de Mayo del 2026',
+  fraccionamiento: 'BOSQUES DE SAN JOSÉ',
+  manzana: '3',
+  lote: '9',
+  prototipo: 'LDLE-ISC',
+  domicilioOficial: 'CALLE ALAMOS #1234',
+  identificacionInventario: 'M3-L9-LDLE-ISC',
+  terrenoExcedente: 32,
+  frenteVerde: true,
+  esquina: false,
+  precioM2Excedente: 850,
+  asesorVentas: 'JUAN HERNÁNDEZ MARTÍNEZ',
+  valorComercial: 950000,
+  valorExcedenteTerreno: 27200,
+  valorFrenteVerde: 15000,
+  valorEsquina: 0,
+  valorVentaFuturo: 992200,
+  costoCreditoAdicional: 12000,
+  precioVenta: 1004200,
+  enganche1pct: 10042,
+  isai2pct: 20084,
+  gastosNotariales6pct: 60252,
+  tipoCredito: 'INFONAVIT TRADICIONAL',
+  pagoDirecto: 50000,
+  montoCreditoTitular: 700000,
+  montoCreditoCotitular: 254200,
+  totalPagosDisponibles: 1004200,
+  clienteNombre: 'PEDRO PÉREZ GÓMEZ (M3-L9-LDLE-ISC)',
+  folio: 'PPG-M3-L9-LDLE-ISC-5/24/2026 14:30:00',
+};
+
+const avisoData = {
+  fechaTexto: '24 de Mayo del 2026',
+  clienteNombre: 'PEDRO PÉREZ GÓMEZ',
+  identificacionInventario: 'M3-L9-LDLE-ISC',
+};
+
+async function main() {
+  await renderToFile(<SolicitudAsignacionPDF data={solicitudData} />, '/tmp/solicitud-preview.pdf');
+  console.log('✔ /tmp/solicitud-preview.pdf');
+
+  await renderToFile(<AvisoPrivacidadPDF data={avisoData} />, '/tmp/aviso-preview.pdf');
+  console.log('✔ /tmp/aviso-preview.pdf');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Tras el merge de Sprint 7b ([#507](https://github.com/beto-sudo/BSOP/pull/507)), la Solicitud de Asignación se estaba yendo a 2 páginas. Compresión vertical de los styles compartidos:

- **Page padding:** top 30→22, bottom 90→60
- **Header band:** paddingVertical 16→11, fontSize 22→18, isotipo 70→52
- **Section title:** marginTop 14→8, fontSize 11→10
- **Row marginBottom** 3→1.5, **divider** 10→5, **rightCol** 6→2
- **Firma** marginTop 28→14, firmaRow 22→10
- **Legal text** 7→6.5pt, lineHeight 1.4→1.25
- **Footer band** 60→45 alto, fontSize 10→9
- **Folio** reubicado a bottom:50

Aviso de Privacidad sobra con esto — sigue en 1 página.

## Verificación

Agregué [`scripts/dilesa-pdf-preview.tsx`](scripts/dilesa-pdf-preview.tsx) — renderiza ambos PDFs a `/tmp` con data sintética, útil para iterar sin levantar el dev server.

```
$ npx tsx scripts/dilesa-pdf-preview.tsx
✔ /tmp/solicitud-preview.pdf
✔ /tmp/aviso-preview.pdf

$ grep -ac '/Type /Page$\|/Type /Page ' /tmp/solicitud-preview.pdf
1  # ✓ una sola página
```

## Test plan

- [ ] CI verde
- [ ] Abrir un detalle de venta en preview, descargar Solicitud → 1 página
- [ ] Descargar Aviso de Privacidad → 1 página

🤖 Generated with [Claude Code](https://claude.com/claude-code)