### PR TITLE
fix(dilesa-proyectos-checklist-inline): detectar cotización por tipo, no subtipo

### DIFF
--- a/app/dilesa/proyectos/anteproyectos/actions.ts
+++ b/app/dilesa/proyectos/anteproyectos/actions.ts
@@ -205,12 +205,14 @@ async function syncPartidaDesdeTarea(
   const { data: t, error: tErr } = await supabase
     .schema('dilesa')
     .from('proyecto_tareas')
-    .select('id, empresa_id, proyecto_id, titulo, subtipo_snapshot')
+    .select('id, empresa_id, proyecto_id, titulo, tipo_snapshot, subtipo_snapshot')
     .eq('id', tareaId)
     .is('deleted_at', null)
     .single();
   if (tErr || !t) return { ok: false, error: tErr?.message ?? 'tarea no encontrada' };
-  if (!esTareaCotizacion(t.subtipo_snapshot as string | null)) return { ok: true };
+  if (!esTareaCotizacion(t.tipo_snapshot as string | null, t.subtipo_snapshot as string | null)) {
+    return { ok: true };
+  }
 
   const { data: existing, error: eErr } = await supabase
     .schema('dilesa')

--- a/components/dilesa/tareas-checklist-types.ts
+++ b/components/dilesa/tareas-checklist-types.ts
@@ -37,11 +37,22 @@ export const PARTIDA_ESTADOS_VALIDOS = [
 export type PartidaEstado = (typeof PARTIDA_ESTADOS_VALIDOS)[number];
 
 /**
- * Detecta si el subtipo (snapshot del catálogo) corresponde a una tarea
- * de cotización. Usado en cliente (decidir si mostrar input de monto)
- * y en servidor (auto-vinculación con partida presupuestal). Mismo
- * criterio en ambos lados para no divergir.
+ * Detecta si una tarea es de cotización. Las tareas canónicas vienen
+ * con `tipo='Cotización'` en el catálogo (las 3 tareas de cotización
+ * son: Urbanización / Construcción / Comercialización con
+ * subtipo='Urbanismo'/'Construcción'/'Comercial' respectivamente).
+ *
+ * El criterio mira tanto `tipo_snapshot` (canónico) como
+ * `subtipo_snapshot` (defensa por si alguien renombra el catálogo).
+ * Mismo criterio en cliente (mostrar input de monto) y servidor
+ * (auto-vinculación con partida presupuestal).
  */
-export function esTareaCotizacion(subtipoSnapshot: string | null | undefined): boolean {
-  return (subtipoSnapshot ?? '').toLowerCase().includes('cotizac');
+export function esTareaCotizacion(
+  tipoSnapshot: string | null | undefined,
+  subtipoSnapshot?: string | null | undefined
+): boolean {
+  const t = (tipoSnapshot ?? '').toLowerCase();
+  if (t.includes('cotizac')) return true;
+  const s = (subtipoSnapshot ?? '').toLowerCase();
+  return s.includes('cotizac');
 }

--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -86,7 +86,7 @@ const OBLIG_TONE: Record<string, BadgeTone> = {
 };
 
 function esCotizacion(t: TareaChecklistRow): boolean {
-  return esTareaCotizacion(t.subtipo_snapshot);
+  return esTareaCotizacion(t.tipo_snapshot, t.subtipo_snapshot);
 }
 
 /**


### PR DESCRIPTION
## Root cause

Sprint 2 dependía de \`esTareaCotizacion(subtipo)\` buscando "cotizac" en el subtipo de la tarea. Pero las 3 tareas canónicas del catálogo tienen \`tipo='Cotización'\` y subtipos sin "cotizac":

| Tarea | tipo | subtipo |
|---|---|---|
| Cotización de Urbanización | Cotización | Urbanismo |
| Cotización de Construcción de Vivienda | Cotización | Construcción |
| Cotización de Comercialización | Cotización | Comercial |

Resultado: el input de monto nunca aparecía en el checklist → Beto reportó "no veo cómo capturar una cotización".

## Fix

- \`esTareaCotizacion(tipo, subtipo?)\` matchea "cotizac" en cualquiera de los dos (defensa si el catálogo cambia).
- Cliente \`tareas-checklist.tsx\` pasa \`t.tipo_snapshot\` + \`t.subtipo_snapshot\`.
- Server \`syncPartidaDesdeTarea\` extiende SELECT a \`tipo_snapshot\` y pasa ambos.

Cero cambio de schema. Cero datos tocados. 991/991 tests verdes.

## Test plan

- [ ] Hard refresh. Abrir cualquier anteproyecto.
- [ ] En el checklist, encontrar "Cotización de Urbanización" → ya debe aparecer el input "Monto cotizado (MXN)".
- [ ] Capturar monto → bajar a "Presupuesto" → partida preliminar nueva con etiqueta "cotización (auto)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)