### PR TITLE
feat(dilesa): construcción como hub con 4 tabs + módulo Prototipos

### DIFF
--- a/app/dilesa/construccion/[id]/page.tsx
+++ b/app/dilesa/construccion/[id]/page.tsx
@@ -149,7 +149,7 @@ function avanceColorClass(pct: number): string {
  */
 export default function ConstruccionDetailPage() {
   return (
-    <RequireAccess empresa="dilesa" modulo="dilesa.construccion">
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.obras">
       <DetailInner />
     </RequireAccess>
   );

--- a/app/dilesa/construccion/contratistas/[id]/page.tsx
+++ b/app/dilesa/construccion/contratistas/[id]/page.tsx
@@ -115,12 +115,12 @@ const ESTADO_LABEL: Record<string, string> = {
 };
 
 /**
- * @module Contratista detail (DILESA)
+ * @module Construcción · Contratista detail (DILESA)
  * @responsive desktop-only
  */
 export default function ContratistaDetailPage() {
   return (
-    <RequireAccess empresa="dilesa" modulo="dilesa.contratistas">
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.contratistas">
       <DetailInner />
     </RequireAccess>
   );
@@ -514,7 +514,7 @@ function DetailInner() {
 function BackLink() {
   return (
     <Link
-      href="/dilesa/contratistas"
+      href="/dilesa/construccion/contratistas"
       className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
     >
       <ArrowLeft className="size-4" /> Volver a contratistas

--- a/app/dilesa/construccion/contratistas/page.tsx
+++ b/app/dilesa/construccion/contratistas/page.tsx
@@ -6,19 +6,24 @@ import { ContratistasModule } from '@/components/dilesa/contratistas-module';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
 /**
- * @module Contratistas (DILESA)
+ * @module Construcción · Contratistas (DILESA)
  * @responsive desktop-only
  *
- * Iniciativa dilesa-construccion · Sprint 3 (UI lectura). Catálogo de
- * contratistas con KPIs derivados: obras en curso, obras terminadas,
+ * Tab "Contratistas" del hub Construcción (sprint tabs+protos). Catálogo
+ * de contratistas con KPIs derivados: obras en curso, obras terminadas,
  * MO ejecutado total, REPSE, retención. Lectura pura.
  *
  * Contratistas viven en `erp.personas` (tipo='contratista') con satélite
  * `dilesa.contratistas_datos` para campos específicos (ADR-032 D2).
+ *
+ * Gate: sub-slug `dilesa.construccion.contratistas` (ADR-030 SS5). El
+ * slug top-level `dilesa.contratistas` fue deprecado en la migración
+ * 20260525152711_dilesa_construccion_tabs_hub.sql — el sub-slug toma su
+ * lugar (con backfill defensivo de permisos).
  */
 export default function Page() {
   return (
-    <RequireAccess empresa="dilesa" modulo="dilesa.contratistas">
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.contratistas">
       <DesktopOnlyNotice module="Contratistas" />
       <div className="hidden sm:block">
         <ContratistasModule empresaId={DILESA_EMPRESA_ID} />

--- a/app/dilesa/construccion/contratos/[id]/page.tsx
+++ b/app/dilesa/construccion/contratos/[id]/page.tsx
@@ -1,0 +1,534 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de detalle DILESA (cf.
+ * app/dilesa/construccion/[id]/page.tsx).
+ */
+
+/**
+ * Detalle de un contrato de construcción (DILESA) — 3 secciones:
+ *   1. Datos generales — código, fecha, contratista (con abrev),
+ *      proyecto, valor total, fianzas URL si hay, notas.
+ *   2. Lotes asignados — tabla con código construcción + unidad +
+ *      prototipo + avance% + valor MO del lote (monto_lote).
+ *   3. KPIs derivados — MO total, MO ejecutado vs por ejecutar (sumando
+ *      `mo_ejecutado` y `valor_contrato_mo` de las obras vinculadas),
+ *      avance promedio.
+ *
+ * Cross-schema queries siguiendo el patrón ventas-module: sin embeds
+ * PostgREST, lookups en memoria.
+ *
+ * Iniciativa dilesa-construccion · Sprint tabs+protos. Acceso vía
+ * sub-slug `dilesa.construccion.contratos` (lectura — el mismo sub-slug
+ * gobierna también el form de captura desde Sprint 4).
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, ExternalLink, FileText, HardHat } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Contrato = {
+  id: string;
+  codigo: string;
+  fecha_contrato: string;
+  contratista_id: string;
+  proyecto_id: string | null;
+  valor_total: number;
+  fianzas_url: string | null;
+  notas: string | null;
+};
+
+type Lote = {
+  id: string;
+  contrato_id: string;
+  construccion_id: string;
+  monto_lote: number | null;
+};
+
+type Construccion = {
+  id: string;
+  codigo: string;
+  unidad_id: string;
+  producto_id: string;
+  avance_pct: number;
+  estado: string;
+  mo_ejecutado: number;
+  valor_contrato_mo: number | null;
+  m2_construccion: number | null;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+function fmtMoney(n: number | null): string | null {
+  return n == null ? null : moneyFmt.format(n);
+}
+
+function fmtFecha(s: string | null): string | null {
+  if (!s) return null;
+  const d = new Date(`${s}T00:00:00`);
+  if (isNaN(d.getTime())) return s;
+  return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+function avanceColorClass(pct: number): string {
+  if (pct >= 66) return 'bg-emerald-500';
+  if (pct >= 33) return 'bg-amber-500';
+  if (pct >= 20) return 'bg-amber-400';
+  return 'bg-rose-500';
+}
+
+const ESTADO_LABEL: Record<string, string> = {
+  arrancada: 'Arrancada',
+  en_progreso: 'En progreso',
+  terminada: 'Terminada',
+  dtu: 'DTU',
+  seguro_calidad: 'Seguro calidad',
+  extraida: 'Extraída',
+  cancelada: 'Cancelada',
+};
+
+/**
+ * @module Construcción · Contrato detail (DILESA)
+ * @responsive desktop-only
+ */
+export default function ContratoDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.contratos">
+      <DetailInner />
+    </RequireAccess>
+  );
+}
+
+function DetailInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [contrato, setContrato] = useState<Contrato | null>(null);
+  const [contratistaNombre, setContratistaNombre] = useState<string | null>(null);
+  const [contratistaAbrev, setContratistaAbrev] = useState<string | null>(null);
+  const [proyectoNombre, setProyectoNombre] = useState<string | null>(null);
+  const [lotes, setLotes] = useState<Lote[]>([]);
+  const [obrasByConstruccionId, setObrasByConstruccionId] = useState<Map<string, Construccion>>(
+    new Map()
+  );
+  const [unidadById, setUnidadById] = useState<Map<string, string>>(new Map());
+  const [productoById, setProductoById] = useState<Map<string, string>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let activo = true;
+    const sb = createSupabaseBrowserClient();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      const { data: cRow, error: cErr } = await sb
+        .schema('dilesa')
+        .from('contratos_construccion')
+        .select('*')
+        .eq('id', id)
+        .is('deleted_at', null)
+        .maybeSingle();
+      if (!activo) return;
+      if (cErr) {
+        setError(getSupabaseErrorMessage(cErr, 'No se pudo cargar el contrato.'));
+        setLoading(false);
+        return;
+      }
+      if (!cRow) {
+        setError('Contrato no encontrado.');
+        setLoading(false);
+        return;
+      }
+      const ctrRow = cRow as unknown as Contrato;
+      setContrato(ctrRow);
+
+      const [persRes, datosRes, prjRes, lotesRes] = await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno')
+          .eq('id', ctrRow.contratista_id)
+          .maybeSingle(),
+        sb
+          .schema('dilesa')
+          .from('contratistas_datos')
+          .select('abreviacion')
+          .eq('persona_id', ctrRow.contratista_id)
+          .maybeSingle(),
+        ctrRow.proyecto_id
+          ? sb
+              .schema('dilesa')
+              .from('proyectos')
+              .select('nombre')
+              .eq('id', ctrRow.proyecto_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+        sb
+          .schema('dilesa')
+          .from('contrato_lotes')
+          .select('id, contrato_id, construccion_id, monto_lote')
+          .eq('contrato_id', ctrRow.id)
+          .is('deleted_at', null),
+      ]);
+      if (!activo) return;
+      const firstErr = persRes.error ?? datosRes.error ?? prjRes.error ?? lotesRes.error;
+      if (firstErr) {
+        setError(getSupabaseErrorMessage(firstErr, 'No se pudo cargar el detalle.'));
+        setLoading(false);
+        return;
+      }
+      const cName = persRes.data
+        ? [persRes.data.nombre, persRes.data.apellido_paterno, persRes.data.apellido_materno]
+            .filter(Boolean)
+            .join(' ')
+        : null;
+      setContratistaNombre(cName);
+      setContratistaAbrev((datosRes.data?.abreviacion as string | null) ?? null);
+      setProyectoNombre((prjRes.data?.nombre as string | null) ?? null);
+      const lotesArr = (lotesRes.data ?? []) as Lote[];
+      setLotes(lotesArr);
+
+      if (lotesArr.length === 0) {
+        setObrasByConstruccionId(new Map());
+        setUnidadById(new Map());
+        setProductoById(new Map());
+        setLoading(false);
+        return;
+      }
+
+      const construccionIds = [...new Set(lotesArr.map((l) => l.construccion_id))];
+      const { data: obras, error: obrasErr } = await sb
+        .schema('dilesa')
+        .from('construccion')
+        .select(
+          'id, codigo, unidad_id, producto_id, avance_pct, estado, mo_ejecutado, valor_contrato_mo, m2_construccion'
+        )
+        .in('id', construccionIds);
+      if (!activo) return;
+      if (obrasErr) {
+        setError(getSupabaseErrorMessage(obrasErr, 'No se pudieron cargar las obras.'));
+        setLoading(false);
+        return;
+      }
+      const obrasMap = new Map<string, Construccion>();
+      for (const o of obras ?? []) obrasMap.set(o.id as string, o as Construccion);
+      setObrasByConstruccionId(obrasMap);
+
+      const unidadIds = [...new Set((obras ?? []).map((o) => o.unidad_id as string))];
+      const productoIds = [...new Set((obras ?? []).map((o) => o.producto_id as string))];
+      const [unidadesRes, productosRes] = await Promise.all([
+        unidadIds.length > 0
+          ? sb.schema('dilesa').from('unidades').select('id, identificador').in('id', unidadIds)
+          : Promise.resolve({ data: [], error: null }),
+        productoIds.length > 0
+          ? sb.schema('dilesa').from('productos').select('id, nombre').in('id', productoIds)
+          : Promise.resolve({ data: [], error: null }),
+      ]);
+      if (!activo) return;
+      const uMap = new Map<string, string>();
+      for (const u of unidadesRes.data ?? []) uMap.set(u.id as string, u.identificador as string);
+      setUnidadById(uMap);
+      const pMap = new Map<string, string>();
+      for (const p of productosRes.data ?? []) pMap.set(p.id as string, p.nombre as string);
+      setProductoById(pMap);
+
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [id]);
+
+  const kpis = useMemo(() => {
+    let moEjecutado = 0;
+    let valorContratoMo = 0;
+    let avancePctSum = 0;
+    let n = 0;
+    for (const l of lotes) {
+      const o = obrasByConstruccionId.get(l.construccion_id);
+      if (!o) continue;
+      moEjecutado += Number(o.mo_ejecutado ?? 0);
+      valorContratoMo += Number(o.valor_contrato_mo ?? l.monto_lote ?? 0);
+      avancePctSum += Number(o.avance_pct ?? 0);
+      n += 1;
+    }
+    const moPorEjecutar = Math.max(0, valorContratoMo - moEjecutado);
+    const avancePromedio = n === 0 ? 0 : avancePctSum / n;
+    return { moEjecutado, valorContratoMo, moPorEjecutar, avancePromedio };
+  }, [lotes, obrasByConstruccionId]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !contrato) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Contrato no encontrado.'}
+        </div>
+      </div>
+    );
+  }
+
+  const fichaGeneral: { label: string; value: React.ReactNode }[] = (
+    [
+      ['Código', contrato.codigo],
+      ['Fecha del contrato', fmtFecha(contrato.fecha_contrato)],
+      [
+        'Contratista',
+        contratistaNombre ? (
+          <Link
+            href={`/dilesa/construccion/contratistas/${contrato.contratista_id}`}
+            className="text-[var(--accent)] hover:underline"
+          >
+            {contratistaAbrev ? `${contratistaAbrev} · ${contratistaNombre}` : contratistaNombre}
+          </Link>
+        ) : null,
+      ],
+      ['Proyecto', proyectoNombre],
+      ['Valor total', fmtMoney(contrato.valor_total)],
+      [
+        'Fianzas',
+        contrato.fianzas_url ? (
+          <a
+            href={contrato.fianzas_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-[var(--accent)] hover:underline"
+          >
+            Ver documento
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        ) : null,
+      ],
+    ] as [string, React.ReactNode][]
+  )
+    .filter((r): r is [string, React.ReactNode] => r[1] != null && r[1] !== '')
+    .map(([label, value]) => ({ label, value }));
+
+  return (
+    <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight text-[var(--text)]">
+            <FileText className="h-5 w-5 text-[var(--accent)]" />
+            {contrato.codigo}
+          </h1>
+          {contratistaNombre ? (
+            <p className="mt-1 text-sm text-[var(--text)]/60">
+              {contratistaNombre}
+              {proyectoNombre ? ` · ${proyectoNombre}` : ''}
+              {` · ${fmtFecha(contrato.fecha_contrato) ?? ''}`}
+            </p>
+          ) : null}
+        </div>
+      </header>
+
+      <Section title="Datos generales">
+        {fichaGeneral.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">Sin datos capturados.</p>
+        ) : (
+          <FichaGrid rows={fichaGeneral} cols={3} />
+        )}
+        {contrato.notas ? (
+          <div className="mt-4 border-t border-[var(--border)] pt-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+              Notas
+            </div>
+            <p className="mt-0.5 whitespace-pre-wrap text-sm text-[var(--text)]/80">
+              {contrato.notas}
+            </p>
+          </div>
+        ) : null}
+      </Section>
+
+      <Section title="KPIs">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <Kpi label="Lotes asignados" value={lotes.length.toString()} accent />
+          <Kpi label="MO ejecutado" value={fmtMoney(kpis.moEjecutado) ?? '$0'} />
+          <Kpi label="MO por ejecutar" value={fmtMoney(kpis.moPorEjecutar) ?? '$0'} />
+          <Kpi label="Avance promedio" value={`${kpis.avancePromedio.toFixed(0)}%`} />
+        </div>
+      </Section>
+
+      <Section
+        title="Lotes asignados"
+        description={
+          lotes.length === 0
+            ? 'sin lotes'
+            : `${lotes.length} lote(s) · MO contratado ${moneyFmt.format(kpis.valorContratoMo)}`
+        }
+      >
+        {lotes.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">
+            Este contrato no tiene lotes asignados todavía.
+          </p>
+        ) : (
+          <ul className="space-y-1.5">
+            {lotes.map((l) => {
+              const obra = obrasByConstruccionId.get(l.construccion_id);
+              if (!obra) {
+                return (
+                  <li
+                    key={l.id}
+                    className="rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-3 py-2 text-sm text-[var(--text)]/50"
+                  >
+                    Construcción {l.construccion_id} no encontrada (¿borrada?).
+                  </li>
+                );
+              }
+              const ident = unidadById.get(obra.unidad_id) ?? obra.codigo;
+              const proto = productoById.get(obra.producto_id) ?? null;
+              const protoSufijo = proto ? proto.split('-').pop() : null;
+              const display = protoSufijo ? `${ident}-${protoSufijo}` : ident;
+              return (
+                <li key={l.id}>
+                  <Link
+                    href={`/dilesa/construccion/${obra.id}`}
+                    className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-3 py-2 hover:border-[var(--accent)] hover:bg-[var(--bg)]/60"
+                  >
+                    <div className="flex items-center gap-2">
+                      <HardHat className="h-4 w-4 text-[var(--text)]/40" />
+                      <div>
+                        <div className="text-sm font-medium text-[var(--text)]">{display}</div>
+                        <div className="text-[11px] text-[var(--text)]/50">
+                          {ESTADO_LABEL[obra.estado] ?? obra.estado}
+                          {obra.m2_construccion != null
+                            ? ` · ${Number(obra.m2_construccion).toFixed(2)} m²`
+                            : ''}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-4">
+                      <div className="flex items-center gap-2">
+                        <div className="h-1.5 w-24 overflow-hidden rounded-full bg-[var(--border)]/40">
+                          <div
+                            className={`h-full rounded-full ${avanceColorClass(obra.avance_pct)}`}
+                            style={{
+                              width: `${Math.min(100, Math.max(0, obra.avance_pct))}%`,
+                            }}
+                          />
+                        </div>
+                        <span className="w-9 shrink-0 text-right text-xs tabular-nums text-[var(--text)]/70">
+                          {obra.avance_pct.toFixed(0)}%
+                        </span>
+                      </div>
+                      <div className="text-right">
+                        <div className="text-[10px] uppercase tracking-wide text-[var(--text)]/50">
+                          MO lote
+                        </div>
+                        <div className="text-sm tabular-nums text-[var(--text)]">
+                          {l.monto_lote != null ? moneyFmt.format(l.monto_lote) : '—'}
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+// ── Sub-componentes ──────────────────────────────────────────────────────
+
+function BackLink() {
+  return (
+    <Link
+      href="/dilesa/construccion/contratos"
+      className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+    >
+      <ArrowLeft className="size-4" /> Volver a contratos
+    </Link>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="mb-4 flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {description ? <span className="text-xs text-[var(--text)]/50">{description}</span> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function FichaGrid({
+  rows,
+  cols = 2,
+}: {
+  rows: { label: string; value: React.ReactNode }[];
+  cols?: 2 | 3;
+}) {
+  const gridCls =
+    cols === 3
+      ? 'grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3'
+      : 'grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2';
+  return (
+    <dl className={gridCls}>
+      {rows.map((r) => (
+        <div key={r.label}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+            {r.label}
+          </dt>
+          <dd className="mt-0.5 text-sm text-[var(--text)]">{r.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function Kpi({ label, value, accent = false }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div
+      className={
+        'rounded-md border bg-[var(--bg)]/30 px-3 py-2 ' +
+        (accent ? 'border-[var(--accent)]/40' : 'border-[var(--border)]')
+      }
+    >
+      <div className="text-[10px] font-medium uppercase tracking-wider text-[var(--text)]/50">
+        {label}
+      </div>
+      <div className="mt-0.5 text-lg font-semibold tabular-nums text-[var(--text)]">{value}</div>
+    </div>
+  );
+}

--- a/app/dilesa/construccion/contratos/nuevo/page.tsx
+++ b/app/dilesa/construccion/contratos/nuevo/page.tsx
@@ -554,7 +554,7 @@ function NuevoContratoForm() {
         });
       }
 
-      router.push(`/dilesa/contratistas/${contratistaId}`);
+      router.push(`/dilesa/construccion/contratistas/${contratistaId}`);
     } catch (e) {
       toast.add({
         title: 'Error al crear contrato',
@@ -813,7 +813,11 @@ function NuevoContratoForm() {
         </p>
         <div className="flex items-center gap-3">
           <Link
-            href={contratistaId ? `/dilesa/contratistas/${contratistaId}` : '/dilesa/contratistas'}
+            href={
+              contratistaId
+                ? `/dilesa/construccion/contratistas/${contratistaId}`
+                : '/dilesa/construccion/contratistas'
+            }
           >
             <Button variant="outline" disabled={submitting}>
               Cancelar

--- a/app/dilesa/construccion/contratos/page.tsx
+++ b/app/dilesa/construccion/contratos/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { ContratosModule } from '@/components/dilesa/contratos-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Construcción · Contratos (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Contratos" del hub Construcción (sprint tabs+protos). Lista
+ * filtrable de los contratos de construcción + botón al form combinado
+ * que crea contrato + arranca N lotes en una sola operación.
+ *
+ * Click en una fila → /dilesa/construccion/contratos/[id] con la ficha
+ * completa: datos generales, lotes asignados, KPIs MO.
+ *
+ * Gate: sub-slug `dilesa.construccion.contratos` (ADR-030 SS5). El mismo
+ * sub-slug gobierna tanto el form de captura (Sprint 4) como la
+ * lista/detalle. write=true habilita el botón "Nuevo contrato".
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.contratos">
+      <DesktopOnlyNotice module="Contratos" />
+      <div className="hidden sm:block">
+        <ContratosModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/construccion/layout.tsx
+++ b/app/dilesa/construccion/layout.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode } from 'react';
+import { RoutedModuleTabs } from '@/components/module-page';
+
+/**
+ * Layout compartido del hub Construcción (DILESA).
+ *
+ * Implementa el patrón "module with submodules / routed tabs" descrito en
+ * ADR-005 (`docs/adr/005_module_with_submodules_routed_tabs.md`) con el
+ * mecanismo de sub-slugs por tab de ADR-030
+ * (`docs/adr/030_submodule_permissions.md`):
+ *
+ *   /dilesa/construccion              → tab "Obras" (default landing).
+ *   /dilesa/construccion/contratos    → tab "Contratos".
+ *   /dilesa/construccion/contratistas → tab "Contratistas".
+ *   /dilesa/construccion/prototipos   → tab "Prototipos".
+ *
+ * El strip de tabs vive aquí para que cualquier ruta del hub (incluyendo
+ * sub-detalles profundos como `/contratos/[id]` o `/prototipos/[id]`)
+ * muestre la misma navegación, manteniendo el contexto del módulo.
+ *
+ * Cada `module` en el TABS array es un sub-slug que `<RoutedModuleTabs>`
+ * filtra automáticamente — tabs sin permiso quedan ocultas. Los gates de
+ * acceso viven en cada sub-page (ADR-030 SS5), no en el layout — así el
+ * AccessDenied de cada page muestra el sub-slug específico faltante en
+ * vez del padre (que sí estaría accesible vía otra tab).
+ *
+ * El sub-slug `dilesa.construccion.contratos` ya existía desde Sprint 4
+ * (Captura) y ahora gobierna también la lista/detalle del tab — mismo
+ * dominio funcional.
+ */
+const TABS = [
+  {
+    label: 'Obras',
+    href: '/dilesa/construccion',
+    exact: true,
+    module: 'dilesa.construccion.obras',
+  },
+  {
+    label: 'Contratos',
+    href: '/dilesa/construccion/contratos',
+    module: 'dilesa.construccion.contratos',
+  },
+  {
+    label: 'Contratistas',
+    href: '/dilesa/construccion/contratistas',
+    module: 'dilesa.construccion.contratistas',
+  },
+  {
+    label: 'Prototipos',
+    href: '/dilesa/construccion/prototipos',
+    module: 'dilesa.construccion.prototipos',
+  },
+] as const;
+
+export default function ConstruccionLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <div className="px-4 pt-4 sm:px-6 sm:pt-6">
+        <RoutedModuleTabs tabs={TABS} />
+      </div>
+      {children}
+    </>
+  );
+}

--- a/app/dilesa/construccion/page.tsx
+++ b/app/dilesa/construccion/page.tsx
@@ -6,21 +6,22 @@ import { ConstruccionModule } from '@/components/dilesa/construccion-module';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
 /**
- * @module Construcción (DILESA)
+ * @module Construcción · Obras (DILESA)
  * @responsive desktop-only
  *
- * Iniciativa dilesa-construccion · Sprint 3 (UI lectura). Lista de
+ * Default landing del hub Construcción (sprint tabs+protos). Lista de
  * construcciones por obra (~1,372 obras importadas en Sprint 2):
  * unidad, prototipo, contratista, avance%, estado, fechas críticas.
  * Click navega a /dilesa/construccion/[id] con la ficha completa,
  * timeline de etapas y tareas terminadas/pendientes.
  *
- * Lectura pura — captura (arrancar obra, registrar tarea) entra en
- * Sprint 4. Sub-slugs de escritura se introducirán en esa fase.
+ * Gate: sub-slug `dilesa.construccion.obras` (ADR-030 SS5). El padre
+ * `dilesa.construccion` queda como umbrella en sidebar; el sub-slug
+ * gobierna el contenido real de esta tab.
  */
 export default function Page() {
   return (
-    <RequireAccess empresa="dilesa" modulo="dilesa.construccion">
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.obras">
       <DesktopOnlyNotice module="Construcción" />
       <div className="hidden sm:block">
         <ConstruccionModule empresaId={DILESA_EMPRESA_ID} />

--- a/app/dilesa/construccion/prototipos/[id]/page.tsx
+++ b/app/dilesa/construccion/prototipos/[id]/page.tsx
@@ -1,0 +1,651 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de detalle DILESA.
+ */
+
+/**
+ * Detalle de un prototipo (DILESA) — 4 secciones:
+ *   1. Datos generales — nombre, descripción, proyecto, m²
+ *      construcción, tiempo construcción, costo materiales/m², último
+ *      precio MO/m² (histórico), TOTAL MO calculado.
+ *   2. Planos — grid de cards con cada plano del JSONB productos.planos.
+ *      Cada card: nombre legible + botón "Abrir" que abre URL en nueva
+ *      pestaña (PDF o imagen indistinto — no preview embed, solo link).
+ *   3. Plantilla de tareas — tabla agrupada por etapa con: tarea, %
+ *      distribución de costo, costo MO calculado (= % × ultimoPrecio ×
+ *      m²). Foot con TOTAL MO (que debe coincidir con SUM ± redondeo).
+ *   4. KPIs derivados — inventario por estado: arrancadas, en
+ *      construcción, terminadas, canceladas; m² acumulados.
+ *
+ * El "último precio MO/m²" se calcula tomando la `construccion` más
+ * reciente con `producto_id` = este prototipo, `precio_mo_x_m2` not
+ * null, ordenada por `fecha_arranque` desc. Si no hay, "—".
+ *
+ * Iniciativa dilesa-construccion · Sprint tabs+protos. Acceso vía
+ * sub-slug `dilesa.construccion.prototipos`.
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ArrowLeft,
+  ExternalLink,
+  FileText,
+  Home,
+  Image as ImageIcon,
+  Map as MapIcon,
+} from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Producto = {
+  id: string;
+  nombre: string;
+  descripcion: string | null;
+  proyecto_id: string;
+  atributos: Record<string, unknown> | null;
+  planos: Record<string, unknown> | null;
+  valor_comercial_referencia: number | null;
+  costo_referencia: number | null;
+};
+
+type Etapa = { id: string; nombre: string; orden: number };
+type Tarea = { id: string; nombre: string };
+type Plantilla = {
+  id: string;
+  tarea_id: string;
+  etapa_id: string;
+  porcentaje_costo: number;
+  tiempo_dias: number;
+};
+type Obra = {
+  id: string;
+  estado: string;
+  fecha_arranque: string | null;
+  precio_mo_x_m2: number | null;
+  m2_construccion: number | null;
+};
+
+// ── Planos: mapa de keys del JSONB → label legible (orden de display) ─────
+// Coincide con PLANOS_MAP de scripts/import_dilesa_construccion_catalogos.ts.
+const PLANOS_LABELS: Array<{ key: string; label: string; group: string }> = [
+  { key: 'arq_planta_baja', label: 'Planta Baja', group: 'Arquitectónico' },
+  { key: 'arq_planta_alta', label: 'Planta Alta', group: 'Arquitectónico' },
+  { key: 'arq_cortes', label: 'Cortes', group: 'Arquitectónico' },
+  { key: 'arq_elevaciones', label: 'Elevaciones', group: 'Arquitectónico' },
+  { key: 'arq_detalles_constructivos', label: 'Detalles constructivos', group: 'Arquitectónico' },
+  { key: 'ej_desplantes', label: 'Desplantes', group: 'Ejecutivo' },
+  { key: 'ej_acabados', label: 'Acabados', group: 'Ejecutivo' },
+  { key: 'ej_carpinteria', label: 'Carpintería', group: 'Ejecutivo' },
+  { key: 'ej_canceleria', label: 'Cancelería', group: 'Ejecutivo' },
+  { key: 'ej_herreria', label: 'Herrería', group: 'Ejecutivo' },
+  { key: 'ej_detalles', label: 'Detalles', group: 'Ejecutivo' },
+  { key: 'ej_plafones', label: 'Plafones', group: 'Ejecutivo' },
+  { key: 'ing_estructural', label: 'Estructural', group: 'Ingeniería' },
+  { key: 'ing_electrica', label: 'Eléctrica', group: 'Ingeniería' },
+  { key: 'ing_hidraulica', label: 'Hidráulica', group: 'Ingeniería' },
+  { key: 'ing_sanitaria', label: 'Sanitaria', group: 'Ingeniería' },
+  { key: 'ing_gas', label: 'Gas', group: 'Ingeniería' },
+];
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+function fmtMoney(n: number | null): string | null {
+  return n == null ? null : moneyFmt.format(n);
+}
+
+function readNumFromAttrs(
+  attrs: Record<string, unknown> | null | undefined,
+  key: string
+): number | null {
+  if (!attrs) return null;
+  const raw = attrs[key];
+  if (raw == null || raw === '') return null;
+  const n = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Detecta si una URL parece PDF. Para iconografía en las cards de planos. */
+function isPdfUrl(url: string): boolean {
+  return /\.pdf(\?|#|$)/i.test(url);
+}
+
+const EN_CURSO = new Set(['arrancada', 'en_progreso']);
+const TERMINADA = new Set(['terminada', 'dtu', 'seguro_calidad', 'extraida']);
+
+/**
+ * @module Construcción · Prototipo detail (DILESA)
+ * @responsive desktop-only
+ */
+export default function PrototipoDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.prototipos">
+      <DetailInner />
+    </RequireAccess>
+  );
+}
+
+function DetailInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [producto, setProducto] = useState<Producto | null>(null);
+  const [proyectoNombre, setProyectoNombre] = useState<string | null>(null);
+  const [etapas, setEtapas] = useState<Etapa[]>([]);
+  const [tareasCat, setTareasCat] = useState<Map<string, Tarea>>(new Map());
+  const [plantilla, setPlantilla] = useState<Plantilla[]>([]);
+  const [obras, setObras] = useState<Obra[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let activo = true;
+    const sb = createSupabaseBrowserClient();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      const { data: pRow, error: pErr } = await sb
+        .schema('dilesa')
+        .from('productos')
+        .select('*')
+        .eq('id', id)
+        .is('deleted_at', null)
+        .maybeSingle();
+      if (!activo) return;
+      if (pErr) {
+        setError(getSupabaseErrorMessage(pErr, 'No se pudo cargar el prototipo.'));
+        setLoading(false);
+        return;
+      }
+      if (!pRow) {
+        setError('Prototipo no encontrado.');
+        setLoading(false);
+        return;
+      }
+      const prodRow = pRow as unknown as Producto;
+      setProducto(prodRow);
+
+      const [prjRes, plRes, etRes, taRes, obrasRes] = await Promise.all([
+        sb
+          .schema('dilesa')
+          .from('proyectos')
+          .select('nombre')
+          .eq('id', prodRow.proyecto_id)
+          .maybeSingle(),
+        sb
+          .schema('dilesa')
+          .from('plantilla_tareas')
+          .select('id, tarea_id, etapa_id, porcentaje_costo, tiempo_dias')
+          .eq('producto_id', prodRow.id)
+          .is('deleted_at', null),
+        sb
+          .schema('dilesa')
+          .from('etapas_construccion')
+          .select('id, nombre, orden')
+          .is('deleted_at', null)
+          .order('orden', { ascending: true }),
+        sb.schema('dilesa').from('tareas_construccion').select('id, nombre').is('deleted_at', null),
+        sb
+          .schema('dilesa')
+          .from('construccion')
+          .select('id, estado, fecha_arranque, precio_mo_x_m2, m2_construccion')
+          .eq('producto_id', prodRow.id)
+          .is('deleted_at', null),
+      ]);
+      if (!activo) return;
+      const firstErr = prjRes.error ?? plRes.error ?? etRes.error ?? taRes.error ?? obrasRes.error;
+      if (firstErr) {
+        setError(getSupabaseErrorMessage(firstErr, 'No se pudo cargar el detalle.'));
+        setLoading(false);
+        return;
+      }
+      setProyectoNombre((prjRes.data?.nombre as string | null) ?? null);
+      setPlantilla((plRes.data ?? []) as Plantilla[]);
+      setEtapas((etRes.data ?? []) as Etapa[]);
+      const tMap = new Map<string, Tarea>();
+      for (const t of taRes.data ?? []) tMap.set(t.id as string, { id: t.id, nombre: t.nombre });
+      setTareasCat(tMap);
+      setObras((obrasRes.data ?? []) as Obra[]);
+
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [id]);
+
+  // Último precio MO/m² histórico: la obra más reciente con
+  // precio_mo_x_m2 not null para este producto.
+  const ultimoPrecioMo = useMemo(() => {
+    let last: { precio: number; fecha: string } | null = null;
+    for (const o of obras) {
+      if (o.precio_mo_x_m2 == null || o.fecha_arranque == null) continue;
+      if (!last || o.fecha_arranque > last.fecha) {
+        last = { precio: Number(o.precio_mo_x_m2), fecha: o.fecha_arranque };
+      }
+    }
+    return last;
+  }, [obras]);
+
+  const m2 = useMemo(() => readNumFromAttrs(producto?.atributos, 'm2_construccion'), [producto]);
+  const tiempo = useMemo(
+    () => readNumFromAttrs(producto?.atributos, 'tiempo_construccion'),
+    [producto]
+  );
+  const costoMateriales = useMemo(
+    () => readNumFromAttrs(producto?.atributos, 'costo_materiales'),
+    [producto]
+  );
+
+  const totalMo = useMemo(() => {
+    if (m2 == null || ultimoPrecioMo == null) return null;
+    return m2 * ultimoPrecioMo.precio;
+  }, [m2, ultimoPrecioMo]);
+
+  const costoMaterialesPorM2 = useMemo(() => {
+    if (costoMateriales == null || m2 == null || m2 === 0) return null;
+    return costoMateriales / m2;
+  }, [costoMateriales, m2]);
+
+  // Plantilla agrupada por etapa con costo MO por tarea calculado.
+  const etapasConTareas = useMemo(() => {
+    const rows = etapas.map((et) => {
+      const items = plantilla
+        .filter((p) => p.etapa_id === et.id)
+        .map((p) => {
+          const tareaInfo = tareasCat.get(p.tarea_id);
+          const pctNum = Number(p.porcentaje_costo ?? 0);
+          // El porcentaje viene como fracción (0.0021 = 0.21%) tras
+          // el import — multiplicamos por 100 para display y por
+          // totalMo para el costo en pesos.
+          const pctDisplay = pctNum * 100;
+          const costoMoTarea = totalMo != null ? pctNum * totalMo : null;
+          return {
+            plantillaId: p.id,
+            nombre: tareaInfo?.nombre ?? '(tarea desconocida)',
+            pctDisplay,
+            costoMoTarea,
+            tiempoDias: Number(p.tiempo_dias ?? 0),
+          };
+        })
+        .sort((a, b) => a.nombre.localeCompare(b.nombre));
+      const pctEtapa = items.reduce((s, it) => s + it.pctDisplay, 0);
+      const costoEtapa = items.reduce((s, it) => s + (it.costoMoTarea ?? 0), 0);
+      return { ...et, items, pctEtapa, costoEtapa };
+    });
+    return rows.filter((r) => r.items.length > 0);
+  }, [etapas, plantilla, tareasCat, totalMo]);
+
+  // Sumas del foot de la tabla de tareas (deben coincidir con totalMo
+  // ± redondeo de los porcentajes).
+  const totalPctSum = useMemo(
+    () => etapasConTareas.reduce((s, et) => s + et.pctEtapa, 0),
+    [etapasConTareas]
+  );
+  const totalCostoSum = useMemo(
+    () => etapasConTareas.reduce((s, et) => s + et.costoEtapa, 0),
+    [etapasConTareas]
+  );
+
+  const kpisInventario = useMemo(() => {
+    let enCurso = 0;
+    let terminadas = 0;
+    let canceladas = 0;
+    for (const o of obras) {
+      if (EN_CURSO.has(o.estado)) enCurso += 1;
+      else if (TERMINADA.has(o.estado)) terminadas += 1;
+      else if (o.estado === 'cancelada') canceladas += 1;
+    }
+    return { enCurso, terminadas, canceladas, total: obras.length };
+  }, [obras]);
+
+  // Planos: lista de cards con URL no-vacía en el orden canónico.
+  const planosUrls = useMemo(() => {
+    const planos = producto?.planos ?? {};
+    return PLANOS_LABELS.map((p) => ({
+      ...p,
+      url: typeof planos[p.key] === 'string' ? (planos[p.key] as string) : null,
+    })).filter((p): p is typeof p & { url: string } => !!p.url && p.url.length > 0);
+  }, [producto]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !producto) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Prototipo no encontrado.'}
+        </div>
+      </div>
+    );
+  }
+
+  const fichaGeneral: { label: string; value: string }[] = (
+    [
+      ['Prototipo', producto.nombre],
+      ['Proyecto', proyectoNombre],
+      ['m² de construcción', m2 != null ? `${m2.toFixed(2)} m²` : null],
+      ['Días de construcción', tiempo != null ? `${tiempo} días` : null],
+      ['Costo de materiales', fmtMoney(costoMateriales)],
+      [
+        'Costo materiales por m²',
+        costoMaterialesPorM2 != null ? `${moneyFmt.format(costoMaterialesPorM2)} / m²` : null,
+      ],
+      [
+        'Último precio MO × m²',
+        ultimoPrecioMo
+          ? `${moneyFmt.format(ultimoPrecioMo.precio)} / m² (${ultimoPrecioMo.fecha})`
+          : null,
+      ],
+      ['Total MO del prototipo', fmtMoney(totalMo)],
+      ['Valor comercial referencia', fmtMoney(producto.valor_comercial_referencia)],
+      ['Costo referencia', fmtMoney(producto.costo_referencia)],
+    ] as [string, string | null][]
+  )
+    .filter((r): r is [string, string] => r[1] != null && r[1] !== '')
+    .map(([label, value]) => ({ label, value }));
+
+  return (
+    <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight text-[var(--text)]">
+            <Home className="h-5 w-5 text-[var(--accent)]" />
+            {producto.nombre}
+          </h1>
+          {proyectoNombre ? (
+            <p className="mt-1 text-sm text-[var(--text)]/60">{proyectoNombre}</p>
+          ) : null}
+        </div>
+      </header>
+
+      <Section title="Datos generales">
+        {fichaGeneral.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">Sin datos capturados.</p>
+        ) : (
+          <FichaGrid rows={fichaGeneral} cols={3} />
+        )}
+        {producto.descripcion ? (
+          <div className="mt-4 border-t border-[var(--border)] pt-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+              Descripción
+            </div>
+            <p className="mt-0.5 whitespace-pre-wrap text-sm text-[var(--text)]/80">
+              {producto.descripcion}
+            </p>
+          </div>
+        ) : null}
+      </Section>
+
+      <Section
+        title="Planos"
+        description={
+          planosUrls.length === 0
+            ? 'sin planos cargados'
+            : `${planosUrls.length} plano(s) registrado(s)`
+        }
+      >
+        {planosUrls.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">
+            Este prototipo no tiene planos cargados todavía en `productos.planos`.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {planosUrls.map((p) => {
+              const Icon = isPdfUrl(p.url) ? FileText : ImageIcon;
+              return (
+                <a
+                  key={p.key}
+                  href={p.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex items-start gap-3 rounded-md border border-[var(--border)] bg-[var(--bg)]/30 p-3 hover:border-[var(--accent)] hover:bg-[var(--bg)]/60"
+                >
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--accent)]/10 text-[var(--accent)]">
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[10px] uppercase tracking-wide text-[var(--text)]/50">
+                      {p.group}
+                    </div>
+                    <div className="truncate text-sm font-medium text-[var(--text)]">{p.label}</div>
+                    <div className="mt-0.5 flex items-center gap-1 text-[11px] text-[var(--text)]/40">
+                      {isPdfUrl(p.url) ? 'PDF' : 'Imagen / link'}
+                      <ExternalLink className="h-2.5 w-2.5 opacity-0 group-hover:opacity-100" />
+                    </div>
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        )}
+      </Section>
+
+      <Section
+        title="Plantilla de tareas de construcción"
+        description={
+          etapasConTareas.length === 0
+            ? 'sin plantilla cargada'
+            : `${etapasConTareas.length} etapa(s) · ${plantilla.length} tareas${totalMo != null ? ` · Total MO ${moneyFmt.format(totalMo)}` : ''}`
+        }
+      >
+        {etapasConTareas.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">
+            La plantilla de tareas no está cargada para este prototipo.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {ultimoPrecioMo == null ? (
+              <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs text-amber-700 dark:text-amber-300">
+                No hay obras de este prototipo con <code>precio_mo_x_m2</code> capturado todavía. Se
+                muestra la plantilla con porcentajes pero sin costos en pesos. Cuando se arranque la
+                primera obra del prototipo (form combinado de contrato), el costo MO se calcula
+                automáticamente.
+              </div>
+            ) : null}
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="border-b border-[var(--border)] text-[10px] uppercase tracking-wide text-[var(--text)]/50">
+                  <tr>
+                    <th className="w-12 px-2 py-1.5 text-left">#</th>
+                    <th className="px-2 py-1.5 text-left">Tarea</th>
+                    <th className="w-20 px-2 py-1.5 text-right">% costo</th>
+                    <th className="w-28 px-2 py-1.5 text-right">Costo MO</th>
+                    <th className="w-16 px-2 py-1.5 text-right">Días</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {etapasConTareas.map((et) => (
+                    <EtapaRows key={et.id} etapa={et} />
+                  ))}
+                </tbody>
+                <tfoot className="border-t border-[var(--border)] text-xs font-medium">
+                  <tr>
+                    <td className="px-2 py-2" colSpan={2}>
+                      TOTAL ({plantilla.length} tareas)
+                    </td>
+                    <td className="px-2 py-2 text-right tabular-nums">{totalPctSum.toFixed(2)}%</td>
+                    <td className="px-2 py-2 text-right tabular-nums">
+                      {totalMo != null ? moneyFmt.format(totalCostoSum) : '—'}
+                    </td>
+                    <td className="px-2 py-2 text-right" />
+                  </tr>
+                </tfoot>
+              </table>
+            </div>
+          </div>
+        )}
+      </Section>
+
+      <Section title="Inventario en construcción">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <Kpi label="En curso" value={kpisInventario.enCurso.toString()} accent />
+          <Kpi label="Terminadas" value={kpisInventario.terminadas.toString()} />
+          <Kpi label="Canceladas" value={kpisInventario.canceladas.toString()} muted />
+          <Kpi label="Total histórico" value={kpisInventario.total.toString()} />
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function EtapaRows({
+  etapa,
+}: {
+  etapa: {
+    id: string;
+    nombre: string;
+    orden: number;
+    items: Array<{
+      plantillaId: string;
+      nombre: string;
+      pctDisplay: number;
+      costoMoTarea: number | null;
+      tiempoDias: number;
+    }>;
+    pctEtapa: number;
+    costoEtapa: number;
+  };
+}) {
+  return (
+    <>
+      <tr className="bg-[var(--bg)]/40 text-[10px] uppercase tracking-wide text-[var(--text)]/60">
+        <td className="px-2 py-1.5 font-mono tabular-nums">{etapa.orden}</td>
+        <td className="px-2 py-1.5 font-medium" colSpan={2}>
+          <span className="inline-flex items-center gap-2">
+            <MapIcon className="h-3 w-3" />
+            {etapa.nombre}
+          </span>
+        </td>
+        <td className="px-2 py-1.5 text-right tabular-nums">
+          {etapa.costoEtapa > 0 ? moneyFmt.format(etapa.costoEtapa) : '—'}
+        </td>
+        <td className="px-2 py-1.5 text-right tabular-nums">{etapa.pctEtapa.toFixed(2)}%</td>
+      </tr>
+      {etapa.items.map((it, idx) => (
+        <tr key={it.plantillaId} className="border-b border-[var(--border)]/30 last:border-0">
+          <td className="px-2 py-1 text-right text-[11px] tabular-nums text-[var(--text)]/40">
+            {idx + 1}
+          </td>
+          <td className="px-2 py-1 text-[var(--text)]/80">{it.nombre}</td>
+          <td className="px-2 py-1 text-right tabular-nums text-[var(--text)]/60">
+            {it.pctDisplay.toFixed(2)}%
+          </td>
+          <td className="px-2 py-1 text-right tabular-nums text-[var(--text)]">
+            {it.costoMoTarea != null ? moneyFmt.format(it.costoMoTarea) : '—'}
+          </td>
+          <td className="px-2 py-1 text-right tabular-nums text-[var(--text)]/50">
+            {it.tiempoDias > 0 ? it.tiempoDias : '—'}
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+// ── Sub-componentes ──────────────────────────────────────────────────────
+
+function BackLink() {
+  return (
+    <Link
+      href="/dilesa/construccion/prototipos"
+      className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+    >
+      <ArrowLeft className="size-4" /> Volver a prototipos
+    </Link>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="mb-4 flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {description ? <span className="text-xs text-[var(--text)]/50">{description}</span> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function FichaGrid({ rows, cols = 2 }: { rows: { label: string; value: string }[]; cols?: 2 | 3 }) {
+  const gridCls =
+    cols === 3
+      ? 'grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3'
+      : 'grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2';
+  return (
+    <dl className={gridCls}>
+      {rows.map((r) => (
+        <div key={r.label}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+            {r.label}
+          </dt>
+          <dd className="mt-0.5 text-sm text-[var(--text)]">{r.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  accent = false,
+  muted = false,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+  muted?: boolean;
+}) {
+  return (
+    <div
+      className={
+        'rounded-md border bg-[var(--bg)]/30 px-3 py-2 ' +
+        (accent
+          ? 'border-[var(--accent)]/40'
+          : muted
+            ? 'border-[var(--border)] opacity-60'
+            : 'border-[var(--border)]')
+      }
+    >
+      <div className="text-[10px] font-medium uppercase tracking-wider text-[var(--text)]/50">
+        {label}
+      </div>
+      <div className="mt-0.5 text-lg font-semibold tabular-nums text-[var(--text)]">{value}</div>
+    </div>
+  );
+}

--- a/app/dilesa/construccion/prototipos/page.tsx
+++ b/app/dilesa/construccion/prototipos/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { PrototiposModule } from '@/components/dilesa/prototipos-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Construcción · Prototipos (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Prototipos" del hub Construcción (sprint tabs+protos). Lista de
+ * modelos de vivienda (`dilesa.productos`) con KPIs derivados de las
+ * obras: último precio MO/m² histórico, total MO calculado, conteo de
+ * obras en curso/terminadas.
+ *
+ * Click → detalle con planos (JSONB productos.planos), plantilla de
+ * tareas con costo MO calculado por tarea, KPIs adicionales.
+ *
+ * Gate: sub-slug `dilesa.construccion.prototipos` (ADR-030 SS5).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.prototipos">
+      <DesktopOnlyNotice module="Prototipos" />
+      <div className="hidden sm:block">
+        <PrototiposModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -75,8 +75,10 @@ export const NAV_ITEMS: NavItem[] = [
           { label: 'Proyectos', href: '/dilesa/proyectos' },
           { label: 'Inventario', href: '/dilesa/inventario' },
           { label: 'Ventas', href: '/dilesa/ventas' },
+          // Construcción ahora es un hub con 4 tabs (Obras / Contratos /
+          // Contratistas / Prototipos) — el sidebar muestra solo la entry
+          // del padre; las tabs viven en el layout (sprint tabs+protos).
           { label: 'Construcción', href: '/dilesa/construccion' },
-          { label: 'Contratistas', href: '/dilesa/contratistas' },
         ],
       },
     ],

--- a/components/dilesa/contratistas-module.tsx
+++ b/components/dilesa/contratistas-module.tsx
@@ -6,7 +6,7 @@
  * Iniciativa dilesa-construccion · Sprint 3 (UI lectura). Lista de los
  * contratistas registrados (~23 en Sprint 2) con KPIs calculados en
  * memoria a partir de `dilesa.construccion`: obras en curso, obras
- * terminadas, MO ejecutado total. Click → /dilesa/contratistas/[id].
+ * terminadas, MO ejecutado total. Click → /dilesa/construccion/contratistas/[id].
  *
  * Modelo (ADR-032 D2): los contratistas viven en `erp.personas` con
  * `tipo='contratista'`. Datos específicos de DILESA (REPSE, retención,
@@ -284,7 +284,7 @@ export function ContratistasModule({ empresaId }: { empresaId: string }) {
   ];
 
   const onRowClick = (c: ContratistaRow) => {
-    router.push(`/dilesa/contratistas/${c.persona_id}`);
+    router.push(`/dilesa/construccion/contratistas/${c.persona_id}`);
   };
 
   return (

--- a/components/dilesa/contratos-module.tsx
+++ b/components/dilesa/contratos-module.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+/**
+ * ContratosModule — lista de contratos de construcción DILESA.
+ *
+ * Iniciativa dilesa-construccion · Sprint tabs+protos. Tab "Contratos" del
+ * hub Construcción. Lista filtrable de los contratos en
+ * `dilesa.contratos_construccion`: código, fecha, contratista (lookup
+ * cross-schema vía erp.personas), proyecto (lookup dilesa.proyectos),
+ * valor total, # lotes asignados (count en `contrato_lotes`).
+ *
+ * Click en fila → /dilesa/construccion/contratos/[id] con la ficha
+ * completa: datos generales, lotes asignados con avance, KPIs MO.
+ *
+ * Carga cross-schema con 4 queries paralelas + lookups Map (mismo patrón
+ * que construccion-module / contratistas-module — evita embeds de
+ * PostgREST cuando la tabla embebida vive en > 1 schema y permite
+ * filtros sobre los nombres derivados sin hits adicionales).
+ *
+ * Botón "+ Nuevo contrato" lleva al form combinado de Sprint 4 que crea
+ * cabecera + arranca N lotes en una sola operación.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { usePermissions } from '@/components/providers';
+import { DataTable, type Column } from '@/components/module-page';
+import { Input } from '@/components/ui/input';
+import { FileText, Plus, RefreshCw, Search } from 'lucide-react';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type ContratoRow = {
+  id: string;
+  codigo: string;
+  fecha_contrato: string;
+  contratista_id: string;
+  proyecto_id: string | null;
+  valor_total: number;
+  /** Computed: nombre del contratista (erp.personas). */
+  contratistaNombre: string;
+  contratistaAbreviacion: string | null;
+  /** Computed: nombre del proyecto (dilesa.proyectos). */
+  proyectoNombre: string;
+  /** Computed: count de contrato_lotes (no soft-deleted). */
+  lotesCount: number;
+};
+
+export function ContratosModule({ empresaId }: { empresaId: string }) {
+  const router = useRouter();
+  const { permissions } = usePermissions();
+  const puedeCrear =
+    permissions.isAdmin || permissions.modulos.get('dilesa.construccion.contratos')?.write === true;
+
+  const [contratos, setContratos] = useState<ContratoRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [contratistaFiltro, setContratistaFiltro] = useState('');
+  const [proyectoFiltro, setProyectoFiltro] = useState('');
+
+  const fetchContratos = useCallback(async (): Promise<{
+    data?: ContratoRow[];
+    error?: string;
+  }> => {
+    const sb = createSupabaseBrowserClient();
+
+    // 4 queries paralelas: contratos + contrato_lotes (para count) +
+    // personas (contratistas) + proyectos (+ satélite de abrev en aparte
+    // para no inflar el cross-join).
+    const [contratosRes, lotesRes, personasRes, proyectosRes, datosRes] = await Promise.all([
+      sb
+        .schema('dilesa')
+        .from('contratos_construccion')
+        .select('id, codigo, fecha_contrato, contratista_id, proyecto_id, valor_total')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('contrato_lotes')
+        .select('contrato_id')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .eq('empresa_id', empresaId)
+        .eq('tipo', 'contratista'),
+      sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, nombre')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('contratistas_datos')
+        .select('persona_id, abreviacion')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr =
+      contratosRes.error ??
+      lotesRes.error ??
+      personasRes.error ??
+      proyectosRes.error ??
+      datosRes.error;
+    if (firstErr) {
+      return { error: getSupabaseErrorMessage(firstErr, 'No se pudieron cargar los contratos.') };
+    }
+
+    const personaMap = new Map<string, string>();
+    for (const p of personasRes.data ?? []) {
+      const nombre = [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' ');
+      personaMap.set(p.id as string, nombre || '(sin nombre)');
+    }
+    const abrevMap = new Map<string, string | null>();
+    for (const d of datosRes.data ?? []) {
+      abrevMap.set(d.persona_id as string, (d.abreviacion as string | null) ?? null);
+    }
+    const proyectoMap = new Map<string, string>();
+    for (const p of proyectosRes.data ?? []) proyectoMap.set(p.id as string, p.nombre as string);
+
+    const lotesByContrato = new Map<string, number>();
+    for (const l of lotesRes.data ?? []) {
+      const cid = l.contrato_id as string;
+      lotesByContrato.set(cid, (lotesByContrato.get(cid) ?? 0) + 1);
+    }
+
+    const rows: ContratoRow[] = (contratosRes.data ?? []).map((c) => {
+      const cid = c.contratista_id as string;
+      const pid = c.proyecto_id as string | null;
+      return {
+        id: c.id as string,
+        codigo: c.codigo as string,
+        fecha_contrato: c.fecha_contrato as string,
+        contratista_id: cid,
+        proyecto_id: pid,
+        valor_total: Number(c.valor_total ?? 0),
+        contratistaNombre: personaMap.get(cid) ?? '(sin contratista)',
+        contratistaAbreviacion: abrevMap.get(cid) ?? null,
+        proyectoNombre: pid ? (proyectoMap.get(pid) ?? '') : '',
+        lotesCount: lotesByContrato.get(c.id as string) ?? 0,
+      };
+    });
+
+    return { data: rows };
+  }, [empresaId]);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: e } = await fetchContratos();
+    if (e) {
+      setError(e);
+      setContratos([]);
+    } else setContratos(data ?? []);
+    setLoading(false);
+  }, [fetchContratos]);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchContratos().then(({ data, error: e }) => {
+      if (!activo) return;
+      if (e) {
+        setError(e);
+        setContratos([]);
+      } else setContratos(data ?? []);
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchContratos]);
+
+  const contratistasPresentes = useMemo(
+    () => [...new Set(contratos.map((c) => c.contratistaNombre).filter(Boolean))].sort(),
+    [contratos]
+  );
+  const proyectosPresentes = useMemo(
+    () => [...new Set(contratos.map((c) => c.proyectoNombre).filter(Boolean))].sort(),
+    [contratos]
+  );
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return contratos.filter((c) => {
+      if (contratistaFiltro && c.contratistaNombre !== contratistaFiltro) return false;
+      if (proyectoFiltro && c.proyectoNombre !== proyectoFiltro) return false;
+      if (q) {
+        const hay =
+          c.codigo.toLowerCase().includes(q) ||
+          c.contratistaNombre.toLowerCase().includes(q) ||
+          c.proyectoNombre.toLowerCase().includes(q);
+        if (!hay) return false;
+      }
+      return true;
+    });
+  }, [contratos, search, contratistaFiltro, proyectoFiltro]);
+
+  const columns: Column<ContratoRow>[] = [
+    {
+      key: 'codigo',
+      label: 'Código',
+      type: 'text',
+      sticky: true,
+      width: 'min-w-[240px]',
+    },
+    { key: 'fecha_contrato', label: 'Fecha', type: 'date' },
+    {
+      key: 'contratistaNombre',
+      label: 'Contratista',
+      type: 'custom',
+      accessor: (c) => c.contratistaNombre,
+      render: (c) =>
+        c.contratistaAbreviacion ? (
+          <span title={c.contratistaNombre}>
+            <span className="font-medium">{c.contratistaAbreviacion}</span>
+            <span className="ml-1 text-[var(--text)]/40">·</span>
+            <span className="ml-1 text-[var(--text)]/60">{c.contratistaNombre}</span>
+          </span>
+        ) : (
+          c.contratistaNombre
+        ),
+    },
+    {
+      key: 'proyectoNombre',
+      label: 'Proyecto',
+      type: 'text',
+      render: (c) => c.proyectoNombre || '—',
+    },
+    { key: 'lotesCount', label: 'Lotes', type: 'number' },
+    { key: 'valor_total', label: 'Valor MO', type: 'currency' },
+  ];
+
+  const onRowClick = (c: ContratoRow) => {
+    router.push(`/dilesa/construccion/contratos/${c.id}`);
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <FileText className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Contratos</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Contratos de construcción con contratistas. Cada uno cubre 1+ lotes con su precio MO/m²
+            y arranca obras en una sola operación.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar código, contratista o proyecto…"
+            className="w-72 pl-9"
+          />
+        </div>
+        <select
+          value={contratistaFiltro}
+          onChange={(e) => setContratistaFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los contratistas</option>
+          {contratistasPresentes.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          value={proyectoFiltro}
+          onChange={(e) => setProyectoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los proyectos</option>
+          {proyectosPresentes.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {filtrados.length} de {contratos.length} contratos
+        </span>
+        {puedeCrear ? (
+          <Link
+            href="/dilesa/construccion/contratos/nuevo"
+            className="flex h-9 items-center gap-1.5 rounded-md bg-[var(--accent)] px-3 text-sm font-medium text-white hover:opacity-90"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Nuevo contrato + arranques
+          </Link>
+        ) : null}
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={onRowClick}
+        initialSort={{ key: 'fecha_contrato', dir: 'desc' }}
+        emptyTitle="Sin contratos"
+        emptyDescription="No hay contratos que coincidan con los filtros actuales."
+        emptyIcon={<FileText className="h-6 w-6" />}
+        maxHeight="calc(100vh - 280px)"
+      />
+    </div>
+  );
+}

--- a/components/dilesa/prototipos-module.tsx
+++ b/components/dilesa/prototipos-module.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+/**
+ * PrototiposModule — lista de prototipos de vivienda DILESA.
+ *
+ * Iniciativa dilesa-construccion · Sprint tabs+protos. Tab "Prototipos"
+ * del hub Construcción. Lista filtrable de `dilesa.productos` (~14
+ * prototipos por proyecto): nombre, proyecto, m² construcción, costo
+ * materiales, último precio MO/m² histórico (derivado de la
+ * construcción más reciente con ese producto_id), total MO calculado,
+ * count de obras en construcción / terminadas.
+ *
+ * Click → /dilesa/construccion/prototipos/[id] con detalle: datos
+ * generales, grid de planos (JSONB productos.planos), plantilla de
+ * tareas con costo MO calculado por tarea, KPIs derivados.
+ *
+ * Atributos del JSONB `productos.atributos`:
+ *   - modelo (string) — sufijo del prototipo (ej. "ISC")
+ *   - m2_construccion (number) — usado por el form de contrato para
+ *     calcular valor MO = precio_mo_x_m2 × m².
+ *   - costo_materiales / tiempo_construccion (number, opcionales) —
+ *     poblados desde Coda en imports históricos; "—" si ausentes.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, type Column } from '@/components/module-page';
+import { Input } from '@/components/ui/input';
+import { Home, RefreshCw, Search } from 'lucide-react';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type PrototipoRow = {
+  id: string;
+  nombre: string;
+  proyectoNombre: string;
+  m2_construccion: number | null;
+  tiempo_construccion: number | null;
+  costo_materiales: number | null;
+  ultimoPrecioMoM2: number | null;
+  totalMoCalculado: number | null;
+  obrasEnConstruccion: number;
+  obrasTerminadas: number;
+};
+
+const EN_CURSO = new Set(['arrancada', 'en_progreso']);
+const TERMINADA = new Set(['terminada', 'dtu', 'seguro_calidad', 'extraida']);
+
+/**
+ * Lee la m² del JSONB atributos (coerciona string a number cuando viene
+ * como texto desde imports legacy). Devuelve null si no hay o no parsea.
+ */
+function readNumFromAttrs(
+  attrs: Record<string, unknown> | null | undefined,
+  key: string
+): number | null {
+  if (!attrs) return null;
+  const raw = attrs[key];
+  if (raw == null || raw === '') return null;
+  const n = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function PrototiposModule({ empresaId }: { empresaId: string }) {
+  const router = useRouter();
+  const [prototipos, setPrototipos] = useState<PrototipoRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [proyectoFiltro, setProyectoFiltro] = useState('');
+
+  const fetchPrototipos = useCallback(async (): Promise<{
+    data?: PrototipoRow[];
+    error?: string;
+  }> => {
+    const sb = createSupabaseBrowserClient();
+
+    // 3 queries paralelas: productos + proyectos (lookup) + construcciones
+    // (para último precio MO histórico + counts).
+    const [productosRes, proyectosRes, obrasRes] = await Promise.all([
+      sb
+        .schema('dilesa')
+        .from('productos')
+        .select('id, nombre, proyecto_id, atributos')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, nombre')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('construccion')
+        .select('producto_id, precio_mo_x_m2, fecha_arranque, estado')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr = productosRes.error ?? proyectosRes.error ?? obrasRes.error;
+    if (firstErr) {
+      return { error: getSupabaseErrorMessage(firstErr, 'No se pudieron cargar los prototipos.') };
+    }
+
+    const proyectoMap = new Map<string, string>();
+    for (const p of proyectosRes.data ?? []) proyectoMap.set(p.id as string, p.nombre as string);
+
+    // Derivados por producto_id: último precio (max fecha_arranque con
+    // precio_mo_x_m2 not null), conteo por estado.
+    type Agg = {
+      ultimoPrecio: number | null;
+      ultimaFecha: string | null;
+      enCurso: number;
+      terminadas: number;
+    };
+    const aggMap = new Map<string, Agg>();
+    for (const o of obrasRes.data ?? []) {
+      const pid = o.producto_id as string;
+      const agg = aggMap.get(pid) ?? {
+        ultimoPrecio: null,
+        ultimaFecha: null,
+        enCurso: 0,
+        terminadas: 0,
+      };
+      const estado = o.estado as string;
+      if (EN_CURSO.has(estado)) agg.enCurso += 1;
+      else if (TERMINADA.has(estado)) agg.terminadas += 1;
+      const precio = o.precio_mo_x_m2 as number | null;
+      const fecha = o.fecha_arranque as string | null;
+      if (precio != null && fecha != null) {
+        if (!agg.ultimaFecha || fecha > agg.ultimaFecha) {
+          agg.ultimaFecha = fecha;
+          agg.ultimoPrecio = Number(precio);
+        }
+      }
+      aggMap.set(pid, agg);
+    }
+
+    const rows: PrototipoRow[] = (productosRes.data ?? []).map((p) => {
+      const attrs = (p.atributos as Record<string, unknown> | null) ?? {};
+      const m2 = readNumFromAttrs(attrs, 'm2_construccion');
+      const tiempo = readNumFromAttrs(attrs, 'tiempo_construccion');
+      const costoMat = readNumFromAttrs(attrs, 'costo_materiales');
+      const agg = aggMap.get(p.id as string) ?? {
+        ultimoPrecio: null,
+        ultimaFecha: null,
+        enCurso: 0,
+        terminadas: 0,
+      };
+      const totalMo = m2 != null && agg.ultimoPrecio != null ? m2 * agg.ultimoPrecio : null;
+      return {
+        id: p.id as string,
+        nombre: p.nombre as string,
+        proyectoNombre: proyectoMap.get(p.proyecto_id as string) ?? '',
+        m2_construccion: m2,
+        tiempo_construccion: tiempo,
+        costo_materiales: costoMat,
+        ultimoPrecioMoM2: agg.ultimoPrecio,
+        totalMoCalculado: totalMo,
+        obrasEnConstruccion: agg.enCurso,
+        obrasTerminadas: agg.terminadas,
+      };
+    });
+
+    return { data: rows };
+  }, [empresaId]);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: e } = await fetchPrototipos();
+    if (e) {
+      setError(e);
+      setPrototipos([]);
+    } else setPrototipos(data ?? []);
+    setLoading(false);
+  }, [fetchPrototipos]);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchPrototipos().then(({ data, error: e }) => {
+      if (!activo) return;
+      if (e) {
+        setError(e);
+        setPrototipos([]);
+      } else setPrototipos(data ?? []);
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchPrototipos]);
+
+  const proyectosPresentes = useMemo(
+    () => [...new Set(prototipos.map((p) => p.proyectoNombre).filter(Boolean))].sort(),
+    [prototipos]
+  );
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return prototipos.filter((p) => {
+      if (proyectoFiltro && p.proyectoNombre !== proyectoFiltro) return false;
+      if (q) {
+        const hay =
+          p.nombre.toLowerCase().includes(q) || p.proyectoNombre.toLowerCase().includes(q);
+        if (!hay) return false;
+      }
+      return true;
+    });
+  }, [prototipos, search, proyectoFiltro]);
+
+  const columns: Column<PrototipoRow>[] = [
+    {
+      key: 'nombre',
+      label: 'Prototipo',
+      type: 'text',
+      sticky: true,
+      width: 'min-w-[220px]',
+    },
+    { key: 'proyectoNombre', label: 'Proyecto', type: 'text' },
+    {
+      key: 'm2_construccion',
+      label: 'm² construcción',
+      type: 'custom',
+      accessor: (p) => p.m2_construccion ?? 0,
+      render: (p) =>
+        p.m2_construccion != null ? (
+          <span className="tabular-nums">{p.m2_construccion.toFixed(2)}</span>
+        ) : (
+          '—'
+        ),
+    },
+    {
+      key: 'tiempo_construccion',
+      label: 'Días est.',
+      type: 'custom',
+      accessor: (p) => p.tiempo_construccion ?? 0,
+      render: (p) =>
+        p.tiempo_construccion != null ? (
+          <span className="tabular-nums">{p.tiempo_construccion}</span>
+        ) : (
+          '—'
+        ),
+    },
+    {
+      key: 'ultimoPrecioMoM2',
+      label: 'Último MO/m²',
+      type: 'custom',
+      accessor: (p) => p.ultimoPrecioMoM2 ?? 0,
+      render: (p) =>
+        p.ultimoPrecioMoM2 != null ? (
+          <span className="tabular-nums">${p.ultimoPrecioMoM2.toFixed(0)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'totalMoCalculado',
+      label: 'Total MO',
+      type: 'custom',
+      accessor: (p) => p.totalMoCalculado ?? 0,
+      render: (p) =>
+        p.totalMoCalculado != null ? (
+          <span className="tabular-nums">${p.totalMoCalculado.toFixed(0)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    { key: 'obrasEnConstruccion', label: 'En curso', type: 'number' },
+    { key: 'obrasTerminadas', label: 'Terminadas', type: 'number' },
+  ];
+
+  const onRowClick = (p: PrototipoRow) => {
+    router.push(`/dilesa/construccion/prototipos/${p.id}`);
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <Home className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Prototipos</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Modelos de vivienda por proyecto con planos, plantilla de tareas, y costo MO calculado
+            del último precio histórico.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar prototipo o proyecto…"
+            className="w-72 pl-9"
+          />
+        </div>
+        <select
+          value={proyectoFiltro}
+          onChange={(e) => setProyectoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los proyectos</option>
+          {proyectosPresentes.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {filtrados.length} de {prototipos.length} prototipos
+        </span>
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={onRowClick}
+        initialSort={{ key: 'nombre', dir: 'asc' }}
+        emptyTitle="Sin prototipos"
+        emptyDescription="No hay prototipos que coincidan con los filtros actuales."
+        emptyIcon={<Home className="h-6 w-6" />}
+        maxHeight="calc(100vh - 280px)"
+      />
+    </div>
+  );
+}

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -186,15 +186,25 @@ const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   'dilesa.inventario',
   'dilesa.ventas',
   'dilesa.construccion',
-  'dilesa.contratistas',
+  // Sub-slugs del hub Construcción (sprint tabs+protos, ADR-030). El padre
+  // `dilesa.construccion` queda como umbrella en sidebar; cada tab
+  // (Obras/Contratos/Contratistas/Prototipos) tiene su sub-slug que
+  // gobierna acceso real al contenido. Ver migración
+  // 20260525152711_dilesa_construccion_tabs_hub.sql.
+  // El slug top-level `dilesa.contratistas` fue deprecado y eliminado por
+  // la misma migración — vive ahora como sub-slug del hub.
+  'dilesa.construccion.obras',
+  'dilesa.construccion.contratos',
+  'dilesa.construccion.contratistas',
+  'dilesa.construccion.prototipos',
   // Sub-slugs de captura del módulo construcción (Sprint 4 dilesa-construccion).
-  // El padre `dilesa.construccion` es umbrella (sidebar + lectura); estos
-  // hijos gobiernan acceso a los forms de captura. Ver ADR-030.
+  // `.tareas` gobierna el form de "Registrar tareas terminadas". `.contratos`
+  // sirve doble propósito: form de captura (Sprint 4) + lista/detalle del
+  // tab Contratos (sprint tabs+protos).
   // Nota: `dilesa.construccion.arrancar` se deprecó post-refactor (un
   // arranque siempre va dentro del contrato — el form combinado vive
   // bajo `.contratos`). El slug puede quedar en DB como vestigio.
   'dilesa.construccion.tareas',
-  'dilesa.construccion.contratos',
   // Sub-slugs por fase del pipeline (Sprint 7a captura por fase)
   'dilesa.ventas.fase01_solicitud',
   'dilesa.ventas.fase02_asignada',

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -37,8 +37,13 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   '/dilesa/proyectos': 'dilesa.proyectos',
   '/dilesa/inventario': 'dilesa.inventario',
   '/dilesa/ventas': 'dilesa.ventas',
-  '/dilesa/construccion': 'dilesa.construccion',
-  '/dilesa/contratistas': 'dilesa.contratistas',
+  // Construcción es un hub con 4 tabs (sprint tabs+protos). El padre
+  // `dilesa.construccion` queda como umbrella; cada tab tiene su sub-slug
+  // (ADR-030 SS2). La URL default mapea al sub-slug del primer tab.
+  '/dilesa/construccion': 'dilesa.construccion.obras',
+  '/dilesa/construccion/contratos': 'dilesa.construccion.contratos',
+  '/dilesa/construccion/contratistas': 'dilesa.construccion.contratistas',
+  '/dilesa/construccion/prototipos': 'dilesa.construccion.prototipos',
   // Captura por fase — sub-slugs ADR-030. Cada URL apunta al sub-slug que
   // gobierna acceso a esa fase. Ver docs/planning/dilesa-ventas-captura.md.
   '/dilesa/ventas/nueva': 'dilesa.ventas.fase01_solicitud',

--- a/supabase/migrations/20260525152711_dilesa_construccion_tabs_hub.sql
+++ b/supabase/migrations/20260525152711_dilesa_construccion_tabs_hub.sql
@@ -1,0 +1,91 @@
+-- ============================================================================
+-- DILESA · Construcción Sprint tabs+prototipos
+--   Conversión del módulo Construcción en HUB con 4 tabs
+-- ----------------------------------------------------------------------------
+-- Refactor arquitectónico: `/dilesa/construccion` deja de ser una single-page
+-- y pasa a ser un hub con 4 tabs hermanas (ADR-030 patrón de sub-slugs por
+-- routed tabs, mismo pattern que `rdb.inventario` / `rdb.productos`):
+--
+--   /dilesa/construccion              → tab "Obras"        (default, lo que ya estaba)
+--   /dilesa/construccion/contratos    → tab "Contratos"     (NUEVO)
+--   /dilesa/construccion/contratistas → tab "Contratistas"  (movido desde top-level)
+--   /dilesa/construccion/prototipos   → tab "Prototipos"    (NUEVO)
+--
+-- Cambios DB:
+--   1. INSERT 3 sub-slugs nuevos en core.modulos:
+--        - dilesa.construccion.obras
+--        - dilesa.construccion.contratistas
+--        - dilesa.construccion.prototipos
+--      (El sub-slug `dilesa.construccion.contratos` YA EXISTE — se creó en
+--      Sprint 4 para el form de captura. ON CONFLICT lo deja igual; ahora
+--      gobierna tanto el form como la lista/detalle del tab.)
+--   2. Backfill defensivo: clonar los permisos del padre `dilesa.construccion`
+--      a cada uno de los 3 sub-slugs nuevos. Patrón ADR-030 SS3 — sin esto,
+--      agregar los sub-slugs ESCONDE las tabs a no-admin users (canAccessModulo
+--      retorna false para slug ausente en permissions.modulos).
+--   3. DELETE el slug top-level `dilesa.contratistas`. ON DELETE CASCADE en
+--      core.permisos_rol y core.permisos_usuario_excepcion limpia las
+--      referencias transitivamente. El submódulo nuevo
+--      `dilesa.construccion.contratistas` toma su lugar.
+--
+-- Idempotente: ON CONFLICT DO NOTHING en INSERTs; el DELETE es no-op si ya
+-- corrió (slug ausente). NOTIFY pgrst al final para refrescar la caché.
+-- ============================================================================
+
+BEGIN;
+
+-- ── Sub-slugs nuevos en core.modulos ───────────────────────────────────────
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT s.slug, s.nombre, s.descripcion, e.id, 'operaciones'
+FROM core.empresas e
+CROSS JOIN (VALUES
+  ('dilesa.construccion.obras',
+   'Construcción · Obras',
+   'Tab Obras del hub Construcción — lista de construcciones activas con avance, contratista y fechas críticas. Default landing del hub.'),
+  ('dilesa.construccion.contratistas',
+   'Construcción · Contratistas',
+   'Tab Contratistas del hub Construcción — catálogo con KPIs (obras en curso/terminadas, MO ejecutado, REPSE, retención). Reemplaza el top-level dilesa.contratistas.'),
+  ('dilesa.construccion.prototipos',
+   'Construcción · Prototipos',
+   'Tab Prototipos del hub Construcción — modelos de vivienda con planos JSONB + plantilla de tareas + costo MO calculado a partir del último precio MO/m² histórico.')
+) AS s(slug, nombre, descripcion)
+WHERE e.slug = 'dilesa'
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+-- Nota: el sub-slug `dilesa.construccion.contratos` ya existe (Sprint 4 —
+-- ver migración 20260525024233_dilesa_construccion_subslugs_captura.sql).
+-- No se reinserta porque ON CONFLICT (empresa_id, slug) DO NOTHING.
+-- Ahora gobierna tanto la captura (form) como la lectura (lista/detalle).
+
+-- ── Backfill defensivo de permisos ─────────────────────────────────────────
+-- Clonar los permisos (acceso_lectura, acceso_escritura) del padre
+-- `dilesa.construccion` a cada uno de los 3 sub-slugs nuevos. Idempotente
+-- vía ON CONFLICT (rol_id, modulo_id) DO NOTHING — si ya se backfilleó
+-- antes, se queda igual. Preserva 100% del status quo: estado pre-PR =
+-- estado post-PR para todos los roles existentes.
+INSERT INTO core.permisos_rol (rol_id, modulo_id, acceso_lectura, acceso_escritura)
+SELECT pr.rol_id, child.id, pr.acceso_lectura, pr.acceso_escritura
+FROM core.permisos_rol pr
+JOIN core.modulos parent
+  ON parent.id = pr.modulo_id
+ AND parent.slug = 'dilesa.construccion'
+JOIN core.modulos child
+  ON child.empresa_id = parent.empresa_id
+ AND child.slug IN (
+   'dilesa.construccion.obras',
+   'dilesa.construccion.contratistas',
+   'dilesa.construccion.prototipos'
+ )
+ON CONFLICT (rol_id, modulo_id) DO NOTHING;
+
+-- ── Deprecar slug top-level `dilesa.contratistas` ──────────────────────────
+-- Ahora vive como sub-slug `dilesa.construccion.contratistas` (clonado
+-- arriba). ON DELETE CASCADE en las FKs hijas limpia las referencias en
+-- core.permisos_rol y core.permisos_usuario_excepcion transitivamente.
+DELETE FROM core.modulos
+WHERE slug = 'dilesa.contratistas'
+  AND empresa_id = (SELECT id FROM core.empresas WHERE slug = 'dilesa');
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260525152711_dilesa_construccion_tabs_hub.sql
+++ b/supabase/migrations/20260525152711_dilesa_construccion_tabs_hub.sql
@@ -23,10 +23,11 @@
 --      a cada uno de los 3 sub-slugs nuevos. Patrón ADR-030 SS3 — sin esto,
 --      agregar los sub-slugs ESCONDE las tabs a no-admin users (canAccessModulo
 --      retorna false para slug ausente en permissions.modulos).
---   3. DELETE el slug top-level `dilesa.contratistas`. ON DELETE CASCADE en
---      core.permisos_rol y core.permisos_usuario_excepcion limpia las
---      referencias transitivamente. El submódulo nuevo
---      `dilesa.construccion.contratistas` toma su lugar.
+--   3. DELETE el slug top-level `dilesa.contratistas`. Como las FKs en
+--      core.permisos_rol y core.permisos_usuario_excepcion **NO tienen**
+--      ON DELETE CASCADE (ver pre_migration_bootstrap.sql), borramos las
+--      filas dependientes explícitamente antes de borrar el módulo. El
+--      submódulo nuevo `dilesa.construccion.contratistas` toma su lugar.
 --
 -- Idempotente: ON CONFLICT DO NOTHING en INSERTs; el DELETE es no-op si ya
 -- corrió (slug ausente). NOTIFY pgrst al final para refrescar la caché.
@@ -80,11 +81,28 @@ ON CONFLICT (rol_id, modulo_id) DO NOTHING;
 
 -- ── Deprecar slug top-level `dilesa.contratistas` ──────────────────────────
 -- Ahora vive como sub-slug `dilesa.construccion.contratistas` (clonado
--- arriba). ON DELETE CASCADE en las FKs hijas limpia las referencias en
--- core.permisos_rol y core.permisos_usuario_excepcion transitivamente.
+-- arriba). Las FKs en core.permisos_rol y core.permisos_usuario_excepcion
+-- NO tienen ON DELETE CASCADE, así que limpiamos las filas dependientes
+-- antes del DELETE del módulo. Idempotente: el WHERE no encuentra nada
+-- si la migración corrió antes (o si el slug nunca existió, como en una
+-- preview branch fresca).
+DELETE FROM core.permisos_rol
+WHERE modulo_id IN (
+  SELECT m.id FROM core.modulos m
+  JOIN core.empresas e ON e.id = m.empresa_id
+  WHERE m.slug = 'dilesa.contratistas' AND e.slug = 'dilesa'
+);
+
+DELETE FROM core.permisos_usuario_excepcion
+WHERE modulo_id IN (
+  SELECT m.id FROM core.modulos m
+  JOIN core.empresas e ON e.id = m.empresa_id
+  WHERE m.slug = 'dilesa.contratistas' AND e.slug = 'dilesa'
+);
+
 DELETE FROM core.modulos
 WHERE slug = 'dilesa.contratistas'
-  AND empresa_id = (SELECT id FROM core.empresas WHERE slug = 'dilesa');
+  AND empresa_id IN (SELECT id FROM core.empresas WHERE slug = 'dilesa');
 
 NOTIFY pgrst, 'reload schema';
 


### PR DESCRIPTION
## Summary

Convierte `/dilesa/construccion` de single-page a hub con 4 routed tabs hermanas (ADR-005 + ADR-030 patrón de sub-slugs por tab — mismo que `rdb.inventario` / `rdb.productos`):

| URL | Tab | Sub-slug |
|-----|-----|----------|
| `/dilesa/construccion` | Obras (default) | `dilesa.construccion.obras` |
| `/dilesa/construccion/contratos` | Contratos (NUEVO) | `dilesa.construccion.contratos` |
| `/dilesa/construccion/contratistas` | Contratistas (movido) | `dilesa.construccion.contratistas` |
| `/dilesa/construccion/prototipos` | Prototipos (NUEVO) | `dilesa.construccion.prototipos` |

### Tab Prototipos — lo más jugoso

- **Lista**: modelos de vivienda (`dilesa.productos`) con KPIs derivados de las obras — último precio MO/m² histórico, total MO calculado, conteo de obras en curso/terminadas.
- **Detalle**:
  1. **Datos generales** — m² construcción, tiempo, costo materiales, último precio MO/m² (con fecha), TOTAL MO calculado.
  2. **Planos** — grid de cards con las 17 keys del JSONB `productos.planos` organizadas por grupo (Arquitectónico / Ejecutivo / Ingeniería). Cada card detecta PDF vs imagen por extensión URL y abre en nueva pestaña.
  3. **Plantilla de tareas** — tabla agrupada por etapa con `costo MO por tarea = porcentaje_costo × precio_mo × m²`, con foot que totaliza. Warning explícito cuando no hay obras con precio histórico.
  4. **KPIs inventario** — conteo por estado.

### Tab Contratos — NUEVO

Lista + detalle de `dilesa.contratos_construccion`. Detalle incluye datos generales, KPIs (MO ejecutado/por ejecutar, avance promedio), y lista de lotes asignados con avance% por obra.

### Tab Contratistas — movido sin perder funcionalidad

`mv app/dilesa/contratistas/ → app/dilesa/construccion/contratistas/` con git rename (preserva historial). Routes internos actualizados. El slug top-level `dilesa.contratistas` se elimina por la migración; el sub-slug nuevo toma su lugar con backfill defensivo de permisos.

### Migración — 1 archivo

`supabase/migrations/20260525152711_dilesa_construccion_tabs_hub.sql`:
- INSERT 3 sub-slugs nuevos (`.obras`, `.contratistas`, `.prototipos`); `.contratos` ya existía desde Sprint 4.
- Backfill defensivo: clona permisos del padre `dilesa.construccion` a los 3 sub-slugs nuevos (ADR-030 SS3).
- DELETE `dilesa.contratistas` (top-level deprecado).
- `NOTIFY pgrst, 'reload schema'`.

Idempotente: ON CONFLICT DO NOTHING en INSERTs, DELETE no-op si ya corrió.

### RBAC sync (4 places)

- **Sidebar** (`components/app-shell/nav-config.ts`): quita entry "Contratistas" top-level. El hub Construcción queda con 1 entry; las tabs viven en el layout.
- **ROUTE_TO_MODULE** (`lib/permissions.ts`): URL default mapea a sub-slug del primer tab (`.obras`) + 3 nuevos sub-slugs.
- **EXPECTED_DB_MODULE_SLUGS** (`lib/permissions.test.ts`): +3 nuevos sub-slugs, -1 deprecado.
- **Migración** (arriba).

### Decisiones de UX

- **Último precio MO/m² del prototipo** se deriva eligiendo la `construccion` más reciente con `precio_mo_x_m2` not null para ese `producto_id` (max fecha_arranque). Si no hay, mostramos "—" y un warning amarillo en la sección de plantilla de tareas explicando que el costo MO depende del primer arranque.
- **Planos** sin preview embed — solo links a URL externa (cada plano es PDF o PNG en un drive externo según la nomenclatura del Coda viejo). Cards con icono según extensión.
- **Foot de tareas** muestra total% + total$ separados de la suma estricta para que el operador vea si los porcentajes del prototipo cierran ~100%.
- **Compat de URL viejas** intencionalmente NO se agregó (el Coda original no las tenía como bookmark, ni hay tráfico externo). Si emerge, redirects son trivial follow-up.

## Test plan

- [ ] Beto: aplicar `supabase/migrations/20260525152711_dilesa_construccion_tabs_hub.sql` en prod vía `supabase db push`.
- [ ] CC: tras db push, regenerar `supabase/SCHEMA_REF.md` y `types/supabase.ts` (`npm run schema:ref && npm run db:types`).
- [ ] Verificación manual en preview:
  - [ ] Sidebar muestra Construcción una sola vez (sin "Contratistas" top-level).
  - [ ] `/dilesa/construccion` carga con las 4 tabs visibles (rol admin) y el tab Obras activo.
  - [ ] `/dilesa/construccion/contratos` lista y permite click → detalle con lotes.
  - [ ] `/dilesa/construccion/contratistas` lista y permite click → detalle con back-link al hub.
  - [ ] `/dilesa/construccion/prototipos` lista 14 prototipos × ~5 proyectos; click muestra planos + plantilla.
  - [ ] Plantilla de tareas muestra costo MO calculado en al menos 1 prototipo con histórico de obras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)