### PR TITLE
feat(salud-protocolo): Sprint 3 — captura por drawer (toma + efectos)

### DIFF
--- a/app/health/actions.ts
+++ b/app/health/actions.ts
@@ -1,0 +1,169 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { getEffectiveUser } from '@/lib/auth/effective-user';
+import { assertNotInPreview } from '@/lib/auth/preview-guard';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import type { ProtocoloClase } from '@/lib/protocolo';
+
+// Captura de la bitácora de protocolo (iniciativa salud-protocolo, Sprint 3).
+//
+// Seguridad: el protocolo es data clínica personal de Beto (admin). La captura
+// es admin-only (v1) — se generaliza a acceso-por-empresa cuando haya
+// multi-usuario. Las tablas health.protocolo_* tienen RLS deny-all, así que la
+// escritura va con service_role (getSupabaseAdminClient), igual que la lectura.
+// Toda mutación respeta el read-only de "viendo como" (assertNotInPreview, ADR-027).
+
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
+const CLASES: ProtocoloClase[] = ['peptido', 'suplemento', 'oral', 'otro'];
+const VIAS = ['subcutanea', 'intramuscular', 'oral', 'topica', 'nasal'];
+
+async function requireProtocoloAdmin() {
+  await assertNotInPreview();
+  const supabase = await createSupabaseServerClient();
+  const eu = await getEffectiveUser(supabase);
+  if (!eu) throw new Error('No autenticado.');
+  if (!eu.isAdmin) throw new Error('Sin acceso al protocolo.');
+  const admin = getSupabaseAdminClient();
+  if (!admin) throw new Error('Servicio no configurado.');
+  return admin;
+}
+
+function clampEscala(v: number | null | undefined): number | null {
+  if (v == null || !Number.isFinite(v)) return null;
+  const n = Math.round(v);
+  return n < 0 || n > 5 ? null : n;
+}
+
+export type RegistrarTomaInput = {
+  compuestoId: string;
+  fecha?: string | null; // ISO; default: ahora
+  dosis: number;
+  unidad?: string | null;
+  sitio?: string | null;
+  nota?: string | null;
+  efectos?: {
+    apetito?: number | null;
+    nausea?: number | null;
+    energia?: number | null;
+    gi?: number | null;
+    nota?: string | null;
+  } | null;
+};
+
+export async function registrarToma(input: RegistrarTomaInput): Promise<ActionResult> {
+  try {
+    const admin = await requireProtocoloAdmin();
+
+    if (!input.compuestoId) return { ok: false, error: 'Falta el compuesto.' };
+    if (!Number.isFinite(input.dosis) || input.dosis <= 0) {
+      return { ok: false, error: 'La dosis debe ser un número mayor a 0.' };
+    }
+    const fecha = input.fecha || new Date().toISOString();
+
+    const { data: toma, error } = await admin
+      .schema('health')
+      .from('protocolo_tomas')
+      .insert({
+        compuesto_id: input.compuestoId,
+        fecha,
+        dosis: input.dosis,
+        unidad: input.unidad?.trim() || null,
+        sitio: input.sitio?.trim() || null,
+        nota: input.nota?.trim() || null,
+      })
+      .select('id')
+      .single();
+
+    if (error || !toma) {
+      return { ok: false, error: getSupabaseErrorMessage(error, 'No se pudo registrar la toma.') };
+    }
+
+    const ef = input.efectos;
+    const efNota = ef?.nota?.trim() || null;
+    const apetito = clampEscala(ef?.apetito);
+    const nausea = clampEscala(ef?.nausea);
+    const energia = clampEscala(ef?.energia);
+    const gi = clampEscala(ef?.gi);
+    const hayEfecto =
+      apetito != null || nausea != null || energia != null || gi != null || !!efNota;
+
+    if (hayEfecto) {
+      const { error: efErr } = await admin
+        .schema('health')
+        .from('protocolo_efectos')
+        .insert({ fecha, toma_id: toma.id, apetito, nausea, energia, gi, nota: efNota });
+      if (efErr) {
+        return {
+          ok: false,
+          error: getSupabaseErrorMessage(
+            efErr,
+            'La toma quedó registrada, pero falló guardar cómo te cayó.'
+          ),
+        };
+      }
+    }
+
+    revalidatePath('/health');
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Error desconocido.' };
+  }
+}
+
+export type CrearCompuestoInput = {
+  nombre: string;
+  clase: ProtocoloClase;
+  via?: string | null;
+  unidadDosis?: string | null;
+  dosisObjetivo?: number | null;
+  frecuencia?: string | null;
+  procedencia?: string | null;
+  fechaInicio?: string | null; // date (YYYY-MM-DD)
+  notas?: string | null;
+};
+
+export async function crearCompuesto(input: CrearCompuestoInput): Promise<ActionResult> {
+  try {
+    const admin = await requireProtocoloAdmin();
+
+    const nombre = input.nombre?.trim();
+    if (!nombre) return { ok: false, error: 'El nombre es obligatorio.' };
+    if (!CLASES.includes(input.clase)) return { ok: false, error: 'Clase inválida.' };
+    if (input.via && !VIAS.includes(input.via)) return { ok: false, error: 'Vía inválida.' };
+    if (
+      input.dosisObjetivo != null &&
+      (!Number.isFinite(input.dosisObjetivo) || input.dosisObjetivo < 0)
+    ) {
+      return { ok: false, error: 'La dosis objetivo debe ser un número ≥ 0.' };
+    }
+
+    const { error } = await admin
+      .schema('health')
+      .from('protocolo_compuestos')
+      .insert({
+        nombre,
+        clase: input.clase,
+        via: input.via || null,
+        unidad_dosis: input.unidadDosis?.trim() || null,
+        dosis_objetivo: input.dosisObjetivo ?? null,
+        frecuencia: input.frecuencia?.trim() || null,
+        procedencia: input.procedencia?.trim() || null,
+        fecha_inicio: input.fechaInicio || null,
+        notas: input.notas?.trim() || null,
+        estado: 'activo',
+      });
+
+    if (error) {
+      return { ok: false, error: getSupabaseErrorMessage(error, 'No se pudo crear el compuesto.') };
+    }
+
+    revalidatePath('/health');
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Error desconocido.' };
+  }
+}

--- a/components/health/protocolo-drawer.tsx
+++ b/components/health/protocolo-drawer.tsx
@@ -1,0 +1,456 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { FieldLabel } from '@/components/ui/field-label';
+import {
+  DetailDrawer,
+  DetailDrawerContent,
+  DetailDrawerSection,
+} from '@/components/detail-page/detail-drawer';
+import { cn } from '@/lib/utils';
+import {
+  crearCompuesto,
+  registrarToma,
+  type CrearCompuestoInput,
+  type RegistrarTomaInput,
+} from '@/app/health/actions';
+import type { ProtocoloClase, ProtocoloCompuestoConTomas } from '@/lib/protocolo';
+
+const SELECT_CLASS =
+  'h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30';
+
+const CLASE_OPCIONES: { value: ProtocoloClase; label: string }[] = [
+  { value: 'peptido', label: 'Péptido' },
+  { value: 'suplemento', label: 'Suplemento' },
+  { value: 'oral', label: 'Oral' },
+  { value: 'otro', label: 'Otro' },
+];
+
+const VIA_OPCIONES = ['subcutanea', 'intramuscular', 'oral', 'topica', 'nasal'];
+
+function toLocalInput(d: Date) {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** Escala 0–5 con botones; clic en el valor activo lo limpia (vuelve a null). */
+function EscalaInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number | null;
+  onChange: (v: number | null) => void;
+}) {
+  return (
+    <div>
+      <FieldLabel>{label}</FieldLabel>
+      <div className="flex gap-1">
+        {[0, 1, 2, 3, 4, 5].map((n) => (
+          <button
+            key={n}
+            type="button"
+            onClick={() => onChange(value === n ? null : n)}
+            className={cn(
+              'h-8 flex-1 rounded-lg border text-sm transition-colors',
+              value === n
+                ? 'border-emerald-400 bg-emerald-50 font-semibold text-emerald-700 dark:border-emerald-400/40 dark:bg-emerald-400/15 dark:text-emerald-200'
+                : 'border-[var(--border)] text-[var(--muted-foreground)] hover:bg-[var(--card)]/60 dark:text-white/50'
+            )}
+          >
+            {n}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type Efectos = {
+  apetito: number | null;
+  nausea: number | null;
+  energia: number | null;
+  gi: number | null;
+  nota: string;
+};
+
+const EFECTOS_VACIOS: Efectos = { apetito: null, nausea: null, energia: null, gi: null, nota: '' };
+
+export function ProtocoloDrawer({
+  open,
+  onOpenChange,
+  compuestos,
+  compuestoInicialId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  compuestos: ProtocoloCompuestoConTomas[];
+  compuestoInicialId?: string | null;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [modo, setModo] = useState<'toma' | 'nuevo'>('toma');
+
+  // Form: registrar toma
+  const [compuestoId, setCompuestoId] = useState('');
+  const [fecha, setFecha] = useState('');
+  const [dosis, setDosis] = useState('');
+  const [unidad, setUnidad] = useState('');
+  const [sitio, setSitio] = useState('');
+  const [nota, setNota] = useState('');
+  const [efectos, setEfectos] = useState<Efectos>(EFECTOS_VACIOS);
+
+  // Form: nuevo compuesto
+  const [nNombre, setNNombre] = useState('');
+  const [nClase, setNClase] = useState<ProtocoloClase>('peptido');
+  const [nVia, setNVia] = useState('subcutanea');
+  const [nUnidad, setNUnidad] = useState('mg');
+  const [nDosis, setNDosis] = useState('');
+  const [nFrecuencia, setNFrecuencia] = useState('');
+  const [nProcedencia, setNProcedencia] = useState('');
+  const [nFechaInicio, setNFechaInicio] = useState('');
+  const [nNotas, setNNotas] = useState('');
+
+  const activos = compuestos.filter((c) => c.estado === 'activo');
+
+  // Al abrir, resetea el form y preselecciona el compuesto que disparó el drawer.
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setModo('toma');
+    const inicial = compuestoInicialId ?? activos[0]?.id ?? '';
+    setCompuestoId(inicial);
+    setFecha(toLocalInput(new Date()));
+    setSitio('');
+    setNota('');
+    setEfectos(EFECTOS_VACIOS);
+    const c = compuestos.find((x) => x.id === inicial);
+    setDosis(c?.dosis_objetivo != null ? String(c.dosis_objetivo) : '');
+    setUnidad(c?.unidad_dosis ?? '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, compuestoInicialId]);
+
+  // Al cambiar el compuesto en el select, hereda su dosis objetivo y unidad.
+  function onCompuestoChange(id: string) {
+    setCompuestoId(id);
+    const c = compuestos.find((x) => x.id === id);
+    setDosis(c?.dosis_objetivo != null ? String(c.dosis_objetivo) : '');
+    setUnidad(c?.unidad_dosis ?? '');
+  }
+
+  function guardarToma() {
+    setError(null);
+    const payload: RegistrarTomaInput = {
+      compuestoId,
+      fecha: fecha ? new Date(fecha).toISOString() : null,
+      dosis: Number(dosis),
+      unidad: unidad || null,
+      sitio: sitio || null,
+      nota: nota || null,
+      efectos: {
+        apetito: efectos.apetito,
+        nausea: efectos.nausea,
+        energia: efectos.energia,
+        gi: efectos.gi,
+        nota: efectos.nota || null,
+      },
+    };
+    startTransition(async () => {
+      const res = await registrarToma(payload);
+      if (res.ok) {
+        onOpenChange(false);
+        router.refresh();
+      } else {
+        setError(res.error);
+      }
+    });
+  }
+
+  function guardarCompuesto() {
+    setError(null);
+    const payload: CrearCompuestoInput = {
+      nombre: nNombre,
+      clase: nClase,
+      via: nVia || null,
+      unidadDosis: nUnidad || null,
+      dosisObjetivo: nDosis ? Number(nDosis) : null,
+      frecuencia: nFrecuencia || null,
+      procedencia: nProcedencia || null,
+      fechaInicio: nFechaInicio || null,
+      notas: nNotas || null,
+    };
+    startTransition(async () => {
+      const res = await crearCompuesto(payload);
+      if (res.ok) {
+        setNNombre('');
+        setNDosis('');
+        setNFrecuencia('');
+        setNProcedencia('');
+        setNFechaInicio('');
+        setNNotas('');
+        setModo('toma');
+        router.refresh();
+      } else {
+        setError(res.error);
+      }
+    });
+  }
+
+  const tomaTitulo = modo === 'toma' ? 'Registrar inyección / toma' : 'Agregar compuesto';
+
+  return (
+    <DetailDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      title={tomaTitulo}
+      description="Protocolo — péptidos y suplementos"
+      footer={
+        <div className="flex items-center justify-between gap-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setError(null);
+              setModo((m) => (m === 'toma' ? 'nuevo' : 'toma'));
+            }}
+            disabled={pending}
+          >
+            {modo === 'toma' ? '+ Nuevo compuesto' : '← Volver a registrar'}
+          </Button>
+          <Button
+            size="sm"
+            onClick={modo === 'toma' ? guardarToma : guardarCompuesto}
+            disabled={pending || (modo === 'toma' ? !compuestoId : !nNombre.trim())}
+          >
+            {pending ? 'Guardando…' : modo === 'toma' ? 'Registrar' : 'Crear compuesto'}
+          </Button>
+        </div>
+      }
+    >
+      <DetailDrawerContent>
+        {error ? (
+          <div className="mb-4 rounded-lg border border-rose-300/40 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-300/25 dark:bg-rose-300/10 dark:text-rose-200">
+            {error}
+          </div>
+        ) : null}
+
+        {modo === 'toma' ? (
+          <>
+            <DetailDrawerSection title="Aplicación" divider={false}>
+              <div className="space-y-3">
+                <div>
+                  <FieldLabel htmlFor="pc-compuesto" required>
+                    Compuesto
+                  </FieldLabel>
+                  <select
+                    id="pc-compuesto"
+                    className={SELECT_CLASS}
+                    value={compuestoId}
+                    onChange={(e) => onCompuestoChange(e.target.value)}
+                  >
+                    {activos.length === 0 ? <option value="">Sin compuestos activos</option> : null}
+                    {activos.map((c) => (
+                      <option key={c.id} value={c.id}>
+                        {c.nombre}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <FieldLabel htmlFor="pc-fecha">Fecha y hora</FieldLabel>
+                    <Input
+                      id="pc-fecha"
+                      type="datetime-local"
+                      value={fecha}
+                      onChange={(e) => setFecha(e.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel htmlFor="pc-dosis" required>
+                      Dosis
+                    </FieldLabel>
+                    <div className="flex items-center gap-1.5">
+                      <Input
+                        id="pc-dosis"
+                        type="number"
+                        step="any"
+                        inputMode="decimal"
+                        value={dosis}
+                        onChange={(e) => setDosis(e.target.value)}
+                      />
+                      <span className="shrink-0 text-sm text-[var(--muted-foreground)] dark:text-white/50">
+                        {unidad}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <FieldLabel htmlFor="pc-sitio">Sitio (rotación)</FieldLabel>
+                  <Input
+                    id="pc-sitio"
+                    value={sitio}
+                    onChange={(e) => setSitio(e.target.value)}
+                    placeholder="abdomen izq, muslo der…"
+                  />
+                </div>
+                <div>
+                  <FieldLabel htmlFor="pc-nota">Nota</FieldLabel>
+                  <Input id="pc-nota" value={nota} onChange={(e) => setNota(e.target.value)} />
+                </div>
+              </div>
+            </DetailDrawerSection>
+
+            <DetailDrawerSection
+              title="¿Cómo te cayó?"
+              description="Opcional — 0 a 5. Apetito/energía: 0 bajo, 5 alto. Náusea/GI: 0 nada, 5 severo."
+            >
+              <div className="space-y-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <EscalaInput
+                    label="Apetito"
+                    value={efectos.apetito}
+                    onChange={(v) => setEfectos((e) => ({ ...e, apetito: v }))}
+                  />
+                  <EscalaInput
+                    label="Náusea"
+                    value={efectos.nausea}
+                    onChange={(v) => setEfectos((e) => ({ ...e, nausea: v }))}
+                  />
+                  <EscalaInput
+                    label="Energía"
+                    value={efectos.energia}
+                    onChange={(v) => setEfectos((e) => ({ ...e, energia: v }))}
+                  />
+                  <EscalaInput
+                    label="Molestia GI"
+                    value={efectos.gi}
+                    onChange={(v) => setEfectos((e) => ({ ...e, gi: v }))}
+                  />
+                </div>
+                <div>
+                  <FieldLabel htmlFor="pc-efnota">Nota de cómo te cayó</FieldLabel>
+                  <Input
+                    id="pc-efnota"
+                    value={efectos.nota}
+                    onChange={(e) => setEfectos((ef) => ({ ...ef, nota: e.target.value }))}
+                  />
+                </div>
+              </div>
+            </DetailDrawerSection>
+          </>
+        ) : (
+          <DetailDrawerSection title="Nuevo compuesto" divider={false}>
+            <div className="space-y-3">
+              <div>
+                <FieldLabel htmlFor="nc-nombre" required>
+                  Nombre
+                </FieldLabel>
+                <Input
+                  id="nc-nombre"
+                  value={nNombre}
+                  onChange={(e) => setNNombre(e.target.value)}
+                  placeholder="Retatrutide, BPC-157, Vitamina D3…"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <FieldLabel htmlFor="nc-clase" required>
+                    Clase
+                  </FieldLabel>
+                  <select
+                    id="nc-clase"
+                    className={SELECT_CLASS}
+                    value={nClase}
+                    onChange={(e) => setNClase(e.target.value as ProtocoloClase)}
+                  >
+                    {CLASE_OPCIONES.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <FieldLabel htmlFor="nc-via">Vía</FieldLabel>
+                  <select
+                    id="nc-via"
+                    className={SELECT_CLASS}
+                    value={nVia}
+                    onChange={(e) => setNVia(e.target.value)}
+                  >
+                    {VIA_OPCIONES.map((v) => (
+                      <option key={v} value={v}>
+                        {v}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <FieldLabel htmlFor="nc-dosis">Dosis objetivo</FieldLabel>
+                  <Input
+                    id="nc-dosis"
+                    type="number"
+                    step="any"
+                    inputMode="decimal"
+                    value={nDosis}
+                    onChange={(e) => setNDosis(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <FieldLabel htmlFor="nc-unidad">Unidad</FieldLabel>
+                  <Input
+                    id="nc-unidad"
+                    value={nUnidad}
+                    onChange={(e) => setNUnidad(e.target.value)}
+                    placeholder="mg, mcg, UI, ml…"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <FieldLabel htmlFor="nc-frec">Frecuencia</FieldLabel>
+                  <Input
+                    id="nc-frec"
+                    value={nFrecuencia}
+                    onChange={(e) => setNFrecuencia(e.target.value)}
+                    placeholder="semanal, diaria…"
+                  />
+                </div>
+                <div>
+                  <FieldLabel htmlFor="nc-inicio">Inicio</FieldLabel>
+                  <Input
+                    id="nc-inicio"
+                    type="date"
+                    value={nFechaInicio}
+                    onChange={(e) => setNFechaInicio(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div>
+                <FieldLabel htmlFor="nc-proc">Procedencia</FieldLabel>
+                <Input
+                  id="nc-proc"
+                  value={nProcedencia}
+                  onChange={(e) => setNProcedencia(e.target.value)}
+                  placeholder="farmacia de compounding, research-grade, marca…"
+                />
+              </div>
+              <div>
+                <FieldLabel htmlFor="nc-notas">Notas</FieldLabel>
+                <Input id="nc-notas" value={nNotas} onChange={(e) => setNNotas(e.target.value)} />
+              </div>
+            </div>
+          </DetailDrawerSection>
+        )}
+      </DetailDrawerContent>
+    </DetailDrawer>
+  );
+}

--- a/components/health/protocolo-section.tsx
+++ b/components/health/protocolo-section.tsx
@@ -1,8 +1,13 @@
 'use client';
 
-import { Syringe, Pill, Beaker, type LucideIcon } from 'lucide-react';
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Syringe, Pill, Beaker, Plus, type LucideIcon } from 'lucide-react';
 import { Surface } from '@/components/ui/surface';
+import { Button } from '@/components/ui/button';
 import { TONES, type ToneKey } from './tones';
+import { ProtocoloDrawer } from './protocolo-drawer';
+import { registrarToma } from '@/app/health/actions';
 import type { ProtocoloClase, ProtocoloCompuestoConTomas, ProtocoloEstado } from '@/lib/protocolo';
 
 const CLASE_META: Record<ProtocoloClase, { label: string; icon: LucideIcon; tomaLabel: string }> = {
@@ -41,13 +46,20 @@ function formatDosis(compuesto: ProtocoloCompuestoConTomas) {
 function CompuestoCard({
   compuesto,
   tone,
+  onQuick,
+  onDetalle,
+  quickPending,
 }: {
   compuesto: ProtocoloCompuestoConTomas;
   tone: (typeof TONES)[ToneKey];
+  onQuick: (c: ProtocoloCompuestoConTomas) => void;
+  onDetalle: (c: ProtocoloCompuestoConTomas) => void;
+  quickPending: boolean;
 }) {
   const meta = CLASE_META[compuesto.clase];
   const Icon = meta.icon;
   const estadoBadge = ESTADO_BADGE[compuesto.estado];
+  const activo = compuesto.estado === 'activo';
   // Últimas 14 tomas en orden cronológico (izq → der) para el mini-timeline.
   const recientes = compuesto.tomas.slice(0, 14).reverse();
 
@@ -135,15 +147,36 @@ function CompuestoCard({
           {compuesto.notas}
         </p>
       ) : null}
+
+      {activo ? (
+        <div className="mt-4 flex items-center gap-2 border-t border-[var(--border)] pt-3">
+          <Button
+            size="sm"
+            onClick={() => onQuick(compuesto)}
+            disabled={quickPending || compuesto.dosis_objetivo == null}
+            title={
+              compuesto.dosis_objetivo == null
+                ? 'Define una dosis objetivo para el registro rápido'
+                : `Registrar ${formatDosis(compuesto)} hoy`
+            }
+          >
+            <Plus className="h-4 w-4" />
+            {quickPending ? 'Guardando…' : 'Hoy'}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => onDetalle(compuesto)}>
+            Registrar…
+          </Button>
+        </div>
+      ) : null}
     </Surface>
   );
 }
 
 /**
  * Bitácora de protocolo — tarjetas de compuestos activos (péptidos, suplementos)
- * con dosis vigente, última toma y un mini-timeline de inyecciones. Lectura
- * (Sprint 2); la captura por drawer y el overlay con biomarcadores llegan
- * después. Iniciativa salud-protocolo.
+ * con dosis vigente, última toma y mini-timeline. Captura por drawer + registro
+ * rápido "Hoy" (Sprint 3). El overlay con biomarcadores llega en Sprint 4.
+ * Iniciativa salud-protocolo.
  */
 export function ProtocoloSection({
   compuestos,
@@ -152,27 +185,70 @@ export function ProtocoloSection({
   compuestos: ProtocoloCompuestoConTomas[];
   errors: string[];
 }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [quickId, setQuickId] = useState<string | null>(null);
+  const [quickError, setQuickError] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerCompuestoId, setDrawerCompuestoId] = useState<string | null>(null);
+
   if (!compuestos.length && !errors.length) return null;
+
+  const activos = compuestos.filter((c) => c.estado === 'activo');
+
+  function quickRegister(c: ProtocoloCompuestoConTomas) {
+    if (c.dosis_objetivo == null) return;
+    setQuickError(null);
+    setQuickId(c.id);
+    startTransition(async () => {
+      const res = await registrarToma({
+        compuestoId: c.id,
+        dosis: c.dosis_objetivo as number,
+        unidad: c.unidad_dosis,
+      });
+      setQuickId(null);
+      if (res.ok) router.refresh();
+      else setQuickError(`${c.nombre}: ${res.error}`);
+    });
+  }
+
+  function openDrawer(compuestoId: string | null) {
+    setQuickError(null);
+    setDrawerCompuestoId(compuestoId);
+    setDrawerOpen(true);
+  }
 
   return (
     <section className="mt-10">
-      <div className="mb-4">
-        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-emerald-600 dark:text-emerald-300">
-          <Syringe className="h-4 w-4" />
-          Protocolo
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-emerald-600 dark:text-emerald-300">
+            <Syringe className="h-4 w-4" />
+            Protocolo
+          </div>
+          <h2 className="mt-2 text-xl font-semibold text-[var(--text)] dark:text-white">
+            Péptidos y suplementos
+          </h2>
+          <p className="mt-2 text-sm text-[var(--muted-foreground)] dark:text-white/55">
+            Lo que te estás administrando, su dosis vigente y la bitácora de cada aplicación. El
+            cruce con peso, pulso en reposo y presión llega en una próxima fase.
+          </p>
         </div>
-        <h2 className="mt-2 text-xl font-semibold text-[var(--text)] dark:text-white">
-          Péptidos y suplementos
-        </h2>
-        <p className="mt-2 text-sm text-[var(--muted-foreground)] dark:text-white/55">
-          Lo que te estás administrando, su dosis vigente y la bitácora de cada aplicación. El cruce
-          con peso, pulso en reposo y presión llega en una próxima fase.
-        </p>
+        <Button size="sm" className="shrink-0" onClick={() => openDrawer(activos[0]?.id ?? null)}>
+          <Plus className="h-4 w-4" />
+          Registrar
+        </Button>
       </div>
 
       {errors.length ? (
         <Surface className="mb-6 border-amber-300/30 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-300/20 dark:bg-amber-300/8 dark:text-amber-100">
           {errors[0]}
+        </Surface>
+      ) : null}
+
+      {quickError ? (
+        <Surface className="mb-6 border-rose-300/30 bg-rose-50 p-4 text-sm text-rose-800 dark:border-rose-300/20 dark:bg-rose-300/8 dark:text-rose-100">
+          {quickError}
         </Surface>
       ) : null}
 
@@ -182,9 +258,19 @@ export function ProtocoloSection({
             key={compuesto.id}
             compuesto={compuesto}
             tone={TONES[PALETTE[index % PALETTE.length]]}
+            onQuick={quickRegister}
+            onDetalle={(c) => openDrawer(c.id)}
+            quickPending={pending && quickId === compuesto.id}
           />
         ))}
       </div>
+
+      <ProtocoloDrawer
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        compuestos={compuestos}
+        compuestoInicialId={drawerCompuestoId}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Qué

Sprint 3 de `salud-protocolo`: la **captura**, para que registres tú sin depender de mí.

- **Drawer "Registrar"** (`protocolo-drawer.tsx`): compuesto, fecha/hora (default ahora), dosis (default la vigente), sitio de rotación, nota; + **cómo te cayó** en escalas 0–5 (apetito/náusea/energía/GI, opcionales) y nota. También **alta de compuesto nuevo** desde el mismo drawer ("agregar otro péptido").
- **Botón "+ Hoy"** de un toque en cada tarjeta: registra la dosis vigente con fecha de hoy, sin abrir el form — pensado para KLOW/Semax diarios.
- **Server actions** (`app/health/actions.ts`): `registrarToma` + `crearCompuesto`. Admin-only, `assertNotInPreview()` (read-only de "viendo como"), escritura con **service role** (las tablas son RLS deny-all). Validación de dosis y escalas server-side.

## Sin auto-merge — a propósito

UI visible + primera **escritura** del módulo health. Para revisar el preview antes de mergear.

⚠️ **El preview escribe a tu bitácora real** (no hay branch de Supabase para este PR, usa la DB de prod). Si pruebas el botón, la toma queda registrada — úsalo con una inyección de verdad, o dime y borro cualquier registro de prueba.

## Checks

`typecheck` · `lint` · `format:check` · `test:run` (77 / 1184) · **`build`** — verdes en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)