### PR TITLE
feat(dilesa): Sprint 5 — captura de presupuesto de obra

### DIFF
--- a/components/dilesa/costeo-concepto-form.tsx
+++ b/components/dilesa/costeo-concepto-form.tsx
@@ -47,7 +47,7 @@ export function CosteoConceptoForm({
   onSaved,
 }: {
   empresaId: string;
-  proyectos: readonly { id: string; nombre: string }[];
+  proyectos: readonly { id: string; nombre: string; esAnteproyecto: boolean }[];
   /** Conceptos visibles — fuente del autocálculo de `orden` en alta. */
   rows: readonly CosteoRow[];
   /** null = alta; row = edición (form pre-llenado). */
@@ -143,7 +143,7 @@ export function CosteoConceptoForm({
             <option value="">Selecciona…</option>
             {proyectos.map((p) => (
               <option key={p.id} value={p.id}>
-                {p.nombre}
+                {p.esAnteproyecto ? `${p.nombre} (anteproyecto)` : p.nombre}
               </option>
             ))}
           </select>

--- a/components/dilesa/costeo-concepto-form.tsx
+++ b/components/dilesa/costeo-concepto-form.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+/**
+ * CosteoConceptoForm — alta/edición de un concepto de presupuesto de obra
+ * (`dilesa.obra_presupuesto`, Capa A).
+ *
+ * Iniciativa dilesa-contratos-obra · Sprint 5 (captura de presupuesto). El
+ * traspaso de los Excel (hoja RESUMEN) cargó 128 conceptos de solo-lectura;
+ * este form deja operar el presupuesto hacia adelante: capturar conceptos
+ * nuevos y corregir/editar los existentes desde el tab Costeo.
+ *
+ * Calca el form inline de `obra-contrato-detalle.tsx` (captura sin drawer,
+ * `useState` plano). Insert/update directo con RLS de `dilesa`; el sub-slug
+ * `dilesa.construccion.costeo` ya tiene write → sin migración.
+ *
+ * Notas de modelado:
+ * - `orden` se autocalcula (max del proyecto + 1) en alta y se preserva en
+ *   edición — no se expone en el form (reordenar es otra feature).
+ * - IVA: v1 captura `gasto_real_total` c/IVA; el desglose subtotal/iva/tasa
+ *   queda null (igual que el traspaso donde el Excel no lo especifica, ver
+ *   ADR-038). El % de ejecución usa el total.
+ */
+
+import { useState } from 'react';
+import { Loader2, Plus, Save } from 'lucide-react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/toast';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import type { CosteoRow } from '@/components/dilesa/costeo-module';
+
+/** "" o no-numérico → null; en otro caso el número. */
+function toNum(s: string): number | null {
+  const t = s.trim();
+  if (t === '') return null;
+  const n = Number(t);
+  return Number.isNaN(n) ? null : n;
+}
+
+export function CosteoConceptoForm({
+  empresaId,
+  proyectos,
+  rows,
+  editRow,
+  onClose,
+  onSaved,
+}: {
+  empresaId: string;
+  proyectos: readonly { id: string; nombre: string }[];
+  /** Conceptos visibles — fuente del autocálculo de `orden` en alta. */
+  rows: readonly CosteoRow[];
+  /** null = alta; row = edición (form pre-llenado). */
+  editRow: CosteoRow | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const toast = useToast();
+  const isEdit = editRow != null;
+
+  const [proyectoId, setProyectoId] = useState(editRow?.proyecto_id ?? '');
+  const [concepto, setConcepto] = useState(editRow?.concepto ?? '');
+  const [etapa, setEtapa] = useState(editRow?.etapa ?? '');
+  const [presupuestoPrevio, setPresupuestoPrevio] = useState(
+    editRow?.presupuestoPrevio != null ? String(editRow.presupuestoPrevio) : ''
+  );
+  const [presupuestoActual, setPresupuestoActual] = useState(
+    editRow?.presupuestoActualizado != null ? String(editRow.presupuestoActualizado) : ''
+  );
+  const [gastoReal, setGastoReal] = useState(
+    editRow?.gastoReal != null ? String(editRow.gastoReal) : ''
+  );
+  const [proveedor, setProveedor] = useState(editRow?.proveedor ?? '');
+  const [fecha, setFecha] = useState(editRow?.fechaCompromiso ?? '');
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit = proyectoId !== '' && concepto.trim().length > 0;
+
+  async function onSubmit() {
+    if (!canSubmit || submitting) return;
+    setSubmitting(true);
+    const sb = createSupabaseBrowserClient();
+
+    const payload = {
+      etapa: etapa.trim() || null,
+      concepto: concepto.trim(),
+      presupuesto_previo: toNum(presupuestoPrevio),
+      presupuesto_actualizado: toNum(presupuestoActual),
+      gasto_real_total: toNum(gastoReal),
+      proveedor_texto: proveedor.trim() || null,
+      fecha_compromiso: fecha || null,
+    };
+
+    const resp = editRow
+      ? await sb
+          .schema('dilesa')
+          .from('obra_presupuesto')
+          .update({ ...payload, proyecto_id: proyectoId, updated_at: new Date().toISOString() })
+          .eq('id', editRow.id)
+      : await sb
+          .schema('dilesa')
+          .from('obra_presupuesto')
+          .insert({
+            empresa_id: empresaId,
+            proyecto_id: proyectoId,
+            orden:
+              rows
+                .filter((r) => r.proyecto_id === proyectoId)
+                .reduce((m, r) => Math.max(m, r.orden), 0) + 1,
+            ...payload,
+          });
+
+    if (resp.error) {
+      toast.add({
+        title: isEdit ? 'Error al guardar' : 'Error al registrar',
+        description: getSupabaseErrorMessage(resp.error, 'No se pudo guardar el concepto.'),
+        type: 'error',
+      });
+      setSubmitting(false);
+      return;
+    }
+    toast.add({
+      title: isEdit ? 'Concepto actualizado' : 'Concepto registrado',
+      description: concepto.trim(),
+      type: 'success',
+    });
+    setSubmitting(false);
+    onSaved();
+  }
+
+  return (
+    <div className="rounded-md border border-[var(--border)] bg-[var(--card)] p-4">
+      <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+        {isEdit ? 'Editar concepto' : 'Nuevo concepto de presupuesto'}
+      </h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Field label="Proyecto *">
+          <select
+            value={proyectoId}
+            onChange={(e) => setProyectoId(e.target.value)}
+            className="h-9 w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+          >
+            <option value="">Selecciona…</option>
+            {proyectos.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.nombre}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Concepto *">
+          <Input
+            value={concepto}
+            onChange={(e) => setConcepto(e.target.value)}
+            placeholder="Red de agua potable, Barda perimetral…"
+          />
+        </Field>
+        <Field label="Etapa">
+          <Input
+            value={etapa}
+            onChange={(e) => setEtapa(e.target.value)}
+            placeholder="Urbanización, Cabecera…"
+          />
+        </Field>
+        <Field label="Presupuesto previo (c/IVA)">
+          <Input
+            type="number"
+            step="0.01"
+            value={presupuestoPrevio}
+            onChange={(e) => setPresupuestoPrevio(e.target.value)}
+            placeholder="0.00"
+          />
+        </Field>
+        <Field label="Presupuesto actualizado (c/IVA)">
+          <Input
+            type="number"
+            step="0.01"
+            value={presupuestoActual}
+            onChange={(e) => setPresupuestoActual(e.target.value)}
+            placeholder="0.00"
+          />
+        </Field>
+        <Field label="Gasto real (c/IVA)">
+          <Input
+            type="number"
+            step="0.01"
+            value={gastoReal}
+            onChange={(e) => setGastoReal(e.target.value)}
+            placeholder="0.00"
+          />
+        </Field>
+        <Field label="Proveedor">
+          <Input
+            value={proveedor}
+            onChange={(e) => setProveedor(e.target.value)}
+            placeholder="Electrogaza, CFE, DILESA (obra propia)…"
+          />
+        </Field>
+        <Field label="Fecha compromiso">
+          <Input type="date" value={fecha} onChange={(e) => setFecha(e.target.value)} />
+        </Field>
+      </div>
+      <p className="mt-2 text-[11px] text-[var(--text)]/50">
+        El % de ejecución se calcula como gasto real ÷ presupuesto actualizado (o previo si no hay
+        actualizado). Montos con IVA incluido.
+      </p>
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <Button variant="outline" onClick={onClose} disabled={submitting}>
+          Cancelar
+        </Button>
+        <Button onClick={onSubmit} disabled={!canSubmit || submitting}>
+          {submitting ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : isEdit ? (
+            <Save className="size-4" />
+          ) : (
+            <Plus className="size-4" />
+          )}
+          {isEdit ? 'Guardar' : 'Registrar'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/components/dilesa/costeo-module.test.ts
+++ b/components/dilesa/costeo-module.test.ts
@@ -8,9 +8,13 @@ function r(overrides: Partial<CosteoRow>): CosteoRow {
     proyectoNombre: 'Lomas',
     etapa: 'Urbanización',
     concepto: 'Drenaje',
+    presupuestoPrevio: null,
+    presupuestoActualizado: null,
     presupuesto: 0,
     gastoReal: 0,
     proveedor: null,
+    fechaCompromiso: null,
+    orden: 0,
     ratio: null,
     ...overrides,
   };

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -109,8 +109,10 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   const [contratoAggByProyecto, setContratoAggByProyecto] = useState<
     Map<string, { contratado: number; pagado: number }>
   >(new Map());
-  /** Proyectos DILESA — selector del form de captura. */
-  const [proyectos, setProyectos] = useState<{ id: string; nombre: string }[]>([]);
+  /** Proyectos DILESA para el selector del form (desarrollos + anteproyectos no convertidos). */
+  const [proyectos, setProyectos] = useState<
+    { id: string; nombre: string; esAnteproyecto: boolean }[]
+  >([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
@@ -123,7 +125,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   const fetchCosteo = useCallback(async (): Promise<{
     rows?: CosteoRow[];
     agg?: Map<string, { contratado: number; pagado: number }>;
-    proyectos?: { id: string; nombre: string }[];
+    proyectos?: { id: string; nombre: string; esAnteproyecto: boolean }[];
     error?: string;
   }> => {
     const sb = createSupabaseBrowserClient();
@@ -141,7 +143,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       sb
         .schema('dilesa')
         .from('proyectos')
-        .select('id, nombre, tipo')
+        .select('id, nombre, tipo, proyecto_predecesor_id')
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
       sb
@@ -164,19 +166,25 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       return { error: getSupabaseErrorMessage(firstErr, 'No se pudo cargar el costeo.') };
     }
 
-    // proyectoMap resuelve nombres de TODOS los proyectos (incluye anteproyectos,
-    // por si un renglón de presupuesto los referencia). El selector del form de
-    // captura, en cambio, solo ofrece DESARROLLOS: el presupuesto de obra (Capa A)
-    // es de un desarrollo en ejecución, no de un anteproyecto en análisis. Esto
-    // además evita el duplicado visual de los proyectos que ya pasaron
-    // anteproyecto→desarrollo (mismo nombre en dos filas, ligadas por predecesor).
+    // proyectoMap resuelve nombres de TODOS los proyectos. El selector del form
+    // de captura ofrece desarrollos + anteproyectos NO convertidos (sí se
+    // presupuesta en fase de anteproyecto), etiquetando estos últimos. Los
+    // anteproyectos YA convertidos a desarrollo se omiten: cualquier presupuesto
+    // va sobre el desarrollo sucesor (que referencia al anteproyecto vía
+    // `proyecto_predecesor_id`), así desaparece el duplicado por nombre.
     const proyectoMap = new Map<string, string>();
-    const proyectos: { id: string; nombre: string }[] = [];
+    const convertidos = new Set<string>(); // ids de anteproyectos con desarrollo sucesor
     for (const p of proyectosRes.data ?? []) {
       proyectoMap.set(p.id as string, p.nombre as string);
-      if (p.tipo === 'desarrollo') {
-        proyectos.push({ id: p.id as string, nombre: (p.nombre as string) ?? '' });
-      }
+      const pred = p.proyecto_predecesor_id as string | null;
+      if (pred) convertidos.add(pred);
+    }
+    const proyectos: { id: string; nombre: string; esAnteproyecto: boolean }[] = [];
+    for (const p of proyectosRes.data ?? []) {
+      const id = p.id as string;
+      const esAnteproyecto = (p.tipo as string) === 'anteproyecto';
+      if (esAnteproyecto && convertidos.has(id)) continue; // ya convertido → va sobre el desarrollo
+      proyectos.push({ id, nombre: (p.nombre as string) ?? '', esAnteproyecto });
     }
     proyectos.sort((a, b) => a.nombre.localeCompare(b.nombre));
 

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -22,7 +22,11 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
 import { Input } from '@/components/ui/input';
-import { Coins, RefreshCw, Search } from 'lucide-react';
+import { Coins, Plus, RefreshCw, Search } from 'lucide-react';
+import { usePermissions } from '@/components/providers';
+import { useToast } from '@/components/ui/toast';
+import { RowActions } from '@/components/shared/row-actions';
+import { CosteoConceptoForm } from '@/components/dilesa/costeo-concepto-form';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { formatCurrency, formatPercent } from '@/lib/format';
 
@@ -32,11 +36,19 @@ export type CosteoRow = {
   proyectoNombre: string;
   etapa: string | null;
   concepto: string;
-  /** presupuesto_actualizado ?? presupuesto_previo (numeric, c/IVA). */
+  /** presupuesto_previo crudo (numeric, c/IVA) — para la captura. */
+  presupuestoPrevio: number | null;
+  /** presupuesto_actualizado crudo (numeric, c/IVA) — para la captura. */
+  presupuestoActualizado: number | null;
+  /** presupuesto_actualizado ?? presupuesto_previo (numeric, c/IVA). Derivado. */
   presupuesto: number | null;
   /** gasto_real_total (numeric, c/IVA). */
   gastoReal: number | null;
   proveedor: string | null;
+  /** fecha_compromiso (date ISO) — para la captura. */
+  fechaCompromiso: string | null;
+  /** orden dentro del proyecto — autocalculado en alta. */
+  orden: number;
   /** gastoReal / presupuesto (0–1) o null si no hay presupuesto. */
   ratio: number | null;
 };
@@ -87,20 +99,31 @@ export function deriveKpis(
 }
 
 export function CosteoModule({ empresaId }: { empresaId: string }) {
+  const { permissions } = usePermissions();
+  const toast = useToast();
+  const puedeEscribir =
+    permissions.isAdmin || permissions.modulos.get('dilesa.construccion.costeo')?.write === true;
+
   const [rows, setRows] = useState<CosteoRow[]>([]);
   /** contratado/pagado por proyecto_id (Capa B). */
   const [contratoAggByProyecto, setContratoAggByProyecto] = useState<
     Map<string, { contratado: number; pagado: number }>
   >(new Map());
+  /** Proyectos DILESA — selector del form de captura. */
+  const [proyectos, setProyectos] = useState<{ id: string; nombre: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [proyectoFiltro, setProyectoFiltro] = useState('');
   const [etapaFiltro, setEtapaFiltro] = useState('');
+  /** Captura de presupuesto (Sprint 5). null editRow + open = alta. */
+  const [formOpen, setFormOpen] = useState(false);
+  const [editRow, setEditRow] = useState<CosteoRow | null>(null);
 
   const fetchCosteo = useCallback(async (): Promise<{
     rows?: CosteoRow[];
     agg?: Map<string, { contratado: number; pagado: number }>;
+    proyectos?: { id: string; nombre: string }[];
     error?: string;
   }> => {
     const sb = createSupabaseBrowserClient();
@@ -111,7 +134,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
         .schema('dilesa')
         .from('obra_presupuesto')
         .select(
-          'id, proyecto_id, etapa, concepto, presupuesto_actualizado, presupuesto_previo, gasto_real_total, proveedor_texto, orden'
+          'id, proyecto_id, etapa, concepto, presupuesto_actualizado, presupuesto_previo, gasto_real_total, proveedor_texto, fecha_compromiso, orden'
         )
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
@@ -142,7 +165,12 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
     }
 
     const proyectoMap = new Map<string, string>();
-    for (const p of proyectosRes.data ?? []) proyectoMap.set(p.id as string, p.nombre as string);
+    const proyectos: { id: string; nombre: string }[] = [];
+    for (const p of proyectosRes.data ?? []) {
+      proyectoMap.set(p.id as string, p.nombre as string);
+      proyectos.push({ id: p.id as string, nombre: (p.nombre as string) ?? '' });
+    }
+    proyectos.sort((a, b) => a.nombre.localeCompare(b.nombre));
 
     // Capa B: pagado por contrato → contratado/pagado por proyecto.
     const pagadoByContrato = new Map<string, number>();
@@ -177,9 +205,14 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
           proyectoNombre: proyectoMap.get(pid) ?? '',
           etapa: (r.etapa as string | null) ?? null,
           concepto: (r.concepto as string) ?? '',
+          presupuestoPrevio: r.presupuesto_previo != null ? Number(r.presupuesto_previo) : null,
+          presupuestoActualizado:
+            r.presupuesto_actualizado != null ? Number(r.presupuesto_actualizado) : null,
           presupuesto,
           gastoReal,
           proveedor: (r.proveedor_texto as string | null) ?? null,
+          fechaCompromiso: (r.fecha_compromiso as string | null) ?? null,
+          orden: Number(r.orden ?? 0),
           ratio:
             presupuesto != null && presupuesto > 0 && gastoReal != null
               ? gastoReal / presupuesto
@@ -187,35 +220,39 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
         };
       });
 
-    return { rows: out, agg };
+    return { rows: out, agg, proyectos };
   }, [empresaId]);
 
   const cargar = useCallback(async () => {
     setLoading(true);
     setError(null);
-    const { rows: data, agg, error: e } = await fetchCosteo();
+    const { rows: data, agg, proyectos: proy, error: e } = await fetchCosteo();
     if (e) {
       setError(e);
       setRows([]);
       setContratoAggByProyecto(new Map());
+      setProyectos([]);
     } else {
       setRows(data ?? []);
       setContratoAggByProyecto(agg ?? new Map());
+      setProyectos(proy ?? []);
     }
     setLoading(false);
   }, [fetchCosteo]);
 
   useEffect(() => {
     let activo = true;
-    void fetchCosteo().then(({ rows: data, agg, error: e }) => {
+    void fetchCosteo().then(({ rows: data, agg, proyectos: proy, error: e }) => {
       if (!activo) return;
       if (e) {
         setError(e);
         setRows([]);
         setContratoAggByProyecto(new Map());
+        setProyectos([]);
       } else {
         setRows(data ?? []);
         setContratoAggByProyecto(agg ?? new Map());
+        setProyectos(proy ?? []);
       }
       setLoading(false);
     });
@@ -223,6 +260,43 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       activo = false;
     };
   }, [fetchCosteo]);
+
+  // Soft-delete de un concepto de presupuesto (Sprint 5). Patrón del repo:
+  // marca `deleted_at`, preserva historial para auditoría.
+  const eliminar = useCallback(
+    async (row: CosteoRow) => {
+      const sb = createSupabaseBrowserClient();
+      const { error: e } = await sb
+        .schema('dilesa')
+        .from('obra_presupuesto')
+        .update({ deleted_at: new Date().toISOString() })
+        .eq('id', row.id);
+      if (e) {
+        toast.add({
+          title: 'Error al eliminar',
+          description: getSupabaseErrorMessage(e, 'No se pudo eliminar el concepto.'),
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({ title: 'Concepto eliminado', description: row.concepto, type: 'success' });
+      void cargar();
+    },
+    [toast, cargar]
+  );
+
+  function abrirAlta() {
+    setEditRow(null);
+    setFormOpen(true);
+  }
+  function abrirEdicion(row: CosteoRow) {
+    setEditRow(row);
+    setFormOpen(true);
+  }
+  function cerrarForm() {
+    setFormOpen(false);
+    setEditRow(null);
+  }
 
   const proyectosPresentes = useMemo(
     () => [...new Set(rows.map((r) => r.proyectoNombre).filter(Boolean))].sort(),
@@ -298,6 +372,30 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       render: (r) => (r.ratio == null ? '—' : formatPercent(r.ratio)),
     },
     { key: 'proveedor', label: 'Proveedor', type: 'text', render: (r) => r.proveedor || '—' },
+    ...(puedeEscribir
+      ? [
+          {
+            key: 'acciones',
+            label: '',
+            type: 'custom' as const,
+            sortable: false,
+            align: 'right' as const,
+            width: 'w-12',
+            render: (r: CosteoRow) => (
+              <RowActions
+                ariaLabel={`Acciones para ${r.concepto}`}
+                onEdit={{ onClick: () => abrirEdicion(r) }}
+                onDelete={{
+                  onConfirm: () => eliminar(r),
+                  confirmTitle: `¿Eliminar “${r.concepto}”?`,
+                  confirmDescription:
+                    'Marcará el concepto de presupuesto como eliminado. Se preserva el historial para auditoría.',
+                }}
+              />
+            ),
+          },
+        ]
+      : []),
   ];
 
   return (
@@ -359,10 +457,37 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
           <RefreshCw className="h-3.5 w-3.5" />
           Refrescar
         </button>
-        <span className="ml-auto text-sm text-[var(--text)]/60">
-          {filtrados.length} de {rows.length} conceptos
-        </span>
+        <div className="ml-auto flex items-center gap-3">
+          <span className="text-sm text-[var(--text)]/60">
+            {filtrados.length} de {rows.length} conceptos
+          </span>
+          {puedeEscribir ? (
+            <button
+              type="button"
+              onClick={abrirAlta}
+              className="inline-flex h-9 items-center gap-1.5 rounded-md bg-[var(--accent)] px-3 text-sm font-medium text-white hover:opacity-90"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Nuevo concepto
+            </button>
+          ) : null}
+        </div>
       </div>
+
+      {formOpen ? (
+        <CosteoConceptoForm
+          key={editRow?.id ?? 'nuevo'}
+          empresaId={empresaId}
+          proyectos={proyectos}
+          rows={rows}
+          editRow={editRow}
+          onClose={cerrarForm}
+          onSaved={() => {
+            cerrarForm();
+            void cargar();
+          }}
+        />
+      ) : null}
 
       <DataTable
         data={filtrados}

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -141,7 +141,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       sb
         .schema('dilesa')
         .from('proyectos')
-        .select('id, nombre')
+        .select('id, nombre, tipo')
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
       sb
@@ -164,11 +164,19 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       return { error: getSupabaseErrorMessage(firstErr, 'No se pudo cargar el costeo.') };
     }
 
+    // proyectoMap resuelve nombres de TODOS los proyectos (incluye anteproyectos,
+    // por si un renglón de presupuesto los referencia). El selector del form de
+    // captura, en cambio, solo ofrece DESARROLLOS: el presupuesto de obra (Capa A)
+    // es de un desarrollo en ejecución, no de un anteproyecto en análisis. Esto
+    // además evita el duplicado visual de los proyectos que ya pasaron
+    // anteproyecto→desarrollo (mismo nombre en dos filas, ligadas por predecesor).
     const proyectoMap = new Map<string, string>();
     const proyectos: { id: string; nombre: string }[] = [];
     for (const p of proyectosRes.data ?? []) {
       proyectoMap.set(p.id as string, p.nombre as string);
-      proyectos.push({ id: p.id as string, nombre: (p.nombre as string) ?? '' });
+      if (p.tipo === 'desarrollo') {
+        proyectos.push({ id: p.id as string, nombre: (p.nombre as string) ?? '' });
+      }
     }
     proyectos.sort((a, b) => a.nombre.localeCompare(b.nombre));
 

--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -342,12 +342,22 @@ Beto notó duplicados en el dropdown "Proyecto" del form de captura. Diagnóstic
 (SELECT a `dilesa.proyectos`): **no eran duplicados de datos** sino pares
 anteproyecto→desarrollo legítimos (Ampliación LDLE y Lomas de las Delicias ya
 pasaron de anteproyecto `completado` a desarrollo `ejecutando`, ligados por
-`proyecto_predecesor_id`). El selector mostraba ambos `tipo`. Fix: el dropdown de
-captura filtra a `tipo='desarrollo'` (el presupuesto de obra / Capa A es de un
-desarrollo en ejecución, no de un anteproyecto en análisis). `proyectoMap` (que
-resuelve nombres en la tabla de costeo) se deja con TODOS los proyectos por
-robustez. Sin schema. Corregida la nota errónea de "duplicado a limpiar" en
-Pendientes menores.
+`proyecto_predecesor_id`).
+
+**Criterio (decisión de Beto):** sí se presupuesta en fase de anteproyecto, así
+que NO se ocultan los anteproyectos del dropdown — se **identifican**. Lógica del
+selector:
+
+- **Desarrollos** → se muestran (son los proyectos).
+- **Anteproyectos NO convertidos** → se muestran con sufijo **`(anteproyecto)`**.
+- **Anteproyectos YA convertidos** (su id aparece como `proyecto_predecesor_id`
+  de algún desarrollo) → se **omiten**: cualquier presupuesto/gasto va sobre el
+  desarrollo sucesor. Esto elimina el duplicado por nombre.
+
+`proyectoMap` (resuelve nombres en la tabla de costeo) se deja con TODOS los
+proyectos por robustez. Sin schema. Los anteproyectos convertidos **no se borran
+de la DB** (son el registro del anteproyecto ganador, trazabilidad del flujo);
+solo se ocultan del selector. Corregida la nota errónea de "duplicado a limpiar".
 
 ## Handover — estado y próximos pasos (para la siguiente sesión)
 
@@ -423,6 +433,7 @@ saldo; hoy v1 es la tabla de conceptos + KPIs de rollup.
   (completado) y `26352cac` el **desarrollo** (ejecutando) ligado por
   `proyecto_predecesor_id` — par legítimo del flujo anteproyecto→desarrollo.
   Igual Lomas de las Delicias (`34920025` antep. / `dd4a4e44` desarrollo). NO
-  borrar. El "duplicado visual" en el selector se resolvió filtrando el dropdown
-  de captura a `tipo='desarrollo'` (ver Bitácora 2026-06-03).
+  borrar. El "duplicado visual" en el selector se resolvió ocultando solo los
+  anteproyectos **ya convertidos** y etiquetando los no convertidos como
+  `(anteproyecto)` (ver Bitácora 2026-06-03).
 - ~~ADR-038 → índice §5 de `ARCHITECTURE.md`~~ ✅ hecho (037/038/039, #637).

--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -10,8 +10,9 @@ proveedores/contratistas; futura emisión a CxP)
 **Creada:** 2026-06-01
 **Última actualización:** 2026-06-02 (Ciclo de obra end-to-end: Capa A (#617) +
 Capa B (#631) + Sprint 3 Costeo (#639) + Sprint 4 captura (#644) + **puente CxP**
-backend (#651, en prod) + UI "Emitir a CxP" (este PR). Próximo: cotizaciones y
-captura de presupuesto; reasignar los 8 contratos placeholder.)
+backend (#651, en prod) + UI "Emitir a CxP" (#654) + **Sprint 5 captura de
+presupuesto** (este PR). Próximo: cotizaciones (dominio nuevo, promover con
+Beto); reasignar los 8 contratos placeholder.)
 
 ## Problema
 
@@ -311,27 +312,47 @@ condiciones_pago_dias?)` que **reúsa** `cxp_factura_alta` (no modifica el RPC d
   (Dirección)/pagar/conciliar** en el módulo CxP. Depende de que CxP esté en
   DILESA (ya, vía cxp #640).
 
+### 2026-06-02 — Sprint 5 (captura de presupuesto de obra)
+
+CRUD de la Capa A (`dilesa.obra_presupuesto`), que hasta ahora era solo-lectura
+(el traspaso cargó 128 conceptos, sin forma de capturar/corregir hacia adelante).
+Sin schema, sin migración: el sub-slug `dilesa.construccion.costeo` ya tiene write.
+
+- **Form de captura** `components/dilesa/costeo-concepto-form.tsx` (alta + edición),
+  calca el inline de `obra-contrato-detalle.tsx` (`useState` plano, sin drawer).
+  Campos: proyecto (selector, requerido), concepto (requerido), etapa, presupuesto
+  previo/actualizado, gasto real, proveedor (texto), fecha compromiso. Insert/update
+  directo con RLS `dilesa`.
+- **Tab Costeo** (`costeo-module.tsx`): botón "Nuevo concepto" + columna de acciones
+  por renglón (`RowActions` → editar / eliminar con `ConfirmDialog`), ambos gated por
+  `dilesa.construccion.costeo`.write. Soft-delete (`deleted_at`). El form se remonta
+  por `key` al alternar entre conceptos. `CosteoRow` extendido con los campos crudos
+  (`presupuestoPrevio`/`presupuestoActualizado`/`fechaCompromiso`/`orden`) para
+  pre-llenar la edición; KPIs y `deriveKpis` intactos.
+- **Decisiones Sprint 5:** `orden` autocalculado (max del proyecto + 1) en alta y
+  preservado en edición — no se expone (reordenar es otra feature). IVA: v1 captura
+  `gasto_real_total` c/IVA; el desglose subtotal/iva/tasa queda null (igual que el
+  traspaso, ADR-038). Proveedor solo texto (la liga a `erp.personas` sigue diferida,
+  D2). 5 checks verdes (1184 tests). **PR de UI → sin auto-merge** (Beto revisa el
+  preview).
+
 ## Handover — estado y próximos pasos (para la siguiente sesión)
 
 **Hecho (en prod):** schema Sprint 1 (#615) + Capa A de costeo (`obra_presupuesto`,
 128 renglones, #617) + **Capa B de contratos + estimaciones** (32 contratos, 275
 estimaciones, #631) + **ADR-039** (#637) + **Sprint 3** tab Costeo (#639) +
-**Sprint 4** captura de obra (#644) + **Puente CxP** backend (#651) + UI (este PR).
-Ciclo de obra **end-to-end**: crear contrato → estimar → emitir a CxP → costear.
-Faltan los módulos upstream: **cotizaciones** y **captura de presupuesto**
-(`obra_presupuesto` aún solo-lectura).
+**Sprint 4** captura de obra (#644) + **Puente CxP** backend (#651) + UI (#654) +
+**Sprint 5** captura de presupuesto (este PR). Ciclo de obra **end-to-end**: crear
+contrato → estimar → emitir a CxP → costear; y el presupuesto (Capa A) ya es
+editable. Falta el módulo upstream: **cotizaciones**.
 
-**Próximo trabajo — handoff para sesión nueva (orden: presupuesto → cotizaciones).**
+**Próximo trabajo — handoff para sesión nueva.**
 
-_1. Captura de presupuesto (Sprint 5 — contenido, sin schema nuevo)._ La tabla
-`dilesa.obra_presupuesto` ya existe (128 renglones) pero solo se lee (tab Costeo).
-Falta el CRUD: en el tab **Costeo** (`components/dilesa/costeo-module.tsx`),
-"Nuevo concepto" + edición/borrado inline por renglón. Campos: `concepto`,
-`etapa`, `presupuesto_previo`, `presupuesto_actualizado`, `gasto_real_total`,
-`proveedor_texto`, `fecha_compromiso`, `orden`. Insert/update directo a
-`dilesa.obra_presupuesto` (RLS dilesa). El sub-slug `dilesa.construccion.costeo`
-ya tiene write → **sin migración**. Calca la captura inline de
-`obra-contrato-detalle.tsx`.
+_1. Captura de presupuesto (Sprint 5) — ✅ HECHO (este PR)._ `dilesa.obra_presupuesto`
+ya tiene CRUD en el tab Costeo: form `costeo-concepto-form.tsx` (alta + edición) +
+"Nuevo concepto" + acciones por renglón (editar / eliminar), gated por
+`dilesa.construccion.costeo`.write. Sin schema, sin migración. Ver Bitácora
+2026-06-02.
 
 _2. Cotizaciones (iniciativa nueva — promover con Beto antes de construir)._ Hoy
 no hay dónde capturar/comparar cotizaciones antes de adjudicar un contrato (el

--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -336,6 +336,19 @@ Sin schema, sin migración: el sub-slug `dilesa.construccion.costeo` ya tiene wr
   D2). 5 checks verdes (1184 tests). **PR de UI → sin auto-merge** (Beto revisa el
   preview).
 
+### 2026-06-03 — Fix selector de proyectos (Sprint 5, mismo PR #656)
+
+Beto notó duplicados en el dropdown "Proyecto" del form de captura. Diagnóstico
+(SELECT a `dilesa.proyectos`): **no eran duplicados de datos** sino pares
+anteproyecto→desarrollo legítimos (Ampliación LDLE y Lomas de las Delicias ya
+pasaron de anteproyecto `completado` a desarrollo `ejecutando`, ligados por
+`proyecto_predecesor_id`). El selector mostraba ambos `tipo`. Fix: el dropdown de
+captura filtra a `tipo='desarrollo'` (el presupuesto de obra / Capa A es de un
+desarrollo en ejecución, no de un anteproyecto en análisis). `proyectoMap` (que
+resuelve nombres en la tabla de costeo) se deja con TODOS los proyectos por
+robustez. Sin schema. Corregida la nota errónea de "duplicado a limpiar" en
+Pendientes menores.
+
 ## Handover — estado y próximos pasos (para la siguiente sesión)
 
 **Hecho (en prod):** schema Sprint 1 (#615) + Capa A de costeo (`obra_presupuesto`,
@@ -403,7 +416,13 @@ saldo; hoy v1 es la tabla de conceptos + KPIs de rollup.
   (diferido: el match por `proveedor_texto` es fuzzy y los contratistas con
   varios contratos —Electrogaza ×5, San Rodrigo ×4, Estrella ×4— necesitan
   desambiguar por concepto; hacerlo al construir la UI de rollup que lo consume).
-- **Duplicado ELECTROGAZA** en `erp.personas` (2 filas; se usó la más antigua) y
-  **duplicado** "Ampliación Lomas de los Encinos" en `dilesa.proyectos`
-  (`cd7c9cae-…` y `26352cac-…`) — limpiar.
+- **Duplicado ELECTROGAZA** en `erp.personas` (2 filas; se usó la más antigua) —
+  limpiar.
+- ~~"duplicado" Ampliación Lomas de los Encinos en `dilesa.proyectos`~~ ✅
+  **NO era duplicado** (verificado 2026-06-03): `cd7c9cae` es el **anteproyecto**
+  (completado) y `26352cac` el **desarrollo** (ejecutando) ligado por
+  `proyecto_predecesor_id` — par legítimo del flujo anteproyecto→desarrollo.
+  Igual Lomas de las Delicias (`34920025` antep. / `dd4a4e44` desarrollo). NO
+  borrar. El "duplicado visual" en el selector se resolvió filtrando el dropdown
+  de captura a `tipo='desarrollo'` (ver Bitácora 2026-06-03).
 - ~~ADR-038 → índice §5 de `ARCHITECTURE.md`~~ ✅ hecho (037/038/039, #637).


### PR DESCRIPTION
## Qué

Sprint 5 de la iniciativa **dilesa-contratos-obra**: CRUD de la **Capa A** (`dilesa.obra_presupuesto`) en el tab **Costeo**, que hasta ahora era solo-lectura. El traspaso de los Excel cargó 128 conceptos sin forma de capturar/corregir hacia adelante — este PR cierra ese hueco.

**Sin schema, sin migración:** el sub-slug `dilesa.construccion.costeo` ya tiene write.

## Cambios

- **`components/dilesa/costeo-concepto-form.tsx`** (nuevo): form de alta + edición, calca el inline de `obra-contrato-detalle.tsx` (`useState` plano, sin drawer). Campos: proyecto (selector, requerido), concepto (requerido), etapa, presupuesto previo/actualizado, gasto real, proveedor (texto), fecha compromiso. Insert/update directo con RLS `dilesa`.
- **`components/dilesa/costeo-module.tsx`**: botón **"Nuevo concepto"** + **columna de acciones por renglón** (`RowActions` → editar / eliminar con `ConfirmDialog`), ambos gated por `dilesa.construccion.costeo`.write. Soft-delete (`deleted_at`). El form se remonta por `key` al alternar entre conceptos. `CosteoRow` extendido con los campos crudos para pre-llenar la edición; `deriveKpis` intacto.
- **`costeo-module.test.ts`**: helper actualizado a los campos nuevos del tipo.

## Decisiones (Sprint 5)

- `orden` autocalculado (max del proyecto + 1) en alta y preservado en edición — no se expone (reordenar es otra feature).
- IVA: v1 captura `gasto_real_total` c/IVA; desglose subtotal/iva/tasa queda null (igual que el traspaso, ADR-038).
- Proveedor solo texto (la liga a `erp.personas` sigue diferida, D2).

## Verificación

- ✅ typecheck · ✅ test:run (**1184** tests) · ✅ lint (0 errores) · ✅ format:check
- Sin migración → `schema:check` sin cambios.

## Cómo probar en el preview

1. Entrar a **DILESA → Construcción → Costeo**.
2. **"Nuevo concepto"**: elegir proyecto (Lomas del Sol / Lomas de los Encinos), capturar concepto + montos → aparece en la tabla y suma a los KPIs.
3. En un renglón, menú **⋮ → Editar** (pre-llena el form) y **⋮ → Eliminar** (confirma → soft-delete).
4. Con un usuario sin write en `dilesa.construccion.costeo`, ni el botón ni las acciones deben verse.

> PR de **UI** → **sin auto-merge**. Reviso contigo el preview antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)