### PR TITLE
fix(dilesa): dropdown prototipo referencia vacío en análisis anteproyecto

### DIFF
--- a/components/dilesa/anteproyecto-detalle.tsx
+++ b/components/dilesa/anteproyecto-detalle.tsx
@@ -256,7 +256,9 @@ export function AnteproyectoDetalle({
     void supabase
       .schema('dilesa')
       .from('productos')
-      .select('id, nombre, valor_comercial_referencia, proyecto:proyectos(nombre)')
+      .select(
+        'id, nombre, valor_comercial_referencia, proyecto:proyectos!productos_proyecto_id_fkey(nombre)'
+      )
       .eq('empresa_id', DILESA_EMPRESA_ID)
       .is('deleted_at', null)
       .order('nombre')


### PR DESCRIPTION
## Summary
- El dropdown de "Prototipo referencia" en el análisis financiero de anteproyectos DILESA aparecía vacío (solo "Ninguno") a pesar de existir 14 productos en la base de datos
- **Root cause**: la migración que agregó `proyectos.prototipo_referencia_id` (FK → `productos`) creó una segunda relación entre ambas tablas. PostgREST retornaba HTTP 300 "Could not embed" por ambigüedad, y el `useEffect` tragaba el error silenciosamente
- **Fix**: desambiguar el embed con `!productos_proyecto_id_fkey` explícito

## Test plan
- [ ] Abrir detalle de un anteproyecto DILESA → sección "Capital Inicial" → dropdown "Prototipo referencia" ahora muestra los 14 productos disponibles con nombre · proyecto · valor comercial
- [ ] Seleccionar un prototipo → los campos de referencia se pre-llenan correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)