### PR TITLE
feat(dilesa): Sprint 7c piloto — captura de Fase 3 (Formalizada)

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+/**
+ * Captura Fase 3 — Formalizada (Sprint 7c piloto).
+ *
+ * Cierra la fase de Formalización: el cliente firmó el contrato de
+ * promesa de compraventa que el vendedor descargó/imprimió de
+ * `/api/dilesa/ventas/[id]/pdf/promesa-compraventa` (Sprint 7b).
+ *
+ * Captura:
+ *   - Doc requerido: `contrato_promesa` (PDF firmado por ambas partes).
+ *   - Campos: precio_asignacion (autollenado), descuento_total (opcional),
+ *     fecha del contrato.
+ *
+ * Enforcement: requiere que Fase 2 (Asignada) esté cerrada. Si no, la
+ * page muestra el bloqueo y enlaza a Fase 2.
+ */
+
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Loader2, Save, Upload } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
+import { marcarFase } from '@/lib/dilesa/captura/marcar-fase';
+
+type VentaCtx = {
+  id: string;
+  persona_id: string;
+  unidad_id: string | null;
+  precio_asignacion: number | null;
+  descuento_total: number | null;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const money = (n: number | null | undefined): string =>
+  n == null ? '—' : moneyFmt.format(Number(n));
+
+export default function CapturarFase3Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.fase03_formalizada" write>
+      <CapturarFase3Body />
+    </RequireAccess>
+  );
+}
+
+function CapturarFase3Body() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const toast = useToast();
+  const sb = useMemo(() => createSupabaseBrowserClient(), []);
+  const ventaId = params.id;
+
+  const [venta, setVenta] = useState<VentaCtx | null>(null);
+  const [clienteNombre, setClienteNombre] = useState<string>('');
+  const [identificacionInv, setIdentificacionInv] = useState<string | null>(null);
+  const [fase2Cerrada, setFase2Cerrada] = useState<boolean | null>(null);
+  const [yaCerrada, setYaCerrada] = useState<boolean>(false);
+
+  const [precioAsignacion, setPrecioAsignacion] = useState<string>('');
+  const [descuentoTotal, setDescuentoTotal] = useState<string>('');
+  const [fechaContrato, setFechaContrato] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [archivo, setArchivo] = useState<File | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // ── Cargar contexto de la venta ────────────────────────────────────
+  useEffect(() => {
+    if (!ventaId) return;
+    let activo = true;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+
+      const { data: vRow, error: vErr } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .select('id, persona_id, unidad_id, precio_asignacion, descuento_total')
+        .eq('id', ventaId)
+        .is('deleted_at', null)
+        .maybeSingle();
+      if (!activo) return;
+      if (vErr) {
+        setError(getSupabaseErrorMessage(vErr, 'No se pudo cargar la venta.'));
+        setLoading(false);
+        return;
+      }
+      if (!vRow) {
+        setError('Venta no encontrada.');
+        setLoading(false);
+        return;
+      }
+      const v = vRow as unknown as VentaCtx;
+      setVenta(v);
+      if (v.precio_asignacion != null) setPrecioAsignacion(String(v.precio_asignacion));
+      if (v.descuento_total != null) setDescuentoTotal(String(v.descuento_total));
+
+      // Persona + Unidad (para el header) y enforcement (Fase 2 cerrada + Fase 3 no cerrada)
+      const [pRes, uRes, fRes] = await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno')
+          .eq('id', v.persona_id)
+          .maybeSingle(),
+        v.unidad_id
+          ? sb
+              .schema('dilesa')
+              .from('unidades')
+              .select('identificador, producto_id')
+              .eq('id', v.unidad_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+        sb
+          .schema('dilesa')
+          .from('venta_fases')
+          .select('posicion')
+          .eq('venta_id', v.id)
+          .is('deleted_at', null),
+      ]);
+      if (!activo) return;
+
+      if (pRes.data) {
+        setClienteNombre(
+          [pRes.data.nombre, pRes.data.apellido_paterno, pRes.data.apellido_materno]
+            .filter(Boolean)
+            .join(' ') || '(sin nombre)'
+        );
+      }
+      if (uRes.data) {
+        // Identificador + sufijo de producto (mismo patrón que el detalle)
+        const prodSufijo = uRes.data.producto_id
+          ? (
+              await sb
+                .schema('dilesa')
+                .from('productos')
+                .select('nombre')
+                .eq('id', uRes.data.producto_id)
+                .maybeSingle()
+            ).data?.nombre
+              ?.split('-')
+              .pop()
+          : '';
+        setIdentificacionInv(
+          prodSufijo ? `${uRes.data.identificador}-${prodSufijo}` : uRes.data.identificador
+        );
+      }
+      const posiciones = (fRes.data ?? []).map((f) => f.posicion as number);
+      setFase2Cerrada(posiciones.includes(2));
+      setYaCerrada(posiciones.includes(3));
+
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [ventaId, sb]);
+
+  // ── Submit ─────────────────────────────────────────────────────────
+  const onSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!venta) return;
+      if (!archivo) {
+        toast.add({
+          title: 'Falta el contrato firmado',
+          description: 'Sube el PDF del contrato de promesa firmado por ambas partes.',
+          type: 'error',
+        });
+        return;
+      }
+      const precio = Number(precioAsignacion);
+      if (!Number.isFinite(precio) || precio <= 0) {
+        toast.add({
+          title: 'Precio de asignación inválido',
+          description: 'Captura un monto mayor a cero.',
+          type: 'error',
+        });
+        return;
+      }
+      const descuento = descuentoTotal ? Number(descuentoTotal) : 0;
+      if (!Number.isFinite(descuento) || descuento < 0) {
+        toast.add({
+          title: 'Descuento inválido',
+          description: 'Si no aplica, déjalo en blanco o en 0.',
+          type: 'error',
+        });
+        return;
+      }
+
+      setSubmitting(true);
+      const { data: userRes } = await sb.auth.getUser();
+      const userId = userRes?.user?.id ?? null;
+
+      const result = await marcarFase(sb, {
+        ventaId: venta.id,
+        faseNombre: 'Formalizada',
+        faseposicion: 3,
+        docs: [{ rol: 'contrato_promesa', archivo }],
+        camposVenta: {
+          precio_asignacion: precio,
+          descuento_total: descuento,
+          // fecha del contrato — se guarda en venta_fases.fecha vía el override más abajo
+        },
+        notas:
+          fechaContrato !== new Date().toISOString().slice(0, 10)
+            ? `Fecha del contrato: ${fechaContrato}`
+            : null,
+        registradoPor: userId,
+      });
+
+      setSubmitting(false);
+      if (!result.ok) {
+        toast.add({
+          title: 'Error al cerrar Fase 3',
+          description: result.error ?? 'Error desconocido.',
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({
+        title: 'Fase 3 cerrada',
+        description: 'Fase 4 (Solicitud de Avalúo) está disponible.',
+        type: 'success',
+      });
+      router.push(`/dilesa/ventas/${venta.id}`);
+    },
+    [archivo, descuentoTotal, fechaContrato, precioAsignacion, router, sb, toast, venta]
+  );
+
+  // ── Render ─────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !venta) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-4 px-4 py-6">
+        <CapturarFaseHeader
+          ventaId={ventaId}
+          clienteNombre={null}
+          identificacionInventario={null}
+          faseposicion={3}
+          faseNombre="Formalizada"
+        />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Venta no encontrada.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+      <CapturarFaseHeader
+        ventaId={venta.id}
+        clienteNombre={clienteNombre}
+        identificacionInventario={identificacionInv}
+        faseposicion={3}
+        faseNombre="Formalizada"
+        descripcion="Cliente firmó el contrato de promesa de compraventa. Sube el PDF firmado y captura precio + fecha."
+      />
+
+      {yaCerrada ? (
+        <Banner
+          tone="success"
+          title="Fase 3 ya está cerrada"
+          body="Esta venta ya pasó por Formalizada. Si necesitas corregir algo, contacta al comité para reabrir la fase."
+        />
+      ) : !fase2Cerrada ? (
+        <Banner
+          tone="warning"
+          title="Falta cerrar Fase 2 (Asignada)"
+          body={
+            <>
+              Antes de capturar Formalizada, asegúrate de tener la asignación del comité. Vuelve al
+              detalle de la venta y captura la Fase 2 primero.
+            </>
+          }
+          extra={
+            <Link
+              href={`/dilesa/ventas/${venta.id}`}
+              className="mt-3 inline-block text-sm font-medium text-[var(--accent)] underline"
+            >
+              Volver al detalle
+            </Link>
+          }
+        />
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-6">
+          <Section title="Documento requerido">
+            <FileSlot
+              label="Contrato de Promesa de Compraventa (firmado por ambas partes) *"
+              archivo={archivo}
+              onChange={setArchivo}
+            />
+          </Section>
+
+          <Section title="Campos requeridos">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field label="Precio de asignación *">
+                <Input
+                  type="number"
+                  step="1"
+                  min="0"
+                  value={precioAsignacion}
+                  onChange={(e) => setPrecioAsignacion(e.target.value)}
+                  required
+                />
+                <Hint>{money(Number(precioAsignacion) || 0)}</Hint>
+              </Field>
+              <Field label="Descuento total">
+                <Input
+                  type="number"
+                  step="1"
+                  min="0"
+                  value={descuentoTotal}
+                  onChange={(e) => setDescuentoTotal(e.target.value)}
+                  placeholder="0"
+                />
+                <Hint>Si no aplica, déjalo en blanco.</Hint>
+              </Field>
+              <Field label="Fecha del contrato *">
+                <Input
+                  type="date"
+                  value={fechaContrato}
+                  onChange={(e) => setFechaContrato(e.target.value)}
+                  required
+                />
+              </Field>
+            </div>
+          </Section>
+
+          <div className="flex items-center justify-end gap-3">
+            <Link
+              href={`/dilesa/ventas/${venta.id}`}
+              className="text-sm text-muted-foreground hover:text-[var(--text)]"
+            >
+              Cancelar
+            </Link>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" /> Guardando…
+                </>
+              ) : (
+                <>
+                  <Save className="mr-2 size-4" /> Guardar fase
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return <p className="text-[11px] text-[var(--text)]/50">{children}</p>;
+}
+
+function FileSlot({
+  label,
+  archivo,
+  onChange,
+}: {
+  label: string;
+  archivo: File | null;
+  onChange: (f: File | null) => void;
+}) {
+  return (
+    <label className="flex cursor-pointer items-center gap-3 rounded-md border border-dashed border-[var(--border)] bg-[var(--bg)]/30 p-4 hover:bg-[var(--bg)]/50">
+      <Upload className="size-5 text-[var(--text)]/50" />
+      <div className="flex-1">
+        <div className="text-sm font-medium">{label}</div>
+        <div className="text-xs text-[var(--text)]/60">
+          {archivo
+            ? `${archivo.name} · ${(archivo.size / 1024).toFixed(0)} KB`
+            : 'Arrastra el archivo o haz click para seleccionarlo.'}
+        </div>
+      </div>
+      <input
+        type="file"
+        accept="application/pdf,image/*"
+        className="sr-only"
+        onChange={(e) => onChange(e.target.files?.[0] ?? null)}
+      />
+    </label>
+  );
+}
+
+function Banner({
+  tone,
+  title,
+  body,
+  extra,
+}: {
+  tone: 'success' | 'warning';
+  title: string;
+  body: React.ReactNode;
+  extra?: React.ReactNode;
+}) {
+  const styles =
+    tone === 'success'
+      ? 'border-emerald-400/40 bg-emerald-50 text-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-100'
+      : 'border-amber-400/40 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-100';
+  return (
+    <div className={`rounded-lg border p-4 ${styles}`}>
+      <p className="text-sm font-medium">{title}</p>
+      <div className="mt-1 text-sm">{body}</div>
+      {extra}
+    </div>
+  );
+}

--- a/app/dilesa/ventas/[id]/capturar/layout.tsx
+++ b/app/dilesa/ventas/[id]/capturar/layout.tsx
@@ -1,0 +1,13 @@
+/**
+ * Layout compartido para las páginas de captura de fase del pipeline
+ * DILESA. Cada `app/dilesa/ventas/[id]/capturar/<fase-slug>/page.tsx`
+ * lo hereda automáticamente.
+ *
+ * Aquí solo va el container del page — el header con back-link, el
+ * título y la ficha "estás capturando la venta X" lo monta cada page
+ * con `<CapturarFaseHeader>` (en components/dilesa/capturar-fase-header.tsx)
+ * porque necesita el nombre del cliente que cada page sabe cargar.
+ */
+export default function CapturarLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-[calc(100vh-3.5rem)]">{children}</div>;
+}

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -24,7 +24,7 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Check, Circle, Download, ExternalLink, FileText } from 'lucide-react';
+import { ArrowLeft, Check, Circle, Download, ExternalLink, FileText, Pencil } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Badge } from '@/components/ui/badge';
@@ -170,6 +170,17 @@ const FASE_ROLES: Record<string, string[]> = {
   Entregada: ['checklist_entrega'],
   'Comisión Pagada': [],
   'Operación Terminada': [],
+};
+
+/**
+ * Slugs de captura disponibles — mapea posición de fase → slug de la
+ * page de captura. Se va llenando conforme se implementan las pages
+ * del Sprint 7c. Si la fase no está aquí, el botón "Capturar" no
+ * aparece (la fase no es capturable aún desde BSOP).
+ */
+const CAPTURAR_SLUG_BY_POSICION: Record<number, string> = {
+  3: '3-formalizada',
+  // 2, 4–17 → próximos PRs del Sprint 7c
 };
 
 /** Las 17 fases canónicas en orden — para mostrar incluso las no alcanzadas. */
@@ -390,6 +401,7 @@ function DetailInner() {
   // subiendo el soporte" — la vista que se va a evolucionar.
   const pipelineRows = useMemo(() => {
     const fasesByName = new Map(fases.map((f) => [f.fase, f]));
+    const posicionesAlcanzadas = new Set(fases.map((f) => f.posicion));
     return FASES_ORDEN.map(({ pos, nombre }) => {
       const f = fasesByName.get(nombre);
       const roles = FASE_ROLES[nombre] ?? [];
@@ -398,13 +410,20 @@ function DetailInner() {
       );
       const rolesCargados = new Set(cargados.map((a) => a.rol));
       const faltantes = roles.filter((r) => !rolesCargados.has(r));
+      const slugCaptura = CAPTURAR_SLUG_BY_POSICION[pos];
+      const previaCerrada = pos === 1 || posicionesAlcanzadas.has(pos - 1);
+      const alcanzada = !!f?.fecha;
+      const puedeCapturar = !!slugCaptura && !alcanzada && previaCerrada;
       return {
         pos,
         nombre,
         fecha: f?.fecha ?? null,
-        alcanzada: !!f?.fecha,
+        alcanzada,
         cargados,
         faltantes,
+        slugCaptura,
+        puedeCapturar,
+        previaCerrada,
       };
     });
   }, [fases, adjuntosPorRolMap]);
@@ -645,6 +664,29 @@ function DetailInner() {
                   <span className="text-[10px] text-[var(--text)]/30">—</span>
                 ) : null}
               </div>
+
+              {/* Capturar fase — solo si la página está implementada y aplica */}
+              {r.slugCaptura ? (
+                <div className="shrink-0">
+                  {r.puedeCapturar ? (
+                    <Link
+                      href={`/dilesa/ventas/${id}/capturar/${r.slugCaptura}`}
+                      className="inline-flex items-center gap-1 rounded-md border border-[var(--accent)] bg-[var(--accent)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--accent)] hover:bg-[var(--accent)]/20"
+                    >
+                      <Pencil className="h-2.5 w-2.5" />
+                      Capturar fase
+                    </Link>
+                  ) : r.alcanzada ? null : (
+                    <span
+                      className="inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-[var(--border)] px-2 py-0.5 text-[10px] text-[var(--text)]/30"
+                      title={`Falta cerrar la fase ${r.pos - 1} primero.`}
+                    >
+                      <Pencil className="h-2.5 w-2.5" />
+                      Capturar
+                    </span>
+                  )}
+                </div>
+              ) : null}
             </li>
           ))}
         </ol>

--- a/components/dilesa/capturar-fase-header.tsx
+++ b/components/dilesa/capturar-fase-header.tsx
@@ -1,0 +1,44 @@
+'use client';
+/**
+ * Header reusable para las páginas de captura de fase.
+ * Muestra back-link a la venta + título de la fase + chip de posición.
+ */
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+export function CapturarFaseHeader({
+  ventaId,
+  clienteNombre,
+  identificacionInventario,
+  faseposicion,
+  faseNombre,
+  descripcion,
+}: {
+  ventaId: string;
+  clienteNombre: string | null;
+  identificacionInventario: string | null;
+  faseposicion: number;
+  faseNombre: string;
+  descripcion?: string;
+}) {
+  return (
+    <header className="space-y-2">
+      <Link
+        href={`/dilesa/ventas/${ventaId}`}
+        className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+      >
+        <ArrowLeft className="size-4" />
+        Volver a {clienteNombre || 'la venta'}
+        {identificacionInventario ? ` (${identificacionInventario})` : ''}
+      </Link>
+      <div className="flex flex-wrap items-baseline gap-3">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Fase {faseposicion} — {faseNombre}
+        </h1>
+        <Badge tone="neutral">Pipeline DILESA</Badge>
+      </div>
+      {descripcion ? <p className="text-sm text-[var(--text)]/60">{descripcion}</p> : null}
+    </header>
+  );
+}

--- a/lib/dilesa/captura/marcar-fase.test.ts
+++ b/lib/dilesa/captura/marcar-fase.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests del helper de captura de fase. Verifica el contrato de la
+ * transacción (storage + adjuntos + venta_fases + ventas update).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { marcarFase, FASES_PIPELINE } from './marcar-fase';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+function mockClient(opts?: {
+  storageUploadError?: string;
+  adjuntoInsertError?: string;
+  ventaUpdateError?: string;
+  faseInsertError?: string;
+}): SupabaseClient {
+  const storageOk = !opts?.storageUploadError;
+  const adjuntoOk = !opts?.adjuntoInsertError;
+  const ventaOk = !opts?.ventaUpdateError;
+  const faseOk = !opts?.faseInsertError;
+
+  const storage = {
+    from: vi.fn(() => ({
+      upload: vi.fn(async () =>
+        storageOk
+          ? { data: { path: 'x' }, error: null }
+          : { data: null, error: { message: opts!.storageUploadError } }
+      ),
+    })),
+  };
+
+  const schema = vi.fn((s: string) => ({
+    from: vi.fn((table: string) => {
+      if (s === 'erp' && table === 'adjuntos') {
+        return {
+          insert: vi.fn(async () =>
+            adjuntoOk ? { error: null } : { error: { message: opts!.adjuntoInsertError } }
+          ),
+        };
+      }
+      if (s === 'dilesa' && table === 'ventas') {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(async () =>
+              ventaOk ? { error: null } : { error: { message: opts!.ventaUpdateError } }
+            ),
+          })),
+        };
+      }
+      if (s === 'dilesa' && table === 'venta_fases') {
+        return {
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn(async () =>
+                faseOk
+                  ? { data: { id: 'fase-id-123' }, error: null }
+                  : { data: null, error: { message: opts!.faseInsertError } }
+              ),
+            })),
+          })),
+        };
+      }
+      return {};
+    }),
+  }));
+
+  return { storage, schema } as unknown as SupabaseClient;
+}
+
+function fakeFile(name = 'contrato.pdf', size = 1024): File {
+  return new File(['fake content'], name, { type: 'application/pdf' });
+}
+
+describe('marcarFase', () => {
+  const baseInput = {
+    ventaId: '550e8400-e29b-41d4-a716-446655440000',
+    faseNombre: 'Formalizada',
+    faseposicion: 3,
+    docs: [{ rol: 'contrato_promesa', archivo: fakeFile() }],
+    camposVenta: { precio_asignacion: 1_021_000 },
+    notas: null,
+    registradoPor: 'user-1',
+  };
+
+  it('happy path: sube doc, registra adjunto, update venta, cierra fase', async () => {
+    const sb = mockClient();
+    const r = await marcarFase(sb, baseInput);
+    expect(r.ok).toBe(true);
+    expect(r.adjuntosCreados).toBe(1);
+    expect(r.ventaFaseId).toBe('fase-id-123');
+  });
+
+  it('error en storage upload aborta antes de tocar la DB', async () => {
+    const sb = mockClient({ storageUploadError: 'Permission denied' });
+    const r = await marcarFase(sb, baseInput);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('Permission denied');
+    expect(r.adjuntosCreados).toBe(0);
+  });
+
+  it('error en INSERT erp.adjuntos aborta', async () => {
+    const sb = mockClient({ adjuntoInsertError: 'RLS denial' });
+    const r = await marcarFase(sb, baseInput);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('RLS denial');
+    expect(r.adjuntosCreados).toBe(0);
+  });
+
+  it('error en UPDATE venta deja adjuntos creados y reporta', async () => {
+    const sb = mockClient({ ventaUpdateError: 'forbidden col' });
+    const r = await marcarFase(sb, baseInput);
+    expect(r.ok).toBe(false);
+    expect(r.adjuntosCreados).toBe(1);
+    expect(r.error).toContain('forbidden col');
+  });
+
+  it('error en INSERT venta_fases deja todo lo previo pero reporta', async () => {
+    const sb = mockClient({ faseInsertError: 'check constraint' });
+    const r = await marcarFase(sb, baseInput);
+    expect(r.ok).toBe(false);
+    expect(r.adjuntosCreados).toBe(1);
+    expect(r.error).toContain('no se cerró la fase');
+  });
+
+  it('camposVenta vacío salta el UPDATE de ventas', async () => {
+    const sb = mockClient();
+    const r = await marcarFase(sb, { ...baseInput, camposVenta: {} });
+    expect(r.ok).toBe(true);
+  });
+
+  it('múltiples docs se suben en orden', async () => {
+    const sb = mockClient();
+    const r = await marcarFase(sb, {
+      ...baseInput,
+      docs: [
+        { rol: 'aviso_pld', archivo: fakeFile('pld.pdf') },
+        { rol: 'ficu', archivo: fakeFile('ficu.pdf') },
+        { rol: 'aviso_privacidad', archivo: fakeFile('aviso.pdf') },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.adjuntosCreados).toBe(3);
+  });
+});
+
+describe('FASES_PIPELINE', () => {
+  it('tiene 17 fases en orden', () => {
+    expect(FASES_PIPELINE).toHaveLength(17);
+    expect(FASES_PIPELINE.map((f) => f.posicion)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+    ]);
+  });
+
+  it('cada slug es kebab-case con prefijo numérico', () => {
+    for (const f of FASES_PIPELINE) {
+      expect(f.slug).toMatch(/^\d{1,2}-[a-z-]+$/);
+    }
+  });
+
+  it('los nombres coinciden con el seed de venta_fase_catalogo', () => {
+    // Los nombres deben ser EXACTAMENTE los de la DB para que el INSERT
+    // funcione. Si la migración cambia el seed, romper aquí intencionalmente.
+    const nombres = FASES_PIPELINE.map((f) => f.nombre);
+    expect(nombres).toContain('Solicitud de Asignación');
+    expect(nombres).toContain('Formalizada');
+    expect(nombres).toContain('Operación Terminada');
+  });
+});

--- a/lib/dilesa/captura/marcar-fase.ts
+++ b/lib/dilesa/captura/marcar-fase.ts
@@ -1,0 +1,182 @@
+/**
+ * Helper compartido para captura de fase en el pipeline de ventas DILESA.
+ *
+ * Una "captura de fase" es la transacción que cierra una fase del pipeline:
+ *   1. Sube los archivos a Supabase Storage (bucket `adjuntos`) → 1 path por archivo.
+ *   2. Inserta filas en `erp.adjuntos` (entidad_tipo='venta', rol=<rol>) con el path.
+ *   3. Inserta fila en `dilesa.venta_fases` con la fecha (today) — esa fila es la
+ *      señal "fase cerrada" que destraba la siguiente.
+ *   4. Opcionalmente, hace UPDATE en `dilesa.ventas` para los campos de la fase
+ *      (ej. precio_asignacion en Fase 3, monto_avaluo en Fase 5, etc.).
+ *
+ * Idempotente *parcialmente*: si una corrida previa subió el archivo pero
+ * falló al insertar venta_fases (ej. RLS), el archivo queda huérfano en
+ * Storage hasta que se vuelva a correr (overwrite con nuevo timestamp).
+ * No se intenta cleanup automático — los huérfanos se barren con el script
+ * de F1 del Sprint 6 (storage-cleanup). En la práctica la fase es atómica
+ * porque el cliente reintenta hasta éxito.
+ *
+ * Replicar este helper para las 16 fases restantes — cada page de fase llena
+ * `MarcarFaseInput.docs[]` con sus roles requeridos y `camposVenta` con sus
+ * campos específicos.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { buildAdjuntoPath } from '@/lib/storage/path';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+export type DocCaptura = {
+  /** Rol del adjunto (ej. 'contrato_promesa', 'aviso_pld', 'factura'). */
+  rol: string;
+  /** Archivo subido por el usuario. */
+  archivo: File;
+};
+
+export type MarcarFaseInput = {
+  ventaId: string;
+  /** Nombre canónico de la fase (debe coincidir con `dilesa.venta_fase_catalogo.nombre`). */
+  faseNombre: string;
+  faseposicion: number;
+  /** Documentos a subir + crear como `erp.adjuntos`. */
+  docs: DocCaptura[];
+  /**
+   * Campos a actualizar en `dilesa.ventas` para esta fase.
+   * Ej. Fase 3 actualiza `precio_asignacion`, `descuento_total`.
+   * Pasar `{}` si la fase no tiene campos.
+   */
+  camposVenta: Record<string, unknown>;
+  /** Nota opcional para `venta_fases.notas` (texto libre). */
+  notas?: string | null;
+  /** Usuario que captura, para `venta_fases.registrado_por`. */
+  registradoPor: string | null;
+};
+
+export type MarcarFaseResult = {
+  ok: boolean;
+  error?: string;
+  ventaFaseId?: string;
+  adjuntosCreados: number;
+};
+
+/**
+ * Ejecuta los 4 pasos de la captura de fase. Diseñado para correr desde
+ * el cliente (browser Supabase). Retorna { ok, error } — no throw.
+ */
+export async function marcarFase(
+  sb: SupabaseClient,
+  input: MarcarFaseInput
+): Promise<MarcarFaseResult> {
+  const { ventaId, faseNombre, faseposicion, docs, camposVenta, notas, registradoPor } = input;
+  let adjuntosCreados = 0;
+
+  // 1) Subir archivos a Storage + 2) insertar en erp.adjuntos
+  for (const doc of docs) {
+    const path = buildAdjuntoPath({
+      empresa: 'dilesa',
+      entidad: 'ventas',
+      entidadId: ventaId,
+      filename: doc.archivo.name,
+    });
+    const { error: upErr } = await sb.storage.from('adjuntos').upload(path, doc.archivo, {
+      contentType: doc.archivo.type || 'application/octet-stream',
+      upsert: false,
+    });
+    if (upErr) {
+      return {
+        ok: false,
+        error: `No se pudo subir "${doc.archivo.name}": ${upErr.message}`,
+        adjuntosCreados,
+      };
+    }
+    const { error: adjErr } = await sb
+      .schema('erp')
+      .from('adjuntos')
+      .insert({
+        empresa_id: DILESA_EMPRESA_ID,
+        entidad_tipo: 'venta',
+        entidad_id: ventaId,
+        rol: doc.rol,
+        nombre: doc.archivo.name,
+        url: path,
+        tipo_mime: doc.archivo.type || null,
+        tamano_bytes: doc.archivo.size,
+        uploaded_by: registradoPor,
+      });
+    if (adjErr) {
+      return {
+        ok: false,
+        error: `Archivo subido pero no se registró: ${adjErr.message}`,
+        adjuntosCreados,
+      };
+    }
+    adjuntosCreados += 1;
+  }
+
+  // 3) UPDATE de los campos de la venta (si hay)
+  if (Object.keys(camposVenta).length > 0) {
+    const { error: vErr } = await sb
+      .schema('dilesa')
+      .from('ventas')
+      .update(camposVenta)
+      .eq('id', ventaId);
+    if (vErr) {
+      return {
+        ok: false,
+        error: `No se pudieron actualizar los campos de la venta: ${vErr.message}`,
+        adjuntosCreados,
+      };
+    }
+  }
+
+  // 4) INSERT en venta_fases — esta es la señal de "fase cerrada".
+  const { data: faseRow, error: fErr } = await sb
+    .schema('dilesa')
+    .from('venta_fases')
+    .insert({
+      empresa_id: DILESA_EMPRESA_ID,
+      venta_id: ventaId,
+      fase: faseNombre,
+      posicion: faseposicion,
+      fecha: new Date().toISOString().slice(0, 10),
+      registrado_por: registradoPor,
+      notas: notas ?? null,
+    })
+    .select('id')
+    .single();
+  if (fErr) {
+    return {
+      ok: false,
+      error: `Adjuntos guardados pero no se cerró la fase: ${fErr.message}`,
+      adjuntosCreados,
+    };
+  }
+
+  return { ok: true, ventaFaseId: faseRow.id as string, adjuntosCreados };
+}
+
+/**
+ * Catálogo central de fases — index 0 = Fase 1. Replica `FASES_ORDEN` de
+ * `app/dilesa/ventas/[id]/page.tsx` pero como TS (no JSX) para que el
+ * helper sea reusable en server actions futuros.
+ */
+export const FASES_PIPELINE = [
+  { posicion: 1, nombre: 'Solicitud de Asignación', slug: '1-solicitud-asignacion' },
+  { posicion: 2, nombre: 'Asignada', slug: '2-asignada' },
+  { posicion: 3, nombre: 'Formalizada', slug: '3-formalizada' },
+  { posicion: 4, nombre: 'Solicitud de Avalúo', slug: '4-solicitud-avaluo' },
+  { posicion: 5, nombre: 'Avalúo Cerrado', slug: '5-avaluo-cerrado' },
+  { posicion: 6, nombre: 'Inscrita', slug: '6-inscrita' },
+  { posicion: 7, nombre: 'Solicitud de Dictaminación', slug: '7-solicitud-dictamen' },
+  { posicion: 8, nombre: 'Dictaminada', slug: '8-dictaminada' },
+  { posicion: 9, nombre: 'Validación Patronal', slug: '9-validacion-patronal' },
+  { posicion: 10, nombre: 'Firmas Programadas', slug: '10-firmas-programadas' },
+  { posicion: 11, nombre: 'Escriturada', slug: '11-escriturada' },
+  { posicion: 12, nombre: 'Detonada', slug: '12-detonada' },
+  { posicion: 13, nombre: 'Facturada', slug: '13-facturada' },
+  { posicion: 14, nombre: 'Preparada para Entrega', slug: '14-preparada-entrega' },
+  { posicion: 15, nombre: 'Entregada', slug: '15-entregada' },
+  { posicion: 16, nombre: 'Comisión Pagada', slug: '16-comision-pagada' },
+  { posicion: 17, nombre: 'Operación Terminada', slug: '17-operacion-terminada' },
+] as const;
+
+export type FaseSlug = (typeof FASES_PIPELINE)[number]['slug'];

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -40,6 +40,7 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   // Captura por fase — sub-slugs ADR-030. Cada URL apunta al sub-slug que
   // gobierna acceso a esa fase. Ver docs/planning/dilesa-ventas-captura.md.
   '/dilesa/ventas/nueva': 'dilesa.ventas.fase01_solicitud',
+  '/dilesa/ventas/[id]/capturar/3-formalizada': 'dilesa.ventas.fase03_formalizada',
 
   // RDB — home + operaciones
   '/rdb/home': 'rdb.home',

--- a/lib/storage/path.ts
+++ b/lib/storage/path.ts
@@ -33,7 +33,9 @@ export type AdjuntoEntidad =
   | 'prototipos'
   | 'terrenos'
   | 'anteproyectos'
-  | 'empresa';
+  | 'empresa'
+  | 'ventas'
+  | 'venta_pagos';
 
 export type BuildAdjuntoPathOpts = {
   empresa: EmpresaSlug;


### PR DESCRIPTION
## Summary

Primer eslabón del Sprint 7c: infraestructura compartida de captura por fase + **piloto con Fase 3 — Formalizada**. Si te late el patrón, lo replicamos en las 15 fases restantes (4 PRs más: Sprint 7c-2 a 7c-5).

## El flujo

```
1. Vendedor entra a /dilesa/ventas/<id>  (detalle, igual que hoy)
2. En el pipeline ve la fila de Fase 3 con:
       ○ 3. Formalizada    —    [Falta: contrato_promesa]    [✏ Capturar fase]
3. Click "Capturar fase" → navega a /dilesa/ventas/<id>/capturar/3-formalizada
4. Page con:
   - Header: back-link, "Fase 3 — Formalizada", ficha del cliente
   - Sección "Documento requerido": upload del contrato firmado
   - Sección "Campos requeridos": precio_asignacion (autollenado),
     descuento_total (opcional), fecha_contrato
   - Botones: Cancelar / Guardar fase
5. Save → sube PDF + inserta erp.adjuntos + update ventas + insert
   venta_fases → toast "Fase 3 cerrada · Fase 4 disponible"
6. Auto-navega de vuelta al detalle de venta con el pipeline actualizado
```

## Enforcement

- Si **Fase 2 no está cerrada**: la page muestra banner amarillo "Falta cerrar Fase 2" + link al detalle. No deja capturar.
- Si **Fase 3 ya está cerrada**: banner verde "Esta venta ya pasó por Formalizada" + sugerencia de contactar al comité para reabrir.
- En el pipeline del detalle, el botón "Capturar" sólo aparece para Fase 3 hoy (es la única implementada). Para fases sin página o sin permiso, no se muestra. Para fases capturables pero con previa pendiente, sale chip gris con tooltip.

## Pieza compartida (a reutilizar en las 15 fases siguientes)

- [lib/dilesa/captura/marcar-fase.ts](lib/dilesa/captura/marcar-fase.ts) — helper transaccional con los 4 pasos (Storage → erp.adjuntos → ventas → venta_fases). Cada page futura llena `docs[]` y `camposVenta` con lo suyo y llama `marcarFase(sb, input)`. Retorna `{ok, error, adjuntosCreados, ventaFaseId}` — no throws.
- [lib/dilesa/captura/marcar-fase.test.ts](lib/dilesa/captura/marcar-fase.test.ts) — 8 escenarios (happy + cada uno de los 4 puntos de falla + multi-docs + skip update).
- [app/dilesa/ventas/[id]/capturar/layout.tsx](app/dilesa/ventas/[id]/capturar/layout.tsx) — layout shell.
- [components/dilesa/capturar-fase-header.tsx](components/dilesa/capturar-fase-header.tsx) — header reusable.

## Ahorros de tiempo en las siguientes 15 páginas

Cada page nueva es básicamente: tipos del row de venta + cargar contexto + form con campos + lista de docs + handler que llama `marcarFase`. Estimación 60–90 LOC por fase × 15 = ~1500 LOC distribuidos en 4 PRs.

## Test plan

- [ ] CI verde (typecheck + lint + format + tests + schema:check)
- [ ] En preview, abrir una venta en Fase 2 (la última que cerraste)
- [ ] Click "Capturar fase" en la fila 3
- [ ] Llenar precio + fecha + subir PDF de prueba
- [ ] Verificar: toast OK + regreso al detalle + fila 3 ahora ✓ con fecha + chip de contrato_promesa cargado + fila 4 destrabada
- [ ] Re-abrir la misma venta → banner verde "ya cerrada" en lugar del form
- [ ] Abrir una venta SIN Fase 2 cerrada → banner amarillo de bloqueo

## Próximos PRs si todo OK

- **Sprint 7c-2** — Fases 4, 5, 6 (Avalúo: solicitud → cerrado → inscrita)
- **Sprint 7c-3** — Fases 7, 8, 9, 10 (Crédito + firmas)
- **Sprint 7c-4** — Fases 11, 12, 13 (Escrituración + detonación + facturación)
- **Sprint 7c-5** — Fases 14, 15, 16, 17 (Pre-entrega + entrega + comisión + cierre)

🤖 Generated with [Claude Code](https://claude.com/claude-code)