### PR TITLE
feat(notificaciones): Sprint 2 — refactor 6 handlers

### DIFF
--- a/app/api/cron/daily-task-summary/route.ts
+++ b/app/api/cron/daily-task-summary/route.ts
@@ -28,6 +28,12 @@ import {
   type EmpresaBranding,
   type TaskSummaryItem,
 } from '@/lib/task-summary-email';
+import {
+  getDefinitionBySlug,
+  renderSubject,
+  splitRecipientsExtra,
+  writeNotificationLog,
+} from '@/lib/notifications';
 
 // 300s cap for cron — tolera crecimiento hasta ~1000 buckets con sleep(220ms)
 // entre envíos y fetch a Resend. Si llegamos cerca del cap, migrar a Workflow
@@ -143,6 +149,26 @@ export async function GET(req: NextRequest) {
   const supabase = createClient(supabaseUrl, serviceKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
+
+  // Iniciativa notificaciones-catalogo · S2: lee config runtime del catálogo
+  // (slug global `task_summary_daily`). Si activo=false → skip todo el cron y
+  // log 1 row con status=skipped (no logs per-bucket porque no se envió nada).
+  // Fail-open: si def es null usa los defaults hardcoded de hoy.
+  const def = await getDefinitionBySlug(supabase, 'task_summary_daily');
+  if (def && !def.activo) {
+    console.log('[daily-task-summary] def.activo=false — skip ciclo completo');
+    await writeNotificationLog(supabase, {
+      definitionId: def.id,
+      status: 'skipped',
+      recipients: { to: [] },
+      subject: `task_summary_daily — skipped por kill switch`,
+    });
+    return NextResponse.json({ ok: true, skipped: true, reason: 'kill_switch' });
+  }
+  const subjectTemplate = def?.subject_template ?? null;
+  const defExtras = def ? splitRecipientsExtra(def.recipients_extra) : { to: [], cc: [], bcc: [] };
+  const defFromName = def?.from_name ?? null;
+  const defReplyTo = def?.reply_to ?? null;
 
   // Whitelist de estados activos (ver fix #119). Fetch en paralelo de tasks y
   // empresas (cross-schema: empresa_id → core.empresas; PostgREST no hace joins
@@ -261,16 +287,36 @@ export async function GET(req: NextRequest) {
     const groups = groupTasksByUrgency(bucket.tasks, todayCst);
     const html = generateTaskSummaryHtml(bucket.firstName, groups, todayCst, branding);
 
-    const fromName = empresaRow.nombre;
+    // Nombre del from: usa override de la definition si tiene, si no usa el
+    // nombre de la empresa (comportamiento legacy: branding per-empresa).
+    const fromName = defFromName ?? empresaRow.nombre;
     const destination = testTo ?? bucket.email;
-    const subject = testTo
-      ? `[TEST → ${bucket.firstName}] Tareas de hoy en ${empresaRow.nombre} — ${subjectDate}`
+    // Subject: usa template editable de la definition (con vars empresa/fecha/firstName)
+    // o fallback al subject hardcoded de hoy.
+    const baseSubject = subjectTemplate
+      ? renderSubject(subjectTemplate, {
+          empresa: empresaRow.nombre,
+          fecha: subjectDate,
+          firstName: bucket.firstName,
+        })
       : `Tareas de hoy en ${empresaRow.nombre} — ${subjectDate}`;
+    const subject = testTo ? `[TEST → ${bucket.firstName}] ${baseSubject}` : baseSubject;
+    const toList = [destination, ...defExtras.to];
 
     if (!firstSend) {
       await sleep(220);
     }
     firstSend = false;
+
+    const resendBody: Record<string, unknown> = {
+      from: `${fromName} <noreply@bsop.io>`,
+      to: toList,
+      subject,
+      html,
+    };
+    if (defReplyTo) resendBody.reply_to = defReplyTo;
+    if (defExtras.cc.length) resendBody.cc = defExtras.cc;
+    if (defExtras.bcc.length) resendBody.bcc = defExtras.bcc;
 
     const resendRes = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -278,12 +324,7 @@ export async function GET(req: NextRequest) {
         Authorization: `Bearer ${resendKey}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        from: `${fromName} <noreply@bsop.io>`,
-        to: [destination],
-        subject,
-        html,
-      }),
+      body: JSON.stringify(resendBody),
     });
 
     if (!resendRes.ok) {
@@ -296,9 +337,19 @@ export async function GET(req: NextRequest) {
         email: bucket.email,
         error: err,
       });
+      await writeNotificationLog(supabase, {
+        definitionId: def?.id ?? null,
+        empresaId: bucket.empresaId,
+        status: 'failed',
+        recipients: { to: toList, cc: defExtras.cc, bcc: defExtras.bcc },
+        subject,
+        errorMessage: `Resend ${resendRes.status}: ${err.slice(0, 800)}`,
+        context: { empleadoId: bucket.empleadoId, totalTasks: bucket.tasks.length },
+      });
       continue;
     }
 
+    const sendJson = (await resendRes.json().catch(() => null)) as { id?: string } | null;
     sent++;
     previews.push({
       empleadoId: bucket.empleadoId,
@@ -307,6 +358,15 @@ export async function GET(req: NextRequest) {
       total: bucket.tasks.length,
       subject,
       fromName,
+    });
+    await writeNotificationLog(supabase, {
+      definitionId: def?.id ?? null,
+      empresaId: bucket.empresaId,
+      status: 'sent',
+      recipients: { to: toList, cc: defExtras.cc, bcc: defExtras.bcc },
+      subject,
+      resendId: sendJson?.id ?? null,
+      context: { empleadoId: bucket.empleadoId, totalTasks: bucket.tasks.length },
     });
   }
 

--- a/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
+++ b/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
@@ -17,6 +17,12 @@ import { NextResponse } from 'next/server';
 import { renderToBuffer } from '@react-pdf/renderer';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { EstimacionPDF, type EstimacionPdfData } from '@/lib/dilesa/pdf/estimacion';
+import {
+  getDefinitionBySlug,
+  renderSubject,
+  splitRecipientsExtra,
+  writeNotificationLog,
+} from '@/lib/notifications';
 
 const MESES_ES = [
   'Enero',
@@ -249,12 +255,44 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     return NextResponse.json({ error: 'RESEND_API_KEY no configurada' }, { status: 500 });
   }
 
+  // Iniciativa notificaciones-catalogo · S2: lee config runtime + log post-envío.
+  const def = await getDefinitionBySlug(sb, 'dilesa_estimacion');
+
+  // Defaults hardcoded como fallback fail-open.
+  let fromAddress = 'DILESA Facturas <facturas@bsop.io>';
+  let replyTo: string | null = 'facturas@dilesa.mx';
+  let toList = [to];
+  let ccList: string[] = [];
+  let bccList: string[] = [];
+
+  if (def) {
+    if (!def.activo) {
+      console.log('[estimaciones/pdf POST] def.activo=false — skip');
+      await writeNotificationLog(sb, {
+        definitionId: def.id,
+        status: 'skipped',
+        recipients: { to: toList },
+        subject: `dilesa_estimacion ${data.codigo} — kill switch`,
+        context: { estimacionId: id },
+      });
+      return NextResponse.json({ ok: true, skipped: true, reason: 'kill_switch' });
+    }
+    fromAddress = def.from_name ? `${def.from_name} <${def.from_email}>` : def.from_email;
+    replyTo = def.reply_to;
+    const extras = splitRecipientsExtra(def.recipients_extra);
+    toList = [to, ...extras.to];
+    ccList = extras.cc;
+    bccList = extras.bcc;
+  }
+
   const buf = await renderToBuffer(<EstimacionPDF data={data} />);
   const base64 = buf.toString('base64');
 
   const subject =
     body.subject?.trim() ||
-    `Estimación ${data.codigo} · favor de emitir factura por $${data.montoNeto.toFixed(2)}`;
+    (def?.subject_template
+      ? renderSubject(def.subject_template, { codigo: data.codigo })
+      : `Estimación ${data.codigo} · favor de emitir factura por $${data.montoNeto.toFixed(2)}`);
 
   const moneyFmt = new Intl.NumberFormat('es-MX', {
     style: 'currency',
@@ -292,29 +330,32 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   </p>
 </div>`.trim();
 
+  // El plan free de Resend solo permite 1 dominio verificado (`bsop.io`); el
+  // display name "DILESA Facturas" preserva el branding al contratista y
+  // `reply_to` redirige las respuestas al buzón real de DILESA.
+  const resendBody: Record<string, unknown> = {
+    from: fromAddress,
+    to: toList,
+    subject,
+    html,
+    attachments: [
+      {
+        filename: `estimacion-${data.codigo}.pdf`,
+        content: base64,
+      },
+    ],
+  };
+  if (replyTo) resendBody.reply_to = replyTo;
+  if (ccList.length) resendBody.cc = ccList;
+  if (bccList.length) resendBody.bcc = bccList;
+
   const emailRes = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${resendKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      // El plan free de Resend solo permite 1 dominio verificado y en este
-      // workspace ya está usado por `bsop.io` (mismo patrón que lib/juntas/email.ts).
-      // El display "DILESA Facturas" preserva el branding al contratista;
-      // `reply_to` redirige las respuestas al buzón real de DILESA.
-      from: 'DILESA Facturas <facturas@bsop.io>',
-      reply_to: 'facturas@dilesa.mx',
-      to: [to],
-      subject,
-      html,
-      attachments: [
-        {
-          filename: `estimacion-${data.codigo}.pdf`,
-          content: base64,
-        },
-      ],
-    }),
+    body: JSON.stringify(resendBody),
   });
   const resJson = (await emailRes.json()) as { id?: string; message?: string; name?: string };
 
@@ -326,11 +367,28 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       status: emailRes.status,
       resendError: resJson,
     });
+    await writeNotificationLog(sb, {
+      definitionId: def?.id ?? null,
+      status: 'failed',
+      recipients: { to: toList, cc: ccList, bcc: bccList },
+      subject,
+      errorMessage: `Resend ${emailRes.status}: ${JSON.stringify(resJson).slice(0, 800)}`,
+      context: { estimacionId: id, codigo: data.codigo },
+    });
     return NextResponse.json(
       { error: resJson.message ?? 'Error al enviar email', detail: resJson },
       { status: 500 }
     );
   }
+
+  await writeNotificationLog(sb, {
+    definitionId: def?.id ?? null,
+    status: 'sent',
+    recipients: { to: toList, cc: ccList, bcc: bccList },
+    subject,
+    resendId: resJson.id ?? null,
+    context: { estimacionId: id, codigo: data.codigo },
+  });
 
   return NextResponse.json({ ok: true, emailId: resJson.id, sentTo: to });
 }

--- a/app/api/juntas/reenviar/route.ts
+++ b/app/api/juntas/reenviar/route.ts
@@ -59,7 +59,12 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const result = await sendMinutaEmail(resendKey, payload);
+  const result = await sendMinutaEmail(resendKey, payload, {
+    sb: supabase,
+    slug: 'junta_reenviar',
+    empresaId: payload.empresaId,
+    juntaId,
+  });
   if (!result.ok) {
     return NextResponse.json({ success: true, emailsSent: 0, emailError: result.emailError });
   }

--- a/app/api/juntas/terminar/route.ts
+++ b/app/api/juntas/terminar/route.ts
@@ -122,7 +122,12 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const result = await sendMinutaEmail(resendKey, payload);
+  const result = await sendMinutaEmail(resendKey, payload, {
+    sb: supabase,
+    slug: 'junta_minuta',
+    empresaId: payload.empresaId,
+    juntaId,
+  });
   if (!result.ok) {
     return NextResponse.json({ success: true, emailsSent: 0, emailError: result.emailError });
   }

--- a/app/api/welcome-email/route.ts
+++ b/app/api/welcome-email/route.ts
@@ -6,6 +6,12 @@ import { welcomeEmailRateLimiter, extractIdentifier } from '@/lib/ratelimit';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { requireAdmin } from '@/lib/empresas/admin-guard';
+import {
+  getDefinitionBySlug,
+  renderSubject,
+  splitRecipientsExtra,
+  writeNotificationLog,
+} from '@/lib/notifications';
 
 const LOGO_MAP: Record<string, string> = {
   rdb: 'https://bsop.io/logo-rdb.png',
@@ -102,26 +108,84 @@ export async function POST(req: NextRequest) {
 
   console.log('[welcome-email-api] Sending welcome email');
 
+  // Iniciativa notificaciones-catalogo · S2: lee overrides runtime + log post-envío.
+  const def = await getDefinitionBySlug(adminClient, 'welcome');
+
+  // Defaults hardcoded como fallback fail-open (estado pre-iniciativa).
+  let fromAddress = 'BSOP <noreply@bsop.io>';
+  let replyTo: string | null = null;
+  let finalSubject = '¡Bienvenido a BSOP! Tu cuenta está lista';
+  let toList = [email];
+  let ccList: string[] = [];
+  let bccList: string[] = [];
+
+  if (def) {
+    if (!def.activo) {
+      console.log('[welcome-email-api] def.activo=false — skip');
+      await writeNotificationLog(adminClient, {
+        definitionId: def.id,
+        status: 'skipped',
+        recipients: { to: toList },
+        subject: finalSubject,
+        context: { usuarioId, email },
+      });
+      return NextResponse.json({ success: true, skipped: true });
+    }
+    fromAddress = def.from_name ? `${def.from_name} <${def.from_email}>` : def.from_email;
+    replyTo = def.reply_to;
+    finalSubject = renderSubject(def.subject_template, {
+      firstName: firstName || email,
+    });
+    const extras = splitRecipientsExtra(def.recipients_extra);
+    toList = [email, ...extras.to];
+    ccList = extras.cc;
+    bccList = extras.bcc;
+  }
+
+  const body: Record<string, unknown> = {
+    from: fromAddress,
+    to: toList,
+    subject: finalSubject,
+    html,
+  };
+  if (replyTo) body.reply_to = replyTo;
+  if (ccList.length) body.cc = ccList;
+  if (bccList.length) body.bcc = bccList;
+
   const emailRes = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${resendKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      from: 'BSOP <noreply@bsop.io>',
-      to: [email],
-      subject: '¡Bienvenido a BSOP! Tu cuenta está lista',
-      html,
-    }),
+    body: JSON.stringify(body),
   });
 
   const emailResult = await emailRes.json();
   console.log('[welcome-email-api] Resend response status:', emailRes.status);
 
   if (!emailRes.ok) {
+    await writeNotificationLog(adminClient, {
+      definitionId: def?.id ?? null,
+      status: 'failed',
+      recipients: { to: toList, cc: ccList, bcc: bccList },
+      subject: finalSubject,
+      errorMessage: `Resend ${emailRes.status}: ${JSON.stringify(emailResult).slice(0, 800)}`,
+      triggeredByUserId: guard.usuario.id,
+      context: { usuarioId, email },
+    });
     return NextResponse.json({ error: 'Resend failed', detail: emailResult }, { status: 500 });
   }
+
+  await writeNotificationLog(adminClient, {
+    definitionId: def?.id ?? null,
+    status: 'sent',
+    recipients: { to: toList, cc: ccList, bcc: bccList },
+    subject: finalSubject,
+    resendId: (emailResult as { id?: string }).id ?? null,
+    triggeredByUserId: guard.usuario.id,
+    context: { usuarioId, email },
+  });
 
   return NextResponse.json({ success: true, emailId: emailResult.id });
 }

--- a/lib/juntas/email.ts
+++ b/lib/juntas/email.ts
@@ -6,6 +6,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { rewriteHtmlImagesWithSignedUrls } from '@/lib/adjuntos';
 import { fetchJuntaUpdates } from '@/lib/juntas/fetch-updates';
+import {
+  getDefinitionBySlug,
+  splitRecipientsExtra,
+  writeNotificationLog,
+} from '@/lib/notifications';
 
 // 1 año — los correos pueden abrirse meses después (archivo, reenvíos).
 // La firma es server-side con service role, sin costo por TTLs largos.
@@ -280,6 +285,9 @@ export async function buildMinutaEmailPayload(
       from: string;
       recipients: string[];
       asistentesCount: number;
+      /** Empresa context para el catálogo de notificaciones (S2 iniciativa
+       *  notificaciones-catalogo). NULL si la junta no tiene empresa. */
+      empresaId: string | null;
     }
   | { ok: false; status: number; error: string }
 > {
@@ -458,27 +466,118 @@ export async function buildMinutaEmailPayload(
     from: fromAddress,
     recipients,
     asistentesCount: asistentes.length,
+    empresaId,
   };
 }
 
+/**
+ * Envía la minuta vía Resend con overrides runtime del catálogo
+ * `core.notification_definitions` (slug `junta_minuta` o `junta_reenviar`)
+ * + log post-envío. Iniciativa notificaciones-catalogo · S2.
+ *
+ * Fail-open: si la definition no se puede leer, usa el `payload` original
+ * (config hardcoded de hoy). El kill switch (activo=false) SÍ se respeta y
+ * skipea el envío, escribiendo log con status=skipped.
+ *
+ * Lookup empresa-aware: primero busca override per-empresa con el `slug`
+ * dado; si no existe, cae a la definition global (mismo slug, empresa NULL).
+ */
 export async function sendMinutaEmail(
   resendKey: string,
-  payload: { html: string; subject: string; from: string; recipients: string[] }
+  payload: { html: string; subject: string; from: string; recipients: string[] },
+  opts: {
+    sb: SupabaseClient;
+    slug: 'junta_minuta' | 'junta_reenviar';
+    empresaId: string | null;
+    juntaId: string;
+    triggeredByUserId?: string | null;
+  }
 ): Promise<{ ok: true; emailId: string } | { ok: false; emailError: unknown }> {
+  const { sb, slug, empresaId, juntaId, triggeredByUserId } = opts;
+  const def = await getDefinitionBySlug(sb, slug, empresaId);
+
+  // Defaults vienen del payload (config legacy de hoy).
+  let fromAddress = payload.from;
+  let replyTo: string | null = null;
+  let toList = payload.recipients;
+  let ccList: string[] = [];
+  let bccList: string[] = [];
+
+  if (def) {
+    if (!def.activo) {
+      console.log(`[juntas/email] ${slug}.activo=false — skip`);
+      await writeNotificationLog(sb, {
+        definitionId: def.id,
+        empresaId,
+        status: 'skipped',
+        recipients: { to: toList },
+        subject: payload.subject,
+        triggeredByUserId,
+        context: { juntaId },
+      });
+      return { ok: false, emailError: { skipped: true, reason: 'kill_switch' } };
+    }
+    // Override del FROM solo si la definition tiene from_email distinto del
+    // default global — para minutas, lo común es que la def per-empresa
+    // sobrescriba (cuando exista). Por ahora si la def NO tiene override
+    // específico, respetamos el `payload.from` que ya viene branded.
+    if (def.from_email && def.from_email !== 'noreply@bsop.io') {
+      fromAddress = def.from_name ? `${def.from_name} <${def.from_email}>` : def.from_email;
+    } else if (def.from_name) {
+      // Caso global: from_name del catálogo aplica si se quiere overridear.
+      fromAddress = `${def.from_name} <noreply@bsop.io>`;
+    }
+    replyTo = def.reply_to;
+    const extras = splitRecipientsExtra(def.recipients_extra);
+    toList = Array.from(new Set([...payload.recipients, ...extras.to]));
+    ccList = extras.cc;
+    bccList = extras.bcc;
+  }
+
+  const resendBody: Record<string, unknown> = {
+    from: fromAddress,
+    to: toList,
+    subject: payload.subject,
+    html: payload.html,
+  };
+  if (replyTo) resendBody.reply_to = replyTo;
+  if (ccList.length) resendBody.cc = ccList;
+  if (bccList.length) resendBody.bcc = bccList;
+
   const emailRes = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${resendKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      from: payload.from,
-      to: payload.recipients,
-      subject: payload.subject,
-      html: payload.html,
-    }),
+    body: JSON.stringify(resendBody),
   });
   const result = await emailRes.json();
-  if (!emailRes.ok) return { ok: false, emailError: result };
+
+  if (!emailRes.ok) {
+    await writeNotificationLog(sb, {
+      definitionId: def?.id ?? null,
+      empresaId,
+      status: 'failed',
+      recipients: { to: toList, cc: ccList, bcc: bccList },
+      subject: payload.subject,
+      errorMessage: `Resend ${emailRes.status}: ${JSON.stringify(result).slice(0, 800)}`,
+      triggeredByUserId,
+      context: { juntaId },
+    });
+    return { ok: false, emailError: result };
+  }
+
+  await writeNotificationLog(sb, {
+    definitionId: def?.id ?? null,
+    empresaId,
+    status: 'sent',
+    recipients: { to: toList, cc: ccList, bcc: bccList },
+    subject: payload.subject,
+    resendId: (result as { id?: string }).id ?? null,
+    triggeredByUserId,
+    context: { juntaId },
+  });
+
   return { ok: true, emailId: result.id };
 }

--- a/lib/notifications/log.ts
+++ b/lib/notifications/log.ts
@@ -52,23 +52,29 @@ export async function writeNotificationLog(
   sb: SupabaseClient,
   input: WriteLogInput
 ): Promise<void> {
-  const { error } = await sb
-    .schema('core')
-    .from('notification_log')
-    .insert({
-      definition_id: input.definitionId,
-      empresa_id: input.empresaId ?? null,
-      status: input.status,
-      recipients: input.recipients,
-      subject: input.subject ?? null,
-      resend_id: input.resendId ?? null,
-      error_message: input.errorMessage ?? null,
-      triggered_by_user_id: input.triggeredByUserId ?? null,
-      context: input.context ?? {},
-    });
+  // Wrap en try/catch — fail-open absoluto: ningún error de DB/cliente
+  // mock/network debe bubble up. El email ya se mandó (o ya falló); perder
+  // la traza es siempre menos malo que romper el handler.
+  try {
+    const { error } = await sb
+      .schema('core')
+      .from('notification_log')
+      .insert({
+        definition_id: input.definitionId,
+        empresa_id: input.empresaId ?? null,
+        status: input.status,
+        recipients: input.recipients,
+        subject: input.subject ?? null,
+        resend_id: input.resendId ?? null,
+        error_message: input.errorMessage ?? null,
+        triggered_by_user_id: input.triggeredByUserId ?? null,
+        context: input.context ?? {},
+      });
 
-  if (error) {
-    // Log to stderr — el email ya se mandó, esto es solo trazabilidad.
-    console.error('[notifications] writeNotificationLog falló:', error.message);
+    if (error) {
+      console.error('[notifications] writeNotificationLog falló:', error.message);
+    }
+  } catch (e) {
+    console.error('[notifications] writeNotificationLog excepción:', (e as Error).message);
   }
 }

--- a/lib/notifications/registry.ts
+++ b/lib/notifications/registry.ts
@@ -61,38 +61,46 @@ export async function getDefinitionBySlug(
   slug: string,
   empresaId: string | null = null
 ): Promise<NotificationDefinition | null> {
-  // Si nos pasan empresa, intentamos exacta primero. Si no, vamos directo a global.
-  if (empresaId) {
+  // Wrap todo en try/catch — el helper está documentado FAIL-OPEN: si la query
+  // falla por cualquier motivo (DB caída, RLS mal config, cliente mock sin
+  // .schema() en tests), el handler debe usar config hardcoded como fallback.
+  try {
+    // Si nos pasan empresa, intentamos exacta primero. Si no, vamos directo a global.
+    if (empresaId) {
+      const { data, error } = await sb
+        .schema('core')
+        .from('notification_definitions')
+        .select('*')
+        .eq('slug', slug)
+        .eq('empresa_id', empresaId)
+        .maybeSingle();
+
+      if (error) {
+        console.error(`[notifications] error leyendo def per-empresa ${slug}:`, error.message);
+        // Caer a global como fallback en lugar de retornar null acá.
+      } else if (data) {
+        return data as NotificationDefinition;
+      }
+    }
+
+    // Global fallback (empresa_id IS NULL).
     const { data, error } = await sb
       .schema('core')
       .from('notification_definitions')
       .select('*')
       .eq('slug', slug)
-      .eq('empresa_id', empresaId)
+      .is('empresa_id', null)
       .maybeSingle();
 
     if (error) {
-      console.error(`[notifications] error leyendo def per-empresa ${slug}:`, error.message);
-      // Caer a global como fallback en lugar de retornar null acá.
-    } else if (data) {
-      return data as NotificationDefinition;
+      console.error(`[notifications] error leyendo def global ${slug}:`, error.message);
+      return null;
     }
-  }
-
-  // Global fallback (empresa_id IS NULL).
-  const { data, error } = await sb
-    .schema('core')
-    .from('notification_definitions')
-    .select('*')
-    .eq('slug', slug)
-    .is('empresa_id', null)
-    .maybeSingle();
-
-  if (error) {
-    console.error(`[notifications] error leyendo def global ${slug}:`, error.message);
+    return (data as NotificationDefinition | null) ?? null;
+  } catch (e) {
+    console.error(`[notifications] excepción leyendo def ${slug}:`, (e as Error).message);
     return null;
   }
-  return (data as NotificationDefinition | null) ?? null;
 }
 
 /**

--- a/scripts/run-dilesa-sync.ts
+++ b/scripts/run-dilesa-sync.ts
@@ -30,6 +30,12 @@
 import { spawn } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
 import { CodaClient } from '../lib/coda-api';
+import {
+  getDefinitionBySlug,
+  renderSubject,
+  splitRecipientsExtra,
+  writeNotificationLog,
+} from '../lib/notifications';
 
 const RESEND_API_KEY = process.env.RESEND_API_KEY ?? '';
 const NOTIFY_EMAIL = process.env.NOTIFY_EMAIL ?? '';
@@ -412,26 +418,91 @@ function escapeHtml(s: string): string {
     .replace(/"/g, '&quot;');
 }
 
-async function sendEmail(subject: string, html: string): Promise<void> {
+/**
+ * Envía el reporte de sync vía Resend, leyendo overrides runtime del catálogo
+ * `core.notification_definitions` (slug `dilesa_sync_report`) y escribiendo
+ * fila en `core.notification_log`. Iniciativa notificaciones-catalogo · S2.
+ *
+ * Fail-open: si la definición no se puede leer o `activo=false`, NO bloquea
+ * el envío con la config hardcoded — el sync nocturno debe seguir llegando
+ * incluso si la DB tiene problemas. El kill switch real es desactivar el
+ * GitHub Actions workflow.
+ */
+async function sendEmail(subject: string, html: string, fecha: string): Promise<void> {
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+  const def = await getDefinitionBySlug(sb, 'dilesa_sync_report');
+
+  // Defaults hardcoded (estado pre-iniciativa) — usados si def es null.
+  let fromAddress = FROM_EMAIL;
+  let replyTo: string | null = null;
+  let finalSubject = subject;
+  let toList = [NOTIFY_EMAIL];
+  let ccList: string[] = [];
+  let bccList: string[] = [];
+
+  if (def) {
+    if (!def.activo) {
+      console.log('⚠ dilesa_sync_report.activo=false — skip envío');
+      await writeNotificationLog(sb, {
+        definitionId: def.id,
+        status: 'skipped',
+        recipients: { to: toList },
+        subject: finalSubject,
+      });
+      return;
+    }
+    const fromName = def.from_name ? `${def.from_name} <${def.from_email}>` : def.from_email;
+    fromAddress = fromName;
+    replyTo = def.reply_to;
+    finalSubject = renderSubject(def.subject_template, { fecha });
+    // Manda con el subject del helper si trae '✓ ' / '✗ ' del status, sino
+    // usa el template editable de la definition.
+    if (subject.startsWith('✗')) finalSubject = subject; // preserva el fail marker
+    const extras = splitRecipientsExtra(def.recipients_extra);
+    toList = [NOTIFY_EMAIL, ...extras.to];
+    ccList = extras.cc;
+    bccList = extras.bcc;
+  }
+
+  const body: Record<string, unknown> = {
+    from: fromAddress,
+    to: toList,
+    subject: finalSubject,
+    html,
+  };
+  if (replyTo) body.reply_to = replyTo;
+  if (ccList.length) body.cc = ccList;
+  if (bccList.length) body.bcc = bccList;
+
   const res = await fetch('https://api.resend.com/emails', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${RESEND_API_KEY}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      from: FROM_EMAIL,
-      to: [NOTIFY_EMAIL],
-      subject,
-      html,
-    }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     const text = await res.text();
     console.error(`✗ Resend error ${res.status}: ${text}`);
+    await writeNotificationLog(sb, {
+      definitionId: def?.id ?? null,
+      status: 'failed',
+      recipients: { to: toList, cc: ccList, bcc: bccList },
+      subject: finalSubject,
+      errorMessage: `Resend ${res.status}: ${text}`.slice(0, 1000),
+    });
     return;
   }
+  const json = (await res.json().catch(() => null)) as { id?: string } | null;
   console.log(`✔ Email enviado a ${NOTIFY_EMAIL}`);
+  await writeNotificationLog(sb, {
+    definitionId: def?.id ?? null,
+    status: 'sent',
+    recipients: { to: toList, cc: ccList, bcc: bccList },
+    subject: finalSubject,
+    resendId: json?.id ?? null,
+  });
 }
 
 async function main(): Promise<void> {
@@ -472,6 +543,12 @@ async function main(): Promise<void> {
   const totalMs = Date.now() - t0;
   console.log(`\n=== Total: ${fmtDuration(totalMs)} ===`);
 
+  const today = new Date().toLocaleDateString('es-MX', {
+    weekday: 'long',
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
   const { subject, html } = buildHtml({
     status: anyFail ? 'fail' : 'ok',
     pre,
@@ -480,7 +557,7 @@ async function main(): Promise<void> {
     steps,
     totalMs,
   });
-  await sendEmail(subject, html);
+  await sendEmail(subject, html, today);
 
   if (anyFail) process.exit(1);
 }
@@ -488,8 +565,15 @@ async function main(): Promise<void> {
 void main().catch((e) => {
   console.error('Error fatal:', e);
   // Best-effort email del fatal antes de salir
+  const today = new Date().toLocaleDateString('es-MX', {
+    weekday: 'long',
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  });
   void sendEmail(
     `✗✗ Sync DILESA Coda→BSOP — error FATAL`,
-    `<pre>${escapeHtml((e as Error).stack ?? String(e))}</pre>`
+    `<pre>${escapeHtml((e as Error).stack ?? String(e))}</pre>`,
+    today
   ).finally(() => process.exit(1));
 });


### PR DESCRIPTION
## Summary

Iniciativa \`notificaciones-catalogo\` · Sprint 2.

Cada handler que manda email ahora lee \`core.notification_definitions\` por slug + escribe \`core.notification_log\` con status/recipients/resend_id post-envío. FAIL-OPEN: si la DB falla usa config hardcoded; si \`activo=false\` skip + log skipped.

**6 handlers refactorizados** (orden de riesgo creciente):

1. \`scripts/run-dilesa-sync.ts\` — bajo impacto
2. \`app/api/welcome-email/route.ts\` — admin trigger
3. \`app/api/cron/daily-task-summary/route.ts\` — Vercel cron
4. \`app/api/dilesa/estimaciones/[id]/pdf/route.tsx\` — manual con PDF
5. \`lib/juntas/email.ts\` \`sendMinutaEmail()\` + \`terminar\` caller
6. \`reenviar\` caller

**Cambios secundarios:**
- \`getDefinitionBySlug\` y \`writeNotificationLog\` capturan excepciones (try/catch) para sobrevivir clientes mock incompletos + crashes random.
- \`buildMinutaEmailPayload\` retorna \`empresaId\` para lookup empresa-aware.
- Daily-task-summary: kill switch global activo=false skipea todo el ciclo.

## Test plan

- [x] typecheck/lint/format/test (6120 OK) verde local
- [ ] CI verde + merge
- [ ] Sprint 3 (UI catálogo) y 4 (edit + test send) a continuación

🤖 Generated with [Claude Code](https://claude.com/claude-code)