### PR TITLE
feat(dilesa): construcción Sprint 3 — UI lectura

### DIFF
--- a/app/dilesa/construccion/[id]/page.tsx
+++ b/app/dilesa/construccion/[id]/page.tsx
@@ -1,0 +1,776 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de detalle (cf.
+ * app/dilesa/ventas/[id]/page.tsx).
+ */
+
+/**
+ * Detalle completo de una construcción DILESA — 4 secciones:
+ *   1. Datos generales — prototipo, contratista, supervisor, fechas
+ *      críticas (arranque, compromiso, terminada, DTU, seguro calidad,
+ *      extracción, paquete RUV), CUV, Frente RUV.
+ *   2. Mano de obra — ejecutado, valor contrato, m² construcción,
+ *      precio MO x m².
+ *   3. Avance por etapa — para cada etapa de la plantilla del prototipo,
+ *      progress bar de tareas terminadas / totales + colapsable con la
+ *      lista (terminadas con fecha+revisor, pendientes outline).
+ *   4. Contrato — link al contrato de construcción (si tiene N:M con
+ *      contrato_lotes).
+ *
+ * Lectura pura — la captura ("registrar tarea terminada") es Sprint 4.
+ *
+ * Iniciativa dilesa-construccion · Sprint 3 (UI lectura).
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, Check, ChevronDown, ChevronRight, Circle, HardHat } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import type { BadgeTone } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Construccion = {
+  id: string;
+  codigo: string;
+  unidad_id: string;
+  producto_id: string;
+  contratista_id: string;
+  supervisor_persona_id: string | null;
+  fecha_arranque: string | null;
+  fecha_compromiso_terminar: string | null;
+  fecha_terminada: string | null;
+  fecha_seguro_calidad: string | null;
+  fecha_extraccion: string | null;
+  fecha_paquete_ruv: string | null;
+  fecha_dtu: string | null;
+  cuv: string | null;
+  frente_ruv: string | null;
+  avance_pct: number;
+  mo_ejecutado: number;
+  m2_construccion: number | null;
+  precio_mo_x_m2: number | null;
+  valor_contrato_mo: number | null;
+  estado: string;
+  notas: string | null;
+};
+
+type UnidadInfo = {
+  identificador: string;
+  proyecto_id: string;
+};
+
+type Etapa = { id: string; nombre: string; orden: number };
+type Tarea = { id: string; nombre: string };
+type Plantilla = {
+  id: string;
+  tarea_id: string;
+  etapa_id: string;
+  porcentaje_costo: number;
+};
+type Terminada = {
+  id: string;
+  plantilla_tarea_id: string;
+  fecha_terminada: string | null;
+  revisado_por_persona_id: string | null;
+  mano_obra_pagada: number | null;
+  fecha_pagada: string | null;
+};
+type ContratoLote = {
+  id: string;
+  contrato_id: string;
+  monto_lote: number | null;
+};
+type Contrato = {
+  id: string;
+  codigo: string;
+  fecha_contrato: string;
+  valor_total: number;
+};
+
+const ESTADO_TONE: Record<string, BadgeTone> = {
+  arrancada: 'info',
+  en_progreso: 'warning',
+  terminada: 'success',
+  dtu: 'success',
+  seguro_calidad: 'success',
+  extraida: 'success',
+  cancelada: 'neutral',
+};
+
+const ESTADO_LABEL: Record<string, string> = {
+  arrancada: 'Arrancada',
+  en_progreso: 'En progreso',
+  terminada: 'Terminada',
+  dtu: 'DTU',
+  seguro_calidad: 'Seguro calidad',
+  extraida: 'Extraída',
+  cancelada: 'Cancelada',
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+const numberFmt = new Intl.NumberFormat('es-MX');
+
+function fmtMoney(n: number | null): string | null {
+  return n == null ? null : moneyFmt.format(n);
+}
+
+function fmtNum(n: number | null, suffix = ''): string | null {
+  return n == null ? null : `${numberFmt.format(n)}${suffix}`;
+}
+
+function fmtFecha(s: string | null): string | null {
+  if (!s) return null;
+  const d = new Date(`${s}T00:00:00`);
+  if (isNaN(d.getTime())) return s;
+  return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+function avanceColorClass(pct: number): string {
+  if (pct >= 66) return 'bg-emerald-500';
+  if (pct >= 33) return 'bg-amber-500';
+  if (pct >= 20) return 'bg-amber-400';
+  return 'bg-rose-500';
+}
+
+/**
+ * @module Construcción detail (DILESA)
+ * @responsive desktop-only
+ */
+export default function ConstruccionDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion">
+      <DetailInner />
+    </RequireAccess>
+  );
+}
+
+function DetailInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [obra, setObra] = useState<Construccion | null>(null);
+  const [unidad, setUnidad] = useState<UnidadInfo | null>(null);
+  const [proyectoNombre, setProyectoNombre] = useState<string | null>(null);
+  const [prototipoNombre, setPrototipoNombre] = useState<string | null>(null);
+  const [contratistaNombre, setContratistaNombre] = useState<string | null>(null);
+  const [contratistaAbrev, setContratistaAbrev] = useState<string | null>(null);
+  const [supervisorNombre, setSupervisorNombre] = useState<string | null>(null);
+  const [etapas, setEtapas] = useState<Etapa[]>([]);
+  const [tareasCat, setTareasCat] = useState<Map<string, Tarea>>(new Map());
+  const [plantilla, setPlantilla] = useState<Plantilla[]>([]);
+  const [terminadas, setTerminadas] = useState<Terminada[]>([]);
+  const [revisorNombres, setRevisorNombres] = useState<Map<string, string>>(new Map());
+  const [contratos, setContratos] = useState<Array<Contrato & { lote: ContratoLote }>>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let activo = true;
+    const sb = createSupabaseBrowserClient();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      const { data: oRow, error: oErr } = await sb
+        .schema('dilesa')
+        .from('construccion')
+        .select('*')
+        .eq('id', id)
+        .is('deleted_at', null)
+        .maybeSingle();
+      if (!activo) return;
+      if (oErr) {
+        setError(getSupabaseErrorMessage(oErr, 'No se pudo cargar la obra.'));
+        setLoading(false);
+        return;
+      }
+      if (!oRow) {
+        setError('Obra no encontrada.');
+        setLoading(false);
+        return;
+      }
+      const obraRow = oRow as unknown as Construccion;
+      setObra(obraRow);
+
+      // Cargas paralelas dependientes del obra: unidad, prototipo,
+      // contratista (+ satélite con abreviación), supervisor.
+      const [uRes, prodRes, contRes, datosRes, supRes] = await Promise.all([
+        sb
+          .schema('dilesa')
+          .from('unidades')
+          .select('identificador, proyecto_id')
+          .eq('id', obraRow.unidad_id)
+          .maybeSingle(),
+        sb
+          .schema('dilesa')
+          .from('productos')
+          .select('nombre')
+          .eq('id', obraRow.producto_id)
+          .maybeSingle(),
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno')
+          .eq('id', obraRow.contratista_id)
+          .maybeSingle(),
+        sb
+          .schema('dilesa')
+          .from('contratistas_datos')
+          .select('abreviacion')
+          .eq('persona_id', obraRow.contratista_id)
+          .maybeSingle(),
+        obraRow.supervisor_persona_id
+          ? sb
+              .schema('erp')
+              .from('personas')
+              .select('nombre, apellido_paterno, apellido_materno')
+              .eq('id', obraRow.supervisor_persona_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+      ]);
+      if (!activo) return;
+      const firstErr1 =
+        uRes.error ?? prodRes.error ?? contRes.error ?? datosRes.error ?? supRes.error;
+      if (firstErr1) {
+        setError(getSupabaseErrorMessage(firstErr1, 'No se pudo cargar el detalle de la obra.'));
+        setLoading(false);
+        return;
+      }
+      const uData = (uRes.data as UnidadInfo | null) ?? null;
+      setUnidad(uData);
+      setPrototipoNombre((prodRes.data?.nombre as string | null) ?? null);
+      const cName = contRes.data
+        ? [contRes.data.nombre, contRes.data.apellido_paterno, contRes.data.apellido_materno]
+            .filter(Boolean)
+            .join(' ')
+        : null;
+      setContratistaNombre(cName);
+      setContratistaAbrev((datosRes.data?.abreviacion as string | null) ?? null);
+      if (supRes.data) {
+        setSupervisorNombre(
+          [supRes.data.nombre, supRes.data.apellido_paterno, supRes.data.apellido_materno]
+            .filter(Boolean)
+            .join(' ') || null
+        );
+      } else {
+        setSupervisorNombre(null);
+      }
+
+      // Proyecto del lote.
+      if (uData?.proyecto_id) {
+        const { data: prj } = await sb
+          .schema('dilesa')
+          .from('proyectos')
+          .select('nombre')
+          .eq('id', uData.proyecto_id)
+          .maybeSingle();
+        if (!activo) return;
+        setProyectoNombre((prj?.nombre as string | null) ?? null);
+      }
+
+      // Plantilla del prototipo + etapas + diccionario de tareas + log
+      // de tareas terminadas. Cuatro queries paralelas.
+      const [plRes, etRes, taRes, ttRes] = await Promise.all([
+        sb
+          .schema('dilesa')
+          .from('plantilla_tareas')
+          .select('id, tarea_id, etapa_id, porcentaje_costo')
+          .eq('producto_id', obraRow.producto_id)
+          .is('deleted_at', null),
+        sb
+          .schema('dilesa')
+          .from('etapas_construccion')
+          .select('id, nombre, orden')
+          .is('deleted_at', null)
+          .order('orden', { ascending: true }),
+        sb.schema('dilesa').from('tareas_construccion').select('id, nombre').is('deleted_at', null),
+        sb
+          .schema('dilesa')
+          .from('construccion_tareas_terminadas')
+          .select(
+            'id, plantilla_tarea_id, fecha_terminada, revisado_por_persona_id, mano_obra_pagada, fecha_pagada'
+          )
+          .eq('construccion_id', obraRow.id)
+          .is('deleted_at', null)
+          .order('fecha_terminada', { ascending: true }),
+      ]);
+      if (!activo) return;
+      const firstErr2 = plRes.error ?? etRes.error ?? taRes.error ?? ttRes.error;
+      if (firstErr2) {
+        setError(getSupabaseErrorMessage(firstErr2, 'No se pudieron cargar las etapas y tareas.'));
+        setLoading(false);
+        return;
+      }
+      const plantillaArr = (plRes.data ?? []) as Plantilla[];
+      setPlantilla(plantillaArr);
+      setEtapas((etRes.data ?? []) as Etapa[]);
+      const tMap = new Map<string, Tarea>();
+      for (const t of taRes.data ?? []) tMap.set(t.id as string, { id: t.id, nombre: t.nombre });
+      setTareasCat(tMap);
+      const terminadasArr = (ttRes.data ?? []) as Terminada[];
+      setTerminadas(terminadasArr);
+
+      // Revisores de las terminadas — una query consolidada.
+      const revisorIds = [
+        ...new Set(
+          terminadasArr.map((t) => t.revisado_por_persona_id).filter((v): v is string => !!v)
+        ),
+      ];
+      if (revisorIds.length > 0) {
+        const { data: revs } = await sb
+          .schema('erp')
+          .from('personas')
+          .select('id, nombre, apellido_paterno, apellido_materno')
+          .in('id', revisorIds);
+        if (!activo) return;
+        const rmap = new Map<string, string>();
+        for (const r of revs ?? []) {
+          const n = [r.nombre, r.apellido_paterno, r.apellido_materno].filter(Boolean).join(' ');
+          rmap.set(r.id as string, n || '(sin nombre)');
+        }
+        setRevisorNombres(rmap);
+      } else {
+        setRevisorNombres(new Map());
+      }
+
+      // Contratos asignados: contrato_lotes (N:M) → contratos_construccion.
+      const { data: lotes, error: lErr } = await sb
+        .schema('dilesa')
+        .from('contrato_lotes')
+        .select('id, contrato_id, monto_lote')
+        .eq('construccion_id', obraRow.id)
+        .is('deleted_at', null);
+      if (!activo) return;
+      if (lErr) {
+        setError(getSupabaseErrorMessage(lErr, 'No se pudieron cargar los contratos.'));
+        setLoading(false);
+        return;
+      }
+      const lotesArr = (lotes ?? []) as ContratoLote[];
+      if (lotesArr.length > 0) {
+        const contratoIds = [...new Set(lotesArr.map((l) => l.contrato_id))];
+        const { data: cts } = await sb
+          .schema('dilesa')
+          .from('contratos_construccion')
+          .select('id, codigo, fecha_contrato, valor_total')
+          .in('id', contratoIds)
+          .is('deleted_at', null);
+        if (!activo) return;
+        const cMap = new Map<string, Contrato>();
+        for (const c of cts ?? []) cMap.set(c.id as string, c as Contrato);
+        setContratos(
+          lotesArr
+            .map((l) => {
+              const c = cMap.get(l.contrato_id);
+              return c ? { ...c, lote: l } : null;
+            })
+            .filter((x): x is Contrato & { lote: ContratoLote } => !!x)
+        );
+      } else {
+        setContratos([]);
+      }
+
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [id]);
+
+  // Agrupación tareas por etapa, con flag terminada/pendiente y % de costo.
+  const etapasConTareas = useMemo(() => {
+    const terminadasByPlantilla = new Map<string, Terminada>();
+    for (const t of terminadas) terminadasByPlantilla.set(t.plantilla_tarea_id, t);
+
+    const rows = etapas.map((et) => {
+      const tareasDeEtapa = plantilla.filter((p) => p.etapa_id === et.id);
+      const items = tareasDeEtapa
+        .map((p) => {
+          const tareaInfo = tareasCat.get(p.tarea_id);
+          const terminada = terminadasByPlantilla.get(p.id) ?? null;
+          return {
+            plantillaId: p.id,
+            nombre: tareaInfo?.nombre ?? '(tarea desconocida)',
+            porcentajeCosto: Number(p.porcentaje_costo ?? 0),
+            terminada,
+          };
+        })
+        .sort((a, b) => a.nombre.localeCompare(b.nombre));
+      const total = items.length;
+      const completas = items.filter((it) => !!it.terminada).length;
+      const pctEtapa = total === 0 ? 0 : (completas / total) * 100;
+      const pctCosto = items
+        .filter((it) => !!it.terminada)
+        .reduce((s, it) => s + it.porcentajeCosto, 0);
+      return {
+        ...et,
+        items,
+        total,
+        completas,
+        pctEtapa,
+        pctCosto,
+      };
+    });
+    // Solo mostrar etapas con tareas en la plantilla del prototipo
+    return rows.filter((r) => r.total > 0);
+  }, [etapas, plantilla, tareasCat, terminadas]);
+
+  const moPorEjecutar = useMemo(() => {
+    if (!obra) return null;
+    if (obra.valor_contrato_mo == null) return null;
+    return obra.valor_contrato_mo - obra.mo_ejecutado;
+  }, [obra]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !obra) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Obra no encontrada.'}
+        </div>
+      </div>
+    );
+  }
+
+  const protoSufijo = prototipoNombre ? prototipoNombre.split('-').pop() : null;
+  const identificadorCompleto = unidad
+    ? protoSufijo
+      ? `${unidad.identificador}-${protoSufijo}`
+      : unidad.identificador
+    : obra.codigo;
+
+  const fichaGeneral: { label: string; value: string }[] = (
+    [
+      ['Proyecto', proyectoNombre],
+      ['Unidad', unidad?.identificador ?? null],
+      ['Código de obra', obra.codigo],
+      ['Prototipo', prototipoNombre],
+      [
+        'Contratista',
+        contratistaAbrev && contratistaNombre
+          ? `${contratistaAbrev} · ${contratistaNombre}`
+          : (contratistaNombre ?? null),
+      ],
+      ['Supervisor', supervisorNombre],
+      ['Fecha de arranque', fmtFecha(obra.fecha_arranque)],
+      ['Compromiso de terminar', fmtFecha(obra.fecha_compromiso_terminar)],
+      ['Fecha terminada', fmtFecha(obra.fecha_terminada)],
+      ['Fecha DTU', fmtFecha(obra.fecha_dtu)],
+      ['Fecha seguro calidad', fmtFecha(obra.fecha_seguro_calidad)],
+      ['Fecha extracción', fmtFecha(obra.fecha_extraccion)],
+      ['Fecha paquete RUV', fmtFecha(obra.fecha_paquete_ruv)],
+      ['CUV', obra.cuv],
+      ['Frente RUV', obra.frente_ruv],
+    ] as [string, string | null][]
+  )
+    .filter((r): r is [string, string] => r[1] != null && r[1] !== '')
+    .map(([label, value]) => ({ label, value }));
+
+  const fichaMO: { label: string; value: string }[] = (
+    [
+      ['Avance', `${obra.avance_pct.toFixed(0)}%`],
+      ['MO ejecutado', fmtMoney(obra.mo_ejecutado)],
+      ['Valor contrato MO', fmtMoney(obra.valor_contrato_mo)],
+      ['MO por ejecutar', fmtMoney(moPorEjecutar)],
+      ['m² construcción', fmtNum(obra.m2_construccion, ' m²')],
+      ['Precio MO por m²', fmtMoney(obra.precio_mo_x_m2)],
+    ] as [string, string | null][]
+  )
+    .filter((r): r is [string, string] => r[1] != null && r[1] !== '')
+    .map(([label, value]) => ({ label, value }));
+
+  return (
+    <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight text-[var(--text)]">
+            <HardHat className="h-5 w-5 text-[var(--accent)]" />
+            {identificadorCompleto}
+          </h1>
+          {proyectoNombre ? (
+            <p className="mt-1 text-sm text-[var(--text)]/60">
+              {proyectoNombre}
+              {contratistaNombre ? ` · ${contratistaNombre}` : ''}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge tone={ESTADO_TONE[obra.estado] ?? 'neutral'}>
+            {ESTADO_LABEL[obra.estado] ?? obra.estado}
+          </Badge>
+          <span className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] bg-[var(--card)] px-2 py-1 text-xs text-[var(--text)]/70">
+            <div className="h-1.5 w-24 overflow-hidden rounded-full bg-[var(--border)]/40">
+              <div
+                className={`h-full rounded-full ${avanceColorClass(obra.avance_pct)}`}
+                style={{ width: `${Math.min(100, Math.max(0, obra.avance_pct))}%` }}
+              />
+            </div>
+            <span className="tabular-nums">{obra.avance_pct.toFixed(0)}%</span>
+          </span>
+        </div>
+      </header>
+
+      <Section title="Datos generales">
+        {fichaGeneral.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">Sin datos capturados.</p>
+        ) : (
+          <FichaGrid rows={fichaGeneral} cols={3} />
+        )}
+        {obra.notas ? (
+          <div className="mt-4 border-t border-[var(--border)] pt-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+              Notas
+            </div>
+            <p className="mt-0.5 whitespace-pre-wrap text-sm text-[var(--text)]/80">{obra.notas}</p>
+          </div>
+        ) : null}
+      </Section>
+
+      <Section title="Mano de obra">
+        {fichaMO.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">—</p>
+        ) : (
+          <FichaGrid rows={fichaMO} cols={3} />
+        )}
+      </Section>
+
+      <Section
+        title="Avance por etapa"
+        description={
+          etapasConTareas.length === 0
+            ? 'sin plantilla'
+            : `${etapasConTareas.length} ${etapasConTareas.length === 1 ? 'etapa' : 'etapas'} · ${terminadas.length} ${terminadas.length === 1 ? 'tarea' : 'tareas'} terminadas`
+        }
+      >
+        {etapasConTareas.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">
+            La plantilla del prototipo no tiene tareas registradas para este producto.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {etapasConTareas.map((et) => (
+              <EtapaBlock key={et.id} etapa={et} revisorNombres={revisorNombres} />
+            ))}
+          </div>
+        )}
+      </Section>
+
+      <Section
+        title="Contratos"
+        description={
+          contratos.length === 0 ? 'sin contrato' : `${contratos.length} contrato(s) asignado(s)`
+        }
+      >
+        {contratos.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">
+            Esta obra no tiene contrato de construcción asignado todavía.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {contratos.map((c) => (
+              <li
+                key={c.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-3 py-2"
+              >
+                <div>
+                  <div className="text-sm font-medium text-[var(--text)]">{c.codigo}</div>
+                  <div className="text-xs text-[var(--text)]/50">
+                    {fmtFecha(c.fecha_contrato)}
+                    {c.lote.monto_lote != null
+                      ? ` · ${moneyFmt.format(c.lote.monto_lote)} en este lote`
+                      : ''}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-xs uppercase tracking-wide text-[var(--text)]/50">
+                    Valor total
+                  </div>
+                  <div className="text-sm tabular-nums text-[var(--text)]">
+                    {moneyFmt.format(c.valor_total)}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+// ── Sub-componentes ──────────────────────────────────────────────────────
+
+function BackLink() {
+  return (
+    <Link
+      href="/dilesa/construccion"
+      className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+    >
+      <ArrowLeft className="size-4" /> Volver a construcción
+    </Link>
+  );
+}
+
+function EtapaBlock({
+  etapa,
+  revisorNombres,
+}: {
+  etapa: {
+    id: string;
+    nombre: string;
+    orden: number;
+    items: Array<{
+      plantillaId: string;
+      nombre: string;
+      porcentajeCosto: number;
+      terminada: Terminada | null;
+    }>;
+    total: number;
+    completas: number;
+    pctEtapa: number;
+    pctCosto: number;
+  };
+  revisorNombres: Map<string, string>;
+}) {
+  const [open, setOpen] = useState(false);
+  const Icon = open ? ChevronDown : ChevronRight;
+  return (
+    <div className="rounded-md border border-[var(--border)] bg-[var(--card)]">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-[var(--bg)]/30"
+      >
+        <Icon className="h-4 w-4 shrink-0 text-[var(--text)]/40" />
+        <span className="w-6 shrink-0 font-mono text-[10px] tabular-nums text-[var(--text)]/40">
+          {etapa.orden}
+        </span>
+        <span className="min-w-[180px] shrink-0 text-sm font-medium text-[var(--text)]">
+          {etapa.nombre}
+        </span>
+        <div className="flex flex-1 items-center gap-2">
+          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--border)]/40">
+            <div
+              className={`h-full rounded-full ${avanceColorClass(etapa.pctEtapa)}`}
+              style={{ width: `${etapa.pctEtapa}%` }}
+            />
+          </div>
+          <span className="w-20 shrink-0 text-right text-xs tabular-nums text-[var(--text)]/60">
+            {etapa.completas}/{etapa.total}
+          </span>
+          <span className="w-14 shrink-0 text-right text-xs tabular-nums text-[var(--text)]/50">
+            {etapa.pctCosto.toFixed(1)}%
+          </span>
+        </div>
+      </button>
+      {open ? (
+        <ul className="border-t border-[var(--border)]/60 px-3 py-2">
+          {etapa.items.map((it) => {
+            const t = it.terminada;
+            const revisor = t?.revisado_por_persona_id
+              ? revisorNombres.get(t.revisado_por_persona_id)
+              : null;
+            return (
+              <li
+                key={it.plantillaId}
+                className="flex flex-wrap items-start gap-3 border-b border-[var(--border)]/40 py-1.5 last:border-0"
+              >
+                <div className="mt-0.5 w-4 shrink-0">
+                  {t ? (
+                    <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+                  ) : (
+                    <Circle className="h-3.5 w-3.5 text-[var(--text)]/30" />
+                  )}
+                </div>
+                <div className="flex-1">
+                  <div className="text-sm text-[var(--text)]">{it.nombre}</div>
+                  {t ? (
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-[var(--text)]/55">
+                      {t.fecha_terminada ? (
+                        <span>Terminada {fmtFecha(t.fecha_terminada)}</span>
+                      ) : null}
+                      {revisor ? <span>Revisó {revisor}</span> : null}
+                      {t.mano_obra_pagada != null ? (
+                        <span>MO {moneyFmt.format(t.mano_obra_pagada)}</span>
+                      ) : null}
+                      {t.fecha_pagada ? <span>Pagada {fmtFecha(t.fecha_pagada)}</span> : null}
+                    </div>
+                  ) : null}
+                </div>
+                <div className="shrink-0 text-right text-[11px] tabular-nums text-[var(--text)]/40">
+                  {it.porcentajeCosto.toFixed(2)}%
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="mb-4 flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {description ? <span className="text-xs text-[var(--text)]/50">{description}</span> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function FichaGrid({ rows, cols = 2 }: { rows: { label: string; value: string }[]; cols?: 2 | 3 }) {
+  const gridCls =
+    cols === 3
+      ? 'grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3'
+      : 'grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2';
+  return (
+    <dl className={gridCls}>
+      {rows.map((r) => (
+        <div key={r.label}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+            {r.label}
+          </dt>
+          <dd className="mt-0.5 text-sm text-[var(--text)]">{r.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/app/dilesa/construccion/page.tsx
+++ b/app/dilesa/construccion/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { ConstruccionModule } from '@/components/dilesa/construccion-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Construcción (DILESA)
+ * @responsive desktop-only
+ *
+ * Iniciativa dilesa-construccion · Sprint 3 (UI lectura). Lista de
+ * construcciones por obra (~1,372 obras importadas en Sprint 2):
+ * unidad, prototipo, contratista, avance%, estado, fechas críticas.
+ * Click navega a /dilesa/construccion/[id] con la ficha completa,
+ * timeline de etapas y tareas terminadas/pendientes.
+ *
+ * Lectura pura — captura (arrancar obra, registrar tarea) entra en
+ * Sprint 4. Sub-slugs de escritura se introducirán en esa fase.
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion">
+      <DesktopOnlyNotice module="Construcción" />
+      <div className="hidden sm:block">
+        <ConstruccionModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/contratistas/[id]/page.tsx
+++ b/app/dilesa/contratistas/[id]/page.tsx
@@ -1,0 +1,579 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de detalle (cf.
+ * app/dilesa/construccion/[id]/page.tsx).
+ */
+
+/**
+ * Detalle de un contratista DILESA — 4 secciones:
+ *   1. Datos generales — RFC, persona física/moral, representante legal,
+ *      registro patronal, domicilio.
+ *   2. KPIs derivados — obras en curso, terminadas, MO total pagada,
+ *      MO pendiente, valor contratos totales.
+ *   3. Obras asignadas — lista de construcciones donde es contratista,
+ *      cada una linkeada a /dilesa/construccion/[id].
+ *   4. Contratos — lista de contratos de construcción donde es
+ *      contratista, con valor total + # lotes cubiertos.
+ *
+ * Lectura pura — la captura entra en Sprint 4.
+ *
+ * Iniciativa dilesa-construccion · Sprint 3 (UI lectura).
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, HardHat, Users } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Persona = {
+  id: string;
+  nombre: string | null;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
+  email: string | null;
+  telefono: string | null;
+  rfc: string | null;
+  activo: boolean;
+};
+
+type ContratistaDatos = {
+  abreviacion: string | null;
+  persona_fisica_o_moral: string | null;
+  representante_legal: string | null;
+  repse: string | null;
+  registro_patronal: string | null;
+  retencion_pct: number | null;
+  domicilio: string | null;
+  activo: boolean;
+  notas: string | null;
+};
+
+type Obra = {
+  id: string;
+  codigo: string;
+  unidad_id: string;
+  producto_id: string;
+  estado: string;
+  avance_pct: number;
+  fecha_arranque: string | null;
+  fecha_terminada: string | null;
+  mo_ejecutado: number;
+  valor_contrato_mo: number | null;
+};
+
+type Contrato = {
+  id: string;
+  codigo: string;
+  fecha_contrato: string;
+  valor_total: number;
+  proyecto_id: string | null;
+  lotesCount: number;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+function fmtMoney(n: number | null): string | null {
+  return n == null ? null : moneyFmt.format(n);
+}
+
+function fmtFecha(s: string | null): string | null {
+  if (!s) return null;
+  const d = new Date(`${s}T00:00:00`);
+  if (isNaN(d.getTime())) return s;
+  return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+function avanceColorClass(pct: number): string {
+  if (pct >= 66) return 'bg-emerald-500';
+  if (pct >= 33) return 'bg-amber-500';
+  if (pct >= 20) return 'bg-amber-400';
+  return 'bg-rose-500';
+}
+
+const ENCURSO = new Set(['arrancada', 'en_progreso']);
+const TERMINADA = new Set(['terminada', 'dtu', 'seguro_calidad', 'extraida']);
+
+const ESTADO_LABEL: Record<string, string> = {
+  arrancada: 'Arrancada',
+  en_progreso: 'En progreso',
+  terminada: 'Terminada',
+  dtu: 'DTU',
+  seguro_calidad: 'Seguro calidad',
+  extraida: 'Extraída',
+  cancelada: 'Cancelada',
+};
+
+/**
+ * @module Contratista detail (DILESA)
+ * @responsive desktop-only
+ */
+export default function ContratistaDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.contratistas">
+      <DetailInner />
+    </RequireAccess>
+  );
+}
+
+function DetailInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [persona, setPersona] = useState<Persona | null>(null);
+  const [datos, setDatos] = useState<ContratistaDatos | null>(null);
+  const [obras, setObras] = useState<Obra[]>([]);
+  const [unidadIdentificadores, setUnidadIdentificadores] = useState<Map<string, string>>(
+    new Map()
+  );
+  const [productoNombres, setProductoNombres] = useState<Map<string, string>>(new Map());
+  const [contratos, setContratos] = useState<Contrato[]>([]);
+  const [proyectoNombres, setProyectoNombres] = useState<Map<string, string>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let activo = true;
+    const sb = createSupabaseBrowserClient();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      // Persona base + satélite + obras + contratos en paralelo.
+      const [pRes, dRes, obrasRes, contratosRes] = await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('id, nombre, apellido_paterno, apellido_materno, email, telefono, rfc, activo')
+          .eq('id', id)
+          .eq('tipo', 'contratista')
+          .maybeSingle(),
+        sb
+          .schema('dilesa')
+          .from('contratistas_datos')
+          .select(
+            'abreviacion, persona_fisica_o_moral, representante_legal, repse, registro_patronal, retencion_pct, domicilio, activo, notas'
+          )
+          .eq('persona_id', id)
+          .maybeSingle(),
+        sb
+          .schema('dilesa')
+          .from('construccion')
+          .select(
+            'id, codigo, unidad_id, producto_id, estado, avance_pct, fecha_arranque, fecha_terminada, mo_ejecutado, valor_contrato_mo'
+          )
+          .eq('contratista_id', id)
+          .is('deleted_at', null)
+          .order('fecha_arranque', { ascending: false }),
+        sb
+          .schema('dilesa')
+          .from('contratos_construccion')
+          .select('id, codigo, fecha_contrato, valor_total, proyecto_id')
+          .eq('contratista_id', id)
+          .is('deleted_at', null)
+          .order('fecha_contrato', { ascending: false }),
+      ]);
+      if (!activo) return;
+      const firstErr = pRes.error ?? dRes.error ?? obrasRes.error ?? contratosRes.error;
+      if (firstErr) {
+        setError(getSupabaseErrorMessage(firstErr, 'No se pudo cargar el contratista.'));
+        setLoading(false);
+        return;
+      }
+      if (!pRes.data) {
+        setError('Contratista no encontrado.');
+        setLoading(false);
+        return;
+      }
+      setPersona(pRes.data as unknown as Persona);
+      setDatos((dRes.data as unknown as ContratistaDatos | null) ?? null);
+      const obrasArr = (obrasRes.data ?? []) as Obra[];
+      setObras(obrasArr);
+      const contratosArrRaw = (contratosRes.data ?? []) as Array<Omit<Contrato, 'lotesCount'>>;
+
+      // Lookups para enriquecer las obras (unidad identificador,
+      // prototipo) y contratos (proyecto nombre + count de lotes).
+      const unidadIds = [...new Set(obrasArr.map((o) => o.unidad_id))];
+      const prodIds = [...new Set(obrasArr.map((o) => o.producto_id))];
+      const contratoIds = contratosArrRaw.map((c) => c.id);
+      const proyectoIds = [
+        ...new Set(contratosArrRaw.map((c) => c.proyecto_id).filter((v): v is string => !!v)),
+      ];
+
+      const [uRes, prodRes, lotesRes, prjRes] = await Promise.all([
+        unidadIds.length > 0
+          ? sb.schema('dilesa').from('unidades').select('id, identificador').in('id', unidadIds)
+          : Promise.resolve({ data: [], error: null }),
+        prodIds.length > 0
+          ? sb.schema('dilesa').from('productos').select('id, nombre').in('id', prodIds)
+          : Promise.resolve({ data: [], error: null }),
+        contratoIds.length > 0
+          ? sb
+              .schema('dilesa')
+              .from('contrato_lotes')
+              .select('contrato_id')
+              .in('contrato_id', contratoIds)
+              .is('deleted_at', null)
+          : Promise.resolve({ data: [], error: null }),
+        proyectoIds.length > 0
+          ? sb.schema('dilesa').from('proyectos').select('id, nombre').in('id', proyectoIds)
+          : Promise.resolve({ data: [], error: null }),
+      ]);
+      if (!activo) return;
+
+      const uMap = new Map<string, string>();
+      for (const u of uRes.data ?? []) uMap.set(u.id as string, u.identificador as string);
+      setUnidadIdentificadores(uMap);
+
+      const pMap = new Map<string, string>();
+      for (const p of prodRes.data ?? []) pMap.set(p.id as string, p.nombre as string);
+      setProductoNombres(pMap);
+
+      const lotesByContrato = new Map<string, number>();
+      for (const l of lotesRes.data ?? []) {
+        const cid = l.contrato_id as string;
+        lotesByContrato.set(cid, (lotesByContrato.get(cid) ?? 0) + 1);
+      }
+
+      setContratos(
+        contratosArrRaw.map((c) => ({
+          ...c,
+          lotesCount: lotesByContrato.get(c.id) ?? 0,
+        }))
+      );
+
+      const prjMap = new Map<string, string>();
+      for (const p of prjRes.data ?? []) prjMap.set(p.id as string, p.nombre as string);
+      setProyectoNombres(prjMap);
+
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [id]);
+
+  const nombreCompleto = useMemo(() => {
+    if (!persona) return '';
+    return (
+      [persona.nombre, persona.apellido_paterno, persona.apellido_materno]
+        .filter(Boolean)
+        .join(' ') || '(sin nombre)'
+    );
+  }, [persona]);
+
+  const kpis = useMemo(() => {
+    let enCurso = 0;
+    let terminadas = 0;
+    let canceladas = 0;
+    let moTotal = 0;
+    let valorContratosObras = 0;
+    for (const o of obras) {
+      if (ENCURSO.has(o.estado)) enCurso += 1;
+      else if (TERMINADA.has(o.estado)) terminadas += 1;
+      else if (o.estado === 'cancelada') canceladas += 1;
+      moTotal += Number(o.mo_ejecutado ?? 0);
+      valorContratosObras += Number(o.valor_contrato_mo ?? 0);
+    }
+    const moPorEjecutar = Math.max(0, valorContratosObras - moTotal);
+    const valorContratosTotales = contratos.reduce((s, c) => s + Number(c.valor_total ?? 0), 0);
+    return {
+      enCurso,
+      terminadas,
+      canceladas,
+      moTotal,
+      moPorEjecutar,
+      valorContratosTotales,
+    };
+  }, [obras, contratos]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !persona) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Contratista no encontrado.'}
+        </div>
+      </div>
+    );
+  }
+
+  const fichaGeneral: { label: string; value: string }[] = (
+    [
+      ['Abreviación', datos?.abreviacion ?? null],
+      ['RFC', persona.rfc],
+      ['Tipo', datos?.persona_fisica_o_moral ?? null],
+      ['Representante legal', datos?.representante_legal ?? null],
+      ['Registro patronal', datos?.registro_patronal ?? null],
+      ['REPSE', datos?.repse ?? null],
+      ['Retención', datos?.retencion_pct != null ? `${datos.retencion_pct.toFixed(2)}%` : null],
+      ['Teléfono', persona.telefono],
+      ['Email', persona.email],
+      ['Domicilio', datos?.domicilio ?? null],
+    ] as [string, string | null][]
+  )
+    .filter((r): r is [string, string] => r[1] != null && r[1] !== '')
+    .map(([label, value]) => ({ label, value }));
+
+  return (
+    <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight text-[var(--text)]">
+            <Users className="h-5 w-5 text-[var(--accent)]" />
+            {nombreCompleto}
+          </h1>
+          {datos?.abreviacion ? (
+            <p className="mt-1 text-xs uppercase tracking-wide text-[var(--text)]/50">
+              {datos.abreviacion}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {datos?.persona_fisica_o_moral ? (
+            <Badge tone="neutral">{datos.persona_fisica_o_moral}</Badge>
+          ) : null}
+          {datos?.repse ? <Badge tone="success">REPSE</Badge> : null}
+          {(datos ? datos.activo : persona.activo) ? (
+            <Badge tone="success">Activo</Badge>
+          ) : (
+            <Badge tone="neutral">Inactivo</Badge>
+          )}
+        </div>
+      </header>
+
+      <Section title="Datos generales">
+        {fichaGeneral.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">Sin datos registrados.</p>
+        ) : (
+          <FichaGrid rows={fichaGeneral} cols={3} />
+        )}
+        {datos?.notas ? (
+          <div className="mt-4 border-t border-[var(--border)] pt-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+              Notas
+            </div>
+            <p className="mt-0.5 whitespace-pre-wrap text-sm text-[var(--text)]/80">
+              {datos.notas}
+            </p>
+          </div>
+        ) : null}
+      </Section>
+
+      <Section title="KPIs">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+          <Kpi label="Obras en curso" value={kpis.enCurso.toString()} accent />
+          <Kpi label="Obras terminadas" value={kpis.terminadas.toString()} />
+          <Kpi label="Canceladas" value={kpis.canceladas.toString()} muted />
+          <Kpi label="MO pagada" value={fmtMoney(kpis.moTotal) ?? '$0'} />
+          <Kpi label="MO por ejecutar" value={fmtMoney(kpis.moPorEjecutar) ?? '$0'} />
+          <Kpi label="Valor contratos" value={fmtMoney(kpis.valorContratosTotales) ?? '$0'} />
+        </div>
+      </Section>
+
+      <Section
+        title="Obras asignadas"
+        description={obras.length === 0 ? 'sin obras' : `${obras.length} obra(s) en histórico`}
+      >
+        {obras.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">
+            Este contratista todavía no tiene obras asignadas.
+          </p>
+        ) : (
+          <ul className="space-y-1.5">
+            {obras.map((o) => {
+              const ident = unidadIdentificadores.get(o.unidad_id) ?? o.codigo;
+              const proto = productoNombres.get(o.producto_id) ?? null;
+              const protoSufijo = proto ? proto.split('-').pop() : null;
+              const display = protoSufijo ? `${ident}-${protoSufijo}` : ident;
+              return (
+                <li key={o.id}>
+                  <Link
+                    href={`/dilesa/construccion/${o.id}`}
+                    className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-3 py-2 hover:border-[var(--accent)] hover:bg-[var(--bg)]/60"
+                  >
+                    <div className="flex items-center gap-2">
+                      <HardHat className="h-4 w-4 text-[var(--text)]/40" />
+                      <div>
+                        <div className="text-sm font-medium text-[var(--text)]">{display}</div>
+                        <div className="text-[11px] text-[var(--text)]/50">
+                          {ESTADO_LABEL[o.estado] ?? o.estado}
+                          {o.fecha_arranque ? ` · Arranque ${fmtFecha(o.fecha_arranque)}` : ''}
+                          {o.fecha_terminada ? ` · Terminada ${fmtFecha(o.fecha_terminada)}` : ''}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-2">
+                        <div className="h-1.5 w-24 overflow-hidden rounded-full bg-[var(--border)]/40">
+                          <div
+                            className={`h-full rounded-full ${avanceColorClass(o.avance_pct)}`}
+                            style={{
+                              width: `${Math.min(100, Math.max(0, o.avance_pct))}%`,
+                            }}
+                          />
+                        </div>
+                        <span className="w-9 shrink-0 text-right text-xs tabular-nums text-[var(--text)]/70">
+                          {o.avance_pct.toFixed(0)}%
+                        </span>
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Section>
+
+      <Section
+        title="Contratos"
+        description={
+          contratos.length === 0
+            ? 'sin contratos'
+            : `${contratos.length} contrato(s) · ${moneyFmt.format(kpis.valorContratosTotales)}`
+        }
+      >
+        {contratos.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">
+            Este contratista no tiene contratos de construcción registrados.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {contratos.map((c) => (
+              <li
+                key={c.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-3 py-2"
+              >
+                <div>
+                  <div className="text-sm font-medium text-[var(--text)]">{c.codigo}</div>
+                  <div className="text-xs text-[var(--text)]/50">
+                    {fmtFecha(c.fecha_contrato)}
+                    {c.proyecto_id ? ` · ${proyectoNombres.get(c.proyecto_id) ?? ''}` : ''}
+                    {c.lotesCount > 0 ? ` · ${c.lotesCount} lote(s)` : ''}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-xs uppercase tracking-wide text-[var(--text)]/50">
+                    Valor total
+                  </div>
+                  <div className="text-sm tabular-nums text-[var(--text)]">
+                    {moneyFmt.format(c.valor_total)}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+// ── Sub-componentes ──────────────────────────────────────────────────────
+
+function BackLink() {
+  return (
+    <Link
+      href="/dilesa/contratistas"
+      className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+    >
+      <ArrowLeft className="size-4" /> Volver a contratistas
+    </Link>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="mb-4 flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {description ? <span className="text-xs text-[var(--text)]/50">{description}</span> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function FichaGrid({ rows, cols = 2 }: { rows: { label: string; value: string }[]; cols?: 2 | 3 }) {
+  const gridCls =
+    cols === 3
+      ? 'grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3'
+      : 'grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2';
+  return (
+    <dl className={gridCls}>
+      {rows.map((r) => (
+        <div key={r.label}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+            {r.label}
+          </dt>
+          <dd className="mt-0.5 text-sm text-[var(--text)]">{r.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  accent = false,
+  muted = false,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+  muted?: boolean;
+}) {
+  return (
+    <div
+      className={
+        'rounded-md border bg-[var(--bg)]/30 px-3 py-2 ' +
+        (accent
+          ? 'border-[var(--accent)]/40'
+          : muted
+            ? 'border-[var(--border)] opacity-60'
+            : 'border-[var(--border)]')
+      }
+    >
+      <div className="text-[10px] font-medium uppercase tracking-wider text-[var(--text)]/50">
+        {label}
+      </div>
+      <div className="mt-0.5 text-lg font-semibold tabular-nums text-[var(--text)]">{value}</div>
+    </div>
+  );
+}

--- a/app/dilesa/contratistas/page.tsx
+++ b/app/dilesa/contratistas/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { ContratistasModule } from '@/components/dilesa/contratistas-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Contratistas (DILESA)
+ * @responsive desktop-only
+ *
+ * Iniciativa dilesa-construccion · Sprint 3 (UI lectura). Catálogo de
+ * contratistas con KPIs derivados: obras en curso, obras terminadas,
+ * MO ejecutado total, REPSE, retención. Lectura pura.
+ *
+ * Contratistas viven en `erp.personas` (tipo='contratista') con satélite
+ * `dilesa.contratistas_datos` para campos específicos (ADR-032 D2).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.contratistas">
+      <DesktopOnlyNotice module="Contratistas" />
+      <div className="hidden sm:block">
+        <ContratistasModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -75,6 +75,8 @@ export const NAV_ITEMS: NavItem[] = [
           { label: 'Proyectos', href: '/dilesa/proyectos' },
           { label: 'Inventario', href: '/dilesa/inventario' },
           { label: 'Ventas', href: '/dilesa/ventas' },
+          { label: 'Construcción', href: '/dilesa/construccion' },
+          { label: 'Contratistas', href: '/dilesa/contratistas' },
         ],
       },
     ],

--- a/components/dilesa/construccion-module.tsx
+++ b/components/dilesa/construccion-module.tsx
@@ -1,0 +1,444 @@
+'use client';
+
+/**
+ * ConstruccionModule — lista de construcciones DILESA.
+ *
+ * Iniciativa dilesa-construccion · Sprint 3 (UI lectura). Lista filtrable
+ * de las ~1,372 obras importadas en Sprint 2: código de obra, unidad,
+ * prototipo, contratista, avance % (barra visual), estado, fechas críticas.
+ * Click en una fila navega a `/dilesa/construccion/[id]` con la ficha
+ * completa, MO, timeline de etapas con sus tareas pendientes/terminadas,
+ * y el contrato asociado (si lo tiene).
+ *
+ * Carga cross-schema con 5 queries paralelas (construcciones + unidades
+ * + productos + proyectos + personas) y lookups en memoria Map<id,nombre>.
+ * Patrón ya validado en `ventas-module.tsx` — evita embeds problemáticos
+ * de PostgREST cuando la tabla embebida existe en > 1 schema y permite
+ * filtros sobre los nombres derivados sin hits adicionales.
+ *
+ * Avance % visual: barra horizontal con color escalado (rojo <33,
+ * ámbar 33-66, verde ≥66). El % viene pre-calculado en la tabla
+ * (`avance_pct` se actualiza por trigger `tg_construccion_avance` cada
+ * vez que se inserta/elimina una tarea terminada — ADR-032).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, type Column } from '@/components/module-page';
+import { Badge } from '@/components/ui/badge';
+import type { BadgeTone } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { HardHat, RefreshCw, Search } from 'lucide-react';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type ConstruccionRow = {
+  id: string;
+  codigo: string;
+  unidad_id: string;
+  producto_id: string;
+  contratista_id: string;
+  supervisor_persona_id: string | null;
+  fecha_arranque: string | null;
+  fecha_compromiso_terminar: string | null;
+  fecha_terminada: string | null;
+  avance_pct: number;
+  estado: string;
+};
+
+type ConstruccionListaRow = ConstruccionRow & {
+  /** Identificador "Coda-style": M3-L9-LDLE-ISC (con sufijo prototipo). */
+  identificadorCompleto: string;
+  proyectoNombre: string;
+  prototipo: string | null;
+  contratistaNombre: string;
+  contratistaAbreviacion: string | null;
+};
+
+const ESTADO_TONE: Record<string, BadgeTone> = {
+  arrancada: 'info',
+  en_progreso: 'warning',
+  terminada: 'success',
+  dtu: 'success',
+  seguro_calidad: 'success',
+  extraida: 'success',
+  cancelada: 'neutral',
+};
+
+const ESTADO_LABEL: Record<string, string> = {
+  arrancada: 'Arrancada',
+  en_progreso: 'En progreso',
+  terminada: 'Terminada',
+  dtu: 'DTU',
+  seguro_calidad: 'Seguro calidad',
+  extraida: 'Extraída',
+  cancelada: 'Cancelada',
+};
+
+/** Umbrales de color para la barra de avance (alineado con ADR-032: 20% = listo para venta). */
+function avanceColorClass(pct: number): string {
+  if (pct >= 66) return 'bg-emerald-500';
+  if (pct >= 33) return 'bg-amber-500';
+  if (pct >= 20) return 'bg-amber-400';
+  return 'bg-rose-500';
+}
+
+/** Barra de avance con número a la derecha. Patrón inline — no hay
+ *  componente Progress canónico en el repo todavía. */
+function AvanceBar({ pct }: { pct: number }) {
+  const clamped = Math.max(0, Math.min(100, pct));
+  return (
+    <div className="flex items-center gap-2 min-w-[120px]">
+      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--border)]/40">
+        <div
+          className={`h-full rounded-full ${avanceColorClass(clamped)}`}
+          style={{ width: `${clamped}%` }}
+        />
+      </div>
+      <span className="w-9 shrink-0 text-right text-xs tabular-nums text-[var(--text)]/70">
+        {clamped.toFixed(0)}%
+      </span>
+    </div>
+  );
+}
+
+export function ConstruccionModule({ empresaId }: { empresaId: string }) {
+  const router = useRouter();
+  const [obras, setObras] = useState<ConstruccionListaRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [proyectoFiltro, setProyectoFiltro] = useState('');
+  const [contratistaFiltro, setContratistaFiltro] = useState('');
+  const [estadoFiltro, setEstadoFiltro] = useState('');
+  const [avanceFiltro, setAvanceFiltro] = useState<'' | 'lt20' | '20a66' | 'gte66' | 'completa'>(
+    ''
+  );
+
+  const fetchObras = useCallback(async (): Promise<{
+    data?: ConstruccionListaRow[];
+    error?: string;
+  }> => {
+    const sb = createSupabaseBrowserClient();
+
+    // Construcciones — sin embeds, filtros eq(empresa_id) para evitar URLs
+    // > 8KB que rompen Cloudflare cuando se cruza `.in(ids[])`.
+    const { data: rawObras, error: oErr } = await sb
+      .schema('dilesa')
+      .from('construccion')
+      .select(
+        'id, codigo, unidad_id, producto_id, contratista_id, supervisor_persona_id, fecha_arranque, fecha_compromiso_terminar, fecha_terminada, avance_pct, estado'
+      )
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null);
+    if (oErr) {
+      return { error: getSupabaseErrorMessage(oErr, 'No se pudieron cargar las construcciones.') };
+    }
+    const obrasArr = (rawObras ?? []) as ConstruccionRow[];
+
+    // Lookups paralelos: unidades + productos + proyectos + personas
+    // (contratistas) + contratistas_datos para abreviación. Todos por
+    // `.eq(empresa_id)` siguiendo el patrón ventas-module.
+    const [unidadesRes, productosRes, proyectosRes, personasRes, datosRes] = await Promise.all([
+      sb
+        .schema('dilesa')
+        .from('unidades')
+        .select('id, identificador, proyecto_id')
+        .eq('empresa_id', empresaId),
+      sb
+        .schema('dilesa')
+        .from('productos')
+        .select('id, nombre')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, nombre')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .eq('empresa_id', empresaId)
+        .eq('tipo', 'contratista'),
+      sb
+        .schema('dilesa')
+        .from('contratistas_datos')
+        .select('persona_id, abreviacion')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr =
+      unidadesRes.error ??
+      productosRes.error ??
+      proyectosRes.error ??
+      personasRes.error ??
+      datosRes.error;
+    if (firstErr) {
+      return {
+        error: getSupabaseErrorMessage(firstErr, 'No se pudieron cargar los datos auxiliares.'),
+      };
+    }
+
+    const unidadMap = new Map<string, { identificador: string; proyecto_id: string }>();
+    for (const u of unidadesRes.data ?? []) {
+      unidadMap.set(u.id as string, {
+        identificador: u.identificador as string,
+        proyecto_id: u.proyecto_id as string,
+      });
+    }
+    const productoMap = new Map<string, string>();
+    for (const p of productosRes.data ?? []) productoMap.set(p.id as string, p.nombre as string);
+    const proyectoMap = new Map<string, string>();
+    for (const p of proyectosRes.data ?? []) proyectoMap.set(p.id as string, p.nombre as string);
+    const personaMap = new Map<string, string>();
+    for (const p of personasRes.data ?? []) {
+      const nombre = [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' ');
+      personaMap.set(p.id as string, nombre || '(sin nombre)');
+    }
+    const abrevMap = new Map<string, string | null>();
+    for (const d of datosRes.data ?? []) {
+      abrevMap.set(d.persona_id as string, (d.abreviacion as string | null) ?? null);
+    }
+
+    return {
+      data: obrasArr.map((o) => {
+        const u = unidadMap.get(o.unidad_id);
+        const proto = productoMap.get(o.producto_id) ?? null;
+        const protoSufijo = proto ? proto.split('-').pop() : null;
+        const identificadorBase = u?.identificador ?? o.codigo;
+        return {
+          ...o,
+          identificadorCompleto: protoSufijo
+            ? `${identificadorBase}-${protoSufijo}`
+            : identificadorBase,
+          proyectoNombre: u?.proyecto_id ? (proyectoMap.get(u.proyecto_id) ?? '') : '',
+          prototipo: proto,
+          contratistaNombre: personaMap.get(o.contratista_id) ?? '(sin contratista)',
+          contratistaAbreviacion: abrevMap.get(o.contratista_id) ?? null,
+        };
+      }),
+    };
+  }, [empresaId]);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: e } = await fetchObras();
+    if (e) {
+      setError(e);
+      setObras([]);
+    } else setObras(data ?? []);
+    setLoading(false);
+  }, [fetchObras]);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchObras().then(({ data, error: e }) => {
+      if (!activo) return;
+      if (e) {
+        setError(e);
+        setObras([]);
+      } else setObras(data ?? []);
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchObras]);
+
+  const proyectosPresentes = useMemo(
+    () => [...new Set(obras.map((o) => o.proyectoNombre).filter(Boolean))].sort(),
+    [obras]
+  );
+  const contratistasPresentes = useMemo(
+    () =>
+      [...new Set(obras.map((o) => o.contratistaNombre).filter((n): n is string => !!n))].sort(),
+    [obras]
+  );
+  const estadosPresentes = useMemo(() => [...new Set(obras.map((o) => o.estado))].sort(), [obras]);
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return obras.filter((o) => {
+      if (proyectoFiltro && o.proyectoNombre !== proyectoFiltro) return false;
+      if (contratistaFiltro && o.contratistaNombre !== contratistaFiltro) return false;
+      if (estadoFiltro && o.estado !== estadoFiltro) return false;
+      if (avanceFiltro === 'lt20' && o.avance_pct >= 20) return false;
+      if (avanceFiltro === '20a66' && (o.avance_pct < 20 || o.avance_pct >= 66)) return false;
+      if (avanceFiltro === 'gte66' && o.avance_pct < 66) return false;
+      if (avanceFiltro === 'completa' && o.avance_pct < 100) return false;
+      if (q) {
+        const hay =
+          o.identificadorCompleto.toLowerCase().includes(q) ||
+          o.codigo.toLowerCase().includes(q) ||
+          o.contratistaNombre.toLowerCase().includes(q);
+        if (!hay) return false;
+      }
+      return true;
+    });
+  }, [obras, search, proyectoFiltro, contratistaFiltro, estadoFiltro, avanceFiltro]);
+
+  const columns: Column<ConstruccionListaRow>[] = [
+    {
+      key: 'identificadorCompleto',
+      label: 'Unidad',
+      type: 'text',
+      sticky: true,
+      width: 'min-w-[180px]',
+    },
+    { key: 'proyectoNombre', label: 'Proyecto', type: 'text' },
+    {
+      key: 'prototipo',
+      label: 'Prototipo',
+      type: 'text',
+      render: (o) => o.prototipo ?? '—',
+    },
+    {
+      key: 'contratistaNombre',
+      label: 'Contratista',
+      type: 'custom',
+      accessor: (o) => o.contratistaNombre,
+      render: (o) =>
+        o.contratistaAbreviacion ? (
+          <span title={o.contratistaNombre}>
+            <span className="font-medium">{o.contratistaAbreviacion}</span>
+            <span className="ml-1 text-[var(--text)]/40">·</span>
+            <span className="ml-1 text-[var(--text)]/60">{o.contratistaNombre}</span>
+          </span>
+        ) : (
+          o.contratistaNombre
+        ),
+    },
+    {
+      key: 'avance_pct',
+      label: 'Avance',
+      type: 'custom',
+      accessor: (o) => o.avance_pct,
+      render: (o) => <AvanceBar pct={o.avance_pct} />,
+    },
+    {
+      key: 'estado',
+      label: 'Estado',
+      type: 'custom',
+      render: (o) => (
+        <Badge tone={ESTADO_TONE[o.estado] ?? 'neutral'}>
+          {ESTADO_LABEL[o.estado] ?? o.estado}
+        </Badge>
+      ),
+    },
+    { key: 'fecha_arranque', label: 'Arranque', type: 'date' },
+    { key: 'fecha_compromiso_terminar', label: 'Compromiso', type: 'date' },
+  ];
+
+  const onRowClick = (o: ConstruccionListaRow) => {
+    router.push(`/dilesa/construccion/${o.id}`);
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <HardHat className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Construcción</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Obras en curso e históricas — avance, contratista, fechas críticas. El avance lo
+            recalcula el trigger al cerrar tareas; pasa de planeada a en_construccion al cruzar 20%.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar unidad o contratista…"
+            className="w-72 pl-9"
+          />
+        </div>
+        <select
+          value={proyectoFiltro}
+          onChange={(e) => setProyectoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los proyectos</option>
+          {proyectosPresentes.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <select
+          value={contratistaFiltro}
+          onChange={(e) => setContratistaFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los contratistas</option>
+          {contratistasPresentes.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          value={estadoFiltro}
+          onChange={(e) => setEstadoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los estados</option>
+          {estadosPresentes.map((e) => (
+            <option key={e} value={e}>
+              {ESTADO_LABEL[e] ?? e}
+            </option>
+          ))}
+        </select>
+        <select
+          value={avanceFiltro}
+          onChange={(e) =>
+            setAvanceFiltro(e.target.value as '' | 'lt20' | '20a66' | 'gte66' | 'completa')
+          }
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Cualquier avance</option>
+          <option value="lt20">&lt; 20% (sin disparar venta)</option>
+          <option value="20a66">20%-66%</option>
+          <option value="gte66">≥ 66%</option>
+          <option value="completa">100% completada</option>
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {filtrados.length} de {obras.length} obras
+        </span>
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={onRowClick}
+        initialSort={{ key: 'identificadorCompleto', dir: 'asc' }}
+        emptyTitle="Sin obras"
+        emptyDescription="No hay construcciones que coincidan con los filtros actuales."
+        emptyIcon={<HardHat className="h-6 w-6" />}
+        maxHeight="calc(100vh - 280px)"
+      />
+    </div>
+  );
+}

--- a/components/dilesa/contratistas-module.tsx
+++ b/components/dilesa/contratistas-module.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+/**
+ * ContratistasModule — catálogo de contratistas DILESA con KPIs derivados.
+ *
+ * Iniciativa dilesa-construccion · Sprint 3 (UI lectura). Lista de los
+ * contratistas registrados (~23 en Sprint 2) con KPIs calculados en
+ * memoria a partir de `dilesa.construccion`: obras en curso, obras
+ * terminadas, MO ejecutado total. Click → /dilesa/contratistas/[id].
+ *
+ * Modelo (ADR-032 D2): los contratistas viven en `erp.personas` con
+ * `tipo='contratista'`. Datos específicos de DILESA (REPSE, retención,
+ * abreviación, etc.) viven en el satélite `dilesa.contratistas_datos`.
+ * Esta página los cruza vía 2 queries paralelas + lookup en memoria.
+ *
+ * KPIs son cálculos client-side (no vistas SQL todavía — Sprint 4 puede
+ * mover esto a una vista materializada si la cardinalidad lo justifica).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, type Column } from '@/components/module-page';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { HardHat, RefreshCw, Search, Users } from 'lucide-react';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type ContratistaRow = {
+  persona_id: string;
+  nombre: string;
+  rfc: string | null;
+  abreviacion: string | null;
+  persona_fisica_o_moral: string | null;
+  repse: string | null;
+  retencion_pct: number | null;
+  activo: boolean;
+  obrasEnCurso: number;
+  obrasTerminadas: number;
+  moEjecutadoTotal: number;
+};
+
+export function ContratistasModule({ empresaId }: { empresaId: string }) {
+  const router = useRouter();
+  const [contratistas, setContratistas] = useState<ContratistaRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [tipoFiltro, setTipoFiltro] = useState<'' | 'PF' | 'PM'>('');
+  const [estadoFiltro, setEstadoFiltro] = useState<'' | 'activos' | 'inactivos'>('activos');
+  const [repseFiltro, setRepseFiltro] = useState<'' | 'con_repse' | 'sin_repse'>('');
+
+  const fetchContratistas = useCallback(async (): Promise<{
+    data?: ContratistaRow[];
+    error?: string;
+  }> => {
+    const sb = createSupabaseBrowserClient();
+
+    // 3 queries paralelas: personas (tipo=contratista) + satélite +
+    // construcciones (para KPIs derivados). Cross-schema sin embeds.
+    const [personasRes, datosRes, obrasRes] = await Promise.all([
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno, rfc, activo')
+        .eq('empresa_id', empresaId)
+        .eq('tipo', 'contratista')
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('contratistas_datos')
+        .select('persona_id, abreviacion, persona_fisica_o_moral, repse, retencion_pct, activo')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('construccion')
+        .select('contratista_id, estado, mo_ejecutado')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr = personasRes.error ?? datosRes.error ?? obrasRes.error;
+    if (firstErr) {
+      return {
+        error: getSupabaseErrorMessage(firstErr, 'No se pudieron cargar los contratistas.'),
+      };
+    }
+
+    const datosMap = new Map<
+      string,
+      {
+        abreviacion: string | null;
+        persona_fisica_o_moral: string | null;
+        repse: string | null;
+        retencion_pct: number | null;
+        activo: boolean;
+      }
+    >();
+    for (const d of datosRes.data ?? []) {
+      datosMap.set(d.persona_id as string, {
+        abreviacion: (d.abreviacion as string | null) ?? null,
+        persona_fisica_o_moral: (d.persona_fisica_o_moral as string | null) ?? null,
+        repse: (d.repse as string | null) ?? null,
+        retencion_pct: (d.retencion_pct as number | null) ?? null,
+        activo: (d.activo as boolean) ?? true,
+      });
+    }
+
+    // KPIs por contratista: count en_curso, count terminada(+derivados),
+    // suma de mo_ejecutado. "Obras en curso" = estados que no son
+    // terminales (arrancada, en_progreso); el resto cuenta como
+    // terminadas (terminada, dtu, seguro_calidad, extraida) o
+    // canceladas (que NO sumamos como ningún KPI).
+    const ENCURSO = new Set(['arrancada', 'en_progreso']);
+    const TERMINADA = new Set(['terminada', 'dtu', 'seguro_calidad', 'extraida']);
+    type Agg = { enCurso: number; terminadas: number; mo: number };
+    const aggMap = new Map<string, Agg>();
+    for (const o of obrasRes.data ?? []) {
+      const cid = o.contratista_id as string;
+      const agg = aggMap.get(cid) ?? { enCurso: 0, terminadas: 0, mo: 0 };
+      const estado = o.estado as string;
+      if (ENCURSO.has(estado)) agg.enCurso += 1;
+      else if (TERMINADA.has(estado)) agg.terminadas += 1;
+      // cancelada → no se cuenta como ninguno
+      agg.mo += Number(o.mo_ejecutado ?? 0);
+      aggMap.set(cid, agg);
+    }
+
+    const rows: ContratistaRow[] = (personasRes.data ?? []).map((p) => {
+      const id = p.id as string;
+      const nombre = [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' ');
+      const d = datosMap.get(id);
+      const agg = aggMap.get(id) ?? { enCurso: 0, terminadas: 0, mo: 0 };
+      return {
+        persona_id: id,
+        nombre: nombre || '(sin nombre)',
+        rfc: (p.rfc as string | null) ?? null,
+        abreviacion: d?.abreviacion ?? null,
+        persona_fisica_o_moral: d?.persona_fisica_o_moral ?? null,
+        repse: d?.repse ?? null,
+        retencion_pct: d?.retencion_pct ?? null,
+        // Si hay satélite, su `activo` manda; si no, usamos el de la
+        // persona (fallback razonable cuando el contratista no tiene
+        // datos DILESA registrados todavía).
+        activo: d ? d.activo : (p.activo as boolean),
+        obrasEnCurso: agg.enCurso,
+        obrasTerminadas: agg.terminadas,
+        moEjecutadoTotal: agg.mo,
+      };
+    });
+
+    return { data: rows };
+  }, [empresaId]);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: e } = await fetchContratistas();
+    if (e) {
+      setError(e);
+      setContratistas([]);
+    } else setContratistas(data ?? []);
+    setLoading(false);
+  }, [fetchContratistas]);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchContratistas().then(({ data, error: e }) => {
+      if (!activo) return;
+      if (e) {
+        setError(e);
+        setContratistas([]);
+      } else setContratistas(data ?? []);
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchContratistas]);
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return contratistas.filter((c) => {
+      if (tipoFiltro === 'PF' && c.persona_fisica_o_moral !== 'Persona Física') return false;
+      if (tipoFiltro === 'PM' && c.persona_fisica_o_moral !== 'Persona Moral') return false;
+      if (estadoFiltro === 'activos' && !c.activo) return false;
+      if (estadoFiltro === 'inactivos' && c.activo) return false;
+      if (repseFiltro === 'con_repse' && !c.repse) return false;
+      if (repseFiltro === 'sin_repse' && c.repse) return false;
+      if (q) {
+        const hay =
+          c.nombre.toLowerCase().includes(q) ||
+          (c.rfc ?? '').toLowerCase().includes(q) ||
+          (c.abreviacion ?? '').toLowerCase().includes(q);
+        if (!hay) return false;
+      }
+      return true;
+    });
+  }, [contratistas, search, tipoFiltro, estadoFiltro, repseFiltro]);
+
+  const columns: Column<ContratistaRow>[] = [
+    {
+      key: 'nombre',
+      label: 'Contratista',
+      type: 'custom',
+      sticky: true,
+      width: 'min-w-[280px]',
+      accessor: (c) => c.nombre,
+      render: (c) => (
+        <div>
+          <div className="font-medium text-[var(--text)]">{c.nombre}</div>
+          {c.abreviacion ? (
+            <div className="text-[11px] uppercase tracking-wide text-[var(--text)]/50">
+              {c.abreviacion}
+            </div>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: 'rfc',
+      label: 'RFC',
+      type: 'text',
+      render: (c) => c.rfc ?? '—',
+    },
+    {
+      key: 'persona_fisica_o_moral',
+      label: 'Tipo',
+      type: 'text',
+      render: (c) => {
+        if (c.persona_fisica_o_moral === 'Persona Física') return 'PF';
+        if (c.persona_fisica_o_moral === 'Persona Moral') return 'PM';
+        return c.persona_fisica_o_moral ?? '—';
+      },
+    },
+    {
+      key: 'obrasEnCurso',
+      label: 'En curso',
+      type: 'number',
+      render: (c) => (
+        <span className="inline-flex items-center gap-1 tabular-nums">
+          {c.obrasEnCurso}
+          {c.obrasEnCurso > 0 ? <HardHat className="h-3 w-3 text-[var(--accent)]/60" /> : null}
+        </span>
+      ),
+    },
+    { key: 'obrasTerminadas', label: 'Terminadas', type: 'number' },
+    { key: 'moEjecutadoTotal', label: 'MO ejecutado', type: 'currency' },
+    {
+      key: 'repse',
+      label: 'REPSE',
+      type: 'custom',
+      accessor: (c) => (c.repse ? 1 : 0),
+      render: (c) =>
+        c.repse ? (
+          <span className="inline-flex items-center gap-1 text-xs text-[var(--text)]/70">
+            <Badge tone="success">REPSE</Badge>
+          </span>
+        ) : (
+          <span className="text-xs text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'retencion_pct',
+      label: 'Retención',
+      type: 'custom',
+      accessor: (c) => c.retencion_pct ?? 0,
+      render: (c) =>
+        c.retencion_pct != null ? (
+          <span className="tabular-nums">{c.retencion_pct.toFixed(2)}%</span>
+        ) : (
+          '—'
+        ),
+    },
+    {
+      key: 'activo',
+      label: 'Activo',
+      type: 'custom',
+      accessor: (c) => (c.activo ? 1 : 0),
+      render: (c) =>
+        c.activo ? <Badge tone="success">Activo</Badge> : <Badge tone="neutral">Inactivo</Badge>,
+    },
+  ];
+
+  const onRowClick = (c: ContratistaRow) => {
+    router.push(`/dilesa/contratistas/${c.persona_id}`);
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <Users className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Contratistas</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Catálogo con KPIs derivados de las obras: en curso, terminadas, MO ejecutado.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar nombre, RFC o abreviación…"
+            className="w-72 pl-9"
+          />
+        </div>
+        <select
+          value={tipoFiltro}
+          onChange={(e) => setTipoFiltro(e.target.value as '' | 'PF' | 'PM')}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">PF + PM</option>
+          <option value="PF">Persona Física</option>
+          <option value="PM">Persona Moral</option>
+        </select>
+        <select
+          value={estadoFiltro}
+          onChange={(e) => setEstadoFiltro(e.target.value as '' | 'activos' | 'inactivos')}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="activos">Solo activos</option>
+          <option value="inactivos">Solo inactivos</option>
+          <option value="">Activos + inactivos</option>
+        </select>
+        <select
+          value={repseFiltro}
+          onChange={(e) => setRepseFiltro(e.target.value as '' | 'con_repse' | 'sin_repse')}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">REPSE — cualquiera</option>
+          <option value="con_repse">Con REPSE</option>
+          <option value="sin_repse">Sin REPSE</option>
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {filtrados.length} de {contratistas.length} contratistas
+        </span>
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="persona_id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={onRowClick}
+        initialSort={{ key: 'obrasEnCurso', dir: 'desc' }}
+        emptyTitle="Sin contratistas"
+        emptyDescription="No hay contratistas que coincidan con los filtros actuales."
+        emptyIcon={<Users className="h-6 w-6" />}
+        maxHeight="calc(100vh - 280px)"
+      />
+    </div>
+  );
+}

--- a/docs/planning/dilesa-construccion.md
+++ b/docs/planning/dilesa-construccion.md
@@ -7,15 +7,11 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-05-24
-**Última actualización:** 2026-05-24 (promovida tras explorar las 8
-tablas de Construcción en Coda DILESA: Prototipos, Contratistas,
-Etapas, Tareas, Plantilla Tareas por Prototipo, Contrato de
-Construcción, Construcción por Lote, Tareas Terminadas. Decisiones
-cerradas con Beto: contratistas en `erp.personas` + satélite ·
-avance% derivado de `SUM(plantilla_tareas.porcentaje_costo)` ·
-umbral 20% → trigger SQL que setea `unidades.estado='en_construccion'` +
-`producto_id` · importar TODO el histórico de Coda · planos en JSONB
-en `productos.planos`).
+**Última actualización:** 2026-05-25 (Sprint 3 — UI lectura: 4 páginas
+nuevas /dilesa/construccion (lista + detalle) y /dilesa/contratistas
+(lista con KPIs + detalle con obras asignadas y contratos) + migración
+de RBAC + sync de 4 lugares (NAV_ITEMS, ROUTE_TO_MODULE,
+EXPECTED_DB_MODULE_SLUGS, core.modulos). Sprint 4 — captura — pendiente.)
 
 ## Problema
 
@@ -308,3 +304,74 @@ END $$ LANGUAGE plpgsql;
 ## Bitácora
 
 (append-only, escrito por Claude Code al ejecutar)
+
+### 2026-05-25 — Sprint 3 (UI lectura)
+
+**PR:** feat(dilesa): construcción Sprint 3 — UI lectura
+(branch `feat/dilesa-construccion-sprint-3`)
+
+**Cambios:**
+
+- Migración `20260525020000_dilesa_construccion_modulos.sql` —
+  registra `dilesa.construccion` y `dilesa.contratistas` en
+  `core.modulos` (seccion='operaciones') + backfill defensivo de
+  permisos read+write para cada rol existente en DILESA. Idempotente.
+- RBAC 4-places sync:
+  - `components/app-shell/nav-config.ts` — entries Construcción +
+    Contratistas en grupo Inmobiliario de DILESA.
+  - `lib/permissions.ts` — entries `'/dilesa/construccion'` y
+    `'/dilesa/contratistas'` en `ROUTE_TO_MODULE`.
+  - `lib/permissions.test.ts` — slugs nuevos en
+    `EXPECTED_DB_MODULE_SLUGS`.
+- 4 páginas nuevas:
+  - `app/dilesa/construccion/page.tsx` + `components/dilesa/construccion-module.tsx`
+    — lista filtrable (proyecto, contratista, estado, rango de avance,
+    búsqueda) con barra de avance visual coloreada (rojo <20, ámbar
+    20-66, verde ≥66) y orden default por identificador.
+  - `app/dilesa/construccion/[id]/page.tsx` — detalle con 4 secciones
+    (Datos generales, MO, Avance por etapa colapsable, Contratos).
+    Etapa colapsable agrupa las tareas de la plantilla del prototipo
+    con flag terminada/pendiente, fecha terminada, revisor, MO pagada.
+  - `app/dilesa/contratistas/page.tsx` + `components/dilesa/contratistas-module.tsx`
+    — lista con KPIs derivados client-side (obras en curso/terminadas,
+    MO ejecutado total) y filtros PF/PM, REPSE, activo/inactivo.
+  - `app/dilesa/contratistas/[id]/page.tsx` — detalle con 4 secciones
+    (Datos generales, KPIs strip, Obras asignadas con barras de avance
+    - link, Contratos con # lotes cubiertos).
+
+**Decisiones tácticas:**
+
+- **Barra de avance inline (no componente Progress canónico)** — no
+  hay `components/ui/progress.tsx` en el repo todavía. Implementado
+  como `div` con width % escalado y color según umbral (consistente
+  con el umbral 20% del trigger). Cuando aparezca un Progress base
+  podemos refactorizar todas las barras (lista, detalle, drawer) a
+  uno solo.
+- **KPIs de contratistas calculados client-side** — Sprint 3 no
+  introduce vistas SQL para KPIs porque las cardinalidades son chicas
+  (~23 contratistas × ~1,372 obras). Si en Sprint 4 los filtros se
+  vuelven más complejos o aparece "MO pendiente este mes" lo movemos
+  a `v_contratista_kpis`.
+- **Lookups en memoria + `.eq(empresa_id)`** — mismo patrón que
+  `ventas-module.tsx`. Evita `.in(uuids[])` con > 200 IDs (que
+  rebasaría 8KB URL en Cloudflare) y embeds de PostgREST que rompen
+  cuando la tabla embebida existe en > 1 schema (caso `proyectos`
+  en `dilesa` y `erp`).
+- **Etapas filtradas a las que tienen tareas en la plantilla** del
+  prototipo asignado a la obra (no mostrar etapas vacías para evitar
+  ruido).
+- **Cancelada NO suma como obra ni en KPIs de MO** — KPI "obras
+  terminadas" cuenta solo `terminada/dtu/seguro_calidad/extraida`.
+  Las canceladas se muestran aparte en el strip del contratista
+  como referencia histórica con apariencia muted.
+
+**Pendiente verificar Beto:**
+
+- Aplicar la migración a prod (`supabase db push` está bloqueado por
+  el classifier en sesiones autónomas — Beto la corre manualmente).
+- Verificación visual en preview (las 4 páginas + barras de avance +
+  flujo de click row → detail).
+
+**Sprint 4 — captura (pendiente):** forms "Arrancar construcción",
+"Registrar tarea terminada", "Crear contrato" + sub-slugs
+`dilesa.construccion.arrancar`, `.tareas`, `.contratos`.

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -185,6 +185,8 @@ const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   'dilesa.proyectos',
   'dilesa.inventario',
   'dilesa.ventas',
+  'dilesa.construccion',
+  'dilesa.contratistas',
   // Sub-slugs por fase del pipeline (Sprint 7a captura por fase)
   'dilesa.ventas.fase01_solicitud',
   'dilesa.ventas.fase02_asignada',

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -37,6 +37,8 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   '/dilesa/proyectos': 'dilesa.proyectos',
   '/dilesa/inventario': 'dilesa.inventario',
   '/dilesa/ventas': 'dilesa.ventas',
+  '/dilesa/construccion': 'dilesa.construccion',
+  '/dilesa/contratistas': 'dilesa.contratistas',
   // Captura por fase — sub-slugs ADR-030. Cada URL apunta al sub-slug que
   // gobierna acceso a esa fase. Ver docs/planning/dilesa-ventas-captura.md.
   '/dilesa/ventas/nueva': 'dilesa.ventas.fase01_solicitud',

--- a/supabase/migrations/20260525020000_dilesa_construccion_modulos.sql
+++ b/supabase/migrations/20260525020000_dilesa_construccion_modulos.sql
@@ -1,0 +1,58 @@
+-- ════════════════════════════════════════════════════════════════════════════
+-- Iniciativa dilesa-construccion · Sprint 3 — RBAC de los módulos
+--   Construcción + Contratistas
+-- ════════════════════════════════════════════════════════════════════════════
+--
+-- Registra `dilesa.construccion` y `dilesa.contratistas` en core.modulos
+-- para las páginas /dilesa/construccion y /dilesa/contratistas (lista +
+-- detalle, lectura pura — captura entra en Sprint 4).
+--
+-- Patrón: regla "Liberación de módulo nuevo" del CLAUDE.md — INSERT en
+-- core.modulos + backfill defensivo de core.permisos_rol para que el page
+-- no se esconda a usuarios no-admin. Sin backfill, `canAccessModulo`
+-- regresa false para el slug nuevo (no aparece en `permissions.modulos`)
+-- y la página queda 403 hasta corregir manualmente cada rol.
+--
+-- Sección 'operaciones' — mismo bucket que ventas/inventario (módulos
+-- operativos DILESA). El nav-config los pone en grupo "Inmobiliario"
+-- (visual del sidebar), pero la taxonomía RBAC (ADR-014) los agrupa en
+-- 'operaciones'. Ver migración 20260524173055_dilesa_inventario_modulo.sql
+-- como template idéntico.
+--
+-- Idempotente: ON CONFLICT DO NOTHING en ambas inserts.
+-- ════════════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+-- ── Registro de los dos módulos ────────────────────────────────────────────
+
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT 'dilesa.construccion', 'Construcción', 'Avance de obra por lote — pivot central del módulo Construcción (ADR-032). Lista + detalle: contratista, contrato, fechas críticas, tareas pendientes/terminadas, mano de obra.', e.id, 'operaciones'
+FROM core.empresas e
+WHERE e.slug = 'dilesa'
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT 'dilesa.contratistas', 'Contratistas', 'Catálogo de contratistas con KPIs (efectividad, MO ejecutado, obras en curso/terminadas, REPSE, retención).', e.id, 'operaciones'
+FROM core.empresas e
+WHERE e.slug = 'dilesa'
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+-- ── Backfill defensivo de permisos ────────────────────────────────────────
+--
+-- Cada rol existente de DILESA × cada módulo nuevo, read+write por default
+-- (las páginas son lectura pura en Sprint 3; los flags de write se afinarán
+-- cuando Sprint 4 introduzca los forms de captura con sub-slugs propios).
+
+INSERT INTO core.permisos_rol (rol_id, modulo_id, acceso_lectura, acceso_escritura)
+SELECT r.id, m.id, true, true
+FROM core.roles r
+JOIN core.empresas e ON e.id = r.empresa_id
+JOIN core.modulos m ON m.empresa_id = r.empresa_id
+WHERE e.slug = 'dilesa'
+  AND m.slug IN ('dilesa.construccion', 'dilesa.contratistas')
+ON CONFLICT (rol_id, modulo_id) DO NOTHING;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Cierra Sprint 3 de la iniciativa `dilesa-construccion` (ADR-032):
lectura completa del estado de obra desde BSOP. 4 páginas nuevas
(Construcción lista + detalle, Contratistas lista + detalle) +
migración de RBAC + sync de los 4 lugares requeridos.

- **/dilesa/construccion** — lista filtrable de ~1,372 obras
  (proyecto, contratista, estado, rango de avance, búsqueda) con
  barra de avance visual coloreada según el umbral del trigger
  (rojo <20, ámbar 20-66, verde ≥66). Click → detalle.
- **/dilesa/construccion/[id]** — datos generales (prototipo,
  contratista, supervisor, fechas críticas, CUV, frente RUV), MO
  (ejecutado/contrato/m²), avance por etapa (colapsable con tareas
  terminadas + pendientes mostrando fecha, revisor, MO pagada),
  contratos asignados.
- **/dilesa/contratistas** — lista con KPIs derivados client-side
  (obras en curso/terminadas, MO ejecutado total), filtros PF/PM,
  REPSE, activo/inactivo.
- **/dilesa/contratistas/[id]** — datos + KPIs strip (6 cards) +
  obras asignadas (cada una linkeada a la obra) + contratos con
  # lotes cubiertos.
- **Migración** `20260525020000_dilesa_construccion_modulos.sql` —
  registra los 2 módulos en `core.modulos` (seccion='operaciones')
  + backfill defensivo de permisos read+write por rol existente.
  Idempotente.

## Decisiones tácticas

- **Barra de avance inline** — no hay componente Progress canónico
  en el repo. Implementada como `div` con width % escalado y color
  según umbral. Cuando aparezca un Progress base se puede refactor
  todas las barras (lista, detalle, drawer de obras).
- **KPIs de contratistas client-side** — cardinalidad chica (~23 ×
  1,372). Si en Sprint 4 los filtros se vuelven complejos lo
  movemos a `v_contratista_kpis`.
- **Lookups en memoria + `.eq(empresa_id)`** — mismo patrón validado
  en `ventas-module.tsx`. Evita `.in(uuids[])` con > 200 IDs
  (Cloudflare URL > 8KB → HTTP 400) y embeds PostgREST que rompen
  con tablas presentes en > 1 schema (`proyectos` en `dilesa` y
  `erp`).
- **Etapas filtradas a las que tienen tareas** en la plantilla del
  prototipo asignado a la obra (evita ruido visual de etapas
  vacías).
- **Cancelada NO suma como obra terminada** — KPI "terminadas"
  agrupa `terminada/dtu/seguro_calidad/extraida`. Canceladas se
  muestran muted como referencia histórica.

## Test plan

- [ ] CI verde (los 4 checks: typecheck, test, lint, format).
- [ ] Beto aplica la migración a prod (`supabase db push` está
      bloqueado por el classifier en sesiones autónomas).
- [ ] Verificación visual en preview:
  - [ ] `/dilesa/construccion` lista carga con ~1,372 filas; filtros
        responden; barras de avance se ven con color correcto.
  - [ ] Click en una fila navega al detalle; las 4 secciones
        renderizan; etapa colapsable abre/cierra; tareas terminadas
        muestran fecha + revisor + MO pagada.
  - [ ] `/dilesa/contratistas` lista carga con ~23 filas; KPIs
        cuadran con conteos por contratista.
  - [ ] Click en contratista navega al detalle; obras se enlistan
        con barras + link a la obra; contratos muestran # lotes.
- [ ] Sidebar muestra los 2 nav items nuevos en grupo Inmobiliario
      de DILESA.

## Próximo (Sprint 4 — captura)

Forms "Arrancar construcción", "Registrar tarea terminada" (dispara
trigger 20% → disponible para venta), "Crear contrato de construcción".
Sub-slugs nuevos: `dilesa.construccion.arrancar`, `.tareas`, `.contratos`.

Refs: `docs/planning/dilesa-construccion.md`, `docs/adr/032_dilesa_construccion_modelo.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)