### PR TITLE
fix(dilesa-proyectos-checklist-inline): hotfix 2 — exports no-async desde 'use server' rompían el bundle

### DIFF
--- a/app/dilesa/proyectos/anteproyectos/actions.ts
+++ b/app/dilesa/proyectos/anteproyectos/actions.ts
@@ -27,24 +27,14 @@ import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { revalidatePath } from 'next/cache';
 import { instanciarPlantillaParaProyecto } from '@/lib/dilesa/instanciar-plantilla';
+import {
+  TAREA_ESTADOS_VALIDOS,
+  type TareaEstado,
+} from '@/components/dilesa/tareas-checklist-types';
 
 type Result = { ok: true; tareasCreadas: number } | { ok: false; error: string };
 
 type SimpleResult = { ok: true } | { ok: false; error: string };
-
-/**
- * Estados válidos de `dilesa.proyecto_tareas.estado`. Mantener en sync
- * con el CHECK constraint declarado en la migración de Sprint 3.
- * Exportado para reuso en el componente checklist y los tests.
- */
-export const TAREA_ESTADOS_VALIDOS = [
-  'pendiente',
-  'bloqueada',
-  'en_curso',
-  'completada',
-  'cancelada',
-] as const;
-export type TareaEstado = (typeof TAREA_ESTADOS_VALIDOS)[number];
 
 async function makeServerClient() {
   const cookieStore = await cookies();

--- a/components/dilesa/tareas-checklist-types.ts
+++ b/components/dilesa/tareas-checklist-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Constantes y types compartidos para el checklist de tareas.
+ *
+ * Iniciativa `dilesa-proyectos-checklist-inline` Sprint 1.
+ *
+ * **NO es server action** — vive en archivo separado del módulo
+ * `actions.ts` que tiene `'use server'`. Next.js solo permite exports
+ * de funciones async desde files con `'use server'`; exportar un const
+ * o type rompe el bundle silenciosamente (queda undefined en cliente
+ * → cascadea a `x.map is not a function` cuando se intenta iterar el
+ * enum). Ver hotfix 2 de la iniciativa.
+ */
+
+export const TAREA_ESTADOS_VALIDOS = [
+  'pendiente',
+  'bloqueada',
+  'en_curso',
+  'completada',
+  'cancelada',
+] as const;
+
+export type TareaEstado = (typeof TAREA_ESTADOS_VALIDOS)[number];

--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -22,13 +22,12 @@ import { FileText } from 'lucide-react';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
 import { FileAttachments } from '@/components/file-attachments/file-attachments';
 import {
-  TAREA_ESTADOS_VALIDOS,
   updateTareaDocumento,
   updateTareaEstado,
   updateTareaMonto,
   updateTareaNotas,
-  type TareaEstado,
 } from '@/app/dilesa/proyectos/anteproyectos/actions';
+import { TAREA_ESTADOS_VALIDOS, type TareaEstado } from './tareas-checklist-types';
 import type { EmpresaSlug } from '@/lib/storage';
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {


### PR DESCRIPTION
## Root cause

El bug `x.map is not a function` aparecía **también en la lista** \`/dilesa/proyectos/anteproyectos\`, no solo en el detalle (lo verifiqué con un screenshot real de Beto que mostró la navegación entre lista y detalle reventando igual). El hotfix 1 ([PR #573](https://github.com/beto-sudo/BSOP/pull/573)) atacaba síntomas en el detalle pero no la causa.

**La causa**: en \`app/dilesa/proyectos/anteproyectos/actions.ts\` (que tiene \`'use server'\` directive) exporté:

\`\`\`ts
export const TAREA_ESTADOS_VALIDOS = ['pendiente', 'bloqueada', ...] as const;
export type TareaEstado = (typeof TAREA_ESTADOS_VALIDOS)[number];
\`\`\`

Next.js solo permite exports de funciones async desde files \`'use server'\`. Cuando exportas un const o type, Next lo deja \`undefined\` en cliente sin error claro — silenciosamente. Cualquier \`.map()\` sobre eso (línea 331 de \`<TareaCard>\`: \`{TAREA_ESTADOS_VALIDOS.map(...)}\`) revienta con \`x.map is not a function\`.

Como \`<AnteproyectosModule>\` importa \`deriveAnalisis\` de \`anteproyecto-detalle.tsx\`, que importa \`<TareasChecklist>\`, que importa \`TAREA_ESTADOS_VALIDOS\` del file server actions → **el bundle entero arrastra el bug**, incluso la lista falla antes de renderizar.

Esto también explica el **React #418 (hydration mismatch)** que aparecía PRIMERO en consola: el chunk se cargaba parcialmente, el árbol de render entraba en estado inconsistente, hidratación rota antes del x.map.

## Fix

- Nuevo archivo: \`components/dilesa/tareas-checklist-types.ts\` con \`TAREA_ESTADOS_VALIDOS\` + \`TareaEstado\` (archivo cliente normal, sin directive).
- \`actions.ts\` importa de ahí (la función \`updateTareaEstado\` necesita el const para el whitelist).
- \`tareas-checklist.tsx\` importa de ahí en lugar de actions.ts.

Cero cambio de modelo, comportamiento ni datos.

## Verificación local

- typecheck ✓
- tests dilesa: 86/86 ✓
- format:check ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)