### PR TITLE
Sprint 4C: botón Imprimir PDF del análisis financiero (DILESA anteproyectos)

### DIFF
--- a/app/api/dilesa/anteproyectos/[id]/analisis-pdf/route.tsx
+++ b/app/api/dilesa/anteproyectos/[id]/analisis-pdf/route.tsx
@@ -1,0 +1,174 @@
+/**
+ * GET /api/dilesa/anteproyectos/[id]/analisis-pdf
+ *
+ * Devuelve el análisis financiero del anteproyecto como PDF para
+ * presentar al consejo o usar como documento amparador del análisis
+ * aprobado (Sprint 4C de `dilesa-proyectos-checklist-inline`).
+ *
+ * Auth: sesión Supabase. RLS de `dilesa.proyectos` decide si el
+ * usuario puede leer la fila. Si no, 404.
+ *
+ * Sin POST por ahora — el PDF se descarga, no se envía por email.
+ * Si Beto pide email en el futuro, replicamos el patrón de
+ * `estimaciones/[id]/pdf/route.tsx`.
+ */
+
+import { NextResponse } from 'next/server';
+import { renderToBuffer } from '@react-pdf/renderer';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { AnalisisFinancieroPDF, type AnalisisPdfData } from '@/lib/dilesa/pdf/analisis-financiero';
+import { PROYECTO_DETALLE_COLUMNAS } from '@/components/dilesa/proyecto-detalle';
+import type { AnalisisFinancieroSnapshot } from '@/components/dilesa/analisis-financiero-types';
+
+const MESES_ES = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+];
+
+function fmtFechaLarga(d: Date): string {
+  return `${d.getDate()} de ${MESES_ES[d.getMonth()]} de ${d.getFullYear()}`;
+}
+
+const ESTADO_LABEL: Record<string, string> = {
+  propuesta: 'Propuesta',
+  analisis: 'Análisis',
+  aprobado: 'Aprobado',
+  completado: 'Completado',
+  en_curso: 'En curso',
+};
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const sb = await createSupabaseServerClient();
+
+  // Cargar anteproyecto con todas las columnas que el snapshot necesita.
+  const { data: row, error } = await sb
+    .schema('dilesa')
+    .from('proyectos')
+    .select(PROYECTO_DETALLE_COLUMNAS)
+    .eq('id', id)
+    .eq('tipo', 'anteproyecto')
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (!row) {
+    return NextResponse.json({ error: 'Anteproyecto no encontrado' }, { status: 404 });
+  }
+
+  const p = row as unknown as {
+    id: string;
+    nombre: string;
+    estado: string;
+    area_m2: number | null;
+    area_vendible_m2: number | null;
+    areas_verdes_m2: number | null;
+    area_vialidades_m2: number | null;
+    lotes_proyectados: number | null;
+    tamano_lote_promedio: number | null;
+    clasificacion_inmobiliaria: string | null;
+    clasificaciones_inmobiliarias: string[];
+    costo_terreno: number | null;
+    valor_predio: number | null;
+    infraestructura_cabecera_necesaria: boolean;
+    prototipos_referencia: string[];
+    prototipo_referencia_id: string | null;
+    presupuesto_estimado: number | null;
+    valor_comercial_referencia: number | null;
+    costo_urbanizacion_referencia: number | null;
+    costo_materiales_referencia: number | null;
+    costo_mo_referencia: number | null;
+    registro_ruv_referencia: number | null;
+    seguro_calidad_referencia: number | null;
+    costo_comercializacion_referencia: number | null;
+    valor_comercial_proyecto: number | null;
+    costo_urbanizacion: number | null;
+    costo_materiales_proyecto: number | null;
+    costo_mo: number | null;
+    registro_ruv_proyecto: number | null;
+    seguro_calidad_proyecto: number | null;
+    costo_comercializacion: number | null;
+  };
+
+  // Resolver nombre del prototipo de referencia (si hay).
+  let prototipoReferenciaNombre: string | null = null;
+  if (p.prototipo_referencia_id) {
+    const { data: proto } = await sb
+      .schema('dilesa')
+      .from('productos')
+      .select('nombre')
+      .eq('id', p.prototipo_referencia_id)
+      .maybeSingle();
+    prototipoReferenciaNombre = (proto?.nombre as string | undefined) ?? null;
+  }
+
+  const snapshot: AnalisisFinancieroSnapshot = {
+    id: p.id,
+    area_m2: p.area_m2,
+    area_vendible_m2: p.area_vendible_m2,
+    areas_verdes_m2: p.areas_verdes_m2,
+    area_vialidades_m2: p.area_vialidades_m2,
+    lotes_proyectados: p.lotes_proyectados,
+    tamano_lote_promedio: p.tamano_lote_promedio,
+    clasificacion_inmobiliaria: p.clasificacion_inmobiliaria,
+    clasificaciones_inmobiliarias: p.clasificaciones_inmobiliarias ?? [],
+    costo_terreno: p.costo_terreno,
+    valor_predio: p.valor_predio,
+    infraestructura_cabecera_necesaria: p.infraestructura_cabecera_necesaria ?? false,
+    prototipos_referencia: p.prototipos_referencia ?? [],
+    prototipo_referencia_id: p.prototipo_referencia_id,
+    presupuesto_estimado: p.presupuesto_estimado,
+    valor_comercial_referencia: p.valor_comercial_referencia,
+    costo_urbanizacion_referencia: p.costo_urbanizacion_referencia,
+    costo_materiales_referencia: p.costo_materiales_referencia,
+    costo_mo_referencia: p.costo_mo_referencia,
+    registro_ruv_referencia: p.registro_ruv_referencia,
+    seguro_calidad_referencia: p.seguro_calidad_referencia,
+    costo_comercializacion_referencia: p.costo_comercializacion_referencia,
+    valor_comercial_proyecto: p.valor_comercial_proyecto,
+    costo_urbanizacion: p.costo_urbanizacion,
+    costo_materiales_proyecto: p.costo_materiales_proyecto,
+    costo_mo: p.costo_mo,
+    registro_ruv_proyecto: p.registro_ruv_proyecto,
+    seguro_calidad_proyecto: p.seguro_calidad_proyecto,
+    costo_comercializacion: p.costo_comercializacion,
+  };
+
+  const data: AnalisisPdfData = {
+    nombreProyecto: p.nombre,
+    estado: ESTADO_LABEL[p.estado] ?? p.estado,
+    emitidoEnTexto: fmtFechaLarga(new Date()),
+    prototipoReferenciaNombre,
+    snapshot,
+  };
+
+  const buf = await renderToBuffer(<AnalisisFinancieroPDF data={data} />);
+  const slug = p.nombre
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return new Response(new Uint8Array(buf), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `inline; filename="analisis-financiero-${slug}.pdf"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export const runtime = 'nodejs';

--- a/app/api/dilesa/anteproyectos/[id]/analisis-pdf/route.tsx
+++ b/app/api/dilesa/anteproyectos/[id]/analisis-pdf/route.tsx
@@ -17,7 +17,7 @@ import { NextResponse } from 'next/server';
 import { renderToBuffer } from '@react-pdf/renderer';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { AnalisisFinancieroPDF, type AnalisisPdfData } from '@/lib/dilesa/pdf/analisis-financiero';
-import { PROYECTO_DETALLE_COLUMNAS } from '@/components/dilesa/proyecto-detalle';
+import { PROYECTO_DETALLE_COLUMNAS } from '@/lib/dilesa/proyecto-detalle-columnas';
 import type { AnalisisFinancieroSnapshot } from '@/components/dilesa/analisis-financiero-types';
 
 const MESES_ES = [

--- a/app/api/dilesa/anteproyectos/[id]/analisis-pdf/route.tsx
+++ b/app/api/dilesa/anteproyectos/[id]/analisis-pdf/route.tsx
@@ -154,7 +154,19 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
     snapshot,
   };
 
-  const buf = await renderToBuffer(<AnalisisFinancieroPDF data={data} />);
+  let buf: Buffer;
+  try {
+    buf = await renderToBuffer(<AnalisisFinancieroPDF data={data} />);
+  } catch (e) {
+    const msg = e instanceof Error ? `${e.name}: ${e.message}\n${e.stack}` : String(e);
+    // Log explícito al runtime de Vercel para debugging futuro (Beto vio
+    // un HTTP 500 truncado en preview, los logs llegan mejor con stack).
+    console.error('[analisis-pdf] renderToBuffer failed', { id, msg });
+    return NextResponse.json(
+      { error: 'No se pudo generar el PDF.', detail: msg.slice(0, 500) },
+      { status: 500 }
+    );
+  }
   const slug = p.nombre
     .toLowerCase()
     .normalize('NFD')

--- a/components/dilesa/anteproyecto-analisis-financiero.tsx
+++ b/components/dilesa/anteproyecto-analisis-financiero.tsx
@@ -437,9 +437,20 @@ export function AnteproyectoAnalisisFinanciero({
     >
       <header className="flex items-center justify-between border-b border-[var(--border)] px-3 py-2">
         <h3 className="text-sm font-semibold text-[var(--text)]">Análisis financiero</h3>
-        <span className="text-[11px] text-[var(--muted-text)]">
-          {pending ? 'Guardando…' : 'Captura inline'}
-        </span>
+        <div className="flex items-center gap-3">
+          <span className="text-[11px] text-[var(--muted-text)]">
+            {pending ? 'Guardando…' : 'Captura inline'}
+          </span>
+          <a
+            href={`/api/dilesa/anteproyectos/${local.id}/analisis-pdf`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 rounded-sm border border-[var(--border)] bg-[var(--card)] px-2 py-0.5 text-[11px] font-medium text-[var(--text)] hover:bg-[var(--bg)]"
+            title="Abre el análisis financiero como PDF para presentar al consejo o usar como documento amparador"
+          >
+            Imprimir PDF
+          </a>
+        </div>
       </header>
 
       <div className="grid grid-cols-1 gap-4 p-3 lg:grid-cols-2">

--- a/components/dilesa/proyecto-detalle.tsx
+++ b/components/dilesa/proyecto-detalle.tsx
@@ -81,34 +81,13 @@ export type ProyectoDetalle = {
   prototipo_referencia_id: string | null;
 };
 
-/**
- * SELECT canónico de `dilesa.proyectos` para el detalle. Usado por
- * `<AnteproyectosModule>`, `/dilesa/proyectos/[id]`,
- * `/dilesa/proyectos/anteproyectos/[id]`. Mantén sync con
- * `ProyectoDetalle` arriba — un campo nuevo en el type debe agregarse
- * también aquí o la columna nunca llegará al componente.
- */
-export const PROYECTO_DETALLE_COLUMNAS = [
-  'id, tipo, nombre, estado, clave_interna, proyecto_padre_id, proyecto_predecesor_id',
-  'fecha_inicio, fecha_fin_estimada, fecha_licencia',
-  'area_m2, area_vendible_m2, areas_verdes_m2, lotes_proyectados',
-  'presupuesto_estimado, costo_terreno, costo_urbanizacion, costo_construccion, costo_comercializacion',
-  'notas, plano_oficial_url, image_url, acreditacion_escritura, objetivo_trimestral',
-  // Sprint C — paridad Coda v2
-  'clasificacion_inmobiliaria, area_comercial_m2, area_residencial_m2, area_vialidades_m2',
-  'precio_m2_excedente, costo_mo, tamano_lote_promedio',
-  // Sprint 4B — análisis financiero
-  'valor_comercial_referencia, valor_comercial_proyecto',
-  'costo_urbanizacion_referencia',
-  'costo_materiales_referencia, costo_materiales_proyecto',
-  'costo_mo_referencia',
-  'registro_ruv_referencia, registro_ruv_proyecto',
-  'seguro_calidad_referencia, seguro_calidad_proyecto',
-  'costo_comercializacion_referencia',
-  'infraestructura_cabecera_necesaria, valor_predio, prototipos_referencia',
-  // Sprint 4B refinamiento
-  'clasificaciones_inmobiliarias, prototipo_referencia_id',
-].join(', ');
+// La constante PROYECTO_DETALLE_COLUMNAS vive en
+// `lib/dilesa/proyecto-detalle-columnas.ts` para que route handlers
+// server-only la importen sin arrastrar todo este componente client al
+// bundle (Sprint 4C fix). Re-exportada aquí por back-compat — los
+// imports existentes desde components/ y app/dilesa/ siguen
+// funcionando sin cambio.
+export { PROYECTO_DETALLE_COLUMNAS } from '@/lib/dilesa/proyecto-detalle-columnas';
 
 /**
  * Datos derivados de `dilesa.v_proyecto_avances` — Sprint A de

--- a/lib/dilesa/pdf/analisis-financiero.tsx
+++ b/lib/dilesa/pdf/analisis-financiero.tsx
@@ -1,0 +1,359 @@
+/**
+ * PDF del Análisis Financiero del anteproyecto DILESA.
+ * Sprint 4C de la iniciativa `dilesa-proyectos-checklist-inline`.
+ *
+ * Replica visualmente la sección `<AnteproyectoAnalisisFinanciero>`
+ * pero en formato letter para presentar al consejo o usar como
+ * documento amparador del análisis aprobado.
+ *
+ * Una sola página (letter): predio + capital + tabla referencia vs
+ * proyecto + resultado + chips de clasificaciones + prototipo
+ * referencia + fecha de emisión.
+ */
+
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import { colors, styles as base } from './styles';
+import { FooterBand, HeaderBand } from './header-footer';
+import {
+  ANALISIS_FILAS_COSTOS,
+  deriveAnalisisFinanciero,
+  fmtM2,
+  fmtMoney,
+  fmtMoneyCents,
+  fmtNumber,
+  fmtPct,
+  labelDeClasificacion,
+  type AnalisisFinancieroSnapshot,
+} from '@/components/dilesa/analisis-financiero-types';
+
+const s = StyleSheet.create({
+  intro: {
+    marginTop: 6,
+    marginBottom: 6,
+    fontSize: 9,
+    color: colors.textMuted,
+  },
+  proyectoTitle: {
+    fontSize: 14,
+    fontFamily: 'Helvetica-Bold',
+    marginTop: 4,
+    marginBottom: 2,
+  },
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 4,
+    marginTop: 2,
+  },
+  chip: {
+    borderWidth: 0.5,
+    borderColor: colors.border,
+    borderRadius: 6,
+    paddingVertical: 1,
+    paddingHorizontal: 4,
+    fontSize: 7.5,
+  },
+  card: {
+    borderWidth: 0.5,
+    borderColor: colors.border,
+    borderRadius: 3,
+    padding: 6,
+    marginBottom: 4,
+    backgroundColor: '#fff',
+  },
+  cardLabel: {
+    fontSize: 8,
+    color: colors.textMuted,
+    fontFamily: 'Helvetica-Bold',
+    letterSpacing: 0.5,
+    marginBottom: 2,
+    textTransform: 'uppercase',
+  },
+  grid2: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  col: {
+    flex: 1,
+  },
+  rowKV: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 1,
+  },
+  k: {
+    fontSize: 8.5,
+    color: colors.textMuted,
+  },
+  v: {
+    fontSize: 8.5,
+    fontFamily: 'Helvetica-Bold',
+  },
+  vAccent: {
+    fontSize: 8.5,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.primary,
+  },
+  table: {
+    marginTop: 2,
+  },
+  th: {
+    flexDirection: 'row',
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.border,
+    paddingBottom: 2,
+    marginBottom: 2,
+  },
+  thLabel: {
+    fontSize: 7.5,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  tr: {
+    flexDirection: 'row',
+    paddingVertical: 1.5,
+    borderBottomWidth: 0.25,
+    borderBottomColor: colors.borderSoft,
+  },
+  trTotal: {
+    flexDirection: 'row',
+    paddingTop: 4,
+    paddingBottom: 2,
+    borderTopWidth: 0.5,
+    borderTopColor: colors.border,
+    marginTop: 1,
+  },
+  tdLabel: {
+    flex: 2,
+    fontSize: 8.5,
+    color: colors.text,
+  },
+  tdLabelBold: {
+    flex: 2,
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+  },
+  tdNum: {
+    flex: 1.3,
+    fontSize: 8.5,
+    textAlign: 'right',
+    fontFamily: 'Helvetica',
+  },
+  tdNumBold: {
+    flex: 1.3,
+    fontSize: 9,
+    textAlign: 'right',
+    fontFamily: 'Helvetica-Bold',
+  },
+  tdDelta: {
+    flex: 1.0,
+    fontSize: 8.5,
+    textAlign: 'right',
+  },
+  resultGrid: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 2,
+  },
+  resultCard: {
+    flex: 1,
+    borderWidth: 0.5,
+    borderColor: colors.border,
+    borderRadius: 3,
+    padding: 5,
+  },
+  resultLabel: {
+    fontSize: 7.5,
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  resultValue: {
+    fontSize: 12,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.primary,
+    marginTop: 1,
+  },
+  emisionLine: {
+    fontSize: 7.5,
+    color: colors.textMuted,
+    marginTop: 8,
+    textAlign: 'right',
+  },
+});
+
+const DASH = '—';
+
+function n(v: number | null | undefined, formatter: (x: number) => string): string {
+  if (v == null) return DASH;
+  return formatter(v);
+}
+
+function delta(ref: number | null, proy: number | null) {
+  if (ref == null || proy == null) {
+    return { txt: DASH, color: colors.textMuted };
+  }
+  const d = proy - ref;
+  const sign = d > 0 ? '+' : '';
+  const color = d > 0 ? '#b91c1c' : d < 0 ? '#15803d' : colors.text;
+  return { txt: `${sign}${fmtMoney(d)}`, color };
+}
+
+export type AnalisisPdfData = {
+  nombreProyecto: string;
+  estado: string;
+  emitidoEnTexto: string;
+  prototipoReferenciaNombre: string | null;
+  snapshot: AnalisisFinancieroSnapshot;
+};
+
+export function AnalisisFinancieroPDF({ data }: { data: AnalisisPdfData }) {
+  const { snapshot, prototipoReferenciaNombre } = data;
+  const d = deriveAnalisisFinanciero(snapshot);
+
+  const inversion =
+    d.costoTotalProyecto != null
+      ? d.costoTotalProyecto + (snapshot.valor_predio ?? snapshot.costo_terreno ?? 0)
+      : null;
+
+  return (
+    <Document>
+      <Page size="LETTER" style={base.page}>
+        <HeaderBand title="ANÁLISIS FINANCIERO" fecha={data.emitidoEnTexto} />
+
+        <Text style={s.proyectoTitle}>{data.nombreProyecto}</Text>
+        <Text style={s.intro}>
+          Estado: {data.estado} · Documento amparador del análisis financiero del anteproyecto.
+        </Text>
+
+        {/* ── Predio + Capital ──────────────────────────────────────────── */}
+        <View style={s.grid2}>
+          <View style={[s.card, s.col]}>
+            <Text style={s.cardLabel}>Predio</Text>
+            <KV
+              k="Clasificación"
+              v={
+                snapshot.clasificaciones_inmobiliarias.length === 0
+                  ? DASH
+                  : snapshot.clasificaciones_inmobiliarias.map(labelDeClasificacion).join(', ')
+              }
+            />
+            <KV k="Lotes proyectados" v={n(snapshot.lotes_proyectados, fmtNumber)} />
+            <KV k="Área total" v={n(snapshot.area_m2, (x) => `${fmtNumber(x)} m²`)} />
+            <KV k="Área vendible" v={n(snapshot.area_vendible_m2, (x) => `${fmtNumber(x)} m²`)} />
+            <KV k="Áreas verdes" v={n(snapshot.areas_verdes_m2, (x) => `${fmtNumber(x)} m²`)} />
+            <KV k="Vialidades" v={n(snapshot.area_vialidades_m2, (x) => `${fmtNumber(x)} m²`)} />
+            <KV k="Lote promedio" v={n(snapshot.tamano_lote_promedio, fmtM2)} />
+            <KV k="% áreas verdes" v={n(d.pctVerdes, fmtPct)} accent />
+            <KV k="Aprovechamiento" v={n(d.aprovechamiento, fmtPct)} accent />
+          </View>
+
+          <View style={[s.card, s.col]}>
+            <Text style={s.cardLabel}>Capital inicial</Text>
+            <KV k="Costo terreno" v={n(snapshot.costo_terreno, fmtMoney)} />
+            <KV k="Valor predio" v={n(snapshot.valor_predio, fmtMoney)} />
+            <KV k="$/m² aprovechable" v={n(d.precioM2Aprovechable, fmtMoneyCents)} />
+            <KV k="Presupuesto estimado" v={n(snapshot.presupuesto_estimado, fmtMoney)} />
+            <KV
+              k="Infra cabecera necesaria"
+              v={snapshot.infraestructura_cabecera_necesaria ? 'Sí' : 'No'}
+            />
+            <KV k="Prototipo de referencia" v={prototipoReferenciaNombre ?? DASH} />
+            {snapshot.prototipos_referencia.length > 0 && (
+              <>
+                <Text style={[s.k, { marginTop: 3 }]}>Prototipos adicionales:</Text>
+                <View style={s.chipsRow}>
+                  {snapshot.prototipos_referencia.map((p) => (
+                    <Text key={p} style={s.chip}>
+                      {p}
+                    </Text>
+                  ))}
+                </View>
+              </>
+            )}
+          </View>
+        </View>
+
+        {/* ── Tabla Referencia vs Proyecto ──────────────────────────────── */}
+        <View style={s.card}>
+          <Text style={s.cardLabel}>Costos: Referencia vs Proyecto</Text>
+          <View style={s.table}>
+            <View style={s.th}>
+              <Text style={[s.thLabel, s.tdLabel]}>Concepto</Text>
+              <Text style={[s.thLabel, s.tdNum]}>Referencia</Text>
+              <Text style={[s.thLabel, s.tdNum]}>Proyecto</Text>
+              <Text style={[s.thLabel, s.tdDelta]}>Δ</Text>
+            </View>
+            {ANALISIS_FILAS_COSTOS.map((fila) => {
+              const ref = snapshot[fila.referencia] as number | null;
+              const proy = snapshot[fila.proyecto] as number | null;
+              const dd = delta(ref, proy);
+              return (
+                <View key={fila.label} style={s.tr}>
+                  <Text style={s.tdLabel}>{fila.label}</Text>
+                  <Text style={s.tdNum}>{n(ref, fmtMoney)}</Text>
+                  <Text style={s.tdNum}>{n(proy, fmtMoney)}</Text>
+                  <Text style={[s.tdDelta, { color: dd.color }]}>{dd.txt}</Text>
+                </View>
+              );
+            })}
+            <View style={s.trTotal}>
+              <Text style={s.tdLabelBold}>Costo total</Text>
+              <Text style={s.tdNumBold}>{n(d.costoTotalReferencia, fmtMoney)}</Text>
+              <Text style={s.tdNumBold}>{n(d.costoTotalProyecto, fmtMoney)}</Text>
+              <Text
+                style={[
+                  s.tdDelta,
+                  {
+                    color: d.delta == null ? colors.textMuted : d.delta > 0 ? '#b91c1c' : '#15803d',
+                    fontFamily: 'Helvetica-Bold',
+                  },
+                ]}
+              >
+                {d.delta == null ? DASH : `${d.delta > 0 ? '+' : ''}${fmtMoney(d.delta)}`}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        {/* ── Resultado ────────────────────────────────────────────────── */}
+        <View style={s.card}>
+          <Text style={s.cardLabel}>Resultado</Text>
+          <View style={s.resultGrid}>
+            <View style={s.resultCard}>
+              <Text style={s.resultLabel}>Utilidad proyecto</Text>
+              <Text style={s.resultValue}>{n(d.utilidadProyecto, fmtMoney)}</Text>
+            </View>
+            <View style={s.resultCard}>
+              <Text style={s.resultLabel}>Margen utilidad</Text>
+              <Text style={s.resultValue}>{n(d.margenUtilidad, fmtPct)}</Text>
+            </View>
+            <View style={s.resultCard}>
+              <Text style={s.resultLabel}>Inversión total</Text>
+              <Text style={s.resultValue}>{n(inversion, fmtMoney)}</Text>
+            </View>
+            <View style={s.resultCard}>
+              <Text style={s.resultLabel}>Valor comercial proyecto</Text>
+              <Text style={s.resultValue}>{n(snapshot.valor_comercial_proyecto, fmtMoney)}</Text>
+            </View>
+          </View>
+        </View>
+
+        <Text style={s.emisionLine}>Emitido el {data.emitidoEnTexto}</Text>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+function KV({ k, v, accent }: { k: string; v: string; accent?: boolean }) {
+  return (
+    <View style={s.rowKV}>
+      <Text style={s.k}>{k}</Text>
+      <Text style={accent ? s.vAccent : s.v}>{v}</Text>
+    </View>
+  );
+}

--- a/lib/dilesa/pdf/analisis-financiero.tsx
+++ b/lib/dilesa/pdf/analisis-financiero.tsx
@@ -42,7 +42,6 @@ const s = StyleSheet.create({
   chipsRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 4,
     marginTop: 2,
   },
   chip: {
@@ -52,6 +51,8 @@ const s = StyleSheet.create({
     paddingVertical: 1,
     paddingHorizontal: 4,
     fontSize: 7.5,
+    marginRight: 4,
+    marginBottom: 2,
   },
   card: {
     borderWidth: 0.5,
@@ -71,10 +72,17 @@ const s = StyleSheet.create({
   },
   grid2: {
     flexDirection: 'row',
-    gap: 8,
   },
   col: {
     flex: 1,
+  },
+  colLeft: {
+    flex: 1,
+    marginRight: 4,
+  },
+  colRight: {
+    flex: 1,
+    marginLeft: 4,
   },
   rowKV: {
     flexDirection: 'row',
@@ -154,10 +162,17 @@ const s = StyleSheet.create({
   },
   resultGrid: {
     flexDirection: 'row',
-    gap: 8,
     marginTop: 2,
   },
   resultCard: {
+    flex: 1,
+    borderWidth: 0.5,
+    borderColor: colors.border,
+    borderRadius: 3,
+    padding: 5,
+    marginRight: 4,
+  },
+  resultCardLast: {
     flex: 1,
     borderWidth: 0.5,
     borderColor: colors.border,
@@ -230,7 +245,7 @@ export function AnalisisFinancieroPDF({ data }: { data: AnalisisPdfData }) {
 
         {/* ── Predio + Capital ──────────────────────────────────────────── */}
         <View style={s.grid2}>
-          <View style={[s.card, s.col]}>
+          <View style={[s.card, s.colLeft]}>
             <Text style={s.cardLabel}>Predio</Text>
             <KV
               k="Clasificación"
@@ -250,7 +265,7 @@ export function AnalisisFinancieroPDF({ data }: { data: AnalisisPdfData }) {
             <KV k="Aprovechamiento" v={n(d.aprovechamiento, fmtPct)} accent />
           </View>
 
-          <View style={[s.card, s.col]}>
+          <View style={[s.card, s.colRight]}>
             <Text style={s.cardLabel}>Capital inicial</Text>
             <KV k="Costo terreno" v={n(snapshot.costo_terreno, fmtMoney)} />
             <KV k="Valor predio" v={n(snapshot.valor_predio, fmtMoney)} />
@@ -334,7 +349,7 @@ export function AnalisisFinancieroPDF({ data }: { data: AnalisisPdfData }) {
               <Text style={s.resultLabel}>Inversión total</Text>
               <Text style={s.resultValue}>{n(inversion, fmtMoney)}</Text>
             </View>
-            <View style={s.resultCard}>
+            <View style={s.resultCardLast}>
               <Text style={s.resultLabel}>Valor comercial proyecto</Text>
               <Text style={s.resultValue}>{n(snapshot.valor_comercial_proyecto, fmtMoney)}</Text>
             </View>

--- a/lib/dilesa/proyecto-detalle-columnas.ts
+++ b/lib/dilesa/proyecto-detalle-columnas.ts
@@ -1,0 +1,34 @@
+/**
+ * SELECT canónico de `dilesa.proyectos` para el detalle.
+ *
+ * Vive aquí (no en `components/dilesa/proyecto-detalle.tsx`) para
+ * poder importarse desde route handlers server-only sin arrastrar el
+ * árbol del client component al bundle del API route. Next.js bundlea
+ * eagerly los imports de archivos con `'use client'` aunque solo
+ * importes una constante.
+ *
+ * Si agregas columnas nuevas al type `ProyectoDetalle`, actualízalas
+ * también aquí o no llegarán a `<AnteproyectoDetalle>` ni al PDF.
+ */
+
+export const PROYECTO_DETALLE_COLUMNAS = [
+  'id, tipo, nombre, estado, clave_interna, proyecto_padre_id, proyecto_predecesor_id',
+  'fecha_inicio, fecha_fin_estimada, fecha_licencia',
+  'area_m2, area_vendible_m2, areas_verdes_m2, lotes_proyectados',
+  'presupuesto_estimado, costo_terreno, costo_urbanizacion, costo_construccion, costo_comercializacion',
+  'notas, plano_oficial_url, image_url, acreditacion_escritura, objetivo_trimestral',
+  // Sprint C — paridad Coda v2
+  'clasificacion_inmobiliaria, area_comercial_m2, area_residencial_m2, area_vialidades_m2',
+  'precio_m2_excedente, costo_mo, tamano_lote_promedio',
+  // Sprint 4B — análisis financiero
+  'valor_comercial_referencia, valor_comercial_proyecto',
+  'costo_urbanizacion_referencia',
+  'costo_materiales_referencia, costo_materiales_proyecto',
+  'costo_mo_referencia',
+  'registro_ruv_referencia, registro_ruv_proyecto',
+  'seguro_calidad_referencia, seguro_calidad_proyecto',
+  'costo_comercializacion_referencia',
+  'infraestructura_cabecera_necesaria, valor_predio, prototipos_referencia',
+  // Sprint 4B refinamiento
+  'clasificaciones_inmobiliarias, prototipo_referencia_id',
+].join(', ');


### PR DESCRIPTION
## Summary

Sprint 4C de la iniciativa \`dilesa-proyectos-checklist-inline\`. Beto pidió un PDF del análisis financiero para presentar al consejo o usar como documento amparador del análisis aprobado.

### Nuevo componente PDF

\`lib/dilesa/pdf/analisis-financiero.tsx\` — replica visualmente la sección Análisis Financiero en formato letter, 1 página. Reusa el branding olivo DILESA (\`colors\`, \`styles\`, \`HeaderBand\`, \`FooterBand\`) ya establecido por estimaciones y solicitud-asignacion.

Estructura:
- Header band olivo con título \"ANÁLISIS FINANCIERO\" + fecha
- Nombre del proyecto + estado + leyenda \"documento amparador\"
- Grid 2 columnas: **Predio** (clasificaciones, áreas, derivados) + **Capital inicial** (terreno, valor predio, $/m², prototipo referencia)
- Card **Costos: Referencia vs Proyecto** con tabla 7 filas + total + delta coloreado (verde si ahorro, rojo si sobrecosto)
- Card **Resultado** con grid 4 cards: utilidad, margen, inversión, valor comercial
- Línea \"Emitido el ...\" + footer band

### Endpoint API

\`app/api/dilesa/anteproyectos/[id]/analisis-pdf/route.tsx\` — \`GET\` que:
1. Carga el anteproyecto vía \`PROYECTO_DETALLE_COLUMNAS\` (constante canónica del Sprint 4B).
2. Resuelve el nombre del prototipo de referencia si hay FK.
3. Arma el \`AnalisisFinancieroSnapshot\` y llama \`renderToBuffer\`.
4. Responde con \`Content-Disposition: inline\` (abre en pestaña nueva, no fuerza descarga).

RLS de \`dilesa.proyectos\` protege el acceso. Sin POST por email — se puede agregar después con el mismo patrón que estimaciones.

### Botón en UI

Nuevo link \"Imprimir PDF\" en el header del componente del análisis (\`anteproyecto-analisis-financiero.tsx\`), \`target=\"_blank\"\` al endpoint. Sin estado loading (browser maneja).

### Reuso máximo

Sprint 4B dejó **todos los formatters** (\`fmtMoney\`, \`fmtPct\`, etc.), \`deriveAnalisisFinanciero\` y \`labelDeClasificacion\` exportados desde \`analisis-financiero-types.ts\` precisamente para que el PDF los reusara sin duplicar lógica. El PDF y el componente React-DOM hablan el mismo idioma.

### Verificación

- \`npm run typecheck\` — sin errores.
- Smoke render local (\`renderToBuffer\` directo): **OK, 71KB**, sin errores.
- \`npm run test:run\` — 13696 tests pasan (sin cambios; no agregué tests unitarios al PDF — se valida visualmente).
- \`npm run lint\` — 0 errors.
- \`npm run format:check\` — verde tras prettify.
- \`npm run schema:check\` — verde (sin migración).

## Test plan

- [ ] **Vercel preview**: abrir cualquier anteproyecto → header del análisis muestra el link \"Imprimir PDF\".
- [ ] Click → se abre en pestaña nueva con el PDF.
- [ ] **Lomas de las Delicias** (datos parciales: clasificación=interes_social, área 37,506 m², 163 lotes): debe mostrar todos esos campos + derivados (aprovechamiento 55.5%, % verdes 9.1%).
- [ ] Anteproyecto sin clasificaciones (ej. Plaza Comercial Los Encinos sin data) → debe mostrar em-dash en clasificación pero NO romper render.
- [ ] Capturar un par de costos referencia y proyecto inline → reabrir PDF → tabla debe mostrar los nuevos valores con delta calculado.
- [ ] Verificar branding: olivo en header + footer, isotipo presente, fecha en español, footer con \"DESARROLLO INMOBILIARIO LOS ENCINOS\" + url.

## Próximo sprint

**4D — Análisis AI** queda pendiente. Necesito tu input cuando estés listo:
- ¿Qué modelo prefieres? (Claude / GPT-4o / Gemini 2.5)
- ¿El plano viene como PDF que el usuario sube, o leemos el \`plano_oficial_url\` ya capturado?
- ¿Qué outputs específicos quieres? (áreas / lotes / vialidades / banquetas / áreas verdes / recomendaciones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)