### PR TITLE
Sprint 4E: análisis con IA del plano del anteproyecto (DILESA)

### DIFF
--- a/app/api/dilesa/anteproyectos/planos/[planoId]/analizar-ai/route.ts
+++ b/app/api/dilesa/anteproyectos/planos/[planoId]/analizar-ai/route.ts
@@ -1,0 +1,188 @@
+/**
+ * POST /api/dilesa/anteproyectos/planos/[planoId]/analizar-ai
+ *
+ * Corre Claude vision sobre el archivo principal del plano y guarda
+ * el resultado en `dilesa.proyecto_planos.ai_analisis` (jsonb).
+ *
+ * Sprint 4E de `dilesa-proyectos-checklist-inline`.
+ *
+ * Flujo:
+ *   1) Carga el row del plano vía RLS (el usuario debe pertenecer a
+ *      la empresa).
+ *   2) Busca el primer adjunto físico vinculado en `erp.adjuntos`
+ *      con `entidad_tipo='proyecto_plano' AND entidad_id=planoId`.
+ *      Si hay varios, toma el más reciente (created_at desc).
+ *   3) Descarga los bytes desde Storage bucket `adjuntos` con
+ *      service-role (RLS de Storage no aplica al admin client).
+ *   4) Llama Claude vision con el schema estructurado.
+ *   5) Normaliza el output (0 → null, "" → null).
+ *   6) UPDATE el jsonb + analizado_en timestamp.
+ *
+ * Cost approx: ~$0.01-0.05 por análisis dependiendo del tamaño del
+ * plano. Claude Opus 4.7 con vision.
+ */
+
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { analizarPlanoConClaude } from '@/lib/dilesa/plano-ai/analizar';
+import { normalizarAnalisis } from '@/lib/dilesa/plano-ai/schema';
+
+async function makeServerClient() {
+  const cookieStore = await cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll() {
+          // no-op
+        },
+      },
+    }
+  );
+}
+
+const SUPPORTED_MIME = new Set([
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+]);
+
+function mediaTypeFromName(name: string): string {
+  const ext = name.toLowerCase().split('.').pop() ?? '';
+  switch (ext) {
+    case 'pdf':
+      return 'application/pdf';
+    case 'png':
+      return 'image/png';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'webp':
+      return 'image/webp';
+    case 'heic':
+    case 'heif':
+    case 'tiff':
+      return ''; // no soportado por Claude vision directo
+    default:
+      return '';
+  }
+}
+
+export async function POST(_req: Request, { params }: { params: Promise<{ planoId: string }> }) {
+  const { planoId } = await params;
+  if (!planoId) {
+    return NextResponse.json({ error: 'planoId requerido' }, { status: 400 });
+  }
+
+  const sb = await makeServerClient();
+
+  // 1) Cargar plano vía RLS — confirma acceso del user a la empresa.
+  const { data: plano, error: planoErr } = await sb
+    .schema('dilesa')
+    .from('proyecto_planos')
+    .select('id, empresa_id, proyecto_id, version')
+    .eq('id', planoId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (planoErr) {
+    return NextResponse.json({ error: planoErr.message }, { status: 500 });
+  }
+  if (!plano) {
+    return NextResponse.json({ error: 'Plano no encontrado' }, { status: 404 });
+  }
+
+  // 2) Buscar el adjunto más reciente vinculado.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: adjuntos, error: adjErr } = await (sb.schema('erp') as any)
+    .from('adjuntos')
+    .select('id, nombre, url, created_at')
+    .eq('entidad_tipo', 'proyecto_plano')
+    .eq('entidad_id', planoId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (adjErr) {
+    return NextResponse.json({ error: adjErr.message }, { status: 500 });
+  }
+  if (!adjuntos || adjuntos.length === 0) {
+    return NextResponse.json(
+      { error: 'Esta versión del plano no tiene archivo. Sube un PDF o imagen primero.' },
+      { status: 400 }
+    );
+  }
+  const adjunto = adjuntos[0] as { id: string; nombre: string; url: string };
+
+  // 3) Validar MIME soportado.
+  const mediaType = mediaTypeFromName(adjunto.nombre);
+  if (!mediaType || !SUPPORTED_MIME.has(mediaType)) {
+    return NextResponse.json(
+      {
+        error:
+          'Formato no soportado por Claude vision. Sube PDF, PNG, JPG o WebP (HEIC/TIFF no aceptados).',
+      },
+      { status: 400 }
+    );
+  }
+
+  // 4) Descargar bytes con service-role (bypassea RLS de Storage; la
+  //    autorización ya la hizo la RLS de proyecto_planos arriba).
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json({ error: 'Cliente admin no disponible' }, { status: 500 });
+  }
+  const { data: blob, error: dlErr } = await admin.storage.from('adjuntos').download(adjunto.url);
+  if (dlErr || !blob) {
+    return NextResponse.json(
+      { error: `No se pudo descargar el archivo: ${dlErr?.message ?? 'unknown'}` },
+      { status: 500 }
+    );
+  }
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+
+  // 5) Llamar Claude vision con schema estructurado.
+  let analisisRaw;
+  try {
+    analisisRaw = await analizarPlanoConClaude(bytes, mediaType);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error('[analizar-plano-ai] Claude vision falló', { planoId, msg });
+    return NextResponse.json({ error: `Claude vision falló: ${msg}` }, { status: 500 });
+  }
+
+  const analisis = normalizarAnalisis(analisisRaw);
+
+  // 6) UPDATE el jsonb + analizado_en timestamp.
+  const payload = {
+    ...analisis,
+    archivo_nombre: adjunto.nombre,
+    archivo_adjunto_id: adjunto.id,
+    analizado_en: new Date().toISOString(),
+    modelo: 'claude-opus-4-7',
+  };
+
+  const { error: upErr } = await sb
+    .schema('dilesa')
+    .from('proyecto_planos')
+    .update({
+      ai_analisis: payload,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', planoId);
+
+  if (upErr) {
+    return NextResponse.json({ error: upErr.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, analisis: payload });
+}
+
+export const runtime = 'nodejs';
+// Claude vision sobre planos grandes puede tardar — extendemos timeout.
+export const maxDuration = 120;

--- a/app/dilesa/proyectos/anteproyectos/[id]/page.tsx
+++ b/app/dilesa/proyectos/anteproyectos/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
@@ -39,27 +39,36 @@ function Body() {
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
 
-  useEffect(() => {
+  const cargarAnteproyecto = useCallback(async () => {
     if (!id) return;
-    let activo = true;
-    void createSupabaseBrowserClient()
+    const { data } = await createSupabaseBrowserClient()
       .schema('dilesa')
       .from('proyectos')
       .select(PROYECTO_DETALLE_COLUMNAS)
       .eq('id', id)
       .eq('tipo', 'anteproyecto')
       .is('deleted_at', null)
-      .maybeSingle()
-      .then(({ data }) => {
-        if (!activo) return;
-        if (!data) setNotFound(true);
-        else setAnteproyecto(data as unknown as ProyectoDetalleType);
-        setLoading(false);
-      });
+      .maybeSingle();
+    if (!data) {
+      setNotFound(true);
+      setAnteproyecto(null);
+    } else {
+      setAnteproyecto(data as unknown as ProyectoDetalleType);
+    }
+    setLoading(false);
+  }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+    let activo = true;
+    void (async () => {
+      await cargarAnteproyecto();
+      if (!activo) return;
+    })();
     return () => {
       activo = false;
     };
-  }, [id]);
+  }, [id, cargarAnteproyecto]);
 
   return (
     <div>
@@ -78,7 +87,12 @@ function Body() {
           No se encontró el anteproyecto. Probablemente fue eliminado o convertido.
         </p>
       )}
-      {!loading && !notFound && anteproyecto && <AnteproyectoDetalle anteproyecto={anteproyecto} />}
+      {!loading && !notFound && anteproyecto && (
+        <AnteproyectoDetalle
+          anteproyecto={anteproyecto}
+          onAnteproyectoChange={cargarAnteproyecto}
+        />
+      )}
     </div>
   );
 }

--- a/app/dilesa/proyectos/anteproyectos/aplicar-ai-actions.test.ts
+++ b/app/dilesa/proyectos/anteproyectos/aplicar-ai-actions.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests para `aplicarAiAlAnalisisFinanciero` (Sprint 4E).
+ * Mock separado del de `planos-actions.test.ts` porque el shape de la
+ * chain es distinto (no necesita order/limit, sí necesita un select
+ * con columnas específicas en proyectos).
+ */
+
+let lastPatch: Record<string, unknown> | null = null;
+let planoRow: {
+  id: string;
+  proyecto_id: string;
+  ai_analisis: Record<string, unknown> | null;
+} | null = null;
+let proyectoRow: Record<string, number | null> | null = null;
+let updateError: { message: string } | null = null;
+
+vi.mock('next/headers', () => ({
+  cookies: async () => ({ getAll: () => [], setAll: () => {} }),
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: () => {} }));
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: () => ({
+    auth: { getUser: async () => ({ data: { user: { email: 'beto@anorte.com' } } }) },
+    schema: (_schemaName: string) => ({
+      from: (table: string) => {
+        if (table === 'proyecto_planos') {
+          return {
+            select: () => ({
+              eq: () => ({
+                is: () => ({
+                  maybeSingle: async () => ({ data: planoRow, error: null }),
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === 'proyectos') {
+          return {
+            select: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({ data: proyectoRow, error: null }),
+              }),
+            }),
+            update: (patch: Record<string, unknown>) => {
+              lastPatch = patch;
+              return {
+                eq: () => Promise.resolve({ error: updateError }),
+              };
+            },
+          };
+        }
+        return {};
+      },
+    }),
+  }),
+}));
+
+beforeEach(() => {
+  lastPatch = null;
+  updateError = null;
+  planoRow = {
+    id: 'plano-1',
+    proyecto_id: 'p1',
+    ai_analisis: {
+      area_total_m2: 50_000,
+      area_vendible_m2: 30_000,
+      areas_verdes_m2: 5_000,
+      area_vialidades_m2: 8_000,
+      lotes_proyectados: 150,
+      tamano_lote_promedio_m2: 200,
+    },
+  };
+  proyectoRow = {
+    area_m2: null,
+    area_vendible_m2: null,
+    areas_verdes_m2: null,
+    area_vialidades_m2: null,
+    lotes_proyectados: null,
+    tamano_lote_promedio: null,
+  };
+});
+
+describe('aplicarAiAlAnalisisFinanciero (Sprint 4E)', () => {
+  it('rechaza planoId vacío', async () => {
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rechaza plano sin análisis AI todavía', async () => {
+    planoRow = { id: 'plano-1', proyecto_id: 'p1', ai_analisis: null };
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('plano-1');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/análisis ai/i);
+  });
+
+  it('rechaza plano no encontrado', async () => {
+    planoRow = null;
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('p-bad');
+    expect(r.ok).toBe(false);
+  });
+
+  it('llena todos los campos cuando proyecto está vacío', async () => {
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('plano-1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.aplicados).toHaveLength(6);
+    expect(lastPatch).toEqual({
+      area_m2: 50_000,
+      area_vendible_m2: 30_000,
+      areas_verdes_m2: 5_000,
+      area_vialidades_m2: 8_000,
+      lotes_proyectados: 150,
+      tamano_lote_promedio: 200,
+    });
+  });
+
+  it('NO machaca valores ya capturados (sin overwrite)', async () => {
+    proyectoRow = {
+      area_m2: 99_999, // ya capturado
+      area_vendible_m2: null,
+      areas_verdes_m2: null,
+      area_vialidades_m2: null,
+      lotes_proyectados: null,
+      tamano_lote_promedio: null,
+    };
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('plano-1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.aplicados).toHaveLength(5);
+    expect((lastPatch as Record<string, unknown>)?.area_m2).toBeUndefined();
+    expect((lastPatch as Record<string, unknown>)?.area_vendible_m2).toBe(30_000);
+  });
+
+  it('overwrite=true pisa valores existentes', async () => {
+    proyectoRow = {
+      area_m2: 99_999,
+      area_vendible_m2: 88_888,
+      areas_verdes_m2: null,
+      area_vialidades_m2: null,
+      lotes_proyectados: null,
+      tamano_lote_promedio: null,
+    };
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('plano-1', { overwrite: true });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.aplicados).toHaveLength(6);
+    expect((lastPatch as Record<string, unknown>)?.area_m2).toBe(50_000);
+    expect((lastPatch as Record<string, unknown>)?.area_vendible_m2).toBe(30_000);
+  });
+
+  it('campos AI null se saltan', async () => {
+    planoRow = {
+      id: 'plano-1',
+      proyecto_id: 'p1',
+      ai_analisis: {
+        area_total_m2: 50_000,
+        // resto null/undefined
+      },
+    };
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('plano-1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.aplicados).toEqual(['area_m2']);
+    expect((lastPatch as Record<string, unknown>)?.area_m2).toBe(50_000);
+  });
+
+  it('cero aplicados cuando todo el proyecto ya está completo', async () => {
+    proyectoRow = {
+      area_m2: 1,
+      area_vendible_m2: 1,
+      areas_verdes_m2: 1,
+      area_vialidades_m2: 1,
+      lotes_proyectados: 1,
+      tamano_lote_promedio: 1,
+    };
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('plano-1');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.aplicados).toHaveLength(0);
+    expect(lastPatch).toBeNull(); // no UPDATE disparado
+  });
+
+  it('propaga error de DB en UPDATE', async () => {
+    updateError = { message: 'RLS denied' };
+    const { aplicarAiAlAnalisisFinanciero } = await import('./planos-actions');
+    const r = await aplicarAiAlAnalisisFinanciero('plano-1');
+    expect(r.ok).toBe(false);
+  });
+});

--- a/app/dilesa/proyectos/anteproyectos/planos-actions.ts
+++ b/app/dilesa/proyectos/anteproyectos/planos-actions.ts
@@ -191,3 +191,94 @@ export async function eliminarPlanoVersion(planoId: string): Promise<SimpleResul
   revalidateAnteproyectosPaths();
   return { ok: true };
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Sprint 4E — aplicar análisis AI al análisis financiero del proyecto
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Toma el `ai_analisis` del plano y pre-llena los campos del análisis
+ * financiero del proyecto (área total, vendible, verdes, vialidades,
+ * lotes, lote promedio). NO machaca valores ya capturados — solo
+ * llena los que están en NULL.
+ *
+ * Si `overwrite=true`, sí pisa los existentes (admin opcionalmente).
+ *
+ * El AI puede equivocarse. Después de aplicar, el usuario revisa en
+ * el componente del análisis financiero y edita lo que necesite.
+ */
+export async function aplicarAiAlAnalisisFinanciero(
+  planoId: string,
+  options: { overwrite?: boolean } = {}
+): Promise<{ ok: true; aplicados: string[] } | { ok: false; error: string }> {
+  if (!planoId) return { ok: false, error: 'planoId requerido' };
+  const supabase = await makeServerClient();
+
+  // Cargar análisis del plano + proyecto_id.
+  const { data: plano, error: pErr } = await supabase
+    .schema('dilesa')
+    .from('proyecto_planos')
+    .select('id, proyecto_id, ai_analisis')
+    .eq('id', planoId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (pErr) return { ok: false, error: pErr.message };
+  if (!plano) return { ok: false, error: 'Plano no encontrado' };
+  if (!plano.ai_analisis) {
+    return { ok: false, error: 'Esta versión no tiene análisis AI todavía' };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ai = plano.ai_analisis as any;
+
+  // Mapeo AI → columnas del proyecto.
+  const candidatos: Array<{ col: string; value: number | null }> = [
+    { col: 'area_m2', value: ai.area_total_m2 ?? null },
+    { col: 'area_vendible_m2', value: ai.area_vendible_m2 ?? null },
+    { col: 'areas_verdes_m2', value: ai.areas_verdes_m2 ?? null },
+    { col: 'area_vialidades_m2', value: ai.area_vialidades_m2 ?? null },
+    { col: 'lotes_proyectados', value: ai.lotes_proyectados ?? null },
+    { col: 'tamano_lote_promedio', value: ai.tamano_lote_promedio_m2 ?? null },
+  ];
+
+  // Cargar el proyecto para no machacar valores existentes (unless overwrite).
+  const { data: proy, error: pyErr } = await supabase
+    .schema('dilesa')
+    .from('proyectos')
+    .select(
+      'area_m2, area_vendible_m2, areas_verdes_m2, area_vialidades_m2, lotes_proyectados, tamano_lote_promedio'
+    )
+    .eq('id', plano.proyecto_id)
+    .maybeSingle();
+  if (pyErr) return { ok: false, error: pyErr.message };
+  if (!proy) return { ok: false, error: 'Proyecto no encontrado' };
+
+  const patch: Record<string, number> = {};
+  const aplicados: string[] = [];
+  for (const c of candidatos) {
+    if (c.value == null) continue;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const current = (proy as any)[c.col] as number | null;
+    if (options.overwrite || current == null) {
+      patch[c.col] = c.value;
+      aplicados.push(c.col);
+    }
+  }
+
+  if (aplicados.length === 0) {
+    return {
+      ok: true,
+      aplicados: [],
+    };
+  }
+
+  const { error: upErr } = await supabase
+    .schema('dilesa')
+    .from('proyectos')
+    .update(patch)
+    .eq('id', plano.proyecto_id);
+  if (upErr) return { ok: false, error: upErr.message };
+
+  revalidateAnteproyectosPaths();
+  return { ok: true, aplicados };
+}

--- a/components/dilesa/anteproyecto-detalle.tsx
+++ b/components/dilesa/anteproyecto-detalle.tsx
@@ -212,7 +212,15 @@ export function deriveAnalisis(p: ProyectoDetalle) {
   };
 }
 
-export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDetalle | null }) {
+export function AnteproyectoDetalle({
+  anteproyecto,
+  onAnteproyectoChange,
+}: {
+  anteproyecto: ProyectoDetalle | null;
+  /** Callback opcional para refrescar el row cuando un hijo (ej.
+   *  PlanoAnteproyecto al aplicar AI) muta columnas del proyecto. */
+  onAnteproyectoChange?: () => void | Promise<void>;
+}) {
   const [tareas, setTareas] = useState<ProyectoTarea[]>([]);
   const [dependencias, setDependencias] = useState<TareaDep[]>([]);
   const [pasos, setPasos] = useState<PasoRow[]>([]);
@@ -470,6 +478,9 @@ export function AnteproyectoDetalle({ anteproyecto }: { anteproyecto: ProyectoDe
         proyectoId={anteproyecto.id}
         empresaId={DILESA_EMPRESA_ID}
         empresaSlug="dilesa"
+        onAnalisisAplicado={() => {
+          void onAnteproyectoChange?.();
+        }}
       />
 
       {/* Ficha física + Costos estimados + Análisis derivado quedaron

--- a/components/dilesa/plano-anteproyecto.tsx
+++ b/components/dilesa/plano-anteproyecto.tsx
@@ -27,6 +27,7 @@ import type { FileRole } from '@/components/file-attachments/types';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import {
   actualizarPlanoDescripcion,
+  aplicarAiAlAnalisisFinanciero,
   crearPlanoVersion,
   eliminarPlanoVersion,
   marcarPlanoVigente,
@@ -38,6 +39,25 @@ export type PlanoVersionRow = {
   descripcion: string | null;
   vigente: boolean;
   created_at: string;
+  ai_analisis: PlanoAiAnalisisPersistido | null;
+};
+
+/** Shape persistida del análisis AI en `ai_analisis jsonb`. */
+export type PlanoAiAnalisisPersistido = {
+  area_total_m2: number | null;
+  area_vendible_m2: number | null;
+  areas_verdes_m2: number | null;
+  area_vialidades_m2: number | null;
+  lotes_proyectados: number | null;
+  tamano_lote_promedio_m2: number | null;
+  tipologia_principal: string | null;
+  observaciones: string | null;
+  recomendaciones: string[];
+  confianza: 'alta' | 'media' | 'baja';
+  archivo_nombre?: string;
+  archivo_adjunto_id?: string;
+  analizado_en?: string;
+  modelo?: string;
 };
 
 const fechaFmt = new Intl.DateTimeFormat('es-MX', {
@@ -56,10 +76,14 @@ export function PlanoAnteproyecto({
   proyectoId,
   empresaId,
   empresaSlug,
+  onAnalisisAplicado,
 }: {
   proyectoId: string;
   empresaId: string;
   empresaSlug: string;
+  /** Se llama después de "Aplicar al análisis financiero" para que el
+   *  padre refresque la sección de análisis financiero. */
+  onAnalisisAplicado?: () => void;
 }) {
   const [planos, setPlanos] = useState<PlanoVersionRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -68,6 +92,8 @@ export function PlanoAnteproyecto({
   const [pending, startTransition] = useTransition();
   const [editingDescId, setEditingDescId] = useState<string | null>(null);
   const [descDraft, setDescDraft] = useState('');
+  const [analizandoAi, setAnalizandoAi] = useState(false);
+  const [aiMessage, setAiMessage] = useState<string | null>(null);
 
   const cargar = useCallback(async () => {
     setLoading(true);
@@ -75,7 +101,7 @@ export function PlanoAnteproyecto({
     const { data, error: err } = await supabase
       .schema('dilesa')
       .from('proyecto_planos')
-      .select('id, version, descripcion, vigente, created_at')
+      .select('id, version, descripcion, vigente, created_at, ai_analisis')
       .eq('proyecto_id', proyectoId)
       .is('deleted_at', null)
       .order('version', { ascending: false });
@@ -93,7 +119,7 @@ export function PlanoAnteproyecto({
   }, [proyectoId]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+     
     void cargar();
   }, [cargar]);
 
@@ -156,6 +182,48 @@ export function PlanoAnteproyecto({
       }
       setEditingDescId(null);
       await cargar();
+    });
+  };
+
+  const handleAnalizarAi = async (planoId: string) => {
+    setError(null);
+    setAiMessage(null);
+    setAnalizandoAi(true);
+    try {
+      const res = await fetch(`/api/dilesa/anteproyectos/planos/${planoId}/analizar-ai`, {
+        method: 'POST',
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!res.ok || !json.ok) {
+        setError(json.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      await cargar();
+    } finally {
+      setAnalizandoAi(false);
+    }
+  };
+
+  const handleAplicarAi = (planoId: string) => {
+    setError(null);
+    setAiMessage(null);
+    startTransition(async () => {
+      const r = await aplicarAiAlAnalisisFinanciero(planoId);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      if (r.aplicados.length === 0) {
+        setAiMessage(
+          'Todos los campos ya tenían valor. Edita manualmente si quieres reemplazarlos.'
+        );
+      } else {
+        setAiMessage(`Aplicado: ${r.aplicados.length} campos pre-llenados al análisis.`);
+      }
+      onAnalisisAplicado?.();
     });
   };
 
@@ -292,11 +360,171 @@ export function PlanoAnteproyecto({
               accept=".pdf,.png,.jpg,.jpeg,.webp,.heic,.heif,.tiff"
               variant="grouped"
             />
+
+            <AiPanel
+              plano={selected}
+              analizando={analizandoAi}
+              pending={pending}
+              onAnalizar={() => handleAnalizarAi(selected.id)}
+              onAplicar={() => handleAplicarAi(selected.id)}
+              message={aiMessage}
+            />
           </article>
         )}
 
         {error && <p className="mt-2 text-xs text-red-600/80">{error}</p>}
       </div>
     </section>
+  );
+}
+
+// ── Panel del análisis AI ────────────────────────────────────────────────────
+
+const numFmt = new Intl.NumberFormat('es-MX');
+const fmtM2 = (n: number | null | undefined): string =>
+  n == null ? '—' : `${numFmt.format(n)} m²`;
+const fmtInt = (n: number | null | undefined): string => (n == null ? '—' : numFmt.format(n));
+
+function confianzaTone(c: 'alta' | 'media' | 'baja' | undefined): string {
+  if (c === 'alta') return 'border-emerald-300 bg-emerald-50 text-emerald-700';
+  if (c === 'media') return 'border-amber-300 bg-amber-50 text-amber-700';
+  if (c === 'baja') return 'border-red-300 bg-red-50 text-red-700';
+  return 'border-[var(--border)] bg-[var(--card)] text-[var(--muted-text)]';
+}
+
+function AiPanel({
+  plano,
+  analizando,
+  pending,
+  onAnalizar,
+  onAplicar,
+  message,
+}: {
+  plano: PlanoVersionRow;
+  analizando: boolean;
+  pending: boolean;
+  onAnalizar: () => void;
+  onAplicar: () => void;
+  message: string | null;
+}) {
+  const ai = plano.ai_analisis;
+  const tieneAnalisis = ai != null;
+  const disabled = analizando || pending;
+
+  return (
+    <div className="rounded-md border border-[var(--border)] bg-[var(--card)] p-3">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-[var(--text)]">
+            Análisis con IA
+          </h4>
+          {tieneAnalisis && (
+            <span
+              className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${confianzaTone(ai?.confianza)}`}
+            >
+              Confianza: {ai?.confianza ?? '—'}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onAnalizar}
+            disabled={disabled}
+            className="h-7 rounded-sm bg-[var(--accent)] px-3 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
+          >
+            {analizando ? 'Analizando…' : tieneAnalisis ? 'Re-analizar' : 'Analizar con IA'}
+          </button>
+          {tieneAnalisis && (
+            <button
+              type="button"
+              onClick={onAplicar}
+              disabled={disabled}
+              className="h-7 rounded-sm border border-[var(--border)] bg-[var(--bg)] px-3 text-xs font-medium text-[var(--text)] hover:bg-[var(--card)] disabled:opacity-50"
+              title="Llena los campos vacíos del análisis financiero con estos valores. No machaca lo capturado."
+            >
+              Aplicar al análisis financiero
+            </button>
+          )}
+        </div>
+      </header>
+
+      {!tieneAnalisis ? (
+        <p className="mt-2 text-xs text-[var(--muted-text)]">
+          Sube un PDF o imagen del plano arriba, luego presiona <strong>Analizar con IA</strong>.
+          Claude vision detecta áreas, lotes, vialidades y propone recomendaciones. Después puedes
+          aplicarlo al análisis financiero (solo llena campos vacíos).
+        </p>
+      ) : (
+        <div className="mt-3 space-y-3">
+          {/* Métricas extraídas */}
+          <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs sm:grid-cols-3 lg:grid-cols-6">
+            <KV k="Área total" v={fmtM2(ai?.area_total_m2 ?? null)} />
+            <KV k="Vendible" v={fmtM2(ai?.area_vendible_m2 ?? null)} />
+            <KV k="Áreas verdes" v={fmtM2(ai?.areas_verdes_m2 ?? null)} />
+            <KV k="Vialidades" v={fmtM2(ai?.area_vialidades_m2 ?? null)} />
+            <KV k="Lotes" v={fmtInt(ai?.lotes_proyectados ?? null)} />
+            <KV k="Lote prom." v={fmtM2(ai?.tamano_lote_promedio_m2 ?? null)} />
+          </div>
+
+          {/* Tipología detectada */}
+          {ai?.tipologia_principal && (
+            <div className="text-xs">
+              <span className="text-[var(--muted-text)]">Tipología detectada: </span>
+              <span className="font-medium text-[var(--text)]">{ai.tipologia_principal}</span>
+            </div>
+          )}
+
+          {/* Observaciones */}
+          {ai?.observaciones && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wide text-[var(--muted-text)]">
+                Observaciones
+              </div>
+              <p className="mt-1 whitespace-pre-line text-xs text-[var(--text)]">
+                {ai.observaciones}
+              </p>
+            </div>
+          )}
+
+          {/* Recomendaciones */}
+          {ai?.recomendaciones && ai.recomendaciones.length > 0 && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wide text-[var(--muted-text)]">
+                Recomendaciones
+              </div>
+              <ul className="mt-1 space-y-1 text-xs text-[var(--text)]">
+                {ai.recomendaciones.map((r, i) => (
+                  <li key={i} className="flex gap-2">
+                    <span aria-hidden className="text-[var(--muted-text)]">
+                      •
+                    </span>
+                    <span>{r}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {ai?.analizado_en && (
+            <p className="text-[10px] text-[var(--muted-text)]">
+              Analizado {new Date(ai.analizado_en).toLocaleString('es-MX')} con{' '}
+              <code>{ai?.modelo ?? 'claude'}</code>.
+            </p>
+          )}
+        </div>
+      )}
+
+      {message && <p className="mt-2 text-xs text-emerald-700">{message}</p>}
+    </div>
+  );
+}
+
+function KV({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] uppercase tracking-wide text-[var(--muted-text)]">{k}</span>
+      <span className="text-xs font-semibold tabular-nums text-[var(--text)]">{v}</span>
+    </div>
   );
 }

--- a/components/dilesa/plano-anteproyecto.tsx
+++ b/components/dilesa/plano-anteproyecto.tsx
@@ -119,7 +119,6 @@ export function PlanoAnteproyecto({
   }, [proyectoId]);
 
   useEffect(() => {
-     
     void cargar();
   }, [cargar]);
 

--- a/lib/dilesa/plano-ai/analizar.ts
+++ b/lib/dilesa/plano-ai/analizar.ts
@@ -1,0 +1,119 @@
+/**
+ * Análisis con IA del plano del anteproyecto vía Claude vision.
+ * Sprint 4E de `dilesa-proyectos-checklist-inline`.
+ *
+ * Reusa la infraestructura de `lib/documentos/extraction-core.ts`:
+ * cliente Anthropic con baseURL explícito + modelo
+ * `claude-opus-4-7` con vision capability. Pasamos el plano en
+ * `content.type='file'` (PDF) o `content.type='image'` según
+ * extensión.
+ *
+ * El prompt instruye al modelo a:
+ *   - Leer áreas, lotes, vialidades, etc. de la lotificación.
+ *   - Inferir métricas faltantes desde escala / proporción cuando
+ *     sea razonable.
+ *   - Retornar 0 si no puede determinar un valor con confianza
+ *     (convención del schema; el consumer normaliza 0 → null).
+ *   - Auto-evaluar confianza (alta/media/baja).
+ *   - Listar recomendaciones concretas para el desarrollo.
+ */
+
+import { generateObject } from 'ai';
+import { anthropic, MODELO_CLAUDE } from '@/lib/documentos/extraction-core';
+import { PlanoAiAnalisisSchema, type PlanoAiAnalisis } from './schema';
+
+const PROMPT = `Eres analista inmobiliario senior de DILESA, una desarrolladora
+de fraccionamientos residenciales y comerciales en Coahuila, México.
+
+Recibes el plano del **anteproyecto** de un fraccionamiento (puede ser un
+borrador, NO es el plano oficial). Tu trabajo es leer el plano y devolver
+un JSON con las métricas geométricas + observaciones técnicas + recomendaciones.
+
+Reglas:
+
+1. Lee con cuidado **TODA la información visible**: leyendas, tablas de
+   datos generales, cuadros de superficies, simbología, escalas. Los planos
+   profesionales suelen traer un cuadro "Resumen" con áreas exactas.
+
+2. Si el plano NO tiene tabla resumen, infiere las áreas desde:
+   - La escala declarada (1:1000, 1:500, etc.).
+   - La proporción visual entre regiones.
+   - El total declarado del predio.
+
+3. Métricas a extraer (m² o conteo):
+   - **area_total_m2**: superficie total del polígono del predio.
+   - **area_vendible_m2**: suma de las áreas de lotes (residenciales,
+     comerciales, mixtos). Excluye vialidades, áreas verdes, donaciones.
+   - **areas_verdes_m2**: áreas marcadas como parques, jardines,
+     plaza, donación de área verde, andador peatonal con vegetación.
+   - **area_vialidades_m2**: arroyo vehicular + banquetas + camellones.
+   - **lotes_proyectados**: conteo total de lotes individuales del plano.
+   - **tamano_lote_promedio_m2**: si lo declara la tabla resumen úsalo,
+     sino calcula area_vendible_m2 / lotes_proyectados.
+
+4. Tipología:
+   - **tipologia_principal**: usa SOLO uno de estos códigos exactos
+     según el patrón observado: \`interes_social\`, \`residencial_medio\`,
+     \`residencial_alto\`, \`plaza_comercial\`, \`usos_mixtos\`,
+     \`naves_industriales\`, \`oficinas\`, \`departamentos\`,
+     \`lotificacion\`. Pista: lotes <120 m² suelen ser interés social;
+     200-400 m² residencial medio; >400 m² residencial alto.
+
+5. Observaciones (texto libre, español, máximo 2 párrafos):
+   - Trazo de calles (rectangular, curvo, mixto).
+   - Ubicación de áreas comunes y accesos.
+   - Infraestructura visible (tanques, subestaciones).
+   - Calidad del plano, escala, orientación, fecha si aparece.
+   - Irregularidades o cosas que llamen la atención.
+
+6. Recomendaciones (lista corta, máximo 6 puntos):
+   - Aspectos a revisar antes de aprobar.
+   - Ajustes sugeridos para mejor aprovechamiento.
+   - Riesgos identificados.
+   - Oportunidades de optimización.
+
+7. Confianza:
+   - \`alta\` si las métricas vienen de tabla resumen o son explícitas.
+   - \`media\` si parte se infirió desde escala/proporción.
+   - \`baja\` si el plano es ilegible o faltan datos críticos.
+
+8. **Si un dato no se puede determinar con confianza razonable, retorna
+   0** (numéricos) o cadena vacía (strings). NO inventes números.
+
+Devuelve SOLO el objeto JSON, sin texto adicional.`;
+
+/**
+ * Analiza el plano (bytes del archivo) con Claude vision y devuelve el
+ * análisis estructurado.
+ *
+ * `mediaType` puede ser:
+ *   - `'application/pdf'` — Claude soporta PDFs hasta 32MB directos.
+ *   - `'image/png'`, `'image/jpeg'`, `'image/webp'` — imágenes hasta
+ *     ~3.75MB después de base64.
+ *
+ * Si el plano es muy grande, comprimirlo / convertirlo a imagen del
+ * lado del caller (no aquí — esto solo orquesta la llamada).
+ */
+export async function analizarPlanoConClaude(
+  bytes: Uint8Array,
+  mediaType: string
+): Promise<PlanoAiAnalisis> {
+  const isImage = mediaType.startsWith('image/');
+  const { object } = await generateObject({
+    model: anthropic(MODELO_CLAUDE),
+    schema: PlanoAiAnalisisSchema,
+    maxRetries: 3,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: PROMPT },
+          isImage
+            ? { type: 'image', image: bytes, mediaType }
+            : { type: 'file', data: bytes, mediaType },
+        ],
+      },
+    ],
+  });
+  return object;
+}

--- a/lib/dilesa/plano-ai/schema.test.ts
+++ b/lib/dilesa/plano-ai/schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { PlanoAiAnalisisSchema, normalizarAnalisis } from './schema';
+
+const minimal = {
+  area_total_m2: 0,
+  area_vendible_m2: 0,
+  areas_verdes_m2: 0,
+  area_vialidades_m2: 0,
+  lotes_proyectados: 0,
+  tamano_lote_promedio_m2: 0,
+  tipologia_principal: '',
+  observaciones: '',
+  recomendaciones: [],
+  confianza: 'media' as const,
+};
+
+describe('PlanoAiAnalisisSchema (Sprint 4E)', () => {
+  it('acepta payload mínimo con todos los 0/empty', () => {
+    const r = PlanoAiAnalisisSchema.safeParse(minimal);
+    expect(r.success).toBe(true);
+  });
+
+  it('rechaza confianza fuera del enum', () => {
+    const r = PlanoAiAnalisisSchema.safeParse({ ...minimal, confianza: 'super-alta' });
+    expect(r.success).toBe(false);
+  });
+
+  it('aplica defaults cuando faltan campos', () => {
+    const r = PlanoAiAnalisisSchema.safeParse({ confianza: 'alta' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.area_total_m2).toBe(0);
+      expect(r.data.tipologia_principal).toBe('');
+      expect(r.data.recomendaciones).toEqual([]);
+    }
+  });
+});
+
+describe('normalizarAnalisis (0 → null, "" → null)', () => {
+  it('todo 0 / "" → todos null', () => {
+    const out = normalizarAnalisis(minimal);
+    expect(out.area_total_m2).toBeNull();
+    expect(out.area_vendible_m2).toBeNull();
+    expect(out.areas_verdes_m2).toBeNull();
+    expect(out.area_vialidades_m2).toBeNull();
+    expect(out.lotes_proyectados).toBeNull();
+    expect(out.tamano_lote_promedio_m2).toBeNull();
+    expect(out.tipologia_principal).toBeNull();
+    expect(out.observaciones).toBeNull();
+    expect(out.recomendaciones).toEqual([]);
+    expect(out.confianza).toBe('media');
+  });
+
+  it('valores > 0 se preservan', () => {
+    const out = normalizarAnalisis({
+      ...minimal,
+      area_total_m2: 50_000,
+      lotes_proyectados: 163,
+      confianza: 'alta',
+    });
+    expect(out.area_total_m2).toBe(50_000);
+    expect(out.lotes_proyectados).toBe(163);
+    expect(out.confianza).toBe('alta');
+  });
+
+  it('strings con whitespace solo se vuelven null', () => {
+    const out = normalizarAnalisis({
+      ...minimal,
+      tipologia_principal: '   ',
+      observaciones: '\t\n  ',
+    });
+    expect(out.tipologia_principal).toBeNull();
+    expect(out.observaciones).toBeNull();
+  });
+
+  it('recomendaciones filtra vacíos y limita a 6', () => {
+    const out = normalizarAnalisis({
+      ...minimal,
+      recomendaciones: ['', '  ', 'R1', 'R2', 'R3', 'R4', 'R5', 'R6', 'R7', 'R8'],
+    });
+    expect(out.recomendaciones).toHaveLength(6);
+    expect(out.recomendaciones[0]).toBe('R1');
+  });
+
+  it('preserva exactamente las 3 confianzas válidas', () => {
+    expect(normalizarAnalisis({ ...minimal, confianza: 'alta' }).confianza).toBe('alta');
+    expect(normalizarAnalisis({ ...minimal, confianza: 'media' }).confianza).toBe('media');
+    expect(normalizarAnalisis({ ...minimal, confianza: 'baja' }).confianza).toBe('baja');
+  });
+});

--- a/lib/dilesa/plano-ai/schema.ts
+++ b/lib/dilesa/plano-ai/schema.ts
@@ -43,9 +43,10 @@ export const PlanoAiAnalisisSchema = z.object({
     ),
   lotes_proyectados: z
     .number()
-    .int()
     .default(0)
-    .describe('Cantidad total de lotes proyectados. 0 si no se puede determinar.'),
+    .describe(
+      'Cantidad total de lotes proyectados (entero). 0 si no se puede determinar. El consumer lo redondea a entero.'
+    ),
   tamano_lote_promedio_m2: z
     .number()
     .default(0)
@@ -99,7 +100,7 @@ export function normalizarAnalisis(raw: PlanoAiAnalisis): {
     area_vendible_m2: num(raw.area_vendible_m2),
     areas_verdes_m2: num(raw.areas_verdes_m2),
     area_vialidades_m2: num(raw.area_vialidades_m2),
-    lotes_proyectados: num(raw.lotes_proyectados),
+    lotes_proyectados: raw.lotes_proyectados > 0 ? Math.round(raw.lotes_proyectados) : null,
     tamano_lote_promedio_m2: num(raw.tamano_lote_promedio_m2),
     tipologia_principal: str(raw.tipologia_principal),
     observaciones: str(raw.observaciones),

--- a/lib/dilesa/plano-ai/schema.ts
+++ b/lib/dilesa/plano-ai/schema.ts
@@ -1,0 +1,109 @@
+/**
+ * Schema Zod del análisis con IA del plano del anteproyecto.
+ * Sprint 4E de `dilesa-proyectos-checklist-inline`.
+ *
+ * Claude vision recibe el plano (PDF/imagen) y debe retornar un JSON
+ * estructurado con las métricas geométricas + observaciones libres.
+ *
+ * Respeta el límite de Anthropic de 16 union-type fields:
+ *   - Los m² individuales son `number` con default 0 → '0 = ausente'
+ *     (normalizado en el consumer).
+ *   - Recomendaciones son `string[]` (no nullable).
+ *   - Confianza es enum.
+ *
+ * Convención: el modelo retorna 0 cuando un dato no aparece o no
+ * puede determinarlo con confianza. El consumer normaliza 0 → null
+ * antes de persistir.
+ */
+
+import { z } from 'zod';
+
+export const PlanoAiAnalisisSchema = z.object({
+  area_total_m2: z
+    .number()
+    .default(0)
+    .describe(
+      'Área total del terreno en metros cuadrados, según el plano. 0 si no se puede determinar.'
+    ),
+  area_vendible_m2: z
+    .number()
+    .default(0)
+    .describe(
+      'Área vendible (suma de lotes residenciales/comerciales) en metros cuadrados. 0 si no se puede determinar.'
+    ),
+  areas_verdes_m2: z
+    .number()
+    .default(0)
+    .describe('Área de zonas verdes / parques en metros cuadrados. 0 si no se puede determinar.'),
+  area_vialidades_m2: z
+    .number()
+    .default(0)
+    .describe(
+      'Área de vialidades, banquetas y arroyos vehiculares en metros cuadrados. 0 si no se puede determinar.'
+    ),
+  lotes_proyectados: z
+    .number()
+    .int()
+    .default(0)
+    .describe('Cantidad total de lotes proyectados. 0 si no se puede determinar.'),
+  tamano_lote_promedio_m2: z
+    .number()
+    .default(0)
+    .describe(
+      'Tamaño promedio de los lotes en metros cuadrados (área vendible / cantidad de lotes). 0 si no se puede determinar.'
+    ),
+  tipologia_principal: z
+    .string()
+    .default('')
+    .describe(
+      'Tipología inmobiliaria predominante observada: "interes_social", "residencial_medio", "residencial_alto", "plaza_comercial", "usos_mixtos", "naves_industriales", "oficinas", "departamentos", "lotificacion". Vacío si no es identificable.'
+    ),
+  observaciones: z
+    .string()
+    .default('')
+    .describe(
+      'Texto libre con observaciones técnicas relevantes: trazo de calles, ubicación de áreas comunes, accesos, infraestructura mostrada, irregularidades, escala, orientación, fecha del plano si visible, etc. Máximo 2 párrafos.'
+    ),
+  recomendaciones: z
+    .array(z.string())
+    .default([])
+    .describe(
+      'Lista de recomendaciones concretas para el desarrollo: aspectos a revisar, ajustes sugeridos a la lotificación, riesgos identificados, oportunidades de mejor aprovechamiento. Hasta 6 puntos cortos.'
+    ),
+  confianza: z
+    .enum(['alta', 'media', 'baja'])
+    .describe(
+      'Auto-evaluación de la confianza del análisis. "alta" si el plano es legible y las métricas son explícitas; "media" si parte se infirió por escala/proporción; "baja" si la calidad del plano impide leer datos con certeza.'
+    ),
+});
+
+export type PlanoAiAnalisis = z.infer<typeof PlanoAiAnalisisSchema>;
+
+/** Normaliza 0 → null en los campos numéricos (convención del prompt). */
+export function normalizarAnalisis(raw: PlanoAiAnalisis): {
+  area_total_m2: number | null;
+  area_vendible_m2: number | null;
+  areas_verdes_m2: number | null;
+  area_vialidades_m2: number | null;
+  lotes_proyectados: number | null;
+  tamano_lote_promedio_m2: number | null;
+  tipologia_principal: string | null;
+  observaciones: string | null;
+  recomendaciones: string[];
+  confianza: 'alta' | 'media' | 'baja';
+} {
+  const num = (n: number) => (n > 0 ? n : null);
+  const str = (s: string) => (s.trim().length > 0 ? s : null);
+  return {
+    area_total_m2: num(raw.area_total_m2),
+    area_vendible_m2: num(raw.area_vendible_m2),
+    areas_verdes_m2: num(raw.areas_verdes_m2),
+    area_vialidades_m2: num(raw.area_vialidades_m2),
+    lotes_proyectados: num(raw.lotes_proyectados),
+    tamano_lote_promedio_m2: num(raw.tamano_lote_promedio_m2),
+    tipologia_principal: str(raw.tipologia_principal),
+    observaciones: str(raw.observaciones),
+    recomendaciones: raw.recomendaciones.filter((r) => r.trim().length > 0).slice(0, 6),
+    confianza: raw.confianza,
+  };
+}


### PR DESCRIPTION
## Summary

Sprint 4E de la iniciativa \`dilesa-proyectos-checklist-inline\`. Botón **"Analizar con IA"** sobre el plano vigente del anteproyecto. Claude Opus 4.7 vision lee el plano (PDF o imagen) y devuelve JSON estructurado: áreas (total/vendible/verdes/vialidades), lotes, lote promedio, tipología detectada, observaciones, recomendaciones y auto-evaluación de confianza.

### Arquitectura

\`\`\`
Click botón ─→ POST /api/dilesa/anteproyectos/planos/[planoId]/analizar-ai
                │
                ├─ RLS verifica acceso (proyecto_planos SELECT)
                ├─ Busca adjunto vinculado en erp.adjuntos
                ├─ Descarga bytes con service-role
                ├─ analizarPlanoConClaude(bytes, mediaType)  ← @ai-sdk/anthropic
                ├─ normalizarAnalisis (0/\"\" → null)
                └─ UPDATE proyecto_planos.ai_analisis
\`\`\`

### Componentes nuevos

- **\`lib/dilesa/plano-ai/schema.ts\`** — Zod schema con defaults sanos (números → 0, strings → \"\" si ausente, respetando el límite de 16 union-types de Anthropic) + \`normalizarAnalisis()\` que colapsa 0/\"\" → null antes de persistir.
- **\`lib/dilesa/plano-ai/analizar.ts\`** — wrapper sobre \`generateObject\` con prompt de analista inmobiliario DILESA. PDF como \`type=file\`, imagen como \`type=image\`.
- **Endpoint \`route.ts\`** — \`maxDuration=120\` para planos grandes.
- **Server action \`aplicarAiAlAnalisisFinanciero\`** — pre-llena los campos del proyecto. **No machaca lo capturado** a menos que pases \`overwrite=true\`.
- **Sub-componente \`<AiPanel>\`** dentro de \`<PlanoAnteproyecto>\`: panel del resultado con grid de métricas + tipología + observaciones + recomendaciones, badge \"confianza\" coloreado (verde/ámbar/rojo), botón \"Aplicar al análisis financiero\".
- **Página padre extendida** con \`onAnteproyectoChange\` callback para refetch del row tras aplicar AI.

### Costos

- Claude Opus 4.7 con vision: aprox **\$0.01-0.05** por plano (depende del tamaño). El test plan abajo cuenta como prueba real.

### Pre-flight verde

- \`typecheck\` — 0 errors
- \`test:run\` — **13730 tests** (17 nuevos: 8 schema + 9 server action)
- \`coverage\` — functions **70.68%** (sobre threshold 70)
- \`lint\` — 0 errors, \`format:check\` — verde

### Pendiente (Sprint 4F)

- Gate de autocompletado: cuando \`ai_analisis\` definitivo → tarea #3 \"Elaboración de Anteproyecto\" se marca completada automáticamente.
- Si plano vigente cambia → AI análisis previo se marca \"pendiente revisión\" en versión nueva.

## Test plan

- [ ] **Vercel preview**: abrir un anteproyecto, crear V1, subir un plano (PDF de fraccionamiento, ej. Lomas de las Delicias).
- [ ] Click **\"Analizar con IA\"** → spinner ~10-30s → aparece el panel con métricas extraídas.
- [ ] Verificar badge de **confianza** acorde al plano (alta si tabla resumen explícita, media si inferido).
- [ ] Click **\"Aplicar al análisis financiero\"** → mensaje verde con N campos aplicados, y la sección Análisis Financiero arriba se actualiza con esos valores (sin sobrescribir lo que ya tuvieras).
- [ ] Probar con plano **sin archivo** → error claro \"Esta versión del plano no tiene archivo\".
- [ ] Probar con HEIC/TIFF → error \"Formato no soportado\".
- [ ] Probar con valores ya capturados manualmente → el botón aplicar dice \"Todos los campos ya tenían valor\" en lugar de machacar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)