### PR TITLE
fix(dilesa-proyectos-checklist-inline): hotfix x.map en detalle de anteproyecto

### DIFF
--- a/components/dilesa/anteproyecto-detalle.tsx
+++ b/components/dilesa/anteproyecto-detalle.tsx
@@ -176,9 +176,11 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
   // proyecto cargado no coincide con el actual, estamos cargando.
   const loadingExtras = anteproyecto != null && loadedId !== anteproyecto.id;
 
-  const fetchExtras = useCallback((proyectoId: string) => {
+  const fetchExtras = useCallback(async (proyectoId: string) => {
     const supabase = createSupabaseBrowserClient();
-    return Promise.all([
+    // Tareas + partidas en paralelo. Las dependencias requieren los IDs de
+    // tareas como input, por lo que viven en una segunda fase.
+    const [tareasRes, partidasRes] = await Promise.all([
       supabase
         .schema('dilesa')
         .from('proyecto_tareas')
@@ -195,12 +197,25 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
         .eq('proyecto_id', proyectoId)
         .is('deleted_at', null)
         .order('partida'),
-      supabase
-        .schema('dilesa')
-        .from('proyecto_tareas_dependencias')
-        .select('tarea_id, depende_de_tarea_id, tarea:proyecto_tareas!tarea_id(proyecto_id)')
-        .eq('tarea.proyecto_id', proyectoId),
     ]);
+
+    // Dependencias por IN sobre los IDs de las tareas del proyecto. Patrón
+    // sin embed PostgREST: si la query falla (RLS, parsing del embed), el
+    // shape de `.data` queda consistentemente array vacío en vez de null
+    // wrapped en algo raro. Aceptamos el round-trip extra.
+    const tareaIds =
+      Array.isArray(tareasRes.data) && tareasRes.data.length > 0
+        ? tareasRes.data.map((t) => t.id as string)
+        : [];
+    const depsRes =
+      tareaIds.length === 0
+        ? { data: [] as Array<{ tarea_id: string; depende_de_tarea_id: string }>, error: null }
+        : await supabase
+            .schema('dilesa')
+            .from('proyecto_tareas_dependencias')
+            .select('tarea_id, depende_de_tarea_id')
+            .in('tarea_id', tareaIds);
+    return [tareasRes, partidasRes, depsRes] as const;
   }, []);
 
   const cargarExtras = useCallback(
@@ -213,7 +228,7 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
         setTareas([]);
       } else {
         setExtrasError(null);
-        setTareas((tareasRes.data ?? []) as ProyectoTarea[]);
+        setTareas(Array.isArray(tareasRes.data) ? (tareasRes.data as ProyectoTarea[]) : []);
       }
       if (partidasRes.error) {
         setExtrasError(
@@ -221,15 +236,12 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
         );
         setPartidas([]);
       } else {
-        setPartidas((partidasRes.data ?? []) as Partida[]);
+        setPartidas(Array.isArray(partidasRes.data) ? (partidasRes.data as Partida[]) : []);
       }
-      if (!depsRes.error) {
-        setDependencias(
-          ((depsRes.data ?? []) as Array<TareaDep & { tarea?: unknown }>).map((d) => ({
-            tarea_id: d.tarea_id,
-            depende_de_tarea_id: d.depende_de_tarea_id,
-          }))
-        );
+      if (!depsRes.error && Array.isArray(depsRes.data)) {
+        setDependencias(depsRes.data as TareaDep[]);
+      } else {
+        setDependencias([]);
       }
       setLoadedId(proyectoId);
     },
@@ -250,7 +262,7 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
         setTareas([]);
       } else {
         setExtrasError(null);
-        setTareas((tareasRes.data ?? []) as ProyectoTarea[]);
+        setTareas(Array.isArray(tareasRes.data) ? (tareasRes.data as ProyectoTarea[]) : []);
       }
       if (partidasRes.error) {
         setExtrasError(
@@ -258,15 +270,12 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
         );
         setPartidas([]);
       } else {
-        setPartidas((partidasRes.data ?? []) as Partida[]);
+        setPartidas(Array.isArray(partidasRes.data) ? (partidasRes.data as Partida[]) : []);
       }
-      if (!depsRes.error) {
-        setDependencias(
-          ((depsRes.data ?? []) as Array<TareaDep & { tarea?: unknown }>).map((d) => ({
-            tarea_id: d.tarea_id,
-            depende_de_tarea_id: d.depende_de_tarea_id,
-          }))
-        );
+      if (!depsRes.error && Array.isArray(depsRes.data)) {
+        setDependencias(depsRes.data as TareaDep[]);
+      } else {
+        setDependencias([]);
       }
       setLoadedId(anteproyecto.id);
     });

--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -17,7 +17,7 @@
  * del desarrollo filtrando por `aplicacion_snapshot`.
  */
 
-import { useCallback, useMemo, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
 import { FileText } from 'lucide-react';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
 import { FileAttachments } from '@/components/file-attachments/file-attachments';
@@ -120,18 +120,24 @@ export function TareasChecklist({
   empresaSlug: EmpresaSlug;
   onChange?: () => void;
 }) {
+  // Guard defensivo: si el padre pasa algo que no es array (race condition
+  // o data corrupta), tratamos como vacío para no romper el render.
+  const tareasSource: readonly TareaChecklistRow[] = Array.isArray(tareasInicial)
+    ? tareasInicial
+    : [];
   // Estado local — optimistic. Rollback si la server action falla.
-  const [tareas, setTareas] = useState<TareaChecklistRow[]>([...tareasInicial]);
+  const [tareas, setTareas] = useState<TareaChecklistRow[]>([...tareasSource]);
   const [error, setError] = useState<string | null>(null);
 
   // Sincroniza state local cuando el padre nos pasa nuevas tareas (refresh).
   // Comparación shallow por id+estado para evitar re-sincronizar la lista local
-  // entera cuando llega el mismo dataset.
-  const idsEstados = tareasInicial.map((t) => `${t.id}:${t.estado}`).join('|');
-  useMemo(() => {
-    setTareas([...tareasInicial]);
+  // entera cuando llega el mismo dataset. setState va dentro de useEffect (no
+  // de useMemo) para respetar la semántica de React 19.
+  const idsEstados = tareasSource.map((t) => `${t.id}:${t.estado}`).join('|');
+  useEffect(() => {
+    setTareas([...tareasSource]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [idsEstados, tareasInicial.length]);
+  }, [idsEstados, tareasSource.length]);
 
   const bloqueadasMap = useMemo(
     () => computeBloqueadasMap(tareas, dependencias),


### PR DESCRIPTION
## Summary

Hotfix sobre Sprint 1 ([PR #572](https://github.com/beto-sudo/BSOP/pull/572)). Beto reportó "Error en DILESA: x.map is not a function" al abrir cualquier anteproyecto post-merge. 4 guards defensivos sin cambio de modelo ni datos.

## Cambios

1. **`<TareasChecklist>`** — `useMemo()` con `setState` dentro era anti-patrón React 19. Refactor a `useEffect()`. `Array.isArray(tareasInicial)` guard al inicio.
2. **`<AnteproyectoDetalle>`** — query de `proyecto_tareas_dependencias` usaba embed PostgREST con filter `tarea.proyecto_id` cross-resource — shape inestable cuando el embed resuelve a `null` por RLS. Refactor a 2 fases: tareas primero, después `.in('tarea_id', tareaIds)`.
3. **Handlers de fetch** — `(data ?? []).map(...)` reemplazado por `Array.isArray(data) ? data as T[] : []`.
4. **Effect inicial** — mismo guard duplicado para carga inicial y refresh.

Cero cambio de schema. Cero migración. Cero cambio de plan.

## Test plan post-merge

- [ ] Abrir `/dilesa/proyectos/anteproyectos/<id>` con cualquier anteproyecto → renderiza checklist (16 tareas, sin banner de error).
- [ ] Cambiar estado de una tarea → persiste, sin error.
- [ ] Capturar monto en cotización → persiste.
- [ ] Refrescar la página → mismo estado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)