### PR TITLE
feat(dilesa): ventas como hub con 5 tabs + Inventario/Fases/Clientes/Vendedores

### DIFF
--- a/app/dilesa/inventario/page.tsx
+++ b/app/dilesa/inventario/page.tsx
@@ -1,28 +1,17 @@
-'use client';
-
-import { RequireAccess } from '@/components/require-access';
-import { DesktopOnlyNotice } from '@/components/responsive';
-import { InventarioModule } from '@/components/dilesa/inventario-module';
-import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { redirect } from 'next/navigation';
 
 /**
- * @module Inventario (DILESA)
- * @responsive desktop-only
+ * Redirect de compatibilidad: el módulo Inventario fue movido a
+ * `/dilesa/ventas/inventario` cuando Ventas se convirtió en hub (sprint
+ * tabs-hub). Cualquier URL vieja (bookmarks, links externos, etc.) cae
+ * acá y se redirige a la nueva ubicación.
  *
- * Vista comercial complementaria a Portafolio:
- * - Portafolio = patrimonio (todos los activos, incluido vendido).
- * - Inventario = unidades disponibles HOY para asignar a un cliente.
- *
- * Lectura pura — al hacer click "Asignar a cliente" navega al form de
- * Solicitud de Asignación con la unidad preseleccionada.
+ * Mantener mientras haya tráfico — borrar cuando ya no haya bookmarks
+ * apuntando aquí. El slug top-level `dilesa.inventario` se elimina en la
+ * migración 20260525112633_dilesa_ventas_tabs_hub.sql, así que el RBAC
+ * ya no aplica acá; el sub-slug `dilesa.ventas.inventario` gobierna en
+ * la página destino.
  */
-export default function Page() {
-  return (
-    <RequireAccess empresa="dilesa" modulo="dilesa.inventario">
-      <DesktopOnlyNotice module="Inventario" />
-      <div className="hidden sm:block">
-        <InventarioModule empresaId={DILESA_EMPRESA_ID} />
-      </div>
-    </RequireAccess>
-  );
+export default function DilesaInventarioRedirectPage() {
+  redirect('/dilesa/ventas/inventario');
 }

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -218,10 +218,14 @@ function fmtFecha(s: string | null): string | null {
 /**
  * @module Venta detail (DILESA)
  * @responsive desktop-only
+ *
+ * Gate: sub-slug `dilesa.ventas.lista` post-refactor a hub (sprint
+ * tabs-hub). El detalle es parte del dominio de la tab "Ventas" — quien
+ * puede ver la lista puede entrar al detalle.
  */
 export default function VentaDetailPage() {
   return (
-    <RequireAccess empresa="dilesa" modulo="dilesa.ventas">
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.lista">
       <DetailInner />
     </RequireAccess>
   );

--- a/app/dilesa/ventas/clientes/[id]/page.tsx
+++ b/app/dilesa/ventas/clientes/[id]/page.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de detalle DILESA
+ * (cf. app/dilesa/ventas/[id]/page.tsx).
+ */
+
+/**
+ * @module Cliente detail (DILESA)
+ * @responsive desktop-only
+ *
+ * Detalle de un cliente del hub Ventas (sprint tabs-hub). Lista compacta
+ * de sus ventas con KPIs en el header (# ventas, monto total, # activas).
+ * Cada venta linkea a su detalle (`/dilesa/ventas/[id]`).
+ *
+ * Gate: sub-slug `dilesa.ventas.clientes` (ADR-030 SS5).
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Persona = {
+  nombre: string | null;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
+  email: string | null;
+  telefono: string | null;
+  curp: string | null;
+  rfc: string | null;
+};
+
+type Venta = {
+  id: string;
+  unidad_id: string | null;
+  estado: string;
+  fase_actual: string | null;
+  fase_posicion: number | null;
+  precio_asignacion: number | null;
+  valor_escrituracion: number | null;
+  valor_comercial: number | null;
+  vendedor: string | null;
+  created_at: string;
+};
+
+type Unidad = {
+  id: string;
+  identificador: string;
+  proyecto_id: string | null;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+export default function ClienteDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.clientes">
+      <ClienteDetailBody />
+    </RequireAccess>
+  );
+}
+
+function ClienteDetailBody() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [persona, setPersona] = useState<Persona | null>(null);
+  const [ventas, setVentas] = useState<Venta[]>([]);
+  const [unidadInfo, setUnidadInfo] = useState<Map<string, Unidad>>(new Map());
+  const [proyectoNombre, setProyectoNombre] = useState<Map<string, string>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let activo = true;
+    const sb = createSupabaseBrowserClient();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      const [pRes, vRes] = await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno, email, telefono, curp, rfc')
+          .eq('id', id)
+          .maybeSingle(),
+        sb
+          .schema('dilesa')
+          .from('ventas')
+          .select(
+            'id, unidad_id, estado, fase_actual, fase_posicion, precio_asignacion, valor_escrituracion, valor_comercial, vendedor, created_at'
+          )
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .eq('persona_id', id)
+          .is('deleted_at', null)
+          .order('created_at', { ascending: false }),
+      ]);
+      if (!activo) return;
+      const firstErr = pRes.error ?? vRes.error;
+      if (firstErr) {
+        setError(getSupabaseErrorMessage(firstErr, 'No se pudo cargar el cliente.'));
+        setLoading(false);
+        return;
+      }
+      setPersona((pRes.data as unknown as Persona) ?? null);
+      const ventasArr = (vRes.data ?? []) as Venta[];
+      setVentas(ventasArr);
+
+      // Cargar unidades + proyectos para nombres legibles.
+      const unidadIds = [
+        ...new Set(ventasArr.map((v) => v.unidad_id).filter((x): x is string => !!x)),
+      ];
+      if (unidadIds.length > 0) {
+        const { data: uns, error: uErr } = await sb
+          .schema('dilesa')
+          .from('unidades')
+          .select('id, identificador, proyecto_id')
+          .in('id', unidadIds);
+        if (!activo) return;
+        if (uErr) {
+          // No bloqueamos — KPIs siguen sin nombres
+          console.warn('No se pudieron cargar unidades:', uErr.message);
+        } else {
+          const uMap = new Map<string, Unidad>();
+          for (const u of (uns ?? []) as Unidad[]) uMap.set(u.id, u);
+          setUnidadInfo(uMap);
+
+          const proyectoIds = [
+            ...new Set((uns ?? []).map((u) => u.proyecto_id).filter((x): x is string => !!x)),
+          ];
+          if (proyectoIds.length > 0) {
+            const { data: prjs } = await sb
+              .schema('dilesa')
+              .from('proyectos')
+              .select('id, nombre')
+              .in('id', proyectoIds);
+            if (!activo) return;
+            const pMap = new Map<string, string>();
+            for (const p of (prjs ?? []) as Array<{ id: string; nombre: string }>) {
+              pMap.set(p.id, p.nombre);
+            }
+            setProyectoNombre(pMap);
+          }
+        }
+      }
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [id]);
+
+  const nombreCliente = useMemo(() => {
+    if (!persona) return '';
+    return (
+      [persona.nombre, persona.apellido_paterno, persona.apellido_materno]
+        .filter(Boolean)
+        .join(' ') || '(sin nombre)'
+    );
+  }, [persona]);
+
+  const montoTotal = useMemo(
+    () =>
+      ventas.reduce(
+        (s, v) => s + (v.valor_escrituracion ?? v.precio_asignacion ?? v.valor_comercial ?? 0),
+        0
+      ),
+    [ventas]
+  );
+  const numActivas = useMemo(() => ventas.filter((v) => v.estado === 'activa').length, [ventas]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-5xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !persona) {
+    return (
+      <div className="container mx-auto max-w-5xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Cliente no encontrado.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-5xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">
+            {nombreCliente}
+          </h1>
+          <p className="mt-1 text-sm text-[var(--text)]/60">
+            {[persona.email, persona.telefono, persona.curp, persona.rfc]
+              .filter(Boolean)
+              .join(' · ') || 'Sin datos de contacto.'}
+          </p>
+        </div>
+      </header>
+
+      <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Kpi label="# Ventas" value={ventas.length} />
+        <Kpi label="# Activas" value={numActivas} />
+        <Kpi label="Monto total" value={moneyFmt.format(montoTotal)} />
+      </section>
+
+      <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+        <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          Timeline de ventas
+        </h2>
+        {ventas.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">Sin ventas registradas.</p>
+        ) : (
+          <ol className="space-y-2">
+            {ventas.map((v) => {
+              const u = v.unidad_id ? unidadInfo.get(v.unidad_id) : null;
+              const proyecto = u?.proyecto_id ? proyectoNombre.get(u.proyecto_id) : null;
+              const monto = v.valor_escrituracion ?? v.precio_asignacion ?? v.valor_comercial ?? 0;
+              return (
+                <li key={v.id}>
+                  <Link
+                    href={`/dilesa/ventas/${v.id}`}
+                    className="flex flex-wrap items-baseline justify-between gap-2 rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-3 py-2 text-sm hover:border-[var(--accent)] hover:bg-[var(--bg)]/60"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-[var(--text)]">
+                        {proyecto ?? '—'} {u ? `· ${u.identificador}` : ''}
+                      </div>
+                      <div className="text-[11px] text-[var(--text)]/60">
+                        {new Date(v.created_at).toLocaleDateString('es-MX', {
+                          day: '2-digit',
+                          month: 'short',
+                          year: 'numeric',
+                        })}
+                        {v.vendedor ? ` · vendedor ${v.vendedor}` : ''}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {v.fase_actual ? (
+                        <Badge tone="neutral">
+                          {v.fase_posicion ? `${v.fase_posicion}. ` : ''}
+                          {v.fase_actual}
+                        </Badge>
+                      ) : null}
+                      <Badge tone={v.estado === 'activa' ? 'info' : 'neutral'}>
+                        {v.estado === 'activa' ? 'Activa' : v.estado}
+                      </Badge>
+                      <span className="tabular-nums text-sm font-medium text-[var(--text)]">
+                        {moneyFmt.format(monto)}
+                      </span>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/dilesa/ventas/clientes"
+      className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+    >
+      <ArrowLeft className="size-4" /> Volver a clientes
+    </Link>
+  );
+}
+
+function Kpi({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-4 py-3">
+      <div className="text-xs font-medium uppercase tracking-wider text-[var(--text)]/50">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums text-[var(--text)]">{value}</div>
+    </div>
+  );
+}

--- a/app/dilesa/ventas/clientes/page.tsx
+++ b/app/dilesa/ventas/clientes/page.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de lectura DILESA
+ * (cf. app/dilesa/ventas/[id]/page.tsx, components/dilesa/construccion-module.tsx).
+ */
+
+/**
+ * @module Ventas · Clientes (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Clientes" del hub Ventas (sprint tabs-hub). Lista de personas con
+ * ≥1 venta DILESA con KPIs derivados de la actividad comercial:
+ * # ventas, monto total comprado, fecha de última venta, proyectos donde
+ * compró. Click en una fila → `/dilesa/ventas/clientes/[id]` con timeline.
+ *
+ * Estrategia de carga (cross-schema):
+ *   1) `dilesa.ventas` (no-deleted) — agrupar en cliente por persona_id.
+ *   2) `dilesa.unidades` (.eq empresa) — para resolver proyecto_id por venta.
+ *   3) `dilesa.proyectos` (.eq empresa) — para resolver nombre.
+ *   4) `erp.personas` (.eq empresa + tipo='cliente') — para resolver nombre
+ *      y datos básicos. Usa `.eq(empresa_id)` en lugar de `.in('id', uuids[])`
+ *      para evitar el URL > 8KB que Cloudflare rechaza con HTTP 400
+ *      cuando hay > ~200 ids (ver memoria `supabase_in_url_limit`).
+ *
+ * Gate: sub-slug `dilesa.ventas.clientes` (ADR-030 SS5).
+ */
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshCw, Search, Users } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, type Column } from '@/components/module-page';
+import { Input } from '@/components/ui/input';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Venta = {
+  id: string;
+  persona_id: string;
+  unidad_id: string | null;
+  estado: string;
+  fase_actual: string | null;
+  fase_posicion: number | null;
+  precio_asignacion: number | null;
+  valor_escrituracion: number | null;
+  valor_comercial: number | null;
+  created_at: string;
+};
+
+type Persona = {
+  id: string;
+  nombre: string | null;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
+  email: string | null;
+  telefono: string | null;
+};
+
+type ClienteRow = {
+  id: string;
+  nombre: string;
+  email: string | null;
+  telefono: string | null;
+  numVentas: number;
+  numActivas: number;
+  montoTotal: number;
+  ultimaVenta: string | null;
+  ultimaFase: string | null;
+  proyectos: string;
+};
+
+export default function VentasClientesPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.clientes">
+      <VentasClientesBody />
+    </RequireAccess>
+  );
+}
+
+function VentasClientesBody() {
+  const router = useRouter();
+  const [clientes, setClientes] = useState<ClienteRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [proyectoFiltro, setProyectoFiltro] = useState('');
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const sb = createSupabaseBrowserClient();
+
+    const [ventasRes, unidadesRes, prjRes, personasRes] = await Promise.all([
+      sb
+        .schema('dilesa')
+        .from('ventas')
+        .select(
+          'id, persona_id, unidad_id, estado, fase_actual, fase_posicion, precio_asignacion, valor_escrituracion, valor_comercial, created_at'
+        )
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('unidades')
+        .select('id, proyecto_id')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, nombre')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null),
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno, email, telefono')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .eq('tipo', 'cliente')
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr = ventasRes.error ?? unidadesRes.error ?? prjRes.error ?? personasRes.error;
+    if (firstErr) {
+      setError(getSupabaseErrorMessage(firstErr, 'No se pudieron cargar los clientes.'));
+      setLoading(false);
+      return;
+    }
+
+    const ventasArr = (ventasRes.data ?? []) as Venta[];
+    const unidadProyecto = new Map<string, string | null>();
+    for (const u of (unidadesRes.data ?? []) as Array<{ id: string; proyecto_id: string | null }>) {
+      unidadProyecto.set(u.id, u.proyecto_id);
+    }
+    const proyectoNombre = new Map<string, string>();
+    for (const p of (prjRes.data ?? []) as Array<{ id: string; nombre: string }>) {
+      proyectoNombre.set(p.id, p.nombre);
+    }
+    const personaMap = new Map<string, Persona>();
+    for (const p of (personasRes.data ?? []) as Persona[]) personaMap.set(p.id, p);
+
+    // Agrupar ventas por persona_id
+    const byPersona = new Map<string, Venta[]>();
+    for (const v of ventasArr) {
+      const arr = byPersona.get(v.persona_id) ?? [];
+      arr.push(v);
+      byPersona.set(v.persona_id, arr);
+    }
+
+    const rows: ClienteRow[] = [];
+    for (const [personaId, ventas] of byPersona.entries()) {
+      const p = personaMap.get(personaId);
+      const nombre =
+        [p?.nombre, p?.apellido_paterno, p?.apellido_materno].filter(Boolean).join(' ') ||
+        '(sin nombre)';
+      const montoTotal = ventas.reduce(
+        (s, v) => s + (v.valor_escrituracion ?? v.precio_asignacion ?? v.valor_comercial ?? 0),
+        0
+      );
+      // Ordenar ventas por created_at DESC para tomar la última
+      const sorted = [...ventas].sort((a, b) => (a.created_at > b.created_at ? -1 : 1));
+      const ultima = sorted[0];
+      const proyectos = new Set<string>();
+      for (const v of ventas) {
+        if (!v.unidad_id) continue;
+        const pid = unidadProyecto.get(v.unidad_id);
+        if (pid) {
+          const nom = proyectoNombre.get(pid);
+          if (nom) proyectos.add(nom);
+        }
+      }
+      const proyectosArr = [...proyectos].sort();
+      rows.push({
+        id: personaId,
+        nombre,
+        email: p?.email ?? null,
+        telefono: p?.telefono ?? null,
+        numVentas: ventas.length,
+        numActivas: ventas.filter((v) => v.estado === 'activa').length,
+        montoTotal,
+        ultimaVenta: ultima?.created_at ?? null,
+        ultimaFase: ultima?.fase_actual ?? null,
+        proyectos: proyectosArr.join(', '),
+      });
+    }
+    rows.sort((a, b) => a.nombre.localeCompare(b.nombre));
+    setClientes(rows);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void cargar();
+  }, [cargar]);
+
+  const proyectosPresentes = useMemo(() => {
+    const set = new Set<string>();
+    for (const c of clientes) {
+      if (!c.proyectos) continue;
+      for (const p of c.proyectos.split(', ')) set.add(p);
+    }
+    return [...set].sort();
+  }, [clientes]);
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return clientes.filter((c) => {
+      if (proyectoFiltro && !c.proyectos.split(', ').includes(proyectoFiltro)) return false;
+      if (q && !c.nombre.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [clientes, search, proyectoFiltro]);
+
+  const columns: Column<ClienteRow>[] = [
+    {
+      key: 'nombre',
+      label: 'Cliente',
+      type: 'text',
+      sticky: true,
+      width: 'min-w-[260px]',
+      render: (c) => (
+        <div>
+          <div className="text-sm text-[var(--text)]">{c.nombre}</div>
+          {c.email || c.telefono ? (
+            <div className="text-[11px] text-[var(--text)]/50">
+              {c.email ?? ''}
+              {c.email && c.telefono ? ' · ' : ''}
+              {c.telefono ?? ''}
+            </div>
+          ) : null}
+        </div>
+      ),
+    },
+    { key: 'numVentas', label: '# ventas', type: 'number' },
+    { key: 'numActivas', label: '# activas', type: 'number' },
+    { key: 'montoTotal', label: 'Monto total', type: 'currency' },
+    {
+      key: 'ultimaVenta',
+      label: 'Última venta',
+      type: 'custom',
+      accessor: (c) => c.ultimaVenta ?? '',
+      render: (c) =>
+        c.ultimaVenta ? (
+          <span className="text-xs text-[var(--text)]/70">
+            {new Date(c.ultimaVenta).toLocaleDateString('es-MX', {
+              day: '2-digit',
+              month: 'short',
+              year: 'numeric',
+            })}
+          </span>
+        ) : (
+          '—'
+        ),
+    },
+    {
+      key: 'ultimaFase',
+      label: 'Última fase',
+      type: 'text',
+      render: (c) => c.ultimaFase ?? '—',
+    },
+    {
+      key: 'proyectos',
+      label: 'Proyectos',
+      type: 'text',
+      render: (c) => c.proyectos || '—',
+    },
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <Users className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Clientes</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Personas con al menos una venta DILESA. KPIs derivados de las ventas: # ventas, monto
+            total comprado, última venta y proyectos en los que compró.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar cliente…"
+            className="w-64 pl-9"
+          />
+        </div>
+        <select
+          value={proyectoFiltro}
+          onChange={(e) => setProyectoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los proyectos</option>
+          {proyectosPresentes.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {filtrados.length} de {clientes.length} clientes
+        </span>
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={(c) => router.push(`/dilesa/ventas/clientes/${c.id}`)}
+        initialSort={{ key: 'nombre', dir: 'asc' }}
+        emptyTitle="Sin clientes"
+        emptyDescription="Aún no hay personas con ventas en DILESA."
+        emptyIcon={<Users className="h-6 w-6" />}
+        maxHeight="calc(100vh - 280px)"
+      />
+
+      <p className="text-[11px] text-[var(--text)]/40">
+        Tip: hacé click en una fila para ver el detalle del cliente con timeline de sus ventas.
+      </p>
+      {/* Anchor sin-uso para futura nav UI */}
+      <Link href="/dilesa/ventas" className="hidden">
+        ir a ventas
+      </Link>
+    </div>
+  );
+}

--- a/app/dilesa/ventas/fases/page.tsx
+++ b/app/dilesa/ventas/fases/page.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de lectura DILESA
+ * (cf. app/dilesa/ventas/[id]/page.tsx, components/dilesa/construccion-module.tsx).
+ */
+
+/**
+ * @module Ventas · Fases (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Fases" del hub Ventas (sprint tabs-hub) — vista pipeline global
+ * de las 17 fases del proceso de comercialización DILESA. Cada fase se
+ * muestra como una card con el conteo de ventas activas que están "en"
+ * esa fase (definida por `dilesa.ventas.fase_actual` denormalizado).
+ *
+ * Click en una card filtra hacia la lista de ventas en esa fase
+ * (`/dilesa/ventas?fase=<nombre>`) — la lista del tab Ventas no consume
+ * el query param hoy pero la URL queda como deep link futuro; mientras
+ * tanto manda al usuario al tab Ventas con scroll natural a la lista.
+ *
+ * Filtros: proyecto, vendedor, mes. Filtran las ventas que se cuentan
+ * en cada fase. Los catálogos (las 17 fases) se cargan desde
+ * `dilesa.venta_fase_catalogo` (single source of truth — viene del Coda
+ * original).
+ *
+ * Gate: sub-slug `dilesa.ventas.fases` (ADR-030 SS5).
+ */
+
+import Link from 'next/link';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronRight, GitBranch, RefreshCw } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { useUrlFilters } from '@/hooks/use-url-filters';
+
+type Fase = {
+  posicion: number;
+  nombre: string;
+  rol: string | null;
+};
+
+type Venta = {
+  id: string;
+  fase_actual: string | null;
+  fase_posicion: number | null;
+  estado: string;
+  vendedor: string | null;
+  vendedor_usuario_id: string | null;
+  unidad_id: string | null;
+  created_at: string;
+};
+
+type Unidad = {
+  id: string;
+  proyecto_id: string | null;
+};
+
+const DEFAULT_FILTERS = {
+  proyecto: '',
+  vendedor: '',
+  mes: '',
+};
+
+export default function VentasFasesPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.fases">
+      <Suspense fallback={<FasesSkeleton />}>
+        <VentasFasesBody />
+      </Suspense>
+    </RequireAccess>
+  );
+}
+
+function VentasFasesBody() {
+  const { filters, setFilter, clearAll, activeCount } = useUrlFilters(DEFAULT_FILTERS);
+
+  const [fases, setFases] = useState<Fase[]>([]);
+  const [ventas, setVentas] = useState<Venta[]>([]);
+  const [unidadProyecto, setUnidadProyecto] = useState<Map<string, string>>(new Map());
+  const [proyectos, setProyectos] = useState<Array<{ id: string; nombre: string }>>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const sb = createSupabaseBrowserClient();
+
+    const [fasesRes, ventasRes, unidadesRes, prjRes] = await Promise.all([
+      sb
+        .schema('dilesa')
+        .from('venta_fase_catalogo')
+        .select('posicion, nombre, rol')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null)
+        .order('posicion', { ascending: true }),
+      sb
+        .schema('dilesa')
+        .from('ventas')
+        .select(
+          'id, fase_actual, fase_posicion, estado, vendedor, vendedor_usuario_id, unidad_id, created_at'
+        )
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('unidades')
+        .select('id, proyecto_id')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, nombre')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null)
+        .order('nombre', { ascending: true }),
+    ]);
+
+    const firstErr = fasesRes.error ?? ventasRes.error ?? unidadesRes.error ?? prjRes.error;
+    if (firstErr) {
+      setError(getSupabaseErrorMessage(firstErr, 'No se pudieron cargar las fases.'));
+      setLoading(false);
+      return;
+    }
+
+    setFases((fasesRes.data ?? []) as Fase[]);
+    setVentas((ventasRes.data ?? []) as Venta[]);
+    const m = new Map<string, string>();
+    for (const u of (unidadesRes.data ?? []) as Unidad[]) {
+      if (u.proyecto_id) m.set(u.id, u.proyecto_id);
+    }
+    setUnidadProyecto(m);
+    setProyectos((prjRes.data ?? []) as Array<{ id: string; nombre: string }>);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void cargar();
+  }, [cargar]);
+
+  // Vendedores únicos (de vendedor texto + usuario_id) para el filtro.
+  // El campo `vendedor` (texto legacy) es lo único user-friendly que
+  // podemos mostrar — usuario_id se omite del selector.
+  const vendedoresUnicos = useMemo(() => {
+    const set = new Set<string>();
+    for (const v of ventas) {
+      if (v.vendedor && v.vendedor.trim()) set.add(v.vendedor.trim());
+    }
+    return [...set].sort();
+  }, [ventas]);
+
+  // Filtrado de ventas según filtros.
+  const ventasFiltradas = useMemo(() => {
+    return ventas.filter((v) => {
+      // Filtro proyecto: vía unidad → proyecto_id
+      if (filters.proyecto) {
+        if (!v.unidad_id) return false;
+        const pid = unidadProyecto.get(v.unidad_id);
+        if (pid !== filters.proyecto) return false;
+      }
+      // Filtro vendedor: solo por campo texto (`vendedor`)
+      if (filters.vendedor) {
+        if (v.vendedor !== filters.vendedor) return false;
+      }
+      // Filtro mes: YYYY-MM contra created_at
+      if (filters.mes) {
+        const m = v.created_at.slice(0, 7); // ISO → 'YYYY-MM'
+        if (m !== filters.mes) return false;
+      }
+      return true;
+    });
+  }, [ventas, filters, unidadProyecto]);
+
+  // Conteo de ventas por nombre de fase. Solo cuenta ventas activas.
+  const conteoPorFase = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const v of ventasFiltradas) {
+      if (v.estado !== 'activa') continue;
+      const key = v.fase_actual ?? '__sin_fase__';
+      m.set(key, (m.get(key) ?? 0) + 1);
+    }
+    return m;
+  }, [ventasFiltradas]);
+
+  const totalActivas = useMemo(
+    () => [...conteoPorFase.values()].reduce((s, n) => s + n, 0),
+    [conteoPorFase]
+  );
+
+  // Meses únicos (YYYY-MM) presentes en las ventas — para el filtro
+  const mesesPresentes = useMemo(() => {
+    const s = new Set<string>();
+    for (const v of ventas) s.add(v.created_at.slice(0, 7));
+    return [...s].sort().reverse();
+  }, [ventas]);
+
+  if (loading) return <FasesSkeleton />;
+
+  if (error) {
+    return (
+      <div className="container mx-auto max-w-7xl space-y-4 px-4 py-6">
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error}
+        </div>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Reintentar
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-7xl space-y-6 px-4 py-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <GitBranch className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Fases</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Pipeline global — las 17 fases del proceso de comercialización DILESA. Click en una fase
+            para ver las ventas correspondientes.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <select
+          value={filters.proyecto}
+          onChange={(e) => setFilter('proyecto', e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los proyectos</option>
+          {proyectos.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.nombre}
+            </option>
+          ))}
+        </select>
+        <select
+          value={filters.vendedor}
+          onChange={(e) => setFilter('vendedor', e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los vendedores</option>
+          {vendedoresUnicos.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+        <select
+          value={filters.mes}
+          onChange={(e) => setFilter('mes', e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Cualquier mes (creación)</option>
+          {mesesPresentes.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        {activeCount > 0 ? (
+          <button
+            type="button"
+            onClick={() => clearAll()}
+            className="text-xs text-[var(--text)]/60 underline hover:text-[var(--text)]"
+          >
+            Limpiar filtros
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {totalActivas} ventas activas en pipeline
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        {fases.map((f) => {
+          const cuenta = conteoPorFase.get(f.nombre) ?? 0;
+          return <FaseCard key={f.posicion} fase={f} cuenta={cuenta} />;
+        })}
+      </div>
+
+      {(conteoPorFase.get('__sin_fase__') ?? 0) > 0 ? (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-xs text-amber-700 dark:text-amber-300">
+          {conteoPorFase.get('__sin_fase__')} venta(s) sin fase asignada (debug: revisar
+          `dilesa.ventas.fase_actual`).
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FaseCard({ fase, cuenta }: { fase: Fase; cuenta: number }) {
+  const href = `/dilesa/ventas?fase=${encodeURIComponent(fase.nombre)}`;
+  return (
+    <Link
+      href={href}
+      className="group flex flex-col rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 transition hover:border-[var(--accent)] hover:shadow-sm"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="font-mono text-xs text-[var(--text)]/40">
+          {String(fase.posicion).padStart(2, '0')}
+        </span>
+        <ChevronRight className="h-3.5 w-3.5 text-[var(--text)]/30 transition group-hover:text-[var(--accent)]" />
+      </div>
+      <div className="mt-1 text-sm font-semibold leading-tight text-[var(--text)]">
+        {fase.nombre}
+      </div>
+      {fase.rol ? (
+        <div className="mt-1 text-[11px] text-[var(--text)]/50">
+          Resp.: <span className="text-[var(--text)]/70">{fase.rol}</span>
+        </div>
+      ) : null}
+      <div className="mt-3 flex items-baseline justify-between">
+        <span className="text-[10px] uppercase tracking-wide text-[var(--text)]/40">
+          Ventas activas
+        </span>
+        <Badge tone={cuenta > 0 ? 'info' : 'neutral'}>{cuenta}</Badge>
+      </div>
+    </Link>
+  );
+}
+
+function FasesSkeleton() {
+  return (
+    <div className="container mx-auto max-w-7xl space-y-6 px-4 py-6">
+      <Skeleton className="h-12 w-64" />
+      <Skeleton className="h-9 w-full" />
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        {Array.from({ length: 17 }).map((_, i) => (
+          <Skeleton key={i} className="h-32 w-full rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/dilesa/ventas/inventario/page.tsx
+++ b/app/dilesa/ventas/inventario/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { InventarioModule } from '@/components/dilesa/inventario-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Ventas · Inventario (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Inventario" del hub Ventas (sprint tabs-hub). Movido desde el
+ * top-level `/dilesa/inventario` — el slug top-level `dilesa.inventario`
+ * se elimina en la migración 20260525112633_dilesa_ventas_tabs_hub.sql
+ * y el sub-slug `dilesa.ventas.inventario` toma su lugar (con backfill
+ * defensivo de permisos clonados desde el padre `dilesa.ventas`).
+ *
+ * Vista comercial complementaria a Portafolio:
+ * - Portafolio = patrimonio (todos los activos, incluido vendido).
+ * - Inventario = unidades disponibles HOY para asignar a un cliente.
+ *
+ * Lectura pura — al hacer click "Asignar a cliente" navega al form de
+ * Solicitud de Asignación con la unidad preseleccionada.
+ *
+ * Gate: sub-slug `dilesa.ventas.inventario` (ADR-030 SS5).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.inventario">
+      <DesktopOnlyNotice module="Inventario" />
+      <div className="hidden sm:block">
+        <InventarioModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/ventas/layout.tsx
+++ b/app/dilesa/ventas/layout.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { RoutedModuleTabs } from '@/components/module-page';
+
+/**
+ * Layout compartido del hub Ventas (DILESA).
+ *
+ * Implementa el patrón "module with submodules / routed tabs" descrito en
+ * ADR-005 (`docs/adr/005_module_with_submodules_routed_tabs.md`) con el
+ * mecanismo de sub-slugs por tab de ADR-030
+ * (`docs/adr/030_submodule_permissions.md`):
+ *
+ *   /dilesa/ventas              → tab "Ventas"      (default landing).
+ *   /dilesa/ventas/inventario   → tab "Inventario"  (movido desde top-level).
+ *   /dilesa/ventas/fases        → tab "Fases".
+ *   /dilesa/ventas/clientes     → tab "Clientes".
+ *   /dilesa/ventas/vendedores   → tab "Vendedores".
+ *
+ * Cada `module` en el TABS array es un sub-slug que `<RoutedModuleTabs>`
+ * filtra automáticamente — tabs sin permiso quedan ocultas. Los gates de
+ * acceso viven en cada sub-page (ADR-030 SS5), no en el layout — así el
+ * AccessDenied de cada page muestra el sub-slug específico faltante en
+ * vez del padre.
+ *
+ * --- Por qué se ocultan las tabs en sub-rutas profundas ---
+ *
+ * El strip de tabs NO se renderiza en sub-páginas que tienen su propia
+ * vista detallada (back-link incluido), porque agregar tabs ahí seria
+ * confuso (el contexto visual ya cambió a "detalle de X"):
+ *
+ *   - /dilesa/ventas/[id]                       (detalle de venta)
+ *   - /dilesa/ventas/nueva                       (form Fase 1)
+ *   - /dilesa/ventas/[id]/capturar/*             (forms de captura por fase)
+ *   - /dilesa/ventas/clientes/[id]               (detalle de cliente)
+ *   - /dilesa/ventas/vendedores/[id]             (detalle de vendedor)
+ *
+ * Las tabs sí se muestran en las 5 URLs canónicas de cada tab + cualquier
+ * otra sub-ruta directa de la tab (sin un siguiente segmento).
+ *
+ * Construcción/layout.tsx no hace este filtrado porque sus detalles
+ * (`/dilesa/construccion/[id]`) son menos invasivos; aquí ya tenemos un
+ * detalle de venta con header propio (back-link, badges, secciones) que
+ * compite visualmente con un strip extra de tabs.
+ */
+const TABS = [
+  {
+    label: 'Ventas',
+    href: '/dilesa/ventas',
+    exact: true,
+    module: 'dilesa.ventas.lista',
+  },
+  {
+    label: 'Inventario',
+    href: '/dilesa/ventas/inventario',
+    module: 'dilesa.ventas.inventario',
+  },
+  {
+    label: 'Fases',
+    href: '/dilesa/ventas/fases',
+    module: 'dilesa.ventas.fases',
+  },
+  {
+    label: 'Clientes',
+    href: '/dilesa/ventas/clientes',
+    module: 'dilesa.ventas.clientes',
+  },
+  {
+    label: 'Vendedores',
+    href: '/dilesa/ventas/vendedores',
+    module: 'dilesa.ventas.vendedores',
+  },
+] as const;
+
+/**
+ * Hrefs que sí muestran tabs (las 5 URLs canónicas de cada tab).
+ */
+const TAB_HREFS: ReadonlySet<string> = new Set(TABS.map((t) => t.href));
+
+/**
+ * Resuelve si la ruta actual debe mostrar el strip de tabs.
+ * - Las 5 URLs canónicas: SI.
+ * - Sub-paths inmediatos de Clientes/Vendedores que son listados
+ *   (segmento extra que no es UUID) — improbable, pero seguro mostrarlos.
+ * - Cualquier otro sub-path: NO (detalle de venta, forms, etc.).
+ */
+function shouldShowTabs(pathname: string): boolean {
+  // Match exacto con cualquiera de las URLs canónicas.
+  if (TAB_HREFS.has(pathname)) return true;
+  // No mostrar en detalles ni forms — son sub-rutas con su propia vista.
+  return false;
+}
+
+export default function VentasLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const showTabs = shouldShowTabs(pathname);
+
+  return (
+    <>
+      {showTabs ? (
+        <div className="px-4 pt-4 sm:px-6 sm:pt-6">
+          <RoutedModuleTabs tabs={TABS} />
+        </div>
+      ) : null}
+      {children}
+    </>
+  );
+}

--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -239,7 +239,7 @@ function NuevaSolicitudForm() {
     void loadMeta();
   }, [loadMeta]);
 
-  // Pre-selección desde `?unidad=<id>` (deep link desde /dilesa/inventario).
+  // Pre-selección desde `?unidad=<id>` (deep link desde /dilesa/ventas/inventario).
   // Espera a que las unidades estén cargadas para resolver el proyecto.
   useEffect(() => {
     const preselectId = searchParams.get('unidad');

--- a/app/dilesa/ventas/page.tsx
+++ b/app/dilesa/ventas/page.tsx
@@ -6,12 +6,22 @@ import { VentasModule } from '@/components/dilesa/ventas-module';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
 /**
- * @module Ventas (DILESA)
+ * @module Ventas · Lista (DILESA)
  * @responsive desktop-only
+ *
+ * Default landing del hub Ventas (sprint tabs-hub). Lista filtrable de las
+ * ventas DILESA con comprador (cross-schema `erp.personas`), proyecto/unidad,
+ * fase actual, precio y vendedor. Click en una fila navega a
+ * `/dilesa/ventas/[id]` con la ficha completa, pipeline (de `venta_fases`),
+ * pagos y expediente digital.
+ *
+ * Gate: sub-slug `dilesa.ventas.lista` (ADR-030 SS5). El padre
+ * `dilesa.ventas` queda como umbrella; el sub-slug gobierna el contenido
+ * real de esta tab.
  */
 export default function Page() {
   return (
-    <RequireAccess empresa="dilesa" modulo="dilesa.ventas">
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.lista">
       <DesktopOnlyNotice module="Ventas" />
       <div className="hidden sm:block">
         <VentasModule empresaId={DILESA_EMPRESA_ID} />

--- a/app/dilesa/ventas/page.tsx
+++ b/app/dilesa/ventas/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import { RequireAccess } from '@/components/require-access';
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { VentasModule } from '@/components/dilesa/ventas-module';
@@ -24,7 +25,11 @@ export default function Page() {
     <RequireAccess empresa="dilesa" modulo="dilesa.ventas.lista">
       <DesktopOnlyNotice module="Ventas" />
       <div className="hidden sm:block">
-        <VentasModule empresaId={DILESA_EMPRESA_ID} />
+        {/* Suspense requerido por `useSearchParams()` dentro de VentasModule
+            (deep-link `?fase=` desde el tab Fases). Next.js 16 + Turbopack. */}
+        <Suspense fallback={null}>
+          <VentasModule empresaId={DILESA_EMPRESA_ID} />
+        </Suspense>
       </div>
     </RequireAccess>
   );

--- a/app/dilesa/ventas/vendedores/[id]/page.tsx
+++ b/app/dilesa/ventas/vendedores/[id]/page.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de detalle DILESA
+ * (cf. app/dilesa/ventas/[id]/page.tsx).
+ */
+
+/**
+ * @module Vendedor detail (DILESA)
+ * @responsive desktop-only
+ *
+ * Detalle del vendedor — lista de sus ventas con click a cada detalle.
+ * El "id" en la URL puede ser el nombre texto del vendedor (legacy del
+ * Coda) o el UUID de `core.usuarios` cuando solo había `vendedor_usuario_id`.
+ * El parser interno decide: parece UUID → filtra por `vendedor_usuario_id`;
+ * si no, filtra por `vendedor` texto.
+ *
+ * Placeholder de v1 — el modelo "vendedor" no es robusto aún; cuando se
+ * estandarice (vendedor_usuario_id en todas las ventas + tabla de perfil
+ * vendedor), evolucionar a UUID-only.
+ *
+ * Gate: sub-slug `dilesa.ventas.vendedores` (ADR-030 SS5).
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Venta = {
+  id: string;
+  persona_id: string;
+  unidad_id: string | null;
+  estado: string;
+  fase_actual: string | null;
+  fase_posicion: number | null;
+  precio_asignacion: number | null;
+  valor_escrituracion: number | null;
+  valor_comercial: number | null;
+  comision_vendedor: number | null;
+  anticipo_comision: number | null;
+  created_at: string;
+};
+
+type Persona = {
+  id: string;
+  nombre: string | null;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export default function VendedorDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.vendedores">
+      <VendedorDetailBody />
+    </RequireAccess>
+  );
+}
+
+function VendedorDetailBody() {
+  const params = useParams<{ id: string }>();
+  const rawId = params.id ? decodeURIComponent(params.id) : '';
+  const isUuid = UUID_RE.test(rawId);
+
+  const [ventas, setVentas] = useState<Venta[]>([]);
+  const [personasMap, setPersonasMap] = useState<Map<string, string>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const sb = createSupabaseBrowserClient();
+
+    let q = sb
+      .schema('dilesa')
+      .from('ventas')
+      .select(
+        'id, persona_id, unidad_id, estado, fase_actual, fase_posicion, precio_asignacion, valor_escrituracion, valor_comercial, comision_vendedor, anticipo_comision, created_at'
+      )
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .is('deleted_at', null);
+
+    if (isUuid) q = q.eq('vendedor_usuario_id', rawId);
+    else q = q.eq('vendedor', rawId);
+
+    const { data, error: vErr } = await q.order('created_at', { ascending: false });
+    if (vErr) {
+      setError(getSupabaseErrorMessage(vErr, 'No se pudieron cargar las ventas del vendedor.'));
+      setLoading(false);
+      return;
+    }
+    const arr = (data ?? []) as Venta[];
+    setVentas(arr);
+
+    const personaIds = [...new Set(arr.map((v) => v.persona_id))];
+    if (personaIds.length > 0) {
+      const { data: pers } = await sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .in('id', personaIds);
+      const m = new Map<string, string>();
+      for (const p of (pers ?? []) as Persona[]) {
+        m.set(
+          p.id,
+          [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' ') ||
+            '(sin nombre)'
+        );
+      }
+      setPersonasMap(m);
+    }
+    setLoading(false);
+  }, [rawId, isUuid]);
+
+  useEffect(() => {
+    void cargar();
+  }, [cargar]);
+
+  const kpis = useMemo(() => {
+    const montoTotal = ventas.reduce(
+      (s, v) => s + (v.valor_escrituracion ?? v.precio_asignacion ?? v.valor_comercial ?? 0),
+      0
+    );
+    const comisionTotal = ventas.reduce((s, v) => s + (v.comision_vendedor ?? 0), 0);
+    const comisionPagada = ventas.reduce((s, v) => s + (v.anticipo_comision ?? 0), 0);
+    return {
+      total: ventas.length,
+      activas: ventas.filter((v) => v.estado === 'activa').length,
+      montoTotal,
+      comisionTotal,
+      comisionPagada,
+      comisionPendiente: Math.max(0, comisionTotal - comisionPagada),
+    };
+  }, [ventas]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-5xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto max-w-5xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-5xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">
+          {isUuid ? `Usuario ${rawId.slice(0, 8)}` : rawId}
+        </h1>
+        <p className="mt-1 text-sm text-[var(--text)]/60">
+          {kpis.total} venta{kpis.total === 1 ? '' : 's'} · {kpis.activas} activa
+          {kpis.activas === 1 ? '' : 's'}
+        </p>
+      </header>
+
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Kpi label="Monto total" value={moneyFmt.format(kpis.montoTotal)} />
+        <Kpi label="Comisión total" value={moneyFmt.format(kpis.comisionTotal)} />
+        <Kpi label="Anticipos" value={moneyFmt.format(kpis.comisionPagada)} />
+        <Kpi label="Por pagar" value={moneyFmt.format(kpis.comisionPendiente)} />
+      </section>
+
+      <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+        <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          Ventas
+        </h2>
+        {ventas.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">
+            Sin ventas registradas para este vendedor.
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {ventas.map((v) => {
+              const monto = v.valor_escrituracion ?? v.precio_asignacion ?? v.valor_comercial ?? 0;
+              const clienteNombre = personasMap.get(v.persona_id) ?? '(sin nombre)';
+              return (
+                <li key={v.id}>
+                  <Link
+                    href={`/dilesa/ventas/${v.id}`}
+                    className="flex flex-wrap items-baseline justify-between gap-2 rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-3 py-2 text-sm hover:border-[var(--accent)] hover:bg-[var(--bg)]/60"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-[var(--text)]">{clienteNombre}</div>
+                      <div className="text-[11px] text-[var(--text)]/60">
+                        {new Date(v.created_at).toLocaleDateString('es-MX', {
+                          day: '2-digit',
+                          month: 'short',
+                          year: 'numeric',
+                        })}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {v.fase_actual ? (
+                        <Badge tone="neutral">
+                          {v.fase_posicion ? `${v.fase_posicion}. ` : ''}
+                          {v.fase_actual}
+                        </Badge>
+                      ) : null}
+                      <Badge tone={v.estado === 'activa' ? 'info' : 'neutral'}>
+                        {v.estado === 'activa' ? 'Activa' : v.estado}
+                      </Badge>
+                      <span className="tabular-nums text-sm font-medium text-[var(--text)]">
+                        {moneyFmt.format(monto)}
+                      </span>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/dilesa/ventas/vendedores"
+      className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+    >
+      <ArrowLeft className="size-4" /> Volver a vendedores
+    </Link>
+  );
+}
+
+function Kpi({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-4 py-3">
+      <div className="text-xs font-medium uppercase tracking-wider text-[var(--text)]/50">
+        {label}
+      </div>
+      <div className="mt-1 text-lg font-semibold tabular-nums text-[var(--text)]">{value}</div>
+    </div>
+  );
+}

--- a/app/dilesa/ventas/vendedores/page.tsx
+++ b/app/dilesa/ventas/vendedores/page.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de lectura DILESA
+ * (cf. app/dilesa/ventas/[id]/page.tsx, components/dilesa/construccion-module.tsx).
+ */
+
+/**
+ * @module Ventas · Vendedores (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Vendedores" del hub Ventas (sprint tabs-hub). Lista de vendedores
+ * con KPIs derivados de las ventas: # activas, # cerradas, monto total
+ * vendido, comisiones pagadas/pendientes, tasa de cierre.
+ *
+ * Modelo: agrupamos por nombre (`dilesa.ventas.vendedor` — texto legacy
+ * del Coda). Cuando `vendedor_usuario_id` está poblado pero `vendedor`
+ * texto NO, igual cae al bucket "(sin nombre)" — no podemos leer
+ * `core.usuarios.first_name` cross-rol sin elevación, y la mayoría de
+ * ventas ya tienen el campo texto. Si en el futuro se quiere mostrar el
+ * email/avatar del vendedor activo, agregar lookup explícito desde el
+ * perfil del propio usuario.
+ *
+ * "Cerrada" (heurística): `fase_posicion >= 15` (Entregada / Comisión
+ * Pagada / Operación Terminada) — el estado escalar `estado` solo es
+ * activa|desasignada, no expresa cierre por sí mismo.
+ *
+ * Gate: sub-slug `dilesa.ventas.vendedores` (ADR-030 SS5).
+ */
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { BadgeDollarSign, RefreshCw, Search } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, type Column } from '@/components/module-page';
+import { Input } from '@/components/ui/input';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+const CIERRE_POSICION_MIN = 15;
+
+type Venta = {
+  id: string;
+  estado: string;
+  fase_posicion: number | null;
+  fase_actual: string | null;
+  precio_asignacion: number | null;
+  valor_escrituracion: number | null;
+  valor_comercial: number | null;
+  comision_vendedor: number | null;
+  anticipo_comision: number | null;
+  vendedor: string | null;
+  vendedor_usuario_id: string | null;
+  created_at: string;
+};
+
+type VendedorRow = {
+  id: string;
+  nombre: string;
+  numVentas: number;
+  numActivas: number;
+  numCerradas: number;
+  montoTotal: number;
+  comisionTotal: number;
+  comisionPagada: number;
+  comisionPendiente: number;
+  tasaCierre: number;
+};
+
+export default function VentasVendedoresPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.vendedores">
+      <VentasVendedoresBody />
+    </RequireAccess>
+  );
+}
+
+function VentasVendedoresBody() {
+  const router = useRouter();
+  const [vendedores, setVendedores] = useState<VendedorRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [mesFiltro, setMesFiltro] = useState('');
+  const [mesesPresentes, setMesesPresentes] = useState<string[]>([]);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const sb = createSupabaseBrowserClient();
+
+    const { data, error: vErr } = await sb
+      .schema('dilesa')
+      .from('ventas')
+      .select(
+        'id, estado, fase_posicion, fase_actual, precio_asignacion, valor_escrituracion, valor_comercial, comision_vendedor, anticipo_comision, vendedor, vendedor_usuario_id, created_at'
+      )
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .is('deleted_at', null);
+    if (vErr) {
+      setError(getSupabaseErrorMessage(vErr, 'No se pudieron cargar los vendedores.'));
+      setLoading(false);
+      return;
+    }
+    const ventas = (data ?? []) as Venta[];
+
+    // Meses (YYYY-MM) únicos para el filtro
+    const meses = new Set<string>();
+    for (const v of ventas) meses.add(v.created_at.slice(0, 7));
+    setMesesPresentes([...meses].sort().reverse());
+
+    // Filtro por mes (los KPIs reflejan solo el mes seleccionado).
+    const filtradoMes = mesFiltro
+      ? ventas.filter((v) => v.created_at.slice(0, 7) === mesFiltro)
+      : ventas;
+
+    const byVendedor = new Map<string, Venta[]>();
+    for (const v of filtradoMes) {
+      // Key: vendedor texto si existe; si no, usuario_id; si no, bucket sin nombre.
+      const key = (v.vendedor && v.vendedor.trim()) || v.vendedor_usuario_id || '(sin nombre)';
+      const arr = byVendedor.get(key) ?? [];
+      arr.push(v);
+      byVendedor.set(key, arr);
+    }
+
+    const rows: VendedorRow[] = [];
+    for (const [key, vs] of byVendedor.entries()) {
+      // El "id" para click se basa en la key; el nombre legible es el campo
+      // texto cuando esté disponible. Si la key es un UUID, mostramos el
+      // sufijo corto para que no se vea hostil.
+      const isUUIDLike = /^[0-9a-f]{8}-[0-9a-f]{4}-/.test(key);
+      const nombre = isUUIDLike ? `Usuario ${key.slice(0, 8)}` : key;
+
+      const numVentas = vs.length;
+      const numActivas = vs.filter((v) => v.estado === 'activa').length;
+      const numCerradas = vs.filter((v) => (v.fase_posicion ?? 0) >= CIERRE_POSICION_MIN).length;
+      const montoTotal = vs.reduce(
+        (s, v) => s + (v.valor_escrituracion ?? v.precio_asignacion ?? v.valor_comercial ?? 0),
+        0
+      );
+      const comisionTotal = vs.reduce((s, v) => s + (v.comision_vendedor ?? 0), 0);
+      const comisionPagada = vs.reduce((s, v) => s + (v.anticipo_comision ?? 0), 0);
+      const comisionPendiente = Math.max(0, comisionTotal - comisionPagada);
+      const tasaCierre = numVentas > 0 ? numCerradas / numVentas : 0;
+
+      rows.push({
+        id: key,
+        nombre,
+        numVentas,
+        numActivas,
+        numCerradas,
+        montoTotal,
+        comisionTotal,
+        comisionPagada,
+        comisionPendiente,
+        tasaCierre,
+      });
+    }
+    rows.sort((a, b) => b.montoTotal - a.montoTotal);
+    setVendedores(rows);
+    setLoading(false);
+  }, [mesFiltro]);
+
+  useEffect(() => {
+    void cargar();
+  }, [cargar]);
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return vendedores;
+    return vendedores.filter((v) => v.nombre.toLowerCase().includes(q));
+  }, [vendedores, search]);
+
+  const columns: Column<VendedorRow>[] = [
+    { key: 'nombre', label: 'Vendedor', type: 'text', sticky: true, width: 'min-w-[220px]' },
+    { key: 'numVentas', label: '# ventas', type: 'number' },
+    { key: 'numActivas', label: '# activas', type: 'number' },
+    { key: 'numCerradas', label: '# cerradas', type: 'number' },
+    {
+      key: 'tasaCierre',
+      label: 'Tasa cierre',
+      type: 'custom',
+      accessor: (v) => v.tasaCierre,
+      render: (v) => <span className="tabular-nums">{(v.tasaCierre * 100).toFixed(0)}%</span>,
+    },
+    { key: 'montoTotal', label: 'Monto total', type: 'currency' },
+    { key: 'comisionTotal', label: 'Comisión total', type: 'currency' },
+    { key: 'comisionPagada', label: 'Anticipos', type: 'currency' },
+    { key: 'comisionPendiente', label: 'Por pagar', type: 'currency' },
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <BadgeDollarSign className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Vendedores</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            KPIs por vendedor — ventas activas, cerradas, monto total, comisiones, tasa de cierre.
+            &laquo;Cerrada&raquo; = fase ≥ {CIERRE_POSICION_MIN} (Entregada en adelante).
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar vendedor…"
+            className="w-64 pl-9"
+          />
+        </div>
+        <select
+          value={mesFiltro}
+          onChange={(e) => setMesFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Acumulado (todos los meses)</option>
+          {mesesPresentes.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {filtrados.length} vendedor{filtrados.length === 1 ? '' : 'es'}
+        </span>
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={(v) => router.push(`/dilesa/ventas/vendedores/${encodeURIComponent(v.id)}`)}
+        initialSort={{ key: 'montoTotal', dir: 'desc' }}
+        emptyTitle="Sin vendedores"
+        emptyDescription="Aún no hay ventas con vendedor asignado."
+        emptyIcon={<BadgeDollarSign className="h-6 w-6" />}
+        maxHeight="calc(100vh - 280px)"
+      />
+    </div>
+  );
+}

--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -73,7 +73,10 @@ export const NAV_ITEMS: NavItem[] = [
         children: [
           { label: 'Portafolio', href: '/dilesa/portafolio' },
           { label: 'Proyectos', href: '/dilesa/proyectos' },
-          { label: 'Inventario', href: '/dilesa/inventario' },
+          // Ventas ahora es un hub con 5 tabs (Ventas / Inventario / Fases /
+          // Clientes / Vendedores) — el sidebar muestra solo la entry del
+          // padre; las tabs viven en el layout (sprint tabs-hub).
+          // Inventario quedó dentro de Ventas como tab — antes era top-level.
           { label: 'Ventas', href: '/dilesa/ventas' },
           // Construcción ahora es un hub con 4 tabs (Obras / Contratos /
           // Contratistas / Prototipos) — el sidebar muestra solo la entry

--- a/components/dilesa/ventas-module.tsx
+++ b/components/dilesa/ventas-module.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { DataTable, type Column } from '@/components/module-page';
 import { Badge } from '@/components/ui/badge';
@@ -55,6 +55,7 @@ const ESTADO_LABEL: Record<string, string> = {
 
 export function VentasModule({ empresaId }: { empresaId: string }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { permissions } = usePermissions();
   const puedeCrearSolicitud =
     permissions.isAdmin ||
@@ -64,8 +65,22 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [proyectoFiltro, setProyectoFiltro] = useState('');
-  const [faseFiltro, setFaseFiltro] = useState('');
   const [estadoFiltro, setEstadoFiltro] = useState('');
+
+  // `faseFiltro` se deriva del query param (single source of truth: el URL).
+  // Deep-link desde tab Fases (`/dilesa/ventas?fase=<nombre>`) pre-selecciona
+  // sin state intermedio. El dropdown actualiza el URL via `setFaseEnUrl`.
+  const faseFiltro = searchParams.get('fase') ?? '';
+  const setFaseEnUrl = useCallback(
+    (value: string) => {
+      const next = new URLSearchParams(searchParams.toString());
+      if (value) next.set('fase', value);
+      else next.delete('fase');
+      const qs = next.toString();
+      router.replace(qs ? `/dilesa/ventas?${qs}` : '/dilesa/ventas');
+    },
+    [router, searchParams]
+  );
 
   // Fetch puro: regresa data o mensaje de error, NO toca state.
   const fetchVentas = useCallback(async (): Promise<{
@@ -303,7 +318,7 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
         </select>
         <select
           value={faseFiltro}
-          onChange={(e) => setFaseFiltro(e.target.value)}
+          onChange={(e) => setFaseEnUrl(e.target.value)}
           className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
         >
           <option value="">Todas las fases</option>

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -183,8 +183,19 @@ const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   'dilesa.proveedores',
   'dilesa.portafolio',
   'dilesa.proyectos',
-  'dilesa.inventario',
   'dilesa.ventas',
+  // Sub-slugs del hub Ventas (sprint tabs-hub, ADR-030). El padre
+  // `dilesa.ventas` queda como umbrella en sidebar; cada tab (Ventas /
+  // Inventario / Fases / Clientes / Vendedores) tiene su sub-slug que
+  // gobierna acceso real al contenido. Ver migración
+  // 20260525112633_dilesa_ventas_tabs_hub.sql.
+  // El slug top-level `dilesa.inventario` fue deprecado y eliminado por
+  // la misma migración — vive ahora como sub-slug del hub.
+  'dilesa.ventas.lista',
+  'dilesa.ventas.inventario',
+  'dilesa.ventas.fases',
+  'dilesa.ventas.clientes',
+  'dilesa.ventas.vendedores',
   'dilesa.construccion',
   // Sub-slugs del hub Construcción (sprint tabs+protos, ADR-030). El padre
   // `dilesa.construccion` queda como umbrella en sidebar; cada tab

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -35,8 +35,15 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   '/dilesa/proveedores': 'dilesa.proveedores',
   '/dilesa/portafolio': 'dilesa.portafolio',
   '/dilesa/proyectos': 'dilesa.proyectos',
-  '/dilesa/inventario': 'dilesa.inventario',
-  '/dilesa/ventas': 'dilesa.ventas',
+  // Ventas es un hub con 5 tabs (sprint tabs-hub). El padre
+  // `dilesa.ventas` queda como umbrella; cada tab tiene su sub-slug
+  // (ADR-030 SS2). La URL default mapea al sub-slug del primer tab
+  // (`.lista`). Inventario quedó como tab del hub — antes era top-level.
+  '/dilesa/ventas': 'dilesa.ventas.lista',
+  '/dilesa/ventas/inventario': 'dilesa.ventas.inventario',
+  '/dilesa/ventas/fases': 'dilesa.ventas.fases',
+  '/dilesa/ventas/clientes': 'dilesa.ventas.clientes',
+  '/dilesa/ventas/vendedores': 'dilesa.ventas.vendedores',
   // Construcción es un hub con 4 tabs (sprint tabs+protos). El padre
   // `dilesa.construccion` queda como umbrella; cada tab tiene su sub-slug
   // (ADR-030 SS2). La URL default mapea al sub-slug del primer tab.

--- a/supabase/migrations/20260525112633_dilesa_ventas_tabs_hub.sql
+++ b/supabase/migrations/20260525112633_dilesa_ventas_tabs_hub.sql
@@ -1,0 +1,122 @@
+-- ============================================================================
+-- DILESA · Ventas Sprint tabs-hub
+--   Conversión del módulo Ventas en HUB con 5 tabs
+-- ----------------------------------------------------------------------------
+-- Refactor arquitectónico: `/dilesa/ventas` deja de ser una single-page
+-- y pasa a ser un hub con 5 tabs hermanas (ADR-030 patrón de sub-slugs por
+-- routed tabs, mismo pattern que `rdb.inventario` / `rdb.productos` /
+-- `dilesa.construccion`):
+--
+--   /dilesa/ventas              → tab "Ventas"      (default, lista actual)
+--   /dilesa/ventas/inventario   → tab "Inventario"  (movido desde top-level)
+--   /dilesa/ventas/fases        → tab "Fases"       (NUEVO — pipeline view)
+--   /dilesa/ventas/clientes     → tab "Clientes"    (NUEVO — KPIs)
+--   /dilesa/ventas/vendedores   → tab "Vendedores"  (NUEVO — KPIs)
+--
+-- Cambios DB:
+--   1. INSERT 5 sub-slugs nuevos en core.modulos:
+--        - dilesa.ventas.lista
+--        - dilesa.ventas.inventario
+--        - dilesa.ventas.fases
+--        - dilesa.ventas.clientes
+--        - dilesa.ventas.vendedores
+--   2. Backfill defensivo: clonar los permisos del padre `dilesa.ventas`
+--      a cada uno de los 5 sub-slugs nuevos. Patrón ADR-030 SS3 — sin
+--      esto, agregar los sub-slugs ESCONDE las tabs a no-admin users
+--      (canAccessModulo retorna false para slug ausente en
+--      permissions.modulos).
+--   3. DELETE el slug top-level `dilesa.inventario`. Como las FKs en
+--      core.permisos_rol y core.permisos_usuario_excepcion **NO tienen**
+--      ON DELETE CASCADE (ver pre_migration_bootstrap.sql), borramos las
+--      filas dependientes explícitamente antes de borrar el módulo. El
+--      submódulo nuevo `dilesa.ventas.inventario` toma su lugar (con
+--      backfill defensivo de permisos clonados desde el padre
+--      `dilesa.ventas`).
+--
+-- Nota sobre `dilesa.ventas` (padre): se preserva como umbrella en
+-- sidebar. NO se elimina ni se modifica. El sub-slug `.lista` gobierna
+-- ahora el acceso real al contenido de la primera tab.
+--
+-- Idempotente: ON CONFLICT DO NOTHING en INSERTs; el DELETE es no-op si
+-- ya corrió (slug ausente). NOTIFY pgrst al final para refrescar la
+-- caché.
+-- ============================================================================
+
+BEGIN;
+
+-- ── Sub-slugs nuevos en core.modulos ───────────────────────────────────────
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT s.slug, s.nombre, s.descripcion, e.id, 'operaciones'
+FROM core.empresas e
+CROSS JOIN (VALUES
+  ('dilesa.ventas.lista',
+   'Ventas · Lista',
+   'Tab Ventas del hub — lista filtrable de ventas activas + detalle por venta + captura Fase 1. Default landing del hub.'),
+  ('dilesa.ventas.inventario',
+   'Ventas · Inventario',
+   'Tab Inventario del hub Ventas — catálogo de unidades disponibles (~1,590) por proyecto + precio calculado. Reemplaza el top-level dilesa.inventario.'),
+  ('dilesa.ventas.fases',
+   'Ventas · Fases',
+   'Tab Fases del hub Ventas — vista pipeline/kanban global de las 17 fases con conteos de ventas por fase, filtrable por proyecto / vendedor / mes.'),
+  ('dilesa.ventas.clientes',
+   'Ventas · Clientes',
+   'Tab Clientes del hub Ventas — lista de personas con ≥1 venta DILESA con KPIs (# ventas, monto total, última venta, proyectos).'),
+  ('dilesa.ventas.vendedores',
+   'Ventas · Vendedores',
+   'Tab Vendedores del hub Ventas — lista con KPIs por vendedor (# ventas activas/cerradas, monto total, comisiones, tasa cierre).')
+) AS s(slug, nombre, descripcion)
+WHERE e.slug = 'dilesa'
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+-- ── Backfill defensivo de permisos ─────────────────────────────────────────
+-- Clonar los permisos (acceso_lectura, acceso_escritura) del padre
+-- `dilesa.ventas` a cada uno de los 5 sub-slugs nuevos. Idempotente
+-- vía ON CONFLICT (rol_id, modulo_id) DO NOTHING — si ya se backfilleó
+-- antes, se queda igual. Preserva 100% del status quo: estado pre-PR =
+-- estado post-PR para todos los roles existentes (incluidos los 5 roles
+-- de ventas con sub-slugs por fase del Sprint 7a).
+INSERT INTO core.permisos_rol (rol_id, modulo_id, acceso_lectura, acceso_escritura)
+SELECT pr.rol_id, child.id, pr.acceso_lectura, pr.acceso_escritura
+FROM core.permisos_rol pr
+JOIN core.modulos parent
+  ON parent.id = pr.modulo_id
+ AND parent.slug = 'dilesa.ventas'
+JOIN core.modulos child
+  ON child.empresa_id = parent.empresa_id
+ AND child.slug IN (
+   'dilesa.ventas.lista',
+   'dilesa.ventas.inventario',
+   'dilesa.ventas.fases',
+   'dilesa.ventas.clientes',
+   'dilesa.ventas.vendedores'
+ )
+ON CONFLICT (rol_id, modulo_id) DO NOTHING;
+
+-- ── Deprecar slug top-level `dilesa.inventario` ────────────────────────────
+-- Ahora vive como sub-slug `dilesa.ventas.inventario` (clonado arriba
+-- desde el padre dilesa.ventas). Las FKs en core.permisos_rol y
+-- core.permisos_usuario_excepcion NO tienen ON DELETE CASCADE, así que
+-- limpiamos las filas dependientes antes del DELETE del módulo.
+-- Idempotente: el WHERE no encuentra nada si la migración corrió antes
+-- (o si el slug nunca existió, como en una preview branch fresca).
+DELETE FROM core.permisos_rol
+WHERE modulo_id IN (
+  SELECT m.id FROM core.modulos m
+  JOIN core.empresas e ON e.id = m.empresa_id
+  WHERE m.slug = 'dilesa.inventario' AND e.slug = 'dilesa'
+);
+
+DELETE FROM core.permisos_usuario_excepcion
+WHERE modulo_id IN (
+  SELECT m.id FROM core.modulos m
+  JOIN core.empresas e ON e.id = m.empresa_id
+  WHERE m.slug = 'dilesa.inventario' AND e.slug = 'dilesa'
+);
+
+DELETE FROM core.modulos
+WHERE slug = 'dilesa.inventario'
+  AND empresa_id IN (SELECT id FROM core.empresas WHERE slug = 'dilesa');
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Convierte `/dilesa/ventas` de single-page a hub con 5 routed tabs hermanas (ADR-005 + ADR-030 patrón de sub-slugs por tab — mismo que `rdb.inventario` / `rdb.productos` / `dilesa.construccion`):

| URL | Tab | Sub-slug |
|-----|-----|----------|
| `/dilesa/ventas` | Ventas (default) | `dilesa.ventas.lista` |
| `/dilesa/ventas/inventario` | Inventario (movido) | `dilesa.ventas.inventario` |
| `/dilesa/ventas/fases` | Fases (NUEVO) | `dilesa.ventas.fases` |
| `/dilesa/ventas/clientes` | Clientes (NUEVO) | `dilesa.ventas.clientes` |
| `/dilesa/ventas/vendedores` | Vendedores (NUEVO) | `dilesa.ventas.vendedores` |

### Tab Fases — pipeline view

Grid responsive (1→5 columnas) con las 17 fases del catálogo `dilesa.venta_fase_catalogo` (single source of truth — viene del Coda original). Cada card muestra posición + nombre + responsable + conteo de ventas activas en esa fase. Filtros URL-sync: proyecto, vendedor, mes. Click en una card → `/dilesa/ventas?fase=<nombre>` (deep link futuro).

### Tab Clientes — lista + detalle con KPIs

Lista cross-schema de personas con ≥1 venta DILESA. Patrón URL-safe: usa `.eq(empresa_id)` en lugar de `.in('id', uuids[])` para evitar el 8KB limit cuando hay >200 clientes. Columnas: cliente (+contacto), # ventas, # activas, monto total, última venta (fecha + fase), proyectos. Filtros: búsqueda + proyecto.

Detalle (`/clientes/[id]`): KPIs (# ventas, # activas, monto total) + timeline cronológico de sus ventas con link a cada detalle.

### Tab Vendedores — KPIs

Agrupación por nombre (`vendedor` texto legacy del Coda) con fallback al `vendedor_usuario_id` cuando el texto falta. Columnas: # ventas, # activas, # cerradas, tasa cierre, monto total, comisión total, anticipos, por pagar. Filtros: búsqueda + mes.

**Heurística "cerrada"**: `fase_posicion >= 15` (Entregada en adelante). El escalar `estado` (activa|desasignada) no expresa cierre — visible en el subtítulo de la página para que el operador entienda.

Detalle (`/vendedores/[id]`): KPIs en cards + lista de sus ventas. URL acepta nombre texto o UUID (regex en el parser).

### Tab Inventario — movido sin perder funcionalidad

`git mv app/dilesa/inventario/page.tsx app/dilesa/ventas/inventario/page.tsx`. El sub-slug `dilesa.ventas.inventario` reemplaza al top-level `dilesa.inventario` (deprecado por la migración). Redirect compat en `/dilesa/inventario` → `/dilesa/ventas/inventario` para bookmarks viejos.

### Hide tabs en sub-rutas profundas

`app/dilesa/ventas/layout.tsx` oculta el strip de tabs en sub-páginas que tienen su propia vista detallada:

- `/dilesa/ventas/[id]` (detalle de venta)
- `/dilesa/ventas/nueva` (form Fase 1)
- `/dilesa/ventas/[id]/capturar/*` (forms de captura por fase)
- `/dilesa/ventas/clientes/[id]` (detalle de cliente)
- `/dilesa/ventas/vendedores/[id]` (detalle de vendedor)

A diferencia de `construccion/layout.tsx` (que muestra tabs en sus detalles), aquí esos sub-flows ya tienen header propio (back-link, badges, secciones) que compite visualmente con un strip extra.

### Migración — 1 archivo

`supabase/migrations/20260525112633_dilesa_ventas_tabs_hub.sql`:
- INSERT 5 sub-slugs nuevos en `core.modulos`.
- Backfill defensivo: clona permisos del padre `dilesa.ventas` a los 5 sub-slugs (ADR-030 SS3).
- DELETE `dilesa.inventario` (top-level deprecado). Borra dependientes en `permisos_rol` y `permisos_usuario_excepcion` ANTES del DELETE del módulo (las FKs no tienen ON DELETE CASCADE — mismo fix que en la migración de construcción).
- `NOTIFY pgrst, 'reload schema'`.

Idempotente: ON CONFLICT DO NOTHING en INSERTs, DELETEs no-op si ya corrió.

### RBAC sync (4 places)

- **Sidebar** (`components/app-shell/nav-config.ts`): quita entry "Inventario" top-level del grupo Inmobiliario.
- **ROUTE_TO_MODULE** (`lib/permissions.ts`): URL default `/dilesa/ventas` mapea a sub-slug del primer tab (`.lista`) + 4 nuevos sub-slugs. Quita `/dilesa/inventario`. NO toca captura por fase.
- **EXPECTED_DB_MODULE_SLUGS** (`lib/permissions.test.ts`): +5 nuevos sub-slugs, -1 deprecado (`dilesa.inventario`).
- **Migración** (arriba).

## Test plan

- [ ] Beto: aplicar `supabase/migrations/20260525112633_dilesa_ventas_tabs_hub.sql` en prod vía `supabase db push`.
- [ ] CC: tras db push, regenerar `supabase/SCHEMA_REF.md` (no se espera diff — solo metadata refresh). Los types de `core.modulos` no cambian.
- [ ] Verificación manual en preview:
  - [ ] Sidebar muestra Ventas una sola vez (sin "Inventario" top-level).
  - [ ] `/dilesa/ventas` carga con las 5 tabs visibles (rol admin) y el tab Ventas activo.
  - [ ] `/dilesa/ventas/inventario` lista las 1,590 unidades disponibles con precio calculado.
  - [ ] `/dilesa/inventario` redirige a `/dilesa/ventas/inventario`.
  - [ ] `/dilesa/ventas/fases` muestra las 17 cards con conteos; filtros funcionan.
  - [ ] `/dilesa/ventas/clientes` lista clientes únicos con KPIs; click → detalle con timeline.
  - [ ] `/dilesa/ventas/vendedores` lista vendedores con KPIs; click → detalle con sus ventas.
  - [ ] `/dilesa/ventas/[id]` (detalle de venta existente) NO muestra strip de tabs.
  - [ ] `/dilesa/ventas/nueva` NO muestra strip de tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)