### PR TITLE
feat(dilesa): estimaciones Sprint 5 — PDF + email al contratista

### DIFF
--- a/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
+++ b/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
@@ -1,0 +1,326 @@
+/**
+ * GET  /api/dilesa/estimaciones/[id]/pdf      → descarga el PDF
+ * POST /api/dilesa/estimaciones/[id]/pdf      → envía PDF por email al contratista
+ *
+ * Iniciativa dilesa-estimaciones · Sprint 5.
+ *
+ * Auth: sesión Supabase. La RLS de `dilesa.estimaciones` decide si el
+ * usuario puede leer la fila. Si no, 404.
+ *
+ * El POST acepta body opcional `{ to?: string; subject?: string }` —
+ * por default usa `erp.personas.email` del contratista y un subject
+ * generado. Esto permite re-enviar a un email distinto sin modificar
+ * la persona en DB.
+ */
+
+import { NextResponse } from 'next/server';
+import { renderToBuffer } from '@react-pdf/renderer';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { EstimacionPDF, type EstimacionPdfData } from '@/lib/dilesa/pdf/estimacion';
+
+const MESES_ES = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+];
+
+function fmtFecha(s: string | null): string {
+  if (!s) return '—';
+  const d = new Date(`${s}T00:00:00`);
+  if (isNaN(d.getTime())) return s;
+  return `${d.getDate()} de ${MESES_ES[d.getMonth()]} de ${d.getFullYear()}`;
+}
+
+/** Construye la data del PDF desde el row de estimación + lookups. */
+async function buildPdfData(
+  sb: Awaited<ReturnType<typeof createSupabaseServerClient>>,
+  estimacionId: string
+): Promise<{ data?: EstimacionPdfData; contratistaEmail?: string | null; error?: string }> {
+  const { data: estim, error: eErr } = await sb
+    .schema('dilesa')
+    .from('estimaciones')
+    .select('*')
+    .eq('id', estimacionId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (eErr || !estim) return { error: 'Estimación no encontrada' };
+
+  const [persRes, datosRes, etRes] = await Promise.all([
+    sb
+      .schema('erp')
+      .from('personas')
+      .select('nombre, apellido_paterno, apellido_materno, rfc, email')
+      .eq('id', estim.contratista_id as string)
+      .maybeSingle(),
+    sb
+      .schema('dilesa')
+      .from('contratistas_datos')
+      .select('abreviacion')
+      .eq('persona_id', estim.contratista_id as string)
+      .is('deleted_at', null)
+      .maybeSingle(),
+    sb
+      .schema('dilesa')
+      .from('estimacion_tareas')
+      .select('tarea_terminada_id, construccion_id, monto_calculado')
+      .eq('estimacion_id', estim.id as string),
+  ]);
+
+  const persona = persRes.data;
+  const datos = datosRes.data;
+  const tareas = etRes.data ?? [];
+
+  // Resolver nombres de obras + unidades + tareas (plantilla → catálogo).
+  const construccionIds = [...new Set(tareas.map((t) => t.construccion_id as string))];
+  const terminadaIds = [...new Set(tareas.map((t) => t.tarea_terminada_id as string))];
+
+  const [cRes, ttRes, taCatRes] = await Promise.all([
+    construccionIds.length
+      ? sb
+          .schema('dilesa')
+          .from('construccion')
+          .select('id, codigo, unidad_id')
+          .in('id', construccionIds)
+      : Promise.resolve({ data: [], error: null }),
+    terminadaIds.length
+      ? sb
+          .schema('dilesa')
+          .from('construccion_tareas_terminadas')
+          .select('id, plantilla_tarea_id, fecha_terminada')
+          .in('id', terminadaIds)
+      : Promise.resolve({ data: [], error: null }),
+    sb.schema('dilesa').from('tareas_construccion').select('id, nombre'),
+  ]);
+
+  const cMap = new Map<string, { codigo: string; unidad_id: string }>();
+  const uidArr: string[] = [];
+  for (const c of cRes.data ?? []) {
+    cMap.set(c.id as string, { codigo: c.codigo as string, unidad_id: c.unidad_id as string });
+    uidArr.push(c.unidad_id as string);
+  }
+
+  const { data: uRes } = uidArr.length
+    ? await sb.schema('dilesa').from('unidades').select('id, identificador').in('id', uidArr)
+    : { data: [] };
+  const uMap = new Map<string, string>();
+  for (const u of uRes ?? []) uMap.set(u.id as string, u.identificador as string);
+
+  const ttMap = new Map<string, { plantilla_tarea_id: string; fecha_terminada: string | null }>();
+  const plantillaIds: string[] = [];
+  for (const tt of ttRes.data ?? []) {
+    ttMap.set(tt.id as string, {
+      plantilla_tarea_id: tt.plantilla_tarea_id as string,
+      fecha_terminada: (tt.fecha_terminada as string | null) ?? null,
+    });
+    plantillaIds.push(tt.plantilla_tarea_id as string);
+  }
+
+  const { data: plRes } = plantillaIds.length
+    ? await sb
+        .schema('dilesa')
+        .from('plantilla_tareas')
+        .select('id, tarea_id')
+        .in('id', [...new Set(plantillaIds)])
+    : { data: [] };
+  const plMap = new Map<string, string>();
+  for (const p of plRes ?? []) plMap.set(p.id as string, p.tarea_id as string);
+
+  const tareaCatMap = new Map<string, string>();
+  for (const t of taCatRes.data ?? []) tareaCatMap.set(t.id as string, t.nombre as string);
+
+  // Agrupar por obra.
+  const grupos = new Map<
+    string,
+    {
+      unidad: string;
+      construccionCodigo: string;
+      tareas: EstimacionPdfData['obras'][number]['tareas'];
+      subtotal: number;
+    }
+  >();
+  for (const et of tareas) {
+    const c = cMap.get(et.construccion_id as string);
+    if (!c) continue;
+    const tt = ttMap.get(et.tarea_terminada_id as string);
+    const tareaId = tt ? plMap.get(tt.plantilla_tarea_id) : null;
+    const nombre = tareaId
+      ? (tareaCatMap.get(tareaId) ?? '(tarea desconocida)')
+      : '(tarea desconocida)';
+    const fecha = tt?.fecha_terminada ? fmtFecha(tt.fecha_terminada) : '—';
+    const monto = Number(et.monto_calculado ?? 0);
+    const cid = et.construccion_id as string;
+    const grupo = grupos.get(cid) ?? {
+      unidad: uMap.get(c.unidad_id) ?? '(sin unidad)',
+      construccionCodigo: c.codigo,
+      tareas: [],
+      subtotal: 0,
+    };
+    grupo.tareas.push({ nombre, fechaTerminada: fecha, monto });
+    grupo.subtotal += monto;
+    grupos.set(cid, grupo);
+  }
+
+  const obras = [...grupos.values()]
+    .map((g) => ({
+      ...g,
+      tareas: g.tareas.sort((a, b) => a.nombre.localeCompare(b.nombre)),
+    }))
+    .sort((a, b) => a.unidad.localeCompare(b.unidad));
+
+  const contratistaNombre =
+    [persona?.nombre, persona?.apellido_paterno, persona?.apellido_materno]
+      .filter(Boolean)
+      .join(' ') || '(sin nombre)';
+
+  const data: EstimacionPdfData = {
+    codigo: estim.codigo as string,
+    fechaCierreTexto: fmtFecha(estim.fecha_cierre as string),
+    fechaPagoTexto: fmtFecha(estim.fecha_pago_programado as string),
+    contratista: {
+      nombre: contratistaNombre,
+      abreviacion: (datos?.abreviacion as string | null) ?? null,
+      rfc: (persona?.rfc as string | null) ?? null,
+      email: (persona?.email as string | null) ?? null,
+    },
+    obras,
+    montoBruto: Number(estim.monto_bruto ?? 0),
+    retencionPct: Number(estim.retencion_pct ?? 5),
+    retencionMonto: Number(estim.retencion_monto ?? 0),
+    montoNeto: Number(estim.monto_neto ?? 0),
+  };
+
+  return { data, contratistaEmail: (persona?.email as string | null) ?? null };
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const sb = await createSupabaseServerClient();
+  const result = await buildPdfData(sb, id);
+  if (result.error || !result.data) {
+    return NextResponse.json({ error: result.error ?? 'Error' }, { status: 404 });
+  }
+  const buf = await renderToBuffer(<EstimacionPDF data={result.data} />);
+  return new Response(new Uint8Array(buf), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="estimacion-${result.data.codigo}.pdf"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const body = (await req.json().catch(() => ({}))) as {
+    to?: string;
+    subject?: string;
+  };
+
+  const sb = await createSupabaseServerClient();
+  const result = await buildPdfData(sb, id);
+  if (result.error || !result.data) {
+    return NextResponse.json({ error: result.error ?? 'Error' }, { status: 404 });
+  }
+  const data = result.data;
+
+  const to = body.to?.trim() || result.contratistaEmail;
+  if (!to) {
+    return NextResponse.json(
+      {
+        error:
+          'El contratista no tiene email registrado. Pasa el destinatario en el body { "to": "email@..." }.',
+      },
+      { status: 400 }
+    );
+  }
+
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!resendKey) {
+    return NextResponse.json({ error: 'RESEND_API_KEY no configurada' }, { status: 500 });
+  }
+
+  const buf = await renderToBuffer(<EstimacionPDF data={data} />);
+  const base64 = buf.toString('base64');
+
+  const subject =
+    body.subject?.trim() ||
+    `Estimación ${data.codigo} · favor de emitir factura por $${data.montoNeto.toFixed(2)}`;
+
+  const moneyFmt = new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+    maximumFractionDigits: 2,
+  });
+
+  const html = `
+<div style="font-family: -apple-system, sans-serif; color: #222; max-width: 600px;">
+  <h2 style="color: #4a5d23;">Estimación ${data.codigo}</h2>
+  <p>Hola ${data.contratista.abreviacion ?? data.contratista.nombre},</p>
+  <p>
+    Adjuntamos la estimación correspondiente al cierre del
+    <strong>${data.fechaCierreTexto}</strong>. El monto neto a pagar es
+    <strong style="color: #4a5d23; font-size: 18px;">${moneyFmt.format(data.montoNeto)}</strong>
+    (bruto ${moneyFmt.format(data.montoBruto)} menos ${data.retencionPct.toFixed(2)}% de
+    retención = ${moneyFmt.format(data.retencionMonto)}).
+  </p>
+  <p>
+    Favor de emitir la factura por el monto neto a nombre de
+    <strong>DESARROLLO INMOBILIARIO LOS ENCINOS, S.A. DE C.V.</strong>
+    y enviarla a <a href="mailto:pagos@dilesa.mx">pagos@dilesa.mx</a>.
+  </p>
+  <p>
+    El pago está programado para el <strong>${data.fechaPagoTexto}</strong>.
+  </p>
+  <p style="color: #666; font-size: 12px;">
+    Cubre ${data.obras.reduce((s, o) => s + o.tareas.length, 0)} tareas terminadas
+    en ${data.obras.length} obras. Detalle desglosado en el PDF adjunto.
+  </p>
+  <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
+  <p style="color: #888; font-size: 11px;">
+    DILESA · Desarrollo Inmobiliario Los Encinos<br/>
+    pagos@dilesa.mx · (878) 791-1818
+  </p>
+</div>`.trim();
+
+  const emailRes = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${resendKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: 'DILESA Pagos <pagos@dilesa.mx>',
+      to: [to],
+      subject,
+      html,
+      attachments: [
+        {
+          filename: `estimacion-${data.codigo}.pdf`,
+          content: base64,
+        },
+      ],
+    }),
+  });
+  const resJson = (await emailRes.json()) as { id?: string; message?: string };
+
+  if (!emailRes.ok) {
+    return NextResponse.json(
+      { error: resJson.message ?? 'Error al enviar email', detail: resJson },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ ok: true, emailId: resJson.id, sentTo: to });
+}
+
+export const runtime = 'nodejs';

--- a/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
+++ b/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
@@ -299,7 +299,12 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: 'DILESA Facturas <facturas@dilesa.mx>',
+      // El plan free de Resend solo permite 1 dominio verificado y en este
+      // workspace ya está usado por `bsop.io` (mismo patrón que lib/juntas/email.ts).
+      // El display "DILESA Facturas" preserva el branding al contratista;
+      // `reply_to` redirige las respuestas al buzón real de DILESA.
+      from: 'DILESA Facturas <facturas@bsop.io>',
+      reply_to: 'facturas@dilesa.mx',
       to: [to],
       subject,
       html,

--- a/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
+++ b/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
@@ -276,7 +276,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   <p>
     Favor de emitir la factura por el monto neto a nombre de
     <strong>DESARROLLO INMOBILIARIO LOS ENCINOS, S.A. DE C.V.</strong>
-    y enviarla a <a href="mailto:pagos@dilesa.mx">pagos@dilesa.mx</a>.
+    y enviarla a <a href="mailto:facturas@dilesa.mx">facturas@dilesa.mx</a>.
   </p>
   <p>
     El pago está programado para el <strong>${data.fechaPagoTexto}</strong>.
@@ -288,7 +288,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
   <p style="color: #888; font-size: 11px;">
     DILESA · Desarrollo Inmobiliario Los Encinos<br/>
-    pagos@dilesa.mx · (878) 791-1818
+    facturas@dilesa.mx · (878) 791-1818
   </p>
 </div>`.trim();
 
@@ -299,7 +299,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: 'DILESA Pagos <pagos@dilesa.mx>',
+      from: 'DILESA Facturas <facturas@dilesa.mx>',
       to: [to],
       subject,
       html,
@@ -311,9 +311,16 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       ],
     }),
   });
-  const resJson = (await emailRes.json()) as { id?: string; message?: string };
+  const resJson = (await emailRes.json()) as { id?: string; message?: string; name?: string };
 
   if (!emailRes.ok) {
+    // Log para Vercel runtime logs — sin esto, los 500 quedan opacos.
+    console.error('[estimaciones/pdf POST] Resend rechazó el envío', {
+      estimacionId: id,
+      to,
+      status: emailRes.status,
+      resendError: resJson,
+    });
     return NextResponse.json(
       { error: resJson.message ?? 'Error al enviar email', detail: resJson },
       { status: 500 }

--- a/app/dilesa/construccion/estimaciones/[id]/page.tsx
+++ b/app/dilesa/construccion/estimaciones/[id]/page.tsx
@@ -29,8 +29,10 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  Download,
   FileText,
   Loader2,
+  Mail,
   X,
 } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
@@ -159,6 +161,11 @@ function DetailInner() {
 
   const [modal, setModal] = useState<ModalKind>(null);
   const [savingTransition, setSavingTransition] = useState(false);
+
+  // Email modal state — pre-fillea con email del contratista si existe.
+  const [emailModalOpen, setEmailModalOpen] = useState(false);
+  const [contratistaEmail, setContratistaEmail] = useState<string | null>(null);
+  const [sendingEmail, setSendingEmail] = useState(false);
 
   const [estim, setEstim] = useState<Estimacion | null>(null);
   const [contratistaNombre, setContratistaNombre] = useState<string | null>(null);
@@ -365,7 +372,7 @@ function DetailInner() {
         sb
           .schema('erp')
           .from('personas')
-          .select('nombre, apellido_paterno, apellido_materno')
+          .select('nombre, apellido_paterno, apellido_materno, email')
           .eq('id', estimRow.contratista_id)
           .maybeSingle(),
         sb
@@ -401,6 +408,7 @@ function DetailInner() {
           .filter(Boolean)
           .join(' ');
         setContratistaNombre(n || '(sin nombre)');
+        setContratistaEmail((persRes.data.email as string | null) ?? null);
         // Buscar abrev en satélite
         const { data: cd } = await sb
           .schema('dilesa')
@@ -605,6 +613,34 @@ function DetailInner() {
         />
       ) : null}
 
+      {/* Acciones de PDF/email — siempre disponibles excepto en borrador.
+          Sin RBAC porque cualquiera con read puede descargar el PDF. */}
+      {estim.estado !== 'borrador' && estim.estado !== 'cancelada' ? (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--card)] p-3">
+          <span className="text-xs uppercase tracking-wide text-[var(--text)]/50">Documento:</span>
+          <a
+            href={`/api/dilesa/estimaciones/${estim.id}/pdf`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm font-medium text-[var(--text)] hover:bg-[var(--bg)]/30"
+          >
+            <Download className="size-4" />
+            Descargar PDF
+          </a>
+          {puedeEscribir ? (
+            <Button onClick={() => setEmailModalOpen(true)}>
+              <Mail className="size-4" />
+              Enviar al contratista
+            </Button>
+          ) : null}
+          {!contratistaEmail ? (
+            <span className="text-[11px] text-amber-700 dark:text-amber-400">
+              El contratista no tiene email registrado — captúralo manual al enviar.
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+
       <Section title="Datos generales">
         <FichaGrid
           rows={[
@@ -710,6 +746,122 @@ function DetailInner() {
           onCancelar={cancelar}
         />
       ) : null}
+
+      {/* Modal para enviar el PDF al contratista vía email Resend. */}
+      {emailModalOpen ? (
+        <EmailModal
+          codigo={estim.codigo}
+          montoNeto={estim.monto_neto}
+          defaultEmail={contratistaEmail}
+          sending={sendingEmail}
+          onClose={() => (sendingEmail ? null : setEmailModalOpen(false))}
+          onSend={async (to) => {
+            setSendingEmail(true);
+            const res = await fetch(`/api/dilesa/estimaciones/${estim.id}/pdf`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ to }),
+            });
+            const json = (await res.json().catch(() => ({}))) as {
+              error?: string;
+              sentTo?: string;
+            };
+            setSendingEmail(false);
+            if (!res.ok) {
+              toast.add({
+                title: 'No se pudo enviar el email',
+                description: json.error ?? 'Error desconocido',
+                type: 'error',
+              });
+              return;
+            }
+            toast.add({
+              title: 'Email enviado',
+              description: `PDF enviado a ${json.sentTo ?? to}`,
+              type: 'success',
+            });
+            setEmailModalOpen(false);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function EmailModal({
+  codigo,
+  montoNeto,
+  defaultEmail,
+  sending,
+  onClose,
+  onSend,
+}: {
+  codigo: string;
+  montoNeto: number;
+  defaultEmail: string | null;
+  sending: boolean;
+  onClose: () => void;
+  onSend: (to: string) => void | Promise<void>;
+}) {
+  const [to, setTo] = useState(defaultEmail ?? '');
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-lg border border-[var(--border)] bg-[var(--card)] p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-[var(--text)]">
+            Enviar estimación al contratista
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={sending}
+            className="rounded-md p-1 text-[var(--text)]/50 hover:bg-[var(--bg)]/30 disabled:opacity-30"
+            aria-label="Cerrar"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <p className="mb-4 text-xs text-[var(--text)]/60">
+          {codigo} · solicita factura por {money(montoNeto)}
+        </p>
+
+        <div className="mb-4 space-y-3">
+          <ModalField label="Email del contratista *">
+            <Input
+              type="email"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              placeholder="contratista@ejemplo.com"
+              required
+            />
+          </ModalField>
+          <p className="text-[11px] text-[var(--text)]/55">
+            Se envía con el PDF de la estimación adjunto + texto pidiendo que emita la factura por
+            el monto neto y la envíe a pagos@dilesa.mx. Puedes re-enviar las veces que necesites.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose} disabled={sending}>
+            Cerrar
+          </Button>
+          <Button
+            onClick={() => void onSend(to)}
+            disabled={sending || !to.trim() || !/^.+@.+\..+$/.test(to)}
+          >
+            {sending ? <Loader2 className="size-4 animate-spin" /> : <Mail className="size-4" />}
+            Enviar PDF por email
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/lib/dilesa/pdf/estimacion.tsx
+++ b/lib/dilesa/pdf/estimacion.tsx
@@ -118,7 +118,7 @@ export function EstimacionPDF({ data }: { data: EstimacionPdfData }) {
           <Text style={solicitudReceptor}>DESARROLLO INMOBILIARIO LOS ENCINOS, S.A. DE C.V.</Text>
           <Text style={solicitudTexto}>
             Por concepto de mano de obra de las tareas relacionadas en esta estimación. Una vez
-            recibida la factura por correo a pagos@dilesa.mx, se programará el pago para la fecha
+            recibida la factura por correo a facturas@dilesa.mx, se programará el pago para la fecha
             indicada arriba.
           </Text>
         </View>

--- a/lib/dilesa/pdf/estimacion.tsx
+++ b/lib/dilesa/pdf/estimacion.tsx
@@ -1,0 +1,259 @@
+/**
+ * Template PDF: Estimación de pago a contratista (DILESA).
+ * Iniciativa dilesa-estimaciones · Sprint 5.
+ *
+ * Replica el formato operativo de Coda: header DILESA + datos del
+ * contratista + tabla desglosada por obra (unidad + tareas + montos) +
+ * totales (bruto, retención 5%, neto) + bloque para solicitar factura.
+ *
+ * El PDF se genera al aprobar la estimación (server-side via
+ * @react-pdf/renderer) y se envía como adjunto en el email al contratista
+ * pidiendo la factura por el monto neto.
+ */
+import { Document, Page, Text, View } from '@react-pdf/renderer';
+import { styles } from './styles';
+import { HeaderBand, FooterBand, Folio } from './header-footer';
+
+export type EstimacionPdfData = {
+  codigo: string;
+  fechaCierreTexto: string;
+  fechaPagoTexto: string;
+  contratista: {
+    nombre: string;
+    abreviacion: string | null;
+    rfc: string | null;
+    email: string | null;
+  };
+  obras: Array<{
+    unidad: string;
+    construccionCodigo: string;
+    tareas: Array<{ nombre: string; fechaTerminada: string; monto: number }>;
+    subtotal: number;
+  }>;
+  montoBruto: number;
+  retencionPct: number;
+  retencionMonto: number;
+  montoNeto: number;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 2,
+});
+const m = (n: number) => moneyFmt.format(n);
+
+export function EstimacionPDF({ data }: { data: EstimacionPdfData }) {
+  const contratistaDisplay = data.contratista.abreviacion
+    ? `${data.contratista.abreviacion} · ${data.contratista.nombre}`
+    : data.contratista.nombre;
+
+  return (
+    <Document title={`Estimación ${data.codigo}`}>
+      <Page size="LETTER" style={styles.page}>
+        <HeaderBand title="ESTIMACIÓN DE PAGO" fecha={data.fechaCierreTexto} />
+        <Folio value={data.codigo} />
+
+        {/* Datos del contratista */}
+        <View style={fichaWrap}>
+          <FichaRow label="Contratista" value={contratistaDisplay} />
+          {data.contratista.rfc ? <FichaRow label="RFC" value={data.contratista.rfc} /> : null}
+          <FichaRow label="Fecha de cierre" value={data.fechaCierreTexto} />
+          <FichaRow label="Pago programado" value={data.fechaPagoTexto} />
+          <FichaRow label="# obras" value={String(data.obras.length)} />
+          <FichaRow
+            label="# tareas"
+            value={String(data.obras.reduce((s, o) => s + o.tareas.length, 0))}
+          />
+        </View>
+
+        {/* Desglose por obra */}
+        <Text style={sectionTitle}>DESGLOSE POR OBRA</Text>
+
+        {data.obras.map((obra) => (
+          <View key={obra.construccionCodigo} style={obraWrap} wrap={false}>
+            <View style={obraHeader}>
+              <Text style={obraHeaderUnidad}>{obra.unidad}</Text>
+              <Text style={obraHeaderCodigo}>{obra.construccionCodigo}</Text>
+              <Text style={obraHeaderSubtotal}>{m(obra.subtotal)}</Text>
+            </View>
+            {/* Filas de tareas */}
+            <View style={tablaHeader}>
+              <Text style={[tablaCellNombre, tablaHeaderText]}>Tarea</Text>
+              <Text style={[tablaCellFecha, tablaHeaderText]}>Fecha</Text>
+              <Text style={[tablaCellMonto, tablaHeaderText]}>Monto</Text>
+            </View>
+            {obra.tareas.map((t, idx) => (
+              <View key={idx} style={tablaRow}>
+                <Text style={tablaCellNombre}>{t.nombre}</Text>
+                <Text style={tablaCellFecha}>{t.fechaTerminada}</Text>
+                <Text style={tablaCellMonto}>{m(t.monto)}</Text>
+              </View>
+            ))}
+          </View>
+        ))}
+
+        {/* Totales */}
+        <View style={totalesWrap} wrap={false}>
+          <View style={totalesRow}>
+            <Text style={totalesLabel}>Monto bruto</Text>
+            <Text style={totalesMonto}>{m(data.montoBruto)}</Text>
+          </View>
+          <View style={totalesRow}>
+            <Text style={totalesLabel}>Retención ({data.retencionPct.toFixed(2)}%)</Text>
+            <Text style={totalesMonto}>− {m(data.retencionMonto)}</Text>
+          </View>
+          <View style={[totalesRow, totalesRowNeto]}>
+            <Text style={totalesLabelNeto}>MONTO NETO A PAGAR</Text>
+            <Text style={totalesMontoNeto}>{m(data.montoNeto)}</Text>
+          </View>
+        </View>
+
+        {/* Solicitud de factura */}
+        <View style={solicitudWrap} wrap={false}>
+          <Text style={solicitudTitulo}>SOLICITUD DE FACTURA</Text>
+          <Text style={solicitudTexto}>
+            Favor de emitir factura por el monto neto de {m(data.montoNeto)} a nombre de:
+          </Text>
+          <Text style={solicitudReceptor}>DESARROLLO INMOBILIARIO LOS ENCINOS, S.A. DE C.V.</Text>
+          <Text style={solicitudTexto}>
+            Por concepto de mano de obra de las tareas relacionadas en esta estimación. Una vez
+            recibida la factura por correo a pagos@dilesa.mx, se programará el pago para la fecha
+            indicada arriba.
+          </Text>
+        </View>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+function FichaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={fichaRowStyle}>
+      <Text style={fichaLabel}>{label}</Text>
+      <Text style={fichaValue}>{value}</Text>
+    </View>
+  );
+}
+
+// Estilos locales (los compartidos vienen de ./styles).
+const fichaWrap = { marginTop: 12, marginBottom: 16 };
+const fichaRowStyle = { flexDirection: 'row' as const, gap: 8, marginVertical: 2 };
+const fichaLabel = {
+  width: 130,
+  fontSize: 9,
+  color: '#666',
+  textTransform: 'uppercase' as const,
+};
+const fichaValue = { flex: 1, fontSize: 10, color: '#111' };
+
+const sectionTitle = {
+  fontSize: 11,
+  fontWeight: 'bold' as const,
+  marginTop: 10,
+  marginBottom: 6,
+  color: '#4a5d23',
+  borderBottom: '1pt solid #4a5d23',
+  paddingBottom: 2,
+};
+
+const obraWrap = { marginBottom: 10 };
+const obraHeader = {
+  flexDirection: 'row' as const,
+  backgroundColor: '#f0f0f0',
+  padding: 4,
+  alignItems: 'center' as const,
+};
+const obraHeaderUnidad = {
+  flex: 1,
+  fontSize: 10,
+  fontWeight: 'bold' as const,
+  color: '#111',
+};
+const obraHeaderCodigo = {
+  width: 200,
+  fontSize: 9,
+  color: '#666',
+};
+const obraHeaderSubtotal = {
+  width: 80,
+  fontSize: 10,
+  fontWeight: 'bold' as const,
+  textAlign: 'right' as const,
+  color: '#111',
+};
+
+const tablaHeader = {
+  flexDirection: 'row' as const,
+  borderBottom: '0.5pt solid #ccc',
+  paddingVertical: 2,
+};
+const tablaHeaderText = { fontSize: 8, color: '#666', textTransform: 'uppercase' as const };
+const tablaRow = {
+  flexDirection: 'row' as const,
+  paddingVertical: 1.5,
+  borderBottom: '0.25pt solid #eee',
+};
+const tablaCellNombre = { flex: 1, fontSize: 8, color: '#333' };
+const tablaCellFecha = { width: 70, fontSize: 8, color: '#666' };
+const tablaCellMonto = {
+  width: 70,
+  fontSize: 8,
+  color: '#333',
+  textAlign: 'right' as const,
+};
+
+const totalesWrap = {
+  marginTop: 16,
+  marginLeft: 'auto' as const,
+  width: 280,
+  padding: 8,
+  border: '0.5pt solid #ccc',
+  borderRadius: 3,
+};
+const totalesRow = {
+  flexDirection: 'row' as const,
+  justifyContent: 'space-between' as const,
+  marginVertical: 2,
+};
+const totalesRowNeto = {
+  borderTop: '0.5pt solid #4a5d23',
+  paddingTop: 6,
+  marginTop: 4,
+};
+const totalesLabel = { fontSize: 9, color: '#666' };
+const totalesMonto = { fontSize: 10, color: '#111', textAlign: 'right' as const };
+const totalesLabelNeto = {
+  fontSize: 10,
+  fontWeight: 'bold' as const,
+  color: '#4a5d23',
+};
+const totalesMontoNeto = {
+  fontSize: 12,
+  fontWeight: 'bold' as const,
+  color: '#4a5d23',
+  textAlign: 'right' as const,
+};
+
+const solicitudWrap = {
+  marginTop: 20,
+  padding: 10,
+  backgroundColor: '#fafaf5',
+  border: '0.5pt solid #4a5d23',
+  borderRadius: 3,
+};
+const solicitudTitulo = {
+  fontSize: 10,
+  fontWeight: 'bold' as const,
+  color: '#4a5d23',
+  marginBottom: 4,
+};
+const solicitudTexto = { fontSize: 9, color: '#333', marginVertical: 2, lineHeight: 1.4 };
+const solicitudReceptor = {
+  fontSize: 9,
+  fontWeight: 'bold' as const,
+  color: '#111',
+  marginVertical: 2,
+};


### PR DESCRIPTION
## Summary

Sprint 5 de \`dilesa-estimaciones\`. Cierra el loop con el contratista: genera PDF formal (estilo Coda) + envía por email pidiendo factura. **Beto ya mergeó Sprint 4** (#527), rebaseado encima de main fresco.

## Archivos nuevos

- \`lib/dilesa/pdf/estimacion.tsx\` — template \`@react-pdf/renderer\` con HeaderBand/FooterBand DILESA (reuso), datos del contratista, desglose por obra (unidad + tareas + monto + subtotal), totales (bruto / retención / neto destacado), bloque "SOLICITUD DE FACTURA".

- \`app/api/dilesa/estimaciones/[id]/pdf/route.tsx\`:
  - **GET** → descarga PDF renderizado server-side (mismo patrón que ventas PDF)
  - **POST** body \`{ to?, subject? }\` → envía email Resend con PDF adjunto

## Cambios en el detalle

Nueva barra "Documento" después de la barra de acciones:

- **Descargar PDF** — link al GET (visible cuando estado != borrador/cancelada)
- **Enviar al contratista** — modal con email pre-llenado del contratista, validación + envío vía POST
- Hint visible si contratista no tiene email en DB (captura manual permitida)

## Coverage de emails contratistas

- **21 de 23** tienen email registrado en \`erp.personas\`
- Los 2 sin email se capturan manual en el modal de envío

## Test plan

- [ ] CI verde
- [ ] Preview: descargar PDF de una estimación histórica (ej. \`EST-2025-W17-MAYA-fc66-001\`) → valida formato, desglose, totales, retención
- [ ] Probar "Enviar al contratista" con tu email para validar el envío + PDF adjunto
- [ ] Verificar fallback cuando contratista no tiene email

## Próximo (Sprint 6 — cutover)

Actualizar \`scripts/dilesa-sync.ts\` con tablas nuevas + plan cutover fin de semana próximo (sábado/domingo) → lunes operativo en BSOP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)