### PR TITLE
feat(dilesa): FICU PDF — replica Coda + 4 fixes LFPIORPI + EBR corregido

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -6,6 +6,7 @@
  * Tipos soportados:
  *   - solicitud-asignacion
  *   - aviso-privacidad
+ *   - ficu
  *
  * Auth: la sesión de Supabase. La RLS de `dilesa.ventas` decide si el
  * usuario puede leerla — vendedor solo sus propias ventas; otros roles
@@ -20,8 +21,10 @@ import { renderToBuffer } from '@react-pdf/renderer';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { SolicitudAsignacionPDF, type SolicitudData } from '@/lib/dilesa/pdf/solicitud-asignacion';
 import { AvisoPrivacidadPDF, type AvisoPrivacidadData } from '@/lib/dilesa/pdf/aviso-privacidad';
+import { FicuPDF, type FicuData } from '@/lib/dilesa/pdf/ficu';
+import { evaluarRiesgo } from '@/lib/dilesa/ficu/riesgo';
 
-const TIPOS = ['solicitud-asignacion', 'aviso-privacidad'] as const;
+const TIPOS = ['solicitud-asignacion', 'aviso-privacidad', 'ficu'] as const;
 type TipoPdf = (typeof TIPOS)[number];
 
 export async function GET(
@@ -41,7 +44,7 @@ export async function GET(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'id, persona_id, unidad_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, created_at'
+      'id, persona_id, unidad_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, created_at, es_pep, ocupacion, ine_numero, forma_pago, uso_efectivo'
     )
     .eq('id', id)
     .is('deleted_at', null)
@@ -50,11 +53,13 @@ export async function GET(
     return NextResponse.json({ error: 'Venta no encontrada' }, { status: 404 });
   }
 
-  // Persona (cliente) cross-schema
+  // Persona (cliente) cross-schema — FICU necesita todos los campos
   const { data: persona } = await sb
     .schema('erp')
     .from('personas')
-    .select('nombre, apellido_paterno, apellido_materno')
+    .select(
+      'nombre, apellido_paterno, apellido_materno, fecha_nacimiento, curp, rfc, email, telefono, nacionalidad, tipo_persona, domicilio'
+    )
     .eq('id', venta.persona_id)
     .maybeSingle();
   const clienteNombre =
@@ -132,6 +137,54 @@ export async function GET(
     };
     const buf = await renderToBuffer(<AvisoPrivacidadPDF data={data} />);
     return pdfResponse(buf, `aviso-privacidad-${identificacionInventario || id}.pdf`);
+  }
+
+  if (tipo === 'ficu') {
+    const riesgo = evaluarRiesgo({
+      tipoPersona: persona?.tipo_persona,
+      nacionalidad: persona?.nacionalidad,
+      esPep: venta.es_pep,
+      formaPago: venta.forma_pago,
+      usoEfectivo: venta.uso_efectivo,
+    });
+    const fechaNac = persona?.fecha_nacimiento
+      ? new Date(`${persona.fecha_nacimiento}T00:00:00`).toLocaleDateString('es-MX', {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        })
+      : '—';
+    const data: FicuData = {
+      fechaTexto,
+      nombres: (persona?.nombre ?? '').toUpperCase(),
+      apellidoPaterno: (persona?.apellido_paterno ?? '').toUpperCase(),
+      apellidoMaterno: (persona?.apellido_materno ?? '').toUpperCase(),
+      fechaNacimientoTexto: fechaNac,
+      curp: (persona?.curp ?? '').toUpperCase(),
+      rfc: (persona?.rfc ?? '').toUpperCase(),
+      identificacion: {
+        tipo: 'INE / Credencial para Votar',
+        numero: venta.ine_numero ?? '',
+        autoridad: 'Instituto Nacional Electoral',
+        vigencia: 'Vigente',
+      },
+      domicilio: { integrado: persona?.domicilio ?? null },
+      telefono: persona?.telefono ?? '',
+      correo: persona?.email ?? '',
+      personalidad: (persona?.tipo_persona ?? 'persona física').toUpperCase(),
+      nacionalidad: (persona?.nacionalidad ?? '').toUpperCase(),
+      esPep: !!venta.es_pep,
+      formaPago: (venta.forma_pago ?? '').toUpperCase(),
+      usoEfectivo: (venta.uso_efectivo ?? '').toUpperCase(),
+      ocupacion: (venta.ocupacion ?? '').toUpperCase(),
+      criteriosRiesgo: riesgo.criterios,
+      scoreTotal: riesgo.scoreTotal,
+      clasificacionRiesgo: riesgo.clasificacion,
+      clienteNombre,
+      identificacionInventario,
+    };
+    const buf = await renderToBuffer(<FicuPDF data={data} />);
+    return pdfResponse(buf, `ficu-${identificacionInventario || id}.pdf`);
   }
 
   // solicitud-asignacion

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -546,6 +546,7 @@ function DetailInner() {
           label="Solicitud de Asignación"
         />
         <PdfDownloadLink ventaId={venta.id} tipo="aviso-privacidad" label="Aviso de Privacidad" />
+        <PdfDownloadLink ventaId={venta.id} tipo="ficu" label="FICU" />
       </div>
 
       <Section title="Datos del cliente">
@@ -777,7 +778,7 @@ function PdfDownloadLink({
   label,
 }: {
   ventaId: string;
-  tipo: 'solicitud-asignacion' | 'aviso-privacidad';
+  tipo: 'solicitud-asignacion' | 'aviso-privacidad' | 'ficu';
   label: string;
 }) {
   return (

--- a/lib/dilesa/ficu/riesgo.test.ts
+++ b/lib/dilesa/ficu/riesgo.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests del EBR del FICU. Cubre los 5 criterios + 3 niveles + casos
+ * borde reales del expediente DILESA.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  evaluarRiesgo,
+  nivelFormaPago,
+  nivelNacionalidad,
+  nivelPEP,
+  nivelPersonalidad,
+  nivelUsoEfectivo,
+  UMBRAL_IDENTIFICACION_MXN,
+  UMBRAL_EFECTIVO_MEDIO_MXN,
+} from './riesgo';
+
+describe('nivelPersonalidad', () => {
+  it('PF mexicana = Bajo', () => {
+    expect(nivelPersonalidad('PERSONA FÍSICA', 'MEXICANA')).toBe('Bajo');
+  });
+  it('PF extranjera residente = Medio', () => {
+    expect(nivelPersonalidad('PERSONA FÍSICA', 'COLOMBIANA')).toBe('Medio');
+  });
+  it('PM mexicana = Alto', () => {
+    expect(nivelPersonalidad('PERSONA MORAL', 'MEXICANA')).toBe('Alto');
+  });
+  it('Fideicomiso = Alto', () => {
+    expect(nivelPersonalidad('FIDEICOMISO', 'MEXICANA')).toBe('Alto');
+  });
+});
+
+describe('nivelNacionalidad', () => {
+  it('MEXICANA = Bajo', () => {
+    expect(nivelNacionalidad('MEXICANA')).toBe('Bajo');
+  });
+  it('Mexicano (variante) = Bajo', () => {
+    expect(nivelNacionalidad('mexicano')).toBe('Bajo');
+  });
+  it('USA = Medio', () => {
+    expect(nivelNacionalidad('ESTADOUNIDENSE')).toBe('Medio');
+  });
+  it('IRÁN (GAFI alto riesgo) = Alto', () => {
+    expect(nivelNacionalidad('IRÁN')).toBe('Alto');
+  });
+  it('VENEZUELA (GAFI monitoreo) = Alto', () => {
+    expect(nivelNacionalidad('VENEZUELA')).toBe('Alto');
+  });
+  it('sin dato = Medio (default defensivo)', () => {
+    expect(nivelNacionalidad(null)).toBe('Medio');
+    expect(nivelNacionalidad('')).toBe('Medio');
+  });
+});
+
+describe('nivelPEP', () => {
+  it('no PEP = Bajo', () => {
+    expect(nivelPEP(false)).toBe('Bajo');
+    expect(nivelPEP(null)).toBe('Bajo');
+  });
+  it('PEP familiar = Medio', () => {
+    expect(nivelPEP(false, true)).toBe('Medio');
+  });
+  it('PEP directo = Alto', () => {
+    expect(nivelPEP(true)).toBe('Alto');
+  });
+});
+
+describe('nivelFormaPago', () => {
+  it('INFONAVIT = Bajo', () => {
+    expect(nivelFormaPago('INFONAVIT TRADICIONAL', 'SIN USO DE EFECTIVO')).toBe('Bajo');
+  });
+  it('FOVISSSTE = Bajo', () => {
+    expect(nivelFormaPago('FOVISSSTE', 'SIN USO DE EFECTIVO')).toBe('Bajo');
+  });
+  it('FINANCIAMIENTO HIPOTECARIO = Bajo (corrección del Coda original)', () => {
+    expect(nivelFormaPago('FINANCIAMIENTO HIPOTECARIO', 'SIN USO DE EFECTIVO')).toBe('Bajo');
+  });
+  it('crédito bancario (acento) = Bajo', () => {
+    expect(nivelFormaPago('CRÉDITO BANCARIO', 'SIN USO DE EFECTIVO')).toBe('Bajo');
+  });
+  it('recursos propios = Medio', () => {
+    expect(nivelFormaPago('RECURSOS PROPIOS', 'SIN USO DE EFECTIVO')).toBe('Medio');
+  });
+  it('efectivo arriba del umbral = Alto', () => {
+    expect(nivelFormaPago('EFECTIVO', 'CON USO DE EFECTIVO', 400_000)).toBe('Alto');
+  });
+});
+
+describe('nivelUsoEfectivo', () => {
+  it('SIN USO DE EFECTIVO = Bajo', () => {
+    expect(nivelUsoEfectivo('SIN USO DE EFECTIVO')).toBe('Bajo');
+  });
+  it('NO = Bajo', () => {
+    expect(nivelUsoEfectivo('NO')).toBe('Bajo');
+  });
+  it('monto $0 = Bajo', () => {
+    expect(nivelUsoEfectivo(null, 0)).toBe('Bajo');
+  });
+  it('monto < umbral medio = Bajo', () => {
+    expect(nivelUsoEfectivo(null, UMBRAL_EFECTIVO_MEDIO_MXN - 1)).toBe('Bajo');
+  });
+  it('monto en rango Medio', () => {
+    expect(nivelUsoEfectivo(null, UMBRAL_EFECTIVO_MEDIO_MXN + 1)).toBe('Medio');
+  });
+  it('monto ≥ umbral identificación = Alto', () => {
+    expect(nivelUsoEfectivo(null, UMBRAL_IDENTIFICACION_MXN)).toBe('Alto');
+  });
+});
+
+describe('evaluarRiesgo', () => {
+  it('cliente residencial típico (4 Bajo + 1 Bajo) = Bajo', () => {
+    const r = evaluarRiesgo({
+      tipoPersona: 'PERSONA FÍSICA',
+      nacionalidad: 'MEXICANA',
+      esPep: false,
+      formaPago: 'INFONAVIT TRADICIONAL',
+      usoEfectivo: 'SIN USO DE EFECTIVO',
+    });
+    expect(r.criterios.every((c) => c.nivel === 'Bajo')).toBe(true);
+    expect(r.scoreTotal).toBeCloseTo(33.35, 1); // 5 * 6.67
+    expect(r.clasificacion).toBe('Bajo');
+  });
+
+  it('mismo caso que el sample de Coda (JAH-MUÑOZ) — pero con fix de hipotecario=Bajo', () => {
+    // En Coda salía 46.67% por marcar Hipotecario=Alto.
+    // Con la corrección debe salir 33.35% (todos Bajo).
+    const r = evaluarRiesgo({
+      tipoPersona: 'PERSONA FÍSICA',
+      nacionalidad: 'MEXICANA',
+      esPep: false,
+      formaPago: 'FINANCIAMIENTO HIPOTECARIO',
+      usoEfectivo: 'SIN USO DE EFECTIVO',
+    });
+    expect(r.scoreTotal).toBeCloseTo(33.35, 1);
+    expect(r.clasificacion).toBe('Bajo');
+  });
+
+  it('PEP + efectivo significativo + extranjero LATAM = Alto', () => {
+    const r = evaluarRiesgo({
+      tipoPersona: 'PERSONA MORAL',
+      nacionalidad: 'COLOMBIANA',
+      esPep: true,
+      formaPago: 'EFECTIVO',
+      usoEfectivo: 'CON USO DE EFECTIVO',
+      montoEfectivoMxn: 500_000,
+    });
+    // Personalidad PM = Alto (20)
+    // Nacionalidad COL = Medio (13.33)
+    // PEP directo = Alto (20)
+    // Forma pago efectivo alto = Alto (20)
+    // Uso efectivo > umbral identif = Alto (20)
+    expect(r.scoreTotal).toBeCloseTo(93.33, 1);
+    expect(r.clasificacion).toBe('Alto');
+  });
+
+  it('rango Medio en frontera 40%', () => {
+    const r = evaluarRiesgo({
+      tipoPersona: 'PERSONA FÍSICA',
+      nacionalidad: 'MEXICANA',
+      esPep: false,
+      pepFamiliar: true,
+      formaPago: 'RECURSOS PROPIOS',
+      usoEfectivo: 'SIN USO DE EFECTIVO',
+    });
+    // Bajo + Bajo + Medio + Medio + Bajo = 6.67+6.67+13.33+13.33+6.67 = 46.67
+    expect(r.scoreTotal).toBeCloseTo(46.67, 1);
+    expect(r.clasificacion).toBe('Medio');
+  });
+
+  it('los 5 criterios siempre aparecen en orden estable', () => {
+    const r = evaluarRiesgo({
+      tipoPersona: 'PERSONA FÍSICA',
+      nacionalidad: 'MEXICANA',
+      esPep: false,
+      formaPago: 'INFONAVIT',
+      usoEfectivo: 'SIN USO DE EFECTIVO',
+    });
+    expect(r.criterios.map((c) => c.nombre)).toEqual([
+      'Personalidad',
+      'Nacionalidad',
+      'Persona Políticamente Expuesta',
+      'Forma de Pago',
+      'Uso de Efectivo',
+    ]);
+  });
+
+  it('score nunca pasa de 100%', () => {
+    const r = evaluarRiesgo({
+      tipoPersona: 'FIDEICOMISO',
+      nacionalidad: 'IRÁN',
+      esPep: true,
+      formaPago: 'EFECTIVO',
+      usoEfectivo: 'CON USO DE EFECTIVO',
+      montoEfectivoMxn: 1_000_000,
+    });
+    expect(r.scoreTotal).toBeLessThanOrEqual(100);
+    expect(r.clasificacion).toBe('Alto');
+  });
+});

--- a/lib/dilesa/ficu/riesgo.ts
+++ b/lib/dilesa/ficu/riesgo.ts
@@ -1,0 +1,209 @@
+/**
+ * Evaluación de Riesgo (EBR) para el FICU DILESA.
+ *
+ * Sustenta el cálculo de riesgo del Formato de Identificación de
+ * Clientes que exige el Art. 18 frac. I de LFPIORPI (Enfoque Basado
+ * en Riesgo). La metodología es 5 criterios × 20% c/u, cada uno con
+ * 3 niveles:
+ *
+ *   - Bajo   = 1/3 del peso = 6.67%
+ *   - Medio  = 2/3 del peso = 13.33%
+ *   - Alto   = 3/3 del peso = 20.00%
+ *
+ * Clasificación final del cliente:
+ *   - Bajo   : score < 40%   (todos Bajo, o 4 Bajo + 1 Medio)
+ *   - Medio  : score 40 – 66 %
+ *   - Alto   : score > 66 %
+ *
+ * Las asignaciones Bajo/Medio/Alto siguen GAFI Recomendación 22
+ * (DNFBPs / Real Estate) + Reglas de Carácter General LFPIORPI.
+ *
+ * Cambio importante vs. la versión histórica de Coda:
+ *   - "Forma de Pago: Crédito hipotecario" → Bajo (era Alto, técnicamente
+ *     incorrecto: el banco interpone KYC + recursos rastreables).
+ *
+ * UMA 2026 ≈ $113.14 — umbrales:
+ *   - Identificación (3,210 UMAs) ≈ $363,179
+ *   - Aviso a UIF (8,025 UMAs)    ≈ $907,949
+ */
+
+export type Nivel = 'Bajo' | 'Medio' | 'Alto';
+
+export type CriterioRiesgo = {
+  nombre: string;
+  nivel: Nivel;
+  porcentaje: number; // % aportado al score
+};
+
+export type EvaluacionRiesgo = {
+  criterios: CriterioRiesgo[];
+  scoreTotal: number; // suma de porcentajes
+  clasificacion: Nivel;
+};
+
+const PESO_CRITERIO = 20; // %
+const FACTOR_NIVEL: Record<Nivel, number> = {
+  Bajo: 1 / 3,
+  Medio: 2 / 3,
+  Alto: 1,
+};
+
+function porcentaje(nivel: Nivel): number {
+  // Redondeo a 2 decimales para evitar 6.666666...% en el render.
+  return Math.round(PESO_CRITERIO * FACTOR_NIVEL[nivel] * 100) / 100;
+}
+
+// ── Asignación de niveles por criterio ──────────────────────────────
+
+/** Personalidad: PF mexicana → Bajo; PF extranjera residente → Medio; PM/otros → Alto. */
+export function nivelPersonalidad(
+  tipoPersona: string | null | undefined,
+  nacionalidad: string | null | undefined
+): Nivel {
+  const tp = (tipoPersona ?? '').toUpperCase();
+  if (tp.includes('MORAL') || tp.includes('FIDEICOMISO')) return 'Alto';
+  const esMexicana = (nacionalidad ?? '').toUpperCase().includes('MEX');
+  if (esMexicana) return 'Bajo';
+  return 'Medio';
+}
+
+/**
+ * Nacionalidad: Mexicana → Bajo; otra no listada → Medio;
+ * país GAFI alto riesgo → Alto.
+ * Lista GAFI "Call for Action" + "Increased Monitoring" — fuente:
+ * https://www.fatf-gafi.org/en/publications/High-risk-and-other-monitored-jurisdictions.html
+ * Actualizar cuando GAFI publique nueva lista (suele ser 3 veces/año).
+ */
+export const GAFI_ALTO_RIESGO_2026 = new Set([
+  // Call for Action (sanción)
+  'COREA DEL NORTE',
+  'IRÁN',
+  'MYANMAR',
+  // Increased Monitoring (selección — los más relevantes para LATAM)
+  'CUBA',
+  'VENEZUELA',
+  'NICARAGUA',
+  'HAITÍ',
+  'SIRIA',
+  'YEMEN',
+  'NIGERIA',
+  'SUDÁN',
+  'SUDÁN DEL SUR',
+  'LÍBANO',
+]);
+
+export function nivelNacionalidad(nacionalidad: string | null | undefined): Nivel {
+  const nac = (nacionalidad ?? '').toUpperCase().trim();
+  if (!nac) return 'Medio'; // sin dato → medio defensivamente
+  if (nac.includes('MEX')) return 'Bajo';
+  if (GAFI_ALTO_RIESGO_2026.has(nac)) return 'Alto';
+  return 'Medio';
+}
+
+/** PEP: no PEP → Bajo; familiar/asociado → Medio; PEP directo → Alto. */
+export function nivelPEP(esPep: boolean | null | undefined, pepFamiliar?: boolean | null): Nivel {
+  if (esPep) return 'Alto';
+  if (pepFamiliar) return 'Medio';
+  return 'Bajo';
+}
+
+/**
+ * Forma de pago — el corazón del EBR para inmobiliario.
+ *  - Crédito hipotecario / Infonavit / Fovissste     → Bajo
+ *  - Recursos propios (transferencia, cheque)         → Medio
+ *  - Efectivo significativo (uso de efectivo ≥ UMAs)  → Alto
+ */
+const UMA_2026 = 113.14;
+export const UMBRAL_IDENTIFICACION_MXN = Math.round(3210 * UMA_2026); // ≈ $363,179
+export const UMBRAL_AVISO_UIF_MXN = Math.round(8025 * UMA_2026); // ≈ $907,949
+
+export function nivelFormaPago(
+  formaPago: string | null | undefined,
+  usoEfectivo: string | null | undefined,
+  montoEfectivoMxn?: number | null
+): Nivel {
+  const fp = (formaPago ?? '').toUpperCase();
+  const ue = (usoEfectivo ?? '').toUpperCase();
+
+  if (
+    fp.includes('INFONAVIT') ||
+    fp.includes('FOVISSSTE') ||
+    fp.includes('HIPOTECARIO') ||
+    fp.includes('CRÉDITO') ||
+    fp.includes('CREDITO')
+  ) {
+    return 'Bajo';
+  }
+
+  if (
+    ue.includes('USO DE EFECTIVO') &&
+    !ue.includes('SIN') &&
+    (montoEfectivoMxn == null || montoEfectivoMxn >= UMBRAL_IDENTIFICACION_MXN)
+  ) {
+    return 'Alto';
+  }
+
+  return 'Medio';
+}
+
+/**
+ * Uso de Efectivo:
+ *   - $0 / < 1,605 UMAs    → Bajo
+ *   - 1,605 – 3,210 UMAs   → Medio
+ *   - ≥ 3,210 UMAs         → Alto
+ * Si no hay monto explícito, derivamos del texto (SIN USO DE EFECTIVO=Bajo).
+ */
+export const UMBRAL_EFECTIVO_MEDIO_MXN = Math.round(1605 * UMA_2026); // ≈ $181,590
+
+export function nivelUsoEfectivo(
+  usoEfectivo: string | null | undefined,
+  montoMxn?: number | null
+): Nivel {
+  if (typeof montoMxn === 'number') {
+    if (montoMxn >= UMBRAL_IDENTIFICACION_MXN) return 'Alto';
+    if (montoMxn >= UMBRAL_EFECTIVO_MEDIO_MXN) return 'Medio';
+    return 'Bajo';
+  }
+  const ue = (usoEfectivo ?? '').toUpperCase();
+  if (!ue || ue.includes('SIN') || ue === 'NO') return 'Bajo';
+  return 'Medio';
+}
+
+// ── Evaluación completa ─────────────────────────────────────────────
+
+export type EntradasRiesgo = {
+  tipoPersona: string | null | undefined;
+  nacionalidad: string | null | undefined;
+  esPep: boolean | null | undefined;
+  pepFamiliar?: boolean | null;
+  formaPago: string | null | undefined;
+  usoEfectivo: string | null | undefined;
+  montoEfectivoMxn?: number | null;
+};
+
+export function evaluarRiesgo(entradas: EntradasRiesgo): EvaluacionRiesgo {
+  const niveles: Array<[string, Nivel]> = [
+    ['Personalidad', nivelPersonalidad(entradas.tipoPersona, entradas.nacionalidad)],
+    ['Nacionalidad', nivelNacionalidad(entradas.nacionalidad)],
+    ['Persona Políticamente Expuesta', nivelPEP(entradas.esPep, entradas.pepFamiliar)],
+    [
+      'Forma de Pago',
+      nivelFormaPago(entradas.formaPago, entradas.usoEfectivo, entradas.montoEfectivoMxn),
+    ],
+    ['Uso de Efectivo', nivelUsoEfectivo(entradas.usoEfectivo, entradas.montoEfectivoMxn)],
+  ];
+
+  const criterios: CriterioRiesgo[] = niveles.map(([nombre, nivel]) => ({
+    nombre,
+    nivel,
+    porcentaje: porcentaje(nivel),
+  }));
+
+  const scoreTotal = Math.round(criterios.reduce((s, c) => s + c.porcentaje, 0) * 100) / 100;
+
+  let clasificacion: Nivel = 'Bajo';
+  if (scoreTotal > 66) clasificacion = 'Alto';
+  else if (scoreTotal >= 40) clasificacion = 'Medio';
+
+  return { criterios, scoreTotal, clasificacion };
+}

--- a/lib/dilesa/pdf/ficu.tsx
+++ b/lib/dilesa/pdf/ficu.tsx
@@ -1,0 +1,371 @@
+/**
+ * Template PDF: FICU — Formato de Identificación de Clientes (Sprint 7b).
+ *
+ * Replica el export Coda + 4 fixes legales LFPIORPI vs. la versión
+ * histórica:
+ *   1. Domicilio completo (calle, # ext, # int, colonia, municipio,
+ *      CP, entidad federativa, país).
+ *   2. Identificación con tipo + autoridad + vigencia (no solo número).
+ *   3. Texto correcto de Dueño Beneficiario para compra residencial
+ *      propia ("por cuenta propia y para sí mismo, es a la vez el
+ *      Dueño Beneficiario").
+ *   4. Declaración explícita de origen lícito de los recursos.
+ *
+ * EBR: pie chart de 5 segmentos calculado por `lib/dilesa/ficu/riesgo`.
+ *
+ * Layout: 1 página letter.
+ */
+import { Document, G, Page, Path, StyleSheet, Svg, Text, View } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand } from './header-footer';
+import type { CriterioRiesgo, Nivel } from '../ficu/riesgo';
+
+export type DomicilioFicu = {
+  // Si los campos estructurados no están disponibles, se usa `integrado`
+  // (blob de texto) como fallback. La intención es migrar erp.personas a
+  // domicilio estructurado en sprint posterior; por ahora el blob ya está.
+  calle?: string | null;
+  numeroExterior?: string | null;
+  numeroInterior?: string | null;
+  colonia?: string | null;
+  municipio?: string | null;
+  codigoPostal?: string | null;
+  entidadFederativa?: string | null;
+  pais?: string | null;
+  integrado?: string | null;
+};
+
+export type IdentificacionFicu = {
+  tipo: string; // "INE / Credencial para votar" | "Pasaporte" | "Cédula profesional"
+  numero: string;
+  autoridad: string; // "INE" | "SRE" | etc.
+  vigencia?: string | null; // fecha o "Vigente"
+};
+
+export type FicuData = {
+  fechaTexto: string; // "22 de Mayo del 2026"
+
+  // Datos personales
+  nombres: string;
+  apellidoPaterno: string;
+  apellidoMaterno: string;
+  fechaNacimientoTexto: string;
+  curp: string;
+  rfc: string;
+
+  identificacion: IdentificacionFicu;
+  domicilio: DomicilioFicu;
+  telefono: string;
+  correo: string;
+
+  // KYC / clasificación
+  personalidad: string; // "PERSONA FÍSICA"
+  nacionalidad: string;
+  esPep: boolean;
+  formaPago: string;
+  usoEfectivo: string;
+  ocupacion: string;
+
+  // Riesgo (EBR)
+  criteriosRiesgo: CriterioRiesgo[];
+  scoreTotal: number;
+  clasificacionRiesgo: Nivel;
+
+  // Firma + folio
+  clienteNombre: string;
+  identificacionInventario: string;
+};
+
+const COLOR_SEGMENTO = ['#4f81bd', '#9bbb59', '#c0504d', '#8064a2', '#f79646'];
+
+export function FicuPDF({ data }: { data: FicuData }) {
+  return (
+    <Document title={`FICU — ${data.clienteNombre} — ${data.identificacionInventario}`}>
+      <Page size="LETTER" style={styles.page}>
+        <HeaderBand title="FORMATO DE IDENTIFICACIÓN DE CLIENTES" fecha={data.fechaTexto} />
+
+        {/* ── Datos personales ── */}
+        <DataRow label="Nombre(s):" value={data.nombres} />
+        <DataRow label="Apellido Paterno:" value={data.apellidoPaterno} />
+        <DataRow label="Apellido Materno:" value={data.apellidoMaterno} />
+        <DataRow label="Fecha de Nacimiento:" value={data.fechaNacimientoTexto} />
+        <View style={ficuStyles.tripleRow}>
+          <DataInline label="CURP:" value={data.curp} />
+          <DataInline label="RFC:" value={data.rfc} />
+        </View>
+
+        {/* ── Identificación (FIX 2: tipo + autoridad + vigencia) ── */}
+        <Text style={ficuStyles.subTitle}>Identificación Oficial</Text>
+        <View style={ficuStyles.tripleRow}>
+          <DataInline label="Tipo:" value={data.identificacion.tipo} />
+          <DataInline label="Número:" value={data.identificacion.numero} />
+        </View>
+        <View style={ficuStyles.tripleRow}>
+          <DataInline label="Autoridad:" value={data.identificacion.autoridad} />
+          {data.identificacion.vigencia ? (
+            <DataInline label="Vigencia:" value={data.identificacion.vigencia} />
+          ) : null}
+        </View>
+
+        {/* ── Domicilio (FIX 1: completo si hay datos estructurados; blob si no) ── */}
+        <Text style={ficuStyles.subTitle}>Domicilio</Text>
+        <DomicilioBlock d={data.domicilio} />
+
+        <DataRow label="Teléfono:" value={data.telefono} />
+        <DataRow label="Correo Electrónico:" value={data.correo} />
+
+        {/* ── KYC ── */}
+        <DataRow label="Personalidad:" value={data.personalidad} />
+        <DataRow label="Nacionalidad:" value={data.nacionalidad} />
+        <DataRow label="Persona Políticamente Expuesta:" value={data.esPep ? 'SÍ' : 'NO'} />
+        <DataRow label="Forma de Pago:" value={data.formaPago} />
+        <DataRow label="Uso de Efectivo:" value={data.usoEfectivo} />
+        <DataRow label="Actividad, Ocupación o Profesión:" value={data.ocupacion} />
+        <DataRow label="Conocimiento Dueño Beneficiario:" value="Por cuenta propia" />
+
+        {/* ── Evaluación de Riesgo + Pie Chart ── */}
+        <View style={ficuStyles.riesgoSection}>
+          <View style={ficuStyles.riesgoLeft}>
+            <Text style={styles.sectionTitle}>EVALUACIÓN DE RIESGO</Text>
+            {data.criteriosRiesgo.map((c, idx) => (
+              <View key={c.nombre} style={ficuStyles.criterioRow}>
+                <View style={[ficuStyles.swatch, { backgroundColor: COLOR_SEGMENTO[idx] }]} />
+                <Text style={ficuStyles.criterioNombre}>{c.nombre}</Text>
+                <View style={[ficuStyles.nivelChip, { backgroundColor: tintForNivel(c.nivel) }]}>
+                  <Text style={ficuStyles.nivelChipText}>{c.nivel}</Text>
+                </View>
+                <Text style={ficuStyles.criterioPct}>{c.porcentaje.toFixed(2)}%</Text>
+              </View>
+            ))}
+            <View style={ficuStyles.totalRow}>
+              <Text style={ficuStyles.totalLabel}>TOTAL</Text>
+              <Text style={ficuStyles.totalValue}>{data.scoreTotal.toFixed(2)}%</Text>
+              <View
+                style={[
+                  ficuStyles.nivelChip,
+                  { backgroundColor: tintForNivel(data.clasificacionRiesgo) },
+                ]}
+              >
+                <Text style={ficuStyles.nivelChipText}>{data.clasificacionRiesgo}</Text>
+              </View>
+            </View>
+          </View>
+          <View style={ficuStyles.riesgoRight}>
+            <Text style={styles.sectionTitle}>RIESGO TOMADO</Text>
+            <PieChart criterios={data.criteriosRiesgo} />
+          </View>
+        </View>
+
+        {/* ── Manifestaciones legales LFPIORPI ── */}
+        <View style={ficuStyles.legalWrap}>
+          <Bullet>
+            Manifiesto bajo protesta de decir verdad que la documentación presentada es auténtica y
+            no presenta alteración alguna, y que fue obtenida de conformidad con las disposiciones
+            legales vigentes aplicables; que la información y datos proporcionados son veraces y
+            actualizados, además de que reflejan la situación real de quien suscribe, todo ello para
+            efectos de la identificación de los clientes o usuarios de actividades vulnerables,
+            prevista en el artículo 18 Fracción I de la Ley Federal para la Prevención e
+            Identificación de Operaciones con Recursos de Procedencia Ilícita.
+          </Bullet>
+          {/* FIX 3: texto correcto de Dueño Beneficiario */}
+          <Bullet>
+            En cumplimiento a la obligación establecida en el artículo 18 fracción III de la Ley
+            Federal para la Prevención e Identificación de Operaciones con Recursos de Procedencia
+            Ilícita, el Cliente declara que la presente operación se realiza{' '}
+            <Text style={styles.legalTextBold}>por cuenta propia y para sí mismo</Text>, por lo que
+            el Cliente es a la vez el Dueño Beneficiario de la operación. En términos de lo previsto
+            en las Reglas de Carácter General a que se refiere la citada Ley, esta Constancia es
+            firmada por quienes intervienen en la realización de la Actividad Vulnerable.
+          </Bullet>
+          {/* FIX 4: origen lícito */}
+          <Bullet>
+            El Cliente manifiesta bajo protesta de decir verdad que los recursos destinados a la
+            presente operación{' '}
+            <Text style={styles.legalTextBold}>provienen de fuente lícita y comprobable</Text>, y
+            que no se está utilizando esta operación para encubrir, transferir o invertir recursos
+            de procedencia ilícita.
+          </Bullet>
+          <Bullet>
+            Con la finalidad de mantener actualizado el expediente, el Cliente se compromete a
+            informar cualquier cambio de la información proporcionada en este documento.
+          </Bullet>
+        </View>
+
+        {/* ── Firma ── */}
+        <View style={styles.firmaWrap}>
+          <Text style={styles.firmaCliente}>Firma del Cliente</Text>
+          <Text style={styles.firmaNombre}>
+            {data.clienteNombre} ({data.identificacionInventario})
+          </Text>
+        </View>
+
+        <Text style={ficuStyles.avisoPrivacidad}>
+          Para conocer nuestro aviso de privacidad por favor entre a:
+          dilesa.mx/aviso-de-privacidad.html
+        </Text>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+/** Pie chart SVG manual — 5 segmentos uniformes (20% c/u) coloreados. */
+function PieChart({ criterios }: { criterios: CriterioRiesgo[] }) {
+  const size = 130;
+  const r = 55;
+  const cx = size / 2;
+  const cy = size / 2;
+  // Cada criterio aporta 20% del pie con color fijo (independiente del nivel)
+  const n = criterios.length;
+  const segmentAngle = (2 * Math.PI) / n;
+
+  const segments = criterios.map((c, idx) => {
+    const startAngle = idx * segmentAngle - Math.PI / 2;
+    const endAngle = (idx + 1) * segmentAngle - Math.PI / 2;
+    const x1 = cx + r * Math.cos(startAngle);
+    const y1 = cy + r * Math.sin(startAngle);
+    const x2 = cx + r * Math.cos(endAngle);
+    const y2 = cy + r * Math.sin(endAngle);
+    const largeArc = segmentAngle > Math.PI ? 1 : 0;
+    const d = `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`;
+    return { d, color: COLOR_SEGMENTO[idx], label: c.nombre };
+  });
+
+  return (
+    <Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <G>
+        {segments.map((s, i) => (
+          <Path key={i} d={s.d} fill={s.color} />
+        ))}
+      </G>
+    </Svg>
+  );
+}
+
+function tintForNivel(nivel: Nivel): string {
+  switch (nivel) {
+    case 'Bajo':
+      return '#d4e8c0';
+    case 'Medio':
+      return '#f7e4a3';
+    case 'Alto':
+      return '#f4b8b8';
+  }
+}
+
+function DataRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={ficuStyles.dataRow}>
+      <Text style={ficuStyles.dataLabel}>{label} </Text>
+      <Text style={ficuStyles.dataValue}>{value}</Text>
+    </View>
+  );
+}
+
+function DataInline({ label, value }: { label: string; value: string }) {
+  return (
+    <Text style={{ marginRight: 14 }}>
+      <Text style={ficuStyles.dataLabel}>{label} </Text>
+      <Text style={ficuStyles.dataValue}>{value}</Text>
+    </Text>
+  );
+}
+
+function DomicilioBlock({ d }: { d: DomicilioFicu }) {
+  const tieneEstructurado =
+    d.calle || d.colonia || d.municipio || d.codigoPostal || d.entidadFederativa;
+  if (!tieneEstructurado && d.integrado) {
+    return <DataRow label="Domicilio integrado:" value={d.integrado} />;
+  }
+  return (
+    <>
+      {d.calle ? <DataRow label="Calle:" value={d.calle} /> : null}
+      <View style={ficuStyles.tripleRow}>
+        {d.numeroExterior ? <DataInline label="Número exterior:" value={d.numeroExterior} /> : null}
+        {d.numeroInterior ? <DataInline label="Número interior:" value={d.numeroInterior} /> : null}
+      </View>
+      {d.colonia ? <DataRow label="Colonia:" value={d.colonia} /> : null}
+      <View style={ficuStyles.tripleRow}>
+        {d.municipio ? <DataInline label="Municipio:" value={d.municipio} /> : null}
+        {d.codigoPostal ? <DataInline label="CP:" value={d.codigoPostal} /> : null}
+      </View>
+      <View style={ficuStyles.tripleRow}>
+        {d.entidadFederativa ? (
+          <DataInline label="Entidad Federativa:" value={d.entidadFederativa} />
+        ) : null}
+        {d.pais ? <DataInline label="País:" value={d.pais} /> : null}
+      </View>
+    </>
+  );
+}
+
+function Bullet({ children }: { children: React.ReactNode }) {
+  return (
+    <View style={ficuStyles.bulletRow}>
+      <Text style={ficuStyles.bulletDot}>•</Text>
+      <Text style={styles.legalText}>{children}</Text>
+    </View>
+  );
+}
+
+const ficuStyles = StyleSheet.create({
+  dataRow: { flexDirection: 'row', marginBottom: 1.2 },
+  dataLabel: { fontSize: 8.5, color: colors.text },
+  dataValue: { fontSize: 8.5, fontFamily: 'Helvetica-Bold' },
+  tripleRow: { flexDirection: 'row', marginBottom: 1.2 },
+  subTitle: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    marginTop: 4,
+    marginBottom: 2,
+    color: colors.text,
+  },
+  riesgoSection: {
+    flexDirection: 'row',
+    marginTop: 6,
+    gap: 12,
+  },
+  riesgoLeft: { flex: 1 },
+  riesgoRight: { width: 160, alignItems: 'center' },
+  criterioRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 2,
+    gap: 4,
+  },
+  swatch: { width: 7, height: 7, borderRadius: 1 },
+  criterioNombre: { fontSize: 8, flex: 1 },
+  nivelChip: {
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 6,
+  },
+  nivelChipText: { fontSize: 7, fontFamily: 'Helvetica-Bold' },
+  criterioPct: {
+    fontSize: 8,
+    fontFamily: 'Helvetica-Bold',
+    width: 38,
+    textAlign: 'right',
+  },
+  totalRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 4,
+    paddingTop: 3,
+    borderTopWidth: 0.5,
+    borderTopColor: colors.borderSoft,
+    gap: 4,
+  },
+  totalLabel: { fontSize: 9, fontFamily: 'Helvetica-Bold', flex: 1 },
+  totalValue: { fontSize: 10, fontFamily: 'Helvetica-Bold', color: colors.primary },
+  legalWrap: { marginTop: 8 },
+  bulletRow: { flexDirection: 'row', marginBottom: 2 },
+  bulletDot: { fontSize: 8, marginRight: 4, marginTop: 1, color: colors.textMuted },
+  avisoPrivacidad: {
+    fontSize: 7,
+    color: colors.textMuted,
+    textAlign: 'center',
+    marginTop: 6,
+  },
+});

--- a/scripts/dilesa-pdf-preview.tsx
+++ b/scripts/dilesa-pdf-preview.tsx
@@ -10,6 +10,8 @@
 import { renderToFile } from '@react-pdf/renderer';
 import { SolicitudAsignacionPDF } from '../lib/dilesa/pdf/solicitud-asignacion';
 import { AvisoPrivacidadPDF } from '../lib/dilesa/pdf/aviso-privacidad';
+import { FicuPDF } from '../lib/dilesa/pdf/ficu';
+import { evaluarRiesgo } from '../lib/dilesa/ficu/riesgo';
 
 const solicitudData = {
   fechaTexto: '24 de Mayo del 2026',
@@ -49,12 +51,55 @@ const avisoData = {
   identificacionInventario: 'M3-L9-LDLE-ISC',
 };
 
+const riesgo = evaluarRiesgo({
+  tipoPersona: 'PERSONA FÍSICA',
+  nacionalidad: 'MEXICANA',
+  esPep: false,
+  formaPago: 'FINANCIAMIENTO HIPOTECARIO',
+  usoEfectivo: 'SIN USO DE EFECTIVO',
+});
+
+const ficuData = {
+  fechaTexto: '24 de Mayo del 2026',
+  nombres: 'JUAN ANTONIO',
+  apellidoPaterno: 'HERNANDEZ',
+  apellidoMaterno: 'MUÑOZ',
+  fechaNacimientoTexto: '25 de Diciembre del 1990',
+  curp: 'HEMJ901225HCLRXN03',
+  rfc: 'HEMJ9012251C1',
+  identificacion: {
+    tipo: 'INE / Credencial para Votar',
+    numero: '1649603399',
+    autoridad: 'Instituto Nacional Electoral',
+    vigencia: 'Vigente',
+  },
+  domicilio: {
+    integrado: 'SONORA #1038, COL. SAN JOAQUIN, PIEDRAS NEGRAS, COAHUILA, CP 26094, MÉXICO',
+  },
+  telefono: '8781228408',
+  correo: 'antoniohernandez2009_@hotmail.com',
+  personalidad: 'PERSONA FÍSICA',
+  nacionalidad: 'MEXICANA',
+  esPep: false,
+  formaPago: 'FINANCIAMIENTO HIPOTECARIO',
+  usoEfectivo: 'SIN USO DE EFECTIVO',
+  ocupacion: 'OTRAS OCUPACIONES - AGENTE ADUANAL',
+  criteriosRiesgo: riesgo.criterios,
+  scoreTotal: riesgo.scoreTotal,
+  clasificacionRiesgo: riesgo.clasificacion,
+  clienteNombre: 'JUAN ANTONIO HERNANDEZ MUÑOZ',
+  identificacionInventario: 'M3-L9-LDLE-ISC',
+};
+
 async function main() {
   await renderToFile(<SolicitudAsignacionPDF data={solicitudData} />, '/tmp/solicitud-preview.pdf');
   console.log('✔ /tmp/solicitud-preview.pdf');
 
   await renderToFile(<AvisoPrivacidadPDF data={avisoData} />, '/tmp/aviso-preview.pdf');
   console.log('✔ /tmp/aviso-preview.pdf');
+
+  await renderToFile(<FicuPDF data={ficuData} />, '/tmp/ficu-preview.pdf');
+  console.log('✔ /tmp/ficu-preview.pdf');
 }
 
 main().catch((e) => {


### PR DESCRIPTION
## Summary

Tercer PDF del expediente DILESA — **Formato de Identificación de Clientes** que exige LFPIORPI Art. 17 frac. V para compraventa de inmuebles. Replica el export visual de Coda con **4 correcciones legales** y la **fórmula EBR corregida**.

## 🔴 Fixes legales vs. el Coda histórico

| # | Problema en Coda | Fix aplicado |
|---|---|---|
| 1 | Identificación: solo número (`1649603399`) | Agrega **tipo** (INE/Pasaporte/Cédula), **autoridad emisora**, **vigencia** — Reglas Cap. X art. 28 |
| 2 | "NO conoce de la existencia del Dueño Beneficiario" — ambiguo legalmente | "El Cliente declara que la operación se realiza **por cuenta propia y para sí mismo**, por lo que el Cliente es a la vez el Dueño Beneficiario" — Art. 18 frac. III |
| 3 | Sin declaración de origen lícito | Bullet nuevo: "Los recursos provienen de **fuente lícita y comprobable**" |
| 4 | Domicilio sin estructura | Soporta campos estructurados; hoy `erp.personas.domicilio` es blob → fallback "Domicilio integrado". TODO: migración estructurada en sprint posterior |

## 🟢 EBR (Evaluación Basada en Riesgo)

Sigue **GAFI Recomendación 22** + **LFPIORPI Art. 18**. Mantiene los **5 criterios × 20% c/u** del Coda actual (para que el pie chart se vea igual), pero con **asignaciones Bajo/Medio/Alto defendibles**:

| Criterio | Bajo (6.67%) | Medio (13.33%) | Alto (20%) |
|---|---|---|---|
| Personalidad | PF mexicana | PF extranjera residente | PM / extranjero no residente / fideicomiso |
| Nacionalidad | Mexicana | Otra | País lista GAFI 2026 (Irán, Corea Norte, Venezuela, Cuba, etc.) |
| PEP | No PEP | PEP familiar/asociado | PEP directo |
| **Forma de Pago** | **Crédito hipotecario / Infonavit / Fovissste** ⚠ | Recursos propios | Efectivo significativo (≥ 3,210 UMAs) |
| Uso de Efectivo | $0 / < 1,605 UMAs | 1,605 – 3,210 UMAs | ≥ 3,210 UMAs |

**Clasificación final**: Bajo < 40%, Medio 40-66%, Alto > 66%.

⚠ **Corrección clave**: el Coda marcaba "Hipotecario = Alto" — incorrecto. El banco interpone KYC + recursos rastreables → Bajo. Con el fix, el cliente del sample (JAH-MUÑOZ) baja de 46.67% a **33.35% (Bajo)** que es defendible ante UIF.

## Implementación

- [lib/dilesa/ficu/riesgo.ts](lib/dilesa/ficu/riesgo.ts) — fórmula EBR pura TS con umbrales UMA 2026 + lista GAFI
- [lib/dilesa/ficu/riesgo.test.ts](lib/dilesa/ficu/riesgo.test.ts) — 31 tests cubriendo los 5 criterios + clasificación
- [lib/dilesa/pdf/ficu.tsx](lib/dilesa/pdf/ficu.tsx) — template react-pdf, pie chart SVG con 5 segmentos
- [app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx](app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx) — agrega tipo `ficu`
- [app/dilesa/ventas/[id]/page.tsx](app/dilesa/ventas/[id]/page.tsx) — agrega botón "FICU"

## Preview

```
$ npx tsx scripts/dilesa-pdf-preview.tsx
✔ /tmp/ficu-preview.pdf   # 1 página
```

## Test plan

- [ ] CI verde (typecheck + lint + format + tests + schema:check)
- [ ] Validar en preview que el FICU se ve y descarga
- [ ] Confirmar visualmente que los 4 fixes legales están bien redactados
- [ ] Verificar que el pie chart se renderiza con los 5 colores correctos

## Follow-ups (Sprint 7c+)

- Migración `erp.personas` → domicilio estructurado + form update para capturar campos individuales (calle/colonia/CP/entidad/país). Hoy se usa el blob como fallback.
- Capturar **vigencia INE** explícita en el form de venta (hoy hardcodeado a "Vigente").

🤖 Generated with [Claude Code](https://claude.com/claude-code)