### PR TITLE
fix+feat(dilesa): construcción · prototipo sin m² + días totales/fecha estim. terminación

### DIFF
--- a/app/dilesa/construccion/[id]/page.tsx
+++ b/app/dilesa/construccion/[id]/page.tsx
@@ -72,6 +72,7 @@ type Plantilla = {
   tarea_id: string;
   etapa_id: string;
   porcentaje_costo: number;
+  tiempo_dias: number | null;
 };
 type Terminada = {
   id: string;
@@ -80,6 +81,7 @@ type Terminada = {
   revisado_por_persona_id: string | null;
   mano_obra_pagada: number | null;
   fecha_pagada: string | null;
+  tiempo_real_dias: number | null;
 };
 type ContratoLote = {
   id: string;
@@ -289,7 +291,7 @@ function DetailInner() {
         sb
           .schema('dilesa')
           .from('plantilla_tareas')
-          .select('id, tarea_id, etapa_id, porcentaje_costo')
+          .select('id, tarea_id, etapa_id, porcentaje_costo, tiempo_dias')
           .eq('producto_id', obraRow.producto_id)
           .is('deleted_at', null),
         sb
@@ -303,7 +305,7 @@ function DetailInner() {
           .schema('dilesa')
           .from('construccion_tareas_terminadas')
           .select(
-            'id, plantilla_tarea_id, fecha_terminada, revisado_por_persona_id, mano_obra_pagada, fecha_pagada'
+            'id, plantilla_tarea_id, fecha_terminada, revisado_por_persona_id, mano_obra_pagada, fecha_pagada, tiempo_real_dias'
           )
           .eq('construccion_id', obraRow.id)
           .is('deleted_at', null)
@@ -437,6 +439,30 @@ function DetailInner() {
     return obra.valor_contrato_mo - obra.mo_ejecutado;
   }, [obra]);
 
+  /** Días estimados = suma del `tiempo_dias` de toda la plantilla del prototipo.
+   *  Asunción: tareas secuenciales (como en Coda). Si en el futuro hay
+   *  paralelismo, esto se convierte en esfuerzo total, no en plazo. */
+  const totalDiasEstimado = useMemo(
+    () => plantilla.reduce((s, p) => s + Number(p.tiempo_dias ?? 0), 0),
+    [plantilla]
+  );
+
+  /** Suma de días reales reportados en las tareas ya terminadas. */
+  const diasRealesAcumulados = useMemo(
+    () => terminadas.reduce((s, t) => s + Number(t.tiempo_real_dias ?? 0), 0),
+    [terminadas]
+  );
+
+  /** Fecha estimada de terminación = fecha_arranque + ceil(totalDiasEstimado).
+   *  Usamos días corridos (Coda no separa hábiles/feriados). */
+  const fechaArranque = obra?.fecha_arranque ?? null;
+  const fechaEstimadaTerminacion = useMemo(() => {
+    if (!fechaArranque || totalDiasEstimado <= 0) return null;
+    const base = new Date(`${fechaArranque}T12:00:00`);
+    base.setDate(base.getDate() + Math.ceil(totalDiasEstimado));
+    return base.toISOString().slice(0, 10);
+  }, [fechaArranque, totalDiasEstimado]);
+
   if (loading) {
     return (
       <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
@@ -480,8 +506,17 @@ function DetailInner() {
       ],
       ['Supervisor', supervisorNombre],
       ['Fecha de arranque', fmtFecha(obra.fecha_arranque)],
+      [
+        'Días estimados (plantilla)',
+        totalDiasEstimado > 0 ? `${totalDiasEstimado.toFixed(1)} días` : null,
+      ],
+      ['Fecha estimada terminación', fmtFecha(fechaEstimadaTerminacion)],
       ['Compromiso de terminar', fmtFecha(obra.fecha_compromiso_terminar)],
       ['Fecha terminada', fmtFecha(obra.fecha_terminada)],
+      [
+        'Días reales (acumulados)',
+        diasRealesAcumulados > 0 ? `${diasRealesAcumulados.toFixed(1)} días` : null,
+      ],
       ['Fecha DTU', fmtFecha(obra.fecha_dtu)],
       ['Fecha seguro calidad', fmtFecha(obra.fecha_seguro_calidad)],
       ['Fecha extracción', fmtFecha(obra.fecha_extraccion)],

--- a/app/dilesa/construccion/contratos/nuevo/page.tsx
+++ b/app/dilesa/construccion/contratos/nuevo/page.tsx
@@ -338,14 +338,22 @@ function NuevoContratoForm() {
 
   const precioMoNum = Number(precioMoM2) || 0;
 
-  /** Detalle por fila: m² del prototipo + valor MO del lote = precio × m². */
+  /** Detalle por fila: m² del prototipo + valor MO del lote = precio × m².
+   *  `error` se popula cuando hay un problema bloqueante de la fila (ej. el
+   *  prototipo elegido no tiene `m2_construccion` capturado). Sin esto, el
+   *  submit producía silent-skip y el toast quedaba con "ningún lote pudo
+   *  arrancarse" sin descripción — debug brutal. */
   const lotesConDetalle = useMemo(() => {
     return lotes.map((l) => {
       const unidad = unidades.find((u) => u.id === l.unidadId) ?? null;
       const producto = productos.find((p) => p.id === l.productoId) ?? null;
       const m2 = producto?.m2_construccion ?? null;
       const valorMo = m2 != null && precioMoNum > 0 ? precioMoNum * m2 : null;
-      return { row: l, unidad, producto, m2, valorMo };
+      let error: string | null = null;
+      if (producto && m2 == null) {
+        error = `${producto.nombre} no tiene m² capturado — abre el prototipo y captúralo antes de arrancar.`;
+      }
+      return { row: l, unidad, producto, m2, valorMo, error };
     });
   }, [lotes, unidades, productos, precioMoNum]);
 
@@ -368,9 +376,14 @@ function NuevoContratoForm() {
 
   const codigoFinal = codigoOverride.trim() || codigoSugerido;
 
+  /** Una fila es válida cuando tiene todos los campos requeridos Y no tiene
+   *  errores derivados (ej. m² del prototipo). */
   const lotesValidos = useMemo(
-    () => lotes.filter((l) => l.unidadId && l.productoId && l.fechaArranque),
-    [lotes]
+    () =>
+      lotesConDetalle.filter(
+        (d) => d.row.unidadId && d.row.productoId && d.row.fechaArranque && d.error === null
+      ),
+    [lotesConDetalle]
   );
 
   const canSubmit = useMemo(
@@ -460,8 +473,19 @@ function NuevoContratoForm() {
       const fallas: Array<{ identificador: string; mensaje: string }> = [];
 
       for (const detalle of lotesConDetalle) {
-        const { row, unidad, producto, m2, valorMo } = detalle;
-        if (!unidad || !producto || m2 == null || valorMo == null) continue;
+        const { row, unidad, producto, m2, valorMo, error } = detalle;
+        // Defensa: canSubmit ya bloquea filas con error/missing, pero por si
+        // alguna se cuela (race condition al editar mientras submit), la
+        // marcamos como falla en lugar de silent skip.
+        if (!unidad || !producto || m2 == null || valorMo == null) {
+          if (unidad) {
+            fallas.push({
+              identificador: unidad.identificador,
+              mensaje: error ?? 'Faltan datos del prototipo (m² o precio).',
+            });
+          }
+          continue;
+        }
 
         // Código de obra estilo Coda: <identificador>-<sufijo prototipo>-<abrev contratista>
         const protoSufijo = producto.nombre.split('-').pop() ?? producto.nombre;
@@ -711,12 +735,14 @@ function NuevoContratoForm() {
               <div className="col-span-1" />
             </div>
             {lotesConDetalle.map((detalle, idx) => {
-              const { row, m2, valorMo } = detalle;
+              const { row, m2, valorMo, error } = detalle;
               const elegibles = unidadesElegiblesParaRow(row.key);
               return (
                 <div
                   key={row.key}
-                  className="grid grid-cols-1 items-start gap-2 rounded-md border border-[var(--border)]/60 bg-[var(--card)] p-2 sm:grid-cols-12"
+                  className={`grid grid-cols-1 items-start gap-2 rounded-md border bg-[var(--card)] p-2 sm:grid-cols-12 ${
+                    error ? 'border-destructive/60' : 'border-[var(--border)]/60'
+                  }`}
                 >
                   <div className="sm:col-span-4">
                     <select
@@ -744,7 +770,7 @@ function NuevoContratoForm() {
                       {productosDelProyecto.map((p) => (
                         <option key={p.id} value={p.id}>
                           {p.nombre}
-                          {p.m2_construccion ? ` · ${p.m2_construccion}m²` : ''}
+                          {p.m2_construccion ? ` · ${p.m2_construccion}m²` : ' · ⚠ falta m²'}
                         </option>
                       ))}
                     </select>
@@ -778,6 +804,9 @@ function NuevoContratoForm() {
                       <X className="h-3.5 w-3.5" />
                     </button>
                   </div>
+                  {error ? (
+                    <div className="text-xs text-destructive sm:col-span-12">{error}</div>
+                  ) : null}
                 </div>
               );
             })}

--- a/app/dilesa/construccion/prototipos/[id]/page.tsx
+++ b/app/dilesa/construccion/prototipos/[id]/page.tsx
@@ -282,7 +282,8 @@ function DetailInner() {
         .sort((a, b) => a.nombre.localeCompare(b.nombre));
       const pctEtapa = items.reduce((s, it) => s + it.pctDisplay, 0);
       const costoEtapa = items.reduce((s, it) => s + (it.costoMoTarea ?? 0), 0);
-      return { ...et, items, pctEtapa, costoEtapa };
+      const tiempoEtapa = items.reduce((s, it) => s + it.tiempoDias, 0);
+      return { ...et, items, pctEtapa, costoEtapa, tiempoEtapa };
     });
     return rows.filter((r) => r.items.length > 0);
   }, [etapas, plantilla, tareasCat, totalMo]);
@@ -295,6 +296,13 @@ function DetailInner() {
   );
   const totalCostoSum = useMemo(
     () => etapasConTareas.reduce((s, et) => s + et.costoEtapa, 0),
+    [etapasConTareas]
+  );
+  // Días totales = suma de los días de cada tarea de la plantilla.
+  // Asunción: tareas secuenciales (como en Coda). Si en el futuro hay
+  // paralelismo, esto deja de ser el plazo real y pasa a ser el esfuerzo.
+  const totalTiempoDias = useMemo(
+    () => etapasConTareas.reduce((s, et) => s + et.tiempoEtapa, 0),
     [etapasConTareas]
   );
 
@@ -346,7 +354,14 @@ function DetailInner() {
       ['Prototipo', producto.nombre],
       ['Proyecto', proyectoNombre],
       ['m² de construcción', m2 != null ? `${m2.toFixed(2)} m²` : null],
-      ['Días de construcción', tiempo != null ? `${tiempo} días` : null],
+      [
+        'Días totales (plantilla)',
+        totalTiempoDias > 0
+          ? `${totalTiempoDias.toFixed(1)} días${tiempo != null && Math.abs(tiempo - totalTiempoDias) > 0.5 ? ` · referencia Coda: ${tiempo}` : ''}`
+          : tiempo != null
+            ? `${tiempo} días (referencia)`
+            : null,
+      ],
       ['Costo de materiales', fmtMoney(costoMateriales)],
       [
         'Costo materiales por m²',
@@ -491,7 +506,9 @@ function DetailInner() {
                     <td className="px-2 py-2 text-right tabular-nums">
                       {totalMo != null ? moneyFmt.format(totalCostoSum) : '—'}
                     </td>
-                    <td className="px-2 py-2 text-right" />
+                    <td className="px-2 py-2 text-right tabular-nums">
+                      {totalTiempoDias > 0 ? totalTiempoDias.toFixed(1) : '—'}
+                    </td>
                   </tr>
                 </tfoot>
               </table>

--- a/scripts/cleanup_prueba_construccion.ts
+++ b/scripts/cleanup_prueba_construccion.ts
@@ -1,0 +1,215 @@
+/**
+ * Cleanup de prueba end-to-end del módulo Construcción.
+ *
+ * Borra todo lo creado por una corrida de prueba: contrato + N lotes +
+ * sus construcciones + tareas terminadas + revierte unidad a estado
+ * 'planeada' con producto_id=NULL.
+ *
+ * El trigger `tg_construccion_avance` regresa automáticamente la
+ * unidad a `planeada` cuando se borran las tareas terminadas (avance
+ * cae a 0 < 20%), pero aplicamos UPDATE explícito como red de seguridad
+ * por si la unidad se quedó en otro estado.
+ *
+ * Uso:
+ *   CONTRATO_ID=<uuid> npx tsx scripts/cleanup_prueba_construccion.ts
+ *
+ * Salida: reporta cuántas filas borró por tabla y el estado final de
+ * las unidades afectadas. No commitea hasta que se confirme con --apply.
+ *
+ * Defaultea a DRY-RUN (solo reporta lo que haría). Para ejecutar real,
+ * agregar `--apply`.
+ */
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const CONTRATO_ID = process.env.CONTRATO_ID;
+const APPLY = process.argv.includes('--apply');
+
+if (!CONTRATO_ID) {
+  console.error('Falta CONTRATO_ID. Uso:');
+  console.error(
+    '  CONTRATO_ID=<uuid> npx tsx scripts/cleanup_prueba_construccion.ts          # dry-run'
+  );
+  console.error(
+    '  CONTRATO_ID=<uuid> npx tsx scripts/cleanup_prueba_construccion.ts --apply  # ejecutar'
+  );
+  process.exit(1);
+}
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SERVICE_ROLE) {
+  console.error('Faltan NEXT_PUBLIC_SUPABASE_URL y/o SUPABASE_SERVICE_ROLE_KEY en .env.local');
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SERVICE_ROLE, {
+  auth: { persistSession: false },
+});
+
+async function main() {
+  console.log(`\n${APPLY ? '⚠️  APPLY' : '🔍 DRY-RUN'} · cleanup del contrato ${CONTRATO_ID}\n`);
+
+  // 1) Verificar que el contrato existe + traer datos
+  const { data: contrato, error: cErr } = await sb
+    .schema('dilesa')
+    .from('contratos_construccion')
+    .select('id, codigo, fecha_contrato, valor_total, contratista_id')
+    .eq('id', CONTRATO_ID)
+    .maybeSingle();
+  if (cErr || !contrato) {
+    console.error(`❌ Contrato ${CONTRATO_ID} no encontrado: ${cErr?.message ?? 'sin resultado'}`);
+    process.exit(1);
+  }
+  console.log(`✓ Contrato encontrado: ${contrato.codigo}  ($${contrato.valor_total})`);
+
+  // 2) Traer construcciones vinculadas (via contrato_lotes)
+  const { data: lotes, error: lErr } = await sb
+    .schema('dilesa')
+    .from('contrato_lotes')
+    .select('id, construccion_id')
+    .eq('contrato_id', CONTRATO_ID);
+  if (lErr) {
+    console.error(`❌ Error trayendo contrato_lotes: ${lErr.message}`);
+    process.exit(1);
+  }
+  const construccionIds = (lotes ?? []).map((l) => l.construccion_id);
+  console.log(`✓ ${lotes?.length ?? 0} contrato_lotes · ${construccionIds.length} construcciones`);
+
+  // 3) Traer las construcciones para saber qué unidades regresar a planeada
+  const { data: construcciones } = await sb
+    .schema('dilesa')
+    .from('construccion')
+    .select('id, codigo, unidad_id, producto_id, avance_pct, estado')
+    .in('id', construccionIds.length ? construccionIds : ['00000000-0000-0000-0000-000000000000']);
+
+  if (construcciones && construcciones.length > 0) {
+    console.log(`✓ Construcciones a borrar:`);
+    for (const c of construcciones) {
+      console.log(`    ${c.codigo} · avance ${c.avance_pct}% · estado=${c.estado}`);
+    }
+  }
+
+  const unidadIds = (construcciones ?? []).map((c) => c.unidad_id);
+
+  // 4) Contar tareas terminadas a borrar
+  const { count: tareasCount } = await sb
+    .schema('dilesa')
+    .from('construccion_tareas_terminadas')
+    .select('id', { count: 'exact', head: true })
+    .in(
+      'construccion_id',
+      construccionIds.length ? construccionIds : ['00000000-0000-0000-0000-000000000000']
+    );
+  console.log(`✓ ${tareasCount ?? 0} tareas_terminadas a borrar\n`);
+
+  if (!APPLY) {
+    console.log(`📋 Plan de ejecución (re-correr con --apply para aplicar):\n`);
+    console.log(
+      `  1. DELETE ${tareasCount ?? 0} construccion_tareas_terminadas WHERE construccion_id IN (...)`
+    );
+    console.log(`     → trigger tg_construccion_avance dispara: avance baja a 0%`);
+    console.log(`     → trigger inverso: unidades pasan de 'en_construccion' a 'planeada'`);
+    console.log(
+      `  2. UPDATE ${unidadIds.length} unidades SET producto_id=NULL, estado='planeada' (red de seguridad)`
+    );
+    console.log(
+      `  3. DELETE ${lotes?.length ?? 0} contrato_lotes WHERE contrato_id=${CONTRATO_ID}`
+    );
+    console.log(`  4. DELETE ${construccionIds.length} construccion WHERE id IN (...)`);
+    console.log(`  5. DELETE 1 contratos_construccion WHERE id=${CONTRATO_ID}`);
+    console.log(`\n  Las personas/contratistas/prototipos NO se tocan.\n`);
+    process.exit(0);
+  }
+
+  // ── APPLY ──────────────────────────────────────────────────────────
+  console.log(`▶ Ejecutando cleanup...\n`);
+
+  // Paso 1: borrar tareas terminadas (trigger ajusta avance + estado)
+  if (construccionIds.length > 0) {
+    const { error: e1, count: deletedTareas } = await sb
+      .schema('dilesa')
+      .from('construccion_tareas_terminadas')
+      .delete({ count: 'exact' })
+      .in('construccion_id', construccionIds);
+    if (e1) {
+      console.error(`❌ Paso 1: ${e1.message}`);
+      process.exit(1);
+    }
+    console.log(`  ✓ ${deletedTareas ?? 0} tareas_terminadas borradas`);
+  }
+
+  // Paso 2: UPDATE unidades como red de seguridad
+  if (unidadIds.length > 0) {
+    const { error: e2 } = await sb
+      .schema('dilesa')
+      .from('unidades')
+      .update({ producto_id: null, estado: 'planeada' })
+      .in('id', unidadIds);
+    if (e2) {
+      console.error(`❌ Paso 2: ${e2.message}`);
+      process.exit(1);
+    }
+    console.log(`  ✓ ${unidadIds.length} unidades regresadas a planeada + producto_id=NULL`);
+  }
+
+  // Paso 3: contrato_lotes
+  const { error: e3, count: deletedLotes } = await sb
+    .schema('dilesa')
+    .from('contrato_lotes')
+    .delete({ count: 'exact' })
+    .eq('contrato_id', CONTRATO_ID);
+  if (e3) {
+    console.error(`❌ Paso 3: ${e3.message}`);
+    process.exit(1);
+  }
+  console.log(`  ✓ ${deletedLotes ?? 0} contrato_lotes borrados`);
+
+  // Paso 4: construcciones
+  if (construccionIds.length > 0) {
+    const { error: e4, count: deletedConstr } = await sb
+      .schema('dilesa')
+      .from('construccion')
+      .delete({ count: 'exact' })
+      .in('id', construccionIds);
+    if (e4) {
+      console.error(`❌ Paso 4: ${e4.message}`);
+      process.exit(1);
+    }
+    console.log(`  ✓ ${deletedConstr ?? 0} construcciones borradas`);
+  }
+
+  // Paso 5: contrato
+  const { error: e5 } = await sb
+    .schema('dilesa')
+    .from('contratos_construccion')
+    .delete()
+    .eq('id', CONTRATO_ID);
+  if (e5) {
+    console.error(`❌ Paso 5: ${e5.message}`);
+    process.exit(1);
+  }
+  console.log(`  ✓ 1 contrato borrado\n`);
+
+  // Verificación final de unidades
+  if (unidadIds.length > 0) {
+    const { data: unidadesFinal } = await sb
+      .schema('dilesa')
+      .from('unidades')
+      .select('identificador, estado, producto_id')
+      .in('id', unidadIds);
+    console.log(`✓ Estado final de las unidades:`);
+    for (const u of unidadesFinal ?? []) {
+      console.log(
+        `    ${u.identificador} · estado=${u.estado} · producto_id=${u.producto_id ?? 'NULL'}`
+      );
+    }
+  }
+
+  console.log(`\n✅ Cleanup completado. Sin huella.\n`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

PR de polish del módulo Construcción detectado durante la prueba end-to-end de Beto. Dos cambios:

### 1. Fix: form contrato bloquea prototipo sin m² (silent skip → error visible)

Beto: **"se generó el contrato pero ningún lote pudo arrancarse"** sin descripción.

**Causa raíz**: el form filtraba lotes válidos por (unidad+prototipo+fecha) pero no por presencia de `productos.atributos.m2_construccion`. Cuando faltaba, `valorMo = precio × m²` quedaba en null, el contrato se insertaba con `valor_total=0`, y el loop hacía `continue` silencioso por cada lote.

**Cambios**:
- `lotesConDetalle` calcula `error: string | null` por fila.
- `lotesValidos` filtra por `error === null` → Submit deshabilitado hasta resolver.
- UI: borde rojo, dropdown muestra **"⚠ falta m²"**, mensaje inline.
- Defensa en el loop: race condition → `fallas` con mensaje (no silent skip).

**Datos** ya backfilled directo a prod (idempotente, derivado del histórico — 14 prototipos con `m2_construccion`).

### 2. Feat: días totales + fecha estimada de terminación

Beto: *"el total de los días para construcción no se calcula sumando las tareas… faltaría ese dato para determinar la fecha estimada de terminación"*.

La data sí existía en `plantilla_tareas.tiempo_dias` (poblada por import de Coda — 0 tareas sin días). Solo no se mostraba.

**Cambios sólo de UI** (sin DB, sin migración):

- **Prototipo** (`/construccion/prototipos/[id]`): suma `totalTiempoDias`, se muestra en tfoot (columna Días) + ficha "Días totales (plantilla)". Si `tiempo_construccion` viejo de Coda difiere, se muestra como referencia.
- **Obra** (`/construccion/[id]`): nuevas filas "Días estimados (plantilla)", "Fecha estimada terminación" = fecha_arranque + ceil(totalDías), y "Días reales (acumulados)" para comparar plan vs ejecución.

**Asunción**: tareas secuenciales en días corridos (como en Coda). Si en el futuro hay paralelismo, esto se vuelve esfuerzo total, no plazo.

### Bonus

`scripts/cleanup_prueba_construccion.ts` para rollback de contratos de prueba end-to-end (`CONTRATO_ID=<uuid> npx tsx ... [--apply]`).

## Test plan

- [ ] CI verde (typecheck + lint + format + tests + drift + Supabase preview)
- [ ] Beto re-corre la prueba en production con M17-L23-LDLE + LDLE-ISC (m²=56.58) → arranca sin error, valor MO ≈ \$215,153
- [ ] En detalle de prototipo LDLE-ISC: aparece "Días totales (plantilla) 72.85 días" en ficha + columna Días sumada en tfoot
- [ ] En detalle de obra (cualquiera importada): aparece "Días estimados (plantilla)" + "Fecha estimada terminación" calculada
- [ ] (Negativo) Prototipo nuevo sin m² → "⚠ falta m²" en dropdown del form + Submit deshabilitado

🤖 Generated with [Claude Code](https://claude.com/claude-code)