### PR TITLE
feat(dilesa-proyectos-checklist-inline): Sprint 2 — partidas auto-vinculadas + UI agrupada

### DIFF
--- a/app/dilesa/proyectos/anteproyectos/actions.ts
+++ b/app/dilesa/proyectos/anteproyectos/actions.ts
@@ -30,7 +30,9 @@ import { instanciarPlantillaParaProyecto } from '@/lib/dilesa/instanciar-plantil
 import {
   TAREA_ESTADOS_VALIDOS,
   type TareaEstado,
+  esTareaCotizacion,
 } from '@/components/dilesa/tareas-checklist-types';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 type Result = { ok: true; tareasCreadas: number } | { ok: false; error: string };
 
@@ -147,8 +149,17 @@ export async function updateTareaEstado(
 
 /**
  * Captura `resultado_monto` en una tarea (ej. cotización). Acepta null
- * para limpiar. La auto-vinculación con `proyecto_presupuesto_partidas`
- * (cuando subtipo='cotizacion') se entrega en Sprint 2.
+ * para limpiar.
+ *
+ * Sprint 2 (auto-vinculación con partida): si la tarea es de cotización
+ * (`subtipo_snapshot` contiene "cotizac"), se llama a
+ * `syncPartidaDesdeTarea` para crear/actualizar/cerrar una partida
+ * preliminar vinculada vía `tarea_origen_id`. Reglas:
+ * - Si no existe partida vinculada y `monto != null` → INSERT preliminar.
+ * - Si existe y está en `preliminar` → UPDATE `monto_estimado`.
+ * - Si está en `preliminar` y `monto = null` → soft delete (`deleted_at`).
+ * - Si existe y está en `autorizada+` → NO machacamos (el monto en la
+ *   partida puede haber sido ajustado en el flujo de autorización).
  */
 export async function updateTareaMonto(
   tareaId: string,
@@ -169,6 +180,108 @@ export async function updateTareaMonto(
     .eq('id', tareaId);
 
   if (error) return { ok: false, error: error.message || 'No se pudo actualizar el monto.' };
+
+  // Sincronización con partida — no bloqueante para el éxito del update
+  // del monto; si falla, log silencioso y seguimos. El usuario puede
+  // re-disparar capturando el monto de nuevo.
+  const partidaSync = await syncPartidaDesdeTarea(supabase, tareaId, monto);
+  if (!partidaSync.ok) {
+    console.warn('[updateTareaMonto] sync partida falló:', partidaSync.error);
+  }
+
+  revalidateAnteproyectosPaths();
+  return { ok: true };
+}
+
+/**
+ * Sincroniza la partida preliminar vinculada a una tarea de cotización.
+ * NO se exporta — se llama desde `updateTareaMonto`. Service-internal.
+ */
+async function syncPartidaDesdeTarea(
+  supabase: SupabaseClient,
+  tareaId: string,
+  monto: number | null
+): Promise<SimpleResult> {
+  const { data: t, error: tErr } = await supabase
+    .schema('dilesa')
+    .from('proyecto_tareas')
+    .select('id, empresa_id, proyecto_id, titulo, subtipo_snapshot')
+    .eq('id', tareaId)
+    .is('deleted_at', null)
+    .single();
+  if (tErr || !t) return { ok: false, error: tErr?.message ?? 'tarea no encontrada' };
+  if (!esTareaCotizacion(t.subtipo_snapshot as string | null)) return { ok: true };
+
+  const { data: existing, error: eErr } = await supabase
+    .schema('dilesa')
+    .from('proyecto_presupuesto_partidas')
+    .select('id, estado')
+    .eq('tarea_origen_id', tareaId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (eErr) return { ok: false, error: eErr.message };
+
+  if (existing) {
+    if (existing.estado !== 'preliminar') return { ok: true };
+    if (monto === null) {
+      const { error } = await supabase
+        .schema('dilesa')
+        .from('proyecto_presupuesto_partidas')
+        .update({ deleted_at: new Date().toISOString() })
+        .eq('id', existing.id);
+      if (error) return { ok: false, error: error.message };
+      return { ok: true };
+    }
+    const { error } = await supabase
+      .schema('dilesa')
+      .from('proyecto_presupuesto_partidas')
+      .update({ monto_estimado: monto })
+      .eq('id', existing.id);
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  }
+
+  if (monto !== null) {
+    const { error } = await supabase.schema('dilesa').from('proyecto_presupuesto_partidas').insert({
+      empresa_id: t.empresa_id,
+      proyecto_id: t.proyecto_id,
+      tarea_origen_id: tareaId,
+      partida: t.titulo,
+      monto_estimado: monto,
+      estado: 'preliminar',
+      fuente: 'cotizacion',
+    });
+    if (error) return { ok: false, error: error.message };
+  }
+  return { ok: true };
+}
+
+/**
+ * Mueve una partida de `preliminar` → `autorizada`. Set
+ * `autorizado_at=NOW()` y `autorizado_por=<userId>`. RLS de la tabla
+ * sigue gobernando quién puede actualizar (rol gate).
+ *
+ * Idempotente: si la partida ya está en `autorizada+`, no hace nada.
+ */
+export async function autorizarPartida(partidaId: string): Promise<SimpleResult> {
+  if (!partidaId) return { ok: false, error: 'partidaId requerido' };
+  const supabase = await makeServerClient();
+
+  const { data: userRes, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userRes?.user) return { ok: false, error: 'No autenticado' };
+
+  const { error } = await supabase
+    .schema('dilesa')
+    .from('proyecto_presupuesto_partidas')
+    .update({
+      estado: 'autorizada',
+      autorizado_at: new Date().toISOString(),
+      autorizado_por: userRes.user.id,
+    })
+    .eq('id', partidaId)
+    .eq('estado', 'preliminar');
+
+  if (error) return { ok: false, error: error.message || 'No se pudo autorizar la partida.' };
   revalidateAnteproyectosPaths();
   return { ok: true };
 }

--- a/components/dilesa/anteproyecto-detalle.tsx
+++ b/components/dilesa/anteproyecto-detalle.tsx
@@ -17,7 +17,7 @@
 
 import { useCallback, useEffect, useState, useTransition } from 'react';
 import { DetailDrawerSection } from '@/components/detail-page';
-import { Badge, type BadgeTone } from '@/components/ui/badge';
+import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
@@ -27,6 +27,7 @@ import {
 } from '@/app/dilesa/proyectos/anteproyectos/actions';
 import { type ProyectoDetalle, ESTADO_TONE, ESTADO_LABEL } from './proyecto-detalle';
 import { TareasChecklist } from './tareas-checklist';
+import { PartidasPresupuestales, type PartidaRow } from './partidas-presupuestales';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
 const numberFmt = new Intl.NumberFormat('es-MX');
@@ -80,21 +81,7 @@ type ProyectoTarea = {
 
 type TareaDep = { tarea_id: string; depende_de_tarea_id: string };
 
-type Partida = {
-  id: string;
-  partida: string;
-  monto_estimado: number | null;
-  monto_aprobado: number | null;
-  estado: string;
-};
-
-const PARTIDA_ESTADO_TONE: Record<string, BadgeTone> = {
-  preliminar: 'neutral',
-  autorizada: 'info',
-  planeada: 'info',
-  en_ejercicio: 'warning',
-  cerrada: 'success',
-};
+type Partida = PartidaRow;
 
 /**
  * Detecta el gate de promoción: la tarea "Aprobación de Comité de
@@ -193,7 +180,9 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
       supabase
         .schema('dilesa')
         .from('proyecto_presupuesto_partidas')
-        .select('id, partida, monto_estimado, monto_aprobado, estado')
+        .select(
+          'id, partida, descripcion, monto_estimado, monto_aprobado, monto_ejercido, fuente, estado, tarea_origen_id, autorizado_at'
+        )
         .eq('proyecto_id', proyectoId)
         .is('deleted_at', null)
         .order('partida'),
@@ -475,52 +464,22 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
       </DetailDrawerSection>
 
       <DetailDrawerSection
-        title="Presupuestos preliminares"
+        title="Presupuesto"
         description={
           loadingExtras
             ? 'Cargando…'
             : partidas.length === 0
-              ? 'Sin partidas capturadas todavía.'
-              : `${partidas.length} partidas`
+              ? 'Captura un monto en una tarea de cotización para iniciar.'
+              : `${partidas.length} ${partidas.length === 1 ? 'partida' : 'partidas'}`
         }
       >
         {loadingExtras ? (
           <Skeleton className="h-16 w-full" />
-        ) : partidas.length === 0 ? (
-          <p className="text-sm text-[var(--text)]/60">
-            La captura inline + workflow de autorización viven en el próximo entregable. Cuando una
-            tarea de cotización registra `resultado_monto`, una partida preliminar se vincula con
-            ella aquí.
-          </p>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
-              <thead className="text-xs uppercase text-[var(--text)]/50">
-                <tr className="border-b border-[var(--border)]">
-                  <th className="py-2 pr-4 text-left">Partida</th>
-                  <th className="py-2 pr-4 text-left">Estado</th>
-                  <th className="py-2 pr-4 text-right">Estimado</th>
-                  <th className="py-2 text-right">Aprobado</th>
-                </tr>
-              </thead>
-              <tbody>
-                {partidas.map((p) => (
-                  <tr key={p.id} className="border-b border-[var(--border)]/40">
-                    <td className="py-2 pr-4 font-medium text-[var(--text)]">{p.partida}</td>
-                    <td className="py-2 pr-4">
-                      <Badge tone={PARTIDA_ESTADO_TONE[p.estado] ?? 'neutral'}>{p.estado}</Badge>
-                    </td>
-                    <td className="py-2 pr-4 text-right text-[var(--text)]/70">
-                      {p.monto_estimado != null ? moneyFmt.format(p.monto_estimado) : '—'}
-                    </td>
-                    <td className="py-2 text-right text-[var(--text)]/70">
-                      {p.monto_aprobado != null ? moneyFmt.format(p.monto_aprobado) : '—'}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <PartidasPresupuestales
+            partidas={partidas}
+            onChange={() => void cargarExtras(anteproyecto.id)}
+          />
         )}
         {extrasError && <p className="mt-2 text-sm text-red-600/80">{extrasError}</p>}
       </DetailDrawerSection>

--- a/components/dilesa/partidas-presupuestales.test.ts
+++ b/components/dilesa/partidas-presupuestales.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { groupByEstado, totalesPorEstado, type PartidaRow } from './partidas-presupuestales';
+
+function p(over: Partial<PartidaRow>): PartidaRow {
+  return {
+    id: over.id ?? 'p-' + Math.random().toString(36).slice(2, 8),
+    partida: 'Partida X',
+    descripcion: null,
+    monto_estimado: null,
+    monto_aprobado: null,
+    monto_ejercido: null,
+    fuente: null,
+    estado: 'preliminar',
+    tarea_origen_id: null,
+    autorizado_at: null,
+    ...over,
+  };
+}
+
+describe('groupByEstado (Sprint 2)', () => {
+  it('devuelve map vacío si no hay partidas', () => {
+    expect(groupByEstado([]).size).toBe(0);
+  });
+
+  it('agrupa por estado', () => {
+    const partidas = [
+      p({ id: 'a', estado: 'preliminar' }),
+      p({ id: 'b', estado: 'preliminar' }),
+      p({ id: 'c', estado: 'autorizada' }),
+    ];
+    const map = groupByEstado(partidas);
+    expect(map.get('preliminar')).toHaveLength(2);
+    expect(map.get('autorizada')).toHaveLength(1);
+    expect(map.has('cerrada')).toBe(false);
+  });
+
+  it('un estado inválido se mete a preliminar como fallback', () => {
+    const map = groupByEstado([p({ estado: 'desconocido' as never })]);
+    expect(map.get('preliminar')).toHaveLength(1);
+  });
+});
+
+describe('totalesPorEstado (Sprint 2)', () => {
+  it('suma monto_aprobado cuando existe, sino monto_estimado', () => {
+    const partidas = [
+      p({ estado: 'preliminar', monto_estimado: 1000 }), // no aprobado
+      p({ estado: 'preliminar', monto_estimado: 500 }),
+      p({ estado: 'autorizada', monto_estimado: 2000, monto_aprobado: 2200 }), // gana aprobado
+    ];
+    const t = totalesPorEstado(partidas);
+    expect(t.preliminar).toBe(1500);
+    expect(t.autorizada).toBe(2200);
+  });
+
+  it('partidas con ambos null no contribuyen', () => {
+    const partidas = [p({ estado: 'preliminar', monto_estimado: null, monto_aprobado: null })];
+    expect(totalesPorEstado(partidas).preliminar).toBe(0);
+  });
+
+  it('estados sin partidas no aparecen en el objeto', () => {
+    const t = totalesPorEstado([p({ estado: 'preliminar', monto_estimado: 100 })]);
+    expect(t.autorizada).toBeUndefined();
+    expect(t.cerrada).toBeUndefined();
+  });
+});

--- a/components/dilesa/partidas-presupuestales.tsx
+++ b/components/dilesa/partidas-presupuestales.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+/**
+ * `<PartidasPresupuestales>` — vista del presupuesto del proyecto
+ * agrupado por estado del ciclo de vida.
+ *
+ * Sprint 2 de `dilesa-proyectos-checklist-inline`. Reemplaza la tabla
+ * read-only que vivía en `<AnteproyectoDetalle>` con un componente
+ * reusable (Sprint 3 lo espejará en el detalle del desarrollo).
+ *
+ * Lectura: lee de `dilesa.proyecto_presupuesto_partidas` con su
+ * `estado` discriminator. Las partidas con `tarea_origen_id` no-null
+ * vinieron auto-vinculadas desde la captura inline de monto en una
+ * tarea de cotización (`updateTareaMonto` server action).
+ *
+ * Escritura: server action `autorizarPartida` mueve una preliminar a
+ * autorizada. Sprint 2 solo expone este transition; los demás
+ * (planeada → en_ejercicio → cerrada) los dispara la maquinaria de
+ * estimaciones existente.
+ */
+
+import { useMemo, useState, useTransition } from 'react';
+import { Badge, type BadgeTone } from '@/components/ui/badge';
+import { autorizarPartida } from '@/app/dilesa/proyectos/anteproyectos/actions';
+import { PARTIDA_ESTADOS_VALIDOS, type PartidaEstado } from './tareas-checklist-types';
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+export type PartidaRow = {
+  id: string;
+  partida: string;
+  descripcion: string | null;
+  monto_estimado: number | null;
+  monto_aprobado: number | null;
+  monto_ejercido: number | null;
+  fuente: string | null;
+  estado: string;
+  tarea_origen_id: string | null;
+  autorizado_at: string | null;
+};
+
+const ESTADO_TONE: Record<string, BadgeTone> = {
+  preliminar: 'neutral',
+  autorizada: 'info',
+  planeada: 'info',
+  en_ejercicio: 'warning',
+  cerrada: 'success',
+};
+const ESTADO_LABEL: Record<string, string> = {
+  preliminar: 'Preliminar',
+  autorizada: 'Autorizada',
+  planeada: 'Planeada',
+  en_ejercicio: 'En ejercicio',
+  cerrada: 'Cerrada',
+};
+
+/**
+ * Agrupa las partidas por estado. Exportado para tests + cálculo de
+ * resumen. Estados sin partidas no se devuelven en el map.
+ */
+export function groupByEstado(partidas: readonly PartidaRow[]): Map<PartidaEstado, PartidaRow[]> {
+  const out = new Map<PartidaEstado, PartidaRow[]>();
+  for (const p of partidas) {
+    const est = (PARTIDA_ESTADOS_VALIDOS as readonly string[]).includes(p.estado)
+      ? (p.estado as PartidaEstado)
+      : ('preliminar' as PartidaEstado);
+    const arr = out.get(est) ?? [];
+    arr.push(p);
+    out.set(est, arr);
+  }
+  return out;
+}
+
+/**
+ * Suma totales por estado. Sprint 2 muestra estos en el header de
+ * cada grupo.
+ */
+export function totalesPorEstado(partidas: readonly PartidaRow[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const p of partidas) {
+    const v = p.monto_aprobado ?? p.monto_estimado ?? 0;
+    out[p.estado] = (out[p.estado] ?? 0) + v;
+  }
+  return out;
+}
+
+export function PartidasPresupuestales({
+  partidas,
+  onChange,
+}: {
+  partidas: readonly PartidaRow[];
+  onChange?: () => void;
+}) {
+  if (partidas.length === 0) {
+    return (
+      <p className="text-sm text-[var(--text)]/60">
+        Sin partidas todavía. Captura un monto en alguna tarea de cotización del checklist para que
+        aparezca aquí como preliminar.
+      </p>
+    );
+  }
+
+  const grupos = groupByEstado(partidas);
+  const totales = totalesPorEstado(partidas);
+
+  return (
+    <div className="space-y-4">
+      {PARTIDA_ESTADOS_VALIDOS.filter((e) => grupos.has(e)).map((estado) => {
+        const filas = grupos.get(estado) ?? [];
+        return (
+          <section key={estado}>
+            <header className="mb-2 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Badge tone={ESTADO_TONE[estado] ?? 'neutral'}>
+                  {ESTADO_LABEL[estado] ?? estado}
+                </Badge>
+                <span className="text-xs text-[var(--text)]/60">
+                  {filas.length} {filas.length === 1 ? 'partida' : 'partidas'}
+                </span>
+              </div>
+              <span className="text-sm tabular-nums text-[var(--text)]/80">
+                {moneyFmt.format(totales[estado] ?? 0)}
+              </span>
+            </header>
+            <div className="overflow-x-auto rounded-md border border-[var(--border)]">
+              <table className="min-w-full text-sm">
+                <thead className="text-xs uppercase text-[var(--text)]/50">
+                  <tr className="border-b border-[var(--border)] bg-[var(--card)]">
+                    <th className="py-2 px-3 text-left">Partida</th>
+                    <th className="py-2 px-3 text-left">Fuente</th>
+                    <th className="py-2 px-3 text-right">Estimado</th>
+                    <th className="py-2 px-3 text-right">Aprobado</th>
+                    <th className="py-2 px-3 text-right">Ejercido</th>
+                    <th className="py-2 px-3 text-right">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filas.map((p) => (
+                    <PartidaRowView key={p.id} partida={p} onChange={onChange} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+function PartidaRowView({ partida, onChange }: { partida: PartidaRow; onChange?: () => void }) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAutorizar = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await autorizarPartida(partida.id);
+      if (!r.ok) setError(r.error);
+      else onChange?.();
+    });
+  };
+
+  const origen = useMemo(() => {
+    if (!partida.fuente) return null;
+    if (partida.fuente === 'cotizacion' && partida.tarea_origen_id) {
+      return 'cotización (auto)';
+    }
+    return partida.fuente;
+  }, [partida.fuente, partida.tarea_origen_id]);
+
+  return (
+    <tr className="border-b border-[var(--border)]/40 last:border-0">
+      <td className="py-2 px-3">
+        <div className="font-medium text-[var(--text)]">{partida.partida}</div>
+        {partida.descripcion && (
+          <div className="text-xs text-[var(--text)]/60">{partida.descripcion}</div>
+        )}
+      </td>
+      <td className="py-2 px-3 text-[var(--text)]/70">{origen ?? '—'}</td>
+      <td className="py-2 px-3 text-right tabular-nums text-[var(--text)]/80">
+        {partida.monto_estimado != null ? moneyFmt.format(partida.monto_estimado) : '—'}
+      </td>
+      <td className="py-2 px-3 text-right tabular-nums text-[var(--text)]/80">
+        {partida.monto_aprobado != null ? moneyFmt.format(partida.monto_aprobado) : '—'}
+      </td>
+      <td className="py-2 px-3 text-right tabular-nums text-[var(--text)]/80">
+        {partida.monto_ejercido != null && partida.monto_ejercido > 0
+          ? moneyFmt.format(partida.monto_ejercido)
+          : '—'}
+      </td>
+      <td className="py-2 px-3 text-right">
+        {partida.estado === 'preliminar' ? (
+          <button
+            type="button"
+            onClick={handleAutorizar}
+            disabled={pending}
+            className="h-7 rounded-md border border-[var(--border)] bg-[var(--accent)]/10 px-3 text-xs font-medium text-[var(--accent)] hover:bg-[var(--accent)]/20 disabled:opacity-50"
+          >
+            {pending ? 'Autorizando…' : 'Autorizar'}
+          </button>
+        ) : null}
+        {error && <div className="mt-1 text-xs text-red-600/80">{error}</div>}
+      </td>
+    </tr>
+  );
+}

--- a/components/dilesa/tareas-checklist-types.ts
+++ b/components/dilesa/tareas-checklist-types.ts
@@ -20,3 +20,28 @@ export const TAREA_ESTADOS_VALIDOS = [
 ] as const;
 
 export type TareaEstado = (typeof TAREA_ESTADOS_VALIDOS)[number];
+
+/**
+ * Estados válidos de `dilesa.proyecto_presupuesto_partidas.estado`.
+ * Sprint 2: vista del ciclo de vida de una partida (preliminar →
+ * autorizada → planeada → en_ejercicio → cerrada).
+ */
+export const PARTIDA_ESTADOS_VALIDOS = [
+  'preliminar',
+  'autorizada',
+  'planeada',
+  'en_ejercicio',
+  'cerrada',
+] as const;
+
+export type PartidaEstado = (typeof PARTIDA_ESTADOS_VALIDOS)[number];
+
+/**
+ * Detecta si el subtipo (snapshot del catálogo) corresponde a una tarea
+ * de cotización. Usado en cliente (decidir si mostrar input de monto)
+ * y en servidor (auto-vinculación con partida presupuestal). Mismo
+ * criterio en ambos lados para no divergir.
+ */
+export function esTareaCotizacion(subtipoSnapshot: string | null | undefined): boolean {
+  return (subtipoSnapshot ?? '').toLowerCase().includes('cotizac');
+}

--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -27,7 +27,11 @@ import {
   updateTareaMonto,
   updateTareaNotas,
 } from '@/app/dilesa/proyectos/anteproyectos/actions';
-import { TAREA_ESTADOS_VALIDOS, type TareaEstado } from './tareas-checklist-types';
+import {
+  TAREA_ESTADOS_VALIDOS,
+  type TareaEstado,
+  esTareaCotizacion,
+} from './tareas-checklist-types';
 import type { EmpresaSlug } from '@/lib/storage';
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -82,7 +86,7 @@ const OBLIG_TONE: Record<string, BadgeTone> = {
 };
 
 function esCotizacion(t: TareaChecklistRow): boolean {
-  return (t.subtipo_snapshot ?? '').toLowerCase().includes('cotizac');
+  return esTareaCotizacion(t.subtipo_snapshot);
 }
 
 /**


### PR DESCRIPTION
## Summary

Sprint 2 cierra el bucle entre captura de monto en una tarea de cotización y la partida presupuestal: cuando el operador captura el monto inline en el checklist, una partida preliminar se crea/actualiza automáticamente con \`tarea_origen_id\` vinculado. La nueva sección "Presupuesto" del detalle muestra todas las partidas agrupadas por estado del ciclo de vida.

## Server actions

- **\`syncPartidaDesdeTarea\`** (interna) — llamada desde \`updateTareaMonto\`. Reglas:
  - Si no existe partida vinculada y \`monto != null\` → INSERT preliminar (fuente='cotizacion').
  - Si existe y está en \`preliminar\` → UPDATE \`monto_estimado\`.
  - Si está en \`preliminar\` y \`monto = null\` → soft delete.
  - Si está en \`autorizada+\` → NO se machaca (el monto puede haber sido ajustado en el flujo de autorización).
- **\`updateTareaMonto\`** extendida — la sync es no-bloqueante (warn silencioso si falla, el update del monto persiste).
- **\`autorizarPartida\`** nueva — \`preliminar → autorizada\` con \`autorizado_at\` + \`autorizado_por\` (sesión). Idempotente.

## Componente \`<PartidasPresupuestales>\`

- Agrupa por estado (preliminar/autorizada/planeada/en_ejercicio/cerrada).
- Header del grupo: badge + count + total ($).
- Tabla por grupo: partida/descripción, fuente (auto-detecta "cotización (auto)"), estimado, aprobado, ejercido, acciones.
- Botón "Autorizar" inline en cada preliminar (optimistic, error per-row).
- Helpers \`groupByEstado\` + \`totalesPorEstado\` exportados para tests.

## Types compartidos

Para evitar caer en la trampa del Hotfix 2 (\`'use server'\` no acepta exports no-async), [components/dilesa/tareas-checklist-types.ts](components/dilesa/tareas-checklist-types.ts) ahora también exporta \`PARTIDA_ESTADOS_VALIDOS\` + \`PartidaEstado\` + \`esTareaCotizacion()\` — usados en cliente y server.

## Verificación local

- typecheck ✓
- test:run → **991/991 verdes** (+6 nuevos en \`partidas-presupuestales.test.ts\`)
- format:check ✓
- lint → 0 errores (94 warnings preexistentes)

## Test plan post-merge

- [ ] Abrir cualquier anteproyecto con tareas Sprint 1 importadas.
- [ ] En el checklist, capturar monto en una tarea de "Urbanización" o "Construcción" o "Comercialización" (las 3 cotizaciones del catálogo).
- [ ] Bajar a la sección "Presupuesto" → debe aparecer una partida nueva en grupo "Preliminar" con monto, etiqueta "cotización (auto)".
- [ ] Click "Autorizar" → la partida se mueve al grupo "Autorizada".
- [ ] Modificar el monto en la tarea (todavía preliminar) → la partida se actualiza.
- [ ] Si autorizaste y después modificas el monto en la tarea → la partida autorizada NO cambia (correcto: snapshot post-autorización).
- [ ] Limpiar monto de la tarea (preliminar) → la partida desaparece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)