### PR TITLE
feat(dilesa): Promesa de Compraventa PDF — replica Coda + 5 fixes + cédula 27 ítems

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -7,6 +7,7 @@
  *   - solicitud-asignacion
  *   - aviso-privacidad
  *   - ficu
+ *   - promesa-compraventa
  *
  * Auth: la sesión de Supabase. La RLS de `dilesa.ventas` decide si el
  * usuario puede leerla — vendedor solo sus propias ventas; otros roles
@@ -22,10 +23,26 @@ import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { SolicitudAsignacionPDF, type SolicitudData } from '@/lib/dilesa/pdf/solicitud-asignacion';
 import { AvisoPrivacidadPDF, type AvisoPrivacidadData } from '@/lib/dilesa/pdf/aviso-privacidad';
 import { FicuPDF, type FicuData } from '@/lib/dilesa/pdf/ficu';
+import { PromesaCompraventaPDF, type PromesaData } from '@/lib/dilesa/pdf/promesa-compraventa';
 import { evaluarRiesgo } from '@/lib/dilesa/ficu/riesgo';
 
-const TIPOS = ['solicitud-asignacion', 'aviso-privacidad', 'ficu'] as const;
+const TIPOS = ['solicitud-asignacion', 'aviso-privacidad', 'ficu', 'promesa-compraventa'] as const;
 type TipoPdf = (typeof TIPOS)[number];
+
+const MESES_ES = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+];
 
 export async function GET(
   _req: Request,
@@ -137,6 +154,92 @@ export async function GET(
     };
     const buf = await renderToBuffer(<AvisoPrivacidadPDF data={data} />);
     return pdfResponse(buf, `aviso-privacidad-${identificacionInventario || id}.pdf`);
+  }
+
+  if (tipo === 'promesa-compraventa') {
+    // Co-titular: si hay monto_credito_cotitular > 0, buscar persona cotitular
+    // Por ahora no hay FK explícita persona_cotitular_id en ventas, sólo el ref
+    // textual. Se deja el co-titular opcional; en sprint 7c se modela la FK.
+    // Si la unidad no se pudo cargar (raro), no podemos generar el contrato.
+    if (!venta.unidad_id) {
+      return NextResponse.json(
+        { error: 'La venta no tiene unidad asignada — no se puede generar el contrato.' },
+        { status: 400 }
+      );
+    }
+    const { data: unidadFull } = await sb
+      .schema('dilesa')
+      .from('unidades')
+      .select('manzana, numero_lote, area_m2, proyecto_id, producto_id')
+      .eq('id', venta.unidad_id)
+      .maybeSingle();
+    const [{ data: proyectoFull }, { data: productoFull }] = await Promise.all([
+      unidadFull?.proyecto_id
+        ? sb
+            .schema('dilesa')
+            .from('proyectos')
+            .select('nombre')
+            .eq('id', unidadFull.proyecto_id)
+            .maybeSingle()
+        : Promise.resolve({ data: null }),
+      unidadFull?.producto_id
+        ? sb
+            .schema('dilesa')
+            .from('productos')
+            .select('nombre')
+            .eq('id', unidadFull.producto_id)
+            .maybeSingle()
+        : Promise.resolve({ data: null }),
+    ]);
+
+    const precio =
+      Number(venta.monto_credito_titular ?? 0) + Number(venta.monto_credito_cotitular ?? 0);
+    const arras1pct = Math.round(precio * 0.01);
+    const arras10pct = Math.round(precio * 0.1);
+    const modeloSufijo = productoFull?.nombre ? (productoFull.nombre.split('-').pop() ?? '') : '';
+
+    const data: PromesaData = {
+      fechaTexto,
+      horaTexto: fechaCreado.toLocaleTimeString('es-MX', {
+        hour: 'numeric',
+        minute: '2-digit',
+      }),
+      diaTexto: String(fechaCreado.getDate()),
+      mesTexto: MESES_ES[fechaCreado.getMonth()],
+      anioTexto: String(fechaCreado.getFullYear()),
+      comprador: {
+        nombre: clienteNombre.toUpperCase(),
+        curp: persona?.curp ?? null,
+        rfc: persona?.rfc ?? null,
+        estadoCivil: null, // TODO sprint-7c: capturar estado civil en form
+        profesion: venta.ocupacion ?? null,
+        domicilio: persona?.domicilio ?? null,
+        ineNumero: venta.ine_numero ?? null,
+      },
+      coTitular: null, // TODO sprint-7c: agregar FK persona_cotitular_id
+      inmueble: {
+        fraccionamiento: proyectoFull?.nombre ?? '',
+        lote: unidadFull?.numero_lote ?? '',
+        manzana: unidadFull?.manzana ?? '',
+        superficieM2: Number(unidadFull?.area_m2 ?? 0),
+        modeloVivienda: modeloSufijo,
+        identificacionInventario,
+      },
+      operacion: {
+        precio,
+        enganche1pct: arras1pct,
+        arras10pct,
+        tipoCredito: venta.tipo_credito ?? '',
+      },
+      folio: `${(clienteNombre || '')
+        .split(/\s+/)
+        .map((p) => p[0]?.toUpperCase())
+        .filter(Boolean)
+        .slice(0, 3)
+        .join('')}-${identificacionInventario}-${fechaCreado.toLocaleString('es-MX')}`,
+    };
+    const buf = await renderToBuffer(<PromesaCompraventaPDF data={data} />);
+    return pdfResponse(buf, `promesa-compraventa-${identificacionInventario || id}.pdf`);
   }
 
   if (tipo === 'ficu') {

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -547,6 +547,11 @@ function DetailInner() {
         />
         <PdfDownloadLink ventaId={venta.id} tipo="aviso-privacidad" label="Aviso de Privacidad" />
         <PdfDownloadLink ventaId={venta.id} tipo="ficu" label="FICU" />
+        <PdfDownloadLink
+          ventaId={venta.id}
+          tipo="promesa-compraventa"
+          label="Promesa de Compraventa"
+        />
       </div>
 
       <Section title="Datos del cliente">
@@ -778,7 +783,7 @@ function PdfDownloadLink({
   label,
 }: {
   ventaId: string;
-  tipo: 'solicitud-asignacion' | 'aviso-privacidad' | 'ficu';
+  tipo: 'solicitud-asignacion' | 'aviso-privacidad' | 'ficu' | 'promesa-compraventa';
   label: string;
 }) {
   return (

--- a/lib/dilesa/contrato/cedula-materiales-default.ts
+++ b/lib/dilesa/contrato/cedula-materiales-default.ts
@@ -1,0 +1,300 @@
+/**
+ * Cédula de Características Generales, Materiales y Acabados de la
+ * Vivienda — Anexo 3 del Contrato de Promesa de Compraventa.
+ *
+ * Hoy todos los prototipos DILESA usan los mismos 27 ítems. Por eso
+ * vive aquí como módulo TS. Cuando agregues prototypes diferentes, el
+ * camino correcto es:
+ *
+ *   1. Migración: `dilesa.productos.cedula_materiales jsonb`
+ *   2. Backfill: clonar este array a todos los productos existentes.
+ *   3. Form de admin para editar la cédula por producto.
+ *   4. El template lee `producto.cedula_materiales`; este archivo
+ *      queda como fallback inicial.
+ *
+ * Estructura tomada del export de Coda existente (DOC: DILESA · Promesa
+ * de Compraventa).
+ */
+
+export type ItemMaterial = {
+  clave: number;
+  descripcion: string;
+  marca: string;
+  etapa: string;
+  norma: string;
+  colocacion: string;
+  recomendacion: string;
+};
+
+export const CEDULA_MATERIALES_DEFAULT: ItemMaterial[] = [
+  {
+    clave: 1,
+    descripcion: 'Tubería hidráulica 1/2" CPVC Ced. 40',
+    marca: 'Cresco',
+    etapa: 'Hidráulica',
+    norma: 'NMX-E-181 CNCP-2006',
+    colocacion:
+      'Revise el tubo / accesorio buscando que esté libre de daños o fisuras. Limpie el tubo con un trapo seco y realice un corte perpendicular sin dejar rebaba en las caras del tubo utilizando tijeras corta tubos plásticos o segueta. En caso de tener un tubo dañado realice un corte de 5 cm antes de la región dañada. Si la tubería está sucia, utilice un limpiador. Pruebe en seco el accesorio en el tubo que debe entrar hasta 2/3 con dificultad. Utilizando cemento de resina de CPVC, con el aplicador del tarro, impregne de cemento la superficie externa del tubo, en un área que cubra la profundidad de la conexión. Sin volver a empapar el aplicador impregne sin exceso de cemento la parte interna de la conexión hasta el tope interior. Inserte el tubo en la conexión mientras va girando un cuarto de vuelta hasta el tope del accesorio. Sostenga la unión durante 10 - 30 segundos, verificando que se forme un anillo de cemento de CPVC en el exterior de la unión del tubo y la conexión. Si el anillo no se forma, corte la conexión y repita el proceso. Finalmente, si existe exceso de cemento retírelo de inmediato con un trapo.',
+    recomendacion:
+      'Siga correctamente los procedimientos de manejo de los materiales. Use herramientas apropiadas para el uso con tubería y conexiones de CPVC. Use el cemento correcto y siga las instrucciones para la aplicación. Corte los extremos del tubo perpendicularmente. Quitar la rebaba y biselar el tubo antes de pegar. No utilice aceites comestibles como lubricante. No utilice cementos que estén caducados, decolorados o gelatinosos. No utilice cementos cerca de una fuente de calor, fuego o mientras está fumando. No realice la prueba de presión antes de que transcurra el tiempo de curado recomendado. No utilice herramientas de corte sin filo o rotas al cortar el tubo.',
+  },
+  {
+    clave: 2,
+    descripcion: 'Conexiones hidráulicas 1/2" CPVC Ced. 40 (tee, codo 90°, codo 45°, cople, etc.)',
+    marca: 'Cresco',
+    etapa: 'Hidráulica',
+    norma: 'NMX-E-181 CNCP-2006',
+    colocacion: 'Mismo procedimiento de unión solvente que para la tubería CPVC (ver ítem 1).',
+    recomendacion: 'Mismas recomendaciones que para la tubería CPVC (ver ítem 1).',
+  },
+  {
+    clave: 3,
+    descripcion: 'Tubería Sanitaria PVC 4"',
+    marca: 'Cresco',
+    etapa: 'Sanitaria',
+    norma: 'NMX-E-181 CNCP-2006',
+    colocacion:
+      'Mismo procedimiento de unión solvente que CPVC, utilizando cemento de resina de PVC para sanitaria. Ver ítem 1 para el detalle paso a paso.',
+    recomendacion: 'Mismas recomendaciones aplicables al PVC sanitario (ver ítem 1).',
+  },
+  {
+    clave: 4,
+    descripcion: 'Conexiones sanitarias PVC 4" (tee, codo 90°, codo 45°, cople, etc.)',
+    marca: 'Cresco',
+    etapa: 'Sanitaria',
+    norma: 'NMX-E-181 CNCP-2006',
+    colocacion: 'Mismo procedimiento de unión solvente PVC sanitario (ver ítem 3).',
+    recomendacion: 'Mismas recomendaciones que para conexiones PVC (ver ítem 1).',
+  },
+  {
+    clave: 5,
+    descripcion: 'Cable eléctrico Cal. 10, 12 y 14',
+    marca: 'Argos',
+    etapa: 'Eléctrica',
+    norma: 'NOM-063-SCFI-2000, NOM-001-SEDE-2005, NMX-J-010-ANCE-2005, NMX-J-012-ANCE-2005',
+    colocacion:
+      'Los conductores de cada circuito independiente parten de su correspondiente PIA en el cuadro eléctrico y recorren la vivienda alojados en el interior por manguera tipo poliducto empotrados en la pared. A lo largo del recorrido, la alimentación de cada receptor (puntos de luz y tomas de corriente) se realiza por derivación de los conductores principales del circuito independiente, en cajas de registro donde se realizan conexiones y empalmes de los cables eléctricos.',
+    recomendacion: 'Aislar bien las conexiones para evitar accidentes.',
+  },
+  {
+    clave: 6,
+    descripcion: 'Piso Cerámico (según proyecto)',
+    marca: '—',
+    etapa: 'Acabados',
+    norma: 'NOM-231-SSA1-2002',
+    colocacion:
+      'Aplique el pegamento sobre la superficie plana, firme, nivelada y limpia. Coloque el pegamento con una llana dentada dejando una junta mínima de 2 mm.',
+    recomendacion:
+      'Los contrapisos deben tener un mínimo de 3 días de secado. Antes de la colocación limpiar las juntas entre piezas — cualquier agente presente puede restar efectividad a la adherencia del porcelanato. Después de la instalación y de sellar las juntas es obligatorio remover la cera protectora, aplicando cemento blanco o con los mismos residuos del pego. No utilizar esponjas de alambre.',
+  },
+  {
+    clave: 7,
+    descripcion: 'Loseta Cerámica (según proyecto)',
+    marca: '—',
+    etapa: 'Acabados',
+    norma: 'NOM-231-SSA1-2002',
+    colocacion: 'Mismo procedimiento que el Piso Cerámico (ver ítem 6).',
+    recomendacion: 'Mismas recomendaciones que el Piso Cerámico (ver ítem 6).',
+  },
+  {
+    clave: 8,
+    descripcion: 'Piso antiderrapante (según proyecto)',
+    marca: '—',
+    etapa: 'Acabados',
+    norma: 'NOM-231-SSA1-2002',
+    colocacion: 'Mismo procedimiento que el Piso Cerámico (ver ítem 6).',
+    recomendacion: 'Mismas recomendaciones que el Piso Cerámico (ver ítem 6).',
+  },
+  {
+    clave: 9,
+    descripcion: 'Concreto Escobillado y/o Floteado — Cemento',
+    marca: 'Monterrey',
+    etapa: 'Acabados',
+    norma: 'NMX-C-061, NMX-C-059, NMX-C-062',
+    colocacion:
+      'Este cemento puede utilizarse en la construcción de todo tipo de elementos o estructuras de concreto simple o armado. Es compatible con todos los materiales de construcción convencionales logrando excelentes resultados en la construcción tradicional de pisos, firmes, castillos, trabes, zapatas, losas, columnas, etc.',
+    recomendacion:
+      'No use la unidad para transportar otros productos diferentes al cemento; en su caso, elimine los residuos del material extraño antes de la carga del cemento. Antes de la carga asegúrese de que el interior de la tolva se encuentra limpio y seco. Después de la carga asegúrese de que las tapas de la tolva cierren herméticamente; mantenga el interior limpio y libre de adherencias. Incluya la limpieza del interior de la tolva y su hermeticidad en los programas de mantenimiento de la unidad.',
+  },
+  {
+    clave: 10,
+    descripcion: 'Adhesivo Blanco Premier Antideslizamiento',
+    marca: 'Interceramic',
+    etapa: 'Generales',
+    norma: 'ANSI A 118.1',
+    colocacion:
+      'Instale conforme a la norma ANSI A108.5. Utilice una llana de tamaño apropiado para asegurar un 100% de cobertura. Extienda la pasta en la superficie utilizando el lado plano de la llana, con una inclinación de 30 a 40 grados; asegúrese que el adhesivo penetre en las irregularidades de la superficie para lograr una máxima adhesión. Enseguida distribúyala con el lado dentado, utilizando una llana de diente cuadrado y extendiendo el adhesivo en sentido horizontal o vertical. Coloque las losetas sobre el adhesivo y presione con firmeza, ajústela con movimientos perpendiculares al rayado del adhesivo.',
+    recomendacion:
+      'USOS: instalar loseta cerámica de baja o alta absorción de agua (con o sin esmalte), mosaico, azulejo, talavera, laja, granito, cantera, mármol claro, conchuela o productos similares sobre concreto sin pulir, enjarre, mortero, tablero cemento ASTM C1325 o ANSI 118.9 y tableros de yeso ASTM 1396/C1396M. LIMITACIONES: no utilizar para mármol verde o negro. No instalar sobre cerámica. Vida útil de la mezcla: 2 horas.',
+  },
+  {
+    clave: 11,
+    descripcion: 'Adhesivo Gris Piso',
+    marca: 'Interceramic',
+    etapa: 'Generales',
+    norma: 'ANSI A 118.1',
+    colocacion: 'Mismo procedimiento que el Adhesivo Blanco Premier (ver ítem 10).',
+    recomendacion:
+      'USOS: loseta cerámica de baja absorción de agua. LIMITACIONES: no usar para mármol verde o negro; no aplicar sobre cerámica. Vida útil de la mezcla: 2 horas.',
+  },
+  {
+    clave: 12,
+    descripcion: 'Pegazulejo',
+    marca: 'Interceramic',
+    etapa: 'Generales',
+    norma: 'ANSI A 118.1',
+    colocacion: 'Mismo procedimiento que los adhesivos cerámicos (ver ítem 10).',
+    recomendacion:
+      'USOS: loseta de alta absorción de agua hasta formatos de 33×33 cm. LIMITACIONES: no usar para mármol verde o negro; no aplicar sobre cerámica. Vida útil de la mezcla: 2 horas.',
+  },
+  {
+    clave: 13,
+    descripcion: 'Boquilla sin Arena',
+    marca: 'Interceramic',
+    etapa: 'Generales',
+    norma: 'ANSI A 118.6',
+    colocacion:
+      'Limpie y humedezca el área a emboquillar. Utilizando una llana de hule rígido, extienda la boquilla en forma diagonal a las líneas de las juntas, fórjela entre las mismas. Retire el exceso de boquilla de la superficie. Espere de 5 a 10 minutos hasta que la boquilla adquiera firmeza en las juntas; enseguida limpie con una esponja exprimida haciendo presión suave y con movimientos circulares.',
+    recomendacion:
+      'USOS: boquilla para interiores y exteriores, espesores de unión menores a 3 mm en loseta cerámica, porcelana, mármol y materiales similares. LIMITACIONES: no usar a temperaturas menores de 15 °C; no aplicar sobre juntas de expansión.',
+  },
+  {
+    clave: 14,
+    descripcion: 'Yeso Máximo',
+    marca: 'Yesera Monterrey',
+    etapa: 'Generales',
+    norma: 'NOM-018',
+    colocacion:
+      'En una batea limpia, libre de residuo de yeso fraguado, agregue agua limpia de acuerdo a las especificaciones, vacíe uniformemente y espolvoree en la batea la cantidad de yeso requerida de acuerdo con la cantidad de agua agregada. Antes de aplicar el yeso verifique que la superficie esté libre de impurezas, aceites, grasas, sales solubles, salitre y trasminación de agua al exterior. Utilice reglas o espátulas para plomear y aplanar el acabado; deben estar limpias y libres de yeso fraguado.',
+    recomendacion:
+      'El uso de agua en exceso alarga el tiempo de fraguado y da un acabado blando; la falta de agua lo reduce y da un acabado áspero. En losas debe estar preferentemente impermeabilizado antes de aplicar el yeso.',
+  },
+  {
+    clave: 15,
+    descripcion: 'Stucco',
+    marca: 'Uniblock',
+    etapa: 'Generales',
+    norma: 'NOM-018-ENER',
+    colocacion:
+      'Moje o selle la superficie. Con una llana metálica cuadrada aplique el recubrimiento UNIBLOCK STUCCO con movimientos de abajo hacia arriba y de derecha a izquierda formando una cruz. Para dar acabado espere 20 minutos y utilice una llana de esponja con movimientos circulares para obtener el acabado flotado. Durante las próximas 72 h humedezca la superficie en la mañana y noche.',
+    recomendacion:
+      'USOS: block, barro block, concreto celular y mortero base cemento-arena. Para uso interior y exterior. Repelente a la humedad. LIMITACIONES: no aplicar sobre paredes recubiertas de pintura ni sobre yeso, paneles con flexión o superficies metálicas/vibraciones extremas.',
+  },
+  {
+    clave: 16,
+    descripcion: 'Aislante Térmico SPRAYFFEL 1506',
+    marca: '—',
+    etapa: 'Generales',
+    norma: 'NOM-018-ENER-2011',
+    colocacion:
+      'Aplicar sobre sustrato limpio (sin grasa, polvo ni residuos). Resanar puntos críticos: chaflanes, domos, tubería que atraviese la losa, fisuras mayores, uniones de losa, juntas constructivas.',
+    recomendacion:
+      'Evita filtraciones, goteras y humedad; rechaza frío, calor y ruido por sus propiedades térmico-acústicas.',
+  },
+  {
+    clave: 17,
+    descripcion: 'Pintura Vinílica',
+    marca: 'Berel',
+    etapa: 'Generales',
+    norma: 'NMX-U-116-SCFI-2018',
+    colocacion:
+      'Aplicar en el interior y exterior de la fachada principal hasta cubrir la superficie (mínimo dos manos), sobre muros previamente sellados con sellador vinílico, resanados y limpios de polvo e impurezas.',
+    recomendacion:
+      'No diluir en exceso ni extender más de la cuenta — se modifican propiedades y rendimiento. Calcular el área de pintado y la cantidad necesaria, considerando textura, porosidad y herramienta (brocha, rodillo o pistola).',
+  },
+  {
+    clave: 18,
+    descripcion: 'Puerta principal 0.90 × 2.03 m, acero de poliestireno color chocolate',
+    marca: '—',
+    etapa: 'Herrería y Carpintería',
+    norma: 'NMX-R-060-SCFI-2013',
+    colocacion:
+      'Dejar espacio de 3 mm a cada lado entre marco y puerta. Recomendable un rebaje inclinado (desveine) hacia adentro para mejor ajuste y espacio para las bisagras. Marcar la posición de las bisagras y rebajar; profundidad igual al espesor del cuerpo de la bisagra. Una vez instaladas, colocar la puerta usando cuñas; marcar y calar las bisagras finales.',
+    recomendacion:
+      'No alterar la estructura de la puerta. Instalar la cerradura al momento de colgar. Las puertas de uso exterior son resistentes a la humedad ambiental.',
+  },
+  {
+    clave: 19,
+    descripcion: 'Puerta de Recámara 0.80 × 2.03 m, tambor color chocolate',
+    marca: '—',
+    etapa: 'Herrería y Carpintería',
+    norma: 'NMX-R-060-SCFI-2013',
+    colocacion: 'Mismo procedimiento de instalación que la Puerta principal (ver ítem 18).',
+    recomendacion: 'Mismas recomendaciones que la Puerta principal (ver ítem 18).',
+  },
+  {
+    clave: 20,
+    descripcion: 'Puerta de Baño 0.70 × 2.03 m, tambor color chocolate',
+    marca: '—',
+    etapa: 'Herrería y Carpintería',
+    norma: 'NMX-R-060-SCFI-2013',
+    colocacion: 'Mismo procedimiento de instalación que la Puerta principal (ver ítem 18).',
+    recomendacion: 'Mismas recomendaciones que la Puerta principal (ver ítem 18).',
+  },
+  {
+    clave: 21,
+    descripcion: 'Puerta corrediza de aluminio color hueso 2", cristal claro 6 mm',
+    marca: '—',
+    etapa: 'Herrería y Carpintería',
+    norma: 'NMX-R-060-SCFI-2013',
+    colocacion:
+      'La ventana llevará garras para su fijación: al menos dos por largo, abiertas antes de su colocación. Mínimo dos garras separadas a no más de 50 cm entre sí; un punto de anclaje como máximo a 25 cm de cada esquina del premarco. Verificar el hueco limpio de yeso y otros materiales, a nivel y con medidas constantes.',
+    recomendacion: 'Verificar correcta operación de los herrajes después de la colocación.',
+  },
+  {
+    clave: 22,
+    descripcion: 'Puerta de servicio 1.75 × 2.70 m, fabricada con PTR 1 1/2" × 1 y 2 × 1"',
+    marca: '—',
+    etapa: 'Herrería y Carpintería',
+    norma: 'NMX-R-060-SCFI-2013',
+    colocacion: 'Mismo procedimiento de instalación que la Puerta principal (ver ítem 18).',
+    recomendacion: 'Mismas recomendaciones que la Puerta principal (ver ítem 18).',
+  },
+  {
+    clave: 23,
+    descripcion: 'Ventanas corredizas y fijos de aluminio color chocolate 1 1/2", cristal 3 mm',
+    marca: '—',
+    etapa: 'Herrería y Carpintería',
+    norma: 'NMX-R-060-SCFI-2013, ASTM C 1363-2011',
+    colocacion: 'Mismo procedimiento que la Puerta corrediza de aluminio (ver ítem 21).',
+    recomendacion:
+      'No retirar las hojas para colocar las ventanas, salvo en casos de envergadura grande (peso/maniobrabilidad). Asegurar que al colocarlas de nuevo queden en la posición adecuada y los herrajes funcionen correctamente.',
+  },
+  {
+    clave: 24,
+    descripcion: 'Sanitario Mónaco SA8238-I-0 color blanco, descarga 4.8 L',
+    marca: 'Interceramic',
+    etapa: 'Baños y Accesorios',
+    norma: 'NOM-009-CNA-2001',
+    colocacion: 'Instalación estándar del inodoro en el baño.',
+    recomendacion:
+      'Limpiar con agua y paño suave. Evitar limpiadores en polvo, químicos o paños ásperos. No utilizar ácidos — causan corrosión. Se recomienda jabón líquido sin alcohol; lavar, enjuagar y secar perfectamente.',
+  },
+  {
+    clave: 25,
+    descripcion: 'Lavabo para manos LUCCA MB-LAVP12038C0',
+    marca: 'Interceramic',
+    etapa: 'Baños y Accesorios',
+    norma: 'NOM-009-CNA-2001',
+    colocacion: 'Instalación estándar del lavabo en el baño.',
+    recomendacion: 'Mismas recomendaciones de limpieza que el Sanitario (ver ítem 24).',
+  },
+  {
+    clave: 26,
+    descripcion: 'Mezcladora monomando para empotrar 34-MC para regadera',
+    marca: 'Rugo',
+    etapa: 'Baños y Accesorios',
+    norma: 'NOM-009-CNA-2001',
+    colocacion: 'Instalación estándar de la mezcladora en la regadera.',
+    recomendacion: 'Mismas recomendaciones de limpieza que el Sanitario (ver ítem 24).',
+  },
+  {
+    clave: 27,
+    descripcion: 'Regadera metálica cromo modelo SH458M',
+    marca: 'AMG',
+    etapa: 'Baños y Accesorios',
+    norma: 'NMX-R-060-SCFI-2013, ASTM C 1363-2011, NOM-008-CONAGUA-1998',
+    colocacion: 'Instalación estándar de regadera en baño.',
+    recomendacion: 'Mismas recomendaciones de limpieza que el Sanitario (ver ítem 24).',
+  },
+];

--- a/lib/dilesa/contrato/constantes.ts
+++ b/lib/dilesa/contrato/constantes.ts
@@ -1,0 +1,91 @@
+/**
+ * Constantes hardcoded para el Contrato de Promesa de Compraventa
+ * DILESA (Sprint 7b). Cada bloque tiene un TODO con dónde debería
+ * vivir cuando lo migremos a DB.
+ *
+ * Mantener este archivo como única fuente de verdad mientras los
+ * datos no estén en DB. Cuando se migren, borrar el bloque
+ * correspondiente y leer desde Supabase.
+ */
+
+// TODO(sprint-7c): mover a `core.empresas.representante_legal` +
+// columna con CURP/RFC/dirección/INE del representante.
+export const REPRESENTANTE_DILESA = {
+  nombre: 'LC NORBERTO GUTIERREZ INFANTE',
+  curp: 'GUIN980718HCLTNR01',
+  rfc: 'GUIN980718M51',
+  nacionalidad: 'mexicano por nacimiento',
+  estadoCivil: 'soltero',
+  profesion: 'profesionista',
+  edad: 'mayor de edad',
+  domicilio: {
+    calle: 'Olímpica',
+    numero: '206',
+    colonia: 'Colinas',
+    cp: '26089',
+    ciudad: 'Piedras Negras, Coahuila',
+  },
+  ine: {
+    numero: 'IDMEX1738991608 06341063634439807187H2612317MEX',
+    autoridad: 'Instituto Nacional Electoral',
+  },
+};
+
+// TODO(sprint-7c): mover a `erp.cuentas_bancarias` con tipo = 'principal_inmobiliaria'.
+export const CUENTA_DILESA = {
+  banco: 'BBVA BANCOMER',
+  numeroCuenta: '0141502492',
+  clabe: '012075001415024923',
+  titular: 'DESARROLLO INMOBILIARIO LOS ENCINOS S.A. DE C.V.',
+};
+
+// TODO(sprint-7c): mover a `core.empresas.escritura_constitutiva` (JSONB que ya existe)
+// y `core.empresas.escritura_modificacion` (nueva columna o array).
+export const ESCRITURAS_CONSTITUTIVAS_DILESA = {
+  constitutiva: {
+    numero: '167',
+    fecha: '04 de septiembre del 2003',
+    notario: '16',
+    distritoNotarial: 'Saltillo',
+    fme: '2299',
+  },
+  modificacion: {
+    numero: '35',
+    fecha: '28 de Abril del 2020',
+    notario: '3',
+    distritoNotarial: 'Piedras Negras',
+    fme: '2299',
+  },
+  rfc: 'DIE030904866',
+};
+
+// TODO(sprint-7c): mover a `dilesa.proyectos.escritura_madre` (JSONB).
+// Cada proyecto tiene 1 escritura madre del terreno; los lotes derivan.
+// Hoy todos los proyectos usan esta misma escritura (Lomas de los Encinos).
+export const ESCRITURA_MADRE_DEFAULT = {
+  numero: '303',
+  fecha: '01 de Diciembre del año 2022 dos mil veintidós',
+  notario: {
+    nombre: 'Lic. GUILLERMO NICOLAS LOPEZ ELIZONDO',
+    numeroNotaria: '25',
+    ciudad: 'Piedras Negras, Coahuila',
+  },
+  registroPublico: {
+    ciudad: 'Piedras Negras, Coahuila',
+    entrada: '41982/2023',
+    fecha: '27 de FEBRERO del año 2023 dos mil veintitrés',
+  },
+};
+
+// TODO(sprint-7c): tabla `dilesa.venta_testigos` para capturar testigos
+// por venta. Por ahora son los 2 fijos que firman todos los contratos.
+export const TESTIGOS_DEFAULT = [
+  { nombre: 'EDGAR DANIEL PEÑA PALOMO' },
+  { nombre: 'NELCY ELIZABETH MARTÍNEZ DÍAZ' },
+];
+
+// Tribunal competente — fijo por ahora, todos los contratos DILESA.
+export const TRIBUNAL_COMPETENTE = {
+  distrito: 'Distrito Río Grande',
+  ciudad: 'Piedras Negras, Coahuila',
+};

--- a/lib/dilesa/pdf/promesa-compraventa.tsx
+++ b/lib/dilesa/pdf/promesa-compraventa.tsx
@@ -1,0 +1,770 @@
+/**
+ * Template PDF: Contrato de Promesa de Compraventa (Sprint 7b).
+ *
+ * Replica el export Coda con interpolación correcta (los datos van
+ * inline donde corresponde, no al final del párrafo como en Coda) y
+ * los siguientes fixes acordados con Beto:
+ *
+ *   Fix 1 — Header del contrato: nombre del comprador + identificador
+ *           del inmueble bien posicionados.
+ *   Fix 2 — Encabezado de comparecencia: hora/día/mes/año desde el
+ *           folio en lugar de "( ) HORAS DEL DIA DE HOY ( ) DE DEL ( )".
+ *   Fix 3 — Cláusula PRIMERA: condiciona el DTU según tipo_credito.
+ *           Si es Infonavit → DTU; si no → fecha de aprobación del
+ *           crédito. (Acuerdo Beto 2026-05-24.)
+ *   Fix 4 — Cláusula TERCERA: "dentro de los 30 días naturales
+ *           siguientes a la firma de este contrato" en lugar del
+ *           vago "el mes calendario".
+ *   Fix 5 — Co-titular: si la venta tiene monto_credito_cotitular > 0,
+ *           se lista al co-titular como segunda PROMITENTE COMPRADORA
+ *           en el cuerpo, en GENERALES y en las firmas.
+ *
+ * Layout: 2 páginas de contrato + ~3 páginas de Cédula de Materiales
+ *         (Anexo 3). El componente react-pdf maneja el salto automático.
+ */
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand, Folio } from './header-footer';
+import {
+  CUENTA_DILESA,
+  ESCRITURAS_CONSTITUTIVAS_DILESA,
+  ESCRITURA_MADRE_DEFAULT,
+  REPRESENTANTE_DILESA,
+  TESTIGOS_DEFAULT,
+  TRIBUNAL_COMPETENTE,
+} from '../contrato/constantes';
+import { CEDULA_MATERIALES_DEFAULT } from '../contrato/cedula-materiales-default';
+
+export type PromesaParte = {
+  nombre: string; // "CHRISTOPHER ALFONSO LIMAS MARTINEZ"
+  curp?: string | null;
+  rfc?: string | null;
+  estadoCivil?: string | null; // "casado" / "soltero"
+  profesion?: string | null;
+  domicilio?: string | null; // blob por ahora
+  ineNumero?: string | null;
+};
+
+export type PromesaData = {
+  fechaTexto: string; // "22 de Mayo del 2026" — fecha del folio
+  horaTexto: string; // "9:35" — hora del folio
+  diaTexto: string; // "22"
+  mesTexto: string; // "Mayo"
+  anioTexto: string; // "2026"
+
+  comprador: PromesaParte;
+  coTitular?: PromesaParte | null;
+
+  inmueble: {
+    fraccionamiento: string;
+    lote: string;
+    manzana: string;
+    superficieM2: number; // 105
+    modeloVivienda: string; // "ISC" — sufijo del prototipo
+    identificacionInventario: string; // "M3-L16-LDLE-ISC"
+  };
+
+  operacion: {
+    precio: number; // 1021000
+    enganche1pct: number; // 10210
+    arras10pct: number; // 102100
+    tipoCredito: string; // "Infonavit" / "Bancario" / "Recursos propios"
+  };
+
+  folio: string; // "CLM-M3-L16-LDLE-ISC-5/24/2026 9:35:36 AM"
+};
+
+const fmtMoney = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const money = (n: number) => fmtMoney.format(Number(n) || 0);
+
+export function PromesaCompraventaPDF({ data }: { data: PromesaData }) {
+  const esInfonavit = /infonavit/i.test(data.operacion.tipoCredito);
+  const fechaMaximaCelebracion = esInfonavit
+    ? 'el día que se cumplan 30 días naturales después de la obtención del Dictamen Técnico Único (DTU)'
+    : 'el día que se cumplan 30 días naturales después de la fecha de aprobación del crédito';
+
+  const compradoresNombre = data.coTitular
+    ? `${data.comprador.nombre} Y ${data.coTitular.nombre}`
+    : data.comprador.nombre;
+
+  return (
+    <Document title={`Promesa de Compraventa — ${data.inmueble.identificacionInventario}`}>
+      <Page size="LETTER" style={styles.page} wrap>
+        <HeaderBand title="CONTRATO DE PROMESA DE COMPRAVENTA" fecha={data.fechaTexto} />
+
+        {/* ── Header del contrato (Fix 1) ── */}
+        <Text style={contratoStyles.encabezado}>
+          CONTRATO DE PROMESA DE COMPRAVENTA ENTRE{' '}
+          <Text style={contratoStyles.bold}>DESARROLLO INMOBILIARIO LOS ENCINOS SA DE CV</Text> Y{' '}
+          <Text style={contratoStyles.bold}>{compradoresNombre}</Text> PARA UN INMUEBLE CON
+          IDENTIFICACIÓN:{' '}
+          <Text style={contratoStyles.bold}>{data.inmueble.identificacionInventario}</Text>
+        </Text>
+
+        {/* ── Comparecencia (Fix 2: fecha completa, no blanks) ── */}
+        <Text style={contratoStyles.parrafo}>
+          EN LA CIUDAD DE PIEDRAS NEGRAS, COAHUILA, MEXICO, SIENDO LAS{' '}
+          <Text style={contratoStyles.bold}>{data.horaTexto}</Text> HORAS DEL DÍA DE HOY{' '}
+          <Text style={contratoStyles.bold}>{data.diaTexto}</Text> DE{' '}
+          <Text style={contratoStyles.bold}>{data.mesTexto.toUpperCase()}</Text> DEL{' '}
+          <Text style={contratoStyles.bold}>{data.anioTexto}</Text> COMPARECIERON: POR UNA PARTE EL{' '}
+          <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.nombre}</Text> EN REPRESENTACIÓN
+          DE{' '}
+          <Text style={contratoStyles.bold}>DESARROLLO INMOBILIARIO LOS ENCINOS S.A DE C.V.</Text>,
+          A QUIEN EN LO SUCESIVO SE LE DENOMINARÁ INDISTINTAMENTE COMO{' '}
+          <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text>; Y POR OTRA PARTE{' '}
+          <Text style={contratoStyles.bold}>{compradoresNombre}</Text>, A{' '}
+          {data.coTitular ? 'QUIENES' : 'QUIEN'} EN LO SUCESIVO SE {data.coTitular ? 'LES' : 'LE'}{' '}
+          DENOMINARÁ <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text> Y A LOS
+          DOS INTERVINIENTES COMO <Text style={contratoStyles.quoted}>“LAS PARTES”</Text>; QUIENES
+          MÁS ADELANTE JUSTIFICARÁN LA PERSONALIDAD CON LA QUE COMPARECEN Y AMBOS LA RECONOCEN
+          MUTUAMENTE DESDE ESTE MOMENTO Y QUE POR ENDE TIENEN CAPACIDAD Y APTITUD LEGAL PARA
+          CONTRATAR. Y DIJERON: QUE ACUDEN A CELEBRAR UN CONTRATO DE PROMESA DE COMPRAVENTA RESPECTO
+          DEL INMUEBLE QUE MÁS ADELANTE SE PRECISARÁ CONFORME A LAS SIGUIENTES DECLARACIONES Y
+          CLÁUSULAS:
+        </Text>
+
+        <Text style={contratoStyles.seccionTitulo}>DECLARACIONES</Text>
+
+        <Text style={contratoStyles.parrafo}>
+          <Text style={contratoStyles.bold}>I.- </Text> Declara{' '}
+          <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> que es dueña en pleno
+          dominio, propiedad y pacífica posesión de un Lote de Terreno URBANO y finca que se
+          identifica de la siguiente manera: Terreno Urbano y finca ubicado en Fraccionamiento{' '}
+          <Text style={contratoStyles.bold}>{data.inmueble.fraccionamiento}</Text> de esta ciudad,
+          que se identifica como Lote Número{' '}
+          <Text style={contratoStyles.bold}>{data.inmueble.lote}</Text> de la Manzana{' '}
+          <Text style={contratoStyles.bold}>{data.inmueble.manzana}</Text> del citado
+          fraccionamiento, el cual tiene una superficie de{' '}
+          <Text style={contratoStyles.bold}>{data.inmueble.superficieM2} m²</Text>.
+        </Text>
+
+        <Text style={contratoStyles.parrafo}>
+          El inmueble antes referido es un modelo de vivienda denominado{' '}
+          <Text style={contratoStyles.bold}>{data.inmueble.modeloVivienda}</Text>, modelo cuyas
+          características — como son la extensión del terreno, superficie construida, tipo de
+          estructura, instalaciones, acabados, accesorios, lugar o lugares de estacionamiento, áreas
+          de uso común con otros inmuebles, clase de materiales utilizados en la construcción,
+          servicios básicos, etc. — se encuentran especificados y descritos en el Anexo 3 del
+          presente contrato y se tienen por aquí reproducidos en su totalidad. Los materiales y
+          acabados quedan sujetos a disponibilidad y existencia de terceros; por tanto, podrán ser
+          modificados en su caso por otro de igual calidad y precio.
+        </Text>
+
+        <Text style={contratoStyles.parrafo}>
+          <Text style={contratoStyles.bold}>II.- </Text> Declara{' '}
+          <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> que acredita el pleno
+          dominio y propiedad mediante Escritura Pública número{' '}
+          <Text style={contratoStyles.bold}>({ESCRITURA_MADRE_DEFAULT.numero})</Text>, de fecha{' '}
+          <Text style={contratoStyles.bold}>{ESCRITURA_MADRE_DEFAULT.fecha}</Text>, pasada ante la
+          fe del <Text style={contratoStyles.bold}>{ESCRITURA_MADRE_DEFAULT.notario.nombre}</Text>,
+          titular de la Notaría Pública número{' '}
+          <Text style={contratoStyles.bold}>{ESCRITURA_MADRE_DEFAULT.notario.numeroNotaria}</Text>,
+          de la Ciudad de{' '}
+          <Text style={contratoStyles.bold}>{ESCRITURA_MADRE_DEFAULT.notario.ciudad}</Text>, la cual
+          se encuentra inscrita en el Registro Público de la Propiedad con residencia en la Ciudad
+          de{' '}
+          <Text style={contratoStyles.bold}>{ESCRITURA_MADRE_DEFAULT.registroPublico.ciudad}</Text>,
+          bajo la entrada{' '}
+          <Text style={contratoStyles.bold}>{ESCRITURA_MADRE_DEFAULT.registroPublico.entrada}</Text>
+          , de fecha{' '}
+          <Text style={contratoStyles.bold}>{ESCRITURA_MADRE_DEFAULT.registroPublico.fecha}</Text>.
+        </Text>
+
+        <Text style={contratoStyles.parrafo}>
+          <Text style={contratoStyles.bold}>III.- </Text> Declara{' '}
+          <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> que la propiedad que
+          en este acto se compromete a vender se encuentra al corriente en el pago de los impuestos,
+          derechos y contribuciones que causa, así como{' '}
+          <Text style={contratoStyles.bold}>LIBRE DE TODO GRAVAMEN Y RESPONSABILIDAD</Text>.
+        </Text>
+
+        <Text style={contratoStyles.seccionTitulo}>CLÁUSULAS</Text>
+
+        <Clausula
+          n="PRIMERA"
+          texto={
+            <>
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> promete vender a{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text>, quien promete
+              adquirir para sí el inmueble que ha quedado descrito y deslindado en la declaración{' '}
+              <Text style={contratoStyles.bold}>I (PRIMERA)</Text> de este Instrumento con todos sus
+              usos, costumbres, servidumbre, entradas, salidas, construcciones, anexidades y todo lo
+              que de hecho y por derecho le corresponda o pudiera corresponderle al referido
+              inmueble, estableciendo la fecha máxima para la celebración del contrato de
+              compraventa <Text style={contratoStyles.bold}>{fechaMaximaCelebracion}</Text>.
+            </>
+          }
+        />
+
+        <Clausula
+          n="SEGUNDA"
+          texto={
+            <>
+              <Text style={contratoStyles.quoted}>“LAS PARTES”</Text> manifiestan que el precio
+              pactado de la PROMESA DE COMPRAVENTA, para efectos de la operación futura, lo
+              constituirá la cantidad de{' '}
+              <Text style={contratoStyles.bold}>
+                {money(data.operacion.precio)} Pesos Mexicanos
+              </Text>
+              , precio que acuerdan <Text style={contratoStyles.quoted}>“LAS PARTES”</Text> como
+              valor total de la operación de compraventa y que se pagará mediante crédito INFONAVIT,
+              bancario o con recursos propios por{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text>, complementando
+              según sea el caso con las diferencias cubiertas de su propio peculio por{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text> a fin de
+              complementar el valor de la operación establecido en la presente cláusula. El precio
+              que deberá pagar <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text>{' '}
+              a <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> será el
+              establecido en las diferentes solicitudes y documentos presentados ante la entidad
+              financiera; al momento de la firma de la escritura pública se deberán cubrir las
+              diferencias que arroje la carta de instrucción notarial a modo de que con el monto de
+              crédito y pago de estas diferencias quede liquidado el saldo total del precio de la
+              operación.
+            </>
+          }
+        />
+
+        {/* Fix 4: TERCERA con plazo explícito */}
+        <Clausula
+          n="TERCERA"
+          texto={
+            <>
+              El presente contrato se respetará y tendrá validez siempre y cuando la PROMITENTE
+              COMPRADORA haya entregado en su totalidad la contraprestación estipulada en la
+              cláusula SEGUNDA del presente contrato{' '}
+              <Text style={contratoStyles.bold}>
+                dentro de los 30 días naturales siguientes a la fecha de firma del presente contrato
+              </Text>
+              ; de lo contrario, el precio se actualizará al que corresponda en el momento en que se
+              cubra la contraprestación antes mencionada.
+            </>
+          }
+        />
+
+        <Clausula
+          n="CUARTA"
+          texto={
+            <>
+              <Text style={contratoStyles.quoted}>“LAS PARTES”</Text> están de acuerdo en que los
+              pagos se realizarán a{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> exclusivamente
+              por cheque de depósito o transferencia bancaria a la cuenta número{' '}
+              <Text style={contratoStyles.bold}>{CUENTA_DILESA.numeroCuenta}</Text> CLABE{' '}
+              <Text style={contratoStyles.bold}>{CUENTA_DILESA.clabe}</Text> del Banco{' '}
+              <Text style={contratoStyles.bold}>{CUENTA_DILESA.banco}</Text> a nombre de{' '}
+              <Text style={contratoStyles.bold}>{CUENTA_DILESA.titular}</Text>, esto en cumplimiento
+              a la Ley Federal para la Prevención e Identificación de Operaciones con Recursos de
+              Procedencia Ilícita. Todo pago hecho en contravención a esta cláusula se dará por no
+              hecho.
+            </>
+          }
+        />
+
+        <Clausula
+          n="QUINTA"
+          texto={
+            <>
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> se obliga en este
+              acto frente a <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text> a
+              entregarle el bien inmueble descrito en la declaración PRIMERA,{' '}
+              <Text style={contratoStyles.bold}>máximo 15 días naturales</Text> después de haber
+              recibido en la cuenta de{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> el valor total
+              del precio de operación, siempre y cuando la vivienda se encuentre terminada,
+              habitable y se haya generado y firmado la escritura de compraventa correspondiente por
+              todas las partes.
+            </>
+          }
+        />
+
+        <Clausula
+          n="SEXTA"
+          texto={
+            <>
+              <Text style={contratoStyles.quoted}>“LAS PARTES”</Text> están de acuerdo en que en
+              esta PROMESA DE COMPRAVENTA no existe error, dolo, lesión ni enriquecimiento
+              ilegítimo, obligándose en los plazos y términos contenidos en el presente contrato.
+            </>
+          }
+        />
+
+        <Clausula
+          n="SÉPTIMA"
+          texto={
+            <>
+              Para la celebración del presente contrato,{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text> debe cubrir por
+              concepto de arras confirmatorias el <Text style={contratoStyles.bold}>1% </Text>(uno
+              por ciento) de la totalidad de la contraprestación estipulada en la cláusula SEGUNDA,
+              que equivale a{' '}
+              <Text style={contratoStyles.bold}>
+                {money(data.operacion.enganche1pct)} pesos mexicanos
+              </Text>{' '}
+              como mínimo. Para este contrato, éstas se imputarán al precio pactado en la cláusula
+              SEGUNDA y se deberán depositar en la cuenta descrita en la cláusula CUARTA.
+            </>
+          }
+        />
+
+        <Clausula
+          n="OCTAVA"
+          texto={
+            <>
+              En caso de que <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text>{' '}
+              solicite a <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> un
+              producto con especificaciones particulares que se salgan de los prototipos de vivienda
+              actuales o del orden del proceso constructivo, deberá cubrir por concepto de arras
+              confirmatorias el equivalente a{' '}
+              <Text style={contratoStyles.bold}>
+                {money(data.operacion.arras10pct)} pesos mexicanos
+              </Text>
+              ; éstas se imputarán al precio pactado en la cláusula SEGUNDA y se deberán depositar
+              en la cuenta descrita en la cláusula CUARTA.
+            </>
+          }
+        />
+
+        <Clausula
+          n="NOVENA"
+          texto={
+            <>
+              En el supuesto de que{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text> por situaciones
+              ajenas a <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> no
+              pudiere cumplir con la promesa de compraventa estipulada en el presente contrato — ya
+              sea por razones económicas, por llegarse la fecha estipulada en la cláusula PRIMERA o
+              por cualquier otra razón ajena a{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> —{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> lo dará por
+              rescindido y conservará el importe de las arras confirmatorias, ya sea el descrito en
+              la cláusula SÉPTIMA y, en su caso, OCTAVA. Esto se podrá llevar a cabo sin necesidad
+              de declaración judicial o notificación adicional al presente contrato.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA"
+          texto={
+            <>
+              En el supuesto de que{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text> por cuestiones
+              de modificación de su relación laboral, modificaciones salariales, modificación de
+              ingreso, aportaciones patronales y demás circunstancias económicas o crediticias se
+              vea afectado en su puntuación y/o monto de crédito y condiciones financieras para
+              poder ejercer su crédito al momento de la inscripción del mismo, y esto resultase en
+              la imposibilidad de cumplimiento del presente contrato,{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> lo dará por
+              rescindido y conservará el importe de las arras confirmatorias, ya sea el descrito en
+              la cláusula SÉPTIMA y, en su caso, OCTAVA. Esto se podrá llevar a cabo sin necesidad
+              de declaración judicial o notificación adicional al presente contrato.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA PRIMERA"
+          texto={
+            <>
+              Una vez que <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> le
+              notifique por cualquier medio electrónico y/o el que sea de común acuerdo a{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text> del fin de
+              construcción del inmueble objeto del presente contrato descrito en la declaración I
+              (PRIMERA), esta última tendrá un plazo máximo de{' '}
+              <Text style={contratoStyles.bold}>30 días naturales</Text> para formalizar ante
+              fedatario público la operación de compraventa. Caso contrario, la ubicación en
+              cuestión quedará como disponible para otro cliente y{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> estará en
+              facultades de asignar otra vivienda al precio actual vigente. En el supuesto de
+              desistir de la formalización de la operación con las nuevas condiciones,{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> lo dará por
+              rescindido y conservará las arras confirmatorias descritas en SÉPTIMA y, en su caso,
+              OCTAVA.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA SEGUNDA"
+          texto={
+            <>
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text> se obliga al
+              saneamiento para el caso de evicción, en los términos de la ley aplicable en la
+              materia.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA TERCERA"
+          texto={
+            <>
+              <Text style={contratoStyles.quoted}>“LAS PARTES”</Text> están de acuerdo en que los
+              gastos de escrituración — que incluyen el Impuesto Sobre Adquisición de Inmuebles,
+              derechos de Registro Público, honorarios de la Notaría y todos los gastos que origine
+              la formalización de la compraventa — correrán a cargo de{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text>, a excepción del
+              Impuesto sobre la Renta, que será a cargo de{' '}
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text>.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA CUARTA"
+          texto={
+            <>
+              Para la interpretación y cumplimiento del presente contrato,{' '}
+              <Text style={contratoStyles.quoted}>“LAS PARTES”</Text> se someten en forma expresa a
+              la competencia y Jurisdicción de los Tribunales del{' '}
+              <Text style={contratoStyles.bold}>{TRIBUNAL_COMPETENTE.distrito}</Text> en la ciudad
+              de <Text style={contratoStyles.bold}>{TRIBUNAL_COMPETENTE.ciudad}</Text>, renunciando
+              al fuero que pudiera corresponderles en lo presente y en lo futuro por razón de sus
+              domicilios.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA QUINTA"
+          texto={
+            <>
+              <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text> manifiesta bajo
+              protesta de decir verdad haber leído el aviso de privacidad que se encuentra publicado
+              y que está de acuerdo con el contenido del mismo.
+            </>
+          }
+        />
+
+        <Text style={contratoStyles.seccionTitulo}>GENERALES</Text>
+
+        <Text style={contratoStyles.parrafo}>
+          <Text style={contratoStyles.quoted}>“LAS PARTES”</Text> manifiestan BAJO PROTESTA DE DECIR
+          VERDAD que han sido enteradas del contenido de este contrato de PROMESA DE COMPRAVENTA y
+          que para este efecto mencionan que sus generales son las siguientes:
+        </Text>
+
+        {/* Vendedora */}
+        <Text style={contratoStyles.parrafo}>
+          <Text style={contratoStyles.quoted}>“LA PROMITENTE VENDEDORA”</Text>, representada en este
+          acto por el <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.nombre}</Text>,
+          manifestó por sus generales ser: {REPRESENTANTE_DILESA.nacionalidad},{' '}
+          {REPRESENTANTE_DILESA.edad}, {REPRESENTANTE_DILESA.estadoCivil},{' '}
+          {REPRESENTANTE_DILESA.profesion}, con la CURP número{' '}
+          <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.curp}</Text> y con el RFC{' '}
+          <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.rfc}</Text>, con domicilio en la
+          casa marcada con el número{' '}
+          <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.domicilio.numero}</Text> de la
+          calle <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.domicilio.calle}</Text>,
+          colonia <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.domicilio.colonia}</Text>{' '}
+          C.P. <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.domicilio.cp}</Text> de esta
+          ciudad de <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.domicilio.ciudad}</Text>{' '}
+          y quien se identifica con Credencial para Votar con fotografía número{' '}
+          <Text style={contratoStyles.bold}>{REPRESENTANTE_DILESA.ine.numero}</Text> expedida por el{' '}
+          {REPRESENTANTE_DILESA.ine.autoridad}, la cual incluye fotografía del compareciente y
+          coincide con su filiación.
+        </Text>
+
+        <Text style={contratoStyles.parrafo}>
+          Así mismo justifica su personalidad y la legal existencia de la sociedad{' '}
+          <Text style={contratoStyles.quoted}>
+            “DESARROLLO INMOBILIARIO LOS ENCINOS, S.A. DE C.V.”
+          </Text>{' '}
+          con la Escritura Pública{' '}
+          <Text style={contratoStyles.bold}>
+            ({ESCRITURAS_CONSTITUTIVAS_DILESA.constitutiva.numero})
+          </Text>{' '}
+          de fecha{' '}
+          <Text style={contratoStyles.bold}>
+            {ESCRITURAS_CONSTITUTIVAS_DILESA.constitutiva.fecha}
+          </Text>
+          , pasada ante la Fe del Notario Público Número{' '}
+          <Text style={contratoStyles.bold}>
+            {ESCRITURAS_CONSTITUTIVAS_DILESA.constitutiva.notario}
+          </Text>{' '}
+          del Distrito Notarial de{' '}
+          <Text style={contratoStyles.bold}>
+            {ESCRITURAS_CONSTITUTIVAS_DILESA.constitutiva.distritoNotarial}
+          </Text>
+          , inscrita ante la oficina del Registro Público del Comercio de esa ciudad bajo el FME{' '}
+          <Text style={contratoStyles.bold}>
+            {ESCRITURAS_CONSTITUTIVAS_DILESA.constitutiva.fme}
+          </Text>
+          ; y con la Escritura Pública{' '}
+          <Text style={contratoStyles.bold}>
+            ({ESCRITURAS_CONSTITUTIVAS_DILESA.modificacion.numero})
+          </Text>{' '}
+          de fecha{' '}
+          <Text style={contratoStyles.bold}>
+            {ESCRITURAS_CONSTITUTIVAS_DILESA.modificacion.fecha}
+          </Text>
+          , pasada ante la Fe del Notario Público Número{' '}
+          <Text style={contratoStyles.bold}>
+            {ESCRITURAS_CONSTITUTIVAS_DILESA.modificacion.notario}
+          </Text>{' '}
+          del Distrito Notarial de{' '}
+          <Text style={contratoStyles.bold}>
+            {ESCRITURAS_CONSTITUTIVAS_DILESA.modificacion.distritoNotarial}
+          </Text>
+          , inscrita bajo el FME{' '}
+          <Text style={contratoStyles.bold}>
+            {ESCRITURAS_CONSTITUTIVAS_DILESA.modificacion.fme}
+          </Text>
+          . Así mismo, la sociedad cuenta con el Registro Federal de Contribuyentes{' '}
+          <Text style={contratoStyles.bold}>{ESCRITURAS_CONSTITUTIVAS_DILESA.rfc}</Text>.
+        </Text>
+
+        {/* Compradora (titular + co-titular si aplica) */}
+        <CompradorGenerales parte={data.comprador} />
+        {data.coTitular ? <CompradorGenerales parte={data.coTitular} esCoTitular /> : null}
+
+        <Text style={contratoStyles.seccionTitulo}>DOCUMENTOS ANEXOS</Text>
+        <Text style={contratoStyles.parrafo}>
+          1.- Identificación Oficial de los comparecientes.
+          {'\n'}
+          2.- Personalidad de “DESARROLLO INMOBILIARIO LOS ENCINOS”, S.A. DE C.V.
+          {'\n'}
+          3.- Cédula de características generales, materiales y acabados de la vivienda.
+        </Text>
+
+        {/* Firmas */}
+        <View style={contratoStyles.firmasGroup}>
+          <FirmaSlot
+            nombre={REPRESENTANTE_DILESA.nombre}
+            rol={'Representante Legal\n“LA PROMITENTE VENDEDORA”'}
+          />
+          <FirmaSlot
+            nombre={`${data.comprador.nombre} (${data.inmueble.identificacionInventario})`}
+            rol={'“LA PROMITENTE COMPRADORA”'}
+          />
+          {data.coTitular ? (
+            <FirmaSlot
+              nombre={`${data.coTitular.nombre} (${data.inmueble.identificacionInventario})`}
+              rol={'“LA PROMITENTE COMPRADORA” (CO-TITULAR)'}
+            />
+          ) : null}
+          {TESTIGOS_DEFAULT.map((t) => (
+            <FirmaSlot key={t.nombre} nombre={t.nombre} rol="TESTIGO" />
+          ))}
+        </View>
+
+        <Folio value={data.folio} />
+        <FooterBand />
+      </Page>
+
+      {/* ── Anexo 3: Cédula de Materiales (multi-página automático) ── */}
+      <Page size="LETTER" style={styles.page} wrap>
+        <HeaderBand title="ANEXO 3 — CÉDULA DE MATERIALES" fecha={data.fechaTexto} />
+        <Text style={contratoStyles.parrafo}>
+          Cédula de características generales, materiales y acabados de la vivienda — referida en la
+          Declaración I y en los Documentos Anexos del presente contrato. Los materiales y acabados
+          quedan sujetos a disponibilidad y existencia de terceros y podrán ser modificados por
+          otros de igual calidad y precio.
+        </Text>
+
+        <CedulaTable />
+
+        <Folio value={data.folio} />
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+function Clausula({ n, texto }: { n: string; texto: React.ReactNode }) {
+  return (
+    <Text style={contratoStyles.clausula}>
+      <Text style={contratoStyles.clausulaNumero}>{n}. — </Text>
+      {texto}
+    </Text>
+  );
+}
+
+function CompradorGenerales({
+  parte,
+  esCoTitular = false,
+}: {
+  parte: PromesaParte;
+  esCoTitular?: boolean;
+}) {
+  return (
+    <Text style={contratoStyles.parrafo}>
+      <Text style={contratoStyles.quoted}>“LA PROMITENTE COMPRADORA”</Text>
+      {esCoTitular ? ' (CO-TITULAR)' : ''}, <Text style={contratoStyles.bold}>{parte.nombre}</Text>,
+      manifestó por sus generales ser: mexicano por nacimiento, mayor de edad,{' '}
+      {parte.estadoCivil ?? '—'}, {parte.profesion ?? 'profesionista'}
+      {parte.curp ? (
+        <>
+          , con la CURP número <Text style={contratoStyles.bold}>{parte.curp}</Text>
+        </>
+      ) : null}
+      {parte.rfc ? (
+        <>
+          {' '}
+          y con el RFC <Text style={contratoStyles.bold}>{parte.rfc}</Text>
+        </>
+      ) : null}
+      {parte.domicilio ? (
+        <>
+          , con domicilio en <Text style={contratoStyles.bold}>{parte.domicilio}</Text>
+        </>
+      ) : null}
+      {parte.ineNumero ? (
+        <>
+          , y quien se identifica con Credencial para Votar con fotografía número{' '}
+          <Text style={contratoStyles.bold}>{parte.ineNumero}</Text> expedida por el Instituto
+          Nacional Electoral, la cual incluye fotografía del compareciente y coincide con su
+          filiación
+        </>
+      ) : null}
+      .
+    </Text>
+  );
+}
+
+function FirmaSlot({ nombre, rol }: { nombre: string; rol: string }) {
+  return (
+    <View style={contratoStyles.firmaSlot} wrap={false}>
+      <View style={contratoStyles.firmaLinea} />
+      <Text style={contratoStyles.firmaNombre}>{nombre}</Text>
+      <Text style={contratoStyles.firmaRol}>{rol}</Text>
+    </View>
+  );
+}
+
+function CedulaTable() {
+  // Anchos en porcentaje — 7 columnas
+  return (
+    <View style={contratoStyles.table}>
+      <View style={[contratoStyles.tableRow, contratoStyles.tableHeader]} fixed>
+        <Text style={[contratoStyles.tableCell, contratoStyles.tableHeaderCell, { width: '4%' }]}>
+          Cve
+        </Text>
+        <Text style={[contratoStyles.tableCell, contratoStyles.tableHeaderCell, { width: '20%' }]}>
+          Descripción
+        </Text>
+        <Text style={[contratoStyles.tableCell, contratoStyles.tableHeaderCell, { width: '8%' }]}>
+          Marca
+        </Text>
+        <Text style={[contratoStyles.tableCell, contratoStyles.tableHeaderCell, { width: '10%' }]}>
+          Etapa
+        </Text>
+        <Text style={[contratoStyles.tableCell, contratoStyles.tableHeaderCell, { width: '12%' }]}>
+          Norma
+        </Text>
+        <Text style={[contratoStyles.tableCell, contratoStyles.tableHeaderCell, { width: '23%' }]}>
+          Colocación
+        </Text>
+        <Text style={[contratoStyles.tableCell, contratoStyles.tableHeaderCell, { width: '23%' }]}>
+          Recomendación
+        </Text>
+      </View>
+      {CEDULA_MATERIALES_DEFAULT.map((m) => (
+        <View key={m.clave} style={contratoStyles.tableRow} wrap={false}>
+          <Text style={[contratoStyles.tableCell, { width: '4%' }]}>{m.clave}</Text>
+          <Text style={[contratoStyles.tableCell, { width: '20%' }]}>{m.descripcion}</Text>
+          <Text style={[contratoStyles.tableCell, { width: '8%' }]}>{m.marca}</Text>
+          <Text style={[contratoStyles.tableCell, { width: '10%' }]}>{m.etapa}</Text>
+          <Text style={[contratoStyles.tableCell, { width: '12%' }]}>{m.norma}</Text>
+          <Text style={[contratoStyles.tableCell, { width: '23%' }]}>{m.colocacion}</Text>
+          <Text style={[contratoStyles.tableCell, { width: '23%' }]}>{m.recomendacion}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const contratoStyles = StyleSheet.create({
+  encabezado: {
+    fontSize: 9.5,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'justify',
+    marginTop: 4,
+    marginBottom: 6,
+    lineHeight: 1.3,
+  },
+  parrafo: {
+    fontSize: 8.5,
+    textAlign: 'justify',
+    marginBottom: 4,
+    lineHeight: 1.35,
+  },
+  seccionTitulo: {
+    fontSize: 11,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'center',
+    marginTop: 8,
+    marginBottom: 4,
+    letterSpacing: 0.5,
+  },
+  bold: { fontFamily: 'Helvetica-Bold' },
+  quoted: { fontFamily: 'Helvetica-Bold' },
+  clausula: {
+    fontSize: 8.5,
+    textAlign: 'justify',
+    marginBottom: 4,
+    lineHeight: 1.35,
+  },
+  clausulaNumero: { fontFamily: 'Helvetica-Bold' },
+  firmasGroup: {
+    marginTop: 18,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-around',
+    gap: 14,
+  },
+  firmaSlot: {
+    width: 200,
+    alignItems: 'center',
+    marginBottom: 14,
+  },
+  firmaLinea: {
+    width: '100%',
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.text,
+    marginBottom: 3,
+    marginTop: 22,
+  },
+  firmaNombre: {
+    fontSize: 8.5,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'center',
+  },
+  firmaRol: {
+    fontSize: 7.5,
+    color: colors.textMuted,
+    textAlign: 'center',
+    marginTop: 1,
+  },
+  table: {
+    marginTop: 8,
+    borderTopWidth: 0.5,
+    borderTopColor: colors.border,
+    borderLeftWidth: 0.5,
+    borderLeftColor: colors.border,
+  },
+  tableHeader: {
+    backgroundColor: colors.primary,
+  },
+  tableHeaderCell: {
+    color: '#fff',
+    fontFamily: 'Helvetica-Bold',
+  },
+  tableRow: {
+    flexDirection: 'row',
+  },
+  tableCell: {
+    fontSize: 6.5,
+    padding: 3,
+    borderRightWidth: 0.5,
+    borderRightColor: colors.border,
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.border,
+    color: colors.text,
+  },
+});

--- a/scripts/dilesa-pdf-preview.tsx
+++ b/scripts/dilesa-pdf-preview.tsx
@@ -12,6 +12,7 @@ import { SolicitudAsignacionPDF } from '../lib/dilesa/pdf/solicitud-asignacion';
 import { AvisoPrivacidadPDF } from '../lib/dilesa/pdf/aviso-privacidad';
 import { FicuPDF } from '../lib/dilesa/pdf/ficu';
 import { evaluarRiesgo } from '../lib/dilesa/ficu/riesgo';
+import { PromesaCompraventaPDF } from '../lib/dilesa/pdf/promesa-compraventa';
 
 const solicitudData = {
   fechaTexto: '24 de Mayo del 2026',
@@ -91,6 +92,39 @@ const ficuData = {
   identificacionInventario: 'M3-L9-LDLE-ISC',
 };
 
+const promesaData = {
+  fechaTexto: '24 de Mayo del 2026',
+  horaTexto: '9:35',
+  diaTexto: '24',
+  mesTexto: 'Mayo',
+  anioTexto: '2026',
+  comprador: {
+    nombre: 'CHRISTOPHER ALFONSO LIMAS MARTINEZ',
+    curp: 'LIMC010418HCLMRHA6',
+    rfc: 'LIMC010418GU4',
+    estadoCivil: 'casado',
+    profesion: 'profesionista',
+    domicilio: 'OBREROS #712 B, COL. VILLA DE FUENTE, PIEDRAS NEGRAS, COAHUILA, CP 26094',
+    ineNumero: '1890265649',
+  },
+  coTitular: null,
+  inmueble: {
+    fraccionamiento: 'Lomas de los Encinos',
+    lote: '16',
+    manzana: '3',
+    superficieM2: 105,
+    modeloVivienda: 'ISC',
+    identificacionInventario: 'M3-L16-LDLE-ISC',
+  },
+  operacion: {
+    precio: 1_021_000,
+    enganche1pct: 10_210,
+    arras10pct: 102_100,
+    tipoCredito: 'Infonavit Tradicional',
+  },
+  folio: 'CLM-M3-L16-LDLE-ISC-5/24/2026 9:35:36 AM',
+};
+
 async function main() {
   await renderToFile(<SolicitudAsignacionPDF data={solicitudData} />, '/tmp/solicitud-preview.pdf');
   console.log('✔ /tmp/solicitud-preview.pdf');
@@ -100,6 +134,9 @@ async function main() {
 
   await renderToFile(<FicuPDF data={ficuData} />, '/tmp/ficu-preview.pdf');
   console.log('✔ /tmp/ficu-preview.pdf');
+
+  await renderToFile(<PromesaCompraventaPDF data={promesaData} />, '/tmp/promesa-preview.pdf');
+  console.log('✔ /tmp/promesa-preview.pdf');
 }
 
 main().catch((e) => {


### PR DESCRIPTION
## Summary

Cuarto y último PDF del expediente de venta DILESA. Replica el export de Coda con **interpolación correcta** (los datos van inline en su lugar, no apilados al final del párrafo como en el sample) y los **5 fixes acordados**.

## 🔴 Fixes vs. el Coda histórico

| # | Bug en Coda | Fix en BSOP |
|---|---|---|
| 1 | Header con nombre duplicado + identificador apilado | "ENTRE DILESA Y \<nombre\> PARA UN INMUEBLE CON IDENTIFICACIÓN: \<identif\>" — limpio |
| 2 | "SIENDO LAS **( )** HORAS DEL DIA DE HOY **( )** DE **DEL ( )**" en blanco | Se llena con hora/día/mes/año del folio (created_at de la venta) |
| 3 | Cláusula PRIMERA habla de DTU (Infonavit) aunque el crédito sea bancario | Condicional: si tipo_credito = Infonavit → DTU; si no → "fecha de aprobación del crédito" |
| 4 | Cláusula TERCERA: "a más tardar en **el mes calendario**" (vago) | "dentro de **los 30 días naturales siguientes a la fecha de firma** del presente contrato" |
| 5 | Co-titular ausente del contrato (aunque la venta tenga monto_credito_cotitular > 0) | Si hay co-titular, se lista como segunda PROMITENTE COMPRADORA en cuerpo, GENERALES y firmas |
| ★ | Datos como Fraccionamiento, Lote, Manzana, m², modelo, precio, arras — aparecían al final del párrafo en el sample | **Interpolación correcta inline** en su lugar |

## 🔵 Parametrización: hardcoded data

Vive en [lib/dilesa/contrato/constantes.ts](lib/dilesa/contrato/constantes.ts) con **TODO sprint-7c** de migrar a DB:
- Representante DILESA (LC Norberto Gutiérrez Infante) → `core.empresas.representante_legal`
- Cuenta bancaria DILESA (BBVA 0141502492) → `erp.cuentas_bancarias`
- Escrituras constitutivas DILESA (167/2003 + 35/2020) → `core.empresas.escritura_constitutiva` JSONB
- Escritura madre del lote (303/2022) → `dilesa.proyectos.escritura_madre` JSONB
- Testigos (Edgar Daniel Peña Palomo + Nelcy Elizabeth Martínez Díaz) → tabla `dilesa.venta_testigos` o config global

## 📋 Cédula de materiales (Anexo 3)

[lib/dilesa/contrato/cedula-materiales-default.ts](lib/dilesa/contrato/cedula-materiales-default.ts) — **27 ítems**: CPVC, sanitaria, eléctrica, pisos, adhesivos, herrería, sanitarios. Cada uno con descripción, marca, etapa, norma, procedimiento de colocación y recomendación.

Hoy todos los prototipos DILESA usan los mismos materiales — por eso vive como módulo TS. Cuando agregues prototypes con materiales distintos:
1. Migración: `dilesa.productos.cedula_materiales jsonb`
2. Backfill: clonar este array a todos los productos existentes
3. Form de admin para editar la cédula por producto
4. Template lee `producto.cedula_materiales`; este archivo queda como fallback

## Implementación

- [lib/dilesa/contrato/constantes.ts](lib/dilesa/contrato/constantes.ts) — constantes hardcoded con TODOs
- [lib/dilesa/contrato/cedula-materiales-default.ts](lib/dilesa/contrato/cedula-materiales-default.ts) — 27 ítems
- [lib/dilesa/pdf/promesa-compraventa.tsx](lib/dilesa/pdf/promesa-compraventa.tsx) — template multi-página
- [app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx](app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx) — agrega tipo `promesa-compraventa`
- [app/dilesa/ventas/[id]/page.tsx](app/dilesa/ventas/[id]/page.tsx) — agrega botón "Promesa de Compraventa"

## Preview

```
$ npx tsx scripts/dilesa-pdf-preview.tsx
✔ /tmp/promesa-preview.pdf   # 6 páginas (2 contrato + 4 cédula)
```

## Test plan

- [ ] CI verde (typecheck + lint + format + tests + schema:check)
- [ ] Bajar el PDF de una venta de prueba en preview
- [ ] Verificar header limpio y datos inline (no apilados)
- [ ] Verificar la cláusula PRIMERA correcta según tipo_credito de la venta
- [ ] Verificar tabla de cédula con cabecera olivo + 27 ítems

## Follow-ups (Sprint 7c+)

- Migraciones DB: `dilesa.proyectos.escritura_madre`, `dilesa.productos.cedula_materiales`, `core.empresas.cuenta_principal_id`
- Form para capturar testigos por venta + estado civil + régimen patrimonial del comprador
- FK `dilesa.ventas.persona_cotitular_id` + UI para asociar co-titular real
- Sprint 8: cláusulas para régimen patrimonial (bienes mancomunados → firma del cónyuge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)