### PR TITLE
refactor(dilesa-checklist): tabla compacta 1-row-por-tarea + expand inline

### DIFF
--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -1,24 +1,26 @@
 'use client';
 
 /**
- * `<TareasChecklist>` — checklist de tareas con captura inline.
+ * `<TareasChecklist>` — checklist compacto de tareas con captura inline.
  *
- * Sprint 1 de `dilesa-proyectos-checklist-inline`. Reemplaza la tabla
- * read-only que vivía en `<AnteproyectoDetalle>`. Cada tarea es una
- * card con:
- * - Header: título, badges (tipo/subtipo/obligatoriedad), dropdown
- *   estado, fechas objetivo.
- * - Captura: input monto (si subtipo='cotizacion'), `<FileAttachments>`
- *   inline (si requiere_archivo_snapshot), notas autosave debounced.
- * - Dependencias bloqueantes como chips.
+ * Sprint 1 de `dilesa-proyectos-checklist-inline` (refactor UI 2026-05-29
+ * tras feedback de Beto: "cada tarea en un solo renglón, más limpio y
+ * organizado").
  *
- * Server actions con whitelist por campo (Sprint 1). Optimistic UI
- * con rollback. Sprint 3 reusará este mismo componente en el detalle
- * del desarrollo filtrando por `aplicacion_snapshot`.
+ * Layout: tabla HTML compacta con sticky header y una fila por tarea.
+ * Cada fila colapsada (default) muestra los campos resumen + 3 acciones
+ * inline (estado dropdown, monto si cotización, indicadores doc/notas).
+ * Click en la fila expande un panel inline debajo con `<FileAttachments>`
+ * completo, textarea de notas, descripción canónica y dependencias
+ * bloqueantes en texto largo.
+ *
+ * Server actions con whitelist por campo (Sprint 1). Optimistic UI con
+ * rollback. Sprint 3 reusará este mismo componente en el detalle del
+ * desarrollo filtrando por `aplicacion_snapshot`.
  */
 
-import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
-import { FileText } from 'lucide-react';
+import { Fragment, useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import { ChevronRight, FileText, MessageSquare, Paperclip } from 'lucide-react';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
 import { FileAttachments } from '@/components/file-attachments/file-attachments';
 import {
@@ -90,6 +92,17 @@ function esCotizacion(t: TareaChecklistRow): boolean {
 }
 
 /**
+ * Formatea una fecha ISO (YYYY-MM-DD) en formato compacto "dd/mmm" para
+ * caber en columna estrecha. Null → "—".
+ */
+function fmtFechaCorta(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(`${iso}T00:00:00`);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('es-MX', { day: '2-digit', month: 'short' }).replace('.', '');
+}
+
+/**
  * Calcula qué tareas están bloqueadas por dependencias incompletas.
  * Devuelve mapa `tareaId → titulos de bloqueantes incompletas`.
  */
@@ -123,24 +136,24 @@ export function TareasChecklist({
   empresaSlug: EmpresaSlug;
   onChange?: () => void;
 }) {
-  // Guard defensivo: si el padre pasa algo que no es array (race condition
-  // o data corrupta), tratamos como vacío para no romper el render.
   const tareasSource: readonly TareaChecklistRow[] = Array.isArray(tareasInicial)
     ? tareasInicial
     : [];
   // Estado local — optimistic. Rollback si la server action falla.
   const [tareas, setTareas] = useState<TareaChecklistRow[]>([...tareasSource]);
   const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  // Sincroniza state local cuando el padre nos pasa nuevas tareas (refresh).
-  // Comparación shallow por id+estado para evitar re-sincronizar la lista local
-  // entera cuando llega el mismo dataset. setState va dentro de useEffect (no
-  // de useMemo) para respetar la semántica de React 19.
-  const idsEstados = tareasSource.map((t) => `${t.id}:${t.estado}`).join('|');
+  // Sincroniza state local cuando el padre nos pasa nuevas tareas. Comparamos
+  // shallow por id+estado+monto+url+notas para no re-sincronizar al re-renderear
+  // con la misma data. setState va dentro de useEffect (regla React 19).
+  const fingerprint = tareasSource
+    .map((t) => `${t.id}:${t.estado}:${t.resultado_monto ?? ''}:${t.resultado_documento_url ?? ''}`)
+    .join('|');
   useEffect(() => {
     setTareas([...tareasSource]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [idsEstados, tareasSource.length]);
+  }, [fingerprint]);
 
   const bloqueadasMap = useMemo(
     () => computeBloqueadasMap(tareas, dependencias),
@@ -151,46 +164,88 @@ export function TareasChecklist({
     setTareas((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
   }, []);
 
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+  }, []);
+
   if (tareas.length === 0) {
     return <p className="text-sm text-[var(--text)]/60">Sin tareas instanciadas todavía.</p>;
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-2">
       {error && (
         <p className="rounded-md border border-red-200 bg-red-50 p-2 text-sm text-red-700">
           {error}
         </p>
       )}
-      {tareas.map((t) => (
-        <TareaCard
-          key={t.id}
-          tarea={t}
-          bloqueadaPor={bloqueadasMap.get(t.id) ?? []}
-          empresaId={empresaId}
-          empresaSlug={empresaSlug}
-          onPatch={patchLocal}
-          onError={setError}
-          onChange={onChange}
-        />
-      ))}
+      <div className="overflow-x-auto rounded-md border border-[var(--border)]">
+        <table className="min-w-full text-sm">
+          <thead className="bg-[var(--card)] text-xs uppercase tracking-wide text-[var(--text)]/50">
+            <tr className="border-b border-[var(--border)]">
+              <th className="w-8 px-2 py-2 text-center">#</th>
+              <th className="px-3 py-2 text-left">Tarea</th>
+              <th className="w-36 px-2 py-2 text-left">Estado</th>
+              <th className="w-20 px-2 py-2 text-left">Vence</th>
+              <th className="w-36 px-2 py-2 text-right">Monto</th>
+              <th className="w-12 px-2 py-2 text-center" aria-label="Documento">
+                <Paperclip className="mx-auto h-3.5 w-3.5" />
+              </th>
+              <th className="w-12 px-2 py-2 text-center" aria-label="Notas">
+                <MessageSquare className="mx-auto h-3.5 w-3.5" />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {tareas.map((t, idx) => (
+              <Fragment key={t.id}>
+                <TareaRowCompact
+                  tarea={t}
+                  orden={idx + 1}
+                  bloqueadaPor={bloqueadasMap.get(t.id) ?? []}
+                  expanded={expandedId === t.id}
+                  onToggleExpand={toggleExpand}
+                  onPatch={patchLocal}
+                  onError={setError}
+                  onChange={onChange}
+                />
+                {expandedId === t.id && (
+                  <TareaRowExpanded
+                    tarea={t}
+                    bloqueadaPor={bloqueadasMap.get(t.id) ?? []}
+                    empresaId={empresaId}
+                    empresaSlug={empresaSlug}
+                    onPatch={patchLocal}
+                    onError={setError}
+                    onChange={onChange}
+                  />
+                )}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }
 
-function TareaCard({
+// ─── Fila compacta (default — 1 renglón) ────────────────────────────────────
+
+function TareaRowCompact({
   tarea,
+  orden,
   bloqueadaPor,
-  empresaId,
-  empresaSlug,
+  expanded,
+  onToggleExpand,
   onPatch,
   onError,
   onChange,
 }: {
   tarea: TareaChecklistRow;
+  orden: number;
   bloqueadaPor: string[];
-  empresaId: string;
-  empresaSlug: EmpresaSlug;
+  expanded: boolean;
+  onToggleExpand: (id: string) => void;
   onPatch: (id: string, patch: Partial<TareaChecklistRow>) => void;
   onError: (msg: string | null) => void;
   onChange?: () => void;
@@ -199,29 +254,47 @@ function TareaCard({
   const [montoLocal, setMontoLocal] = useState(
     tarea.resultado_monto != null ? String(tarea.resultado_monto) : ''
   );
-  const [notasLocal, setNotasLocal] = useState(tarea.descripcion ?? '');
+
+  // Sincroniza el input si el padre cambia el monto externamente (refresh).
+  // setState va dentro de microtask para no triggerear cascada (regla del repo).
+  useEffect(() => {
+    let activo = true;
+    void Promise.resolve().then(() => {
+      if (!activo) return;
+      setMontoLocal(tarea.resultado_monto != null ? String(tarea.resultado_monto) : '');
+    });
+    return () => {
+      activo = false;
+    };
+  }, [tarea.resultado_monto]);
+
   const esCot = esCotizacion(tarea);
-  const requiereArchivo = !!tarea.requiere_archivo_snapshot;
+  const tieneDoc = !!tarea.resultado_documento_url;
+  const tieneNotas = !!(tarea.descripcion && tarea.descripcion.trim() !== '');
+  const completada = tarea.estado === 'completada';
 
-  const handleEstadoChange = (next: TareaEstado) => {
-    const prev = tarea.estado;
-    onPatch(tarea.id, {
-      estado: next,
-      fecha_completada: next === 'completada' ? new Date().toISOString().slice(0, 10) : null,
-    });
-    startTransition(async () => {
-      const r = await updateTareaEstado(tarea.id, next);
-      if (!r.ok) {
-        onPatch(tarea.id, { estado: prev });
-        onError(r.error);
-      } else {
-        onError(null);
-        onChange?.();
-      }
-    });
-  };
+  const handleEstadoChange = useCallback(
+    (next: TareaEstado) => {
+      const prev = tarea.estado;
+      onPatch(tarea.id, {
+        estado: next,
+        fecha_completada: next === 'completada' ? new Date().toISOString().slice(0, 10) : null,
+      });
+      startTransition(async () => {
+        const r = await updateTareaEstado(tarea.id, next);
+        if (!r.ok) {
+          onPatch(tarea.id, { estado: prev });
+          onError(r.error);
+        } else {
+          onError(null);
+          onChange?.();
+        }
+      });
+    },
+    [tarea.id, tarea.estado, onPatch, onError, onChange]
+  );
 
-  const handleMontoBlur = () => {
+  const handleMontoBlur = useCallback(() => {
     const trimmed = montoLocal.trim();
     const parsed = trimmed === '' ? null : Number(trimmed);
     if (parsed != null && (!Number.isFinite(parsed) || parsed < 0)) {
@@ -242,9 +315,160 @@ function TareaCard({
         onChange?.();
       }
     });
-  };
+  }, [montoLocal, tarea.id, tarea.resultado_monto, onPatch, onError, onChange]);
 
-  const handleNotasBlur = () => {
+  return (
+    <tr
+      className={`border-b border-[var(--border)]/60 transition-colors hover:bg-[var(--card)]/60 ${
+        expanded ? 'bg-[var(--card)]/40' : ''
+      } ${completada ? 'text-[var(--text)]/60' : ''}`}
+    >
+      <td className="px-2 py-1.5 text-center text-xs text-[var(--text)]/40 tabular-nums">
+        {orden}
+      </td>
+      <td className="px-3 py-1.5">
+        <button
+          type="button"
+          onClick={() => onToggleExpand(tarea.id)}
+          className="-mx-1 flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left hover:bg-[var(--card)]/80"
+        >
+          <ChevronRight
+            className={`h-3.5 w-3.5 text-[var(--text)]/40 transition-transform ${
+              expanded ? 'rotate-90' : ''
+            }`}
+          />
+          <span
+            className={`flex-1 truncate font-medium ${
+              completada ? 'line-through' : 'text-[var(--text)]'
+            }`}
+          >
+            {tarea.titulo}
+          </span>
+          {tarea.obligatoriedad_snapshot && tarea.obligatoriedad_snapshot !== 'opcional' && (
+            <Badge tone={OBLIG_TONE[tarea.obligatoriedad_snapshot] ?? 'neutral'}>
+              {tarea.obligatoriedad_snapshot === 'obligatoria' ? 'obl.' : 'cond.'}
+            </Badge>
+          )}
+          {bloqueadaPor.length > 0 && (
+            <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
+              bloqueada
+            </span>
+          )}
+        </button>
+      </td>
+      <td className="px-2 py-1.5">
+        <select
+          value={tarea.estado}
+          disabled={pending}
+          onChange={(e) => handleEstadoChange(e.target.value as TareaEstado)}
+          onClick={(e) => e.stopPropagation()}
+          className={`h-7 w-full rounded-md border bg-[var(--bg)] px-1.5 text-xs disabled:opacity-50 ${
+            ESTADO_TONE[tarea.estado] === 'success'
+              ? 'border-emerald-300 text-emerald-700'
+              : ESTADO_TONE[tarea.estado] === 'warning'
+                ? 'border-amber-300 text-amber-700'
+                : ESTADO_TONE[tarea.estado] === 'info'
+                  ? 'border-sky-300 text-sky-700'
+                  : 'border-[var(--border)] text-[var(--text)]'
+          }`}
+          aria-label={`Estado de ${tarea.titulo}`}
+        >
+          {TAREA_ESTADOS_VALIDOS.map((e) => (
+            <option key={e} value={e}>
+              {ESTADO_LABEL[e] ?? e}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td className="px-2 py-1.5 text-xs text-[var(--text)]/70 tabular-nums">
+        {fmtFechaCorta(tarea.fecha_objetivo_fin)}
+      </td>
+      <td className="px-2 py-1.5 text-right">
+        {esCot ? (
+          <input
+            type="number"
+            inputMode="decimal"
+            step="0.01"
+            value={montoLocal}
+            onChange={(e) => setMontoLocal(e.target.value)}
+            onBlur={handleMontoBlur}
+            onClick={(e) => e.stopPropagation()}
+            disabled={pending}
+            placeholder="$ —"
+            className="h-7 w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-2 text-right text-xs tabular-nums focus:border-[var(--accent)] focus:outline-none disabled:opacity-50"
+            aria-label={`Monto cotizado de ${tarea.titulo}`}
+          />
+        ) : (
+          <span className="text-xs text-[var(--text)]/30">—</span>
+        )}
+      </td>
+      <td className="px-2 py-1.5 text-center">
+        <button
+          type="button"
+          onClick={() => onToggleExpand(tarea.id)}
+          className="inline-flex h-6 w-6 items-center justify-center rounded hover:bg-[var(--card)]"
+          aria-label={tieneDoc ? 'Ver documento' : 'Subir documento'}
+        >
+          <Paperclip
+            className={`h-3.5 w-3.5 ${tieneDoc ? 'text-[var(--accent)]' : 'text-[var(--text)]/25'}`}
+          />
+        </button>
+      </td>
+      <td className="px-2 py-1.5 text-center">
+        <button
+          type="button"
+          onClick={() => onToggleExpand(tarea.id)}
+          className="inline-flex h-6 w-6 items-center justify-center rounded hover:bg-[var(--card)]"
+          aria-label={tieneNotas ? 'Ver notas' : 'Agregar notas'}
+        >
+          <MessageSquare
+            className={`h-3.5 w-3.5 ${
+              tieneNotas ? 'text-[var(--accent)]' : 'text-[var(--text)]/25'
+            }`}
+          />
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+// ─── Fila expandida (panel de captura inline) ───────────────────────────────
+
+function TareaRowExpanded({
+  tarea,
+  bloqueadaPor,
+  empresaId,
+  empresaSlug,
+  onPatch,
+  onError,
+  onChange,
+}: {
+  tarea: TareaChecklistRow;
+  bloqueadaPor: string[];
+  empresaId: string;
+  empresaSlug: EmpresaSlug;
+  onPatch: (id: string, patch: Partial<TareaChecklistRow>) => void;
+  onError: (msg: string | null) => void;
+  onChange?: () => void;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [notasLocal, setNotasLocal] = useState(tarea.descripcion ?? '');
+
+  useEffect(() => {
+    let activo = true;
+    void Promise.resolve().then(() => {
+      if (!activo) return;
+      setNotasLocal(tarea.descripcion ?? '');
+    });
+    return () => {
+      activo = false;
+    };
+  }, [tarea.descripcion]);
+
+  const requiereArchivo = !!tarea.requiere_archivo_snapshot;
+  const esCot = esCotizacion(tarea);
+
+  const handleNotasBlur = useCallback(() => {
     const next = notasLocal.trim() === '' ? null : notasLocal;
     if (next === tarea.descripcion) return;
     const prev = tarea.descripcion;
@@ -260,22 +484,9 @@ function TareaCard({
         onChange?.();
       }
     });
-  };
+  }, [notasLocal, tarea.id, tarea.descripcion, onPatch, onError, onChange]);
 
-  const handleAttachmentsChange = () => {
-    // Sprint 1 minimal: registramos la subida en `proyecto_tareas.resultado_documento_url`
-    // como atajo de UI; el legajo completo vive en `erp.adjuntos`. La URL
-    // efectiva la resolvemos pidiendo al componente que avise; el caller
-    // refresca el detalle completo para traer la URL recién escrita por
-    // server action.
-    onChange?.();
-  };
-
-  // Como el slot de FileAttachments se monta inline sin "primer adjunto",
-  // el shortcut `resultado_documento_url` se mantiene como referencia
-  // textual editable hasta que el operador suba un archivo real (que
-  // dispara onChange y refresca el legajo desde erp.adjuntos).
-  const handleLimpiarDocumento = () => {
+  const handleLimpiarDocumento = useCallback(() => {
     const prev = tarea.resultado_documento_url;
     onPatch(tarea.id, { resultado_documento_url: null });
     startTransition(async () => {
@@ -288,92 +499,46 @@ function TareaCard({
         onChange?.();
       }
     });
-  };
-
-  const fechaCompletadaLabel = tarea.fecha_completada
-    ? `Completada ${tarea.fecha_completada}`
-    : tarea.fecha_objetivo_inicio || tarea.fecha_objetivo_fin
-      ? `Objetivo ${tarea.fecha_objetivo_inicio ?? '—'} → ${tarea.fecha_objetivo_fin ?? '—'}`
-      : null;
+  }, [tarea.id, tarea.resultado_documento_url, onPatch, onError, onChange]);
 
   return (
-    <article className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
-      <header className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h4 className="text-sm font-medium text-[var(--text)]">{tarea.titulo}</h4>
-            {tarea.obligatoriedad_snapshot && (
-              <Badge tone={OBLIG_TONE[tarea.obligatoriedad_snapshot] ?? 'neutral'}>
-                {tarea.obligatoriedad_snapshot}
-              </Badge>
-            )}
+    <tr className="border-b border-[var(--border)]/60 bg-[var(--card)]/30">
+      <td colSpan={7} className="px-3 py-3">
+        <div className="space-y-3">
+          {/* Meta info: tipo · subtipo · entidad responsable · fechas largas */}
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[var(--text)]/60">
             {tarea.tipo_snapshot && (
-              <span className="text-xs text-[var(--text)]/60">
+              <span>
                 {tarea.tipo_snapshot}
                 {tarea.subtipo_snapshot ? ` · ${tarea.subtipo_snapshot}` : ''}
               </span>
             )}
-          </div>
-          <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-[var(--text)]/60">
             {tarea.entidad_responsable_snapshot && (
               <span>{tarea.entidad_responsable_snapshot}</span>
             )}
-            {fechaCompletadaLabel && <span>{fechaCompletadaLabel}</span>}
-          </div>
-          {bloqueadaPor.length > 0 && (
-            <p className="mt-2 text-xs text-amber-700">Bloqueada por: {bloqueadaPor.join(', ')}</p>
-          )}
-        </div>
-        <select
-          value={tarea.estado}
-          disabled={pending}
-          onChange={(e) => handleEstadoChange(e.target.value as TareaEstado)}
-          className="h-8 rounded-md border border-[var(--border)] bg-[var(--bg)] px-2 text-xs text-[var(--text)] disabled:opacity-50"
-          aria-label={`Estado de ${tarea.titulo}`}
-        >
-          {TAREA_ESTADOS_VALIDOS.map((e) => (
-            <option key={e} value={e}>
-              {ESTADO_LABEL[e] ?? e}
-            </option>
-          ))}
-        </select>
-      </header>
-
-      <div className="mt-3 flex items-center gap-2">
-        <Badge tone={ESTADO_TONE[tarea.estado] ?? 'neutral'}>
-          {ESTADO_LABEL[tarea.estado] ?? tarea.estado}
-        </Badge>
-      </div>
-
-      {(esCot || requiereArchivo) && (
-        <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {esCot && (
-            <label className="block text-xs">
-              <span className="mb-1 block uppercase tracking-wide text-[var(--text)]/50">
-                Monto cotizado (MXN)
+            {(tarea.fecha_objetivo_inicio || tarea.fecha_objetivo_fin) && (
+              <span>
+                Objetivo {fmtFechaCorta(tarea.fecha_objetivo_inicio)} →{' '}
+                {fmtFechaCorta(tarea.fecha_objetivo_fin)}
               </span>
-              <input
-                type="number"
-                inputMode="decimal"
-                step="0.01"
-                value={montoLocal}
-                onChange={(e) => setMontoLocal(e.target.value)}
-                onBlur={handleMontoBlur}
-                disabled={pending}
-                placeholder="0"
-                className="h-9 w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 text-sm text-[var(--text)] focus:border-[var(--accent)] focus:outline-none disabled:opacity-50"
-              />
-              {tarea.resultado_monto != null && (
-                <span className="mt-1 block text-xs text-[var(--text)]/60">
-                  {moneyFmt.format(tarea.resultado_monto)}
-                </span>
-              )}
-            </label>
+            )}
+            {tarea.fecha_completada && (
+              <span className="text-emerald-700">Completada {tarea.fecha_completada}</span>
+            )}
+          </div>
+
+          {bloqueadaPor.length > 0 && (
+            <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              <strong>Bloqueada por:</strong> {bloqueadaPor.join(', ')}
+            </p>
           )}
-          {requiereArchivo && (
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {/* Documento(s) — siempre visible en expand, pero más prominente
+                cuando requiere_archivo. */}
             <div>
-              <span className="mb-1 block text-xs uppercase tracking-wide text-[var(--text)]/50">
-                Documento(s)
+              <span className="mb-1 block text-[11px] uppercase tracking-wide text-[var(--text)]/50">
+                {requiereArchivo ? 'Documento requerido' : 'Documentos'}
               </span>
               <div className="rounded-md border border-[var(--border)] bg-[var(--bg)] p-2">
                 <FileAttachments
@@ -382,16 +547,20 @@ function TareaCard({
                   entidad="proyecto_tareas"
                   entidadId={tarea.id}
                   roles={[
-                    { id: 'resultado', label: 'Resultado', icon: <FileText className="h-3 w-3" /> },
+                    {
+                      id: 'resultado',
+                      label: 'Resultado',
+                      icon: <FileText className="h-3 w-3" />,
+                    },
                     { id: 'anexo', label: 'Anexo' },
                   ]}
                   defaultUploadRole="resultado"
                   variant="flat"
-                  onChange={handleAttachmentsChange}
+                  onChange={onChange}
                 />
               </div>
               {tarea.resultado_documento_url && (
-                <div className="mt-1 flex items-center gap-2 text-xs">
+                <div className="mt-1 flex items-center gap-2 text-[11px]">
                   <a
                     href={tarea.resultado_documento_url}
                     target="_blank"
@@ -411,22 +580,40 @@ function TareaCard({
                 </div>
               )}
             </div>
-          )}
-        </div>
-      )}
 
-      <label className="mt-3 block text-xs">
-        <span className="mb-1 block uppercase tracking-wide text-[var(--text)]/50">Notas</span>
-        <textarea
-          value={notasLocal}
-          onChange={(e) => setNotasLocal(e.target.value)}
-          onBlur={handleNotasBlur}
-          disabled={pending}
-          rows={2}
-          placeholder="Comentarios, contexto, decisión…"
-          className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm text-[var(--text)] focus:border-[var(--accent)] focus:outline-none disabled:opacity-50"
-        />
-      </label>
-    </article>
+            {/* Resumen del monto cuando es cotización + número formateado.
+                El input está en la row compacta. */}
+            {esCot && tarea.resultado_monto != null && (
+              <div>
+                <span className="mb-1 block text-[11px] uppercase tracking-wide text-[var(--text)]/50">
+                  Monto capturado
+                </span>
+                <div className="rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm tabular-nums">
+                  {moneyFmt.format(tarea.resultado_monto)}
+                </div>
+                <span className="mt-1 block text-[11px] text-[var(--text)]/60">
+                  Genera una partida preliminar vinculada en el presupuesto.
+                </span>
+              </div>
+            )}
+          </div>
+
+          <label className="block">
+            <span className="mb-1 block text-[11px] uppercase tracking-wide text-[var(--text)]/50">
+              Notas
+            </span>
+            <textarea
+              value={notasLocal}
+              onChange={(e) => setNotasLocal(e.target.value)}
+              onBlur={handleNotasBlur}
+              disabled={pending}
+              rows={2}
+              placeholder="Comentarios, contexto, decisión…"
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm focus:border-[var(--accent)] focus:outline-none disabled:opacity-50"
+            />
+          </label>
+        </div>
+      </td>
+    </tr>
   );
 }


### PR DESCRIPTION
## Summary

Beto reportó "se ve muy revuelto, debe ser cada tarea en un solo renglón". Refactor del componente \`<TareasChecklist>\` de cards multi-renglón a tabla compacta con expand on click.

## Layout nuevo

| # | Tarea | Estado | Vence | Monto | 📎 | 💬 |
|---|---|---|---|---|---|---|
| 1 | Levantamiento Topográfico [obl.] | Pendiente ▾ | 12/jun | — | 📎 | 💬 |
| 2 | Cotización Urbanización | En curso ▾ | 03/jul | $ 1,200,000 | 📎• | 💬 |

- **1 fila ~32px** por tarea. Hover marca, completadas en gris + tachado.
- **Estado dropdown** nativo coloreado por tone (verde/ámbar/azul/neutral). \`stopPropagation()\` para no toggle expand.
- **Monto input inline** solo si la tarea es de cotización; sino "—".
- **📎 / 💬 indicators**: accent cuando hay contenido, ghost cuando vacíos. Click expande.
- **Badges**: "obl." / "cond." solo cuando ≠ opcional. Pill amarillo "bloqueada" cuando tiene deps incompletas.
- **Vence**: formato corto "12/jun".

## Expand on click

Click en la fila (o en chevron, paperclip, message) abre un panel inline debajo con:

- Meta info: tipo · subtipo · entidad responsable · objetivo largo · completada-en si aplica.
- Banner ámbar "Bloqueada por: X, Y, Z" si hay deps incompletas.
- \`<FileAttachments>\` completo (con label "Documento requerido" si \`requiere_archivo\`).
- Resumen del monto con texto explicativo "Genera partida preliminar vinculada".
- \`<textarea>\` notas (autosave on blur).

Solo una fila expandida a la vez. Click en la misma fila la cierra.

## Comportamiento

- Optimistic UI con rollback por server action (igual que antes).
- \`useEffect\` sincroniza monto/notas locales con prop cuando el padre refresca (sin drift).
- setState dentro de microtask para no triggerear cascada (regla del repo).
- \`fingerprint\` extendido a \`id:estado:monto:url\` para detectar cambios externos correctamente.

## Cambios

Solo [components/dilesa/tareas-checklist.tsx](components/dilesa/tareas-checklist.tsx). Cero cambio de modelo, server actions, datos ni tests.

## Verificación local

- typecheck ✓
- tests 992/992 ✓
- lint 0 errores
- format:check ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)