### PR TITLE
fix(dilesa): backfill RUV y seguro calidad en productos (7/7 conceptos completos)

### DIFF
--- a/supabase/migrations/20260531000000_dilesa_backfill_ruv_seguro_calidad.sql
+++ b/supabase/migrations/20260531000000_dilesa_backfill_ruv_seguro_calidad.sql
@@ -1,0 +1,30 @@
+-- Backfill RUV y seguro de calidad de referencia en dilesa.productos.
+--
+-- Fórmulas confirmadas por Beto (2026-05-31):
+--   - Registro RUV       = 0.03%  del valor comercial de referencia
+--   - Seguro de calidad  = 0.065% del valor comercial de referencia
+--   - Comercialización   = 2%     del valor comercial (ya aplicado en
+--     migración 20260530210000, repetido aquí por idempotencia)
+
+UPDATE dilesa.productos
+SET registro_ruv_referencia = round(valor_comercial_referencia * 0.0003, 2)
+WHERE deleted_at IS NULL
+  AND valor_comercial_referencia IS NOT NULL
+  AND valor_comercial_referencia > 0
+  AND registro_ruv_referencia IS NULL;
+
+UPDATE dilesa.productos
+SET seguro_calidad_referencia = round(valor_comercial_referencia * 0.00065, 2)
+WHERE deleted_at IS NULL
+  AND valor_comercial_referencia IS NOT NULL
+  AND valor_comercial_referencia > 0
+  AND seguro_calidad_referencia IS NULL;
+
+UPDATE dilesa.productos
+SET costo_comercializacion_referencia = round(valor_comercial_referencia * 0.02, 2)
+WHERE deleted_at IS NULL
+  AND valor_comercial_referencia IS NOT NULL
+  AND valor_comercial_referencia > 0
+  AND costo_comercializacion_referencia IS NULL;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- RUV = 0.03% del valor comercial de referencia
- Seguro calidad = 0.065% del valor comercial de referencia
- Con esto quedan **7/7 conceptos de referencia completos** para los 11 productos con valor comercial
- Migración idempotente (solo actualiza donde IS NULL)

## Test plan
- [ ] Abrir anteproyecto → seleccionar prototipo → los 7 campos de referencia se llenan automáticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)