### PR TITLE
refactor(dilesa): helper de selector de proyecto + réplica a nuevo-obra

### DIFF
--- a/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
+++ b/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
@@ -29,9 +29,14 @@ import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { formatCurrency } from '@/lib/format';
+import {
+  buildProyectoOptions,
+  proyectoOptionLabel,
+  type ProyectoOption,
+  type ProyectoSelectorRow,
+} from '@/lib/dilesa/proyectos-selector';
 
 type Contratista = { id: string; nombre: string; abreviacion: string | null };
-type Proyecto = { id: string; nombre: string };
 
 /** Tipos de obra no-vivienda (ADR-038). `vivienda` se captura en /nuevo. */
 const TIPOS_OBRA = [
@@ -62,7 +67,7 @@ function NuevoContratoObraBody() {
   const [loadingMeta, setLoadingMeta] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [contratistas, setContratistas] = useState<Contratista[]>([]);
-  const [proyectos, setProyectos] = useState<Proyecto[]>([]);
+  const [proyectos, setProyectos] = useState<ProyectoOption[]>([]);
   const [seqByContratista, setSeqByContratista] = useState<Map<string, number>>(new Map());
 
   // ── Form ───────────────────────────────────────────────────────────────
@@ -99,7 +104,7 @@ function NuevoContratoObraBody() {
       sb
         .schema('dilesa')
         .from('proyectos')
-        .select('id, nombre')
+        .select('id, nombre, tipo, proyecto_predecesor_id')
         .eq('empresa_id', DILESA_EMPRESA_ID)
         .is('deleted_at', null),
       // Conteo de contratos de obra (no-vivienda) por contratista → seq del código.
@@ -136,7 +141,7 @@ function NuevoContratoObraBody() {
         .sort((a, b) => a.nombre.localeCompare(b.nombre))
     );
     setProyectos(
-      ((proyectosRes.data ?? []) as Proyecto[]).sort((a, b) => a.nombre.localeCompare(b.nombre))
+      buildProyectoOptions((proyectosRes.data ?? []) as unknown as ProyectoSelectorRow[])
     );
 
     const seq = new Map<string, number>();
@@ -270,7 +275,7 @@ function NuevoContratoObraBody() {
               <option value="">— selecciona —</option>
               {proyectos.map((p) => (
                 <option key={p.id} value={p.id}>
-                  {p.nombre}
+                  {proyectoOptionLabel(p)}
                 </option>
               ))}
             </select>

--- a/components/dilesa/costeo-concepto-form.tsx
+++ b/components/dilesa/costeo-concepto-form.tsx
@@ -28,6 +28,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { proyectoOptionLabel, type ProyectoOption } from '@/lib/dilesa/proyectos-selector';
 import type { CosteoRow } from '@/components/dilesa/costeo-module';
 
 /** "" o no-numérico → null; en otro caso el número. */
@@ -47,7 +48,7 @@ export function CosteoConceptoForm({
   onSaved,
 }: {
   empresaId: string;
-  proyectos: readonly { id: string; nombre: string; esAnteproyecto: boolean }[];
+  proyectos: readonly ProyectoOption[];
   /** Conceptos visibles — fuente del autocálculo de `orden` en alta. */
   rows: readonly CosteoRow[];
   /** null = alta; row = edición (form pre-llenado). */
@@ -143,7 +144,7 @@ export function CosteoConceptoForm({
             <option value="">Selecciona…</option>
             {proyectos.map((p) => (
               <option key={p.id} value={p.id}>
-                {p.esAnteproyecto ? `${p.nombre} (anteproyecto)` : p.nombre}
+                {proyectoOptionLabel(p)}
               </option>
             ))}
           </select>

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -27,6 +27,11 @@ import { usePermissions } from '@/components/providers';
 import { useToast } from '@/components/ui/toast';
 import { RowActions } from '@/components/shared/row-actions';
 import { CosteoConceptoForm } from '@/components/dilesa/costeo-concepto-form';
+import {
+  buildProyectoOptions,
+  type ProyectoOption,
+  type ProyectoSelectorRow,
+} from '@/lib/dilesa/proyectos-selector';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { formatCurrency, formatPercent } from '@/lib/format';
 
@@ -110,9 +115,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
     Map<string, { contratado: number; pagado: number }>
   >(new Map());
   /** Proyectos DILESA para el selector del form (desarrollos + anteproyectos no convertidos). */
-  const [proyectos, setProyectos] = useState<
-    { id: string; nombre: string; esAnteproyecto: boolean }[]
-  >([]);
+  const [proyectos, setProyectos] = useState<ProyectoOption[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
@@ -125,7 +128,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   const fetchCosteo = useCallback(async (): Promise<{
     rows?: CosteoRow[];
     agg?: Map<string, { contratado: number; pagado: number }>;
-    proyectos?: { id: string; nombre: string; esAnteproyecto: boolean }[];
+    proyectos?: ProyectoOption[];
     error?: string;
   }> => {
     const sb = createSupabaseBrowserClient();
@@ -166,27 +169,17 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       return { error: getSupabaseErrorMessage(firstErr, 'No se pudo cargar el costeo.') };
     }
 
-    // proyectoMap resuelve nombres de TODOS los proyectos. El selector del form
-    // de captura ofrece desarrollos + anteproyectos NO convertidos (sí se
-    // presupuesta en fase de anteproyecto), etiquetando estos últimos. Los
-    // anteproyectos YA convertidos a desarrollo se omiten: cualquier presupuesto
-    // va sobre el desarrollo sucesor (que referencia al anteproyecto vía
-    // `proyecto_predecesor_id`), así desaparece el duplicado por nombre.
+    // proyectoMap resuelve nombres de TODOS los proyectos (para la tabla de
+    // costeo). El selector del form usa buildProyectoOptions: oculta los
+    // anteproyectos ya convertidos y etiqueta los no convertidos
+    // (ver lib/dilesa/proyectos-selector).
     const proyectoMap = new Map<string, string>();
-    const convertidos = new Set<string>(); // ids de anteproyectos con desarrollo sucesor
     for (const p of proyectosRes.data ?? []) {
       proyectoMap.set(p.id as string, p.nombre as string);
-      const pred = p.proyecto_predecesor_id as string | null;
-      if (pred) convertidos.add(pred);
     }
-    const proyectos: { id: string; nombre: string; esAnteproyecto: boolean }[] = [];
-    for (const p of proyectosRes.data ?? []) {
-      const id = p.id as string;
-      const esAnteproyecto = (p.tipo as string) === 'anteproyecto';
-      if (esAnteproyecto && convertidos.has(id)) continue; // ya convertido → va sobre el desarrollo
-      proyectos.push({ id, nombre: (p.nombre as string) ?? '', esAnteproyecto });
-    }
-    proyectos.sort((a, b) => a.nombre.localeCompare(b.nombre));
+    const proyectos = buildProyectoOptions(
+      (proyectosRes.data ?? []) as unknown as ProyectoSelectorRow[]
+    );
 
     // Capa B: pagado por contrato → contratado/pagado por proyecto.
     const pagadoByContrato = new Map<string, number>();

--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -359,6 +359,24 @@ proyectos por robustez. Sin schema. Los anteproyectos convertidos **no se borran
 de la DB** (son el registro del anteproyecto ganador, trazabilidad del flujo);
 solo se ocultan del selector. Corregida la nota errónea de "duplicado a limpiar".
 
+### 2026-06-03 — Helper compartido del selector + réplica a nuevo-obra (PR aparte)
+
+A pedido de Beto, se replicó el patrón del selector a los demás forms de captura.
+Para no duplicar la lógica se extrajo a **`lib/dilesa/proyectos-selector.ts`**
+(`buildProyectoOptions` + `proyectoOptionLabel`, helper puro + test de 7 casos):
+
+- **`costeo-module` / `costeo-concepto-form`** → ahora usan el helper (antes inline).
+- **`/contratos/nuevo-obra`** (contrato de obra) → aplica el mismo patrón; antes
+  listaba los proyectos crudos y mostraba el duplicado anteproyecto/desarrollo.
+
+**Forms que NO lo necesitan** (verificado): `/contratos/nuevo` (vivienda) y
+`/ventas/nueva` ya derivan su selector de las **unidades/lotes** elegibles
+(`proyectosConUnidades`), así que un anteproyecto sin unidades nunca aparece —
+no tienen el duplicado. Los **filtros** de proyecto en las vistas de lista
+(contratos-module, ventas-module, etc.) sí muestran el duplicado, pero es de bajo
+impacto (filtrar por el gemelo viejo da 0 filas); pendiente menor si Beto lo quiere.
+Sin schema, sin migración.
+
 ## Handover — estado y próximos pasos (para la siguiente sesión)
 
 **Hecho (en prod):** schema Sprint 1 (#615) + Capa A de costeo (`obra_presupuesto`,

--- a/lib/dilesa/proyectos-selector.test.ts
+++ b/lib/dilesa/proyectos-selector.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProyectoOptions,
+  proyectoOptionLabel,
+  type ProyectoSelectorRow,
+} from './proyectos-selector';
+
+function row(o: Partial<ProyectoSelectorRow> & { id: string }): ProyectoSelectorRow {
+  return {
+    nombre: o.id,
+    tipo: 'desarrollo',
+    proyecto_predecesor_id: null,
+    ...o,
+  };
+}
+
+describe('buildProyectoOptions (selector de proyecto DILESA)', () => {
+  it('incluye desarrollos sin marcarlos como anteproyecto', () => {
+    const out = buildProyectoOptions([
+      row({ id: 'a', nombre: 'Lomas del Sol', tipo: 'desarrollo' }),
+    ]);
+    expect(out).toEqual([{ id: 'a', nombre: 'Lomas del Sol', esAnteproyecto: false }]);
+  });
+
+  it('incluye anteproyectos NO convertidos, marcados esAnteproyecto', () => {
+    const out = buildProyectoOptions([
+      row({ id: 'ap', nombre: 'Loma Escondida', tipo: 'anteproyecto' }),
+    ]);
+    expect(out).toEqual([{ id: 'ap', nombre: 'Loma Escondida', esAnteproyecto: true }]);
+  });
+
+  it('omite el anteproyecto YA convertido (referenciado por un desarrollo)', () => {
+    const out = buildProyectoOptions([
+      row({ id: 'ap', nombre: 'Ampliación', tipo: 'anteproyecto' }),
+      row({ id: 'dev', nombre: 'Ampliación', tipo: 'desarrollo', proyecto_predecesor_id: 'ap' }),
+    ]);
+    // Solo el desarrollo sobrevive → sin duplicado por nombre.
+    expect(out).toEqual([{ id: 'dev', nombre: 'Ampliación', esAnteproyecto: false }]);
+  });
+
+  it('mantiene el anteproyecto suelto aunque otro par esté convertido', () => {
+    const out = buildProyectoOptions([
+      row({ id: 'ap1', nombre: 'Delicias', tipo: 'anteproyecto' }),
+      row({ id: 'dev1', nombre: 'Delicias', tipo: 'desarrollo', proyecto_predecesor_id: 'ap1' }),
+      row({ id: 'ap2', nombre: 'Bosque', tipo: 'anteproyecto' }),
+    ]);
+    expect(out.map((o) => o.id)).toEqual(['ap2', 'dev1']); // ap1 omitido; orden por nombre
+    expect(out.find((o) => o.id === 'ap2')?.esAnteproyecto).toBe(true);
+  });
+
+  it('ordena por nombre', () => {
+    const out = buildProyectoOptions([
+      row({ id: 'z', nombre: 'Zafiro' }),
+      row({ id: 'a', nombre: 'Ámbar' }),
+      row({ id: 'm', nombre: 'Mango' }),
+    ]);
+    expect(out.map((o) => o.nombre)).toEqual(['Ámbar', 'Mango', 'Zafiro']);
+  });
+
+  it('tolera nombre null → cadena vacía', () => {
+    const out = buildProyectoOptions([row({ id: 'x', nombre: null })]);
+    expect(out[0]?.nombre).toBe('');
+  });
+});
+
+describe('proyectoOptionLabel', () => {
+  it('agrega "(anteproyecto)" solo a anteproyectos', () => {
+    expect(proyectoOptionLabel({ id: 'a', nombre: 'Loma', esAnteproyecto: true })).toBe(
+      'Loma (anteproyecto)'
+    );
+    expect(proyectoOptionLabel({ id: 'b', nombre: 'Sol', esAnteproyecto: false })).toBe('Sol');
+  });
+});

--- a/lib/dilesa/proyectos-selector.ts
+++ b/lib/dilesa/proyectos-selector.ts
@@ -1,0 +1,58 @@
+/**
+ * Helper compartido para los selectores de proyecto DILESA (forms de captura).
+ *
+ * Regla (iniciativa dilesa-contratos-obra, 2026-06-03): un proyecto puede
+ * existir como `anteproyecto` y, al ganar, promoverse a `desarrollo` — una fila
+ * nueva ligada al anteproyecto por `proyecto_predecesor_id`. En un selector de
+ * captura eso se ve como un duplicado por nombre. Criterio acordado con Beto:
+ *
+ *  - **Desarrollos** → se muestran (son los proyectos).
+ *  - **Anteproyectos NO convertidos** → se muestran etiquetados (sí se
+ *    presupuesta/contrata en fase de anteproyecto); `esAnteproyecto = true`.
+ *  - **Anteproyectos YA convertidos** (su id es `proyecto_predecesor_id` de
+ *    algún desarrollo) → se omiten: cualquier captura va sobre el desarrollo
+ *    sucesor, así desaparece el duplicado.
+ *
+ * Helper PURO (sin fetch) para ser testeable y reutilizable desde cualquier
+ * form. El SELECT debe traer `id, nombre, tipo, proyecto_predecesor_id`.
+ */
+
+export type ProyectoSelectorRow = {
+  id: string;
+  nombre: string | null;
+  tipo: string | null;
+  proyecto_predecesor_id: string | null;
+};
+
+export type ProyectoOption = {
+  id: string;
+  nombre: string;
+  /** true cuando el proyecto es un anteproyecto (la UI lo etiqueta). */
+  esAnteproyecto: boolean;
+};
+
+/**
+ * Construye la lista de opciones para un selector de proyecto de captura,
+ * ordenada por nombre. Omite los anteproyectos ya convertidos a desarrollo.
+ */
+export function buildProyectoOptions(rows: readonly ProyectoSelectorRow[]): ProyectoOption[] {
+  // ids de anteproyectos que ya tienen un desarrollo sucesor.
+  const convertidos = new Set<string>();
+  for (const p of rows) {
+    if (p.proyecto_predecesor_id) convertidos.add(p.proyecto_predecesor_id);
+  }
+
+  const out: ProyectoOption[] = [];
+  for (const p of rows) {
+    const esAnteproyecto = p.tipo === 'anteproyecto';
+    if (esAnteproyecto && convertidos.has(p.id)) continue; // ya convertido → va sobre el desarrollo
+    out.push({ id: p.id, nombre: p.nombre ?? '', esAnteproyecto });
+  }
+  out.sort((a, b) => a.nombre.localeCompare(b.nombre));
+  return out;
+}
+
+/** Etiqueta de display: nombre + sufijo "(anteproyecto)" cuando aplica. */
+export function proyectoOptionLabel(o: ProyectoOption): string {
+  return o.esAnteproyecto ? `${o.nombre} (anteproyecto)` : o.nombre;
+}


### PR DESCRIPTION
## Qué

Sigue a #656. Replica el patrón del selector de proyecto (etiquetar anteproyectos / ocultar los ya convertidos) al resto de forms de captura DILESA, **sin duplicar la lógica**: se extrae a un helper puro y testeado.

## Cambios

- **`lib/dilesa/proyectos-selector.ts`** (nuevo): `buildProyectoOptions` + `proyectoOptionLabel`. Oculta los anteproyectos ya convertidos a desarrollo (su id es `proyecto_predecesor_id` de un desarrollo) y etiqueta `(anteproyecto)` los no convertidos. Helper puro → **test de 7 casos** (`proyectos-selector.test.ts`).
- **`costeo-module.tsx` / `costeo-concepto-form.tsx`**: usan el helper (antes la lógica estaba inline en #656).
- **`/contratos/nuevo-obra`**: aplica el patrón. Antes listaba los proyectos crudos → mostraba el duplicado anteproyecto/desarrollo.

## Scope — qué NO se tocó (y por qué)

- **`/contratos/nuevo` (vivienda)** y **`/ventas/nueva`**: sus selectores ya derivan de las **unidades/lotes elegibles** (`proyectosConUnidades`), así que un anteproyecto sin unidades nunca aparece — no tienen el duplicado. Tocar­los sería churn sin beneficio.
- **Filtros** de proyecto en vistas de lista (contratos-module, ventas-module…): sí muestran el duplicado, pero es de bajo impacto (filtrar por el gemelo viejo da 0 filas). Pendiente menor — lo extiendo si lo quieres.

## Verificación

- ✅ typecheck · ✅ test:run (**1191** tests, +7 del helper) · ✅ lint (0 errores) · ✅ format:check
- Sin schema, sin migración.

## Probar en preview

**DILESA → Construcción → Contratos → Nuevo contrato de obra** → el dropdown "Proyecto" ahora oculta los anteproyectos ya convertidos (Ampliación LDLE, Lomas de las Delicias) y etiqueta los sueltos como `(anteproyecto)`.

> PR de UI → **sin auto-merge**. Reviso contigo el preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)