### PR TITLE
fix(dilesa): inventario solo muestra unidades con obra >= 20%

### DIFF
--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -153,7 +153,11 @@ function NuevaSolicitudForm() {
     setLoadingMeta(true);
     setLoadError(null);
 
-    // Unidades disponibles = activas en proyecto, sin venta vigente ligada.
+    // Unidades disponibles para asignar = obra arrancada con avance >= 20%
+    // (`en_construccion`, set automático por trigger `tg_construccion_avance`)
+    // o ya terminada físicamente (`terminada`). Las `planeada`/`lote_urbanizado`
+    // NO aparecen aquí — son lotes sin obra arrancada y no son vendibles aún
+    // bajo la regla operativa DILESA (regla 20%).
     const [uRes, prjRes, prodRes, tcRes, prRes, persRes] = await Promise.all([
       sb
         .schema('dilesa')
@@ -163,7 +167,7 @@ function NuevaSolicitudForm() {
         )
         .eq('empresa_id', DILESA_EMPRESA_ID)
         .is('deleted_at', null)
-        .in('estado', ['disponible', 'planeada']),
+        .in('estado', ['en_construccion', 'terminada']),
       sb
         .schema('dilesa')
         .from('proyectos')

--- a/components/dilesa/inventario-module.tsx
+++ b/components/dilesa/inventario-module.tsx
@@ -6,7 +6,12 @@
  * Iniciativa dilesa-portafolio-activos. Distinta de Portafolio (que muestra
  * todos los activos patrimoniales). Aquí solo aparecen unidades que se
  * pueden ofrecer a un cliente hoy:
- *   estado IN ('disponible', 'planeada')
+ *   estado IN ('en_construccion', 'terminada')
+ *
+ * Regla operativa DILESA: una unidad NO es vendible hasta que su obra
+ * cruzó el 20% de avance (trigger `tg_construccion_avance` marca la unidad
+ * como `en_construccion` automáticamente). Las `planeada` / `lote_urbanizado`
+ * son lotes sin obra arrancada y no aparecen aquí.
  *
  * Cada fila muestra el precio calculado (vía RPC fn_calcular_precio_venta)
  * para que el vendedor pueda cotizar sin tener que abrir el form. Click en
@@ -47,13 +52,13 @@ type UnidadListaRow = UnidadRow & {
 };
 
 const ESTADO_TONE: Record<string, BadgeTone> = {
-  disponible: 'success',
-  planeada: 'info',
+  en_construccion: 'info',
+  terminada: 'success',
 };
 
 const ESTADO_LABEL: Record<string, string> = {
-  disponible: 'Disponible',
-  planeada: 'Planeada',
+  en_construccion: 'En construcción',
+  terminada: 'Terminada',
 };
 
 export function InventarioModule({ empresaId }: { empresaId: string }) {
@@ -73,8 +78,12 @@ export function InventarioModule({ empresaId }: { empresaId: string }) {
   }> => {
     const sb = createSupabaseBrowserClient();
 
-    // Unidades disponibles. `.eq(empresa_id)` para evitar `.in(ids[])` que
-    // rebasaría URL si hubiera muchas; filtro de estado en query (no JS).
+    // Unidades disponibles para asignar = obra arrancada con avance >= 20%
+    // (`en_construccion`, set automático por trigger `tg_construccion_avance`)
+    // o ya terminada físicamente (`terminada`). Las `planeada`/`lote_urbanizado`
+    // NO aparecen aquí — son lotes sin obra arrancada y no son vendibles aún
+    // bajo la regla operativa DILESA. `.eq(empresa_id)` para evitar `.in(ids[])`
+    // que rebasaría URL si hubiera muchas; filtro de estado en query (no JS).
     const { data: uns, error: uErr } = await sb
       .schema('dilesa')
       .from('unidades')
@@ -83,7 +92,7 @@ export function InventarioModule({ empresaId }: { empresaId: string }) {
       )
       .eq('empresa_id', empresaId)
       .is('deleted_at', null)
-      .in('estado', ['disponible', 'planeada']);
+      .in('estado', ['en_construccion', 'terminada']);
     if (uErr) return { error: getSupabaseErrorMessage(uErr, 'No se pudo cargar el inventario.') };
     const unidadesArr = (uns ?? []) as UnidadRow[];
 


### PR DESCRIPTION
## Summary

Beto detectó en prueba end-to-end que **unidades sin obra arrancada (M17-L23-LDLE, estado \`planeada\`) seguían apareciendo como disponibles para asignar al equipo de ventas**.

**Regla operativa DILESA**: una vivienda no es vendible hasta que su obra cruzó el 20% de avance (estado \`en_construccion\`, set automático por trigger \`tg_construccion_avance\`).

**Causa**: el filtro era \`.in('estado', ['disponible', 'planeada'])\`. Doble problema:
- \`'disponible'\` ni siquiera es un estado válido del check constraint — deadcode heredado.
- \`'planeada'\` incluye lotes sin obra arrancada → premature.

## Cambios

Filtro corregido en 2 lugares:

\`\`\`diff
- .in('estado', ['disponible', 'planeada'])
+ .in('estado', ['en_construccion', 'terminada'])
\`\`\`

- \`components/dilesa/inventario-module.tsx\`: filtro + mapas ESTADO_TONE/ESTADO_LABEL actualizados + doc header del módulo refleja la nueva regla.
- \`app/dilesa/ventas/nueva/page.tsx\`: mismo filtro en el form de Nueva Solicitud. Comentario corregido (decía "sin venta vigente ligada" pero el filtro nunca verificaba eso — ahora describe la regla real del 20%).

## Test plan

- [ ] CI verde
- [ ] En preview: \`/dilesa/ventas/inventario\` ya **no** muestra M17-L23-LDLE (estado \`planeada\`, sin obra)
- [ ] En preview: \`/dilesa/ventas/nueva\` selector de unidades tampoco muestra M17-L23-LDLE
- [ ] (Loop completo) Una vez que se mergee #519 + #520, Beto arranca obra de M17-L23-LDLE, paloméa tareas hasta cruzar 20% → la unidad pasa a \`en_construccion\` automáticamente vía trigger → ahora SÍ aparece en Inventario + Nueva Solicitud
- [ ] Verificar que otras unidades históricas en estado \`en_construccion\` o \`terminada\` siguen apareciendo igual que antes

🤖 Generated with [Claude Code](https://claude.com/claude-code)