### PR TITLE
docs(salud-protocolo): Sprint 1 cerrado — seed de 3 compuestos en prod

### DIFF
--- a/docs/planning/salud-protocolo.md
+++ b/docs/planning/salud-protocolo.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-06-02
-**Última actualización:** 2026-06-02 (Sprint 1 aplicado a prod — 3 tablas en `health` con RLS deny-all; `SCHEMA_REF`/`types` regenerados. Pendiente: seed del Retatrutide tras confirmar fecha)
+**Última actualización:** 2026-06-02 (Sprint 1 **cerrado** — 3 tablas en `health` (RLS deny-all) + seed de 3 compuestos (Retatrutide/KLOW/Semax, 13 tomas) en prod. Próximo: Sprint 2 — lectura/UI)
 
 ## Problema
 
@@ -120,7 +120,7 @@ Los biomarcadores (peso, RHR, HRV, BP) **no se duplican**: viven en
 - [x] **RLS privada** aplicada. Hallazgo: `health` no usaba RLS (grants a `authenticated`; `lib/health.ts` lee con `service_role`). Decisión: RLS **deny-all** + grant solo `service_role` — más estricto que `health_metrics`/etc. Verificado en prod: `rls_on=true`, cero grants a authenticated/anon/authenticator.
 - [x] `NOTIFY pgrst, 'reload schema';` al final.
 - [x] Aplicado a prod tras OK explícito de Beto. **No** vía `db push` (drift: 2 migraciones remotas de otras sesiones sin archivo local) → vía connector `apply_migration` (quirúrgico, solo mi DDL). Verificado con SELECT a `pg_class`/grants. `SCHEMA_REF.md` + `types/supabase.ts` regenerados.
-- [ ] **Seed** del Retatrutide (clase `peptido`, vía `subcutanea`, unidad `mg`, dosis*objetivo `2.5`, frecuencia `semanal`, estado `activo`) + las tomas que ya lleva. \_Dato pendiente: fecha de inicio + tomas — recuperar de `~/.claude/PERSONAL.md` o confirmar con Beto al ejecutar.*
+- [x] **Seed aplicado a prod** (3 compuestos + 13 tomas): **Retatrutide** 2.5 mg semanal (11 tomas, 17-mar → 29-may; martes → viernes tras el viaje de moto SD–Seattle; plan: 3 mg el 5-jun), **KLOW** 0.2 ml diario (desde 1-jun; 80 mg/3 ml BAC) y **Semax** 500 mcg diario (desde 2-jun). Insertado vía connector `execute_sql` (data personal — fuera de migraciones versionadas, no corre en preview).
 
 ### Sprint 2 — Lectura (read-only)
 
@@ -170,6 +170,7 @@ Los biomarcadores (peso, RHR, HRV, BP) **no se duplican**: viven en
 
 - **2026-06-02** — Promovida a `planned`. Beto pidió una bitácora de péptidos en SANREN → Salud (arranque: Retatrutide 2.5 mg SC semanal; planea agregar otros "para medir interacciones con su cuerpo"). Exploración: `/health` es dashboard read-only de Apple Health; `health.health_medications` existe pero no se renderiza; los biomarcadores viven en `health.health_metrics`. Alcance v1 cerrado con 4 decisiones (protocolo completo / escalas 0–5 + nota / drawer web / promover). Modelo de 3 tablas en `health` propuesto. Pendiente: OK verbal de Beto para aplicar el schema (Sprint 1).
 - **2026-06-02** — Sprint 1 aplicado a prod (proyecto `ybklderteyhuugzfmxbi`, migración `20260602145253_health_protocolo_peptidos`). Tras OK explícito de Beto. `db push` descartado por drift (migraciones `20260602020000`/`20260602180000` de otras sesiones en remoto sin archivo local — no se tocaron); aplicado quirúrgicamente vía connector `apply_migration`. RLS deny-all verificada (cero grants a authenticated/anon). `SCHEMA_REF.md` + `types/supabase.ts` regenerados (diff limpio, solo las 3 tablas). **Pendiente para cerrar Sprint 1: seed del Retatrutide** — falta fecha de la 1ª inyección + historial de tomas (PERSONAL.md solo tiene compuesto + dosis 2.5 mg, no fechas).
+- **2026-06-02** — **Sprint 1 cerrado.** Seed aplicado a prod vía `execute_sql`: 3 compuestos activos + 13 tomas. **Retatrutide** 2.5 mg semanal — 11 tomas (martes 17-mar → 5-may; lunes 11-may adelantada por viaje de moto SD–Seattle; viernes 22 y 29-may; ya en cadencia de viernes; plan subir a 3 mg el 5-jun). **KLOW** 0.2 ml/día (80 mg en 3 ml agua BAC) desde 1-jun. **Semax** 500 mcg/día desde 2-jun. Fechas validadas por día de semana antes de insertar. Seed fuera de migraciones versionadas (data personal, no debe correr en preview). Próximo: Sprint 2 (lectura/UI).
 
 ## Decisiones registradas
 


### PR DESCRIPTION
Cierra el **Sprint 1** de `salud-protocolo`: seed del protocolo de Beto en `health.protocolo_*` (vía connector, data personal fuera de migraciones versionadas).

## Sembrado (verificado en prod)
- **Retatrutide** 2.5 mg semanal — **11 tomas** (martes 17-mar → 5-may; lunes 11-may adelantada por viaje de moto SD–Seattle; viernes 22 y 29-may; ya en cadencia de viernes). Plan: subir a 3 mg el 5-jun.
- **KLOW** 0.2 ml/día (80 mg en 3 ml agua BAC) — desde 1-jun.
- **Semax** 500 mcg/día — desde 2-jun.

Fechas validadas por día de semana antes de insertar. Solo cambia el planning doc (checkbox del seed + bitácora); el dato vive en prod.

La iniciativa sigue `in_progress` → **Sprint 2** (lectura: `lib/protocolo` + `ProtocoloSection` en `/health`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)