### PR TITLE
fix(cxp): gate de aprobación usa rol Dirección (no puesto Comité)

### DIFF
--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-04-28
-**Última actualización:** 2026-06-01 (**Sprint 1 aplicado a prod**: extiende `erp.facturas` + crea `cxp_pagos`/`cxp_pago_aplicaciones` + 6 RPCs + `es_comite_ejecutivo` + trigger de saldo. Gate de aprobación **estricto a Comité Ejecutivo** sin override de admin (decisión de Beto). Modo autónomo. Próximo: Sprint 2 ingesta XML. Ver Bitácora.)
+**Última actualización:** 2026-06-01 (**Sprint 1 aplicado a prod** + corrección del gate: extiende `erp.facturas` + crea `cxp_pagos`/`cxp_pago_aplicaciones` + 6 RPCs + trigger de saldo. Gate de aprobación = **rol "Dirección"** vía `core.fn_user_has_role` (corregido del puesto "Comité Ejecutivo" por Beto; mig `214500` elimina `es_comite_ejecutivo`). Sin override de admin. Modo autónomo. Próximo: Sprint 2 ingesta XML. Ver Bitácora.)
 
 ## Problema
 
@@ -191,6 +191,26 @@ patrón canónico de **ADR-037** (subledger gemelo):
   reusan CxC y CxP (convención `shared-modules-refactor`, ADR-011).
 
 ## Bitácora
+
+### 2026-06-01 — Corrección del gate de aprobación: rol "Dirección" (no puesto Comité)
+
+Beto corrigió un día después de Sprint 1: la autoridad para aprobar pagos es el
+**rol "Dirección"** (modelo `core.usuarios_empresas` + `core.roles`), que tienen
+asignado Ale, Michelle y Beto — **no** el puesto "Comité Ejecutivo" de
+`erp.empleados_puestos` que se usó por error en Sprint 1. Beto además tiene admin,
+que **no** cuenta para aprobar (control financiero estricto).
+
+- Migración `20260601214500_cxp_gate_aprobacion_direccion.sql`: `cxp_pago_aprobar`
+  pasa a gatear con `core.fn_user_has_role('Dirección', empresa)` (helper canónico,
+  ver memoria `reference_roles_por_empresa`) y se **elimina** `erp.es_comite_ejecutivo`.
+- Verificado en prod: `es_comite_ejecutivo` eliminado, `cxp_pago_aprobar` usa
+  Dirección, **4 usuarios con rol Dirección** (6 asignaciones usuario-empresa) →
+  mejor cobertura que el modelo de puesto (solo mapeaba 2). Resuelve el riesgo de
+  cobertura del gate que se había flageado.
+- Aplicado a prod vía `execute_sql` (DDL idempotente: CREATE OR REPLACE + DROP)
+  para evitar carrera de `db push` con el PR paralelo del fix de CxC (#627). El
+  archivo de migración queda como fuente de verdad y la CI lo valida fresco en el
+  Supabase Preview branch.
 
 ### 2026-06-01 — Sprint 1 (schema CxP, DB-puro) aplicado a prod
 

--- a/supabase/migrations/20260601214500_cxp_gate_aprobacion_direccion.sql
+++ b/supabase/migrations/20260601214500_cxp_gate_aprobacion_direccion.sql
@@ -1,0 +1,62 @@
+-- ╭──────────────────────────────────────────────────────────────────╮
+-- │  20260601214500_cxp_gate_aprobacion_direccion                      │
+-- │                                                                    │
+-- │  Corrección del gate de aprobación de pagos CxP (decisión de Beto):│
+-- │  la autoridad de aprobación es el ROL "Dirección" (modelo de roles │
+-- │  core.usuarios_empresas + core.roles), NO el puesto "Comité         │
+-- │  Ejecutivo" (erp.empleados_puestos) que se usó por error en la      │
+-- │  migración 20260601200000.                                         │
+-- │                                                                    │
+-- │  Ale, Michelle y Beto tienen el rol "Dirección" (Beto además tiene │
+-- │  admin, que NO cuenta para aprobar — control financiero estricto). │
+-- │                                                                    │
+-- │  1. cxp_pago_aprobar pasa a gatear con core.fn_user_has_role(       │
+-- │     'Dirección', empresa) — el helper canónico (ver memoria         │
+-- │     reference_roles_por_empresa / ADR de roles por empresa).        │
+-- │  2. Se elimina erp.es_comite_ejecutivo (modelo equivocado, recién   │
+-- │     introducido en 200000, sin consumidores fuera de aquí).         │
+-- │                                                                    │
+-- │  Iniciativa: `cxp` (Sprint 1, corrección).                         │
+-- ╰──────────────────────────────────────────────────────────────────╯
+
+BEGIN;
+
+-- 1. Gate por rol "Dirección" (core.fn_user_has_role usa auth.uid() interno).
+CREATE OR REPLACE FUNCTION erp.cxp_pago_aprobar(p_pago_id uuid)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = erp, public
+AS $$
+DECLARE
+  v erp.cxp_pagos%ROWTYPE;
+BEGIN
+  SELECT * INTO v FROM erp.cxp_pagos
+   WHERE id = p_pago_id AND deleted_at IS NULL FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Pago % no existe o está cancelado', p_pago_id;
+  END IF;
+  IF v.estado <> 'programado' THEN
+    RAISE EXCEPTION 'El pago no está en estado programado (estado actual: %)', v.estado;
+  END IF;
+  -- Autoridad de aprobación = rol "Dirección" de la empresa. Sin override
+  -- de admin (decisión de Beto, control financiero estricto).
+  IF NOT core.fn_user_has_role('Dirección', v.empresa_id) THEN
+    RAISE EXCEPTION 'Solo un usuario con rol Dirección puede aprobar pagos';
+  END IF;
+
+  UPDATE erp.cxp_pagos
+     SET estado = 'aprobado', aprobado_por = auth.uid(), aprobado_at = now(), updated_at = now()
+   WHERE id = p_pago_id;
+
+  INSERT INTO core.audit_log (empresa_id, usuario_id, accion, tabla, registro_id, datos_nuevos)
+  VALUES (v.empresa_id, auth.uid(), 'cxp_pago_aprobado', 'erp.cxp_pagos', p_pago_id, '{}'::jsonb);
+END;
+$$;
+
+-- 2. Eliminar el helper del modelo equivocado (puesto Comité Ejecutivo).
+DROP FUNCTION IF EXISTS erp.es_comite_ejecutivo(uuid, uuid);
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
Corrección del gate de aprobación de pagos CxP (Sprint 1), por instrucción de Beto.

**La autoridad para aprobar pagos es el rol "Dirección"** (`core.usuarios_empresas` + `core.roles`) — que tienen Ale, Michelle y Beto — **no** el puesto "Comité Ejecutivo" de `erp.empleados_puestos` que se usó por error en Sprint 1 (#626). Beto además tiene admin, que **no** cuenta para aprobar (control financiero estricto).

- `cxp_pago_aprobar` ahora gatea con `core.fn_user_has_role('Dirección', empresa)` (helper canónico — ver memoria `reference_roles_por_empresa`).
- Elimina `erp.es_comite_ejecutivo` (modelo equivocado).
- **Verificado en prod**: `es_comite_ejecutivo` eliminado, gate usa Dirección, **4 usuarios con rol Dirección** (6 asignaciones) → mejor cobertura que el modelo de puesto (mapeaba 2).
- Aplicado a prod vía `execute_sql` idempotente (CREATE OR REPLACE + DROP) para evitar carrera de `db push` con el PR paralelo #627; el archivo de migración `20260601214500` queda como fuente de verdad y CI lo valida en el Supabase Preview branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)