### PR TITLE
docs(dilesa): script de traspaso Capa A (obra_presupuesto) + handover

### DIFF
--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -199,3 +199,54 @@ Verificado en prod: 6 columnas nuevas, 2 tablas, 266 backfill. `SCHEMA_REF` +
 **Pendiente:** ADR → índice §5 de `ARCHITECTURE.md` (piggyback al cerrar
 iniciativa). **Próximo sprint:** parser de traspaso LDLE+LDS (best-effort,
 marca renglones sin tasa de IVA clara para revisión de Beto).
+
+### 2026-06-01 — Traspaso Capa A (RESUMEN → obra_presupuesto) cargado a prod
+
+Parser `scripts/import_dilesa_obra_presupuesto.py` (DRY_RUN + genera JSON; la
+carga se hizo por `psql` con `SUPABASE_DB_URL`, transaccional con DELETE previo
+idempotente). **128 renglones cargados y verificados en prod:**
+
+- **Lomas del Sol** (`a506b99f-…`): 73 conceptos, 3 etapas, presup. actual.
+  $12,186,209.13, gasto real $11,708,916.24, 26 proveedores.
+- **Lomas de los Encinos** (`42c64197-…`): 55 conceptos, 3 etapas, presup.
+  actual. $73,845,012.61, gasto real $61,002,480.36, 27 proveedores.
+
+Bug detectado y corregido en DRY_RUN: el RESUMEN de LDLE trae un bloque
+agregado "RESUMEN POR ETAPA" cuyo header es "ETAPA" (no la cadena literal que
+sí trae LDS) → causaba doble conteo. La etapa se deriva de cada fila
+`TOTAL <ETAPA>` (LDLE no la marca en la columna). IVA: 128 renglones con total
+c/IVA, sin desglose (`gasto_real_subtotal/iva/iva_tasa` null) — el Excel no lo
+especifica; se completa con facturas.
+
+## Handover — estado y próximos pasos (para la siguiente sesión)
+
+**Hecho (en prod + main):** schema Sprint 1 (#615) + Capa A de costeo
+(`obra_presupuesto`, 128 renglones de LDLE+LDS). Este PR registra el script.
+
+**Decisiones ya cerradas (no re-preguntar):**
+
+- Proyecto del Excel **LDLE = "Lomas de los Encinos"** (`42c64197-2358-4607-a21c-97556ceb3110`),
+  **LDS = "Lomas del Sol"** (`a506b99f-1b6e-4024-a94a-59deaed48727`). empresa
+  DILESA `f5942ed4-7a6b-4c39-af18-67b9fbf7f479`.
+- IVA **8% frontera / 16% excepción**, desglose solo donde esté especificado
+  (ver [[project_iva_frontera]] y ADR-038).
+- Estimaciones de obra en tabla nueva `obra_estimaciones` (no en `dilesa.estimaciones`).
+
+**Pendiente — Capa B (contratos + estimaciones):** parsear las **hojas de
+detalle** de `~/Downloads/Proyecto LDLE.xlsx` y `Proyecto LDS.xlsx`
+(ELECTRIFICACION, AGUA POTABLE DRENAJE, PAVIMENTACION, CORDON, BARDA, CASETA,
+PORTON, PLAZA, MAQUINARIA, etc.) → `contratos_construccion` (tipo no-vivienda,
+con `anticipo_pct`/`retencion_pct`/`iva_tasa`) + `obra_estimaciones`. Layout por
+hoja: bloque de cabecera (Contrato · Anticipo % · Retención % · Total de
+estimaciones · Total Pagado) + tabla de estimaciones (Fecha · Estímación
+etiqueta libre "Anticipo/1/2A/Finiquito" · # Factura · Total · nota de pago).
+**Ojo:** una hoja puede tener **varios contratos** (1ª/2ª etapa, o subobras como
+Red Eléctrica vs Voz y Datos) — cada uno con su propio anticipo/retención. Usar
+DRY_RUN igual que la Capa A; ligar cada contrato a su concepto de
+`obra_presupuesto` por proveedor/nombre cuando sea claro (campo `contrato_id`).
+
+**Pendientes menores:** normalizar variantes de proveedor ("Electrogaza" vs
+"Electrogaza SA de CV", "DILESA (Proyectos/maquinaria)") a `erp.personas`;
+**limpiar el duplicado** "Ampliación Lomas de los Encinos" en `dilesa.proyectos`
+(dos filas idénticas, ids `cd7c9cae-…` y `26352cac-…`); ADR-038 → índice §5 de
+`ARCHITECTURE.md`.

--- a/scripts/import_dilesa_obra_presupuesto.py
+++ b/scripts/import_dilesa_obra_presupuesto.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Traspaso de la hoja RESUMEN de los Excel de proyecto DILESA (LDLE, LDS) a
+`dilesa.obra_presupuesto`. Iniciativa dilesa-contratos-obra · Sprint traspaso.
+
+DRY_RUN por default: parsea, reporta y escribe el JSON intermedio
+(/tmp/obra_presupuesto_traspaso.json) SIN tocar la DB. La carga real se hace
+después, tras revisión de Beto, desde ese JSON.
+
+  python3 scripts/import_dilesa_obra_presupuesto.py            # dry-run + reporte
+"""
+import json
+import os
+import unicodedata
+
+EMPRESA_DILESA = "f5942ed4-7a6b-4c39-af18-67b9fbf7f479"
+# Mapeo Excel -> proyecto. LDS es inequívoco; LDLE tiene candidatos (ver reporte).
+ARCHIVOS = [
+    {
+        "path": os.path.expanduser("~/Downloads/Proyecto LDS.xlsx"),
+        "proyecto_id": "a506b99f-1b6e-4024-a94a-59deaed48727",
+        "proyecto_nombre": "Lomas del Sol",
+        "prefijo": "LDS",
+        "proyecto_confirmado": True,
+    },
+    {
+        "path": os.path.expanduser("~/Downloads/Proyecto LDLE.xlsx"),
+        "proyecto_id": "42c64197-2358-4607-a21c-97556ceb3110",  # "Lomas de los Encinos" — A CONFIRMAR
+        "proyecto_nombre": "Lomas de los Encinos",
+        "prefijo": "LDLE",
+        "proyecto_confirmado": False,
+    },
+]
+
+
+def norm(s):
+    if s is None:
+        return ""
+    s = "".join(c for c in unicodedata.normalize("NFD", str(s)) if unicodedata.category(c) != "Mn")
+    return s.strip().lower()
+
+
+def num(v):
+    if v is None or v == "":
+        return None
+    if isinstance(v, (int, float)):
+        return round(float(v), 2)
+    s = str(v).replace("$", "").replace(",", "").strip()
+    if s in ("", "#DIV/0!", "-"):
+        return None
+    try:
+        return round(float(s), 2)
+    except ValueError:
+        return None
+
+
+def build_colmap(header_row):
+    """nombre normalizado de columna -> índice, a partir de la fila de encabezado."""
+    m = {}
+    for j, v in enumerate(header_row):
+        n = norm(v)
+        if not n:
+            continue
+        if "etapa" in n and "etapa" == n:
+            m["etapa"] = j
+        elif n == "concepto":
+            m["concepto"] = j
+        elif "presupuesto previo" in n:
+            m["previo"] = j
+        elif "presupuesto actualizado" in n:
+            m["actualizado"] = j
+        elif n.startswith("gasto real"):
+            m["gasto_real"] = j
+        elif n == "proveedor":
+            m["proveedor"] = j
+        elif n.startswith("factura"):
+            m["factura"] = j
+        elif "fecha compromiso" in n:
+            m["fecha"] = j
+    return m
+
+
+SKIP_CONCEPTOS = {"etapa", "presupuestado", "pres. actual.", "pagado", "ejercido"}
+
+
+def parse_resumen(path):
+    import openpyxl
+
+    wb = openpyxl.load_workbook(path, data_only=True)
+    ws = wb["RESUMEN"]
+    rows = list(ws.iter_rows(values_only=True))
+    wb.close()
+    cm = build_colmap(rows[0])
+    if "concepto" not in cm or "gasto_real" not in cm:
+        raise SystemExit(f"No pude mapear columnas en {path}: {cm}")
+
+    out = []
+    buffer = []  # conceptos del segmento actual, etapa se asigna al cerrar con su TOTAL
+    etapa_fwd = None  # etapa explícita en columna (LDS la trae; LDLE no)
+    orden = 0
+
+    def emit(etapa):
+        nonlocal orden
+        for r in buffer:
+            orden += 1
+            r["orden"] = orden
+            r["etapa"] = r["etapa"] or etapa
+            out.append(r)
+        buffer.clear()
+
+    for i, row in enumerate(rows[1:], start=2):
+        def cell(key):
+            j = cm.get(key)
+            return row[j] if (j is not None and j < len(row)) else None
+
+        et = cell("etapa")
+        if et not in (None, ""):
+            etapa_fwd = str(et).strip()
+        concepto = cell("concepto")
+        cn = norm(concepto)
+        # Cortar en el bloque agregado de resumen por etapa
+        if cn == "etapa" or any(norm(v) == "resumen por etapa" for v in row if v):
+            break
+        # Fila TOTAL: cierra el segmento → su etapa se deriva del texto "TOTAL <ETAPA>"
+        if cn.startswith("total"):
+            etapa = str(concepto).strip()[len("TOTAL "):].strip().title() or etapa_fwd
+            emit(etapa)
+            etapa_fwd = None
+            continue
+        if not cn or cn in SKIP_CONCEPTOS:
+            continue
+        gasto = num(cell("gasto_real"))
+        previo = num(cell("previo"))
+        actualizado = num(cell("actualizado"))
+        proveedor = cell("proveedor")
+        if gasto is None and previo is None and actualizado is None and not proveedor:
+            continue
+        buffer.append(
+            {
+                "etapa": etapa_fwd,  # si la columna la trae (LDS); si no, la pone el TOTAL
+                "concepto": str(concepto).strip(),
+                "orden": 0,
+                "presupuesto_previo": previo,
+                "presupuesto_actualizado": actualizado,
+                "gasto_real_total": gasto,
+                "gasto_real_subtotal": None,  # desglose IVA no especificado en el Excel
+                "gasto_real_iva": None,
+                "gasto_real_iva_tasa": None,
+                "proveedor_texto": str(proveedor).strip() if proveedor else None,
+                "factura_ref": (str(cell("factura")).strip() if cell("factura") else None),
+                "source_ref": f"{os.path.basename(path)}/RESUMEN/r{i}",
+            }
+        )
+    emit(etapa_fwd)  # cualquier remanente sin TOTAL final
+    return out
+
+
+def main():
+    registros = []
+    print("=" * 70)
+    for a in ARCHIVOS:
+        recs = parse_resumen(a["path"])
+        suma_prev = sum(r["presupuesto_previo"] or 0 for r in recs)
+        suma_act = sum(r["presupuesto_actualizado"] or 0 for r in recs)
+        suma_real = sum(r["gasto_real_total"] or 0 for r in recs)
+        provs = sorted({r["proveedor_texto"] for r in recs if r["proveedor_texto"]})
+        etapas = sorted({r["etapa"] for r in recs if r["etapa"]})
+        print(f"\n■ {a['prefijo']} → proyecto '{a['proyecto_nombre']}'"
+              f"{'' if a['proyecto_confirmado'] else '  ⚠️ PROYECTO A CONFIRMAR'}")
+        print(f"  conceptos: {len(recs)} | etapas: {etapas}")
+        print(f"  presupuesto previo:      ${suma_prev:,.2f}")
+        print(f"  presupuesto actualizado: ${suma_act:,.2f}")
+        print(f"  gasto real (c/IVA):      ${suma_real:,.2f}  (sin desglose IVA — no especificado)")
+        print(f"  proveedores únicos ({len(provs)}): {', '.join(provs[:12])}{' …' if len(provs) > 12 else ''}")
+        for r in recs:
+            r["empresa_id"] = EMPRESA_DILESA
+            r["proyecto_id"] = a["proyecto_id"]
+        registros.extend(recs)
+
+    out_path = "/tmp/obra_presupuesto_traspaso.json"
+    with open(out_path, "w") as f:
+        json.dump(registros, f, ensure_ascii=False, indent=2)
+    print(f"\n{'=' * 70}")
+    print(f"TOTAL a cargar: {len(registros)} renglones de obra_presupuesto")
+    print(f"JSON intermedio → {out_path}  (DRY-RUN: nada escrito en la DB)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Registra el parser del traspaso y documenta el handover para continuar en otra sesión.

**Capa A del traspaso ya cargada en prod** (vía psql, transaccional): 128 renglones
en `dilesa.obra_presupuesto` — costeo presupuesto vs gasto real por concepto/etapa.

- Lomas del Sol: 73 conceptos · presup. $12.19M · gasto real $11.71M
- Lomas de los Encinos: 55 conceptos · presup. $73.85M · gasto real $61.00M

Este PR agrega:
- `scripts/import_dilesa_obra_presupuesto.py` — parser del RESUMEN (DRY_RUN + JSON).
- Planning doc: bitácora de la Capa A + **sección de handover** con decisiones cerradas
  (proyecto LDLE, IVA 8/16, tabla de estimaciones) y próximos pasos (Capa B: contratos +
  estimaciones de las hojas de detalle; normalización de proveedores; duplicado de proyecto a limpiar).

Sin cambios de schema ni de app (solo script auxiliar + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)