### PR TITLE
feat(dilesa): cargar lotes de Delicias + Ampliación desde el plano aprobado

### DIFF
--- a/scripts/import_dilesa_lotes_ampliacion.ts
+++ b/scripts/import_dilesa_lotes_ampliacion.ts
@@ -1,0 +1,190 @@
+/**
+ * import_dilesa_lotes_ampliacion.ts
+ *
+ * Carga el desglose de lotes del desarrollo "Ampliación Lomas de los
+ * Encinos" en `dilesa.unidades`, derivado del Cuadro de Áreas Manzanero
+ * del plano oficial aprobado (PDF en `dilesa.proyecto_planos`).
+ *
+ * Extraído por visión del cuadro renderizado a 400-500 DPI y VALIDADO
+ * contra los 20 totales de columna impresos (checksum exacto): 358 lotes
+ * (354 habitacionales + 4 municipales), 51,344.36 m². Las manzanas son
+ * 19, 23-41 (continúan la numeración de "Lomas de los Encinos").
+ *
+ * Mismo formato que Delicias: identificador `M{mz}-L{lote}`, estado
+ * `planeada`, municipales con `tipo_lote='municipal'`.
+ *
+ * Idempotente: aborta si el desarrollo ya tiene unidades.
+ * Uso:
+ *   DRY_RUN=1 npx tsx --env-file=/Users/Beto/BSOP/.env.local scripts/import_dilesa_lotes_ampliacion.ts
+ *   npx tsx --env-file=/Users/Beto/BSOP/.env.local scripts/import_dilesa_lotes_ampliacion.ts
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+if (!SUPABASE_URL || !SUPABASE_KEY) throw new Error('Faltan credenciales de Supabase');
+
+const PROYECTO_NOMBRE = 'Ampliación Lomas de los Encinos';
+
+// Definición compacta: manzana -> { rango lotes [inicio,fin], overrides (≠120) }.
+// Lo no listado en overrides es 120.00.
+type Def = { rango: [number, number]; ov: Record<number, number> };
+const MZ: Record<number, Def> = {
+  19: { rango: [1, 20], ov: { 1: 197.08 } },
+  23: {
+    rango: [34, 41],
+    ov: { 35: 120.26, 36: 120.7, 37: 121.15, 38: 121.59, 39: 122.03, 40: 122.48, 41: 134.86 },
+  },
+  24: { rango: [1, 43], ov: { 1: 170.57, 21: 164.26, 22: 132.77, 43: 161.8 } },
+  25: { rango: [1, 34], ov: { 1: 175.58, 16: 186.84, 17: 155.35, 34: 166.75 } },
+  26: { rango: [1, 24], ov: { 1: 175.58, 11: 214.43, 12: 182.94, 24: 166.75 } },
+  27: { rango: [1, 1], ov: { 1: 1565.13 } }, // municipal
+  28: { rango: [1, 26], ov: { 1: 171.42, 2: 127.26, 3: 120.04, 17: 167.28, 18: 153.18 } },
+  29: { rango: [1, 15], ov: { 15: 214.05 } },
+  30: { rango: [1, 30], ov: { 1: 125.26, 16: 162.3, 17: 130.82, 30: 156.74 } },
+  31: { rango: [1, 30], ov: { 1: 125.26, 16: 162.3, 17: 130.82, 30: 156.74 } },
+  32: { rango: [1, 30], ov: { 1: 125.26, 16: 162.3, 17: 130.82, 30: 156.74 } },
+  33: { rango: [1, 30], ov: { 1: 125.26, 16: 162.3, 17: 130.82, 30: 156.74 } },
+  34: { rango: [1, 1], ov: { 1: 1407.28 } }, // municipal
+  35: { rango: [1, 14], ov: { 14: 133.36 } },
+  36: { rango: [1, 1], ov: { 1: 3545.67 } }, // municipal
+  37: { rango: [1, 10], ov: { 1: 125.3, 5: 182.31, 6: 195.63, 10: 156.78 } },
+  38: { rango: [1, 12], ov: { 1: 125.3, 6: 190.76, 7: 204.08, 12: 156.78 } },
+  39: { rango: [1, 14], ov: { 1: 125.3, 7: 199.21, 8: 212.53, 14: 156.78 } },
+  40: { rango: [1, 14], ov: { 1: 125.3, 8: 207.66, 9: 248.88, 14: 156.78 } },
+  41: { rango: [1, 1], ov: { 1: 156.04 } }, // municipal
+};
+const TOTALES_COL: Record<number, number> = {
+  19: 2477.08,
+  23: 983.08,
+  24: 5309.4,
+  25: 4284.52,
+  26: 3139.7,
+  27: 1565.13,
+  28: 3259.18,
+  29: 1894.05,
+  30: 3695.12,
+  31: 3695.12,
+  32: 3695.12,
+  33: 3695.12,
+  34: 1407.28,
+  35: 1693.36,
+  36: 3545.67,
+  37: 1380.02,
+  38: 1636.92,
+  39: 1893.82,
+  40: 1938.62,
+  41: 156.04,
+};
+const MUNICIPALES = new Set(['27-1', '34-1', '36-1', '41-1']);
+
+function areaDe(mz: number, lote: number): number {
+  return MZ[mz].ov[lote] ?? 120;
+}
+function* lotesDe(mz: number): Generator<number> {
+  const [a, b] = MZ[mz].rango;
+  for (let l = a; l <= b; l++) yield l;
+}
+
+function validar(): { ok: boolean; total: number; area: number } {
+  let ok = true;
+  for (const mzStr of Object.keys(MZ)) {
+    const mz = Number(mzStr);
+    let suma = 0;
+    for (const l of lotesDe(mz)) suma += areaDe(mz, l);
+    if (Math.abs(suma - TOTALES_COL[mz]) >= 0.05) {
+      console.error(`  ✗ Mz${mz}: suma ${suma.toFixed(2)} ≠ total ${TOTALES_COL[mz]}`);
+      ok = false;
+    }
+  }
+  let total = 0;
+  let area = 0;
+  for (const mzStr of Object.keys(MZ)) {
+    const mz = Number(mzStr);
+    for (const l of lotesDe(mz)) {
+      total++;
+      area += areaDe(mz, l);
+    }
+  }
+  return { ok, total, area: Math.round(area * 100) / 100 };
+}
+
+async function main() {
+  const v = validar();
+  if (!v.ok) throw new Error('Validación de matriz falló — revisar transcripción.');
+  console.log(
+    `Matriz validada: ${v.total} lotes, ${v.area.toFixed(2)} m² (checksum por columna OK).`
+  );
+  if (v.total !== 358) throw new Error(`Esperaba 358 lotes, hay ${v.total}.`);
+
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+  const { data: emp } = await sb
+    .schema('core')
+    .from('empresas')
+    .select('id')
+    .eq('slug', 'dilesa')
+    .single();
+  const empresaId = (emp as { id: string }).id;
+
+  const { data: proy, error: pErr } = await sb
+    .schema('dilesa')
+    .from('proyectos')
+    .select('id')
+    .eq('empresa_id', empresaId)
+    .eq('nombre', PROYECTO_NOMBRE)
+    .eq('tipo', 'desarrollo')
+    .is('deleted_at', null)
+    .single();
+  if (pErr || !proy) throw new Error(`No se encontró el desarrollo "${PROYECTO_NOMBRE}".`);
+  const proyectoId = (proy as { id: string }).id;
+
+  const { count } = await sb
+    .schema('dilesa')
+    .from('unidades')
+    .select('id', { count: 'exact', head: true })
+    .eq('proyecto_id', proyectoId)
+    .is('deleted_at', null);
+  if ((count ?? 0) > 0) {
+    throw new Error(`El desarrollo ya tiene ${count} unidades. Abortando para no duplicar.`);
+  }
+
+  const rows: Record<string, unknown>[] = [];
+  for (const mzStr of Object.keys(MZ)) {
+    const mz = Number(mzStr);
+    for (const lote of lotesDe(mz)) {
+      const muni = MUNICIPALES.has(`${mz}-${lote}`);
+      rows.push({
+        empresa_id: empresaId,
+        proyecto_id: proyectoId,
+        identificador: `M${mz}-L${lote}`,
+        manzana: String(mz),
+        numero_lote: String(lote),
+        area_m2: areaDe(mz, lote),
+        estado: 'planeada',
+        tipo_lote: muni ? 'municipal' : 'habitacional',
+      });
+    }
+  }
+
+  console.log(
+    `${DRY_RUN ? '[DRY_RUN] ' : ''}${rows.length} unidades a crear ` +
+      `(${rows.filter((r) => r.tipo_lote === 'municipal').length} municipales) en "${PROYECTO_NOMBRE}".`
+  );
+  if (DRY_RUN) {
+    console.log('Muestra:', rows.slice(0, 2), '…', rows.slice(-2));
+    return;
+  }
+
+  const { error: insErr, count: insCount } = await sb
+    .schema('dilesa')
+    .from('unidades')
+    .insert(rows, { count: 'exact' });
+  if (insErr) throw new Error(`Insert falló: ${insErr.message}`);
+  console.log(`✓ ${insCount ?? rows.length} unidades creadas en "${PROYECTO_NOMBRE}".`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/import_dilesa_lotes_delicias.ts
+++ b/scripts/import_dilesa_lotes_delicias.ts
@@ -1,0 +1,309 @@
+/**
+ * import_dilesa_lotes_delicias.ts
+ *
+ * Carga el desglose de lotes del desarrollo "Lomas de las Delicias" en
+ * `dilesa.unidades`, derivado del Cuadro de Manzanero y de Áreas del plano
+ * oficial aprobado por el municipio (PDF subido a `dilesa.proyecto_planos`).
+ *
+ * El cuadro se renderizó a 300 DPI, se leyó con visión y se VALIDÓ contra
+ * los 12 totales de columna impresos (checksum exacto): 165 lotes (163
+ * habitacionales + 2 municipales), 23,941.70 m². Ver matriz abajo.
+ *
+ * Identificador `M{manzana}-L{lote}` (consistente con import_dilesa_inventario).
+ * Estado `planeada` (aún no urbanizado). Precio/prototipo NO se cargan —
+ * eso es info comercial que se captura después.
+ *
+ * Idempotente: aborta si el desarrollo ya tiene unidades.
+ *
+ * Prerequisites: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.
+ * Uso:
+ *   DRY_RUN=1 npx tsx --env-file=/Users/Beto/BSOP/.env.local scripts/import_dilesa_lotes_delicias.ts
+ *   npx tsx --env-file=/Users/Beto/BSOP/.env.local scripts/import_dilesa_lotes_delicias.ts
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+if (!SUPABASE_URL || !SUPABASE_KEY) throw new Error('Faltan credenciales de Supabase');
+
+const PROYECTO_NOMBRE = 'Lomas de las Delicias';
+
+// Cuadro de Manzanero y de Áreas (plano oficial AGOSTO 2025, LOT-001/25).
+// manzana -> { lote: superficie_m2 }. Validado contra totales de columna.
+const MATRIZ: Record<number, Record<number, number>> = {
+  1: { 1: 129.91, 2: 120.0, 3: 193.13 },
+  2: { 1: 167.33, 2: 120, 3: 120, 4: 120, 5: 120, 6: 120, 7: 120, 8: 120, 9: 120, 10: 179.11 },
+  3: { 1: 145.0, 2: 120, 3: 120, 4: 120, 5: 120, 6: 172.89 },
+  4: { 1: 130.42, 2: 127.82, 3: 141.91 },
+  5: {
+    1: 205.37,
+    2: 120,
+    3: 120,
+    4: 120,
+    5: 120,
+    6: 120,
+    7: 120,
+    8: 120,
+    9: 120,
+    10: 191.43,
+    11: 166.24,
+    12: 120,
+    13: 120,
+    14: 120,
+    15: 120,
+    16: 120,
+    17: 120,
+    18: 120,
+    19: 120,
+    20: 120,
+    21: 188.87,
+  },
+  6: {
+    1: 136.21,
+    2: 120,
+    3: 120,
+    4: 120,
+    5: 120,
+    6: 120,
+    7: 120,
+    8: 120,
+    9: 146.31,
+    10: 146.31,
+    11: 120,
+    12: 120,
+    13: 120,
+    14: 120,
+    15: 120,
+    16: 120,
+    17: 120,
+    18: 168.63,
+  },
+  7: {
+    1: 144.02,
+    2: 120,
+    3: 120,
+    4: 120,
+    5: 120,
+    6: 120,
+    7: 120,
+    8: 120,
+    9: 120,
+    10: 120,
+    11: 120,
+    12: 120,
+    13: 126.81,
+    14: 62.81,
+  },
+  8: {
+    1: 127.97,
+    2: 120,
+    3: 120,
+    4: 120,
+    5: 120,
+    6: 120,
+    7: 120,
+    8: 120,
+    9: 120,
+    10: 120,
+    11: 120,
+    12: 120,
+    13: 120,
+    14: 134.75,
+    15: 177.71,
+    16: 120,
+    17: 120,
+    18: 120,
+    19: 120,
+    20: 120,
+    21: 120,
+    22: 120,
+    23: 120,
+    24: 120,
+    25: 120,
+    26: 120,
+    27: 157.65,
+  },
+  9: {
+    1: 168.58,
+    2: 120,
+    3: 120,
+    4: 120,
+    5: 120,
+    6: 120,
+    7: 120,
+    8: 120,
+    9: 120,
+    10: 120,
+    11: 120,
+    12: 195.9,
+    13: 163.48,
+    14: 120,
+    15: 120,
+    16: 120,
+    17: 120,
+    18: 120,
+    19: 120,
+    20: 120,
+    21: 120,
+    22: 120,
+    23: 120,
+    24: 137.6,
+  },
+  10: {
+    1: 120,
+    2: 120,
+    3: 120,
+    4: 120,
+    5: 120,
+    6: 120,
+    7: 120,
+    8: 120,
+    9: 127.48,
+    10: 193.64,
+    11: 120,
+    12: 120,
+    13: 120,
+    14: 120,
+    15: 120,
+    16: 120,
+    17: 120,
+  },
+  11: {
+    1: 132.97,
+    2: 120,
+    3: 120,
+    4: 120,
+    5: 120,
+    6: 120,
+    7: 120,
+    8: 120,
+    9: 120,
+    10: 120,
+    11: 169.49,
+    12: 137.07,
+    13: 120,
+    14: 120,
+    15: 120,
+    16: 120,
+    17: 120,
+    18: 120,
+    19: 120,
+    20: 120,
+    21: 170.27,
+  },
+  12: { 1: 3076.63 },
+};
+// Totales de columna impresos en el plano (checksum).
+const TOTALES_COL: Record<number, number> = {
+  1: 443.04,
+  2: 1306.44,
+  3: 797.89,
+  4: 400.14,
+  5: 2791.91,
+  6: 2277.46,
+  7: 1653.64,
+  8: 3358.08,
+  9: 3065.56,
+  10: 2121.12,
+  11: 2649.8,
+  12: 3076.63,
+};
+// Lotes municipales (área verde / equipamiento, no vendibles): "mz-lote".
+const MUNICIPALES = new Set(['12-1', '7-14']);
+
+function validar(): { ok: boolean; total: number; area: number } {
+  let ok = true;
+  for (const mzStr of Object.keys(MATRIZ)) {
+    const mz = Number(mzStr);
+    const suma = Object.values(MATRIZ[mz]).reduce((a, b) => a + b, 0);
+    if (Math.abs(suma - TOTALES_COL[mz]) >= 0.05) {
+      console.error(`  ✗ Mz${mz}: suma ${suma.toFixed(2)} ≠ total ${TOTALES_COL[mz]}`);
+      ok = false;
+    }
+  }
+  const total = Object.values(MATRIZ).reduce((a, m) => a + Object.keys(m).length, 0);
+  const area = Object.values(MATRIZ).reduce(
+    (a, m) => a + Object.values(m).reduce((x, y) => x + y, 0),
+    0
+  );
+  return { ok, total, area };
+}
+
+async function main() {
+  const v = validar();
+  if (!v.ok) throw new Error('Validación de matriz falló — revisar transcripción.');
+  console.log(`Matriz validada: ${v.total} lotes, ${v.area.toFixed(2)} m² (checksum OK).`);
+  if (v.total !== 165) throw new Error(`Esperaba 165 lotes, hay ${v.total}.`);
+
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+  const { data: emp } = await sb
+    .schema('core')
+    .from('empresas')
+    .select('id')
+    .eq('slug', 'dilesa')
+    .single();
+  const empresaId = (emp as { id: string }).id;
+
+  const { data: proy, error: pErr } = await sb
+    .schema('dilesa')
+    .from('proyectos')
+    .select('id, lotes_proyectados')
+    .eq('empresa_id', empresaId)
+    .eq('nombre', PROYECTO_NOMBRE)
+    .eq('tipo', 'desarrollo')
+    .is('deleted_at', null)
+    .single();
+  if (pErr || !proy) throw new Error(`No se encontró el desarrollo "${PROYECTO_NOMBRE}".`);
+  const proyectoId = (proy as { id: string }).id;
+
+  // Idempotencia.
+  const { count } = await sb
+    .schema('dilesa')
+    .from('unidades')
+    .select('id', { count: 'exact', head: true })
+    .eq('proyecto_id', proyectoId)
+    .is('deleted_at', null);
+  if ((count ?? 0) > 0) {
+    throw new Error(`El desarrollo ya tiene ${count} unidades. Abortando para no duplicar.`);
+  }
+
+  const rows = Object.keys(MATRIZ).flatMap((mzStr) => {
+    const mz = Number(mzStr);
+    return Object.keys(MATRIZ[mz]).map((loteStr) => {
+      const lote = Number(loteStr);
+      const muni = MUNICIPALES.has(`${mz}-${lote}`);
+      return {
+        empresa_id: empresaId,
+        proyecto_id: proyectoId,
+        identificador: `M${mz}-L${lote}`,
+        manzana: String(mz),
+        numero_lote: String(lote),
+        area_m2: MATRIZ[mz][lote],
+        estado: 'planeada',
+        tipo_lote: muni ? 'municipal' : 'habitacional',
+      };
+    });
+  });
+
+  console.log(
+    `${DRY_RUN ? '[DRY_RUN] ' : ''}${rows.length} unidades a crear ` +
+      `(${rows.filter((r) => r.tipo_lote === 'municipal').length} municipales) en "${PROYECTO_NOMBRE}".`
+  );
+  if (DRY_RUN) {
+    console.log('Muestra:', rows.slice(0, 3), '…', rows.slice(-2));
+    return;
+  }
+
+  const { error: insErr, count: insCount } = await sb
+    .schema('dilesa')
+    .from('unidades')
+    .insert(rows, { count: 'exact' });
+  if (insErr) throw new Error(`Insert falló: ${insErr.message}`);
+  console.log(`✓ ${insCount ?? rows.length} unidades creadas en "${PROYECTO_NOMBRE}".`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Carga el desglose de unidades de 2 desarrollos recién promovidos, derivado del **Cuadro de Áreas Manzanero** de su plano oficial aprobado por el municipio.

## Método (validado)
Renderizar el cuadro del PDF a 300-500 DPI → leer con visión → **validar contra los totales de columna impresos** (checksum exacto, columna por columna) antes de cargar. El texto del plano (CAD) no se extrae confiable por parsing, pero el render es nítido y el checksum garantiza precisión.

## Resultado
| Desarrollo | Lotes | Municipales | Manzanas | Área |
|---|---|---|---|---|
| Lomas de las Delicias | 165 | 2 | 12 | 23,941.72 m² |
| Ampliación Lomas de los Encinos | 358 | 4 | 20 (19, 23-41) | 51,344.34 m² |

Ambos verificados en prod contra el plano. Cada unidad: `M{mz}-L{lote}`, manzana, lote, area_m2, estado `planeada`, `tipo_lote` (habitacional/municipal). Idempotente. Precio/prototipo se capturan después (no están en el plano de lotificación).

Scripts one-off de carga (ya ejecutados). Sin cambios de código de app ni schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)