### PR TITLE
feat(dilesa): estimaciones Sprint 3 — UI lista + detalle (5° tab Construcción)

### DIFF
--- a/app/dilesa/construccion/estimaciones/[id]/page.tsx
+++ b/app/dilesa/construccion/estimaciones/[id]/page.tsx
@@ -1,0 +1,615 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de detalle.
+ */
+
+/**
+ * Detalle de una estimación de pago a contratista (DILESA).
+ *
+ * Iniciativa dilesa-estimaciones · Sprint 3. Solo lectura — los botones
+ * de transición de estado (aprobar/marcar facturada/marcar pagada) y la
+ * generación de borradores nuevos llegan en Sprint 4-5.
+ *
+ * Secciones:
+ *   1. Datos generales — código, contratista, fechas, retención, montos
+ *      brutos/retenidos/netos, factura (si existe), audit trail.
+ *   2. Desglose por obra — acordeón con todas las construcciones
+ *      afectadas, sus tareas vinculadas y subtotales. La estimación
+ *      es multi-obra por diseño (1 contratista trabaja varias
+ *      viviendas a la vez).
+ */
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, Banknote, ChevronDown, ChevronRight } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Badge } from '@/components/ui/badge';
+import type { BadgeTone } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type Estimacion = {
+  id: string;
+  codigo: string;
+  contratista_id: string;
+  fecha_cierre: string;
+  fecha_pago_programado: string;
+  monto_bruto: number;
+  retencion_pct: number;
+  retencion_monto: number;
+  monto_neto: number;
+  factura_url: string | null;
+  factura_folio: string | null;
+  factura_fecha: string | null;
+  aprobada_por_user_id: string | null;
+  aprobada_at: string | null;
+  pagada_por_user_id: string | null;
+  pagada_at: string | null;
+  referencia_pago: string | null;
+  estado: string;
+  notas: string | null;
+};
+
+type EstimTarea = {
+  id: string;
+  tarea_terminada_id: string;
+  construccion_id: string;
+  monto_calculado: number;
+};
+
+type Construccion = {
+  id: string;
+  codigo: string;
+  unidad_id: string;
+};
+
+type TareaTerminada = {
+  id: string;
+  plantilla_tarea_id: string;
+  fecha_terminada: string | null;
+};
+
+type Plantilla = {
+  id: string;
+  tarea_id: string;
+};
+
+type Tarea = { id: string; nombre: string };
+
+const ESTADO_TONE: Record<string, BadgeTone> = {
+  borrador: 'neutral',
+  aprobada: 'info',
+  facturada: 'warning',
+  pagada: 'success',
+  cancelada: 'danger',
+};
+const ESTADO_LABEL: Record<string, string> = {
+  borrador: 'Borrador',
+  aprobada: 'Aprobada',
+  facturada: 'Facturada',
+  pagada: 'Pagada',
+  cancelada: 'Cancelada',
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const money = (n: number | null) => (n == null ? '—' : moneyFmt.format(n));
+
+function fmtFecha(s: string | null): string {
+  if (!s) return '—';
+  const d = new Date(`${s}T00:00:00`);
+  if (isNaN(d.getTime())) return s;
+  return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+function fmtFechaHora(s: string | null): string {
+  if (!s) return '—';
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return s;
+  return d.toLocaleString('es-MX', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * @module Estimación detail (DILESA)
+ * @responsive desktop-only
+ */
+export default function EstimacionDetailPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.estimaciones">
+      <DetailInner />
+    </RequireAccess>
+  );
+}
+
+function DetailInner() {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+
+  const [estim, setEstim] = useState<Estimacion | null>(null);
+  const [contratistaNombre, setContratistaNombre] = useState<string | null>(null);
+  const [contratistaAbrev, setContratistaAbrev] = useState<string | null>(null);
+  const [aprobadaPor, setAprobadaPor] = useState<string | null>(null);
+  const [pagadaPor, setPagadaPor] = useState<string | null>(null);
+  const [estTareas, setEstTareas] = useState<EstimTarea[]>([]);
+  const [construcciones, setConstrucciones] = useState<Map<string, Construccion>>(new Map());
+  const [unidadIds, setUnidadIds] = useState<Map<string, string>>(new Map());
+  const [terminadas, setTerminadas] = useState<Map<string, TareaTerminada>>(new Map());
+  const [plantillas, setPlantillas] = useState<Map<string, Plantilla>>(new Map());
+  const [tareasCat, setTareasCat] = useState<Map<string, Tarea>>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let activo = true;
+    const sb = createSupabaseBrowserClient();
+    setLoading(true);
+    setError(null);
+
+    (async () => {
+      const { data: eRow, error: eErr } = await sb
+        .schema('dilesa')
+        .from('estimaciones')
+        .select('*')
+        .eq('id', id)
+        .is('deleted_at', null)
+        .maybeSingle();
+      if (!activo) return;
+      if (eErr) {
+        setError(getSupabaseErrorMessage(eErr, 'No se pudo cargar la estimación.'));
+        setLoading(false);
+        return;
+      }
+      if (!eRow) {
+        setError('Estimación no encontrada.');
+        setLoading(false);
+        return;
+      }
+      const estimRow = eRow as unknown as Estimacion;
+      setEstim(estimRow);
+
+      // Cargas paralelas: contratista, audit users, estimacion_tareas.
+      const [persRes, etRes, aprobUserRes, pagUserRes] = await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno')
+          .eq('id', estimRow.contratista_id)
+          .maybeSingle(),
+        sb
+          .schema('dilesa')
+          .from('estimacion_tareas')
+          .select('id, tarea_terminada_id, construccion_id, monto_calculado')
+          .eq('estimacion_id', estimRow.id),
+        estimRow.aprobada_por_user_id
+          ? sb
+              .schema('core')
+              .from('usuarios')
+              .select('first_name, email')
+              .eq('id', estimRow.aprobada_por_user_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+        estimRow.pagada_por_user_id
+          ? sb
+              .schema('core')
+              .from('usuarios')
+              .select('first_name, email')
+              .eq('id', estimRow.pagada_por_user_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+      ]);
+      if (!activo) return;
+
+      if (persRes.data) {
+        const n = [
+          persRes.data.nombre,
+          persRes.data.apellido_paterno,
+          persRes.data.apellido_materno,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        setContratistaNombre(n || '(sin nombre)');
+        // Buscar abrev en satélite
+        const { data: cd } = await sb
+          .schema('dilesa')
+          .from('contratistas_datos')
+          .select('abreviacion')
+          .eq('persona_id', estimRow.contratista_id)
+          .is('deleted_at', null)
+          .maybeSingle();
+        if (activo) setContratistaAbrev((cd?.abreviacion as string | null) ?? null);
+      }
+      if (aprobUserRes.data) {
+        setAprobadaPor(
+          (aprobUserRes.data.first_name as string | null) ??
+            (aprobUserRes.data.email as string | null) ??
+            null
+        );
+      }
+      if (pagUserRes.data) {
+        setPagadaPor(
+          (pagUserRes.data.first_name as string | null) ??
+            (pagUserRes.data.email as string | null) ??
+            null
+        );
+      }
+
+      const etArr = (etRes.data ?? []) as EstimTarea[];
+      setEstTareas(etArr);
+
+      // Cargar construcciones + tareas terminadas + plantillas + catálogo de
+      // tareas para el desglose por obra.
+      const construccionIds = [...new Set(etArr.map((e) => e.construccion_id))];
+      const tareaTerminadaIds = [...new Set(etArr.map((e) => e.tarea_terminada_id))];
+
+      if (construccionIds.length === 0) {
+        setLoading(false);
+        return;
+      }
+
+      const [cRes, ttRes, taRes] = await Promise.all([
+        sb
+          .schema('dilesa')
+          .from('construccion')
+          .select('id, codigo, unidad_id')
+          .in('id', construccionIds),
+        sb
+          .schema('dilesa')
+          .from('construccion_tareas_terminadas')
+          .select('id, plantilla_tarea_id, fecha_terminada')
+          .in('id', tareaTerminadaIds),
+        sb.schema('dilesa').from('tareas_construccion').select('id, nombre'),
+      ]);
+      if (!activo) return;
+
+      const cMap = new Map<string, Construccion>();
+      const uMap = new Map<string, string>();
+      for (const c of cRes.data ?? []) {
+        cMap.set(c.id as string, c as Construccion);
+        uMap.set(c.id as string, c.unidad_id as string);
+      }
+      setConstrucciones(cMap);
+
+      const ttMap = new Map<string, TareaTerminada>();
+      const plantillaIds = new Set<string>();
+      for (const tt of ttRes.data ?? []) {
+        ttMap.set(tt.id as string, tt as TareaTerminada);
+        plantillaIds.add(tt.plantilla_tarea_id as string);
+      }
+      setTerminadas(ttMap);
+
+      const tMap = new Map<string, Tarea>();
+      for (const t of taRes.data ?? []) tMap.set(t.id as string, { id: t.id, nombre: t.nombre });
+      setTareasCat(tMap);
+
+      // Plantillas → tareas (mapping plantilla_id → tarea_id)
+      if (plantillaIds.size > 0) {
+        const { data: pRes } = await sb
+          .schema('dilesa')
+          .from('plantilla_tareas')
+          .select('id, tarea_id')
+          .in('id', [...plantillaIds]);
+        if (!activo) return;
+        const pMap = new Map<string, Plantilla>();
+        for (const p of pRes ?? []) pMap.set(p.id as string, p as Plantilla);
+        setPlantillas(pMap);
+      }
+
+      // Unidades (identificadores)
+      const unidadIdsArr = [...new Set([...uMap.values()])];
+      if (unidadIdsArr.length > 0) {
+        const { data: uRes } = await sb
+          .schema('dilesa')
+          .from('unidades')
+          .select('id, identificador')
+          .in('id', unidadIdsArr);
+        if (!activo) return;
+        const idMap = new Map<string, string>();
+        for (const u of uRes ?? []) idMap.set(u.id as string, u.identificador as string);
+        setUnidadIds(idMap);
+      }
+
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [id]);
+
+  /** Desglose: por construccion_id, lista de tareas con su nombre + monto. */
+  const desglosePorObra = useMemo(() => {
+    const grupos = new Map<
+      string,
+      Array<{ nombre: string; fecha: string | null; monto: number }>
+    >();
+    for (const et of estTareas) {
+      const tt = terminadas.get(et.tarea_terminada_id);
+      const plantilla = tt ? plantillas.get(tt.plantilla_tarea_id) : null;
+      const tareaInfo = plantilla ? tareasCat.get(plantilla.tarea_id) : null;
+      const nombre = tareaInfo?.nombre ?? '(tarea desconocida)';
+      const arr = grupos.get(et.construccion_id) ?? [];
+      arr.push({ nombre, fecha: tt?.fecha_terminada ?? null, monto: et.monto_calculado });
+      grupos.set(et.construccion_id, arr);
+    }
+    return [...grupos.entries()]
+      .map(([construccion_id, items]) => {
+        const c = construcciones.get(construccion_id);
+        const unidadId = c?.unidad_id ?? null;
+        const identificador = unidadId
+          ? (unidadIds.get(unidadId) ?? '(sin unidad)')
+          : '(sin unidad)';
+        const subtotal = items.reduce((s, i) => s + i.monto, 0);
+        return {
+          construccion_id,
+          construccion_codigo: c?.codigo ?? '—',
+          unidad_identificador: identificador,
+          items: items.sort((a, b) => a.nombre.localeCompare(b.nombre)),
+          subtotal,
+        };
+      })
+      .sort((a, b) => a.unidad_identificador.localeCompare(b.unidad_identificador));
+  }, [estTareas, terminadas, plantillas, tareasCat, construcciones, unidadIds]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !estim) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Estimación no encontrada.'}
+        </div>
+      </div>
+    );
+  }
+
+  const contratistaDisplay = contratistaAbrev
+    ? `${contratistaAbrev} · ${contratistaNombre ?? ''}`
+    : (contratistaNombre ?? '—');
+
+  return (
+    <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight text-[var(--text)]">
+            <Banknote className="h-5 w-5 text-[var(--accent)]" />
+            {estim.codigo}
+          </h1>
+          <p className="mt-1 text-sm text-[var(--text)]/60">
+            {contratistaDisplay} · cierre {fmtFecha(estim.fecha_cierre)}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge tone={ESTADO_TONE[estim.estado] ?? 'neutral'}>
+            {ESTADO_LABEL[estim.estado] ?? estim.estado}
+          </Badge>
+          <div className="rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5">
+            <div className="text-[10px] uppercase tracking-wide text-[var(--text)]/50">Neto</div>
+            <div className="text-base font-semibold tabular-nums text-[var(--text)]">
+              {money(estim.monto_neto)}
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <Section title="Datos generales">
+        <FichaGrid
+          rows={[
+            ['Código', estim.codigo],
+            ['Contratista', contratistaDisplay],
+            ['Fecha de cierre', fmtFecha(estim.fecha_cierre)],
+            ['Pago programado', fmtFecha(estim.fecha_pago_programado)],
+            ['Tareas incluidas', String(estTareas.length)],
+            [
+              'Retención',
+              `${Number(estim.retencion_pct).toFixed(1)}% (${money(estim.retencion_monto)})`,
+            ],
+            ['Monto bruto', money(estim.monto_bruto)],
+            ['Monto neto', money(estim.monto_neto)],
+          ]}
+        />
+        {estim.notas ? (
+          <div className="mt-4 border-t border-[var(--border)] pt-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+              Notas
+            </div>
+            <p className="mt-0.5 whitespace-pre-wrap text-sm text-[var(--text)]/80">
+              {estim.notas}
+            </p>
+          </div>
+        ) : null}
+      </Section>
+
+      {/* Factura + Pago — solo mostrar si hay datos */}
+      {estim.factura_url ||
+      estim.factura_folio ||
+      estim.referencia_pago ||
+      estim.aprobada_at ||
+      estim.pagada_at ? (
+        <Section title="Factura y pago">
+          <FichaGrid
+            rows={
+              [
+                estim.factura_folio ? ['Factura folio', estim.factura_folio] : null,
+                estim.factura_fecha ? ['Factura fecha', fmtFecha(estim.factura_fecha)] : null,
+                estim.factura_url
+                  ? [
+                      'Factura URL',
+                      (
+                        <a
+                          href={estim.factura_url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-[var(--accent)] hover:underline"
+                          key="url"
+                        >
+                          Abrir factura
+                        </a>
+                      ) as unknown as string,
+                    ]
+                  : null,
+                estim.aprobada_at
+                  ? [
+                      'Aprobada',
+                      `${fmtFechaHora(estim.aprobada_at)}${aprobadaPor ? ` por ${aprobadaPor}` : ''}`,
+                    ]
+                  : null,
+                estim.pagada_at
+                  ? [
+                      'Pagada',
+                      `${fmtFechaHora(estim.pagada_at)}${pagadaPor ? ` por ${pagadaPor}` : ''}`,
+                    ]
+                  : null,
+                estim.referencia_pago ? ['Referencia de pago', estim.referencia_pago] : null,
+              ].filter((r): r is [string, string] => !!r) as [string, string][]
+            }
+          />
+        </Section>
+      ) : null}
+
+      <Section
+        title="Desglose por obra"
+        description={`${desglosePorObra.length} obra(s) · ${estTareas.length} tarea(s)`}
+      >
+        {desglosePorObra.length === 0 ? (
+          <p className="text-sm text-[var(--text)]/60">Sin tareas vinculadas.</p>
+        ) : (
+          <div className="space-y-2">
+            {desglosePorObra.map((g) => (
+              <ObraBlock key={g.construccion_id} grupo={g} />
+            ))}
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function ObraBlock({
+  grupo,
+}: {
+  grupo: {
+    construccion_id: string;
+    construccion_codigo: string;
+    unidad_identificador: string;
+    items: Array<{ nombre: string; fecha: string | null; monto: number }>;
+    subtotal: number;
+  };
+}) {
+  const [open, setOpen] = useState(false);
+  const Icon = open ? ChevronDown : ChevronRight;
+  return (
+    <div className="rounded-md border border-[var(--border)] bg-[var(--card)]">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-[var(--bg)]/30"
+      >
+        <Icon className="h-4 w-4 shrink-0 text-[var(--text)]/40" />
+        <Link
+          href={`/dilesa/construccion/${grupo.construccion_id}`}
+          onClick={(e) => e.stopPropagation()}
+          className="text-sm font-medium text-[var(--text)] hover:text-[var(--accent)]"
+        >
+          {grupo.unidad_identificador}
+        </Link>
+        <span className="text-xs text-[var(--text)]/50">{grupo.construccion_codigo}</span>
+        <span className="ml-auto text-xs tabular-nums text-[var(--text)]/60">
+          {grupo.items.length} tarea{grupo.items.length === 1 ? '' : 's'}
+        </span>
+        <span className="w-32 shrink-0 text-right text-sm font-medium tabular-nums text-[var(--text)]">
+          {moneyFmt.format(grupo.subtotal)}
+        </span>
+      </button>
+      {open ? (
+        <ul className="border-t border-[var(--border)]/60 px-3 py-2">
+          {grupo.items.map((it, idx) => (
+            <li
+              key={idx}
+              className="flex items-start gap-3 border-b border-[var(--border)]/40 py-1.5 text-xs last:border-0"
+            >
+              <div className="flex-1 text-[var(--text)]/80">{it.nombre}</div>
+              <div className="w-24 shrink-0 text-right tabular-nums text-[var(--text)]/55">
+                {it.fecha ? fmtFecha(it.fecha) : '—'}
+              </div>
+              <div className="w-28 shrink-0 text-right tabular-nums text-[var(--text)]">
+                {moneyFmt.format(it.monto)}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/dilesa/construccion/estimaciones"
+      className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+    >
+      <ArrowLeft className="size-4" /> Volver a estimaciones
+    </Link>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="mb-4 flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {description ? <span className="text-xs text-[var(--text)]/50">{description}</span> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function FichaGrid({ rows }: { rows: [string, string][] }) {
+  return (
+    <dl className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
+      {rows.map((r) => (
+        <div key={r[0]}>
+          <dt className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+            {r[0]}
+          </dt>
+          <dd className="mt-0.5 text-sm text-[var(--text)]">{r[1]}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/app/dilesa/construccion/estimaciones/page.tsx
+++ b/app/dilesa/construccion/estimaciones/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { EstimacionesModule } from '@/components/dilesa/estimaciones-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Construcción · Estimaciones (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Estimaciones" del hub Construcción (iniciativa dilesa-estimaciones
+ * · Sprint 3). Lista filtrable de las filas en `dilesa.estimaciones` con
+ * desglose mínimo (código, contratista, monto neto, estado) + acceso al
+ * detalle por click en fila.
+ *
+ * Gate: sub-slug `dilesa.construccion.estimaciones` (creado en Sprint 2).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.estimaciones">
+      <DesktopOnlyNotice module="Estimaciones" />
+      <div className="hidden sm:block">
+        <EstimacionesModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/construccion/layout.tsx
+++ b/app/dilesa/construccion/layout.tsx
@@ -50,6 +50,11 @@ const TABS = [
     href: '/dilesa/construccion/prototipos',
     module: 'dilesa.construccion.prototipos',
   },
+  {
+    label: 'Estimaciones',
+    href: '/dilesa/construccion/estimaciones',
+    module: 'dilesa.construccion.estimaciones',
+  },
 ] as const;
 
 export default function ConstruccionLayout({ children }: { children: ReactNode }) {

--- a/components/dilesa/estimaciones-module.tsx
+++ b/components/dilesa/estimaciones-module.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+/**
+ * EstimacionesModule — lista de estimaciones de pago a contratistas DILESA.
+ *
+ * Iniciativa dilesa-estimaciones · Sprint 3. Tab "Estimaciones" del hub
+ * Construcción. Lista filtrable de las filas en `dilesa.estimaciones`:
+ * código, fecha de cierre, contratista, # tareas, monto neto, estado.
+ *
+ * Click en fila → /dilesa/construccion/estimaciones/[id] con la ficha
+ * completa + desglose por obra.
+ *
+ * Carga cross-schema con queries paralelas + lookups Map (mismo patrón
+ * que contratos-module / construccion-module).
+ *
+ * El botón "+ Nueva estimación" se agrega en Sprint 4. En Sprint 3 solo
+ * es lectura — Beto verifica el histórico migrado de Coda (188 fichas
+ * pagadas, $25M+ acumulado).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Banknote, RefreshCw, Search } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { BadgeTone } from '@/components/ui/badge';
+import { DataTable, type Column } from '@/components/module-page';
+import { Input } from '@/components/ui/input';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+type EstimacionRow = {
+  id: string;
+  codigo: string;
+  fecha_cierre: string;
+  fecha_pago_programado: string;
+  contratista_id: string;
+  monto_bruto: number;
+  monto_neto: number;
+  estado: string;
+  pagada_at: string | null;
+  /** Computed cross-schema (erp.personas). */
+  contratistaNombre: string;
+  contratistaAbreviacion: string | null;
+  /** Computed: # de tareas vinculadas. */
+  tareasCount: number;
+};
+
+const ESTADO_TONE: Record<string, BadgeTone> = {
+  borrador: 'neutral',
+  aprobada: 'info',
+  facturada: 'warning',
+  pagada: 'success',
+  cancelada: 'danger',
+};
+
+const ESTADO_LABEL: Record<string, string> = {
+  borrador: 'Borrador',
+  aprobada: 'Aprobada',
+  facturada: 'Facturada',
+  pagada: 'Pagada',
+  cancelada: 'Cancelada',
+};
+
+const ESTADO_OPTIONS = ['borrador', 'aprobada', 'facturada', 'pagada', 'cancelada'] as const;
+
+export function EstimacionesModule({ empresaId }: { empresaId: string }) {
+  const router = useRouter();
+
+  const [estimaciones, setEstimaciones] = useState<EstimacionRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [contratistaFiltro, setContratistaFiltro] = useState('');
+  const [estadoFiltro, setEstadoFiltro] = useState<string>('');
+
+  const fetchEstimaciones = useCallback(async (): Promise<{
+    data?: EstimacionRow[];
+    error?: string;
+  }> => {
+    const sb = createSupabaseBrowserClient();
+
+    // 4 queries paralelas: estimaciones + estimacion_tareas (count) +
+    // personas (contratistas, cross-schema) + datos satellite (abrev).
+    const [eRes, etRes, personasRes, datosRes] = await Promise.all([
+      sb
+        .schema('dilesa')
+        .from('estimaciones')
+        .select(
+          'id, codigo, fecha_cierre, fecha_pago_programado, contratista_id, monto_bruto, monto_neto, estado, pagada_at'
+        )
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('estimacion_tareas')
+        .select('estimacion_id')
+        .eq('empresa_id', empresaId),
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .eq('empresa_id', empresaId)
+        .eq('tipo', 'contratista'),
+      sb
+        .schema('dilesa')
+        .from('contratistas_datos')
+        .select('persona_id, abreviacion')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr = eRes.error ?? etRes.error ?? personasRes.error ?? datosRes.error;
+    if (firstErr) {
+      return {
+        error: getSupabaseErrorMessage(firstErr, 'No se pudieron cargar las estimaciones.'),
+      };
+    }
+
+    const personaMap = new Map<string, string>();
+    for (const p of personasRes.data ?? []) {
+      const nombre = [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' ');
+      personaMap.set(p.id as string, nombre || '(sin nombre)');
+    }
+    const abrevMap = new Map<string, string | null>();
+    for (const d of datosRes.data ?? []) {
+      abrevMap.set(d.persona_id as string, (d.abreviacion as string | null) ?? null);
+    }
+
+    const tareasByEstim = new Map<string, number>();
+    for (const t of etRes.data ?? []) {
+      const eid = t.estimacion_id as string;
+      tareasByEstim.set(eid, (tareasByEstim.get(eid) ?? 0) + 1);
+    }
+
+    const rows: EstimacionRow[] = (eRes.data ?? []).map((e) => {
+      const cid = e.contratista_id as string;
+      return {
+        id: e.id as string,
+        codigo: e.codigo as string,
+        fecha_cierre: e.fecha_cierre as string,
+        fecha_pago_programado: e.fecha_pago_programado as string,
+        contratista_id: cid,
+        monto_bruto: Number(e.monto_bruto ?? 0),
+        monto_neto: Number(e.monto_neto ?? 0),
+        estado: e.estado as string,
+        pagada_at: (e.pagada_at as string | null) ?? null,
+        contratistaNombre: personaMap.get(cid) ?? '(sin contratista)',
+        contratistaAbreviacion: abrevMap.get(cid) ?? null,
+        tareasCount: tareasByEstim.get(e.id as string) ?? 0,
+      };
+    });
+
+    return { data: rows };
+  }, [empresaId]);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: e } = await fetchEstimaciones();
+    if (e) {
+      setError(e);
+      setEstimaciones([]);
+    } else setEstimaciones(data ?? []);
+    setLoading(false);
+  }, [fetchEstimaciones]);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchEstimaciones().then(({ data, error: e }) => {
+      if (!activo) return;
+      if (e) {
+        setError(e);
+        setEstimaciones([]);
+      } else setEstimaciones(data ?? []);
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchEstimaciones]);
+
+  const contratistasPresentes = useMemo(
+    () => [...new Set(estimaciones.map((e) => e.contratistaNombre).filter(Boolean))].sort(),
+    [estimaciones]
+  );
+
+  const filtradas = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return estimaciones.filter((e) => {
+      if (contratistaFiltro && e.contratistaNombre !== contratistaFiltro) return false;
+      if (estadoFiltro && e.estado !== estadoFiltro) return false;
+      if (q) {
+        const hay =
+          e.codigo.toLowerCase().includes(q) || e.contratistaNombre.toLowerCase().includes(q);
+        if (!hay) return false;
+      }
+      return true;
+    });
+  }, [estimaciones, search, contratistaFiltro, estadoFiltro]);
+
+  /** Suma de montos visibles según filtros — útil para el operador que
+   *  filtra por contratista/semana y quiere ver el total acumulado. */
+  const totalesFiltrados = useMemo(() => {
+    let bruto = 0;
+    let neto = 0;
+    for (const e of filtradas) {
+      bruto += e.monto_bruto;
+      neto += e.monto_neto;
+    }
+    return { bruto, neto };
+  }, [filtradas]);
+
+  const columns: Column<EstimacionRow>[] = [
+    {
+      key: 'codigo',
+      label: 'Código',
+      type: 'text',
+      sticky: true,
+      width: 'min-w-[260px]',
+    },
+    { key: 'fecha_cierre', label: 'Fecha cierre', type: 'date' },
+    {
+      key: 'contratistaNombre',
+      label: 'Contratista',
+      type: 'custom',
+      accessor: (e) => e.contratistaNombre,
+      render: (e) =>
+        e.contratistaAbreviacion ? (
+          <span title={e.contratistaNombre}>
+            <span className="font-medium">{e.contratistaAbreviacion}</span>
+            <span className="ml-1 text-[var(--text)]/40">·</span>
+            <span className="ml-1 text-[var(--text)]/60">{e.contratistaNombre}</span>
+          </span>
+        ) : (
+          e.contratistaNombre
+        ),
+    },
+    { key: 'tareasCount', label: 'Tareas', type: 'number' },
+    { key: 'monto_bruto', label: 'Bruto', type: 'currency' },
+    { key: 'monto_neto', label: 'Neto', type: 'currency' },
+    {
+      key: 'estado',
+      label: 'Estado',
+      type: 'custom',
+      accessor: (e) => e.estado,
+      render: (e) => (
+        <Badge tone={ESTADO_TONE[e.estado] ?? 'neutral'}>
+          {ESTADO_LABEL[e.estado] ?? e.estado}
+        </Badge>
+      ),
+    },
+  ];
+
+  const onRowClick = (e: EstimacionRow) => {
+    router.push(`/dilesa/construccion/estimaciones/${e.id}`);
+  };
+
+  const moneyFmt = new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+    maximumFractionDigits: 0,
+  });
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <Banknote className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Estimaciones</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Ciclo de pago semanal a contratistas: cierre miércoles, pago jueves. Cada estimación
+            agrupa las tareas terminadas pendientes y aplica retención 5%.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar código o contratista…"
+            className="w-72 pl-9"
+          />
+        </div>
+        <select
+          value={contratistaFiltro}
+          onChange={(e) => setContratistaFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los contratistas</option>
+          {contratistasPresentes.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          value={estadoFiltro}
+          onChange={(e) => setEstadoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los estados</option>
+          {ESTADO_OPTIONS.map((e) => (
+            <option key={e} value={e}>
+              {ESTADO_LABEL[e]}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {filtradas.length} de {estimaciones.length} estimaciones
+          {filtradas.length > 0 ? (
+            <>
+              {' · '}
+              <span className="tabular-nums text-[var(--text)]/80">
+                Neto {moneyFmt.format(totalesFiltrados.neto)}
+              </span>
+            </>
+          ) : null}
+        </span>
+      </div>
+
+      <DataTable
+        data={filtradas}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={onRowClick}
+        initialSort={{ key: 'fecha_cierre', dir: 'desc' }}
+        emptyTitle="Sin estimaciones"
+        emptyDescription="No hay estimaciones que coincidan con los filtros actuales."
+        emptyIcon={<Banknote className="h-6 w-6" />}
+        maxHeight="calc(100vh - 280px)"
+      />
+    </div>
+  );
+}

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -51,6 +51,7 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   '/dilesa/construccion/contratos': 'dilesa.construccion.contratos',
   '/dilesa/construccion/contratistas': 'dilesa.construccion.contratistas',
   '/dilesa/construccion/prototipos': 'dilesa.construccion.prototipos',
+  '/dilesa/construccion/estimaciones': 'dilesa.construccion.estimaciones',
   // Captura por fase — sub-slugs ADR-030. Cada URL apunta al sub-slug que
   // gobierna acceso a esa fase. Ver docs/planning/dilesa-ventas-captura.md.
   '/dilesa/ventas/nueva': 'dilesa.ventas.fase01_solicitud',


### PR DESCRIPTION
## Summary

Sprint 3 de \`dilesa-estimaciones\`. Expone el 5° tab del hub Construcción con lista filtrable + detalle. **Solo lectura** — los botones de transición (aprobar/facturar/pagar) y la generación de borradores llegan en Sprint 4-5.

## Archivos nuevos

- \`components/dilesa/estimaciones-module.tsx\` — lista con filtros (búsqueda, contratista, estado) + columnas (código / fecha / contratista / # tareas / bruto / neto / estado). Total neto agregado de filas visibles. Patrón cross-schema igual a contratos-module.
- \`app/dilesa/construccion/estimaciones/page.tsx\` — wrapper RBAC sub-slug \`dilesa.construccion.estimaciones\`.
- \`app/dilesa/construccion/estimaciones/[id]/page.tsx\` — detalle con:
  - Header: código + contratista + monto neto + badge estado
  - Datos generales: contratista, fechas, retención, montos (bruto/retenido/neto)
  - Factura y pago: solo si hay data (URL, folio, fecha, audit)
  - **Desglose por obra**: acordeón agrupando tareas vinculadas con subtotales. Links a \`/construccion/[id]\` para profundizar en cada obra.

## Wiring

- \`app/dilesa/construccion/layout.tsx\`: 5° tab "Estimaciones"
- \`lib/permissions.ts\`: ROUTE_TO_MODULE de la nueva ruta

## Sin DB changes

Toda la infraestructura está en prod desde Sprints 1+2 (188 estimaciones históricas backfilled de Coda, lock activo, RBAC creado).

## Test plan

- [ ] CI verde
- [ ] Preview: \`/dilesa/construccion/estimaciones\` muestra 188 estimaciones, todas en estado "Pagada"
- [ ] Filtros funcionan (búsqueda, contratista, estado)
- [ ] Total neto en footer suma correctamente
- [ ] Click en fila → detalle muestra desglose por obra con tareas y subtotales
- [ ] Link a obra en desglose navega al detalle de obra

## Próximo (Sprint 4-5)

- Sprint 4: form "Nueva estimación" + botones de transición (aprobar/facturar/pagar)
- Sprint 5: PDF + email Resend al aprobar pidiendo factura

🤖 Generated with [Claude Code](https://claude.com/claude-code)