### PR TITLE
feat(dilesa): auto-llenar Proyecto con Referencia como baseline al seleccionar prototipo

### DIFF
--- a/app/dilesa/proyectos/anteproyectos/actions-analisis.test.ts
+++ b/app/dilesa/proyectos/anteproyectos/actions-analisis.test.ts
@@ -35,10 +35,15 @@ let rpcResult: { data: string | null; error: { message: string } | null } = {
 };
 
 // Sprint 4B refinamiento — lookup de producto para autopopulate.
-let productoRow: {
-  valor_comercial_referencia: number | null;
-  costo_referencia: number | null;
-} | null = { valor_comercial_referencia: 900_000, costo_referencia: null };
+let productoRow: Record<string, number | null> | null = {
+  valor_comercial_referencia: 900_000,
+  costo_urbanizacion_referencia: null,
+  costo_materiales_referencia: null,
+  costo_mo_referencia: null,
+  registro_ruv_referencia: null,
+  seguro_calidad_referencia: null,
+  costo_comercializacion_referencia: null,
+};
 let productoError: { message: string } | null = null;
 
 // ── Mocks ──────────────────────────────────────────────────────────────
@@ -107,7 +112,6 @@ vi.mock('@supabase/ssr', () => ({
           };
         }
         if (schemaName === 'dilesa' && table === 'proyectos') {
-          // Distinguir entre SELECT (promote: leer empresa) y UPDATE (Sprint 4B análisis).
           const chain = {
             update: (patch: Record<string, unknown>) => {
               lastPatch = patch;
@@ -121,6 +125,18 @@ vi.mock('@supabase/ssr', () => ({
             select: () => ({
               eq: () => ({
                 maybeSingle: async () => ({ data: anteproyectoRow, error: anteproyectoError }),
+                single: async () => ({
+                  data: {
+                    valor_comercial_proyecto: null,
+                    costo_urbanizacion: null,
+                    costo_materiales_proyecto: null,
+                    costo_mo: null,
+                    registro_ruv_proyecto: null,
+                    seguro_calidad_proyecto: null,
+                    costo_comercializacion: null,
+                  },
+                  error: null,
+                }),
               }),
             }),
           };
@@ -158,7 +174,15 @@ beforeEach(() => {
   rolesData = [];
   asignacionesData = [];
   rpcResult = { data: 'desarrollo-1', error: null };
-  productoRow = { valor_comercial_referencia: 900_000, costo_referencia: null };
+  productoRow = {
+    valor_comercial_referencia: 900_000,
+    costo_urbanizacion_referencia: null,
+    costo_materiales_referencia: null,
+    costo_mo_referencia: null,
+    registro_ruv_referencia: null,
+    seguro_calidad_referencia: null,
+    costo_comercializacion_referencia: null,
+  };
   productoError = null;
 });
 
@@ -219,19 +243,42 @@ describe('updateAnteproyectoPrototipoReferencia (Sprint 4B refinamiento)', () =>
     expect(lastPatch).toEqual({ prototipo_referencia_id: null });
   });
 
-  it('productoId válido autopopula valor_comercial_referencia', async () => {
-    productoRow = { valor_comercial_referencia: 1_200_000, costo_referencia: null };
+  it('productoId válido autopopula referencia + proyecto baseline', async () => {
+    productoRow = {
+      valor_comercial_referencia: 1_200_000,
+      costo_urbanizacion_referencia: 50_000,
+      costo_materiales_referencia: null,
+      costo_mo_referencia: 120_000,
+      registro_ruv_referencia: null,
+      seguro_calidad_referencia: null,
+      costo_comercializacion_referencia: 24_000,
+    };
     const { updateAnteproyectoPrototipoReferencia } = await import('./actions');
     const r = await updateAnteproyectoPrototipoReferencia('p1', 'prod-1');
     expect(r.ok).toBe(true);
-    expect(lastPatch).toEqual({
+    expect(lastPatch).toMatchObject({
       prototipo_referencia_id: 'prod-1',
       valor_comercial_referencia: 1_200_000,
+      costo_urbanizacion_referencia: 50_000,
+      costo_mo_referencia: 120_000,
+      costo_comercializacion_referencia: 24_000,
+      valor_comercial_proyecto: 1_200_000,
+      costo_urbanizacion: 50_000,
+      costo_mo: 120_000,
+      costo_comercializacion: 24_000,
     });
   });
 
-  it('producto sin valor_comercial_referencia → solo setea el FK', async () => {
-    productoRow = { valor_comercial_referencia: null, costo_referencia: null };
+  it('producto sin valores → solo setea el FK', async () => {
+    productoRow = {
+      valor_comercial_referencia: null,
+      costo_urbanizacion_referencia: null,
+      costo_materiales_referencia: null,
+      costo_mo_referencia: null,
+      registro_ruv_referencia: null,
+      seguro_calidad_referencia: null,
+      costo_comercializacion_referencia: null,
+    };
     const { updateAnteproyectoPrototipoReferencia } = await import('./actions');
     const r = await updateAnteproyectoPrototipoReferencia('p1', 'prod-1');
     expect(r.ok).toBe(true);

--- a/app/dilesa/proyectos/anteproyectos/actions.ts
+++ b/app/dilesa/proyectos/anteproyectos/actions.ts
@@ -752,6 +752,37 @@ export async function updateAnteproyectoPrototipoReferencia(
     for (const f of refFields) {
       if (producto[f] != null) patch[f] = producto[f];
     }
+
+    // Pre-llenar campos Proyecto con los valores de Referencia como
+    // baseline editable (solo donde el campo está null).
+    const { data: proyecto, error: projErr } = await supabase
+      .schema('dilesa')
+      .from('proyectos')
+      .select(
+        'valor_comercial_proyecto, costo_urbanizacion, costo_materiales_proyecto, costo_mo, registro_ruv_proyecto, seguro_calidad_proyecto, costo_comercializacion'
+      )
+      .eq('id', proyectoId)
+      .single();
+    if (projErr) return { ok: false, error: projErr.message };
+
+    const refToProj: [keyof typeof producto, string][] = [
+      ['valor_comercial_referencia', 'valor_comercial_proyecto'],
+      ['costo_urbanizacion_referencia', 'costo_urbanizacion'],
+      ['costo_materiales_referencia', 'costo_materiales_proyecto'],
+      ['costo_mo_referencia', 'costo_mo'],
+      ['registro_ruv_referencia', 'registro_ruv_proyecto'],
+      ['seguro_calidad_referencia', 'seguro_calidad_proyecto'],
+      ['costo_comercializacion_referencia', 'costo_comercializacion'],
+    ];
+    for (const [refKey, projKey] of refToProj) {
+      if (
+        producto[refKey] != null &&
+        (proyecto[projKey as keyof typeof proyecto] == null ||
+          proyecto[projKey as keyof typeof proyecto] === 0)
+      ) {
+        patch[projKey] = producto[refKey];
+      }
+    }
   }
 
   const { error } = await supabase

--- a/components/dilesa/anteproyecto-analisis-financiero.tsx
+++ b/components/dilesa/anteproyecto-analisis-financiero.tsx
@@ -402,6 +402,22 @@ export function AnteproyectoAnalisisFinanciero({
           for (const [src, dst] of refFields) {
             if (proto[src] != null) (next as Record<string, unknown>)[dst] = proto[src];
           }
+          // Pre-llenar Proyecto con Referencia como baseline (solo si null o 0)
+          const refToProj: [keyof typeof proto, string][] = [
+            ['valor_comercial_referencia', 'valor_comercial_proyecto'],
+            ['costo_urbanizacion_referencia', 'costo_urbanizacion'],
+            ['costo_materiales_referencia', 'costo_materiales_proyecto'],
+            ['costo_mo_referencia', 'costo_mo'],
+            ['registro_ruv_referencia', 'registro_ruv_proyecto'],
+            ['seguro_calidad_referencia', 'seguro_calidad_proyecto'],
+            ['costo_comercializacion_referencia', 'costo_comercializacion'],
+          ];
+          for (const [refKey, projKey] of refToProj) {
+            const current = prev[projKey as keyof typeof prev] as number | null;
+            if (proto[refKey] != null && (current == null || current === 0)) {
+              (next as Record<string, unknown>)[projKey] = proto[refKey];
+            }
+          }
         }
         return next;
       });
@@ -419,6 +435,13 @@ export function AnteproyectoAnalisisFinanciero({
             registro_ruv_referencia: snapshot.registro_ruv_referencia,
             seguro_calidad_referencia: snapshot.seguro_calidad_referencia,
             costo_comercializacion_referencia: snapshot.costo_comercializacion_referencia,
+            valor_comercial_proyecto: snapshot.valor_comercial_proyecto,
+            costo_urbanizacion: snapshot.costo_urbanizacion,
+            costo_materiales_proyecto: snapshot.costo_materiales_proyecto,
+            costo_mo: snapshot.costo_mo,
+            registro_ruv_proyecto: snapshot.registro_ruv_proyecto,
+            seguro_calidad_proyecto: snapshot.seguro_calidad_proyecto,
+            costo_comercializacion: snapshot.costo_comercializacion,
           }));
         } else {
           onChange?.();
@@ -437,6 +460,13 @@ export function AnteproyectoAnalisisFinanciero({
       snapshot.registro_ruv_referencia,
       snapshot.seguro_calidad_referencia,
       snapshot.costo_comercializacion_referencia,
+      snapshot.valor_comercial_proyecto,
+      snapshot.costo_urbanizacion,
+      snapshot.costo_materiales_proyecto,
+      snapshot.costo_mo,
+      snapshot.registro_ruv_proyecto,
+      snapshot.seguro_calidad_proyecto,
+      snapshot.costo_comercializacion,
     ]
   );
 


### PR DESCRIPTION
## Summary
- Al seleccionar un prototipo de referencia, ahora se pre-llenan los 7 campos de la columna **Proyecto** con los mismos valores de **Referencia** como baseline editable
- Solo se pre-llena si el campo está null o en $0 (no pisa valores ya capturados)
- Esto permite ver inmediatamente: Costo total, Delta ($0 como punto de partida), Utilidad proyecto, Margen utilidad, Inversión total
- El usuario ajusta los valores de Proyecto según las condiciones reales del nuevo anteproyecto

## Test plan
- [ ] Seleccionar prototipo en anteproyecto con campos Proyecto vacíos → ambas columnas se llenan, delta = $0, utilidad y margen se calculan
- [ ] Cambiar un valor en Proyecto → delta se actualiza correctamente
- [ ] Re-seleccionar prototipo con campos Proyecto ya capturados → no se pisan los valores existentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)