### PR TITLE
feat(dilesa-checklist): Sprint 3 — pasos por tarea (4 conceptos canónicos)

### DIFF
--- a/app/dilesa/proyectos/anteproyectos/actions.ts
+++ b/app/dilesa/proyectos/anteproyectos/actions.ts
@@ -485,3 +485,53 @@ export async function marcarPasoEstado(
 ): Promise<SimpleResult> {
   return upsertPaso(tareaId, paso, { estado });
 }
+
+/**
+ * Autoriza un paso (típicamente `cotizacion`) por dirección. Setea
+ * `autorizado_at=NOW()` y `autorizado_por=<user>`. Requiere usuario
+ * admin (Sprint 3.5 v1: solo admin puede autorizar; roles director
+ * específicos vendrán después si Beto los pide).
+ *
+ * Idempotente: si el paso ya está autorizado, no-op silencioso.
+ */
+export async function autorizarPaso(tareaId: string, paso: TareaPaso): Promise<SimpleResult> {
+  if (!tareaId) return { ok: false, error: 'tareaId requerido' };
+  if (!(TAREA_PASOS_VALIDOS as readonly string[]).includes(paso)) {
+    return { ok: false, error: `Paso inválido: ${paso}` };
+  }
+
+  const supabase = await makeServerClient();
+  const { data: userRes, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userRes?.user) return { ok: false, error: 'No autenticado' };
+  const userId = userRes.user.id;
+  const email = userRes.user.email;
+  if (!email) return { ok: false, error: 'JWT sin email' };
+
+  // Role gate: solo admin por ahora. El check se hace contra
+  // core.usuarios.rol (mismo patrón que `lib/empresas/admin-guard.ts`).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: coreUser, error: roleErr } = await (supabase.schema('core') as any)
+    .from('usuarios')
+    .select('rol')
+    .eq('email', email)
+    .maybeSingle();
+  if (roleErr) return { ok: false, error: roleErr.message };
+  if (!coreUser || coreUser.rol !== 'admin') {
+    return { ok: false, error: 'Requiere rol admin/dirección para autorizar' };
+  }
+
+  const { error } = await supabase
+    .schema('dilesa')
+    .from('proyecto_tarea_pasos')
+    .update({
+      autorizado_at: new Date().toISOString(),
+      autorizado_por: userId,
+    })
+    .eq('tarea_id', tareaId)
+    .eq('paso', paso)
+    .is('autorizado_at', null);
+
+  if (error) return { ok: false, error: error.message || 'No se pudo autorizar el paso.' };
+  revalidateAnteproyectosPaths();
+  return { ok: true };
+}

--- a/app/dilesa/proyectos/anteproyectos/actions.ts
+++ b/app/dilesa/proyectos/anteproyectos/actions.ts
@@ -31,6 +31,11 @@ import {
   TAREA_ESTADOS_VALIDOS,
   type TareaEstado,
   esTareaCotizacion,
+  TAREA_PASOS_VALIDOS,
+  type TareaPaso,
+  PASO_ESTADOS_VALIDOS,
+  type PasoEstado,
+  PASO_TO_PARTIDA_ESTADO,
 } from '@/components/dilesa/tareas-checklist-types';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
@@ -337,4 +342,146 @@ export async function updateTareaNotas(
   if (error) return { ok: false, error: error.message || 'No se pudieron actualizar las notas.' };
   revalidateAnteproyectosPaths();
   return { ok: true };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Sprint 3 de `dilesa-proyectos-checklist-inline` — pasos por tarea
+// ──────────────────────────────────────────────────────────────────────────────
+
+export type PasoPatch = {
+  monto?: number | null;
+  documento_url?: string | null;
+  fecha?: string | null;
+  estado?: PasoEstado;
+  notas?: string | null;
+};
+
+/**
+ * Upsert universal de un paso (cotización / factura / pago / resultado)
+ * de una tarea. Si el paso no existe lo crea con `estado='pendiente'`;
+ * después aplica el patch. Whitelist por campo + validación.
+ *
+ * Side effects mantienen compat con los atajos de Sprint 1:
+ * - Cuando el paso `cotizacion` actualiza `monto` → también escribe a
+ *   `proyecto_tareas.resultado_monto` y dispara `syncPartidaDesdeTarea`
+ *   para que la partida preliminar quede en sync (Sprint 2).
+ * - Cuando el paso `resultado` actualiza `documento_url` → también
+ *   escribe a `proyecto_tareas.resultado_documento_url`.
+ *
+ * El flujo extendido para factura/pago (autorizada/en_ejercicio en la
+ * partida) se entrega en un sprint posterior — Sprint 3 entrega
+ * captura + persistencia limpias por paso.
+ */
+export async function upsertPaso(
+  tareaId: string,
+  paso: TareaPaso,
+  patch: PasoPatch
+): Promise<SimpleResult> {
+  if (!tareaId) return { ok: false, error: 'tareaId requerido' };
+  if (!(TAREA_PASOS_VALIDOS as readonly string[]).includes(paso)) {
+    return { ok: false, error: `Paso inválido: ${paso}` };
+  }
+
+  // Validación por campo (todos opcionales — el caller solo manda lo
+  // que cambió).
+  const update: Record<string, unknown> = {};
+  if ('monto' in patch) {
+    if (patch.monto != null) {
+      if (!Number.isFinite(patch.monto) || patch.monto < 0) {
+        return { ok: false, error: 'Monto debe ser número ≥ 0' };
+      }
+    }
+    update.monto = patch.monto ?? null;
+  }
+  if ('documento_url' in patch) {
+    update.documento_url =
+      patch.documento_url != null && patch.documento_url.trim() === ''
+        ? null
+        : (patch.documento_url ?? null);
+  }
+  if ('fecha' in patch) {
+    if (patch.fecha != null && !/^\d{4}-\d{2}-\d{2}$/.test(patch.fecha)) {
+      return { ok: false, error: 'Fecha debe ser YYYY-MM-DD' };
+    }
+    update.fecha = patch.fecha ?? null;
+  }
+  if ('estado' in patch && patch.estado) {
+    if (!(PASO_ESTADOS_VALIDOS as readonly string[]).includes(patch.estado)) {
+      return { ok: false, error: `Estado de paso inválido: ${patch.estado}` };
+    }
+    update.estado = patch.estado;
+  }
+  if ('notas' in patch) {
+    update.notas = patch.notas != null && patch.notas.trim() === '' ? null : (patch.notas ?? null);
+  }
+  if (Object.keys(update).length === 0) return { ok: false, error: 'sin cambios' };
+
+  const supabase = await makeServerClient();
+
+  // 1) Leer tarea para empresa_id (necesario para el upsert por unique
+  //    (tarea_id, paso) y para RLS).
+  const { data: tareaRow, error: tareaErr } = await supabase
+    .schema('dilesa')
+    .from('proyecto_tareas')
+    .select('id, empresa_id')
+    .eq('id', tareaId)
+    .is('deleted_at', null)
+    .single();
+  if (tareaErr || !tareaRow) {
+    return { ok: false, error: tareaErr?.message ?? 'tarea no encontrada' };
+  }
+  const empresaId = (tareaRow as { empresa_id: string }).empresa_id;
+
+  // 2) Upsert por (tarea_id, paso). La unique constraint hace que un
+  //    INSERT del mismo (tarea_id, paso) actualice en lugar de duplicar.
+  const upsertRow = {
+    empresa_id: empresaId,
+    tarea_id: tareaId,
+    paso,
+    estado: 'pendiente' as const,
+    ...update,
+  };
+  const { error: upsertErr } = await supabase
+    .schema('dilesa')
+    .from('proyecto_tarea_pasos')
+    .upsert(upsertRow, { onConflict: 'tarea_id,paso' });
+  if (upsertErr) {
+    return { ok: false, error: upsertErr.message || 'No se pudo guardar el paso.' };
+  }
+
+  // 3) Side effects backwards-compat con atajos en `proyecto_tareas`.
+  if (paso === 'cotizacion' && 'monto' in update) {
+    const newMonto = (update.monto as number | null) ?? null;
+    await supabase
+      .schema('dilesa')
+      .from('proyecto_tareas')
+      .update({ resultado_monto: newMonto })
+      .eq('id', tareaId);
+    // Mantén la sincronización con partida preliminar del Sprint 2.
+    void syncPartidaDesdeTarea(supabase, tareaId, newMonto).catch((e) =>
+      console.warn('[upsertPaso] sync partida falló:', e)
+    );
+  }
+  if (paso === 'resultado' && 'documento_url' in update) {
+    await supabase
+      .schema('dilesa')
+      .from('proyecto_tareas')
+      .update({ resultado_documento_url: update.documento_url ?? null })
+      .eq('id', tareaId);
+  }
+
+  revalidateAnteproyectosPaths();
+  return { ok: true };
+}
+
+/**
+ * Marca un paso como `hecho`, `pendiente` o `no_aplica`. Atajo cuando
+ * el caller solo quiere mover el estado sin tocar monto/doc/fecha.
+ */
+export async function marcarPasoEstado(
+  tareaId: string,
+  paso: TareaPaso,
+  estado: PasoEstado
+): Promise<SimpleResult> {
+  return upsertPaso(tareaId, paso, { estado });
 }

--- a/components/dilesa/anteproyecto-detalle.tsx
+++ b/components/dilesa/anteproyecto-detalle.tsx
@@ -29,6 +29,7 @@ import { type ProyectoDetalle, ESTADO_TONE, ESTADO_LABEL } from './proyecto-deta
 import { TareasChecklist, type PasoRow } from './tareas-checklist';
 import { PartidasPresupuestales, type PartidaRow } from './partidas-presupuestales';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { useEffectiveUser } from '@/components/providers';
 
 const numberFmt = new Intl.NumberFormat('es-MX');
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -150,6 +151,8 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
   const [tareas, setTareas] = useState<ProyectoTarea[]>([]);
   const [dependencias, setDependencias] = useState<TareaDep[]>([]);
   const [pasos, setPasos] = useState<PasoRow[]>([]);
+  const { data: effectiveUser } = useEffectiveUser();
+  const puedeAutorizar = !!effectiveUser?.isAdmin;
   const [partidas, setPartidas] = useState<Partida[]>([]);
   const [loadedId, setLoadedId] = useState<string | null>(null);
   const [extrasError, setExtrasError] = useState<string | null>(null);
@@ -212,7 +215,9 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
             supabase
               .schema('dilesa')
               .from('proyecto_tarea_pasos')
-              .select('id, tarea_id, paso, monto, documento_url, fecha, estado, notas')
+              .select(
+                'id, tarea_id, paso, monto, documento_url, fecha, estado, notas, autorizado_at, autorizado_por'
+              )
               .in('tarea_id', tareaIds)
               .is('deleted_at', null),
           ]);
@@ -481,6 +486,7 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
             pasos={pasos}
             empresaId={DILESA_EMPRESA_ID}
             empresaSlug="dilesa"
+            puedeAutorizar={puedeAutorizar}
             onChange={() => void cargarExtras(anteproyecto.id)}
           />
         )}

--- a/components/dilesa/anteproyecto-detalle.tsx
+++ b/components/dilesa/anteproyecto-detalle.tsx
@@ -26,7 +26,7 @@ import {
   promoteAnteproyecto,
 } from '@/app/dilesa/proyectos/anteproyectos/actions';
 import { type ProyectoDetalle, ESTADO_TONE, ESTADO_LABEL } from './proyecto-detalle';
-import { TareasChecklist } from './tareas-checklist';
+import { TareasChecklist, type PasoRow } from './tareas-checklist';
 import { PartidasPresupuestales, type PartidaRow } from './partidas-presupuestales';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
@@ -149,6 +149,7 @@ export function deriveAnalisis(p: ProyectoDetalle) {
 export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDetalle | null }) {
   const [tareas, setTareas] = useState<ProyectoTarea[]>([]);
   const [dependencias, setDependencias] = useState<TareaDep[]>([]);
+  const [pasos, setPasos] = useState<PasoRow[]>([]);
   const [partidas, setPartidas] = useState<Partida[]>([]);
   const [loadedId, setLoadedId] = useState<string | null>(null);
   const [extrasError, setExtrasError] = useState<string | null>(null);
@@ -188,28 +189,39 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
         .order('partida'),
     ]);
 
-    // Dependencias por IN sobre los IDs de las tareas del proyecto. Patrón
-    // sin embed PostgREST: si la query falla (RLS, parsing del embed), el
-    // shape de `.data` queda consistentemente array vacío en vez de null
+    // Dependencias + pasos por IN sobre los IDs de las tareas del proyecto.
+    // Patrón sin embed PostgREST: si la query falla (RLS, parsing del embed),
+    // el shape de `.data` queda consistentemente array vacío en vez de null
     // wrapped en algo raro. Aceptamos el round-trip extra.
     const tareaIds =
       Array.isArray(tareasRes.data) && tareasRes.data.length > 0
         ? tareasRes.data.map((t) => t.id as string)
         : [];
-    const depsRes =
+    const [depsRes, pasosRes] =
       tareaIds.length === 0
-        ? { data: [] as Array<{ tarea_id: string; depende_de_tarea_id: string }>, error: null }
-        : await supabase
-            .schema('dilesa')
-            .from('proyecto_tareas_dependencias')
-            .select('tarea_id, depende_de_tarea_id')
-            .in('tarea_id', tareaIds);
-    return [tareasRes, partidasRes, depsRes] as const;
+        ? [
+            { data: [] as Array<{ tarea_id: string; depende_de_tarea_id: string }>, error: null },
+            { data: [] as PasoRow[], error: null },
+          ]
+        : await Promise.all([
+            supabase
+              .schema('dilesa')
+              .from('proyecto_tareas_dependencias')
+              .select('tarea_id, depende_de_tarea_id')
+              .in('tarea_id', tareaIds),
+            supabase
+              .schema('dilesa')
+              .from('proyecto_tarea_pasos')
+              .select('id, tarea_id, paso, monto, documento_url, fecha, estado, notas')
+              .in('tarea_id', tareaIds)
+              .is('deleted_at', null),
+          ]);
+    return [tareasRes, partidasRes, depsRes, pasosRes] as const;
   }, []);
 
   const cargarExtras = useCallback(
     async (proyectoId: string) => {
-      const [tareasRes, partidasRes, depsRes] = await fetchExtras(proyectoId);
+      const [tareasRes, partidasRes, depsRes, pasosRes] = await fetchExtras(proyectoId);
       if (tareasRes.error) {
         setExtrasError(
           getSupabaseErrorMessage(tareasRes.error, 'No se pudieron cargar las tareas.')
@@ -232,6 +244,11 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
       } else {
         setDependencias([]);
       }
+      if (!pasosRes.error && Array.isArray(pasosRes.data)) {
+        setPasos(pasosRes.data as PasoRow[]);
+      } else {
+        setPasos([]);
+      }
       setLoadedId(proyectoId);
     },
     [fetchExtras]
@@ -242,7 +259,7 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
   useEffect(() => {
     if (!anteproyecto) return;
     let activo = true;
-    void fetchExtras(anteproyecto.id).then(([tareasRes, partidasRes, depsRes]) => {
+    void fetchExtras(anteproyecto.id).then(([tareasRes, partidasRes, depsRes, pasosRes]) => {
       if (!activo) return;
       if (tareasRes.error) {
         setExtrasError(
@@ -265,6 +282,11 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
         setDependencias(depsRes.data as TareaDep[]);
       } else {
         setDependencias([]);
+      }
+      if (!pasosRes.error && Array.isArray(pasosRes.data)) {
+        setPasos(pasosRes.data as PasoRow[]);
+      } else {
+        setPasos([]);
       }
       setLoadedId(anteproyecto.id);
     });
@@ -456,6 +478,7 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
           <TareasChecklist
             tareas={tareas}
             dependencias={dependencias}
+            pasos={pasos}
             empresaId={DILESA_EMPRESA_ID}
             empresaSlug="dilesa"
             onChange={() => void cargarExtras(anteproyecto.id)}

--- a/components/dilesa/tarea-pasos.test.ts
+++ b/components/dilesa/tarea-pasos.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { computeAvanceTarea, sumMontosPasos, type PasoRow } from './tarea-pasos';
+
+function p(over: Partial<PasoRow>): PasoRow {
+  return {
+    id: over.id ?? 'p-' + Math.random().toString(36).slice(2, 8),
+    tarea_id: 'tarea-x',
+    paso: over.paso ?? 'cotizacion',
+    monto: null,
+    documento_url: null,
+    fecha: null,
+    estado: 'pendiente',
+    notas: null,
+    ...over,
+  };
+}
+
+describe('computeAvanceTarea (Sprint 3)', () => {
+  it('sin pasos → 0%', () => {
+    expect(computeAvanceTarea([])).toBe(0);
+  });
+
+  it('todos pendientes → 0%', () => {
+    expect(
+      computeAvanceTarea([
+        p({ paso: 'cotizacion' }),
+        p({ paso: 'factura' }),
+        p({ paso: 'pago' }),
+        p({ paso: 'resultado' }),
+      ])
+    ).toBe(0);
+  });
+
+  it('1 de 4 hechos → 25%', () => {
+    expect(
+      computeAvanceTarea([
+        p({ paso: 'cotizacion', estado: 'hecho' }),
+        p({ paso: 'factura' }),
+        p({ paso: 'pago' }),
+        p({ paso: 'resultado' }),
+      ])
+    ).toBe(25);
+  });
+
+  it('todos hechos → 100%', () => {
+    expect(
+      computeAvanceTarea([
+        p({ paso: 'cotizacion', estado: 'hecho' }),
+        p({ paso: 'factura', estado: 'hecho' }),
+        p({ paso: 'pago', estado: 'hecho' }),
+        p({ paso: 'resultado', estado: 'hecho' }),
+      ])
+    ).toBe(100);
+  });
+
+  it('"no_aplica" se saca del denominador', () => {
+    // 1 hecho de 1 aplicable (3 son N/A) → 100%
+    expect(
+      computeAvanceTarea([
+        p({ paso: 'cotizacion', estado: 'no_aplica' }),
+        p({ paso: 'factura', estado: 'no_aplica' }),
+        p({ paso: 'pago', estado: 'no_aplica' }),
+        p({ paso: 'resultado', estado: 'hecho' }),
+      ])
+    ).toBe(100);
+  });
+
+  it('todos N/A → 0%', () => {
+    expect(
+      computeAvanceTarea([
+        p({ paso: 'cotizacion', estado: 'no_aplica' }),
+        p({ paso: 'factura', estado: 'no_aplica' }),
+        p({ paso: 'pago', estado: 'no_aplica' }),
+        p({ paso: 'resultado', estado: 'no_aplica' }),
+      ])
+    ).toBe(0);
+  });
+
+  it('redondea a entero', () => {
+    // 2 hechos de 3 aplicables = 66.66... → 67
+    expect(
+      computeAvanceTarea([
+        p({ paso: 'cotizacion', estado: 'hecho' }),
+        p({ paso: 'factura', estado: 'hecho' }),
+        p({ paso: 'pago' }),
+        p({ paso: 'resultado', estado: 'no_aplica' }),
+      ])
+    ).toBe(67);
+  });
+});
+
+describe('sumMontosPasos (Sprint 3)', () => {
+  it('suma solo los 3 financieros, excluye resultado', () => {
+    const pasos = [
+      p({ paso: 'cotizacion', monto: 1000 }),
+      p({ paso: 'factura', monto: 1000 }),
+      p({ paso: 'pago', monto: 1000 }),
+      p({ paso: 'resultado', monto: 9999 }), // ignorado
+    ];
+    expect(sumMontosPasos(pasos)).toBe(3000);
+  });
+
+  it('null/undefined no contribuyen', () => {
+    expect(
+      sumMontosPasos([p({ paso: 'cotizacion', monto: null }), p({ paso: 'factura', monto: 500 })])
+    ).toBe(500);
+  });
+
+  it('sin pasos → 0', () => {
+    expect(sumMontosPasos([])).toBe(0);
+  });
+});

--- a/components/dilesa/tarea-pasos.test.ts
+++ b/components/dilesa/tarea-pasos.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { computeAvanceTarea, sumMontosPasos, type PasoRow } from './tarea-pasos';
+import {
+  computeAvanceTarea,
+  estadoVisualDePaso,
+  pasoRequiereAutorizacion,
+  sumMontosPasos,
+  type PasoRow,
+} from './tarea-pasos';
 
 function p(over: Partial<PasoRow>): PasoRow {
   return {
@@ -11,6 +17,8 @@ function p(over: Partial<PasoRow>): PasoRow {
     fecha: null,
     estado: 'pendiente',
     notas: null,
+    autorizado_at: null,
+    autorizado_por: null,
     ...over,
   };
 }
@@ -108,5 +116,48 @@ describe('sumMontosPasos (Sprint 3)', () => {
 
   it('sin pasos → 0', () => {
     expect(sumMontosPasos([])).toBe(0);
+  });
+});
+
+describe('pasoRequiereAutorizacion (Sprint 3.5)', () => {
+  it('cotizacion requiere autorización', () => {
+    expect(pasoRequiereAutorizacion('cotizacion')).toBe(true);
+  });
+  it('factura/pago/resultado NO requieren autorización en v1', () => {
+    expect(pasoRequiereAutorizacion('factura')).toBe(false);
+    expect(pasoRequiereAutorizacion('pago')).toBe(false);
+    expect(pasoRequiereAutorizacion('resultado')).toBe(false);
+  });
+});
+
+describe('estadoVisualDePaso (Sprint 3.5)', () => {
+  it('pendiente → pendiente', () => {
+    expect(estadoVisualDePaso(p({ paso: 'cotizacion', estado: 'pendiente' }))).toBe('pendiente');
+  });
+
+  it('no_aplica → no_aplica', () => {
+    expect(estadoVisualDePaso(p({ paso: 'cotizacion', estado: 'no_aplica' }))).toBe('no_aplica');
+  });
+
+  it('paso que requiere autorización + hecho + sin autorizado_at → esperando_autorizacion', () => {
+    expect(
+      estadoVisualDePaso(p({ paso: 'cotizacion', estado: 'hecho', autorizado_at: null }))
+    ).toBe('esperando_autorizacion');
+  });
+
+  it('paso que requiere autorización + hecho + autorizado_at set → autorizado', () => {
+    expect(
+      estadoVisualDePaso(
+        p({ paso: 'cotizacion', estado: 'hecho', autorizado_at: '2026-05-29T12:00:00Z' })
+      )
+    ).toBe('autorizado');
+  });
+
+  it('factura hecho → hecho (no requiere autorización en v1)', () => {
+    expect(estadoVisualDePaso(p({ paso: 'factura', estado: 'hecho' }))).toBe('hecho');
+  });
+
+  it('resultado hecho → hecho', () => {
+    expect(estadoVisualDePaso(p({ paso: 'resultado', estado: 'hecho' }))).toBe('hecho');
   });
 });

--- a/components/dilesa/tarea-pasos.tsx
+++ b/components/dilesa/tarea-pasos.tsx
@@ -1,21 +1,25 @@
 'use client';
 
 /**
- * `<TareaPasos>` — grid 2×2 con los 4 pasos canónicos de una tarea.
+ * `<TareaPasos>` — grid 1×4 horizontal con los 4 pasos canónicos.
  *
  * Sprint 3 de `dilesa-proyectos-checklist-inline`. Cada celda captura
  * monto + documento + fecha + estado (pendiente/hecho/N/A) + notas
  * para uno de los pasos: cotizacion · factura · pago · resultado.
+ *
+ * Sprint 3.5 (refactor 2026-05-29): el grid pasa de 2×2 a 1×4 para
+ * aprovechar pantallas anchas (en mobile/tablet se apila). Botón
+ * "Autorizar" en el paso cotización gateado por rol director.
  *
  * Se monta dentro del expand de `<TareasChecklist>` (1 fila por tarea
  * cuando está colapsada; este grid aparece debajo al hacer click).
  */
 
 import { useEffect, useState, useTransition } from 'react';
-import { Check, Circle, FileText, Minus } from 'lucide-react';
+import { Check, Circle, FileText, Minus, ShieldCheck } from 'lucide-react';
 import { FileAttachments } from '@/components/file-attachments/file-attachments';
 import { Badge } from '@/components/ui/badge';
-import { upsertPaso } from '@/app/dilesa/proyectos/anteproyectos/actions';
+import { autorizarPaso, upsertPaso } from '@/app/dilesa/proyectos/anteproyectos/actions';
 import {
   type PasoEstado,
   type TareaPaso,
@@ -39,7 +43,41 @@ export type PasoRow = {
   fecha: string | null;
   estado: PasoEstado;
   notas: string | null;
+  autorizado_at: string | null;
+  autorizado_por: string | null;
 };
+
+/**
+ * Pasos que requieren autorización adicional (rol director/admin).
+ * v1: solo `cotizacion`. Extender si Beto pide para factura/pago.
+ */
+const PASOS_REQUIEREN_AUTORIZACION: ReadonlySet<TareaPaso> = new Set(['cotizacion']);
+
+export function pasoRequiereAutorizacion(paso: TareaPaso): boolean {
+  return PASOS_REQUIEREN_AUTORIZACION.has(paso);
+}
+
+/**
+ * "Estado visual" del paso, derivado del estado + autorización.
+ * Útil para la mini visualización en la fila compacta y para el badge
+ * del header de cada celda.
+ */
+export type EstadoVisual =
+  | 'pendiente'
+  | 'hecho'
+  | 'esperando_autorizacion'
+  | 'autorizado'
+  | 'no_aplica';
+
+export function estadoVisualDePaso(p: PasoRow): EstadoVisual {
+  if (p.estado === 'no_aplica') return 'no_aplica';
+  if (p.estado === 'pendiente') return 'pendiente';
+  // estado = 'hecho'
+  if (pasoRequiereAutorizacion(p.paso)) {
+    return p.autorizado_at ? 'autorizado' : 'esperando_autorizacion';
+  }
+  return 'hecho';
+}
 
 const PASO_LABEL: Record<TareaPaso, string> = {
   cotizacion: 'Cotización',
@@ -76,12 +114,16 @@ export function TareaPasos({
   pasos: pasosProp,
   empresaId,
   empresaSlug,
+  puedeAutorizar = false,
   onChange,
 }: {
   tareaId: string;
   pasos: readonly PasoRow[];
   empresaId: string;
   empresaSlug: EmpresaSlug;
+  /** Si true, el botón "Autorizar" se muestra en pasos pendientes de
+   *  autorización. Default false. El padre resuelve el rol del usuario. */
+  puedeAutorizar?: boolean;
   onChange?: () => void;
 }) {
   // Index por paso para acceso O(1). Si falta algún paso lo tratamos
@@ -89,7 +131,7 @@ export function TareaPasos({
   const byPaso = new Map(pasosProp.map((p) => [p.paso, p]));
 
   return (
-    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
       {TAREA_PASOS_VALIDOS.map((paso) => (
         <PasoCard
           key={paso}
@@ -98,6 +140,7 @@ export function TareaPasos({
           row={byPaso.get(paso) ?? null}
           empresaId={empresaId}
           empresaSlug={empresaSlug}
+          puedeAutorizar={puedeAutorizar}
           onChange={onChange}
         />
       ))}
@@ -111,6 +154,7 @@ function PasoCard({
   row,
   empresaId,
   empresaSlug,
+  puedeAutorizar,
   onChange,
 }: {
   tareaId: string;
@@ -118,6 +162,7 @@ function PasoCard({
   row: PasoRow | null;
   empresaId: string;
   empresaSlug: EmpresaSlug;
+  puedeAutorizar: boolean;
   onChange?: () => void;
 }) {
   const [pending, startTransition] = useTransition();
@@ -173,28 +218,48 @@ function PasoCard({
     guardar({ estado: next });
   };
 
+  const handleAutorizar = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await autorizarPaso(tareaId, paso);
+      if (!r.ok) setError(r.error);
+      else onChange?.();
+    });
+  };
+
   const isNoAplica = estado === 'no_aplica';
   const isHecho = estado === 'hecho';
+  const requiereAut = pasoRequiereAutorizacion(paso);
+  const yaAutorizado = !!row?.autorizado_at;
+  const esperandoAut = requiereAut && isHecho && !yaAutorizado;
+
+  // Tonalidad del card según estado visual.
+  const cardTone = isNoAplica
+    ? 'border-[var(--border)] bg-[var(--card)]/30 opacity-50'
+    : esperandoAut
+      ? 'border-amber-300 bg-amber-50/40'
+      : yaAutorizado
+        ? 'border-emerald-300 bg-emerald-50/50'
+        : isHecho
+          ? 'border-emerald-200 bg-emerald-50/40'
+          : 'border-[var(--border)] bg-[var(--bg)]';
 
   return (
-    <div
-      className={`rounded-md border p-3 transition-colors ${
-        isNoAplica
-          ? 'border-[var(--border)] bg-[var(--card)]/30 opacity-50'
-          : isHecho
-            ? 'border-emerald-200 bg-emerald-50/40'
-            : 'border-[var(--border)] bg-[var(--bg)]'
-      }`}
-    >
-      <div className="mb-2 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold uppercase tracking-wide text-[var(--text)]/70">
+    <div className={`rounded-md border p-3 transition-colors ${cardTone}`}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate text-xs font-semibold uppercase tracking-wide text-[var(--text)]/70">
             {PASO_LABEL[paso]}
           </span>
           {partidaSugerida && (
             <Badge tone="neutral">
               <span className="text-[10px] normal-case">→ {partidaSugerida}</span>
             </Badge>
+          )}
+          {yaAutorizado && (
+            <span title="Autorizado por dirección">
+              <ShieldCheck className="h-3 w-3 text-emerald-600" aria-label="Autorizado" />
+            </span>
           )}
         </div>
         <div className="flex items-center gap-0.5">
@@ -290,6 +355,31 @@ function PasoCard({
             <p className="text-[10px] tabular-nums text-[var(--text)]/60">
               {moneyFmt.format(row.monto)}
               {row.fecha ? ` · ${row.fecha}` : ''}
+            </p>
+          )}
+
+          {esperandoAut && (
+            <div className="mt-1 rounded-md border border-amber-300 bg-amber-100/60 px-2 py-1.5 text-[11px] text-amber-900">
+              <div className="font-medium">Esperando autorización</div>
+              {puedeAutorizar ? (
+                <button
+                  type="button"
+                  onClick={handleAutorizar}
+                  disabled={pending}
+                  className="mt-1 inline-flex h-6 items-center gap-1 rounded border border-amber-400 bg-amber-200 px-2 text-[11px] font-medium text-amber-900 hover:bg-amber-300 disabled:opacity-50"
+                >
+                  <ShieldCheck className="h-3 w-3" />
+                  {pending ? 'Autorizando…' : 'Autorizar'}
+                </button>
+              ) : (
+                <span className="text-amber-800/70">Requiere rol de dirección.</span>
+              )}
+            </div>
+          )}
+
+          {yaAutorizado && row?.autorizado_at && (
+            <p className="text-[10px] text-emerald-700">
+              Autorizado {row.autorizado_at.slice(0, 10)}
             </p>
           )}
         </div>

--- a/components/dilesa/tarea-pasos.tsx
+++ b/components/dilesa/tarea-pasos.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+/**
+ * `<TareaPasos>` — grid 2×2 con los 4 pasos canónicos de una tarea.
+ *
+ * Sprint 3 de `dilesa-proyectos-checklist-inline`. Cada celda captura
+ * monto + documento + fecha + estado (pendiente/hecho/N/A) + notas
+ * para uno de los pasos: cotizacion · factura · pago · resultado.
+ *
+ * Se monta dentro del expand de `<TareasChecklist>` (1 fila por tarea
+ * cuando está colapsada; este grid aparece debajo al hacer click).
+ */
+
+import { useEffect, useState, useTransition } from 'react';
+import { Check, Circle, FileText, Minus } from 'lucide-react';
+import { FileAttachments } from '@/components/file-attachments/file-attachments';
+import { Badge } from '@/components/ui/badge';
+import { upsertPaso } from '@/app/dilesa/proyectos/anteproyectos/actions';
+import {
+  type PasoEstado,
+  type TareaPaso,
+  TAREA_PASOS_VALIDOS,
+  PASO_TO_PARTIDA_ESTADO,
+} from './tareas-checklist-types';
+import type { EmpresaSlug } from '@/lib/storage';
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+export type PasoRow = {
+  id: string;
+  tarea_id: string;
+  paso: TareaPaso;
+  monto: number | null;
+  documento_url: string | null;
+  fecha: string | null;
+  estado: PasoEstado;
+  notas: string | null;
+};
+
+const PASO_LABEL: Record<TareaPaso, string> = {
+  cotizacion: 'Cotización',
+  factura: 'Factura',
+  pago: 'Pago',
+  resultado: 'Resultado',
+};
+
+/**
+ * Calcula el avance % de una tarea: hechos / aplicables × 100.
+ * Aplicables = pasos cuyo estado ≠ 'no_aplica'. Si no hay pasos
+ * instanciados, devuelve 0. Exportado para tests.
+ */
+export function computeAvanceTarea(pasos: readonly PasoRow[]): number {
+  const aplicables = pasos.filter((p) => p.estado !== 'no_aplica');
+  if (aplicables.length === 0) return 0;
+  const hechos = aplicables.filter((p) => p.estado === 'hecho').length;
+  return Math.round((100 * hechos) / aplicables.length);
+}
+
+/**
+ * Suma los montos capturados en los pasos financieros (cotización +
+ * factura + pago). Útil para mostrar "$ acum." en la fila compacta.
+ */
+export function sumMontosPasos(pasos: readonly PasoRow[]): number {
+  return pasos.reduce((acc, p) => {
+    if (p.paso === 'resultado') return acc;
+    return acc + (p.monto ?? 0);
+  }, 0);
+}
+
+export function TareaPasos({
+  tareaId,
+  pasos: pasosProp,
+  empresaId,
+  empresaSlug,
+  onChange,
+}: {
+  tareaId: string;
+  pasos: readonly PasoRow[];
+  empresaId: string;
+  empresaSlug: EmpresaSlug;
+  onChange?: () => void;
+}) {
+  // Index por paso para acceso O(1). Si falta algún paso lo tratamos
+  // como pendiente vacío (la UI permite capturar y el upsert lo crea).
+  const byPaso = new Map(pasosProp.map((p) => [p.paso, p]));
+
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+      {TAREA_PASOS_VALIDOS.map((paso) => (
+        <PasoCard
+          key={paso}
+          tareaId={tareaId}
+          paso={paso}
+          row={byPaso.get(paso) ?? null}
+          empresaId={empresaId}
+          empresaSlug={empresaSlug}
+          onChange={onChange}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PasoCard({
+  tareaId,
+  paso,
+  row,
+  empresaId,
+  empresaSlug,
+  onChange,
+}: {
+  tareaId: string;
+  paso: TareaPaso;
+  row: PasoRow | null;
+  empresaId: string;
+  empresaSlug: EmpresaSlug;
+  onChange?: () => void;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [montoLocal, setMontoLocal] = useState(row?.monto != null ? String(row.monto) : '');
+  const [fechaLocal, setFechaLocal] = useState(row?.fecha ?? '');
+
+  // Sincroniza estado local cuando el prop cambia (refresh externo).
+  useEffect(() => {
+    let activo = true;
+    void Promise.resolve().then(() => {
+      if (!activo) return;
+      setMontoLocal(row?.monto != null ? String(row.monto) : '');
+      setFechaLocal(row?.fecha ?? '');
+    });
+    return () => {
+      activo = false;
+    };
+  }, [row?.monto, row?.fecha]);
+
+  const estado: PasoEstado = row?.estado ?? 'pendiente';
+  const esFinanciero = paso !== 'resultado';
+  const partidaSugerida = PASO_TO_PARTIDA_ESTADO[paso];
+
+  const guardar = (patch: Parameters<typeof upsertPaso>[2]) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await upsertPaso(tareaId, paso, patch);
+      if (!r.ok) setError(r.error);
+      else onChange?.();
+    });
+  };
+
+  const handleMontoBlur = () => {
+    const trimmed = montoLocal.trim();
+    const parsed = trimmed === '' ? null : Number(trimmed);
+    if (parsed != null && (!Number.isFinite(parsed) || parsed < 0)) {
+      setError('Monto debe ser número ≥ 0');
+      return;
+    }
+    if (parsed === (row?.monto ?? null)) return;
+    guardar({ monto: parsed });
+  };
+
+  const handleFechaBlur = () => {
+    const next = fechaLocal === '' ? null : fechaLocal;
+    if (next === (row?.fecha ?? null)) return;
+    guardar({ fecha: next });
+  };
+
+  const handleEstadoToggle = (next: PasoEstado) => {
+    if (next === estado) return;
+    guardar({ estado: next });
+  };
+
+  const isNoAplica = estado === 'no_aplica';
+  const isHecho = estado === 'hecho';
+
+  return (
+    <div
+      className={`rounded-md border p-3 transition-colors ${
+        isNoAplica
+          ? 'border-[var(--border)] bg-[var(--card)]/30 opacity-50'
+          : isHecho
+            ? 'border-emerald-200 bg-emerald-50/40'
+            : 'border-[var(--border)] bg-[var(--bg)]'
+      }`}
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-[var(--text)]/70">
+            {PASO_LABEL[paso]}
+          </span>
+          {partidaSugerida && (
+            <Badge tone="neutral">
+              <span className="text-[10px] normal-case">→ {partidaSugerida}</span>
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-0.5">
+          <EstadoButton
+            current={estado}
+            target="pendiente"
+            label="Pendiente"
+            icon={<Circle className="h-3 w-3" />}
+            disabled={pending}
+            onClick={() => handleEstadoToggle('pendiente')}
+          />
+          <EstadoButton
+            current={estado}
+            target="hecho"
+            label="Hecho"
+            icon={<Check className="h-3 w-3" />}
+            disabled={pending}
+            onClick={() => handleEstadoToggle('hecho')}
+          />
+          <EstadoButton
+            current={estado}
+            target="no_aplica"
+            label="N/A"
+            icon={<Minus className="h-3 w-3" />}
+            disabled={pending}
+            onClick={() => handleEstadoToggle('no_aplica')}
+          />
+        </div>
+      </div>
+
+      {!isNoAplica && (
+        <div className="space-y-2">
+          {esFinanciero && (
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                inputMode="decimal"
+                step="0.01"
+                value={montoLocal}
+                onChange={(e) => setMontoLocal(e.target.value)}
+                onBlur={handleMontoBlur}
+                disabled={pending}
+                placeholder="$ —"
+                className="h-7 flex-1 rounded-md border border-[var(--border)] bg-[var(--bg)] px-2 text-right text-xs tabular-nums focus:border-[var(--accent)] focus:outline-none disabled:opacity-50"
+                aria-label={`Monto de ${PASO_LABEL[paso]}`}
+              />
+              <input
+                type="date"
+                value={fechaLocal}
+                onChange={(e) => setFechaLocal(e.target.value)}
+                onBlur={handleFechaBlur}
+                disabled={pending}
+                className="h-7 rounded-md border border-[var(--border)] bg-[var(--bg)] px-2 text-xs focus:border-[var(--accent)] focus:outline-none disabled:opacity-50"
+                aria-label={`Fecha de ${PASO_LABEL[paso]}`}
+              />
+            </div>
+          )}
+
+          {!esFinanciero && (
+            <input
+              type="date"
+              value={fechaLocal}
+              onChange={(e) => setFechaLocal(e.target.value)}
+              onBlur={handleFechaBlur}
+              disabled={pending}
+              className="h-7 w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-2 text-xs focus:border-[var(--accent)] focus:outline-none disabled:opacity-50"
+              aria-label={`Fecha de entrega del resultado`}
+            />
+          )}
+
+          <div className="rounded border border-dashed border-[var(--border)] bg-[var(--bg)] p-1">
+            <FileAttachments
+              empresaId={empresaId}
+              empresaSlug={empresaSlug}
+              entidad="proyecto_tarea_pasos"
+              entidadId={row?.id ?? ''}
+              roles={[
+                { id: paso, label: PASO_LABEL[paso], icon: <FileText className="h-3 w-3" /> },
+              ]}
+              defaultUploadRole={paso}
+              variant="flat"
+              readOnly={!row?.id}
+              onChange={onChange}
+            />
+            {!row?.id && (
+              <p className="px-1 text-[10px] text-[var(--text)]/50">
+                Captura monto o estado primero para habilitar subida de archivos.
+              </p>
+            )}
+          </div>
+
+          {esFinanciero && row?.monto != null && row.monto > 0 && (
+            <p className="text-[10px] tabular-nums text-[var(--text)]/60">
+              {moneyFmt.format(row.monto)}
+              {row.fecha ? ` · ${row.fecha}` : ''}
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && <p className="mt-2 text-[11px] text-red-600/80">{error}</p>}
+    </div>
+  );
+}
+
+function EstadoButton({
+  current,
+  target,
+  label,
+  icon,
+  disabled,
+  onClick,
+}: {
+  current: PasoEstado;
+  target: PasoEstado;
+  label: string;
+  icon: React.ReactNode;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  const active = current === target;
+  const tone =
+    target === 'hecho'
+      ? active
+        ? 'bg-emerald-100 text-emerald-700'
+        : 'text-[var(--text)]/40 hover:bg-emerald-50 hover:text-emerald-600'
+      : target === 'no_aplica'
+        ? active
+          ? 'bg-[var(--card)] text-[var(--text)]/70'
+          : 'text-[var(--text)]/40 hover:bg-[var(--card)]'
+        : active
+          ? 'bg-[var(--card)] text-[var(--text)]'
+          : 'text-[var(--text)]/40 hover:bg-[var(--card)]';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || active}
+      title={label}
+      aria-label={label}
+      className={`inline-flex h-6 w-6 items-center justify-center rounded transition-colors disabled:cursor-default ${tone}`}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/components/dilesa/tareas-checklist-types.ts
+++ b/components/dilesa/tareas-checklist-types.ts
@@ -37,6 +37,39 @@ export const PARTIDA_ESTADOS_VALIDOS = [
 export type PartidaEstado = (typeof PARTIDA_ESTADOS_VALIDOS)[number];
 
 /**
+ * Pasos canónicos del ciclo de vida operativo de una tarea (Sprint 3).
+ * Cada tarea instancia los 4 pasos al crearse; el operador marca
+ * `no_aplica` los que no apliquen para su flujo específico.
+ */
+export const TAREA_PASOS_VALIDOS = ['cotizacion', 'factura', 'pago', 'resultado'] as const;
+export type TareaPaso = (typeof TAREA_PASOS_VALIDOS)[number];
+
+/**
+ * Estados válidos de `dilesa.proyecto_tarea_pasos.estado`. `no_aplica`
+ * saca al paso del denominador del avance.
+ */
+export const PASO_ESTADOS_VALIDOS = ['pendiente', 'hecho', 'no_aplica'] as const;
+export type PasoEstado = (typeof PASO_ESTADOS_VALIDOS)[number];
+
+/**
+ * Mapping del paso canónico al estado de la partida presupuestal
+ * vinculada (auto-flujo D4). Cuando un paso pasa a `hecho`, la partida
+ * se mueve al estado correspondiente:
+ *
+ *   cotizacion → preliminar (monto_estimado = monto del paso)
+ *   factura    → autorizada (monto_aprobado = monto del paso)
+ *   pago       → en_ejercicio (monto_ejercido = monto del paso)
+ *   resultado  → (no toca partida, cierra el ciclo cuando los 3
+ *                financieros aplicables están hechos)
+ */
+export const PASO_TO_PARTIDA_ESTADO: Record<TareaPaso, PartidaEstado | null> = {
+  cotizacion: 'preliminar',
+  factura: 'autorizada',
+  pago: 'en_ejercicio',
+  resultado: null,
+};
+
+/**
  * Detecta si una tarea es de cotización. Las tareas canónicas vienen
  * con `tipo='Cotización'` en el catálogo (las 3 tareas de cotización
  * son: Urbanización / Construcción / Comercialización con

--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -20,20 +20,11 @@
  */
 
 import { Fragment, useCallback, useEffect, useMemo, useState, useTransition } from 'react';
-import { ChevronRight, FileText, MessageSquare, Paperclip } from 'lucide-react';
+import { ChevronRight, MessageSquare, Paperclip } from 'lucide-react';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
-import { FileAttachments } from '@/components/file-attachments/file-attachments';
-import {
-  updateTareaDocumento,
-  updateTareaEstado,
-  updateTareaMonto,
-  updateTareaNotas,
-} from '@/app/dilesa/proyectos/anteproyectos/actions';
-import {
-  TAREA_ESTADOS_VALIDOS,
-  type TareaEstado,
-  esTareaCotizacion,
-} from './tareas-checklist-types';
+import { updateTareaEstado, updateTareaNotas } from '@/app/dilesa/proyectos/anteproyectos/actions';
+import { TAREA_ESTADOS_VALIDOS, type TareaEstado } from './tareas-checklist-types';
+import { TareaPasos, type PasoRow, computeAvanceTarea, sumMontosPasos } from './tarea-pasos';
 import type { EmpresaSlug } from '@/lib/storage';
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -66,6 +57,8 @@ export type TareaDependencia = {
   depende_de_tarea_id: string;
 };
 
+export type { PasoRow } from './tarea-pasos';
+
 const ESTADO_TONE: Record<string, BadgeTone> = {
   pendiente: 'neutral',
   bloqueada: 'warning',
@@ -87,9 +80,12 @@ const OBLIG_TONE: Record<string, BadgeTone> = {
   condicional: 'info',
 };
 
-function esCotizacion(t: TareaChecklistRow): boolean {
-  return esTareaCotizacion(t.tipo_snapshot, t.subtipo_snapshot);
-}
+const moneyFmtCompact = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
 
 /**
  * Formatea una fecha ISO (YYYY-MM-DD) en formato compacto "dd/mmm" para
@@ -126,12 +122,14 @@ export function computeBloqueadasMap(
 export function TareasChecklist({
   tareas: tareasInicial,
   dependencias,
+  pasos,
   empresaId,
   empresaSlug,
   onChange,
 }: {
   tareas: readonly TareaChecklistRow[];
   dependencias: readonly TareaDependencia[];
+  pasos: readonly PasoRow[];
   empresaId: string;
   empresaSlug: EmpresaSlug;
   onChange?: () => void;
@@ -160,6 +158,16 @@ export function TareasChecklist({
     [tareas, dependencias]
   );
 
+  const pasosPorTarea = useMemo(() => {
+    const m = new Map<string, PasoRow[]>();
+    for (const p of pasos) {
+      const arr = m.get(p.tarea_id) ?? [];
+      arr.push(p);
+      m.set(p.tarea_id, arr);
+    }
+    return m;
+  }, [pasos]);
+
   const patchLocal = useCallback((id: string, patch: Partial<TareaChecklistRow>) => {
     setTareas((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
   }, []);
@@ -187,10 +195,8 @@ export function TareasChecklist({
               <th className="px-3 py-2 text-left">Tarea</th>
               <th className="w-36 px-2 py-2 text-left">Estado</th>
               <th className="w-20 px-2 py-2 text-left">Vence</th>
-              <th className="w-36 px-2 py-2 text-right">Monto</th>
-              <th className="w-12 px-2 py-2 text-center" aria-label="Documento">
-                <Paperclip className="mx-auto h-3.5 w-3.5" />
-              </th>
+              <th className="w-16 px-2 py-2 text-right">Avance</th>
+              <th className="w-24 px-2 py-2 text-right">$ acum.</th>
               <th className="w-12 px-2 py-2 text-center" aria-label="Notas">
                 <MessageSquare className="mx-auto h-3.5 w-3.5" />
               </th>
@@ -201,6 +207,7 @@ export function TareasChecklist({
               <Fragment key={t.id}>
                 <TareaRowCompact
                   tarea={t}
+                  pasos={pasosPorTarea.get(t.id) ?? []}
                   orden={idx + 1}
                   bloqueadaPor={bloqueadasMap.get(t.id) ?? []}
                   expanded={expandedId === t.id}
@@ -212,6 +219,7 @@ export function TareasChecklist({
                 {expandedId === t.id && (
                   <TareaRowExpanded
                     tarea={t}
+                    pasos={pasosPorTarea.get(t.id) ?? []}
                     bloqueadaPor={bloqueadasMap.get(t.id) ?? []}
                     empresaId={empresaId}
                     empresaSlug={empresaSlug}
@@ -233,6 +241,7 @@ export function TareasChecklist({
 
 function TareaRowCompact({
   tarea,
+  pasos,
   orden,
   bloqueadaPor,
   expanded,
@@ -242,6 +251,7 @@ function TareaRowCompact({
   onChange,
 }: {
   tarea: TareaChecklistRow;
+  pasos: readonly PasoRow[];
   orden: number;
   bloqueadaPor: string[];
   expanded: boolean;
@@ -251,27 +261,12 @@ function TareaRowCompact({
   onChange?: () => void;
 }) {
   const [pending, startTransition] = useTransition();
-  const [montoLocal, setMontoLocal] = useState(
-    tarea.resultado_monto != null ? String(tarea.resultado_monto) : ''
-  );
 
-  // Sincroniza el input si el padre cambia el monto externamente (refresh).
-  // setState va dentro de microtask para no triggerear cascada (regla del repo).
-  useEffect(() => {
-    let activo = true;
-    void Promise.resolve().then(() => {
-      if (!activo) return;
-      setMontoLocal(tarea.resultado_monto != null ? String(tarea.resultado_monto) : '');
-    });
-    return () => {
-      activo = false;
-    };
-  }, [tarea.resultado_monto]);
+  const avance = useMemo(() => computeAvanceTarea(pasos), [pasos]);
+  const montoAcum = useMemo(() => sumMontosPasos(pasos), [pasos]);
 
-  const esCot = esCotizacion(tarea);
-  const tieneDoc = !!tarea.resultado_documento_url;
   const tieneNotas = !!(tarea.descripcion && tarea.descripcion.trim() !== '');
-  const completada = tarea.estado === 'completada';
+  const completada = tarea.estado === 'completada' || avance === 100;
 
   const handleEstadoChange = useCallback(
     (next: TareaEstado) => {
@@ -293,29 +288,6 @@ function TareaRowCompact({
     },
     [tarea.id, tarea.estado, onPatch, onError, onChange]
   );
-
-  const handleMontoBlur = useCallback(() => {
-    const trimmed = montoLocal.trim();
-    const parsed = trimmed === '' ? null : Number(trimmed);
-    if (parsed != null && (!Number.isFinite(parsed) || parsed < 0)) {
-      onError('Monto debe ser número ≥ 0');
-      return;
-    }
-    if (parsed === tarea.resultado_monto) return;
-    const prev = tarea.resultado_monto;
-    onPatch(tarea.id, { resultado_monto: parsed });
-    startTransition(async () => {
-      const r = await updateTareaMonto(tarea.id, parsed);
-      if (!r.ok) {
-        onPatch(tarea.id, { resultado_monto: prev });
-        setMontoLocal(prev != null ? String(prev) : '');
-        onError(r.error);
-      } else {
-        onError(null);
-        onChange?.();
-      }
-    });
-  }, [montoLocal, tarea.id, tarea.resultado_monto, onPatch, onError, onChange]);
 
   return (
     <tr
@@ -384,35 +356,14 @@ function TareaRowCompact({
         {fmtFechaCorta(tarea.fecha_objetivo_fin)}
       </td>
       <td className="px-2 py-1.5 text-right">
-        {esCot ? (
-          <input
-            type="number"
-            inputMode="decimal"
-            step="0.01"
-            value={montoLocal}
-            onChange={(e) => setMontoLocal(e.target.value)}
-            onBlur={handleMontoBlur}
-            onClick={(e) => e.stopPropagation()}
-            disabled={pending}
-            placeholder="$ —"
-            className="h-7 w-full rounded-md border border-[var(--border)] bg-[var(--bg)] px-2 text-right text-xs tabular-nums focus:border-[var(--accent)] focus:outline-none disabled:opacity-50"
-            aria-label={`Monto cotizado de ${tarea.titulo}`}
-          />
-        ) : (
-          <span className="text-xs text-[var(--text)]/30">—</span>
-        )}
+        <AvanceBar pct={avance} />
       </td>
-      <td className="px-2 py-1.5 text-center">
-        <button
-          type="button"
-          onClick={() => onToggleExpand(tarea.id)}
-          className="inline-flex h-6 w-6 items-center justify-center rounded hover:bg-[var(--card)]"
-          aria-label={tieneDoc ? 'Ver documento' : 'Subir documento'}
-        >
-          <Paperclip
-            className={`h-3.5 w-3.5 ${tieneDoc ? 'text-[var(--accent)]' : 'text-[var(--text)]/25'}`}
-          />
-        </button>
+      <td className="px-2 py-1.5 text-right text-xs tabular-nums text-[var(--text)]/70">
+        {montoAcum > 0 ? (
+          moneyFmtCompact.format(montoAcum)
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        )}
       </td>
       <td className="px-2 py-1.5 text-center">
         <button
@@ -436,6 +387,7 @@ function TareaRowCompact({
 
 function TareaRowExpanded({
   tarea,
+  pasos,
   bloqueadaPor,
   empresaId,
   empresaSlug,
@@ -444,6 +396,7 @@ function TareaRowExpanded({
   onChange,
 }: {
   tarea: TareaChecklistRow;
+  pasos: readonly PasoRow[];
   bloqueadaPor: string[];
   empresaId: string;
   empresaSlug: EmpresaSlug;
@@ -465,9 +418,6 @@ function TareaRowExpanded({
     };
   }, [tarea.descripcion]);
 
-  const requiereArchivo = !!tarea.requiere_archivo_snapshot;
-  const esCot = esCotizacion(tarea);
-
   const handleNotasBlur = useCallback(() => {
     const next = notasLocal.trim() === '' ? null : notasLocal;
     if (next === tarea.descripcion) return;
@@ -486,26 +436,10 @@ function TareaRowExpanded({
     });
   }, [notasLocal, tarea.id, tarea.descripcion, onPatch, onError, onChange]);
 
-  const handleLimpiarDocumento = useCallback(() => {
-    const prev = tarea.resultado_documento_url;
-    onPatch(tarea.id, { resultado_documento_url: null });
-    startTransition(async () => {
-      const r = await updateTareaDocumento(tarea.id, null);
-      if (!r.ok) {
-        onPatch(tarea.id, { resultado_documento_url: prev });
-        onError(r.error);
-      } else {
-        onError(null);
-        onChange?.();
-      }
-    });
-  }, [tarea.id, tarea.resultado_documento_url, onPatch, onError, onChange]);
-
   return (
     <tr className="border-b border-[var(--border)]/60 bg-[var(--card)]/30">
       <td colSpan={7} className="px-3 py-3">
         <div className="space-y-3">
-          {/* Meta info: tipo · subtipo · entidad responsable · fechas largas */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[var(--text)]/60">
             {tarea.tipo_snapshot && (
               <span>
@@ -533,70 +467,13 @@ function TareaRowExpanded({
             </p>
           )}
 
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            {/* Documento(s) — siempre visible en expand, pero más prominente
-                cuando requiere_archivo. */}
-            <div>
-              <span className="mb-1 block text-[11px] uppercase tracking-wide text-[var(--text)]/50">
-                {requiereArchivo ? 'Documento requerido' : 'Documentos'}
-              </span>
-              <div className="rounded-md border border-[var(--border)] bg-[var(--bg)] p-2">
-                <FileAttachments
-                  empresaId={empresaId}
-                  empresaSlug={empresaSlug}
-                  entidad="proyecto_tareas"
-                  entidadId={tarea.id}
-                  roles={[
-                    {
-                      id: 'resultado',
-                      label: 'Resultado',
-                      icon: <FileText className="h-3 w-3" />,
-                    },
-                    { id: 'anexo', label: 'Anexo' },
-                  ]}
-                  defaultUploadRole="resultado"
-                  variant="flat"
-                  onChange={onChange}
-                />
-              </div>
-              {tarea.resultado_documento_url && (
-                <div className="mt-1 flex items-center gap-2 text-[11px]">
-                  <a
-                    href={tarea.resultado_documento_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-[var(--accent)] hover:underline"
-                  >
-                    URL legada
-                  </a>
-                  <button
-                    type="button"
-                    onClick={handleLimpiarDocumento}
-                    disabled={pending}
-                    className="text-[var(--text)]/50 hover:text-[var(--text)]"
-                  >
-                    Limpiar
-                  </button>
-                </div>
-              )}
-            </div>
-
-            {/* Resumen del monto cuando es cotización + número formateado.
-                El input está en la row compacta. */}
-            {esCot && tarea.resultado_monto != null && (
-              <div>
-                <span className="mb-1 block text-[11px] uppercase tracking-wide text-[var(--text)]/50">
-                  Monto capturado
-                </span>
-                <div className="rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 py-2 text-sm tabular-nums">
-                  {moneyFmt.format(tarea.resultado_monto)}
-                </div>
-                <span className="mt-1 block text-[11px] text-[var(--text)]/60">
-                  Genera una partida preliminar vinculada en el presupuesto.
-                </span>
-              </div>
-            )}
-          </div>
+          <TareaPasos
+            tareaId={tarea.id}
+            pasos={pasos}
+            empresaId={empresaId}
+            empresaSlug={empresaSlug}
+            onChange={onChange}
+          />
 
           <label className="block">
             <span className="mb-1 block text-[11px] uppercase tracking-wide text-[var(--text)]/50">
@@ -615,5 +492,27 @@ function TareaRowExpanded({
         </div>
       </td>
     </tr>
+  );
+}
+
+// ─── Avance bar (mini barra horizontal para columna de avance) ──────────────
+
+function AvanceBar({ pct }: { pct: number }) {
+  const safe = Math.max(0, Math.min(100, pct));
+  const tone =
+    safe === 100
+      ? 'bg-emerald-500'
+      : safe >= 50
+        ? 'bg-sky-500'
+        : safe > 0
+          ? 'bg-amber-500'
+          : 'bg-[var(--border)]';
+  return (
+    <div className="flex items-center justify-end gap-1.5">
+      <div className="h-1.5 w-12 overflow-hidden rounded-full bg-[var(--border)]/40">
+        <div className={`h-full ${tone}`} style={{ width: `${safe}%` }} />
+      </div>
+      <span className="text-xs tabular-nums text-[var(--text)]/70">{safe}%</span>
+    </div>
   );
 }

--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -24,7 +24,14 @@ import { ChevronRight, MessageSquare, Paperclip } from 'lucide-react';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
 import { updateTareaEstado, updateTareaNotas } from '@/app/dilesa/proyectos/anteproyectos/actions';
 import { TAREA_ESTADOS_VALIDOS, type TareaEstado } from './tareas-checklist-types';
-import { TareaPasos, type PasoRow, computeAvanceTarea, sumMontosPasos } from './tarea-pasos';
+import {
+  TareaPasos,
+  type PasoRow,
+  type EstadoVisual,
+  computeAvanceTarea,
+  estadoVisualDePaso,
+  sumMontosPasos,
+} from './tarea-pasos';
 import type { EmpresaSlug } from '@/lib/storage';
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -125,6 +132,7 @@ export function TareasChecklist({
   pasos,
   empresaId,
   empresaSlug,
+  puedeAutorizar = false,
   onChange,
 }: {
   tareas: readonly TareaChecklistRow[];
@@ -132,6 +140,7 @@ export function TareasChecklist({
   pasos: readonly PasoRow[];
   empresaId: string;
   empresaSlug: EmpresaSlug;
+  puedeAutorizar?: boolean;
   onChange?: () => void;
 }) {
   const tareasSource: readonly TareaChecklistRow[] = Array.isArray(tareasInicial)
@@ -193,8 +202,15 @@ export function TareasChecklist({
             <tr className="border-b border-[var(--border)]">
               <th className="w-8 px-2 py-2 text-center">#</th>
               <th className="px-3 py-2 text-left">Tarea</th>
+              <th className="hidden w-32 px-2 py-2 text-left lg:table-cell">Entidad</th>
               <th className="w-36 px-2 py-2 text-left">Estado</th>
               <th className="w-20 px-2 py-2 text-left">Vence</th>
+              <th className="w-28 px-2 py-2 text-center">
+                <span className="block">C · F · P · R</span>
+                <span className="block text-[9px] normal-case tracking-normal text-[var(--text)]/40">
+                  cotiz · factura · pago · result
+                </span>
+              </th>
               <th className="w-16 px-2 py-2 text-right">Avance</th>
               <th className="w-24 px-2 py-2 text-right">$ acum.</th>
               <th className="w-12 px-2 py-2 text-center" aria-label="Notas">
@@ -223,6 +239,7 @@ export function TareasChecklist({
                     bloqueadaPor={bloqueadasMap.get(t.id) ?? []}
                     empresaId={empresaId}
                     empresaSlug={empresaSlug}
+                    puedeAutorizar={puedeAutorizar}
                     onPatch={patchLocal}
                     onError={setError}
                     onChange={onChange}
@@ -328,6 +345,11 @@ function TareaRowCompact({
           )}
         </button>
       </td>
+      <td className="hidden px-2 py-1.5 text-xs text-[var(--text)]/70 lg:table-cell">
+        <span className="block truncate">
+          {tarea.entidad_responsable_snapshot ?? <span className="text-[var(--text)]/30">—</span>}
+        </span>
+      </td>
       <td className="px-2 py-1.5">
         <select
           value={tarea.estado}
@@ -354,6 +376,9 @@ function TareaRowCompact({
       </td>
       <td className="px-2 py-1.5 text-xs text-[var(--text)]/70 tabular-nums">
         {fmtFechaCorta(tarea.fecha_objetivo_fin)}
+      </td>
+      <td className="px-2 py-1.5 text-center">
+        <PasosMini pasos={pasos} />
       </td>
       <td className="px-2 py-1.5 text-right">
         <AvanceBar pct={avance} />
@@ -391,6 +416,7 @@ function TareaRowExpanded({
   bloqueadaPor,
   empresaId,
   empresaSlug,
+  puedeAutorizar,
   onPatch,
   onError,
   onChange,
@@ -400,6 +426,7 @@ function TareaRowExpanded({
   bloqueadaPor: string[];
   empresaId: string;
   empresaSlug: EmpresaSlug;
+  puedeAutorizar: boolean;
   onPatch: (id: string, patch: Partial<TareaChecklistRow>) => void;
   onError: (msg: string | null) => void;
   onChange?: () => void;
@@ -472,6 +499,7 @@ function TareaRowExpanded({
             pasos={pasos}
             empresaId={empresaId}
             empresaSlug={empresaSlug}
+            puedeAutorizar={puedeAutorizar}
             onChange={onChange}
           />
 
@@ -492,6 +520,60 @@ function TareaRowExpanded({
         </div>
       </td>
     </tr>
+  );
+}
+
+// ─── Mini visualización de pasos (4 cuadrados en la fila compacta) ──────────
+
+const PASO_ORDER: readonly ('cotizacion' | 'factura' | 'pago' | 'resultado')[] = [
+  'cotizacion',
+  'factura',
+  'pago',
+  'resultado',
+];
+
+const ESTADO_VISUAL_TONE: Record<EstadoVisual, string> = {
+  pendiente: 'bg-[var(--border)]/40 border-[var(--border)]',
+  hecho: 'bg-emerald-500 border-emerald-500',
+  esperando_autorizacion: 'bg-amber-400 border-amber-500',
+  autorizado: 'bg-emerald-600 border-emerald-600',
+  no_aplica: 'bg-transparent border-[var(--border)]/40 border-dashed',
+};
+
+const ESTADO_VISUAL_LABEL: Record<EstadoVisual, string> = {
+  pendiente: 'pendiente',
+  hecho: 'hecho',
+  esperando_autorizacion: 'esperando autorización',
+  autorizado: 'autorizado',
+  no_aplica: 'no aplica',
+};
+
+const PASO_SHORT_LABEL: Record<'cotizacion' | 'factura' | 'pago' | 'resultado', string> = {
+  cotizacion: 'C',
+  factura: 'F',
+  pago: 'P',
+  resultado: 'R',
+};
+
+function PasosMini({ pasos }: { pasos: readonly PasoRow[] }) {
+  const byPaso = new Map(pasos.map((p) => [p.paso, p]));
+  return (
+    <div className="inline-flex items-center gap-1">
+      {PASO_ORDER.map((paso) => {
+        const row = byPaso.get(paso);
+        const visual: EstadoVisual = row ? estadoVisualDePaso(row) : 'pendiente';
+        return (
+          <span
+            key={paso}
+            title={`${PASO_SHORT_LABEL[paso]}: ${ESTADO_VISUAL_LABEL[visual]}`}
+            aria-label={`${PASO_SHORT_LABEL[paso]} ${ESTADO_VISUAL_LABEL[visual]}`}
+            className={`inline-flex h-3 w-3 items-center justify-center rounded-sm border text-[8px] font-bold ${ESTADO_VISUAL_TONE[visual]}`}
+          >
+            <span className="sr-only">{PASO_SHORT_LABEL[paso]}</span>
+          </span>
+        );
+      })}
+    </div>
   );
 }
 

--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -205,7 +205,7 @@ export function TareasChecklist({
               <th className="hidden w-32 px-2 py-2 text-left lg:table-cell">Entidad</th>
               <th className="w-36 px-2 py-2 text-left">Estado</th>
               <th className="w-20 px-2 py-2 text-left">Vence</th>
-              <th className="w-28 px-2 py-2 text-center">
+              <th className="w-40 px-2 py-2 text-center">
                 <span className="block">C · F · P · R</span>
                 <span className="block text-[9px] normal-case tracking-normal text-[var(--text)]/40">
                   cotiz · factura · pago · result
@@ -558,17 +558,32 @@ const PASO_SHORT_LABEL: Record<'cotizacion' | 'factura' | 'pago' | 'resultado', 
 function PasosMini({ pasos }: { pasos: readonly PasoRow[] }) {
   const byPaso = new Map(pasos.map((p) => [p.paso, p]));
   return (
-    <div className="inline-flex items-center gap-1">
+    <div className="inline-flex items-center gap-1.5">
       {PASO_ORDER.map((paso) => {
         const row = byPaso.get(paso);
         const visual: EstadoVisual = row ? estadoVisualDePaso(row) : 'pendiente';
+        const doc = row?.documento_url ?? null;
+        const label = `${PASO_SHORT_LABEL[paso]}: ${ESTADO_VISUAL_LABEL[visual]}`;
+        const baseCls = `inline-flex h-4 w-4 items-center justify-center rounded-sm border text-[9px] font-bold ${ESTADO_VISUAL_TONE[visual]}`;
+
+        if (doc) {
+          return (
+            <a
+              key={paso}
+              href={doc}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              title={`${label} — click para abrir documento`}
+              aria-label={`Abrir documento de ${PASO_SHORT_LABEL[paso]}`}
+              className={`${baseCls} cursor-pointer ring-offset-1 transition-shadow hover:ring-2 hover:ring-[var(--accent)]/60`}
+            >
+              <span className="sr-only">{PASO_SHORT_LABEL[paso]} con documento adjunto</span>
+            </a>
+          );
+        }
         return (
-          <span
-            key={paso}
-            title={`${PASO_SHORT_LABEL[paso]}: ${ESTADO_VISUAL_LABEL[visual]}`}
-            aria-label={`${PASO_SHORT_LABEL[paso]} ${ESTADO_VISUAL_LABEL[visual]}`}
-            className={`inline-flex h-3 w-3 items-center justify-center rounded-sm border text-[8px] font-bold ${ESTADO_VISUAL_TONE[visual]}`}
-          >
+          <span key={paso} title={label} aria-label={label} className={baseCls}>
             <span className="sr-only">{PASO_SHORT_LABEL[paso]}</span>
           </span>
         );

--- a/docs/planning/dilesa-proyectos-checklist-inline.md
+++ b/docs/planning/dilesa-proyectos-checklist-inline.md
@@ -2,11 +2,11 @@
 
 **Slug:** `dilesa-proyectos-checklist-inline`
 **Empresas:** DILESA
-**Schemas afectados:** ninguno (cero ALTER). Reusa `dilesa.proyecto_tareas` + `proyecto_tareas_dependencias` + `proyecto_presupuesto_partidas` + `proyecto_documentos` + `proyecto_hitos` + `plantilla_proyecto_tareas` ya existentes.
+**Schemas afectados:** `dilesa.proyecto_tarea_pasos` (tabla nueva Sprint 3); reusa `dilesa.proyecto_tareas` + `proyecto_tareas_dependencias` + `proyecto_presupuesto_partidas` + `proyecto_documentos` + `proyecto_hitos` + `plantilla_proyecto_tareas`.
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-05-28
-**Última actualización:** 2026-05-28 (promoción + arranque Sprint 1)
+**Última actualización:** 2026-05-29 (Sprints 1+1.5+2 mergeados + compactación visual + hotfix detección cotización; Sprint 3 reformulado a "pasos por tarea" tras propuesta de Beto)
 
 ## Problema
 
@@ -158,15 +158,147 @@ dilesa.proyectos
    por estado (preliminar · autorizada · planeada · en ejercicio · cerrada).
 3. Server action `autorizarPartida` con role gate.
 
-### Sprint 3 — Espejar checklist en desarrollo + backfill
+### Sprint 3 — Pasos por tarea (reformulado 2026-05-29)
 
-1. Backfill SQL para los 8 desarrollos vivos.
-2. `<ProyectoDetalle>` agrega secciones `<TareasChecklist>` y
+**Cambio de visión propuesto por Beto:** cada tarea pasa de ser
+"una cosa" (1 doc + 1 monto) a tener **4 pasos canónicos** que
+modelan el ciclo de vida operativo de la tarea:
+
+| Paso         | Captura                                                 | Avance | Efecto en `proyecto_presupuesto_partidas` |
+| ------------ | ------------------------------------------------------- | ------ | ----------------------------------------- |
+| `cotizacion` | monto + cotización.pdf + fecha                          | 25%    | partida `preliminar` (`monto_estimado`)   |
+| `factura`    | monto + factura.pdf + fecha                             | 25%    | partida `autorizada` (`monto_aprobado`)   |
+| `pago`       | monto + comprobante.pdf + fecha                         | 25%    | partida `en_ejercicio` (`monto_ejercido`) |
+| `resultado`  | el entregable (escritura, plano, dictamen, certificado) | 25%    | — (cierra el ciclo)                       |
+
+Pasos opcionales con `estado='no_aplica'` se sacan del denominador
+del cálculo. El avance de la tarea = `pasos_hechos / pasos_aplicables × 100`.
+
+**Decisiones cerradas D1-D6 (2026-05-29):**
+
+- **D1:** Los 4 pasos aparecen siempre; el operador marca "N/A" los
+  que no aplican. Más simple que codificarlos en el catálogo.
+- **D2:** Avance tarea = `hechos / aplicables × 100`. Peso igual.
+- **D3:** Avance proyecto = promedio ponderado por obligatoriedad:
+  obligatoria=1, condicional=0.5, opcional=0. Lo opcional no estorba.
+- **D4:** Auto-flujo con partidas: paso cotizacion → preliminar,
+  factura → autorizada+monto_aprobado, pago → en_ejercicio +
+  monto_ejercido. Cuando los 3 pasos financieros aplicables están
+  hechos, partida pasa a `cerrada`. Sprint 2 ya cubre cotización.
+- **D5:** Backfill cero-pérdida desde Sprint 1+1.5: cada tarea con
+  `resultado_documento_url` poblado → INSERT paso='resultado'
+  estado='hecho'. Cada tarea con `resultado_monto` poblado → INSERT
+  paso='cotizacion' estado='hecho'. Los atajos en `proyecto_tareas`
+  se mantienen como referencia rápida (deprecados para captura nueva).
+- **D6:** Mergear primero PR #581 (compactación visual independiente);
+  el rediseño con pasos viene encima.
+
+**Schema delta:**
+
+```sql
+CREATE TABLE dilesa.proyecto_tarea_pasos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES core.empresas(id),
+  tarea_id uuid NOT NULL REFERENCES dilesa.proyecto_tareas(id) ON DELETE CASCADE,
+  paso text NOT NULL CHECK (paso IN ('cotizacion','factura','pago','resultado')),
+  monto numeric,                    -- NULL si N/A o no capturado
+  documento_url text,               -- URL del proxy (atajo del adjunto principal)
+  fecha date,                       -- fecha del paso (cotizado/facturado/pagado/entregado)
+  estado text NOT NULL DEFAULT 'pendiente'
+    CHECK (estado IN ('pendiente','hecho','no_aplica')),
+  notas text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  UNIQUE (tarea_id, paso)
+);
+CREATE INDEX idx_proyecto_tarea_pasos_tarea ON dilesa.proyecto_tarea_pasos(tarea_id)
+  WHERE deleted_at IS NULL;
+
+-- RLS canónica DILESA: SELECT/INSERT/UPDATE para miembros de empresa,
+--                     DELETE solo admin.
+
+-- Vista de avance derivado:
+CREATE VIEW dilesa.v_proyecto_avance AS
+WITH paso_tarea AS (
+  SELECT
+    pt.tarea_id,
+    COUNT(*) FILTER (WHERE pt.estado <> 'no_aplica') AS aplicables,
+    COUNT(*) FILTER (WHERE pt.estado = 'hecho') AS hechos
+  FROM dilesa.proyecto_tarea_pasos pt
+  WHERE pt.deleted_at IS NULL
+  GROUP BY pt.tarea_id
+), avance_tarea AS (
+  SELECT
+    t.id AS tarea_id,
+    t.proyecto_id,
+    t.obligatoriedad_snapshot,
+    CASE
+      WHEN pt.aplicables IS NULL OR pt.aplicables = 0 THEN 0
+      ELSE ROUND(100.0 * pt.hechos / pt.aplicables, 2)
+    END AS avance_pct,
+    CASE t.obligatoriedad_snapshot
+      WHEN 'obligatoria' THEN 1.0
+      WHEN 'condicional' THEN 0.5
+      ELSE 0.0
+    END AS peso
+  FROM dilesa.proyecto_tareas t
+  LEFT JOIN paso_tarea pt ON pt.tarea_id = t.id
+  WHERE t.deleted_at IS NULL
+)
+SELECT
+  proyecto_id,
+  COUNT(*) FILTER (WHERE peso > 0) AS tareas_aplicables,
+  ROUND(
+    SUM(avance_pct * peso) / NULLIF(SUM(peso), 0),
+    2
+  ) AS avance_pct
+FROM avance_tarea
+GROUP BY proyecto_id;
+```
+
+**Backfill:** script idempotente extrae `resultado_documento_url` y
+`resultado_monto` de las 80 tareas backfilleadas en Sprint 1 → crea
+pasos `resultado` y `cotizacion` respectivos con `estado='hecho'`.
+
+**Storage:** `lib/storage/path.ts` agrega `'proyecto_tarea_pasos'`
+al union `AdjuntoEntidad`. Adjuntos individuales por paso vía
+`entidad_tipo='proyecto_tarea_paso'`. El campo `documento_url` del
+paso es atajo al adjunto principal (igual que `resultado_documento_url`
+es atajo al de la tarea hoy).
+
+**Server actions:**
+
+- `upsertPasoMonto(tareaId, paso, monto)`: idempotente, crea row
+  con `estado='pendiente'` si no existe.
+- `upsertPasoDocumento(tareaId, paso, url)`: idem.
+- `marcarPasoEstado(tareaId, paso, estado)`: incluyendo `no_aplica`.
+- Cada uno dispara `syncPartidaDesdeTarea` extendido para mapear
+  estado de paso → estado de partida (D4).
+
+**UI:**
+
+- Tabla compacta mantiene 1 row por tarea con columnas nuevas:
+  **Avance %** + **$ acum.** (suma de los 3 montos financieros
+  capturados).
+- Expand al click muestra **grid 2×2 de pasos**; cada celda tiene
+  input monto + slot `<FileAttachments>` mini + selector estado +
+  fecha.
+- `<PartidasPresupuestales>` queda igual; el auto-flujo lo alimenta
+  desde los pasos en lugar del campo `resultado_monto` antiguo.
+
+### Sprint 4 — Espejar a desarrollo + backfill desarrollos
+
+(Pospuesto desde el plan original Sprint 3 — se ejecuta una vez que
+los pasos por tarea estén estables en anteproyecto.)
+
+1. Backfill SQL para los 8 desarrollos vivos (tareas + pasos).
+2. `<ProyectoDetalle>` agrega `<TareasChecklist>` +
    `<PartidasPresupuestales>` filtradas por
    `aplicacion_snapshot IN ('desarrollo','ambas')`.
 3. Banner sticky "Marcar histórico" para acelerar marcado en bulk.
 
-### Sprint 4 — Documentos + hitos unificados
+### Sprint 5 — Documentos + hitos unificados
 
 1. Sección `<DocumentosProyecto>` que agrega URLs sueltas +
    `resultado_documento_url` de tareas + filas de
@@ -196,6 +328,34 @@ dilesa.proyectos
   patrón existe y funciona (otros módulos ya lo usan).
 
 ## Bitácora
+
+- **2026-05-29 (Sprint 3 reformulado a "pasos por tarea")** — Beto
+  propuso un rediseño del modelo: cada tarea debe tener 4 sub-pasos
+  (cotización · factura · pago · resultado), cada uno con su monto +
+  documento + estado + fecha. La misma tarea sirve de control
+  documental + presupuestal + avance. Cerradas D1-D6 documentadas
+  arriba. PR #581 mergeado (compactación visual independiente).
+  Sprint 3 original "espejar a desarrollo" pospuesto a Sprint 4.
+
+- **2026-05-29 (hotfix detección cotización + compactación UI)** —
+  Bug detectado: helper buscaba "cotizac" en subtipo (Urbanismo/
+  Construcción/Comercial) en lugar de tipo ('Cotización'). PR #580
+  con fix de 1 línea. Beto reportó que la UI se veía "revuelta sin
+  organización"; PR #581 refactor a tabla compacta con expand inline
+  (1 fila por tarea, ~32px alto, click expande captura completa).
+
+- **2026-05-28 (Sprint 2)** — Auto-vinculación tarea → partida +
+  componente `<PartidasPresupuestales>` agrupado por estado +
+  `autorizarPartida` server action. PR #579 mergeado.
+
+- **2026-05-28 (Sprint 1.5)** — Import de 29 PDFs/JPGs desde Coda
+  `grid-XLc0Md6iHp` (3 anteproyectos: LDLE/LDLD/LE). PR #577.
+
+- **2026-05-28 (Sprint 1 + hotfixes)** — PR #572 mergeado con captura
+  inline + 4 server actions + `<TareasChecklist>` + backfill de 80
+  tareas + 105 dependencias en 5 anteproyectos. Hotfixes: PR #573
+  guards defensivos + PR #575 root cause `'use server'` no exporta
+  const/types (movidos a `tareas-checklist-types.ts`).
 
 - **2026-05-28 (promoción)** — Iniciativa promovida tras análisis profundo
   con Beto comparando UI actual contra visión de "plantilla expuesta

--- a/lib/storage/path.ts
+++ b/lib/storage/path.ts
@@ -36,7 +36,8 @@ export type AdjuntoEntidad =
   | 'empresa'
   | 'ventas'
   | 'venta_pagos'
-  | 'proyecto_tareas';
+  | 'proyecto_tareas'
+  | 'proyecto_tarea_pasos';
 
 export type BuildAdjuntoPathOpts = {
   empresa: EmpresaSlug;

--- a/scripts/backfill_dilesa_proyecto_tarea_pasos.ts
+++ b/scripts/backfill_dilesa_proyecto_tarea_pasos.ts
@@ -1,0 +1,162 @@
+/**
+ * backfill_dilesa_proyecto_tarea_pasos.ts
+ *
+ * Iniciativa `dilesa-proyectos-checklist-inline` Sprint 3 (D5).
+ *
+ * Migra los atajos de Sprint 1 + 1.5 (`proyecto_tareas.resultado_monto`,
+ * `proyecto_tareas.resultado_documento_url`) a la nueva tabla
+ * `dilesa.proyecto_tarea_pasos`:
+ *
+ *   - Cada tarea con `resultado_documento_url` poblado → INSERT paso
+ *     `resultado` con `estado='hecho'`, `documento_url` copiado, y
+ *     `fecha` = `fecha_completada` (o hoy si NULL).
+ *   - Cada tarea con `resultado_monto` poblado → INSERT paso
+ *     `cotizacion` con `estado='hecho'`, `monto` copiado, `fecha` =
+ *     `fecha_completada` (o hoy).
+ *
+ * Idempotente: usa `ON CONFLICT (tarea_id, paso) DO NOTHING` por la
+ * UNIQUE de la tabla. Re-correr el script no duplica nada.
+ *
+ * Los atajos en `proyecto_tareas` se MANTIENEN — son referencia rápida
+ * para UI sin re-fetch del paso. Cuando la UI escriba pasos nuevos,
+ * también actualiza los atajos (o no — decisión post-Sprint 3 si
+ * conviene deprecarlos).
+ *
+ * Uso:
+ *   DRY_RUN=1 npx tsx scripts/backfill_dilesa_proyecto_tarea_pasos.ts
+ *   npx tsx scripts/backfill_dilesa_proyecto_tarea_pasos.ts
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Faltan NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+}
+
+type TareaSemilla = {
+  id: string;
+  empresa_id: string;
+  proyecto_id: string;
+  titulo: string;
+  resultado_monto: number | null;
+  resultado_documento_url: string | null;
+  fecha_completada: string | null;
+};
+
+async function main() {
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+  const { data: tareasRaw, error } = await sb
+    .schema('dilesa')
+    .from('proyecto_tareas')
+    .select(
+      'id, empresa_id, proyecto_id, titulo, resultado_monto, resultado_documento_url, fecha_completada'
+    )
+    .is('deleted_at', null);
+  if (error) throw new Error(`Error leyendo tareas: ${error.message}`);
+  const tareas = (tareasRaw ?? []) as TareaSemilla[];
+
+  const conMonto = tareas.filter((t) => t.resultado_monto != null);
+  const conDoc = tareas.filter((t) => t.resultado_documento_url != null);
+  console.log(
+    `${DRY_RUN ? '[DRY RUN] ' : ''}Tareas: ${tareas.length} | con monto: ${conMonto.length} | con doc: ${conDoc.length}\n`
+  );
+
+  type PasoCanonico = 'cotizacion' | 'factura' | 'pago' | 'resultado';
+  type Insert = {
+    empresa_id: string;
+    tarea_id: string;
+    paso: PasoCanonico;
+    monto: number | null;
+    documento_url: string | null;
+    fecha: string | null;
+    estado: 'hecho' | 'pendiente';
+  };
+  const inserts: Insert[] = [];
+
+  const hoy = new Date().toISOString().slice(0, 10);
+  const PASOS_TODOS: readonly PasoCanonico[] = ['cotizacion', 'factura', 'pago', 'resultado'];
+
+  // Por cada tarea, generar los 4 pasos. Para los que tenemos data en los
+  // atajos, los marcamos `hecho`. El resto arranca `pendiente` para que la
+  // UI muestre dónde falta capturar.
+  for (const t of tareas) {
+    for (const paso of PASOS_TODOS) {
+      const esCotConMonto = paso === 'cotizacion' && t.resultado_monto != null;
+      const esResConDoc = paso === 'resultado' && t.resultado_documento_url != null;
+      if (esCotConMonto) {
+        inserts.push({
+          empresa_id: t.empresa_id,
+          tarea_id: t.id,
+          paso,
+          monto: t.resultado_monto,
+          documento_url: null,
+          fecha: t.fecha_completada ?? hoy,
+          estado: 'hecho',
+        });
+      } else if (esResConDoc) {
+        inserts.push({
+          empresa_id: t.empresa_id,
+          tarea_id: t.id,
+          paso,
+          monto: null,
+          documento_url: t.resultado_documento_url,
+          fecha: t.fecha_completada ?? hoy,
+          estado: 'hecho',
+        });
+      } else {
+        inserts.push({
+          empresa_id: t.empresa_id,
+          tarea_id: t.id,
+          paso,
+          monto: null,
+          documento_url: null,
+          fecha: null,
+          estado: 'pendiente',
+        });
+      }
+    }
+  }
+
+  console.log(`A insertar: ${inserts.length} pasos\n`);
+
+  if (DRY_RUN) {
+    for (const i of inserts.slice(0, 5)) {
+      console.log(
+        `  [dry] tarea=${i.tarea_id.slice(0, 8)} paso=${i.paso} monto=${i.monto ?? '—'} doc=${i.documento_url ? '✓' : '—'} fecha=${i.fecha}`
+      );
+    }
+    if (inserts.length > 5) console.log(`  ... y ${inserts.length - 5} más`);
+    return;
+  }
+
+  // Insert batch con upsert por unique (tarea_id, paso).
+  let ok = 0;
+  let fail = 0;
+  // Procesar por lotes de 100 para no exceder URL/payload.
+  const BATCH = 100;
+  for (let i = 0; i < inserts.length; i += BATCH) {
+    const chunk = inserts.slice(i, i + BATCH);
+    const { error: insErr } = await sb
+      .schema('dilesa')
+      .from('proyecto_tarea_pasos')
+      .upsert(chunk, { onConflict: 'tarea_id,paso', ignoreDuplicates: true });
+    if (insErr) {
+      console.log(`  ✗ batch ${i}-${i + chunk.length}: ${insErr.message}`);
+      fail += chunk.length;
+    } else {
+      ok += chunk.length;
+    }
+  }
+
+  console.log(`\nSummary: ok=${ok} fail=${fail}`);
+}
+
+main().catch((e) => {
+  console.error('Backfill failed:', e);
+  process.exit(1);
+});

--- a/scripts/migrate_adjuntos_proyecto_tareas_to_pasos.ts
+++ b/scripts/migrate_adjuntos_proyecto_tareas_to_pasos.ts
@@ -1,0 +1,127 @@
+/**
+ * migrate_adjuntos_proyecto_tareas_to_pasos.ts
+ *
+ * Iniciativa `dilesa-proyectos-checklist-inline` Sprint 3.6.
+ *
+ * Sprint 1.5 importó 29 adjuntos desde Coda con
+ * `entidad_tipo='proyecto_tarea'` apuntando al ID de la tarea. Sprint 3
+ * introdujo el modelo de pasos y el `<FileAttachments>` de cada paso
+ * filtra por `entidad_tipo='proyecto_tarea_paso'` con
+ * `entidad_id=<paso.id>`. Eso deja los 29 archivos importados
+ * invisibles en la nueva UI aunque sí están en Storage y en el row
+ * `proyecto_tareas.resultado_documento_url`.
+ *
+ * Este script migra los rows en `erp.adjuntos` para que apunten al
+ * paso `resultado` correspondiente:
+ * - `entidad_tipo`: 'proyecto_tarea' → 'proyecto_tarea_paso'
+ * - `entidad_id`: tarea.id → paso.id (donde paso.paso='resultado')
+ * - `url` (path en Storage) NO cambia — el archivo físico sigue en
+ *   `dilesa/proyecto_tareas/<tarea_id>/<file>`. El proxy URL solo
+ *   necesita el path, así que sigue funcionando.
+ *
+ * Idempotente: skipea rows que ya están migrados (entidad_tipo ya
+ * es 'proyecto_tarea_paso' o ya existe otro row con esa combinación).
+ *
+ * Uso:
+ *   DRY_RUN=1 npx tsx scripts/migrate_adjuntos_proyecto_tareas_to_pasos.ts
+ *   npx tsx scripts/migrate_adjuntos_proyecto_tareas_to_pasos.ts
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Faltan NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+}
+
+async function main() {
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+  // 1) Leer los adjuntos con entidad_tipo='proyecto_tarea' que pertenecen
+  //    a DILESA. Idem para 'proyecto_tareas' por si quedó algún caso plural
+  //    (no debería, pero defensivo).
+  const { data: adjuntosRaw, error: errAdj } = await sb
+    .schema('erp')
+    .from('adjuntos')
+    .select('id, empresa_id, entidad_tipo, entidad_id, nombre')
+    .in('entidad_tipo', ['proyecto_tarea', 'proyecto_tareas']);
+  if (errAdj) throw new Error(`Error leyendo adjuntos: ${errAdj.message}`);
+  const adjuntos = (adjuntosRaw ?? []) as Array<{
+    id: string;
+    empresa_id: string;
+    entidad_tipo: string;
+    entidad_id: string;
+    nombre: string;
+  }>;
+
+  console.log(
+    `${DRY_RUN ? '[DRY RUN] ' : ''}Adjuntos legacy con entidad_tipo=proyecto_tarea: ${adjuntos.length}\n`
+  );
+
+  if (adjuntos.length === 0) {
+    console.log('Nada que migrar.');
+    return;
+  }
+
+  // 2) Pre-cargar los pasos 'resultado' de las tareas referenciadas.
+  const tareaIds = Array.from(new Set(adjuntos.map((a) => a.entidad_id)));
+  const { data: pasosRaw } = await sb
+    .schema('dilesa')
+    .from('proyecto_tarea_pasos')
+    .select('id, tarea_id, paso')
+    .in('tarea_id', tareaIds)
+    .eq('paso', 'resultado')
+    .is('deleted_at', null);
+  const pasos = (pasosRaw ?? []) as Array<{ id: string; tarea_id: string; paso: string }>;
+  const pasoIdByTareaId = new Map(pasos.map((p) => [p.tarea_id, p.id]));
+
+  console.log(`Pasos 'resultado' encontrados para mapeo: ${pasos.length} (de ${tareaIds.length} tareas distintas)\n`);
+
+  let ok = 0;
+  let skip = 0;
+  let fail = 0;
+
+  for (const a of adjuntos) {
+    const pasoId = pasoIdByTareaId.get(a.entidad_id);
+    if (!pasoId) {
+      console.log(`  ✗ [sin paso resultado] tarea=${a.entidad_id.slice(0, 8)} ${a.nombre}`);
+      fail++;
+      continue;
+    }
+
+    if (DRY_RUN) {
+      console.log(
+        `  [dry] adjunto ${a.id.slice(0, 8)} | ${a.nombre} | tarea=${a.entidad_id.slice(0, 8)} → paso=${pasoId.slice(0, 8)}`
+      );
+      ok++;
+      continue;
+    }
+
+    const { error: updErr } = await sb
+      .schema('erp')
+      .from('adjuntos')
+      .update({
+        entidad_tipo: 'proyecto_tarea_paso',
+        entidad_id: pasoId,
+      })
+      .eq('id', a.id);
+
+    if (updErr) {
+      console.log(`  ✗ [update] ${a.id.slice(0, 8)} | ${a.nombre} | ${updErr.message}`);
+      fail++;
+    } else {
+      console.log(`  ✓ ${a.id.slice(0, 8)} | ${a.nombre} → paso ${pasoId.slice(0, 8)}`);
+      ok++;
+    }
+  }
+
+  console.log(`\nSummary: ok=${ok} skip=${skip} fail=${fail}`);
+}
+
+main().catch((e) => {
+  console.error('Migration failed:', e);
+  process.exit(1);
+});

--- a/supabase/SCHEMA_REF.md
+++ b/supabase/SCHEMA_REF.md
@@ -841,6 +841,8 @@ _(sin columnas)_
 - **created_at** `timestamp with time zone` NOT NULL DEFAULT `now()`
 - **updated_at** `timestamp with time zone` NOT NULL DEFAULT `now()`
 - **deleted_at** `timestamp with time zone`
+- **autorizado_at** `timestamp with time zone`
+- **autorizado_por** `uuid` — FK → `core.usuarios(id)`
 
 ### `dilesa.proyecto_tareas`
 

--- a/supabase/SCHEMA_REF.md
+++ b/supabase/SCHEMA_REF.md
@@ -825,6 +825,23 @@ _(sin columnas)_
 - **nombre_externo** `text`
 - **created_at** `timestamp with time zone` NOT NULL DEFAULT `now()`
 
+### `dilesa.proyecto_tarea_pasos`
+
+> Pasos del ciclo de vida operativo de una tarea (cotización, factura, pago, resultado). Cada paso captura monto + documento + fecha + estado. UNIQUE(tarea_id, paso) garantiza un solo row por paso. Sprint 3 de dilesa-proyectos-checklist-inline.
+
+- **id** `uuid` NOT NULL DEFAULT `gen_random_uuid()` — PK
+- **empresa_id** `uuid` NOT NULL — FK → `core.empresas(id)`
+- **tarea_id** `uuid` NOT NULL — FK → `dilesa.proyecto_tareas(id)`
+- **paso** `text` NOT NULL
+- **monto** `numeric`
+- **documento_url** `text`
+- **fecha** `date`
+- **estado** `text` NOT NULL DEFAULT `'pendiente'::text`
+- **notas** `text`
+- **created_at** `timestamp with time zone` NOT NULL DEFAULT `now()`
+- **updated_at** `timestamp with time zone` NOT NULL DEFAULT `now()`
+- **deleted_at** `timestamp with time zone`
+
 ### `dilesa.proyecto_tareas`
 
 > Tareas de un proyecto. Agnóstico al tipo de proyecto (hereda el patrón del módulo Tareas existente).
@@ -1008,6 +1025,16 @@ _(sin columnas)_
 - **monto_bruto_total** `numeric`
 - **retencion_total** `numeric`
 - **monto_neto_total** `numeric`
+
+### `dilesa.v_proyecto_avance` _(view)_
+
+> Avance del proyecto derivado de `proyecto_tarea_pasos`. Promedio ponderado por obligatoriedad de la tarea (obligatoria=1, condicional=0.5, opcional=0). Sprint 3 de dilesa-proyectos-checklist-inline.
+
+- **proyecto_id** `uuid`
+- **empresa_id** `uuid`
+- **tareas_aplicables** `bigint`
+- **tareas_completadas** `bigint`
+- **avance_pct** `numeric`
 
 ### `dilesa.v_proyecto_avances` _(view)_
 

--- a/supabase/migrations/20260529160000_dilesa_proyecto_tarea_pasos.sql
+++ b/supabase/migrations/20260529160000_dilesa_proyecto_tarea_pasos.sql
@@ -1,0 +1,169 @@
+-- Iniciativa: dilesa-proyectos-checklist-inline Sprint 3 — pasos por tarea.
+--
+-- Cada tarea pasa de tener (`resultado_monto`, `resultado_documento_url`)
+-- a tener 4 pasos canónicos modelados en tabla aparte: cotizacion,
+-- factura, pago, resultado. Cada paso captura monto + documento +
+-- fecha + estado (pendiente/hecho/no_aplica) + notas.
+--
+-- Decisiones cerradas D1-D6 documentadas en
+-- `docs/planning/dilesa-proyectos-checklist-inline.md` §Sprint 3.
+--
+-- Backfill posterior (script Node, no parte de esta migración):
+-- - Cada tarea con `resultado_documento_url` → INSERT paso='resultado'
+--   estado='hecho' con `documento_url` poblado.
+-- - Cada tarea con `resultado_monto` → INSERT paso='cotizacion'
+--   estado='hecho' con `monto` poblado.
+-- Los atajos en `proyecto_tareas` se mantienen como referencia rápida
+-- (deprecados para captura nueva — la UI escribe a la tabla nueva).
+
+BEGIN;
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 1) Tabla `dilesa.proyecto_tarea_pasos`
+-- ════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS dilesa.proyecto_tarea_pasos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES core.empresas(id),
+  tarea_id uuid NOT NULL REFERENCES dilesa.proyecto_tareas(id) ON DELETE CASCADE,
+  paso text NOT NULL CHECK (paso IN ('cotizacion', 'factura', 'pago', 'resultado')),
+  monto numeric,
+  documento_url text,
+  fecha date,
+  estado text NOT NULL DEFAULT 'pendiente'
+    CHECK (estado IN ('pendiente', 'hecho', 'no_aplica')),
+  notas text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  UNIQUE (tarea_id, paso)
+);
+
+COMMENT ON TABLE dilesa.proyecto_tarea_pasos IS
+  'Pasos del ciclo de vida operativo de una tarea (cotización, factura, pago, resultado). Cada paso captura monto + documento + fecha + estado. UNIQUE(tarea_id, paso) garantiza un solo row por paso. Sprint 3 de dilesa-proyectos-checklist-inline.';
+COMMENT ON COLUMN dilesa.proyecto_tarea_pasos.estado IS
+  'pendiente=sin capturar, hecho=monto/doc capturado y operador lo marca como cerrado, no_aplica=el paso no es relevante para esta tarea (se saca del denominador del avance).';
+COMMENT ON COLUMN dilesa.proyecto_tarea_pasos.documento_url IS
+  'Atajo a la URL pública del adjunto principal del paso (vía `/api/adjuntos/<path>`). El legajo completo vive en `erp.adjuntos` con entidad_tipo=''proyecto_tarea_paso''.';
+
+CREATE INDEX IF NOT EXISTS idx_proyecto_tarea_pasos_tarea
+  ON dilesa.proyecto_tarea_pasos (tarea_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_proyecto_tarea_pasos_empresa
+  ON dilesa.proyecto_tarea_pasos (empresa_id)
+  WHERE deleted_at IS NULL;
+
+-- Updated_at trigger reutilizando la convención DILESA.
+CREATE OR REPLACE FUNCTION dilesa.fn_proyecto_tarea_pasos_set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_proyecto_tarea_pasos_updated_at ON dilesa.proyecto_tarea_pasos;
+CREATE TRIGGER trg_proyecto_tarea_pasos_updated_at
+  BEFORE UPDATE ON dilesa.proyecto_tarea_pasos
+  FOR EACH ROW
+  EXECUTE FUNCTION dilesa.fn_proyecto_tarea_pasos_set_updated_at();
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 2) RLS canónica DILESA
+-- ════════════════════════════════════════════════════════════════════════════
+-- Política estándar: miembros de la empresa pueden SELECT/INSERT/UPDATE;
+-- DELETE reservado a admin. Sigue el patrón usado en
+-- `proyecto_presupuesto_partidas` (ver migración 20260526220000).
+
+ALTER TABLE dilesa.proyecto_tarea_pasos ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS proyecto_tarea_pasos_select ON dilesa.proyecto_tarea_pasos;
+CREATE POLICY proyecto_tarea_pasos_select
+  ON dilesa.proyecto_tarea_pasos
+  FOR SELECT
+  USING (core.fn_has_empresa(empresa_id) OR core.fn_is_admin());
+
+DROP POLICY IF EXISTS proyecto_tarea_pasos_insert ON dilesa.proyecto_tarea_pasos;
+CREATE POLICY proyecto_tarea_pasos_insert
+  ON dilesa.proyecto_tarea_pasos
+  FOR INSERT
+  WITH CHECK (core.fn_has_empresa(empresa_id) OR core.fn_is_admin());
+
+DROP POLICY IF EXISTS proyecto_tarea_pasos_update ON dilesa.proyecto_tarea_pasos;
+CREATE POLICY proyecto_tarea_pasos_update
+  ON dilesa.proyecto_tarea_pasos
+  FOR UPDATE
+  USING (core.fn_has_empresa(empresa_id) OR core.fn_is_admin())
+  WITH CHECK (core.fn_has_empresa(empresa_id) OR core.fn_is_admin());
+
+DROP POLICY IF EXISTS proyecto_tarea_pasos_delete ON dilesa.proyecto_tarea_pasos;
+CREATE POLICY proyecto_tarea_pasos_delete
+  ON dilesa.proyecto_tarea_pasos
+  FOR DELETE
+  USING (core.fn_is_admin());
+
+-- ════════════════════════════════════════════════════════════════════════════
+-- 3) Vista `dilesa.v_proyecto_avance` — avance ponderado por proyecto
+-- ════════════════════════════════════════════════════════════════════════════
+-- Avance tarea = (hechos / aplicables) * 100 (D2).
+-- Avance proyecto = promedio ponderado por obligatoriedad (D3):
+--   - obligatoria: peso 1.0
+--   - condicional: peso 0.5
+--   - opcional: peso 0 (se saca del cálculo)
+--   - NULL (legacy): peso 1.0 (tratamos como obligatoria por defecto seguro)
+--
+-- Las tareas sin pasos instanciados tienen avance 0% (denominator NULL → 0).
+-- security_invoker=on para respetar RLS del lector.
+
+CREATE OR REPLACE VIEW dilesa.v_proyecto_avance
+WITH (security_invoker = on) AS
+WITH paso_tarea AS (
+  SELECT
+    pt.tarea_id,
+    COUNT(*) FILTER (WHERE pt.estado <> 'no_aplica') AS aplicables,
+    COUNT(*) FILTER (WHERE pt.estado = 'hecho') AS hechos
+  FROM dilesa.proyecto_tarea_pasos pt
+  WHERE pt.deleted_at IS NULL
+  GROUP BY pt.tarea_id
+),
+avance_tarea AS (
+  SELECT
+    t.id AS tarea_id,
+    t.proyecto_id,
+    t.empresa_id,
+    t.obligatoriedad_snapshot,
+    CASE
+      WHEN pt.aplicables IS NULL OR pt.aplicables = 0 THEN 0
+      ELSE ROUND(100.0 * pt.hechos / pt.aplicables, 2)
+    END AS avance_pct,
+    CASE
+      WHEN t.obligatoriedad_snapshot = 'obligatoria' THEN 1.0
+      WHEN t.obligatoriedad_snapshot = 'condicional' THEN 0.5
+      WHEN t.obligatoriedad_snapshot = 'opcional' THEN 0.0
+      ELSE 1.0
+    END AS peso
+  FROM dilesa.proyecto_tareas t
+  LEFT JOIN paso_tarea pt ON pt.tarea_id = t.id
+  WHERE t.deleted_at IS NULL
+)
+SELECT
+  proyecto_id,
+  empresa_id,
+  COUNT(*) FILTER (WHERE peso > 0) AS tareas_aplicables,
+  COUNT(*) FILTER (WHERE peso > 0 AND avance_pct = 100) AS tareas_completadas,
+  CASE
+    WHEN SUM(peso) = 0 THEN 0
+    ELSE ROUND(SUM(avance_pct * peso) / NULLIF(SUM(peso), 0), 2)
+  END AS avance_pct
+FROM avance_tarea
+GROUP BY proyecto_id, empresa_id;
+
+COMMENT ON VIEW dilesa.v_proyecto_avance IS
+  'Avance del proyecto derivado de `proyecto_tarea_pasos`. Promedio ponderado por obligatoriedad de la tarea (obligatoria=1, condicional=0.5, opcional=0). Sprint 3 de dilesa-proyectos-checklist-inline.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260529210000_dilesa_proyecto_tarea_pasos_autorizacion.sql
+++ b/supabase/migrations/20260529210000_dilesa_proyecto_tarea_pasos_autorizacion.sql
@@ -1,0 +1,25 @@
+-- Sprint 3.5 de `dilesa-proyectos-checklist-inline`: autorización de
+-- cotización (y cualquier paso financiero en el futuro).
+--
+-- Agrega `autorizado_at` + `autorizado_por` a `dilesa.proyecto_tarea_pasos`
+-- mismo patrón que `dilesa.proyecto_presupuesto_partidas` (Sprint 2).
+--
+-- Para v1 solo aplica a `cotizacion`. La server action que mueve un
+-- paso de pendiente → hecho NO setea autorización; un endpoint
+-- separado `autorizarPaso(tareaId, paso)` lo hace, gateado por rol
+-- director / admin a nivel app.
+
+BEGIN;
+
+ALTER TABLE dilesa.proyecto_tarea_pasos
+  ADD COLUMN IF NOT EXISTS autorizado_at timestamptz,
+  ADD COLUMN IF NOT EXISTS autorizado_por uuid REFERENCES core.usuarios(id);
+
+COMMENT ON COLUMN dilesa.proyecto_tarea_pasos.autorizado_at IS
+  'Timestamp de autorización por dirección. Aplica primariamente a paso=cotizacion. NULL = no autorizado todavía. Sprint 3.5.';
+COMMENT ON COLUMN dilesa.proyecto_tarea_pasos.autorizado_por IS
+  'Usuario que autorizó el paso. FK a core.usuarios. Sprint 3.5.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -2674,6 +2674,59 @@ export type Database = {
           },
         ]
       }
+      proyecto_tarea_pasos: {
+        Row: {
+          created_at: string
+          deleted_at: string | null
+          documento_url: string | null
+          empresa_id: string
+          estado: string
+          fecha: string | null
+          id: string
+          monto: number | null
+          notas: string | null
+          paso: string
+          tarea_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          deleted_at?: string | null
+          documento_url?: string | null
+          empresa_id: string
+          estado?: string
+          fecha?: string | null
+          id?: string
+          monto?: number | null
+          notas?: string | null
+          paso: string
+          tarea_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          deleted_at?: string | null
+          documento_url?: string | null
+          empresa_id?: string
+          estado?: string
+          fecha?: string | null
+          id?: string
+          monto?: number | null
+          notas?: string | null
+          paso?: string
+          tarea_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "proyecto_tarea_pasos_tarea_id_fkey"
+            columns: ["tarea_id"]
+            isOneToOne: false
+            referencedRelation: "proyecto_tareas"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       proyecto_tareas: {
         Row: {
           aplicacion_snapshot: string | null
@@ -3559,6 +3612,31 @@ export type Database = {
           semana_iso: number | null
         }
         Relationships: []
+      }
+      v_proyecto_avance: {
+        Row: {
+          avance_pct: number | null
+          empresa_id: string | null
+          proyecto_id: string | null
+          tareas_aplicables: number | null
+          tareas_completadas: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "proyecto_tareas_proyecto_id_fkey"
+            columns: ["proyecto_id"]
+            isOneToOne: false
+            referencedRelation: "proyectos"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "proyecto_tareas_proyecto_id_fkey"
+            columns: ["proyecto_id"]
+            isOneToOne: false
+            referencedRelation: "v_proyecto_avances"
+            referencedColumns: ["proyecto_id"]
+          },
+        ]
       }
       v_proyecto_avances: {
         Row: {

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -2676,6 +2676,8 @@ export type Database = {
       }
       proyecto_tarea_pasos: {
         Row: {
+          autorizado_at: string | null
+          autorizado_por: string | null
           created_at: string
           deleted_at: string | null
           documento_url: string | null
@@ -2690,6 +2692,8 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          autorizado_at?: string | null
+          autorizado_por?: string | null
           created_at?: string
           deleted_at?: string | null
           documento_url?: string | null
@@ -2704,6 +2708,8 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          autorizado_at?: string | null
+          autorizado_por?: string | null
           created_at?: string
           deleted_at?: string | null
           documento_url?: string | null


### PR DESCRIPTION
## Cambio de modelo

Beto propuso elevar cada tarea de "una cosa monolítica" (1 doc + 1 monto) a **4 pasos canónicos** que cubren el ciclo de vida operativo. La misma tarea sirve de control documental + presupuestal + avance.

| Paso | Captura | Genera en \`<PartidasPresupuestales>\` |
|---|---|---|
| **Cotización** | monto + cotización.pdf + fecha | partida \`preliminar\` |
| **Factura** | monto + factura.pdf + fecha | partida \`autorizada\` (sprint próximo) |
| **Pago** | monto + comprobante.pdf + fecha | partida \`en_ejercicio\` (sprint próximo) |
| **Resultado** | el entregable de la tarea (escritura, plano, dictamen) | — |

Decisiones D1–D6 documentadas en [planning](docs/planning/dilesa-proyectos-checklist-inline.md).

## Resultado del backfill (live en prod)

- **320 pasos** creados (80 tareas × 4) — idempotente.
- 27 tareas con resultado del Sprint 1.5 → paso \`resultado\` en \`hecho\`.
- 53 tareas con todos los 4 pasos en \`pendiente\`.
- Vista \`v_proyecto_avance\` ya devuelve % por anteproyecto: Lomas de las Delicias y Ampliación Lomas de los Encinos al **19%** (12/13 con resultado pendiente factura+pago+cotización), Loma Escondida al **6%**, los 2 nuevos al **0%**.

## Schema

- Tabla nueva \`dilesa.proyecto_tarea_pasos\` con \`UNIQUE(tarea_id, paso)\`, RLS canónica, trigger updated_at.
- Vista \`dilesa.v_proyecto_avance\` (security_invoker=on) con avance ponderado por obligatoriedad.
- \`AdjuntoEntidad\` gana \`'proyecto_tarea_pasos'\` (adjuntos individuales por paso).

## Server actions

- \`upsertPaso(tareaId, paso, patch)\` universal: whitelist por campo, valida tipos, upsert por unique.
- Side effects mantienen compat con atajos de Sprint 1 (\`resultado_monto\`, \`resultado_documento_url\`).
- Auto-flujo con partida preliminar de Sprint 2 sigue funcionando — el paso \`cotizacion\` dispara la sync.

## UI

**Vista compacta (1 row por tarea):**
\`\`\`
#  Tarea                              Estado     Vence    Avance     $ acum.    💬
1  Levantamiento Topográfico [obl.]  Pendiente  12/jun   ▓░░░░ 25%  —          ·
2  Lotificación [obl.]               Hecho ✓    22/jun   ▓▓▓▓░ 75%  $80k       💬
\`\`\`

**Vista expandida (click en row):**

Grid 2×2 con los 4 pasos. Cada celda:
- Header: label + badge "→ {partida_estado}".
- 3 botones de estado (⭕ Pendiente · ✓ Hecho · ➖ N/A).
- Input monto inline (solo financieros) + input fecha.
- Slot \`<FileAttachments>\` mini.
- Resumen del monto y fecha al pie.

Notas inline al final del expand.

## Verificación local

- typecheck ✓
- tests **102/102** (+10 nuevos en \`tarea-pasos.test.ts\`)
- format:check ✓
- lint 0 errores (97 warnings preexistentes)

## Test plan post-merge

- [ ] Abrir cualquier anteproyecto. Las tareas deben aparecer con la columna **Avance** mostrando barras y porcentajes; las 3 con resultado importado de Coda al 25%.
- [ ] Click en una fila → expand muestra grid 2×2 de pasos.
- [ ] En **Cotización** capturar monto + fecha → al pulsar Hecho, avance sube a 50% inline.
- [ ] Bajar a sección **Presupuesto** → partida preliminar nueva con etiqueta "cotización (auto)".
- [ ] Subir un PDF en el slot \`FileAttachments\` del paso → aparece en \`/api/adjuntos/...\` después del refresh.
- [ ] Marcar uno como **N/A** → opacity-50 y se saca del denominador del avance.

## No incluido (próximos sprints)

- Auto-flujo extendido factura → autorizada y pago → en_ejercicio en la partida (este sprint solo el de cotización).
- Espejar a desarrollo (Sprint 4, originalmente Sprint 3).
- Documentos + hitos unificados (Sprint 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)