### PR TITLE
feat(dilesa): mostrar costos de referencia en prototipos y materiales/MO en construcción

### DIFF
--- a/components/dilesa/construccion-module.test.ts
+++ b/components/dilesa/construccion-module.test.ts
@@ -23,6 +23,8 @@ function o(overrides: Partial<ConstruccionListaRow>): ConstruccionListaRow {
     contratistaNombre: 'Contratista',
     contratistaAbreviacion: null,
     supervisorNombre: null,
+    costo_materiales: null,
+    valor_contrato_mo: null,
     ...overrides,
   };
 }

--- a/components/dilesa/construccion-module.tsx
+++ b/components/dilesa/construccion-module.tsx
@@ -39,7 +39,7 @@ import {
 } from '@/components/filters/date-range-filter';
 import { HardHat, Plus, RefreshCw, Search } from 'lucide-react';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
-import { formatPercent } from '@/lib/format';
+import { formatCurrency, formatPercent } from '@/lib/format';
 
 type ConstruccionRow = {
   id: string;
@@ -56,6 +56,8 @@ type ConstruccionRow = {
   fecha_dtu: string | null;
   avance_pct: number;
   estado: string;
+  costo_materiales: number | null;
+  valor_contrato_mo: number | null;
 };
 
 export type ConstruccionListaRow = ConstruccionRow & {
@@ -186,7 +188,7 @@ export function ConstruccionModule({ empresaId }: { empresaId: string }) {
       .schema('dilesa')
       .from('construccion')
       .select(
-        'id, codigo, unidad_id, producto_id, contratista_id, supervisor_persona_id, fecha_arranque, fecha_compromiso_terminar, fecha_terminada, fecha_seguro_calidad, fecha_paquete_ruv, fecha_dtu, avance_pct, estado'
+        'id, codigo, unidad_id, producto_id, contratista_id, supervisor_persona_id, fecha_arranque, fecha_compromiso_terminar, fecha_terminada, fecha_seguro_calidad, fecha_paquete_ruv, fecha_dtu, avance_pct, estado, costo_materiales, valor_contrato_mo'
       )
       .eq('empresa_id', empresaId)
       .is('deleted_at', null);
@@ -396,6 +398,30 @@ export function ConstruccionModule({ empresaId }: { empresaId: string }) {
           {ESTADO_LABEL[o.estado] ?? o.estado}
         </Badge>
       ),
+    },
+    {
+      key: 'valor_contrato_mo',
+      label: 'MO contrato',
+      type: 'custom',
+      accessor: (o) => o.valor_contrato_mo ?? 0,
+      render: (o) =>
+        o.valor_contrato_mo != null ? (
+          <span className="tabular-nums">{formatCurrency(o.valor_contrato_mo)}</span>
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
+    },
+    {
+      key: 'costo_materiales',
+      label: 'Materiales',
+      type: 'custom',
+      accessor: (o) => o.costo_materiales ?? 0,
+      render: (o) =>
+        o.costo_materiales != null ? (
+          <span className="tabular-nums">{formatCurrency(o.costo_materiales)}</span>
+        ) : (
+          <span className="text-[var(--text)]/30">—</span>
+        ),
     },
     { key: 'fecha_arranque', label: 'Arranque', type: 'date' },
     { key: 'fecha_compromiso_terminar', label: 'Compromiso', type: 'date' },

--- a/components/dilesa/prototipos-module.test.ts
+++ b/components/dilesa/prototipos-module.test.ts
@@ -13,6 +13,13 @@ function p(overrides: Partial<PrototipoRow>): PrototipoRow {
     totalMoCalculado: null,
     obrasEnConstruccion: 0,
     obrasTerminadas: 0,
+    valor_comercial_referencia: null,
+    costo_urbanizacion_referencia: null,
+    costo_materiales_referencia: null,
+    costo_mo_referencia: null,
+    registro_ruv_referencia: null,
+    seguro_calidad_referencia: null,
+    costo_comercializacion_referencia: null,
     ...overrides,
   };
 }

--- a/components/dilesa/prototipos-module.tsx
+++ b/components/dilesa/prototipos-module.tsx
@@ -42,6 +42,13 @@ export type PrototipoRow = {
   totalMoCalculado: number | null;
   obrasEnConstruccion: number;
   obrasTerminadas: number;
+  valor_comercial_referencia: number | null;
+  costo_urbanizacion_referencia: number | null;
+  costo_materiales_referencia: number | null;
+  costo_mo_referencia: number | null;
+  registro_ruv_referencia: number | null;
+  seguro_calidad_referencia: number | null;
+  costo_comercializacion_referencia: number | null;
 };
 
 const EN_CURSO = new Set(['arrancada', 'en_progreso']);
@@ -111,7 +118,9 @@ export function PrototiposModule({ empresaId }: { empresaId: string }) {
       sb
         .schema('dilesa')
         .from('productos')
-        .select('id, nombre, proyecto_id, atributos')
+        .select(
+          'id, nombre, proyecto_id, atributos, valor_comercial_referencia, costo_urbanizacion_referencia, costo_materiales_referencia, costo_mo_referencia, registro_ruv_referencia, seguro_calidad_referencia, costo_comercializacion_referencia'
+        )
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
       sb
@@ -190,6 +199,13 @@ export function PrototiposModule({ empresaId }: { empresaId: string }) {
         totalMoCalculado: totalMo,
         obrasEnConstruccion: agg.enCurso,
         obrasTerminadas: agg.terminadas,
+        valor_comercial_referencia: p.valor_comercial_referencia as number | null,
+        costo_urbanizacion_referencia: p.costo_urbanizacion_referencia as number | null,
+        costo_materiales_referencia: p.costo_materiales_referencia as number | null,
+        costo_mo_referencia: p.costo_mo_referencia as number | null,
+        registro_ruv_referencia: p.registro_ruv_referencia as number | null,
+        seguro_calidad_referencia: p.seguro_calidad_referencia as number | null,
+        costo_comercializacion_referencia: p.costo_comercializacion_referencia as number | null,
       };
     });
 
@@ -295,6 +311,92 @@ export function PrototiposModule({ empresaId }: { empresaId: string }) {
       render: (p) =>
         p.totalMoCalculado != null ? (
           <span className="tabular-nums">${p.totalMoCalculado.toFixed(0)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'valor_comercial_referencia',
+      label: 'Valor comercial',
+      type: 'custom',
+      accessor: (p) => p.valor_comercial_referencia ?? 0,
+      render: (p) =>
+        p.valor_comercial_referencia != null ? (
+          <span className="tabular-nums">{formatCurrency(p.valor_comercial_referencia)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'costo_materiales_referencia',
+      label: 'Materiales ref',
+      type: 'custom',
+      accessor: (p) => p.costo_materiales_referencia ?? 0,
+      render: (p) =>
+        p.costo_materiales_referencia != null ? (
+          <span className="tabular-nums">{formatCurrency(p.costo_materiales_referencia)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'costo_mo_referencia',
+      label: 'MO ref',
+      type: 'custom',
+      accessor: (p) => p.costo_mo_referencia ?? 0,
+      render: (p) =>
+        p.costo_mo_referencia != null ? (
+          <span className="tabular-nums">{formatCurrency(p.costo_mo_referencia)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'costo_urbanizacion_referencia',
+      label: 'Urbanización ref',
+      type: 'custom',
+      accessor: (p) => p.costo_urbanizacion_referencia ?? 0,
+      render: (p) =>
+        p.costo_urbanizacion_referencia != null ? (
+          <span className="tabular-nums">{formatCurrency(p.costo_urbanizacion_referencia)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'registro_ruv_referencia',
+      label: 'RUV ref',
+      type: 'custom',
+      accessor: (p) => p.registro_ruv_referencia ?? 0,
+      render: (p) =>
+        p.registro_ruv_referencia != null ? (
+          <span className="tabular-nums">{formatCurrency(p.registro_ruv_referencia)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'seguro_calidad_referencia',
+      label: 'Seguro cal. ref',
+      type: 'custom',
+      accessor: (p) => p.seguro_calidad_referencia ?? 0,
+      render: (p) =>
+        p.seguro_calidad_referencia != null ? (
+          <span className="tabular-nums">{formatCurrency(p.seguro_calidad_referencia)}</span>
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'costo_comercializacion_referencia',
+      label: 'Comercializ. ref',
+      type: 'custom',
+      accessor: (p) => p.costo_comercializacion_referencia ?? 0,
+      render: (p) =>
+        p.costo_comercializacion_referencia != null ? (
+          <span className="tabular-nums">
+            {formatCurrency(p.costo_comercializacion_referencia)}
+          </span>
         ) : (
           <span className="text-[var(--text)]/40">—</span>
         ),


### PR DESCRIPTION
## Summary
- **Grid de prototipos**: agrega 7 columnas con los costos promedio de referencia por modelo (valor comercial, materiales, MO, urbanización, RUV, seguro calidad, comercialización) — derivados de datos reales de ventas y obras terminadas
- **Grid de construcción**: agrega columnas de MO contrato y costo de materiales por obra individual, visibles para verificar los datos unitarios que alimentan los promedios

## Test plan
- [ ] DILESA → Construcción → tab Prototipos: verificar que las 7 columnas de referencia aparecen con valores
- [ ] DILESA → Construcción → tab Obras: verificar columnas "MO contrato" y "Materiales" con datos por obra
- [ ] Scroll horizontal funciona correctamente con las columnas adicionales

🤖 Generated with [Claude Code](https://claude.com/claude-code)