### PR TITLE
feat(dilesa-proyectos-anteproyectos): Sprint 2 — UI base de Anteproyectos

### DIFF
--- a/app/dilesa/proyectos/anteproyectos/page.tsx
+++ b/app/dilesa/proyectos/anteproyectos/page.tsx
@@ -2,69 +2,25 @@
 
 import { RequireAccess } from '@/components/require-access';
 import { DesktopOnlyNotice } from '@/components/responsive';
-import { ClipboardList } from 'lucide-react';
+import { AnteproyectosModule } from '@/components/dilesa/anteproyectos-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
 /**
  * @module Proyectos · Anteproyectos (DILESA)
  * @responsive desktop-only
  *
- * Skeleton del Sprint 1 (iniciativa `dilesa-proyectos-anteproyectos`).
- * El UI real (listado conectado a `dilesa.anteproyectos` + análisis
- * financiero desde `v_anteproyectos_analisis` + checklist por plantilla
- * + presupuestos preliminares + conversión a proyecto) se construye en
- * Sprints 2-4 — ver `docs/planning/dilesa-proyectos-anteproyectos.md`.
- *
- * Por ahora la página solo señala el alcance y el estado para que la
- * navegación funcione end-to-end desde el día del refactor.
+ * Tab "Anteproyectos" del hub Proyectos. Lista los rows de
+ * `dilesa.proyectos` con `tipo='anteproyecto'` — evaluaciones de
+ * viabilidad antes del arranque formal como desarrollo. Sprint 2 de la
+ * iniciativa `dilesa-proyectos-anteproyectos`. Sprints 3-4 agregan
+ * checklist canónico de tareas y conversión a desarrollo.
  */
 export default function AnteproyectosPage() {
   return (
     <RequireAccess empresa="dilesa" modulo="dilesa.proyectos.anteproyectos">
       <DesktopOnlyNotice module="Anteproyectos" />
-      <div className="hidden space-y-6 p-4 sm:block sm:p-6">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Anteproyectos</h1>
-          <p className="text-sm text-muted-foreground">
-            Evaluación de viabilidad de nuevos desarrollos antes de su arranque formal como
-            proyecto.
-          </p>
-        </div>
-
-        <div className="rounded-lg border bg-card text-card-foreground shadow-sm">
-          <div className="flex items-center gap-3 p-6 pb-3">
-            <div className="rounded-lg bg-muted p-2">
-              <ClipboardList className="h-5 w-5 text-muted-foreground" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold leading-none tracking-tight">
-                UI en construcción
-              </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                El módulo se construye en los siguientes sprints de la iniciativa.
-              </p>
-            </div>
-          </div>
-          <div className="space-y-3 px-6 pb-6 text-sm text-muted-foreground">
-            <p>Lo que viene en próximos sprints:</p>
-            <ul className="ml-5 list-disc space-y-1">
-              <li>
-                <strong>Sprint 2</strong> — listado de anteproyectos con filtros, KPIs reactivos y
-                detalle con análisis financiero conectado a la vista existente{' '}
-                <code>dilesa.v_anteproyectos_analisis</code>.
-              </li>
-              <li>
-                <strong>Sprint 3</strong> — plantilla canónica de 35 tareas (trámites, estudios,
-                cotizaciones), checklist auto-instanciado por anteproyecto con dependencias y fechas
-                objetivo en calendario hábil MX, presupuestos preliminares ligables a tareas.
-              </li>
-              <li>
-                <strong>Sprint 4</strong> — conversión anteproyecto → proyecto (gated por tarea
-                &quot;Aprobación de Comité de Inversión&quot;) que rehoga tareas y snapshot-copia
-                presupuestos autorizados al modelo de control del proyecto.
-              </li>
-            </ul>
-          </div>
-        </div>
+      <div className="hidden sm:block">
+        <AnteproyectosModule empresaId={DILESA_EMPRESA_ID} />
       </div>
     </RequireAccess>
   );

--- a/app/dilesa/proyectos/page.tsx
+++ b/app/dilesa/proyectos/page.tsx
@@ -20,7 +20,7 @@ export default function Page() {
     <RequireAccess empresa="dilesa" modulo="dilesa.proyectos.activos">
       <DesktopOnlyNotice module="Proyectos" />
       <div className="hidden sm:block">
-        <ProyectosModule empresaId={DILESA_EMPRESA_ID} />
+        <ProyectosModule empresaId={DILESA_EMPRESA_ID} excluirTipos={['anteproyecto']} />
       </div>
     </RequireAccess>
   );

--- a/components/dilesa/anteproyecto-detail-drawer.tsx
+++ b/components/dilesa/anteproyecto-detail-drawer.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+/**
+ * AnteproyectoDetailDrawer — detalle de un anteproyecto DILESA con su
+ * análisis financiero derivado.
+ *
+ * Iniciativa `dilesa-proyectos-anteproyectos` Sprint 2. Anteproyectos
+ * son rows en `dilesa.proyectos` con `tipo='anteproyecto'` — comparten
+ * el shape de un `<ProyectoDetalle>` pero NO tienen unidades aún
+ * (no se materializan hasta que el anteproyecto se promueve a desarrollo).
+ *
+ * Foco de la UI: análisis de viabilidad. Muestra la ficha del
+ * anteproyecto + indicadores derivados client-side (suma de costos,
+ * aprovechamiento, % áreas verdes, costo por lote, costo por m²
+ * vendible) que ayudan a la decisión "arrancar o descartar". La
+ * checklist de tareas y el presupuesto preliminar son entregables del
+ * Sprint 3.
+ */
+
+import { DetailDrawer, DetailDrawerContent, DetailDrawerSection } from '@/components/detail-page';
+import { Badge } from '@/components/ui/badge';
+import { type ProyectoDetalle, ESTADO_TONE, ESTADO_LABEL } from './proyecto-detail-drawer';
+
+const numberFmt = new Intl.NumberFormat('es-MX');
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const pctFmt = new Intl.NumberFormat('es-MX', {
+  style: 'percent',
+  maximumFractionDigits: 1,
+});
+
+function fmtM2(n: number | null): string | null {
+  return n == null ? null : `${numberFmt.format(n)} m²`;
+}
+
+function fmtMoney(n: number | null): string | null {
+  return n == null ? null : moneyFmt.format(n);
+}
+
+function fmtInt(n: number | null): string | null {
+  return n == null ? null : numberFmt.format(n);
+}
+
+function fmtPct(n: number | null): string | null {
+  return n == null ? null : pctFmt.format(n);
+}
+
+function fmtFecha(s: string | null): string | null {
+  if (!s) return null;
+  const d = new Date(`${s}T00:00:00`);
+  if (isNaN(d.getTime())) return s;
+  return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+/**
+ * Indicadores derivados client-side desde las columnas de
+ * `dilesa.proyectos`. Se exportan para reuso en tests + KPIs agregados.
+ */
+export function deriveAnalisis(p: ProyectoDetalle) {
+  const costoTerreno = p.costo_terreno ?? 0;
+  const costoUrb = p.costo_urbanizacion ?? 0;
+  const costoConst = p.costo_construccion ?? 0;
+  const costoCom = p.costo_comercializacion ?? 0;
+  const hasCostos = [
+    p.costo_terreno,
+    p.costo_urbanizacion,
+    p.costo_construccion,
+    p.costo_comercializacion,
+  ].some((c) => c != null);
+  const costoTotal = hasCostos ? costoTerreno + costoUrb + costoConst + costoCom : null;
+
+  const aprovechamiento = p.area_m2 && p.area_vendible_m2 ? p.area_vendible_m2 / p.area_m2 : null;
+  const pctVerdes = p.area_m2 && p.areas_verdes_m2 ? p.areas_verdes_m2 / p.area_m2 : null;
+
+  const costoPorLote =
+    costoTotal != null && p.lotes_proyectados ? costoTotal / p.lotes_proyectados : null;
+  const costoPorM2Vendible =
+    costoTotal != null && p.area_vendible_m2 ? costoTotal / p.area_vendible_m2 : null;
+
+  // Diferencia entre presupuesto y suma de costos (control de consistencia).
+  // Si el presupuesto cuadra con la suma de partidas, el delta es ~0.
+  const deltaPresupuesto =
+    p.presupuesto_estimado != null && costoTotal != null
+      ? p.presupuesto_estimado - costoTotal
+      : null;
+
+  return {
+    costoTotal,
+    aprovechamiento,
+    pctVerdes,
+    costoPorLote,
+    costoPorM2Vendible,
+    deltaPresupuesto,
+  };
+}
+
+export function AnteproyectoDetailDrawer({
+  anteproyecto,
+  open,
+  onOpenChange,
+}: {
+  anteproyecto: ProyectoDetalle | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  if (!anteproyecto) return null;
+
+  const analisis = deriveAnalisis(anteproyecto);
+
+  const fichaFisica: { label: string; value: string }[] = (
+    [
+      ['Clave interna', anteproyecto.clave_interna],
+      ['Inicio', fmtFecha(anteproyecto.fecha_inicio)],
+      ['Fin estimado', fmtFecha(anteproyecto.fecha_fin_estimada)],
+      ['Licencia de fraccionamiento', fmtFecha(anteproyecto.fecha_licencia)],
+      ['Área total', fmtM2(anteproyecto.area_m2)],
+      ['Área vendible', fmtM2(anteproyecto.area_vendible_m2)],
+      ['Áreas verdes', fmtM2(anteproyecto.areas_verdes_m2)],
+      ['Lotes proyectados', fmtInt(anteproyecto.lotes_proyectados)],
+    ] as [string, string | null][]
+  )
+    .filter((r): r is [string, string] => r[1] != null)
+    .map(([label, value]) => ({ label, value }));
+
+  const fichaCostos: { label: string; value: string }[] = (
+    [
+      ['Presupuesto estimado', fmtMoney(anteproyecto.presupuesto_estimado)],
+      ['Costo de terreno', fmtMoney(anteproyecto.costo_terreno)],
+      ['Costo de urbanización', fmtMoney(anteproyecto.costo_urbanizacion)],
+      ['Costo de construcción', fmtMoney(anteproyecto.costo_construccion)],
+      ['Costo de comercialización', fmtMoney(anteproyecto.costo_comercializacion)],
+    ] as [string, string | null][]
+  )
+    .filter((r): r is [string, string] => r[1] != null)
+    .map(([label, value]) => ({ label, value }));
+
+  const fichaAnalisis: { label: string; value: string; tone?: 'success' | 'warning' }[] = (
+    [
+      ['Costo total (suma de partidas)', fmtMoney(analisis.costoTotal)],
+      ['Aprovechamiento (vendible/total)', fmtPct(analisis.aprovechamiento)],
+      ['% Áreas verdes', fmtPct(analisis.pctVerdes)],
+      ['Costo por lote', fmtMoney(analisis.costoPorLote)],
+      ['Costo por m² vendible', fmtMoney(analisis.costoPorM2Vendible)],
+    ] as [string, string | null][]
+  )
+    .filter((r): r is [string, string] => r[1] != null)
+    .map(([label, value]) => ({ label, value }));
+
+  return (
+    <DetailDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      size="xl"
+      title={anteproyecto.nombre}
+      meta={
+        <>
+          <Badge tone="info">Anteproyecto</Badge>
+          <Badge tone={ESTADO_TONE[anteproyecto.estado] ?? 'neutral'}>
+            {ESTADO_LABEL[anteproyecto.estado] ?? anteproyecto.estado}
+          </Badge>
+        </>
+      }
+    >
+      <DetailDrawerContent>
+        <DetailDrawerSection title="Ficha física" divider={false}>
+          {fichaFisica.length > 0 ? (
+            <dl className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+              {fichaFisica.map((r) => (
+                <div key={r.label}>
+                  <dt className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+                    {r.label}
+                  </dt>
+                  <dd className="mt-0.5 text-sm text-[var(--text)]">{r.value}</dd>
+                </div>
+              ))}
+            </dl>
+          ) : (
+            <p className="text-sm text-[var(--text)]/60">Sin datos físicos capturados todavía.</p>
+          )}
+        </DetailDrawerSection>
+
+        {fichaCostos.length > 0 && (
+          <DetailDrawerSection title="Costos estimados">
+            <dl className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+              {fichaCostos.map((r) => (
+                <div key={r.label}>
+                  <dt className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+                    {r.label}
+                  </dt>
+                  <dd className="mt-0.5 text-sm text-[var(--text)]">{r.value}</dd>
+                </div>
+              ))}
+            </dl>
+            {analisis.deltaPresupuesto != null && Math.abs(analisis.deltaPresupuesto) > 1 && (
+              <p className="mt-3 text-xs text-[var(--text)]/60">
+                {analisis.deltaPresupuesto > 0
+                  ? `El presupuesto excede la suma de partidas en ${fmtMoney(analisis.deltaPresupuesto)} (holgura).`
+                  : `La suma de partidas excede el presupuesto en ${fmtMoney(Math.abs(analisis.deltaPresupuesto))} (sobre-asignación).`}
+              </p>
+            )}
+          </DetailDrawerSection>
+        )}
+
+        {fichaAnalisis.length > 0 && (
+          <DetailDrawerSection title="Análisis derivado">
+            <dl className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+              {fichaAnalisis.map((r) => (
+                <div key={r.label}>
+                  <dt className="text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+                    {r.label}
+                  </dt>
+                  <dd className="mt-0.5 text-sm text-[var(--text)]">{r.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </DetailDrawerSection>
+        )}
+
+        {anteproyecto.notas ? (
+          <DetailDrawerSection title="Notas">
+            <p className="whitespace-pre-line text-sm text-[var(--text)]/80">
+              {anteproyecto.notas}
+            </p>
+          </DetailDrawerSection>
+        ) : null}
+
+        <DetailDrawerSection title="Próximamente">
+          <p className="text-sm text-[var(--text)]/60">
+            Sprint 3 agrega el checklist de tareas canónicas (35 trámites/estudios/cotizaciones) con
+            dependencias y fechas objetivo, y la captura de presupuestos preliminares. Sprint 4
+            agrega la acción &quot;promover a desarrollo&quot;.
+          </p>
+        </DetailDrawerSection>
+      </DetailDrawerContent>
+    </DetailDrawer>
+  );
+}

--- a/components/dilesa/anteproyectos-module.test.ts
+++ b/components/dilesa/anteproyectos-module.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import { deriveKpis } from './anteproyectos-module';
+import { deriveAnalisis } from './anteproyecto-detail-drawer';
+import type { ProyectoDetalle } from './proyecto-detail-drawer';
+
+function ap(overrides: Partial<ProyectoDetalle>): ProyectoDetalle {
+  return {
+    id: 'id',
+    tipo: 'anteproyecto',
+    nombre: 'Anteproyecto',
+    estado: 'analisis',
+    clave_interna: null,
+    proyecto_padre_id: null,
+    fecha_inicio: null,
+    fecha_fin_estimada: null,
+    fecha_licencia: null,
+    area_m2: null,
+    area_vendible_m2: null,
+    areas_verdes_m2: null,
+    lotes_proyectados: null,
+    presupuesto_estimado: null,
+    costo_terreno: null,
+    costo_urbanizacion: null,
+    costo_construccion: null,
+    costo_comercializacion: null,
+    notas: null,
+    ...overrides,
+  };
+}
+
+describe('deriveKpis (Anteproyectos DILESA — ADR-034 + D2)', () => {
+  it('returns 5 KPIs en orden D2', () => {
+    const kpis = deriveKpis([]);
+    expect(kpis).toHaveLength(5);
+    expect(kpis.map((k) => k.key)).toEqual([
+      'total',
+      'activos',
+      'inversion',
+      'lotes',
+      'en_decision',
+    ]);
+  });
+
+  it('total = rows.length', () => {
+    expect(deriveKpis([ap({}), ap({}), ap({})])[0]?.value).toBe(3);
+  });
+
+  it('activos = count(estado IN propuesta|analisis|aprobado)', () => {
+    const rows = [
+      ap({ estado: 'propuesta' }),
+      ap({ estado: 'analisis' }),
+      ap({ estado: 'aprobado' }),
+      ap({ estado: 'completado' }),
+      ap({ estado: 'archivado' }),
+    ];
+    expect(deriveKpis(rows)[1]?.value).toBe(3);
+  });
+
+  it('inversión proyectada suma compact, ignora null', () => {
+    const rows = [
+      ap({ presupuesto_estimado: 8_000_000 }),
+      ap({ presupuesto_estimado: 4_000_000 }),
+      ap({ presupuesto_estimado: null }),
+    ];
+    expect(String(deriveKpis(rows)[2]?.value)).toContain('12');
+  });
+
+  it('inversión "—" cuando no hay rows', () => {
+    expect(deriveKpis([])[2]?.value).toBe('—');
+  });
+
+  it('lotes proyectados suma sin decimales', () => {
+    const rows = [
+      ap({ lotes_proyectados: 40 }),
+      ap({ lotes_proyectados: 80 }),
+      ap({ lotes_proyectados: null }),
+    ];
+    expect(deriveKpis(rows)[3]?.value).toBe('120');
+  });
+
+  it('en decisión = count(estado="analisis")', () => {
+    const rows = [
+      ap({ estado: 'analisis' }),
+      ap({ estado: 'analisis' }),
+      ap({ estado: 'propuesta' }),
+      ap({ estado: 'aprobado' }),
+    ];
+    expect(deriveKpis(rows)[4]?.value).toBe(2);
+  });
+
+  it('reactivity: filtrar por estado cambia activos y en decisión', () => {
+    const todos = [
+      ap({ estado: 'analisis', presupuesto_estimado: 6_000_000, lotes_proyectados: 30 }),
+      ap({ estado: 'completado', presupuesto_estimado: 1_000_000, lotes_proyectados: 5 }),
+    ];
+    const soloAnalisis = todos.filter((r) => r.estado === 'analisis');
+    const k = deriveKpis(soloAnalisis);
+    expect(k[0]?.value).toBe(1);
+    expect(k[1]?.value).toBe(1);
+    expect(k[4]?.value).toBe(1);
+  });
+});
+
+describe('deriveAnalisis (financiero derivado client-side)', () => {
+  it('costo total suma las 4 partidas', () => {
+    const a = deriveAnalisis(
+      ap({
+        costo_terreno: 2_000_000,
+        costo_urbanizacion: 3_000_000,
+        costo_construccion: 5_000_000,
+        costo_comercializacion: 1_000_000,
+      })
+    );
+    expect(a.costoTotal).toBe(11_000_000);
+  });
+
+  it('costo total es null cuando todas las partidas son null', () => {
+    expect(deriveAnalisis(ap({})).costoTotal).toBeNull();
+  });
+
+  it('costo total trata null como 0 cuando al menos una partida está poblada', () => {
+    const a = deriveAnalisis(
+      ap({
+        costo_terreno: 2_000_000,
+        costo_urbanizacion: null,
+        costo_construccion: null,
+        costo_comercializacion: null,
+      })
+    );
+    expect(a.costoTotal).toBe(2_000_000);
+  });
+
+  it('aprovechamiento = area_vendible / area_total', () => {
+    const a = deriveAnalisis(ap({ area_m2: 10_000, area_vendible_m2: 7_500 }));
+    expect(a.aprovechamiento).toBeCloseTo(0.75);
+  });
+
+  it('% áreas verdes = areas_verdes / area_total', () => {
+    const a = deriveAnalisis(ap({ area_m2: 10_000, areas_verdes_m2: 1_500 }));
+    expect(a.pctVerdes).toBeCloseTo(0.15);
+  });
+
+  it('costo por lote = costoTotal / lotes_proyectados', () => {
+    const a = deriveAnalisis(
+      ap({
+        costo_terreno: 5_000_000,
+        costo_urbanizacion: 5_000_000,
+        costo_construccion: null,
+        costo_comercializacion: null,
+        lotes_proyectados: 50,
+      })
+    );
+    expect(a.costoPorLote).toBe(200_000);
+  });
+
+  it('costo por m² vendible = costoTotal / area_vendible_m2', () => {
+    const a = deriveAnalisis(
+      ap({
+        costo_terreno: 4_000_000,
+        costo_urbanizacion: null,
+        costo_construccion: null,
+        costo_comercializacion: null,
+        area_vendible_m2: 8_000,
+      })
+    );
+    expect(a.costoPorM2Vendible).toBe(500);
+  });
+
+  it('delta presupuesto positivo = holgura, negativo = sobre-asignación', () => {
+    const conHolgura = deriveAnalisis(
+      ap({
+        presupuesto_estimado: 12_000_000,
+        costo_terreno: 10_000_000,
+        costo_urbanizacion: null,
+        costo_construccion: null,
+        costo_comercializacion: null,
+      })
+    );
+    expect(conHolgura.deltaPresupuesto).toBe(2_000_000);
+
+    const sobreAsignado = deriveAnalisis(
+      ap({
+        presupuesto_estimado: 10_000_000,
+        costo_terreno: 8_000_000,
+        costo_urbanizacion: 5_000_000,
+        costo_construccion: null,
+        costo_comercializacion: null,
+      })
+    );
+    expect(sobreAsignado.deltaPresupuesto).toBe(-3_000_000);
+  });
+
+  it('todos los derivados son null cuando faltan los insumos', () => {
+    const a = deriveAnalisis(ap({}));
+    expect(a.aprovechamiento).toBeNull();
+    expect(a.pctVerdes).toBeNull();
+    expect(a.costoPorLote).toBeNull();
+    expect(a.costoPorM2Vendible).toBeNull();
+    expect(a.deltaPresupuesto).toBeNull();
+  });
+});

--- a/components/dilesa/anteproyectos-module.tsx
+++ b/components/dilesa/anteproyectos-module.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+/**
+ * AnteproyectosModule — lista de anteproyectos DILESA.
+ *
+ * Iniciativa `dilesa-proyectos-anteproyectos` Sprint 2. Anteproyectos
+ * son rows en `dilesa.proyectos` con `tipo='anteproyecto'` (no una
+ * tabla separada — el schema v2 los unificó con discriminador).
+ *
+ * Foco: evaluación de viabilidad. KPIs derivados del portafolio en
+ * análisis. El checklist + presupuestos preliminares + conversión a
+ * desarrollo son entregables de Sprints 3-4.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+  DateRangeFilter,
+  EMPTY_DATE_RANGE,
+  isInDateRange,
+  type DateRange,
+} from '@/components/filters/date-range-filter';
+import { ClipboardList, RefreshCw, Search } from 'lucide-react';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { formatCurrency, formatNumber } from '@/lib/format';
+import { AnteproyectoDetailDrawer, deriveAnalisis } from './anteproyecto-detail-drawer';
+import { type ProyectoDetalle, ESTADO_TONE, ESTADO_LABEL } from './proyecto-detail-drawer';
+
+/** Estados que cuentan como "activos" (en pipeline de evaluación). */
+const ESTADOS_ACTIVOS = new Set(['propuesta', 'analisis', 'aprobado']);
+
+/**
+ * KPIs reactivos a filtros — ADR-034.
+ *
+ * Curaduría D2 cerrada en planning doc. Los 5 KPIs originales eran
+ * # activos / inversión proyectada / utilidad proyectada / margen / #
+ * en decisión pendiente. Para v1 los KPIs 3 y 4 se reemplazan por
+ * "Lotes proyectados" y "Área vendible" porque `dilesa.proyectos` no
+ * tiene un campo directo de "valor de venta proyectado" del cual
+ * derivar utilidad/margen sin asumir un precio promedio (pivote
+ * documentado). Cuando se modele el ingreso proyectado en Sprint 3
+ * (vía cotización de comercialización) o como columna derivada, se
+ * reemplazan los KPIs 4 y 5 por los originales.
+ *
+ * KPIs:
+ * 1. Total anteproyectos — `rows.length`.
+ * 2. Activos — `count(estado IN propuesta|analisis|aprobado)`.
+ * 3. Inversión proyectada — `SUM(presupuesto_estimado)`.
+ * 4. Lotes proyectados — `SUM(lotes_proyectados)`.
+ * 5. En decisión — `count(estado='analisis')`.
+ */
+export function deriveKpis(rows: readonly ProyectoDetalle[]): readonly ModuleKpi[] {
+  const total = rows.length;
+  const activos = rows.filter((p) => ESTADOS_ACTIVOS.has(p.estado)).length;
+  const inversion = rows.reduce((acc, p) => acc + (p.presupuesto_estimado ?? 0), 0);
+  const lotes = rows.reduce((acc, p) => acc + (p.lotes_proyectados ?? 0), 0);
+  const enDecision = rows.filter((p) => p.estado === 'analisis').length;
+
+  return [
+    { key: 'total', label: 'Anteproyectos', value: total },
+    { key: 'activos', label: 'Activos', value: activos },
+    {
+      key: 'inversion',
+      label: 'Inversión proyectada',
+      value: total === 0 ? '—' : formatCurrency(inversion, { compact: true }),
+    },
+    {
+      key: 'lotes',
+      label: 'Lotes proyectados',
+      value: total === 0 ? '—' : formatNumber(lotes, { decimals: 0 }),
+    },
+    { key: 'en_decision', label: 'En decisión', value: enDecision },
+  ];
+}
+
+export function AnteproyectosModule({ empresaId }: { empresaId: string }) {
+  const [anteproyectos, setAnteproyectos] = useState<ProyectoDetalle[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [estadoFiltro, setEstadoFiltro] = useState<string>('');
+  const [rangoInicio, setRangoInicio] = useState<DateRange>(EMPTY_DATE_RANGE);
+  const [selected, setSelected] = useState<ProyectoDetalle | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const fetchAnteproyectos = useCallback(
+    () =>
+      createSupabaseBrowserClient()
+        .schema('dilesa')
+        .from('proyectos')
+        .select(
+          'id, tipo, nombre, estado, clave_interna, proyecto_padre_id, fecha_inicio, fecha_fin_estimada, fecha_licencia, area_m2, area_vendible_m2, areas_verdes_m2, lotes_proyectados, presupuesto_estimado, costo_terreno, costo_urbanizacion, costo_construccion, costo_comercializacion, notas'
+        )
+        .eq('empresa_id', empresaId)
+        .eq('tipo', 'anteproyecto')
+        .is('deleted_at', null)
+        .order('nombre'),
+    [empresaId]
+  );
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: err } = await fetchAnteproyectos();
+    if (err) {
+      setError(getSupabaseErrorMessage(err, 'No se pudieron cargar los anteproyectos.'));
+      setAnteproyectos([]);
+    } else {
+      setAnteproyectos((data ?? []) as ProyectoDetalle[]);
+    }
+    setLoading(false);
+  }, [fetchAnteproyectos]);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchAnteproyectos().then(({ data, error: err }) => {
+      if (!activo) return;
+      if (err) {
+        setError(getSupabaseErrorMessage(err, 'No se pudieron cargar los anteproyectos.'));
+        setAnteproyectos([]);
+      } else {
+        setAnteproyectos((data ?? []) as ProyectoDetalle[]);
+      }
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchAnteproyectos]);
+
+  const filtrados = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return anteproyectos.filter((p) => {
+      if (estadoFiltro && p.estado !== estadoFiltro) return false;
+      if (!isInDateRange(p.fecha_inicio, rangoInicio)) return false;
+      if (q && !p.nombre.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [anteproyectos, search, estadoFiltro, rangoInicio]);
+
+  const kpis = useMemo(() => deriveKpis(filtrados), [filtrados]);
+
+  const columns: Column<ProyectoDetalle>[] = [
+    { key: 'nombre', label: 'Nombre', type: 'text', sticky: true, width: 'min-w-[240px]' },
+    {
+      key: 'estado',
+      label: 'Estado',
+      type: 'custom',
+      render: (p) => (
+        <Badge tone={ESTADO_TONE[p.estado] ?? 'neutral'}>
+          {ESTADO_LABEL[p.estado] ?? p.estado}
+        </Badge>
+      ),
+    },
+    {
+      key: 'clave_interna',
+      label: 'Clave',
+      type: 'text',
+      render: (p) => p.clave_interna ?? <span className="text-[var(--text)]/30">—</span>,
+    },
+    { key: 'fecha_inicio', label: 'Inicio', type: 'date' },
+    {
+      key: 'lotes_proyectados',
+      label: 'Lotes',
+      type: 'number',
+      render: (p) => (p.lotes_proyectados != null ? String(p.lotes_proyectados) : '—'),
+    },
+    {
+      key: 'area_vendible_m2',
+      label: 'Área vendible m²',
+      type: 'number',
+      render: (p) =>
+        p.area_vendible_m2 != null ? (
+          formatNumber(p.area_vendible_m2)
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
+    { key: 'presupuesto_estimado', label: 'Presupuesto', type: 'currency' },
+    {
+      key: 'costo_total',
+      label: 'Costo total',
+      type: 'custom',
+      accessor: (p) => deriveAnalisis(p).costoTotal ?? 0,
+      render: (p) => {
+        const total = deriveAnalisis(p).costoTotal;
+        return total != null ? (
+          formatCurrency(total)
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        );
+      },
+    },
+    {
+      key: 'costo_por_lote',
+      label: 'Costo / lote',
+      type: 'custom',
+      accessor: (p) => deriveAnalisis(p).costoPorLote ?? 0,
+      render: (p) => {
+        const v = deriveAnalisis(p).costoPorLote;
+        return v != null ? formatCurrency(v) : <span className="text-[var(--text)]/30">—</span>;
+      },
+    },
+  ];
+
+  const estadosPresentes = useMemo(
+    () => Array.from(new Set(anteproyectos.map((p) => p.estado))).sort(),
+    [anteproyectos]
+  );
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <ClipboardList className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">
+            Anteproyectos
+          </h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Evaluación de viabilidad antes del arranque formal como desarrollo.
+          </p>
+        </div>
+      </header>
+
+      <ModuleKpiStrip stats={kpis} cols={5} />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar por nombre…"
+            className="w-64 pl-9"
+          />
+        </div>
+        <select
+          value={estadoFiltro}
+          onChange={(e) => setEstadoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los estados</option>
+          {estadosPresentes.map((s) => (
+            <option key={s} value={s}>
+              {ESTADO_LABEL[s] ?? s}
+            </option>
+          ))}
+        </select>
+        <DateRangeFilter
+          label="Inicio"
+          ariaPrefix="Fecha inicio"
+          value={rangoInicio}
+          onChange={setRangoInicio}
+        />
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+      </div>
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={(p) => {
+          setSelected(p);
+          setDrawerOpen(true);
+        }}
+        initialSort={{ key: 'nombre', dir: 'asc' }}
+        emptyTitle="Sin anteproyectos"
+        emptyDescription="Aún no hay anteproyectos en evaluación. Cuando se promuevan a desarrollos cambiarán de tab."
+        emptyIcon={<ClipboardList className="h-6 w-6" />}
+      />
+
+      <AnteproyectoDetailDrawer
+        anteproyecto={selected}
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+      />
+    </div>
+  );
+}

--- a/components/dilesa/proyectos-module.tsx
+++ b/components/dilesa/proyectos-module.tsx
@@ -84,7 +84,25 @@ export function deriveKpis(rows: readonly ProyectoDetalle[]): readonly ModuleKpi
   ];
 }
 
-export function ProyectosModule({ empresaId }: { empresaId: string }) {
+const EMPTY_TIPOS: readonly string[] = [];
+
+/**
+ * Props del módulo.
+ *
+ * - `excluirTipos` permite filtrar tipos específicos en el query base.
+ *   Caso de uso: la tab "Activos" del hub Proyectos
+ *   (`/dilesa/proyectos`) pasa `['anteproyecto']` para que los
+ *   anteproyectos vivan solo en su tab hermana (iniciativa
+ *   `dilesa-proyectos-anteproyectos` Sprint 2). Default vacío preserva
+ *   el comportamiento histórico (todos los tipos).
+ */
+export function ProyectosModule({
+  empresaId,
+  excluirTipos = EMPTY_TIPOS,
+}: {
+  empresaId: string;
+  excluirTipos?: readonly string[];
+}) {
   const [proyectos, setProyectos] = useState<ProyectoDetalle[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -94,19 +112,22 @@ export function ProyectosModule({ empresaId }: { empresaId: string }) {
   const [selected, setSelected] = useState<ProyectoDetalle | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
-  const fetchProyectos = useCallback(
-    () =>
-      createSupabaseBrowserClient()
-        .schema('dilesa')
-        .from('proyectos')
-        .select(
-          'id, tipo, nombre, estado, clave_interna, proyecto_padre_id, fecha_inicio, fecha_fin_estimada, fecha_licencia, area_m2, area_vendible_m2, areas_verdes_m2, lotes_proyectados, presupuesto_estimado, costo_terreno, costo_urbanizacion, costo_construccion, costo_comercializacion, notas'
-        )
-        .eq('empresa_id', empresaId)
-        .is('deleted_at', null)
-        .order('nombre'),
-    [empresaId]
-  );
+  const fetchProyectos = useCallback(() => {
+    let q = createSupabaseBrowserClient()
+      .schema('dilesa')
+      .from('proyectos')
+      .select(
+        'id, tipo, nombre, estado, clave_interna, proyecto_padre_id, fecha_inicio, fecha_fin_estimada, fecha_licencia, area_m2, area_vendible_m2, areas_verdes_m2, lotes_proyectados, presupuesto_estimado, costo_terreno, costo_urbanizacion, costo_construccion, costo_comercializacion, notas'
+      )
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null);
+    if (excluirTipos.length > 0) {
+      // PostgREST: usar `not.in` con lista entre paréntesis. Valores
+      // sin comillas porque `tipo` es text sin caracteres especiales.
+      q = q.not('tipo', 'in', `(${excluirTipos.join(',')})`);
+    }
+    return q.order('nombre');
+  }, [empresaId, excluirTipos]);
 
   const cargar = useCallback(async () => {
     setLoading(true);


### PR DESCRIPTION
## Resumen

Sprint 2 de [`dilesa-proyectos-anteproyectos`](../blob/main/docs/planning/dilesa-proyectos-anteproyectos.md). La tab `/dilesa/proyectos/anteproyectos` ahora muestra UI real (no skeleton).

## Cambios

### Tab Anteproyectos

- **`<AnteproyectosModule>`** lista rows de `dilesa.proyectos` con `tipo='anteproyecto'`.
- **5 KPIs reactivos** (ADR-034) según D2: total · activos · inversión proyectada · lotes proyectados · en decisión.
  - Pivote v1: utilidad/margen reemplazados por lotes/área hasta que el modelo de ingreso proyectado quede listo (Sprint 3 con cotización de comercialización).
- **Filtros**: búsqueda por nombre, estado, rango de fechas.
- **`<DataTable>`** con 9 columnas incluyendo `costo_total` y `costo/lote` derivados client-side.
- **`<AnteproyectoDetailDrawer>`** con 4 secciones (ficha física, costos estimados con delta vs presupuesto, análisis derivado con aprovechamiento/% verdes/costo por lote, notas).

### Tab Activos

- **`<ProyectosModule>`** gana prop `excluirTipos?: readonly string[]` (PostgREST `not.in`).
- `app/dilesa/proyectos/page.tsx` pasa `excluirTipos={['anteproyecto']}`.
- Default vacío preserva el comportamiento histórico.

### Tests

- 17 nuevos en `anteproyectos-module.test.ts`: los 5 KPIs (con reactivity) + los 6 indicadores derivados.

## Test plan

- [x] `npm run typecheck` — verde
- [x] `npm run test:run` — 890 tests (873 + 17 nuevos)
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — verde
- [ ] Smoke en preview: navegar `/dilesa/proyectos` (no debe mostrar los 5 anteproyectos) y `/dilesa/proyectos/anteproyectos` (debe listar los 5 con KPIs cargados).

Cero queries nuevas a DB — todo deriva de columnas existentes.

## Próximo

Sprint 3 — Plantilla canónica + tareas + presupuestos preliminares (4 tablas nuevas + ALTER `proyecto_tareas` + seed 35 tareas + helper calendario hábil MX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)