### PR TITLE
fix(dilesa-coda-sync): exponer SUPABASE_DB_URL al workflow

### DIFF
--- a/.github/workflows/dilesa-coda-sync.yml
+++ b/.github/workflows/dilesa-coda-sync.yml
@@ -46,6 +46,7 @@ jobs:
       CODA_API_KEY: ${{ secrets.CODA_API_KEY }}
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
       SYNC_FROM_EMAIL: ${{ secrets.SYNC_FROM_EMAIL }}


### PR DESCRIPTION
## Problema

El sync nocturno DILESA → BSOP del 2026-05-27 falló en el paso **Tareas terminadas** (exit code 1 en 1s):

```
Error: Falta SUPABASE_DB_URL (para disable/enable trigger via psql)
    at scripts/import_dilesa_tareas_terminadas.ts:52
```

El script (introducido en #513) usa `psql` para hacer `DISABLE TRIGGER` antes del bulk UPSERT y `ENABLE TRIGGER` después, para evitar 750k recálculos. Eso requiere `SUPABASE_DB_URL`, que **ya existe como secret en GH Actions** (cargado 2026-04-20) — pero el workflow `dilesa-coda-sync.yml` no lo declaraba en el bloque `env:`.

## Impacto observable

- `dilesa.construccion_tareas_terminadas`: BSOP 14,374 vs Coda 15,529 → **drift de 1,155 rows** acumulado.
- Estimaciones (incremental) corren pero sobre datos viejos → avance por obra desfasado.

## Fix

Una línea en [.github/workflows/dilesa-coda-sync.yml](.github/workflows/dilesa-coda-sync.yml):

```yaml
SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
```

## Post-merge

Disparar manualmente el workflow desde la pestaña Actions (no esperar al cron de las 03:00 CST) para validar que cierra el drift. El siguiente reporte debería mostrar `Tareas terminadas` con ✓ y conteo subiendo a ~15,529.

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run test:run` ✓ (924 tests)
- [x] `npm run lint` ✓ (0 errors)
- [x] `npm run format:check` ✓
- [ ] Post-merge: trigger manual `gh workflow run dilesa-coda-sync.yml` y verificar que `Tareas terminadas` pasa verde y conteos se acercan a Coda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)