### PR TITLE
feat(cxc): captura de abono + generar plan (Sprint 2.2)

### DIFF
--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -303,6 +303,9 @@ function DetailInner() {
   const [cargos, setCargos] = useState<Cargo[]>([]);
   const [abonos, setAbonos] = useState<Abono[]>([]);
   const [aplicadoPorAbono, setAplicadoPorAbono] = useState<Map<string, number>>(new Map());
+  const [comprobantesPorAbono, setComprobantesPorAbono] = useState<Map<string, Adjunto[]>>(
+    new Map()
+  );
   const [adjuntos, setAdjuntos] = useState<Adjunto[]>([]);
   const [calculo, setCalculo] = useState<DesgloseCalculo | null>(null);
   const [vendedorNombre, setVendedorNombre] = useState<string | null>(null);
@@ -416,6 +419,22 @@ function DetailInner() {
             m.set(ap.pago_id, (m.get(ap.pago_id) ?? 0) + Number(ap.monto_aplicado));
           }
           setAplicadoPorAbono(m);
+        }
+
+        const { data: adjAbonos } = await sb
+          .schema('erp')
+          .from('adjuntos')
+          .select('id, entidad_tipo, entidad_id, rol, nombre, url, tipo_mime')
+          .eq('entidad_tipo', 'cxc_pago')
+          .in('entidad_id', abonoIds);
+        if (activo) {
+          const am = new Map<string, Adjunto[]>();
+          for (const a of (adjAbonos ?? []) as Adjunto[]) {
+            const arr = am.get(a.entidad_id) ?? [];
+            arr.push(a);
+            am.set(a.entidad_id, arr);
+          }
+          setComprobantesPorAbono(am);
         }
       }
 
@@ -1019,7 +1038,8 @@ function DetailInner() {
                       <th className="py-1 pr-2 font-medium">Fuente</th>
                       <th className="py-1 pr-2 text-right font-medium">Monto</th>
                       <th className="py-1 pr-2 text-right font-medium">Aplicado</th>
-                      <th className="py-1 pl-2 text-right font-medium">Saldo a favor</th>
+                      <th className="py-1 pr-2 text-right font-medium">Saldo a favor</th>
+                      <th className="py-1 pl-2 font-medium">Comprobante</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -1038,7 +1058,7 @@ function DetailInner() {
                           <td className="py-1.5 pr-2 text-right tabular-nums text-[var(--text)]/70">
                             {moneyFmt.format(aplicado)}
                           </td>
-                          <td className="py-1.5 pl-2 text-right tabular-nums">
+                          <td className="py-1.5 pr-2 text-right tabular-nums">
                             {favor > 0 ? (
                               <span className="font-medium text-amber-600">
                                 {moneyFmt.format(favor)}
@@ -1046,6 +1066,16 @@ function DetailInner() {
                             ) : (
                               <span className="text-[var(--text)]/30">—</span>
                             )}
+                          </td>
+                          <td className="py-1.5 pl-2">
+                            <div className="flex flex-wrap gap-1">
+                              {(comprobantesPorAbono.get(a.id) ?? []).map((adj) => (
+                                <AdjuntoLink key={adj.id} a={adj} compact />
+                              ))}
+                              {(comprobantesPorAbono.get(a.id) ?? []).length === 0 ? (
+                                <span className="text-[var(--text)]/30">—</span>
+                              ) : null}
+                            </div>
                           </td>
                         </tr>
                       );

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -25,7 +25,16 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Check, Circle, Download, ExternalLink, FileText, Pencil } from 'lucide-react';
+import {
+  ArrowLeft,
+  Check,
+  Circle,
+  Download,
+  ExternalLink,
+  FileText,
+  Pencil,
+  Plus,
+} from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Badge } from '@/components/ui/badge';
@@ -33,6 +42,8 @@ import type { BadgeTone } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getAdjuntoProxyUrl } from '@/lib/adjuntos';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { useToast } from '@/components/ui/toast';
+import { AbonoCaptureDrawer } from '@/components/dilesa/abono-capture-drawer';
 import {
   snapshotHold,
   formatearVencimiento,
@@ -42,6 +53,7 @@ import {
 
 type Venta = {
   id: string;
+  empresa_id: string;
   persona_id: string;
   unidad_id: string | null;
   vendedor_usuario_id: string | null;
@@ -297,6 +309,9 @@ function DetailInner() {
   const [holdSnapshot, setHoldSnapshot] = useState<HoldSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [abonoOpen, setAbonoOpen] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const toast = useToast();
 
   useEffect(() => {
     if (!id) return;
@@ -507,7 +522,24 @@ function DetailInner() {
     return () => {
       activo = false;
     };
-  }, [id]);
+  }, [id, refreshKey]);
+
+  const handleGenerarPlan = async () => {
+    const sb = createSupabaseBrowserClient();
+    const { error: rpcErr } = await sb
+      .schema('dilesa')
+      .rpc('fn_generar_plan_pagos', { p_venta_id: id });
+    if (rpcErr) {
+      toast.add({
+        title: 'No se pudo generar el plan',
+        description: getSupabaseErrorMessage(rpcErr, 'Error en el RPC.'),
+        type: 'error',
+      });
+      return;
+    }
+    toast.add({ title: 'Plan de pagos generado', type: 'success' });
+    setRefreshKey((k) => k + 1);
+  };
 
   const clienteNombre = useMemo(() => {
     if (!persona) return '';
@@ -894,6 +926,24 @@ function DetailInner() {
             : `saldo ${moneyFmt.format(saldoPendiente)} de ${moneyFmt.format(totalACobrar)}`
         }
       >
+        <div className="mb-4 flex flex-wrap justify-end gap-2">
+          {cargos.length === 0 ? (
+            <button
+              type="button"
+              onClick={handleGenerarPlan}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-sm text-[var(--text)] hover:bg-[var(--panel)]"
+            >
+              Generar plan
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => setAbonoOpen(true)}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--text)] px-3 py-1.5 text-sm font-medium text-[var(--card)] hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" /> Registrar abono
+          </button>
+        </div>
         {cargos.length === 0 && abonos.length === 0 ? (
           <p className="text-sm text-[var(--text)]/60">
             Sin plan de pagos generado para esta venta.
@@ -1037,6 +1087,16 @@ function DetailInner() {
           </div>
         )}
       </Section>
+
+      <AbonoCaptureDrawer
+        open={abonoOpen}
+        onOpenChange={setAbonoOpen}
+        ventaId={id}
+        empresaId={venta.empresa_id}
+        personaId={venta.persona_id}
+        clienteNombre={clienteNombre}
+        onDone={() => setRefreshKey((k) => k + 1)}
+      />
     </div>
   );
 }

--- a/components/dilesa/abono-capture-drawer.tsx
+++ b/components/dilesa/abono-capture-drawer.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+/**
+ * AbonoCaptureDrawer — captura de un abono CxC desde el detalle de venta
+ * DILESA. Reemplaza el form de Coda "Depositos Clientes".
+ *
+ * Llama `erp.cxc_pago_registrar`, que inserta el abono y lo auto-aplica
+ * FIFO a los cargos abiertos de la venta (ver iniciativa `cxc`, ADR-037).
+ * La fuente (cliente/institución) es etiqueta para cobranza/reportería,
+ * no filtra el cálculo.
+ */
+
+import { Plus } from 'lucide-react';
+import { z } from 'zod';
+
+import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
+import { Combobox } from '@/components/ui/combobox';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/toast';
+import { Form, FormActions, FormField, FormRow, useZodForm } from '@/components/forms';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+const FUENTE_OPTIONS = [
+  { value: 'cliente', label: 'Cliente' },
+  { value: 'institucion', label: 'Institución' },
+];
+
+const FORMA_PAGO_OPTIONS = [
+  { value: 'transferencia', label: 'Transferencia' },
+  { value: 'deposito', label: 'Depósito' },
+  { value: 'efectivo', label: 'Efectivo' },
+  { value: 'cheque', label: 'Cheque' },
+  { value: 'tarjeta', label: 'Tarjeta' },
+  { value: 'otro', label: 'Otro' },
+];
+
+const AbonoSchema = z.object({
+  fecha: z.string().min(1, 'Indica la fecha del abono'),
+  monto: z
+    .string()
+    .min(1, 'Indica el monto')
+    .refine((v) => Number(v) > 0, 'El monto debe ser mayor a 0'),
+  fuente: z.enum(['cliente', 'institucion']),
+  forma_pago: z.string().default(''),
+  referencia: z.string().default(''),
+  notas: z.string().default(''),
+});
+
+type AbonoValues = z.infer<typeof AbonoSchema>;
+
+const defaults: AbonoValues = {
+  fecha: '',
+  monto: '',
+  fuente: 'cliente',
+  forma_pago: '',
+  referencia: '',
+  notas: '',
+};
+
+export type AbonoCaptureDrawerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  ventaId: string;
+  empresaId: string;
+  personaId: string;
+  clienteNombre: string;
+  /** Llamado tras registrar con éxito — el detalle re-fetchea. */
+  onDone: () => void;
+};
+
+export function AbonoCaptureDrawer({
+  open,
+  onOpenChange,
+  ventaId,
+  empresaId,
+  personaId,
+  clienteNombre,
+  onDone,
+}: AbonoCaptureDrawerProps) {
+  const toast = useToast();
+  const form = useZodForm({ schema: AbonoSchema, defaultValues: defaults });
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) form.reset(defaults);
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async (values: AbonoValues) => {
+    const sb = createSupabaseBrowserClient();
+    const { error } = await sb.schema('erp').rpc('cxc_pago_registrar', {
+      p_empresa_id: empresaId,
+      p_persona_id: personaId,
+      p_origen_id: ventaId,
+      p_monto: Number(values.monto),
+      p_fecha: values.fecha,
+      p_fuente: values.fuente,
+      p_forma_pago: values.forma_pago || undefined,
+      p_referencia: values.referencia || undefined,
+      p_notas: values.notas || undefined,
+    });
+
+    if (error) {
+      toast.add({
+        title: 'No se pudo registrar el abono',
+        description: getSupabaseErrorMessage(error, 'Error en el RPC.'),
+        type: 'error',
+      });
+      return;
+    }
+
+    toast.add({ title: 'Abono registrado', type: 'success' });
+    form.reset(defaults);
+    onOpenChange(false);
+    onDone();
+  };
+
+  return (
+    <DetailDrawer
+      open={open}
+      onOpenChange={handleOpenChange}
+      size="sm"
+      title="Registrar abono"
+      description={clienteNombre}
+    >
+      <DetailDrawerContent>
+        <Form form={form} onSubmit={handleSubmit} className="space-y-5">
+          <FormRow cols={2}>
+            <FormField name="fecha" label="Fecha" required>
+              {(field) => (
+                <Input
+                  {...field}
+                  id={field.id}
+                  type="date"
+                  aria-invalid={field.invalid || undefined}
+                  aria-describedby={field.describedBy}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
+              )}
+            </FormField>
+
+            <FormField name="monto" label="Monto" required>
+              {(field) => (
+                <Input
+                  {...field}
+                  id={field.id}
+                  type="number"
+                  inputMode="decimal"
+                  step="0.01"
+                  min="0"
+                  placeholder="0.00"
+                  aria-invalid={field.invalid || undefined}
+                  aria-describedby={field.describedBy}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-right tabular-nums text-[var(--text)]"
+                />
+              )}
+            </FormField>
+          </FormRow>
+
+          <FormRow cols={2}>
+            <FormField
+              name="fuente"
+              label="Fuente"
+              description="Cliente o institución (Infonavit/Fovissste/banco)"
+            >
+              {(field) => (
+                <Combobox
+                  id={field.id}
+                  value={field.value}
+                  onChange={field.onChange}
+                  options={FUENTE_OPTIONS}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
+              )}
+            </FormField>
+
+            <FormField name="forma_pago" label="Forma de pago">
+              {(field) => (
+                <Combobox
+                  id={field.id}
+                  value={field.value}
+                  onChange={field.onChange}
+                  options={FORMA_PAGO_OPTIONS}
+                  placeholder="Sin especificar"
+                  allowClear
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
+              )}
+            </FormField>
+          </FormRow>
+
+          <FormField name="referencia" label="Referencia">
+            {(field) => (
+              <Input
+                {...field}
+                id={field.id}
+                placeholder="Folio, número de operación..."
+                aria-invalid={field.invalid || undefined}
+                aria-describedby={field.describedBy}
+                className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
+            )}
+          </FormField>
+
+          <FormField name="notas" label="Notas">
+            {(field) => (
+              <Textarea
+                {...field}
+                id={field.id}
+                rows={2}
+                placeholder="Opcional..."
+                aria-invalid={field.invalid || undefined}
+                aria-describedby={field.describedBy}
+                className="resize-none rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
+            )}
+          </FormField>
+
+          <FormActions
+            cancelLabel="Cancelar"
+            submitLabel="Registrar abono"
+            submittingLabel="Registrando..."
+            submitIcon={<Plus className="h-4 w-4" />}
+            onCancel={() => handleOpenChange(false)}
+            stretch
+          />
+        </Form>
+      </DetailDrawerContent>
+    </DetailDrawer>
+  );
+}

--- a/components/dilesa/abono-capture-drawer.tsx
+++ b/components/dilesa/abono-capture-drawer.tsx
@@ -10,6 +10,7 @@
  * no filtra el cálculo.
  */
 
+import { useState } from 'react';
 import { Plus } from 'lucide-react';
 import { z } from 'zod';
 
@@ -21,6 +22,8 @@ import { useToast } from '@/components/ui/toast';
 import { Form, FormActions, FormField, FormRow, useZodForm } from '@/components/forms';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { buildAdjuntoPath } from '@/lib/storage/path';
+import { WizardFileSlot } from '@/components/wizard/wizard-file-slot';
 
 const FUENTE_OPTIONS = [
   { value: 'cliente', label: 'Cliente' },
@@ -80,16 +83,22 @@ export function AbonoCaptureDrawer({
   onDone,
 }: AbonoCaptureDrawerProps) {
   const toast = useToast();
+  const [comprobante, setComprobante] = useState<File | null>(null);
   const form = useZodForm({ schema: AbonoSchema, defaultValues: defaults });
 
+  const reset = () => {
+    form.reset(defaults);
+    setComprobante(null);
+  };
+
   const handleOpenChange = (next: boolean) => {
-    if (!next) form.reset(defaults);
+    if (!next) reset();
     onOpenChange(next);
   };
 
   const handleSubmit = async (values: AbonoValues) => {
     const sb = createSupabaseBrowserClient();
-    const { error } = await sb.schema('erp').rpc('cxc_pago_registrar', {
+    const { data: pagoId, error } = await sb.schema('erp').rpc('cxc_pago_registrar', {
       p_empresa_id: empresaId,
       p_persona_id: personaId,
       p_origen_id: ventaId,
@@ -110,8 +119,43 @@ export function AbonoCaptureDrawer({
       return;
     }
 
+    // Sube el comprobante ligado al abono recién creado (deferred upload,
+    // ADR-022): el abono ya existe, así que tenemos su id como entidadId.
+    if (comprobante && typeof pagoId === 'string') {
+      const path = buildAdjuntoPath({
+        empresa: 'dilesa',
+        entidad: 'cxc_pagos',
+        entidadId: pagoId,
+        filename: comprobante.name,
+      });
+      const { error: upErr } = await sb.storage.from('adjuntos').upload(path, comprobante, {
+        contentType: comprobante.type || 'application/octet-stream',
+        upsert: false,
+      });
+      if (upErr) {
+        toast.add({
+          title: 'Abono registrado, pero el comprobante no se subió',
+          description: getSupabaseErrorMessage(upErr, 'Reintenta adjuntar el comprobante.'),
+          type: 'error',
+        });
+      } else {
+        await sb
+          .schema('erp')
+          .from('adjuntos')
+          .insert({
+            empresa_id: empresaId,
+            entidad_tipo: 'cxc_pago',
+            entidad_id: pagoId,
+            rol: 'comprobante',
+            nombre: comprobante.name,
+            url: path,
+            tipo_mime: comprobante.type || null,
+          });
+      }
+    }
+
     toast.add({ title: 'Abono registrado', type: 'success' });
-    form.reset(defaults);
+    reset();
     onOpenChange(false);
     onDone();
   };
@@ -216,6 +260,17 @@ export function AbonoCaptureDrawer({
               />
             )}
           </FormField>
+
+          <div>
+            <span className="mb-1.5 block text-xs font-medium text-[var(--text)]">Comprobante</span>
+            <WizardFileSlot
+              role="comprobante"
+              label="Comprobante del pago"
+              file={comprobante}
+              onChange={setComprobante}
+              accept=".pdf,.jpg,.jpeg,.png,.webp,.heic"
+            />
+          </div>
 
           <FormActions
             cancelLabel="Cancelar"

--- a/lib/storage/path.ts
+++ b/lib/storage/path.ts
@@ -36,6 +36,7 @@ export type AdjuntoEntidad =
   | 'empresa'
   | 'ventas'
   | 'venta_pagos'
+  | 'cxc_pagos'
   | 'proyecto_tareas'
   | 'proyecto_tarea_pasos'
   | 'proyecto_planos';


### PR DESCRIPTION
**Sprint 2.2 de `cxc`** — la captura que reemplaza el form de Coda "Depositos Clientes".

## Qué agrega (detalle de venta `/dilesa/ventas/[id]`, sección Estado de cuenta)
- **Botón "Registrar abono"** → drawer con form (fecha, monto, fuente, forma de pago, referencia, notas). Llama `erp.cxc_pago_registrar` → inserta el abono, lo **auto-aplica FIFO** a los cargos abiertos, y refresca el estado de cuenta. Toast de éxito/error.
- **Botón "Generar plan"** (solo si la venta no tiene cargos) → `dilesa.fn_generar_plan_pagos`. Para ventas nuevas sin plan.

## Notas
- El cálculo usa el FIFO ya corregido (#619) — la fuente es etiqueta, no barrera.
- RPCs verificadas con `EXECUTE` para `authenticated`.
- **Sin auto-merge** — pruébalo en el preview (registra un abono de prueba en una venta y mira cómo baja el saldo).

## CI local
typecheck ✓ · test ✓ (1134) · lint ✓ · format ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)