### PR TITLE
feat(cxp): Sprint 2 — ingesta XML CFDI (parser + endpoint upload-xml)

### DIFF
--- a/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
+++ b/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
@@ -1,0 +1,228 @@
+/**
+ * POST /api/<empresa>/cxp/facturas/upload-xml — ingesta de facturas de egreso
+ * desde XML CFDI (CxP Sprint 2, iniciativa `cxp`).
+ *
+ * Acepta 1..N archivos XML (campo `file` del FormData → bulk). Por cada uno:
+ *   1. Parsea el CFDI (determinista, lib/cxp/cfdi-parser — sin LLM).
+ *   2. Valida que el receptor del CFDI sea esta empresa (por RFC).
+ *   3. Dedup por folio fiscal (uuid_sat).
+ *   4. Matchea el emisor con un proveedor (persona por RFC); si no existe, la
+ *      factura se crea igual con proveedor nulo y se sugiere el alta del
+ *      proveedor (carga inclusiva — "mejor capturar de más", planning cxp).
+ *   5. Da de alta la factura vía `erp.cxp_factura_alta` (RPC, dedup defensivo).
+ *   6. Sube el XML a storage (`adjuntos`) + registra `erp.adjuntos` + `xml_url`.
+ *
+ * Devuelve un resultado por archivo (éxito o error) para no abortar el lote
+ * completo por un XML malo.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { buildAdjuntoPath, type EmpresaSlug } from '@/lib/storage/path';
+import { parseCfdiXml, CfdiParseError } from '@/lib/cxp/cfdi-parser';
+
+const EMPRESA_SLUGS: EmpresaSlug[] = ['dilesa', 'rdb', 'ansa', 'coagan'];
+
+type Params = { params: Promise<{ empresa: string }> };
+
+type FacturaResult = {
+  filename: string;
+  ok: boolean;
+  facturaId?: string;
+  uuid?: string | null;
+  proveedorId?: string | null;
+  /** Si el emisor no matcheó un proveedor existente, se sugiere darlo de alta. */
+  proveedorSugerido?: { rfc: string; nombre: string | null } | null;
+  error?: string;
+};
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const { empresa: empresaSlug } = await params;
+  if (!EMPRESA_SLUGS.includes(empresaSlug as EmpresaSlug)) {
+    return NextResponse.json({ ok: false, error: 'Empresa inválida.' }, { status: 400 });
+  }
+
+  // Auth.
+  const userSupa = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await userSupa.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ ok: false, error: 'No autenticado.' }, { status: 401 });
+  }
+
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    return NextResponse.json(
+      { ok: false, error: 'Configuración de servidor incompleta.' },
+      { status: 500 }
+    );
+  }
+
+  // Resolver empresa por slug.
+  const { data: emp } = await admin
+    .schema('core')
+    .from('empresas')
+    .select('id, rfc, slug')
+    .eq('slug', empresaSlug)
+    .maybeSingle();
+  if (!emp) {
+    return NextResponse.json({ ok: false, error: 'Empresa no encontrada.' }, { status: 404 });
+  }
+
+  // Acceso: miembro activo de la empresa o admin global.
+  const [{ data: u }, { data: mem }] = await Promise.all([
+    admin.schema('core').from('usuarios').select('rol').eq('id', user.id).maybeSingle(),
+    admin
+      .schema('core')
+      .from('usuarios_empresas')
+      .select('id')
+      .eq('usuario_id', user.id)
+      .eq('empresa_id', emp.id)
+      .eq('activo', true)
+      .maybeSingle(),
+  ]);
+  if (!mem && u?.rol !== 'admin') {
+    return NextResponse.json({ ok: false, error: 'Sin acceso a esta empresa.' }, { status: 403 });
+  }
+
+  // Archivos (1..N).
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Cuerpo inválido (se esperaba multipart).' },
+      {
+        status: 400,
+      }
+    );
+  }
+  const files = form.getAll('file').filter((f): f is File => f instanceof File);
+  if (files.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: 'No se adjuntaron archivos XML.' },
+      {
+        status: 400,
+      }
+    );
+  }
+
+  const empresaRfc = String(emp.rfc ?? '')
+    .toUpperCase()
+    .trim();
+  const results: FacturaResult[] = [];
+
+  for (const file of files) {
+    const r: FacturaResult = { filename: file.name, ok: false };
+    try {
+      const cfdi = parseCfdiXml(await file.text());
+
+      // El receptor del CFDI debe ser esta empresa.
+      if (empresaRfc && cfdi.receptorRfc !== empresaRfc) {
+        r.error = `El CFDI es para el RFC ${cfdi.receptorRfc}, no para ${empresaSlug} (${empresaRfc}).`;
+        results.push(r);
+        continue;
+      }
+
+      // Dedup por folio fiscal.
+      if (cfdi.uuid) {
+        const { data: dup } = await admin
+          .schema('erp')
+          .from('facturas')
+          .select('id')
+          .eq('uuid_sat', cfdi.uuid)
+          .maybeSingle();
+        if (dup) {
+          r.uuid = cfdi.uuid;
+          r.error = `Ya existe una factura con folio fiscal ${cfdi.uuid}.`;
+          results.push(r);
+          continue;
+        }
+      }
+
+      // Emisor → proveedor (persona por RFC).
+      const { data: prov } = await admin
+        .schema('erp')
+        .from('personas')
+        .select('id')
+        .eq('rfc', cfdi.emisorRfc)
+        .maybeSingle();
+      const proveedorId: string | null = prov?.id ?? null;
+
+      // Alta de la factura (RPC SECURITY DEFINER).
+      const { data: facturaId, error: rpcErr } = await admin.schema('erp').rpc('cxp_factura_alta', {
+        // p_proveedor_id es posicionalmente requerido en el SQL pero la
+        // columna acepta NULL: el cast permite pasar null cuando el emisor
+        // no matchea un proveedor existente (carga inclusiva).
+        p_empresa_id: emp.id,
+        p_proveedor_id: proveedorId as string,
+        p_total: cfdi.total,
+        p_subtotal: cfdi.subtotal,
+        p_iva: cfdi.ivaTrasladado,
+        p_fecha_emision: cfdi.fecha || undefined,
+        p_uuid_sat: cfdi.uuid ?? undefined,
+        p_emisor_rfc: cfdi.emisorRfc,
+        p_emisor_nombre: cfdi.emisorNombre ?? undefined,
+        p_receptor_rfc: cfdi.receptorRfc,
+        p_forma_pago_sat: cfdi.formaPago ?? undefined,
+        p_metodo_pago_sat:
+          cfdi.metodoPago === 'PUE' || cfdi.metodoPago === 'PPD' ? cfdi.metodoPago : undefined,
+        p_uso_cfdi: cfdi.usoCfdi ?? undefined,
+        p_tasa_iva: cfdi.tasaIva ?? undefined,
+        p_retencion_iva: cfdi.retencionIva,
+        p_retencion_isr: cfdi.retencionIsr,
+      });
+      if (rpcErr) {
+        r.error = rpcErr.message;
+        results.push(r);
+        continue;
+      }
+
+      // Guardar el XML + registrar adjunto + xml_url (best-effort; la factura
+      // ya quedó creada aunque el storage falle).
+      const path = buildAdjuntoPath({
+        empresa: empresaSlug as EmpresaSlug,
+        entidad: 'facturas',
+        entidadId: facturaId as string,
+        filename: file.name,
+      });
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      const { error: upErr } = await admin.storage
+        .from('adjuntos')
+        .upload(path, bytes, { contentType: 'application/xml', upsert: false });
+      if (!upErr) {
+        await admin.schema('erp').from('adjuntos').insert({
+          empresa_id: emp.id,
+          entidad_tipo: 'cxp_factura',
+          entidad_id: facturaId,
+          rol: 'xml_cfdi',
+          nombre: file.name,
+          url: path,
+          tipo_mime: 'application/xml',
+        });
+        await admin.schema('erp').from('facturas').update({ xml_url: path }).eq('id', facturaId);
+      }
+
+      r.ok = true;
+      r.facturaId = facturaId as string;
+      r.uuid = cfdi.uuid;
+      r.proveedorId = proveedorId;
+      r.proveedorSugerido = proveedorId ? null : { rfc: cfdi.emisorRfc, nombre: cfdi.emisorNombre };
+    } catch (e) {
+      r.error =
+        e instanceof CfdiParseError ? e.message : `Error inesperado: ${(e as Error).message}`;
+    }
+    results.push(r);
+  }
+
+  const exitosos = results.filter((x) => x.ok).length;
+  return NextResponse.json({
+    ok: exitosos > 0,
+    total: results.length,
+    exitosos,
+    results,
+  });
+}

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-04-28
-**Última actualización:** 2026-06-01 (**Sprint 1 aplicado a prod** + corrección del gate: extiende `erp.facturas` + crea `cxp_pagos`/`cxp_pago_aplicaciones` + 6 RPCs + trigger de saldo. Gate de aprobación = **rol "Dirección"** vía `core.fn_user_has_role` (corregido del puesto "Comité Ejecutivo" por Beto; mig `214500` elimina `es_comite_ejecutivo`). Sin override de admin. Modo autónomo. Próximo: Sprint 2 ingesta XML. Ver Bitácora.)
+**Última actualización:** 2026-06-01 (**Sprint 1 aplicado a prod** + corrección del gate: extiende `erp.facturas` + crea `cxp_pagos`/`cxp_pago_aplicaciones` + 6 RPCs + trigger de saldo. Gate de aprobación = **rol "Dirección"** vía `core.fn_user_has_role` (corregido del puesto "Comité Ejecutivo" por Beto; mig `214500` elimina `es_comite_ejecutivo`). Sin override de admin. **Sprint 2** (ingesta XML CFDI: parser determinista + endpoint upload-xml) en este PR. Modo autónomo. Próximo: Sprint 3 UI. Ver Bitácora.)
 
 ## Problema
 
@@ -71,7 +71,7 @@ Resultado operativo: doble captura entre la realidad bancaria y la contable, rie
   - Toda transición escribe a `audit_log`.
   - **Regenerar `SCHEMA_REF.md`** y commitearlo.
 
-- [ ] **Sprint 2 — Ingesta XML CFDI + match con OC**:
+- [x] **Sprint 2 — Ingesta XML CFDI** (parser + endpoint; match-OC y PDF-LLM diferidos):
   - Endpoint `POST /api/<empresa>/cxp/facturas/upload-xml` (parser determinista, no LLM — el CFDI es estructurado).
   - Validaciones: `Receptor.Rfc = empresa.rfc`, dedup por `uuid_sat`, emisor existe en `erp.proveedores` (si no, sugiere alta — reutiliza `proveedores-csf-ai`).
   - Sugerencia automática de OC: si el emisor tiene OCs cerradas con saldo pendiente de pagar, las propone para match.
@@ -143,7 +143,7 @@ Resultado operativo: doble captura entre la realidad bancaria y la contable, rie
 | --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | --------- |
 | 0   | Promoción: este doc + fila en INITIATIVES.md                                                                                                                                                                         | _este PR_ | —         |
 | 1   | DB: extender `erp.facturas` + crear `cxp_pagos` + `cxp_pago_aplicaciones` + RPCs (alta, cancelar, programar, aprobar, marcar_pagado, cancelar_pago) + helper `es_comite_ejecutivo` + backfill + regenerar SCHEMA_REF | aplicado  | _este PR_ |
-| 2   | Ingesta XML CFDI (parser determinista) + match con OC + bulk upload + sugerencia de alta de proveedor                                                                                                                | pending   | —         |
+| 2   | Parser CFDI determinista (`lib/cxp`) + endpoint `upload-xml` (bulk + dedup `uuid_sat` + validación receptor + sugerencia de proveedor). Match-OC automático y PDF-LLM diferidos a Sprint 3/follow-up                 | en PR     | _este PR_ |
 | 3   | UI RDB facturas (lista + drawer) + aging + vista por proveedor                                                                                                                                                       | pending   | —         |
 | 4   | UI RDB programación + aprobación por Comité + email de notificación                                                                                                                                                  | pending   | —         |
 | 5   | Pago efectivo + conciliación contra cortes (engancha con `cortes-conciliacion`)                                                                                                                                      | pending   | —         |
@@ -191,6 +191,30 @@ patrón canónico de **ADR-037** (subledger gemelo):
   reusan CxC y CxP (convención `shared-modules-refactor`, ADR-011).
 
 ## Bitácora
+
+### 2026-06-01 — Sprint 2 (ingesta XML CFDI: parser + endpoint)
+
+App-layer (sin migración). Backend de la carga de facturas de egreso.
+
+- **`lib/cxp/cfdi-parser.ts`** — parser determinista de CFDI 4.0/3.3 (con
+  `fast-xml-parser`, sin LLM). Extrae folio fiscal (UUID del TimbreFiscalDigital),
+  emisor/receptor, montos, IVA trasladado + tasa derivada (0/8/16), retenciones
+  IVA (002) e ISR (001), forma/método de pago, uso CFDI y tipo. 13 tests
+  (`cfdi-parser.test.ts`): CFDI completo, retenciones de servicios profesionales,
+  frontera 8%, sin timbrar (uuid null) y errores.
+- **`POST /api/[empresa]/cxp/facturas/upload-xml`** — acepta 1..N XML (bulk). Por
+  archivo: auth + acceso a la empresa (miembro o admin) → parse → valida que el
+  receptor sea la empresa (por RFC) → dedup por `uuid_sat` → matchea emisor a
+  proveedor (persona por RFC; si no existe, factura con proveedor nulo + sugiere
+  alta) → `erp.cxp_factura_alta` → sube el XML a storage + `erp.adjuntos` +
+  `xml_url`. Devuelve un resultado por archivo (no aborta el lote por un XML malo).
+- Dep nueva: `fast-xml-parser ^5.8.0`. `'facturas'` agregado a `AdjuntoEntidad`.
+- **Diferido** (Sprint 3 UI / follow-up): sugerencia automática de OC del emisor
+  con saldo pendiente, y el parser opcional de PDF vía LLM (`extraction-core`)
+  para facturas sin XML.
+- typecheck + 1155 tests + lint + format verdes. PR _(este PR)_.
+
+**Próximo:** Sprint 3 — UI RDB (lista de facturas + drawer + aging por proveedor).
 
 ### 2026-06-01 — Corrección del gate de aprobación: rol "Dirección" (no puesto Comité)
 

--- a/lib/cxp/cfdi-parser.test.ts
+++ b/lib/cxp/cfdi-parser.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { parseCfdiXml, CfdiParseError } from './cfdi-parser';
+
+/**
+ * Tests del parser CFDI (CxP Sprint 2). Lógica pura sobre XML estructurado del
+ * SAT — env=node, sin DOM. Cubre: CFDI 4.0 completo, retenciones (servicios
+ * profesionales), tasa frontera 8%, sin timbrar (uuid null), y errores.
+ */
+
+const CFDI_40_IVA16 = `<?xml version="1.0" encoding="UTF-8"?>
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4" xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital"
+  Version="4.0" Serie="A" Folio="1234" Fecha="2026-01-15T10:30:00"
+  SubTotal="1000.00" Total="1160.00" Moneda="MXN" FormaPago="03" MetodoPago="PUE" TipoDeComprobante="I">
+  <cfdi:Emisor Rfc="aaa010101aaa" Nombre="Proveedor Demo SA de CV" RegimenFiscal="601"/>
+  <cfdi:Receptor Rfc="DIE030904866" Nombre="DESARROLLO INMOBILIARIO LOS ENCINOS" UsoCFDI="G03"/>
+  <cfdi:Conceptos>
+    <cfdi:Concepto ClaveProdServ="01010101" Cantidad="1" Descripcion="Servicio" ValorUnitario="1000.00" Importe="1000.00"/>
+  </cfdi:Conceptos>
+  <cfdi:Impuestos TotalImpuestosTrasladados="160.00">
+    <cfdi:Traslados>
+      <cfdi:Traslado Base="1000.00" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.160000" Importe="160.00"/>
+    </cfdi:Traslados>
+  </cfdi:Impuestos>
+  <cfdi:Complemento>
+    <tfd:TimbreFiscalDigital Version="1.1" UUID="a1b2c3d4-e5f6-7890-abcd-ef1234567890" FechaTimbrado="2026-01-15T10:31:00"/>
+  </cfdi:Complemento>
+</cfdi:Comprobante>`;
+
+// Servicios profesionales: traslado IVA 16% + retenciones IVA (10.6667%) e ISR (10%).
+const CFDI_40_RETENCIONES = `<?xml version="1.0" encoding="UTF-8"?>
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4" xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital"
+  Version="4.0" Folio="55" Fecha="2026-02-20T09:00:00" SubTotal="1000.00" Total="1053.33"
+  Moneda="MXN" FormaPago="03" MetodoPago="PPD" TipoDeComprobante="I">
+  <cfdi:Emisor Rfc="XAXX010101000" Nombre="Despacho Contable"/>
+  <cfdi:Receptor Rfc="DIE030904866" Nombre="DESARROLLO INMOBILIARIO LOS ENCINOS" UsoCFDI="G03"/>
+  <cfdi:Impuestos TotalImpuestosTrasladados="160.00" TotalImpuestosRetenidos="206.67">
+    <cfdi:Retenciones>
+      <cfdi:Retencion Impuesto="002" Importe="106.67"/>
+      <cfdi:Retencion Impuesto="001" Importe="100.00"/>
+    </cfdi:Retenciones>
+    <cfdi:Traslados>
+      <cfdi:Traslado Base="1000.00" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.160000" Importe="160.00"/>
+    </cfdi:Traslados>
+  </cfdi:Impuestos>
+  <cfdi:Complemento>
+    <tfd:TimbreFiscalDigital UUID="11111111-2222-3333-4444-555555555555"/>
+  </cfdi:Complemento>
+</cfdi:Comprobante>`;
+
+// Frontera norte: IVA 8%, sin timbrar (borrador sin Complemento).
+const CFDI_40_FRONTERA_SIN_TIMBRE = `<?xml version="1.0" encoding="UTF-8"?>
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4" Version="4.0" Fecha="2026-03-01T12:00:00"
+  SubTotal="500.00" Total="540.00" Moneda="MXN" FormaPago="01" MetodoPago="PUE" TipoDeComprobante="I">
+  <cfdi:Emisor Rfc="BBB020202BB2" Nombre="Ferretería Frontera"/>
+  <cfdi:Receptor Rfc="DIE030904866" UsoCFDI="G01"/>
+  <cfdi:Impuestos TotalImpuestosTrasladados="40.00">
+    <cfdi:Traslados>
+      <cfdi:Traslado Base="500.00" Impuesto="002" TipoFactor="Tasa" TasaOCuota="0.080000" Importe="40.00"/>
+    </cfdi:Traslados>
+  </cfdi:Impuestos>
+</cfdi:Comprobante>`;
+
+describe('parseCfdiXml — CFDI 4.0 con IVA 16%', () => {
+  const r = parseCfdiXml(CFDI_40_IVA16);
+
+  it('extrae folio fiscal (UUID) en mayúsculas', () => {
+    expect(r.uuid).toBe('A1B2C3D4-E5F6-7890-ABCD-EF1234567890');
+  });
+  it('extrae emisor y receptor (RFC normalizado a mayúsculas)', () => {
+    expect(r.emisorRfc).toBe('AAA010101AAA');
+    expect(r.emisorNombre).toBe('Proveedor Demo SA de CV');
+    expect(r.receptorRfc).toBe('DIE030904866');
+  });
+  it('extrae montos y moneda', () => {
+    expect(r.subtotal).toBe(1000);
+    expect(r.total).toBe(1160);
+    expect(r.moneda).toBe('MXN');
+  });
+  it('deriva IVA trasladado y tasa 16', () => {
+    expect(r.ivaTrasladado).toBeCloseTo(160, 2);
+    expect(r.tasaIva).toBe(16);
+  });
+  it('sin retenciones', () => {
+    expect(r.retencionIva).toBe(0);
+    expect(r.retencionIsr).toBe(0);
+  });
+  it('extrae forma/método de pago, uso CFDI, tipo y fecha (solo día)', () => {
+    expect(r.formaPago).toBe('03');
+    expect(r.metodoPago).toBe('PUE');
+    expect(r.usoCfdi).toBe('G03');
+    expect(r.tipoComprobante).toBe('I');
+    expect(r.fecha).toBe('2026-01-15');
+    expect(r.version).toBe('4.0');
+  });
+});
+
+describe('parseCfdiXml — retenciones de servicios profesionales', () => {
+  const r = parseCfdiXml(CFDI_40_RETENCIONES);
+  it('separa retención de IVA (002) e ISR (001)', () => {
+    expect(r.retencionIva).toBeCloseTo(106.67, 2);
+    expect(r.retencionIsr).toBeCloseTo(100, 2);
+  });
+  it('mantiene el IVA trasladado y método PPD', () => {
+    expect(r.ivaTrasladado).toBeCloseTo(160, 2);
+    expect(r.metodoPago).toBe('PPD');
+  });
+});
+
+describe('parseCfdiXml — frontera 8% sin timbrar', () => {
+  const r = parseCfdiXml(CFDI_40_FRONTERA_SIN_TIMBRE);
+  it('tasa 8 y uuid null (sin TimbreFiscalDigital)', () => {
+    expect(r.tasaIva).toBe(8);
+    expect(r.uuid).toBeNull();
+  });
+  it('receptorNombre null cuando no viene', () => {
+    expect(r.receptorNombre).toBeNull();
+    expect(r.emisorRfc).toBe('BBB020202BB2');
+  });
+});
+
+describe('parseCfdiXml — errores', () => {
+  it('lanza en XML vacío', () => {
+    expect(() => parseCfdiXml('')).toThrow(CfdiParseError);
+  });
+  it('lanza si no hay nodo Comprobante', () => {
+    expect(() => parseCfdiXml('<?xml version="1.0"?><foo><bar/></foo>')).toThrow(/Comprobante/);
+  });
+  it('lanza si falta RFC del emisor', () => {
+    const sinEmisor = CFDI_40_IVA16.replace(/Rfc="aaa010101aaa"/, 'Rfc=""');
+    expect(() => parseCfdiXml(sinEmisor)).toThrow(CfdiParseError);
+  });
+});

--- a/lib/cxp/cfdi-parser.ts
+++ b/lib/cxp/cfdi-parser.ts
@@ -1,0 +1,189 @@
+/**
+ * Parser determinista de CFDI (4.0 / 3.3) para la ingesta de facturas de
+ * egreso de CxP (iniciativa `cxp`, Sprint 2). El CFDI es XML estructurado del
+ * SAT — NO se usa LLM aquí (eso queda para el path opcional de PDF sin XML).
+ *
+ * Extrae los campos que consume `erp.cxp_factura_alta`: folio fiscal (UUID del
+ * TimbreFiscalDigital), emisor/receptor, montos, impuestos (IVA trasladado +
+ * retenciones IVA/ISR), forma/método de pago y uso CFDI.
+ *
+ * Namespaces: parseamos con `removeNSPrefix` para que `cfdi:Comprobante`,
+ * `tfd:TimbreFiscalDigital`, etc. queden como `Comprobante` /
+ * `TimbreFiscalDigital`. Claves SAT de impuestos: IVA = '002', ISR = '001'.
+ */
+
+import { XMLParser } from 'fast-xml-parser';
+
+export type CfdiParsed = {
+  /** Versión del CFDI ('4.0' | '3.3' | ...). */
+  version: string;
+  /** Folio fiscal (UUID del TimbreFiscalDigital). null si no está timbrado. */
+  uuid: string | null;
+  serie: string | null;
+  folio: string | null;
+  /** Fecha de emisión en ISO `YYYY-MM-DD` (la parte de fecha del atributo Fecha). */
+  fecha: string;
+  emisorRfc: string;
+  emisorNombre: string | null;
+  receptorRfc: string;
+  receptorNombre: string | null;
+  /** Clave de uso CFDI del receptor (G01, G03, ...). */
+  usoCfdi: string | null;
+  subtotal: number;
+  total: number;
+  moneda: string;
+  /** Clave SAT de forma de pago (01 efectivo, 03 transferencia, ...). */
+  formaPago: string | null;
+  /** Método de pago: 'PUE' (una exhibición) | 'PPD' (parcialidades/diferido). */
+  metodoPago: string | null;
+  /** Tipo de comprobante: 'I' ingreso, 'E' egreso (nota de crédito), 'P' pago, etc. */
+  tipoComprobante: string;
+  /** IVA trasladado total. */
+  ivaTrasladado: number;
+  /** Tasa de IVA dominante derivada de los traslados (0, 8 o 16). null si no hay. */
+  tasaIva: number | null;
+  /** Retención de IVA total (impuesto 002). */
+  retencionIva: number;
+  /** Retención de ISR total (impuesto 001). */
+  retencionIsr: number;
+};
+
+/** Error de parseo de CFDI con mensaje legible para el operador. */
+export class CfdiParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CfdiParseError';
+  }
+}
+
+function asArray<T>(v: T | T[] | undefined | null): T[] {
+  if (v == null) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
+function num(v: unknown): number {
+  if (v == null || v === '') return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function str(v: unknown): string | null {
+  if (v == null) return null;
+  const s = String(v).trim();
+  return s.length ? s : null;
+}
+
+/**
+ * Parsea el texto XML de un CFDI y devuelve los campos normalizados.
+ * @throws {CfdiParseError} si el XML no es un CFDI válido (sin nodo Comprobante,
+ *   sin emisor/receptor, o sin total).
+ */
+export function parseCfdiXml(xml: string): CfdiParsed {
+  if (!xml || !xml.trim()) {
+    throw new CfdiParseError('El archivo XML está vacío.');
+  }
+
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    removeNSPrefix: true,
+    parseAttributeValue: false, // mantener strings; convertimos nosotros
+    trimValues: true,
+  });
+
+  let doc: Record<string, unknown>;
+  try {
+    doc = parser.parse(xml) as Record<string, unknown>;
+  } catch (e) {
+    throw new CfdiParseError(`XML mal formado: ${(e as Error).message}`);
+  }
+
+  const comp = doc.Comprobante as Record<string, unknown> | undefined;
+  if (!comp) {
+    throw new CfdiParseError('El XML no contiene un nodo Comprobante (¿es un CFDI?).');
+  }
+
+  const emisor = comp.Emisor as Record<string, unknown> | undefined;
+  const receptor = comp.Receptor as Record<string, unknown> | undefined;
+  const emisorRfc = str(emisor?.['@_Rfc']);
+  const receptorRfc = str(receptor?.['@_Rfc']);
+  if (!emisorRfc) throw new CfdiParseError('El CFDI no tiene RFC del emisor.');
+  if (!receptorRfc) throw new CfdiParseError('El CFDI no tiene RFC del receptor.');
+
+  const totalRaw = comp['@_Total'];
+  if (totalRaw == null || totalRaw === '') {
+    throw new CfdiParseError('El CFDI no tiene Total.');
+  }
+
+  // UUID del timbre. Complemento puede ser objeto o arreglo; el TFD también.
+  let uuid: string | null = null;
+  const complementos = asArray(comp.Complemento as unknown);
+  for (const c of complementos) {
+    const tfd = (c as Record<string, unknown>)?.TimbreFiscalDigital;
+    const first = asArray(tfd)[0] as Record<string, unknown> | undefined;
+    const u = str(first?.['@_UUID']);
+    if (u) {
+      uuid = u.toUpperCase();
+      break;
+    }
+  }
+
+  // Impuestos: trasladado IVA (002) + retenciones IVA (002) / ISR (001).
+  const impuestos = comp.Impuestos as Record<string, unknown> | undefined;
+  let ivaTrasladado = 0;
+  let tasaIva: number | null = null;
+  let retencionIva = 0;
+  let retencionIsr = 0;
+
+  if (impuestos) {
+    const traslados = asArray(
+      (impuestos.Traslados as Record<string, unknown> | undefined)?.Traslado as unknown
+    );
+    for (const t of traslados) {
+      const tr = t as Record<string, unknown>;
+      if (str(tr['@_Impuesto']) === '002') {
+        ivaTrasladado += num(tr['@_Importe']);
+        const tasa = num(tr['@_TasaOCuota']); // 0.160000 / 0.080000 / 0.000000
+        // Tasa dominante = la del traslado de mayor importe (o la primera 16/8/0).
+        const tasaPct = Math.round(tasa * 100);
+        if (tasaIva === null || tasaPct > 0) tasaIva = tasaPct;
+      }
+    }
+
+    const retenciones = asArray(
+      (impuestos.Retenciones as Record<string, unknown> | undefined)?.Retencion as unknown
+    );
+    for (const r of retenciones) {
+      const rr = r as Record<string, unknown>;
+      const imp = str(rr['@_Impuesto']);
+      if (imp === '002') retencionIva += num(rr['@_Importe']);
+      else if (imp === '001') retencionIsr += num(rr['@_Importe']);
+    }
+  }
+
+  const fechaRaw = str(comp['@_Fecha']) ?? '';
+  const fecha = fechaRaw.split('T')[0]; // "2026-01-15T10:30:00" → "2026-01-15"
+
+  return {
+    version: str(comp['@_Version']) ?? str(comp['@_version']) ?? '',
+    uuid,
+    serie: str(comp['@_Serie']),
+    folio: str(comp['@_Folio']),
+    fecha,
+    emisorRfc: emisorRfc.toUpperCase(),
+    emisorNombre: str(emisor?.['@_Nombre']),
+    receptorRfc: receptorRfc.toUpperCase(),
+    receptorNombre: str(receptor?.['@_Nombre']),
+    usoCfdi: str(receptor?.['@_UsoCFDI']),
+    subtotal: num(comp['@_SubTotal']),
+    total: num(totalRaw),
+    moneda: str(comp['@_Moneda']) ?? 'MXN',
+    formaPago: str(comp['@_FormaPago']),
+    metodoPago: str(comp['@_MetodoPago']),
+    tipoComprobante: str(comp['@_TipoDeComprobante']) ?? '',
+    ivaTrasladado,
+    tasaIva,
+    retencionIva,
+    retencionIsr,
+  };
+}

--- a/lib/storage/path.ts
+++ b/lib/storage/path.ts
@@ -37,6 +37,7 @@ export type AdjuntoEntidad =
   | 'ventas'
   | 'venta_pagos'
   | 'cxc_pagos'
+  | 'facturas'
   | 'proyecto_tareas'
   | 'proyecto_tarea_pasos'
   | 'proyecto_planos';

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "fast-xml-parser": "^5.8.0",
         "heic2any": "^0.0.4",
         "lucide-react": "^1.7.0",
         "next": "^16.2.6",
@@ -2892,6 +2893,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8520,6 +8533,44 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -11813,6 +11864,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -13829,6 +13895,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -15169,6 +15247,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "fast-xml-parser": "^5.8.0",
     "heic2any": "^0.0.4",
     "lucide-react": "^1.7.0",
     "next": "^16.2.6",


### PR DESCRIPTION
**Iniciativa `cxp` — Sprint 2 (backend, sin migración).** Ingesta de facturas de egreso desde XML CFDI. Modo autónomo.

## Qué
- **`lib/cxp/cfdi-parser.ts`** — parser determinista CFDI 4.0/3.3 (`fast-xml-parser`, sin LLM). Extrae folio fiscal (UUID del TimbreFiscalDigital), emisor/receptor, montos, IVA trasladado + tasa derivada (0/8/16), retenciones IVA (002)/ISR (001), forma/método de pago, uso CFDI, tipo. **13 tests** (CFDI completo, retenciones de servicios profesionales, frontera 8%, sin timbrar, errores).
- **`POST /api/[empresa]/cxp/facturas/upload-xml`** — acepta 1..N XML (bulk). Por archivo: auth + acceso a la empresa (miembro/admin) → parse → valida receptor = empresa (RFC) → dedup `uuid_sat` → matchea emisor → proveedor (si no existe, factura con proveedor nulo + sugiere alta) → `erp.cxp_factura_alta` → sube XML a storage + `erp.adjuntos` + `xml_url`. Devuelve resultado por archivo (no aborta el lote por un XML malo).

## Notas
- Dep nueva: `fast-xml-parser ^5.8.0`. `'facturas'` agregado a `AdjuntoEntidad`.
- **Diferido** a Sprint 3 / follow-up: sugerencia automática de OC del emisor con saldo, y parser opcional de PDF vía LLM (`extraction-core`) para facturas sin XML.
- Sin migración (usa el schema de Sprint 1, ya en prod).

## Verificación
typecheck + **1155 tests** + lint (0 errores) + format verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)