### PR TITLE
feat(dilesa): Sprint 2 — columnas adicionales en 4 tablas

### DIFF
--- a/components/dilesa/construccion-module.test.ts
+++ b/components/dilesa/construccion-module.test.ts
@@ -12,6 +12,9 @@ function o(overrides: Partial<ConstruccionListaRow>): ConstruccionListaRow {
     fecha_arranque: null,
     fecha_compromiso_terminar: null,
     fecha_terminada: null,
+    fecha_seguro_calidad: null,
+    fecha_paquete_ruv: null,
+    fecha_dtu: null,
     avance_pct: 0,
     estado: 'arrancada',
     identificadorCompleto: 'M1-L1',
@@ -19,6 +22,7 @@ function o(overrides: Partial<ConstruccionListaRow>): ConstruccionListaRow {
     prototipo: null,
     contratistaNombre: 'Contratista',
     contratistaAbreviacion: null,
+    supervisorNombre: null,
     ...overrides,
   };
 }

--- a/components/dilesa/construccion-module.tsx
+++ b/components/dilesa/construccion-module.tsx
@@ -51,6 +51,9 @@ type ConstruccionRow = {
   fecha_arranque: string | null;
   fecha_compromiso_terminar: string | null;
   fecha_terminada: string | null;
+  fecha_seguro_calidad: string | null;
+  fecha_paquete_ruv: string | null;
+  fecha_dtu: string | null;
   avance_pct: number;
   estado: string;
 };
@@ -62,6 +65,8 @@ export type ConstruccionListaRow = ConstruccionRow & {
   prototipo: string | null;
   contratistaNombre: string;
   contratistaAbreviacion: string | null;
+  /** Nombre del supervisor — lookup a erp.personas por supervisor_persona_id. */
+  supervisorNombre: string | null;
 };
 
 /** Estados que cuentan como "en progreso" (consumen recursos hoy). */
@@ -181,7 +186,7 @@ export function ConstruccionModule({ empresaId }: { empresaId: string }) {
       .schema('dilesa')
       .from('construccion')
       .select(
-        'id, codigo, unidad_id, producto_id, contratista_id, supervisor_persona_id, fecha_arranque, fecha_compromiso_terminar, fecha_terminada, avance_pct, estado'
+        'id, codigo, unidad_id, producto_id, contratista_id, supervisor_persona_id, fecha_arranque, fecha_compromiso_terminar, fecha_terminada, fecha_seguro_calidad, fecha_paquete_ruv, fecha_dtu, avance_pct, estado'
       )
       .eq('empresa_id', empresaId)
       .is('deleted_at', null);
@@ -211,12 +216,14 @@ export function ConstruccionModule({ empresaId }: { empresaId: string }) {
         .select('id, nombre')
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
+      // Sin filtro por tipo: contratistas y supervisores (empleados) viven
+      // ambos en erp.personas. DILESA tiene ~1400 personas — el costo es
+      // marginal y evita un 2do round-trip para resolver supervisores.
       sb
         .schema('erp')
         .from('personas')
         .select('id, nombre, apellido_paterno, apellido_materno')
-        .eq('empresa_id', empresaId)
-        .eq('tipo', 'contratista'),
+        .eq('empresa_id', empresaId),
       sb
         .schema('dilesa')
         .from('contratistas_datos')
@@ -273,6 +280,9 @@ export function ConstruccionModule({ empresaId }: { empresaId: string }) {
           prototipo: proto,
           contratistaNombre: personaMap.get(o.contratista_id) ?? '(sin contratista)',
           contratistaAbreviacion: abrevMap.get(o.contratista_id) ?? null,
+          supervisorNombre: o.supervisor_persona_id
+            ? (personaMap.get(o.supervisor_persona_id) ?? null)
+            : null,
         };
       }),
     };
@@ -389,6 +399,77 @@ export function ConstruccionModule({ empresaId }: { empresaId: string }) {
     },
     { key: 'fecha_arranque', label: 'Arranque', type: 'date' },
     { key: 'fecha_compromiso_terminar', label: 'Compromiso', type: 'date' },
+    {
+      key: 'fecha_terminada',
+      label: 'Terminada',
+      type: 'custom',
+      accessor: (o) => o.fecha_terminada ?? '',
+      render: (o) =>
+        o.fecha_terminada ? (
+          new Date(o.fecha_terminada).toLocaleDateString('es-MX', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          })
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
+    {
+      key: 'supervisorNombre',
+      label: 'Supervisor',
+      type: 'custom',
+      accessor: (o) => o.supervisorNombre ?? '',
+      render: (o) => o.supervisorNombre ?? <span className="text-[var(--text)]/30">—</span>,
+    },
+    {
+      key: 'fecha_seguro_calidad',
+      label: 'Seguro calidad',
+      type: 'custom',
+      accessor: (o) => o.fecha_seguro_calidad ?? '',
+      render: (o) =>
+        o.fecha_seguro_calidad ? (
+          new Date(o.fecha_seguro_calidad).toLocaleDateString('es-MX', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          })
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
+    {
+      key: 'fecha_paquete_ruv',
+      label: 'Paquete RUV',
+      type: 'custom',
+      accessor: (o) => o.fecha_paquete_ruv ?? '',
+      render: (o) =>
+        o.fecha_paquete_ruv ? (
+          new Date(o.fecha_paquete_ruv).toLocaleDateString('es-MX', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          })
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
+    {
+      key: 'fecha_dtu',
+      label: 'DTU',
+      type: 'custom',
+      accessor: (o) => o.fecha_dtu ?? '',
+      render: (o) =>
+        o.fecha_dtu ? (
+          new Date(o.fecha_dtu).toLocaleDateString('es-MX', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          })
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
   ];
 
   const onRowClick = (o: ConstruccionListaRow) => {

--- a/components/dilesa/estimaciones-module.tsx
+++ b/components/dilesa/estimaciones-module.tsx
@@ -267,6 +267,23 @@ export function EstimacionesModule({ empresaId }: { empresaId: string }) {
       width: 'min-w-[260px]',
     },
     { key: 'fecha_cierre', label: 'Fecha cierre', type: 'date' },
+    { key: 'fecha_pago_programado', label: 'Pago programado', type: 'date' },
+    {
+      key: 'pagada_at',
+      label: 'Pagada',
+      type: 'custom',
+      accessor: (e) => e.pagada_at ?? '',
+      render: (e) =>
+        e.pagada_at ? (
+          new Date(e.pagada_at).toLocaleDateString('es-MX', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          })
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
     {
       key: 'contratistaNombre',
       label: 'Contratista',

--- a/components/dilesa/proyectos-module.tsx
+++ b/components/dilesa/proyectos-module.tsx
@@ -155,6 +155,12 @@ export function ProyectosModule({ empresaId }: { empresaId: string }) {
   const columns: Column<ProyectoDetalle>[] = [
     { key: 'nombre', label: 'Nombre', type: 'text', sticky: true, width: 'min-w-[220px]' },
     {
+      key: 'clave_interna',
+      label: 'Clave',
+      type: 'text',
+      render: (p) => p.clave_interna ?? <span className="text-[var(--text)]/30">—</span>,
+    },
+    {
       key: 'tipo',
       label: 'Tipo',
       type: 'custom',
@@ -173,12 +179,43 @@ export function ProyectosModule({ empresaId }: { empresaId: string }) {
     { key: 'fecha_inicio', label: 'Inicio', type: 'date' },
     { key: 'fecha_fin_estimada', label: 'Fin estimado', type: 'date' },
     {
+      key: 'fecha_licencia',
+      label: 'Licencia',
+      type: 'custom',
+      accessor: (p) => p.fecha_licencia ?? '',
+      render: (p) =>
+        p.fecha_licencia ? (
+          new Date(p.fecha_licencia).toLocaleDateString('es-MX', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          })
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
+    {
       key: 'lotes_proyectados',
       label: 'Lotes',
       type: 'number',
       render: (p) => (p.lotes_proyectados != null ? String(p.lotes_proyectados) : '—'),
     },
+    {
+      key: 'area_vendible_m2',
+      label: 'Área vendible m²',
+      type: 'number',
+      render: (p) =>
+        p.area_vendible_m2 != null ? (
+          formatNumber(p.area_vendible_m2)
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
     { key: 'presupuesto_estimado', label: 'Presupuesto', type: 'currency' },
+    { key: 'costo_terreno', label: 'Costo terreno', type: 'currency' },
+    { key: 'costo_urbanizacion', label: 'Costo urb.', type: 'currency' },
+    { key: 'costo_construccion', label: 'Costo const.', type: 'currency' },
+    { key: 'costo_comercializacion', label: 'Costo com.', type: 'currency' },
   ];
 
   const tiposPresentes = useMemo(

--- a/components/dilesa/ventas-module.tsx
+++ b/components/dilesa/ventas-module.tsx
@@ -339,6 +339,12 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
         v.fase_actual ? <Badge tone="neutral">{v.fase_actual}</Badge> : <span>—</span>,
     },
     { key: 'precio', label: 'Precio', type: 'currency' },
+    {
+      key: 'tipo_credito',
+      label: 'Crédito',
+      type: 'text',
+      render: (v) => v.tipo_credito ?? <span className="text-[var(--text)]/30">—</span>,
+    },
     { key: 'fecha_escritura', label: 'Escritura', type: 'date' },
     {
       key: 'estado',


### PR DESCRIPTION
## Summary

Iniciativa \`dilesa-tablas-filtros-columnas\` · Sprint 2.

Expone los campos que ya venían en los queries Supabase pero no se rendereaban (más 3 hitos burocráticos que sumé al SELECT de obras):

- **Estimaciones** (7 → 9): +\`fecha_pago_programado\`, +\`pagada_at\`
- **Obras** (8 → 13): +\`fecha_terminada\`, +\`supervisor\` (nombre via erp.personas), +\`fecha_seguro_calidad\`, +\`fecha_paquete_ruv\`, +\`fecha_dtu\`
- **Proyectos** (7 → 14): +\`clave_interna\`, +\`area_vendible_m2\`, +\`fecha_licencia\`, +\`costo_terreno/urbanizacion/construccion/comercializacion\`
- **Ventas** (9 → 10): +\`tipo_credito\`. \`numero_escritura\` queda fuera por decisión explícita

Obras y Proyectos quedan con 13–14 cols → scroll horizontal. Las pages son \`desktop-only\` así que no afecta mobile.

En Obras dejé de filtrar el lookup de personas por \`tipo='contratista'\` (~1400 rows en DILESA, costo marginal) para resolver supervisores en la misma query sin 2do round-trip.

## Test plan

- [x] \`npm run typecheck\` — 0 errores
- [x] \`npm run lint\` — 0 errores
- [x] \`npm run test:run\` — 5238 OK (test de \`deriveKpis\` de obras actualizado para el shape extendido)
- [x] \`npm run format:check\` — clean
- [ ] Beto verifica en preview: las 4 tablas muestran las columnas nuevas; obras/proyectos hacen scroll horizontal sin romper el layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)