### PR TITLE
feat(dilesa): estimaciones Sprint 4 — generar borrador + transiciones

### DIFF
--- a/app/dilesa/construccion/estimaciones/[id]/page.tsx
+++ b/app/dilesa/construccion/estimaciones/[id]/page.tsx
@@ -23,12 +23,25 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Banknote, ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  ArrowLeft,
+  Banknote,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Loader2,
+  X,
+} from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { usePermissions } from '@/components/providers';
 import { Badge } from '@/components/ui/badge';
 import type { BadgeTone } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 
 type Estimacion = {
@@ -133,9 +146,19 @@ export default function EstimacionDetailPage() {
   );
 }
 
+type ModalKind = 'aprobar' | 'facturar' | 'pagar' | 'cancelar' | null;
+
 function DetailInner() {
   const params = useParams<{ id: string }>();
   const id = params.id;
+  const { permissions } = usePermissions();
+  const toast = useToast();
+  const puedeEscribir =
+    permissions.isAdmin ||
+    permissions.modulos.get('dilesa.construccion.estimaciones')?.write === true;
+
+  const [modal, setModal] = useState<ModalKind>(null);
+  const [savingTransition, setSavingTransition] = useState(false);
 
   const [estim, setEstim] = useState<Estimacion | null>(null);
   const [contratistaNombre, setContratistaNombre] = useState<string | null>(null);
@@ -150,6 +173,163 @@ function DetailInner() {
   const [tareasCat, setTareasCat] = useState<Map<string, Tarea>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Refresca el estado de la estimación tras una transición (sin recargar
+  // toda la página). Hace una query liviana al row de estimaciones.
+  async function refetchEstim() {
+    if (!id) return;
+    const sb = createSupabaseBrowserClient();
+    const { data } = await sb
+      .schema('dilesa')
+      .from('estimaciones')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    if (data) setEstim(data as unknown as Estimacion);
+  }
+
+  /** Transición borrador → aprobada. En Sprint 5 esto disparará el email. */
+  async function aprobar() {
+    if (!estim || savingTransition) return;
+    setSavingTransition(true);
+    const sb = createSupabaseBrowserClient();
+    const { data: auth } = await sb.auth.getUser();
+    const { error: e } = await sb
+      .schema('dilesa')
+      .from('estimaciones')
+      .update({
+        estado: 'aprobada',
+        aprobada_por_user_id: auth?.user?.id ?? null,
+        aprobada_at: new Date().toISOString(),
+      })
+      .eq('id', estim.id);
+    setSavingTransition(false);
+    if (e) {
+      toast.add({
+        title: 'No se pudo aprobar',
+        description: getSupabaseErrorMessage(e, 'Error al transicionar.'),
+        type: 'error',
+      });
+      return;
+    }
+    toast.add({ title: 'Estimación aprobada', type: 'success' });
+    setModal(null);
+    await refetchEstim();
+  }
+
+  /** Transición aprobada → facturada. Captura folio + URL + fecha. */
+  async function marcarFacturada(input: { folio: string; url: string; fecha: string }) {
+    if (!estim || savingTransition) return;
+    setSavingTransition(true);
+    const sb = createSupabaseBrowserClient();
+    const { error: e } = await sb
+      .schema('dilesa')
+      .from('estimaciones')
+      .update({
+        estado: 'facturada',
+        factura_folio: input.folio || null,
+        factura_url: input.url || null,
+        factura_fecha: input.fecha || null,
+      })
+      .eq('id', estim.id);
+    setSavingTransition(false);
+    if (e) {
+      toast.add({
+        title: 'No se pudo registrar la factura',
+        description: getSupabaseErrorMessage(e, 'Error al transicionar.'),
+        type: 'error',
+      });
+      return;
+    }
+    toast.add({ title: 'Factura registrada', type: 'success' });
+    setModal(null);
+    await refetchEstim();
+  }
+
+  /** Transición facturada → pagada. Captura referencia + fecha de pago.
+   *  Tras esto, las tareas vinculadas quedan locked (trigger SQL). */
+  async function marcarPagada(input: { referencia: string; fechaPago: string }) {
+    if (!estim || savingTransition) return;
+    setSavingTransition(true);
+    const sb = createSupabaseBrowserClient();
+    const { data: auth } = await sb.auth.getUser();
+    const pagadaAt = input.fechaPago
+      ? new Date(`${input.fechaPago}T12:00:00`).toISOString()
+      : new Date().toISOString();
+    const { error: e } = await sb
+      .schema('dilesa')
+      .from('estimaciones')
+      .update({
+        estado: 'pagada',
+        pagada_por_user_id: auth?.user?.id ?? null,
+        pagada_at: pagadaAt,
+        referencia_pago: input.referencia || null,
+      })
+      .eq('id', estim.id);
+    setSavingTransition(false);
+    if (e) {
+      toast.add({
+        title: 'No se pudo registrar el pago',
+        description: getSupabaseErrorMessage(e, 'Error al transicionar.'),
+        type: 'error',
+      });
+      return;
+    }
+    toast.add({ title: 'Estimación pagada · tareas locked', type: 'success' });
+    setModal(null);
+    await refetchEstim();
+  }
+
+  /** Transición borrador|aprobada → cancelada. Libera las tareas
+   *  borrando las filas de estimacion_tareas (CASCADE no aplica porque
+   *  estimaciones queda como cancelada, no eliminada). */
+  async function cancelar() {
+    if (!estim || savingTransition) return;
+    setSavingTransition(true);
+    const sb = createSupabaseBrowserClient();
+    // 1. Borrar las vinculaciones para liberar las tareas.
+    const { error: dErr } = await sb
+      .schema('dilesa')
+      .from('estimacion_tareas')
+      .delete()
+      .eq('estimacion_id', estim.id);
+    if (dErr) {
+      setSavingTransition(false);
+      toast.add({
+        title: 'No se pudieron liberar las tareas',
+        description: getSupabaseErrorMessage(dErr, 'Error al borrar vinculaciones.'),
+        type: 'error',
+      });
+      return;
+    }
+    // 2. Marcar estimación como cancelada + zero montos.
+    const { error: uErr } = await sb
+      .schema('dilesa')
+      .from('estimaciones')
+      .update({
+        estado: 'cancelada',
+        monto_bruto: 0,
+        retencion_monto: 0,
+        monto_neto: 0,
+      })
+      .eq('id', estim.id);
+    setSavingTransition(false);
+    if (uErr) {
+      toast.add({
+        title: 'No se pudo cancelar',
+        description: getSupabaseErrorMessage(uErr, 'Error al transicionar.'),
+        type: 'error',
+      });
+      return;
+    }
+    toast.add({
+      title: 'Estimación cancelada · tareas liberadas',
+      type: 'success',
+    });
+    setModal(null);
+    setEstTareas([]);
+    await refetchEstim();
+  }
 
   useEffect(() => {
     if (!id) return;
@@ -415,6 +595,16 @@ function DetailInner() {
         </div>
       </header>
 
+      {puedeEscribir ? (
+        <ActionBar
+          estado={estim.estado}
+          onAprobar={() => setModal('aprobar')}
+          onFacturar={() => setModal('facturar')}
+          onPagar={() => setModal('pagar')}
+          onCancelar={() => setModal('cancelar')}
+        />
+      ) : null}
+
       <Section title="Datos generales">
         <FichaGrid
           rows={[
@@ -504,6 +694,239 @@ function DetailInner() {
           </div>
         )}
       </Section>
+
+      {/* Modal de transiciones de estado. Solo se renderiza si hay modal activo. */}
+      {modal ? (
+        <TransitionModal
+          kind={modal}
+          codigo={estim.codigo}
+          montoBruto={estim.monto_bruto}
+          fechaPagoProgramado={estim.fecha_pago_programado}
+          saving={savingTransition}
+          onClose={() => (savingTransition ? null : setModal(null))}
+          onAprobar={aprobar}
+          onFacturar={marcarFacturada}
+          onPagar={marcarPagada}
+          onCancelar={cancelar}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function ActionBar({
+  estado,
+  onAprobar,
+  onFacturar,
+  onPagar,
+  onCancelar,
+}: {
+  estado: string;
+  onAprobar: () => void;
+  onFacturar: () => void;
+  onPagar: () => void;
+  onCancelar: () => void;
+}) {
+  // Botones contextuales según estado actual. Estados terminales
+  // (pagada/cancelada) no tienen acciones.
+  const acciones: React.ReactNode[] = [];
+  if (estado === 'borrador') {
+    acciones.push(
+      <Button key="aprobar" onClick={onAprobar}>
+        <Check className="size-4" /> Aprobar
+      </Button>,
+      <Button key="cancelar" variant="outline" onClick={onCancelar}>
+        <X className="size-4" /> Cancelar
+      </Button>
+    );
+  } else if (estado === 'aprobada') {
+    acciones.push(
+      <Button key="facturar" onClick={onFacturar}>
+        <FileText className="size-4" /> Marcar factura recibida
+      </Button>,
+      <Button key="cancelar" variant="outline" onClick={onCancelar}>
+        <X className="size-4" /> Cancelar
+      </Button>
+    );
+  } else if (estado === 'facturada') {
+    acciones.push(
+      <Button key="pagar" onClick={onPagar}>
+        <Banknote className="size-4" /> Marcar pagada
+      </Button>
+    );
+  }
+
+  if (acciones.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--card)] p-3">
+      <span className="text-xs uppercase tracking-wide text-[var(--text)]/50">Acciones:</span>
+      {acciones}
+    </div>
+  );
+}
+
+function TransitionModal({
+  kind,
+  codigo,
+  montoBruto,
+  fechaPagoProgramado,
+  saving,
+  onClose,
+  onAprobar,
+  onFacturar,
+  onPagar,
+  onCancelar,
+}: {
+  kind: NonNullable<ModalKind>;
+  codigo: string;
+  montoBruto: number;
+  fechaPagoProgramado: string;
+  saving: boolean;
+  onClose: () => void;
+  onAprobar: () => void | Promise<void>;
+  onFacturar: (input: { folio: string; url: string; fecha: string }) => void | Promise<void>;
+  onPagar: (input: { referencia: string; fechaPago: string }) => void | Promise<void>;
+  onCancelar: () => void | Promise<void>;
+}) {
+  // State local del modal según kind (formularios distintos).
+  const [folio, setFolio] = useState('');
+  const [url, setUrl] = useState('');
+  const [fechaFactura, setFechaFactura] = useState(new Date().toISOString().slice(0, 10));
+  const [referencia, setReferencia] = useState('');
+  const [fechaPago, setFechaPago] = useState(fechaPagoProgramado);
+
+  const titulo = (
+    {
+      aprobar: 'Aprobar estimación',
+      facturar: 'Registrar factura recibida',
+      pagar: 'Marcar como pagada',
+      cancelar: 'Cancelar estimación',
+    } as Record<NonNullable<ModalKind>, string>
+  )[kind];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-lg border border-[var(--border)] bg-[var(--card)] p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-[var(--text)]">{titulo}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-md p-1 text-[var(--text)]/50 hover:bg-[var(--bg)]/30 disabled:opacity-30"
+            aria-label="Cerrar"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <p className="mb-4 text-xs text-[var(--text)]/60">
+          {codigo} · {moneyFmt.format(montoBruto)} bruto
+        </p>
+
+        {kind === 'aprobar' ? (
+          <p className="mb-4 text-sm text-[var(--text)]/80">
+            Una vez aprobada, la estimación queda lista para que se reciba la factura del
+            contratista. (Sprint 5 enviará automáticamente PDF + email al aprobar.)
+          </p>
+        ) : null}
+
+        {kind === 'cancelar' ? (
+          <div className="mb-4 rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-amber-700 dark:text-amber-300">
+            Al cancelar, las tareas vinculadas se liberan y vuelven a aparecer como pendientes de
+            pago. Esta acción no se puede deshacer.
+          </div>
+        ) : null}
+
+        {kind === 'facturar' ? (
+          <div className="mb-4 space-y-3">
+            <ModalField label="Folio de factura *">
+              <Input value={folio} onChange={(e) => setFolio(e.target.value)} required />
+            </ModalField>
+            <ModalField label="URL de la factura (opcional)">
+              <Input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://…"
+              />
+            </ModalField>
+            <ModalField label="Fecha de la factura *">
+              <Input
+                type="date"
+                value={fechaFactura}
+                onChange={(e) => setFechaFactura(e.target.value)}
+                required
+              />
+            </ModalField>
+          </div>
+        ) : null}
+
+        {kind === 'pagar' ? (
+          <div className="mb-4 space-y-3">
+            <ModalField label="Referencia de pago *">
+              <Input
+                value={referencia}
+                onChange={(e) => setReferencia(e.target.value)}
+                placeholder="SPEI, transferencia, cheque…"
+                required
+              />
+            </ModalField>
+            <ModalField label="Fecha de pago *">
+              <Input
+                type="date"
+                value={fechaPago}
+                onChange={(e) => setFechaPago(e.target.value)}
+                required
+              />
+            </ModalField>
+            <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-2 text-[11px] text-amber-700 dark:text-amber-300">
+              Una vez pagada, las tareas vinculadas quedan locked: nadie las puede des-palomear
+              excepto Dirección o admin.
+            </div>
+          </div>
+        ) : null}
+
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cerrar
+          </Button>
+          <Button
+            onClick={() => {
+              if (kind === 'aprobar') void onAprobar();
+              else if (kind === 'facturar') void onFacturar({ folio, url, fecha: fechaFactura });
+              else if (kind === 'pagar') void onPagar({ referencia, fechaPago });
+              else if (kind === 'cancelar') void onCancelar();
+            }}
+            disabled={
+              saving ||
+              (kind === 'facturar' && (!folio.trim() || !fechaFactura)) ||
+              (kind === 'pagar' && (!referencia.trim() || !fechaPago))
+            }
+          >
+            {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+            Confirmar
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ModalField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-[var(--text)]/60">
+        {label}
+      </div>
+      {children}
     </div>
   );
 }

--- a/app/dilesa/construccion/estimaciones/nueva/page.tsx
+++ b/app/dilesa/construccion/estimaciones/nueva/page.tsx
@@ -1,0 +1,515 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de forms (cf. ventas/nueva, contratos/nuevo).
+ */
+
+/**
+ * Form: Generar estimación borrador (DILESA).
+ *
+ * Iniciativa dilesa-estimaciones · Sprint 4.
+ *
+ * Flujo:
+ *   1. Selecciona contratista (solo los activos con tareas pendientes).
+ *   2. Selecciona fecha de cierre (default = hoy, convencionalmente
+ *      miércoles).
+ *   3. (Opcional) Ajusta retención % (default 5%).
+ *   4. Preview en vivo de las tareas pendientes que se incluirán
+ *      (cuántas + monto bruto total) — query a v_tareas_pendientes_de_pago.
+ *   5. Submit → llama RPC fn_generar_estimacion_borrador → redirige al
+ *      detalle de la nueva estimación.
+ *
+ * No hay "des-seleccionar" tareas en este Sprint — la estimación se
+ * genera con TODAS las pendientes del contratista hasta la fecha de
+ * cierre. Si el operador quiere granularidad fina, puede cancelar el
+ * borrador y volver a generar con fecha distinta. v2 podría permitir
+ * quitar tareas individuales.
+ *
+ * Acceso: sub-slug `dilesa.construccion.estimaciones` (creado en Sprint 2).
+ */
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, Banknote, Loader2, Save } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+type ContratistaOpt = {
+  id: string;
+  nombre: string;
+  abreviacion: string | null;
+  tareasPendientes: number;
+  montoPendiente: number;
+};
+
+type PreviewStats = {
+  tareas: number;
+  montoBruto: number;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const money = (n: number) => moneyFmt.format(n);
+
+export default function NuevaEstimacionPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.construccion.estimaciones" write>
+      {/* Suspense por useSearchParams (Next.js 16 + Turbopack). */}
+      <Suspense fallback={null}>
+        <NuevaEstimacionForm />
+      </Suspense>
+    </RequireAccess>
+  );
+}
+
+function NuevaEstimacionForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const toast = useToast();
+  const sb = useMemo(() => createSupabaseBrowserClient(), []);
+
+  // ── Catálogo: contratistas con tareas pendientes ────────────────────
+  const [contratistas, setContratistas] = useState<ContratistaOpt[]>([]);
+  const [loadingMeta, setLoadingMeta] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // ── Form ────────────────────────────────────────────────────────────
+  const [contratistaId, setContratistaId] = useState<string>('');
+  const [fechaCierre, setFechaCierre] = useState<string>(() =>
+    new Date().toISOString().slice(0, 10)
+  );
+  const [retencionPct, setRetencionPct] = useState<string>('5');
+
+  // ── Preview ─────────────────────────────────────────────────────────
+  const [preview, setPreview] = useState<PreviewStats | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const loadMeta = useCallback(async () => {
+    setLoadingMeta(true);
+    setLoadError(null);
+
+    // 1. Tareas pendientes agregadas por contratista (vía vista SQL).
+    const { data: pendRes, error: pendErr } = await sb
+      .schema('dilesa')
+      .from('v_tareas_pendientes_de_pago')
+      .select('contratista_id, monto_calculado')
+      .eq('empresa_id', DILESA_EMPRESA_ID);
+    if (pendErr) {
+      setLoadError(
+        getSupabaseErrorMessage(pendErr, 'No se pudieron cargar las tareas pendientes.')
+      );
+      setLoadingMeta(false);
+      return;
+    }
+
+    const agregado = new Map<string, { tareas: number; monto: number }>();
+    for (const row of pendRes ?? []) {
+      const cid = row.contratista_id as string;
+      const cur = agregado.get(cid) ?? { tareas: 0, monto: 0 };
+      cur.tareas += 1;
+      cur.monto += Number(row.monto_calculado ?? 0);
+      agregado.set(cid, cur);
+    }
+
+    if (agregado.size === 0) {
+      setContratistas([]);
+      setLoadingMeta(false);
+      return;
+    }
+
+    // 2. Lookup de nombres + abrev sólo para los contratistas con pendientes.
+    const cIds = [...agregado.keys()];
+    const [persRes, datosRes] = await Promise.all([
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .in('id', cIds),
+      sb
+        .schema('dilesa')
+        .from('contratistas_datos')
+        .select('persona_id, abreviacion')
+        .in('persona_id', cIds)
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr = persRes.error ?? datosRes.error;
+    if (firstErr) {
+      setLoadError(getSupabaseErrorMessage(firstErr, 'No se pudieron cargar los contratistas.'));
+      setLoadingMeta(false);
+      return;
+    }
+
+    const persMap = new Map<string, string>();
+    for (const p of persRes.data ?? []) {
+      const nombre = [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' ');
+      persMap.set(p.id as string, nombre || '(sin nombre)');
+    }
+    const abrevMap = new Map<string, string | null>();
+    for (const d of datosRes.data ?? []) {
+      abrevMap.set(d.persona_id as string, (d.abreviacion as string | null) ?? null);
+    }
+
+    const opts: ContratistaOpt[] = [...agregado.entries()]
+      .map(([id, agg]) => ({
+        id,
+        nombre: persMap.get(id) ?? '(sin contratista)',
+        abreviacion: abrevMap.get(id) ?? null,
+        tareasPendientes: agg.tareas,
+        montoPendiente: agg.monto,
+      }))
+      .sort((a, b) => b.montoPendiente - a.montoPendiente);
+
+    setContratistas(opts);
+    setLoadingMeta(false);
+  }, [sb]);
+
+  useEffect(() => {
+    void loadMeta();
+  }, [loadMeta]);
+
+  // Deep link ?contratista=
+  useEffect(() => {
+    const cid = searchParams.get('contratista');
+    if (cid && contratistas.find((c) => c.id === cid) && !contratistaId) {
+      setContratistaId(cid);
+    }
+  }, [searchParams, contratistas, contratistaId]);
+
+  // Preview de lo que se va a incluir cuando cambian contratista o fecha.
+  useEffect(() => {
+    if (!contratistaId || !fechaCierre) {
+      setPreview(null);
+      return;
+    }
+    let activo = true;
+    setPreviewing(true);
+    (async () => {
+      const { data, error } = await sb
+        .schema('dilesa')
+        .from('v_tareas_pendientes_de_pago')
+        .select('monto_calculado')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .eq('contratista_id', contratistaId)
+        .lte('fecha_terminada', fechaCierre);
+      if (!activo) return;
+      if (error || !data) {
+        setPreview({ tareas: 0, montoBruto: 0 });
+      } else {
+        let monto = 0;
+        for (const r of data) monto += Number(r.monto_calculado ?? 0);
+        setPreview({ tareas: data.length, montoBruto: monto });
+      }
+      setPreviewing(false);
+    })();
+    return () => {
+      activo = false;
+    };
+  }, [sb, contratistaId, fechaCierre]);
+
+  const contratistaSel = useMemo(
+    () => contratistas.find((c) => c.id === contratistaId) ?? null,
+    [contratistas, contratistaId]
+  );
+
+  const retencionNum = Number(retencionPct) || 0;
+  const retencionValida = retencionNum >= 0 && retencionNum <= 100;
+  const previewNeto = preview ? preview.montoBruto * (1 - retencionNum / 100) : 0;
+  const previewRetMonto = preview ? preview.montoBruto * (retencionNum / 100) : 0;
+
+  const canSubmit =
+    !!contratistaId &&
+    !!fechaCierre &&
+    retencionValida &&
+    !!preview &&
+    preview.tareas > 0 &&
+    !submitting;
+
+  async function onSubmit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    const { data, error } = await sb.schema('dilesa').rpc('fn_generar_estimacion_borrador', {
+      p_contratista_id: contratistaId,
+      p_fecha_cierre: fechaCierre,
+      p_retencion_pct: retencionNum,
+    });
+    setSubmitting(false);
+
+    if (error) {
+      toast.add({
+        title: 'No se pudo generar la estimación',
+        description: getSupabaseErrorMessage(error, 'Error en el RPC.'),
+        type: 'error',
+      });
+      return;
+    }
+
+    if (!data) {
+      toast.add({
+        title: 'Sin tareas pendientes',
+        description:
+          'El contratista no tiene tareas pendientes de pago en la ventana seleccionada.',
+        type: 'warning',
+      });
+      return;
+    }
+
+    toast.add({
+      title: 'Estimación generada',
+      description: `Borrador con ${preview?.tareas} tarea(s) · neto ${money(previewNeto)}`,
+      type: 'success',
+    });
+    router.push(`/dilesa/construccion/estimaciones/${data as string}`);
+  }
+
+  if (loadingMeta) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {loadError}
+        </div>
+      </div>
+    );
+  }
+
+  if (contratistas.length === 0) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 text-center">
+          <Banknote className="mx-auto mb-3 h-8 w-8 text-[var(--text)]/40" />
+          <h2 className="text-sm font-medium text-[var(--text)]">
+            No hay tareas pendientes de pago
+          </h2>
+          <p className="mt-1 text-xs text-[var(--text)]/60">
+            Para generar una estimación, los contratistas deben tener tareas terminadas (palomeadas)
+            que aún no estén vinculadas a otra estimación.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+      <BackLink />
+
+      <header>
+        <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+          <Banknote className="h-5 w-5 text-[var(--accent)]" />
+          Nueva estimación
+        </h1>
+        <p className="mt-1 text-sm text-[var(--text)]/60">
+          Se genera un borrador agrupando todas las tareas pendientes del contratista hasta la fecha
+          de cierre. Convención DILESA: cierre miércoles, pago jueves.
+        </p>
+      </header>
+
+      <Section title="Datos de la estimación">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label="Contratista *">
+            <select
+              className="h-9 w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm"
+              value={contratistaId}
+              onChange={(e) => setContratistaId(e.target.value)}
+            >
+              <option value="">— selecciona —</option>
+              {contratistas.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.abreviacion ? `${c.abreviacion} · ` : ''}
+                  {c.nombre} · {c.tareasPendientes} pendientes · {money(c.montoPendiente)}
+                </option>
+              ))}
+            </select>
+            <Hint>
+              Solo aparecen contratistas con tareas pendientes (no vinculadas a otra estimación).
+            </Hint>
+          </Field>
+
+          <Field label="Fecha de cierre *">
+            <Input
+              type="date"
+              value={fechaCierre}
+              onChange={(e) => setFechaCierre(e.target.value)}
+              required
+            />
+            <Hint>Incluirá tareas terminadas en esta fecha o antes.</Hint>
+          </Field>
+
+          <Field label="Retención %">
+            <Input
+              type="number"
+              step="0.01"
+              min="0"
+              max="100"
+              value={retencionPct}
+              onChange={(e) => setRetencionPct(e.target.value)}
+            />
+            <Hint>
+              {retencionValida
+                ? 'Convención DILESA: 5%. Editable por excepción.'
+                : 'Debe estar entre 0 y 100.'}
+            </Hint>
+          </Field>
+        </div>
+      </Section>
+
+      {contratistaId ? (
+        <Section
+          title="Preview de la estimación"
+          description={
+            previewing
+              ? 'calculando…'
+              : preview
+                ? `${preview.tareas} tarea(s) en la ventana seleccionada`
+                : '—'
+          }
+        >
+          {previewing ? (
+            <Skeleton className="h-20 w-full rounded-md" />
+          ) : preview && preview.tareas > 0 ? (
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <Stat label="Tareas a incluir" value={preview.tareas.toString()} />
+              <Stat label="Monto bruto" value={money(preview.montoBruto)} />
+              <Stat label={`Neto (${retencionPct}% ret.)`} value={money(previewNeto)} accent />
+              <Stat
+                label="Retención"
+                value={`${money(previewRetMonto)} (${retencionPct}%)`}
+                subtle
+              />
+              {contratistaSel ? (
+                <Stat
+                  label="Total acumulado del contratista"
+                  value={money(contratistaSel.montoPendiente)}
+                  subtle
+                />
+              ) : null}
+            </div>
+          ) : (
+            <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-amber-700 dark:text-amber-300">
+              No hay tareas pendientes de este contratista en la ventana seleccionada. Cambia la
+              fecha de cierre a algo más reciente o selecciona otro contratista.
+            </div>
+          )}
+        </Section>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-[var(--text)]/60">
+          {preview && preview.tareas > 0
+            ? `Se creará una estimación en estado "borrador" — podrás revisarla y aprobarla después.`
+            : 'Selecciona contratista y fecha de cierre para ver el preview.'}
+        </p>
+        <div className="flex items-center gap-3">
+          <Link href="/dilesa/construccion/estimaciones">
+            <Button variant="outline" disabled={submitting}>
+              Cancelar
+            </Button>
+          </Link>
+          <Button onClick={onSubmit} disabled={!canSubmit}>
+            {submitting ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Generar borrador
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/dilesa/construccion/estimaciones"
+      className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
+    >
+      <ArrowLeft className="size-4" /> Volver a estimaciones
+    </Link>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="mb-4 flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {description ? <span className="text-xs text-[var(--text)]/50">{description}</span> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-[var(--text)]/60">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return <p className="mt-1 text-[11px] text-[var(--text)]/50">{children}</p>;
+}
+
+function Stat({
+  label,
+  value,
+  accent,
+  subtle,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+  subtle?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 ${
+        accent ? 'ring-1 ring-[var(--accent)]/30' : ''
+      }`}
+    >
+      <div className="text-[10px] uppercase tracking-wide text-[var(--text)]/50">{label}</div>
+      <div
+        className={`mt-0.5 text-sm font-semibold tabular-nums ${
+          subtle ? 'text-[var(--text)]/70' : 'text-[var(--text)]'
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/components/dilesa/estimaciones-module.tsx
+++ b/components/dilesa/estimaciones-module.tsx
@@ -19,9 +19,11 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import { Banknote, RefreshCw, Search } from 'lucide-react';
+import { usePermissions } from '@/components/providers';
+import { Banknote, Plus, RefreshCw, Search } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import type { BadgeTone } from '@/components/ui/badge';
 import { DataTable, type Column } from '@/components/module-page';
@@ -65,6 +67,10 @@ const ESTADO_OPTIONS = ['borrador', 'aprobada', 'facturada', 'pagada', 'cancelad
 
 export function EstimacionesModule({ empresaId }: { empresaId: string }) {
   const router = useRouter();
+  const { permissions } = usePermissions();
+  const puedeCrear =
+    permissions.isAdmin ||
+    permissions.modulos.get('dilesa.construccion.estimaciones')?.write === true;
 
   const [estimaciones, setEstimaciones] = useState<EstimacionRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -329,6 +335,15 @@ export function EstimacionesModule({ empresaId }: { empresaId: string }) {
             </>
           ) : null}
         </span>
+        {puedeCrear ? (
+          <Link
+            href="/dilesa/construccion/estimaciones/nueva"
+            className="flex h-9 items-center gap-1.5 rounded-md bg-[var(--accent)] px-3 text-sm font-medium text-white hover:opacity-90"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Nueva estimación
+          </Link>
+        ) : null}
       </div>
 
       <DataTable


### PR DESCRIPTION
## Summary

Sprint 4 de \`dilesa-estimaciones\`. Cierra el flujo operativo end-to-end: el gerente puede generar borradores y mover una estimación por todos sus estados.

## Archivos nuevos

- \`app/dilesa/construccion/estimaciones/nueva/page.tsx\` — form de 3 campos:
  - **Contratista** (solo los con tareas pendientes, ordenados por monto)
  - **Fecha de cierre** (default = hoy)
  - **Retención %** (default 5%, editable)
  - Preview en vivo: # tareas + monto bruto + neto calculado
  - Submit → RPC \`fn_generar_estimacion_borrador\` → redirige a detalle

## Cambios

- \`components/dilesa/estimaciones-module.tsx\` — botón "+ Nueva estimación" (RBAC-gated).
- \`app/dilesa/construccion/estimaciones/[id]/page.tsx\` — barra de acciones contextual + modal de transición:

| Estado | Acciones disponibles | Captura |
|---|---|---|
| \`borrador\` | Aprobar · Cancelar | — / warning libera tareas |
| \`aprobada\` | Marcar factura recibida · Cancelar | folio + URL + fecha factura |
| \`facturada\` | Marcar pagada | referencia + fecha pago |
| \`pagada\` | (terminal) | — |
| \`cancelada\` | (terminal) | — |

## Detalles del comportamiento

- **Aprobar**: setea \`estado='aprobada'\` + \`aprobada_por_user_id\` + \`aprobada_at\`. (Sprint 5 disparará email + PDF aquí.)
- **Marcar pagada**: setea estado + \`pagada_por_user_id\` + \`pagada_at\` + \`referencia_pago\`. Tras esto el trigger SQL bloquea modificaciones de las tareas vinculadas (excepto Dirección / admin).
- **Cancelar**: borra \`estimacion_tareas\` (libera tareas para próxima estimación) + marca estimación como cancelada + zero montos. Warning explícito en el modal.

## Sin DB changes

Todo el backend está listo desde Sprints 1-2 (RPC + trigger lock + roles).

## Test plan

- [ ] CI verde
- [ ] Preview: \`/dilesa/construccion/estimaciones/nueva\` → seleccionar contratista (vacío post-backfill, los históricos quedaron pagados; necesita palomear tareas nuevas)
- [ ] Generar borrador → ver detalle con barra de acciones
- [ ] Aprobar → estado avanza, audit trail aparece
- [ ] Marcar factura recibida → folio/URL/fecha aparecen en sección "Factura y pago"
- [ ] Marcar pagada → estado terminal + intento de des-palomear una tarea da error de lock SQL
- [ ] Cancelar un borrador → tareas vuelven a "pendientes de pago"

## Próximo (Sprint 5)

PDF template + email Resend al aprobar pidiendo factura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)