### PR TITLE
feat(settings): acceso delegado por empresa a Configuración → Empresas (RBAC)

### DIFF
--- a/app/settings/empresas/[slug]/page.tsx
+++ b/app/settings/empresas/[slug]/page.tsx
@@ -217,13 +217,25 @@ function EmpresaPageInner() {
  * @module Settings — Empresa detail
  * @responsive desktop-only
  */
+function EmpresaPageGate() {
+  const params = useParams<{ slug: string }>();
+  // Requiere el módulo settings.empresas Y acceso a la empresa del slug, para
+  // que ni escribiendo la URL de otra empresa (p. ej. /settings/empresas/ansa)
+  // se abra una a la que el usuario no tiene acceso. Admin bypasea ambos.
+  return (
+    <RequireAccess modulo="settings.empresas" empresa={params?.slug}>
+      <EmpresaPageInner />
+    </RequireAccess>
+  );
+}
+
 export default function Page() {
   return (
-    <RequireAccess adminOnly>
+    <>
       <DesktopOnlyNotice module="Empresa" />
       <div className="hidden sm:block">
-        <EmpresaPageInner />
+        <EmpresaPageGate />
       </div>
-    </RequireAccess>
+    </>
   );
 }

--- a/app/settings/empresas/page.tsx
+++ b/app/settings/empresas/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { RequireAccess } from '@/components/require-access';
+import { usePermissions } from '@/components/providers';
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
@@ -160,6 +161,7 @@ function EmpresaGroupTable({
 
 function EmpresasSettingsInner() {
   const supabase = createSupabaseBrowserClient();
+  const { permissions } = usePermissions();
   const [empresas, setEmpresas] = useState<EmpresaRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -199,12 +201,16 @@ function EmpresasSettingsInner() {
     for (const e of empresas) {
       if (!e.activa) continue;
       if (e.slug === 'settings') continue;
+      // Solo las empresas a las que el usuario tiene acceso (admin ve todas).
+      // El acceso a la página lo gobierna el módulo `settings.empresas`; QUÉ
+      // empresas ve sale de core.usuarios_empresas (permissions.empresas).
+      if (!permissions.isAdmin && !permissions.empresas.has(e.slug)) continue;
       if (e.tipo_contribuyente === 'persona_moral') out.persona_moral.push(e);
       else if (e.tipo_contribuyente === 'persona_fisica') out.persona_fisica.push(e);
       else out.otros.push(e);
     }
     return out;
-  }, [empresas]);
+  }, [empresas, permissions]);
 
   const totalVisibles =
     grupos.persona_moral.length + grupos.persona_fisica.length + grupos.otros.length;
@@ -300,7 +306,7 @@ function EmpresasSettingsInner() {
  */
 export default function Page() {
   return (
-    <RequireAccess adminOnly>
+    <RequireAccess modulo="settings.empresas">
       <DesktopOnlyNotice module="Empresas" />
       <div className="hidden sm:block">
         <EmpresasSettingsInner />

--- a/components/app-shell/sidebar.tsx
+++ b/components/app-shell/sidebar.tsx
@@ -107,6 +107,21 @@ export function Sidebar({
         return acc;
       }
 
+      // `settings` no es una empresa operativa: es el bucket de módulos de
+      // sistema (Acceso, Notificaciones, Empresas). Su visibilidad se decide
+      // por MÓDULO, no por pertenencia a una empresa — mostrar solo los
+      // children con módulo accesible y ocultar el grupo si no queda ninguno.
+      // Los children sin módulo mapeado (placeholders como Integraciones /
+      // Preferencias) quedan solo para admin, que retorna arriba en :86.
+      if (empresaSlug === 'settings') {
+        const visibleChildren = (item.children ?? []).filter((child) => {
+          const moduloSlug = ROUTE_TO_MODULE[child.href];
+          return moduloSlug ? canAccessModulo(permissions, moduloSlug) : false;
+        });
+        if (visibleChildren.length > 0) acc.push({ ...item, children: visibleChildren });
+        return acc;
+      }
+
       // Check empresa-level access.
       if (!canAccessEmpresa(permissions, empresaSlug)) return acc;
 

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -168,9 +168,9 @@ describe('route maps', () => {
  * permisos. El test falla si tocas (2) sin tocar (3) — recordatorio
  * de que falta migración. Ver `BSOP/CLAUDE.md` sección "Reglas DB".
  *
- * NO incluye slugs que existen solo en DB sin URL en sidebar
- * (ej. `settings.empresas` vive en `core.modulos` pero no se mapea
- * desde una URL — Settings → Empresas no tiene gating fino por módulo).
+ * NO incluye slugs que existen solo en DB sin URL en sidebar. (Históricamente
+ * `settings.empresas` era uno de esos casos; desde la migración
+ * 20260602160000 /settings/empresas se gobierna por módulo y sí se mapea.)
  */
 const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   // DILESA
@@ -311,6 +311,7 @@ const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   'rdb.rh.departamentos',
 
   // Settings
+  'settings.empresas',
   'settings.acceso',
   'settings.notificaciones',
 ]);

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -127,6 +127,10 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   '/rdb/rh/departamentos': 'rdb.rh.departamentos',
 
   // Settings
+  // `/settings/empresas` pasó de admin-only a RBAC por módulo: el módulo
+  // gobierna el acceso a la página; QUÉ empresas ve cada quien lo filtra la
+  // UI desde core.usuarios_empresas. Ver migración 20260602160000.
+  '/settings/empresas': 'settings.empresas',
   '/settings/acceso': 'settings.acceso',
   '/settings/notificaciones': 'settings.notificaciones',
 };

--- a/supabase/migrations/20260602160000_modulo_settings_empresas.sql
+++ b/supabase/migrations/20260602160000_modulo_settings_empresas.sql
@@ -1,0 +1,49 @@
+-- ════════════════════════════════════════════════════════════════════════════
+-- Módulo RBAC `settings.empresas` — acceso delegado a Configuración → Empresas
+-- ════════════════════════════════════════════════════════════════════════════
+--
+-- Hasta ahora /settings/empresas (listado + detalle) vivía detrás de
+-- `<RequireAccess adminOnly>`: o eras admin global y veías TODAS las empresas,
+-- o no entrabas. No había forma de delegar el módulo a un usuario no-admin ni
+-- de acotar qué empresas ve.
+--
+-- Esta migración registra el módulo `settings.empresas` en `core.modulos` para
+-- que la página se gobierne por RBAC (igual que `settings.acceso` y
+-- `settings.notificaciones`). Con el módulo en su lugar, un admin puede
+-- delegarlo desde /settings/acceso — vía rol o vía "Excepción de módulo" por
+-- usuario (lectura). El filtro de qué empresas ve cada quien lo aplica la UI a
+-- partir de `core.usuarios_empresas` (las empresas a las que el usuario tiene
+-- acceso); ver app/settings/empresas/page.tsx.
+--
+-- Bajo la empresa "Configuración" (slug `settings`), sección `sistema` — mismo
+-- bucket que `settings.acceso` / `settings.notificaciones`.
+--
+-- ── Sin backfill de permisos_rol (a propósito) ──────────────────────────────
+-- El comportamiento previo era admin-only. El default correcto al introducir
+-- el módulo es CERRADO: ningún no-admin lo obtiene automáticamente (admin sigue
+-- entrando por `core.fn_is_admin()` / bypass de permisos). Esto PRESERVA el
+-- status quo. La delegación es deliberada y manual, empresa por empresa, desde
+-- /settings/acceso. (La RLS de las tablas sensibles del detalle —
+-- empresa_socios, gobierno_*, empresa_documentos — ya aísla por empresa vía
+-- `core.fn_has_empresa(empresa_id) OR core.fn_is_admin()`, así que el delegado
+-- solo lee gobierno/cuadro accionario de las empresas que tiene asignadas.)
+--
+-- Idempotente: ON CONFLICT DO NOTHING.
+-- ════════════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT
+  'settings.empresas',
+  'Empresas',
+  'Datos fiscales, branding, cuadro accionario, gobierno corporativo y actas de cada empresa. El acceso se acota a las empresas asignadas al usuario en core.usuarios_empresas.',
+  e.id,
+  'sistema'
+FROM core.empresas e
+WHERE e.slug = 'settings'
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Qué

Hoy **Configuración → Empresas** (`/settings/empresas`, listado y detalle) está detrás de `<RequireAccess adminOnly>`: o eres admin global y ves **todas** las empresas, o no entras. No había forma de delegar el módulo a un usuario no-admin ni de acotar qué empresas ve.

Este PR convierte la página a **RBAC por módulo** (`settings.empresas`) y la filtra por las empresas asignadas al usuario. Si a alguien le das acceso solo a DILESA, en Configuración → Empresas **solo verá DILESA**.

> Alcance de esta fase: **solo visibilidad**. La escritura (editar fiscal/branding, cuadro accionario, gobierno) sigue **admin-only** — se decidirá por separado.

## Cambios

- **Migración `20260602160000`** — registra `settings.empresas` en `core.modulos` (empresa `settings`, sección `sistema`). **Sin backfill de `permisos_rol`**: el default es cerrado, lo que preserva el comportamiento admin-only previo; la delegación es manual desde Configuración → Acceso.
- **`lib/permissions.ts` + test** — mapea `/settings/empresas → settings.empresas` y lo agrega a `EXPECTED_DB_MODULE_SLUGS`.
- **Gates** — el listado usa `modulo="settings.empresas"`; el detalle exige además `empresa={slug}`, así nadie abre otra empresa escribiendo la URL (p. ej. `/settings/empresas/ansa`).
- **Sidebar** — el grupo Configuración pasa a ser **module-driven**: se muestra si hay ≥1 módulo `settings.*` accesible, ocultando a no-admin los placeholders sin módulo (Integraciones / Preferencias).

## Por qué es seguro mostrar el detalle completo

Las tablas sensibles del detalle (`empresa_socios`, `gobierno_*`, `empresa_documentos`) **ya aíslan por empresa** vía RLS (`fn_has_empresa(empresa_id) OR fn_is_admin()`). Es decir: el delegado solo lee el cuadro accionario / gobierno de las empresas que tiene asignadas — la base de datos lo bloquea para el resto, incluso por API. El filtro de la app cubre el listado y los datos fiscales/branding (`core.empresas` es legible por cualquier autenticado).

## Cómo delegar (después del merge)

En **Configuración → Acceso → Usuarios → [usuario]**:
1. **Acceso a empresas** → marca DILESA (con su rol). Esto define qué empresas verá.
2. **Excepciones de módulo** → Empresa "Configuración", Módulo "Empresas", **Lectura** ✓. Esto le da entrar a la página.

Resultado: el usuario ve el grupo Configuración → Empresas en el sidebar, entra, y solo ve/abre DILESA.

## Verificación

- Migración aplicada a prod (idempotente, data-only): `settings.empresas` existe con **0 roles / 0 excepciones** (admin-only de facto, status quo intacto).
- `typecheck` ✓ · `test:run` 1184 ✓ · `format:check` ✓ · `lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
