### PR TITLE
fix(dilesa-ventas): email bienvenida + solicitud firmada + recibos enganche en Fase 2

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/2-asignada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/2-asignada/page.tsx
@@ -32,10 +32,16 @@ import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { marcarFase, type DocCaptura } from '@/lib/dilesa/captura/marcar-fase';
 
-const ROLES_REQUERIDOS = ['aviso_privacidad', 'ficu', 'expediente_digital'] as const;
+const ROLES_REQUERIDOS = [
+  'solicitud_asignacion',
+  'aviso_privacidad',
+  'ficu',
+  'expediente_digital',
+] as const;
 type RolRequerido = (typeof ROLES_REQUERIDOS)[number];
 
 const ROL_LABEL: Record<RolRequerido, string> = {
+  solicitud_asignacion: 'Solicitud de asignación firmada por cliente',
   aviso_privacidad: 'Aviso de privacidad firmado',
   ficu: 'FICU firmado',
   expediente_digital: 'Expediente digital (paquete KYC)',
@@ -43,9 +49,21 @@ const ROL_LABEL: Record<RolRequerido, string> = {
 
 type VentaCtx = {
   id: string;
+  empresa_id: string;
+  persona_id: string;
   unidad_id: string | null;
   fase_posicion: number | null;
   estado: string;
+  enganche_requerido: number | null;
+};
+
+type ReciboEnganche = {
+  id: string;
+  fecha: string | null;
+  monto: number;
+  forma_pago: string | null;
+  referencia: string | null;
+  notas: string | null;
 };
 
 export default function CapturarFase2Page() {
@@ -65,6 +83,8 @@ function CapturarFase2Body() {
   const [esLider, setEsLider] = useState<boolean | null>(null);
   const [adjuntosCargados, setAdjuntosCargados] = useState<Set<string>>(new Set());
   const [archivos, setArchivos] = useState<Partial<Record<RolRequerido, File>>>({});
+  const [recibos, setRecibos] = useState<ReciboEnganche[]>([]);
+  const [totalEnganchePagado, setTotalEnganchePagado] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -76,7 +96,7 @@ function CapturarFase2Body() {
     const { data: v, error: vErr } = await sb
       .schema('dilesa')
       .from('ventas')
-      .select('id, unidad_id, fase_posicion, estado')
+      .select('id, empresa_id, persona_id, unidad_id, fase_posicion, estado, enganche_requerido')
       .eq('id', ventaId)
       .maybeSingle();
     if (vErr || !v) {
@@ -110,6 +130,38 @@ function CapturarFase2Body() {
       .eq('entidad_id', ventaId);
     const set = new Set<string>(((adj ?? []) as Array<{ rol: string }>).map((a) => a.rol));
     setAdjuntosCargados(set);
+
+    // Recibos del enganche — la asignación requiere ver que el cliente
+    // ya pagó el enganche. Leemos dilesa.venta_pagos con tipo='enganche'
+    // (o variantes legacy de Coda) para que el autorizador vea el monto
+    // pagado vs el requerido antes de aprobar.
+    const { data: pagosRows } = await sb
+      .schema('dilesa')
+      .from('venta_pagos')
+      .select('id, fecha, monto, tipo, notas')
+      .eq('venta_id', ventaId)
+      .is('deleted_at', null)
+      .order('fecha', { ascending: true });
+    const recibosEnganche = (
+      (pagosRows ?? []) as Array<{
+        id: string;
+        fecha: string | null;
+        monto: number;
+        tipo: string | null;
+        notas: string | null;
+      }>
+    )
+      .filter((p) => (p.tipo ?? '').toLowerCase().includes('enganche'))
+      .map((p) => ({
+        id: p.id,
+        fecha: p.fecha,
+        monto: Number(p.monto) || 0,
+        forma_pago: null as string | null,
+        referencia: null as string | null,
+        notas: p.notas,
+      }));
+    setRecibos(recibosEnganche);
+    setTotalEnganchePagado(recibosEnganche.reduce((acc, r) => acc + r.monto, 0));
 
     setLoading(false);
   }, [ventaId]);
@@ -271,6 +323,13 @@ function CapturarFase2Body() {
         </div>
       </section>
 
+      {/* Recibos del enganche — referencia para autorizar */}
+      <RecibosEngancheSection
+        recibos={recibos}
+        totalPagado={totalEnganchePagado}
+        engancheRequerido={venta.enganche_requerido}
+      />
+
       <div className="flex justify-end pt-2">
         <Button onClick={onAutorizar} disabled={!puedeAutorizar}>
           {submitting ? (
@@ -283,5 +342,87 @@ function CapturarFase2Body() {
         </Button>
       </div>
     </div>
+  );
+}
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+
+function RecibosEngancheSection({
+  recibos,
+  totalPagado,
+  engancheRequerido,
+}: {
+  recibos: ReciboEnganche[];
+  totalPagado: number;
+  engancheRequerido: number | null;
+}) {
+  const requerido = Number(engancheRequerido ?? 0);
+  const cubre = requerido > 0 ? totalPagado >= requerido : totalPagado > 0;
+  return (
+    <section>
+      <h2 className="mb-3 text-sm font-medium uppercase tracking-wide text-[var(--text)]/50">
+        Recibos del enganche
+      </h2>
+      <p className="mb-3 text-xs text-[var(--text)]/60">
+        La asignación requiere que el cliente haya pagado el enganche. Verifica que los recibos
+        registrados cubran el monto requerido antes de autorizar.
+      </p>
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+        <div className="mb-3 grid grid-cols-3 gap-3 text-xs">
+          <div>
+            <div className="text-[var(--text)]/50">Enganche requerido</div>
+            <div className="mt-0.5 text-sm font-medium">{moneyFmt.format(requerido)}</div>
+          </div>
+          <div>
+            <div className="text-[var(--text)]/50">Pagado</div>
+            <div className="mt-0.5 text-sm font-medium">{moneyFmt.format(totalPagado)}</div>
+          </div>
+          <div>
+            <div className="text-[var(--text)]/50">Estado</div>
+            <div
+              className={`mt-0.5 inline-flex items-center gap-1 text-xs ${
+                cubre
+                  ? 'text-emerald-600 dark:text-emerald-400'
+                  : 'text-amber-600 dark:text-amber-400'
+              }`}
+            >
+              {cubre ? (
+                <>
+                  <CheckCircle2 className="h-3.5 w-3.5" /> Cubre el enganche
+                </>
+              ) : (
+                <>
+                  <XCircle className="h-3.5 w-3.5" /> Pendiente de cubrir
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+        {recibos.length === 0 ? (
+          <p className="text-xs text-[var(--text)]/40">
+            Aún no hay recibos de enganche registrados para esta venta.
+          </p>
+        ) : (
+          <ul className="space-y-1.5 text-xs">
+            {recibos.map((r) => (
+              <li
+                key={r.id}
+                className="flex items-center justify-between border-t border-[var(--border)] pt-1.5"
+              >
+                <span className="text-[var(--text)]/70">
+                  {r.fecha ?? '—'}
+                  {r.notas ? ` · ${r.notas}` : ''}
+                </span>
+                <span className="font-mono font-medium">{moneyFmt.format(r.monto)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
   );
 }

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -214,7 +214,7 @@ const moneyFmt = new Intl.NumberFormat('es-MX', {
  */
 const FASE_ROLES: Record<string, string[]> = {
   'Solicitud de Asignación': ['solicitud_asignacion'],
-  Asignada: ['expediente_digital', 'ficu', 'aviso_privacidad'],
+  Asignada: ['solicitud_asignacion', 'expediente_digital', 'ficu', 'aviso_privacidad'],
   Formalizada: ['contrato_promesa'],
   'Solicitud de Avalúo': [],
   'Avalúo Cerrado': ['avaluo_comercial'],

--- a/lib/dilesa/hold-emails.ts
+++ b/lib/dilesa/hold-emails.ts
@@ -21,7 +21,14 @@
 
 import { formatearVencimiento } from './hold-cola';
 
-const RESEND_FROM = 'DILESA <ventas@dilesa.mx>';
+/**
+ * `From` para Resend. Usa `noreply@bsop.io` porque es el dominio que el
+ * proyecto tiene verificado en Resend (mismo patrón que `lib/juntas/email.ts`).
+ * Usar `@dilesa.mx` sin verificar el dominio en Resend hace que TODOS los
+ * envíos sean rechazados silenciosamente — fue la causa de que el primer
+ * email de hold no llegara.
+ */
+const RESEND_FROM = 'DILESA <noreply@bsop.io>';
 const URL_BSOP = 'https://bsop.io';
 
 export type HoldEventType = 'hold_creado' | 'hold_promovido' | 'hold_4h_warning' | 'hold_expirada';
@@ -111,14 +118,27 @@ function renderTemplate(
   switch (type) {
     case 'hold_creado':
       return {
-        subject: `Solicitud de asignación creada — ${ref}`,
+        subject: `Bienvenido a DILESA — Tu solicitud por ${ref}`,
         html: `
-          <p>Hola,</p>
-          <p>Se registró una <b>solicitud de asignación</b> para la unidad <b>${escapeHtml(ref)}</b> a nombre de <b>${escapeHtml(ctx.clienteNombre)}</b>.</p>
-          <p>Esta unidad queda en <b>hold</b> hasta <b>${fechaDeadline ?? 'el plazo definido'}</b>. Antes de esa fecha hay que completar el expediente con todos los documentos firmados; si no, el hold se pierde y la siguiente solicitud en la fila toma el lugar.</p>
+          <p>Hola <b>${escapeHtml(ctx.clienteNombre)}</b>,</p>
+          <p>En DILESA estamos felices de acompañarte en el proceso de compra de tu nueva vivienda.
+             Te damos la bienvenida y te confirmamos que se registró tu <b>solicitud de asignación</b>
+             para la unidad <b>${escapeHtml(ref)}</b>.</p>
+          <p>A partir de hoy te <b>llevaremos de la mano</b> paso a paso por todo el proceso —
+             desde la firma del contrato de promesa, el avalúo del banco, la dictaminación del
+             crédito, hasta la escrituración y entrega de las llaves de tu vivienda.</p>
+          <p><b>Tu unidad queda apartada (en "hold") hasta ${fechaDeadline ?? 'el plazo definido'}.</b>
+             En ese plazo necesitamos que nos entregues el expediente completo con todos los
+             documentos firmados — solicitud de asignación, aviso de privacidad, FICU y expediente
+             digital — y el comprobante del pago del enganche.</p>
+          <p>Si por algún motivo no se completa el expediente en ese plazo, el apartado se libera
+             y la unidad pasa a la siguiente persona interesada. Por eso es importante que avancemos
+             juntos en estos 2 días hábiles.</p>
           ${faltantesHtml}
-          <p><a href="${linkVenta}">Ver expediente en BSOP</a></p>
-          <p>— DILESA</p>
+          <p>Cualquier duda, tu asesor de ventas
+             <b>${escapeHtml(ctx.vendedorNombre ?? 'asignado')}</b> te puede orientar en cada paso.</p>
+          <p><a href="${linkVenta}">Ver el avance de tu expediente</a></p>
+          <p>Bienvenido a tu nuevo hogar,<br/>— Equipo DILESA</p>
         `.trim(),
       };
     case 'hold_promovido':


### PR DESCRIPTION
## Summary

3 fixes detectados con cliente fantasma de Beto.

**1. Email hold_creado no llegaba** — `from: ventas@dilesa.mx` no está verificado en Resend → todos los envíos silenciosamente rechazados. Cambiado a `noreply@bsop.io` (mismo dominio verificado que usa [`lib/juntas/email.ts`](lib/juntas/email.ts)).

**2. Email hold_creado reescrito con tono bienvenida.** Subject nuevo: "Bienvenido a DILESA — Tu solicitud por <unidad>". Cuerpo saluda al cliente por nombre, explica el acompañamiento DILESA paso a paso por todo el proceso, informa el plazo de 2 días hábiles y qué documentos faltan, invita a contactar al asesor. Cierra con "Bienvenido a tu nuevo hogar".

**3. Fase 2 ahora requiere `solicitud_asignacion` firmada + muestra recibos del enganche.**

- `FASE_ROLES['Asignada']` y `ROLES_REQUERIDOS` agregan `solicitud_asignacion`.
- Page Fase 2 muestra sección "Recibos del enganche" leyendo `dilesa.venta_pagos` con `tipo` que contenga 'enganche'. Muestra requerido vs pagado + estado (cubre/pendiente) + lista de recibos.

El sub-componente `RecibosEngancheSection` es solo lectura — captura de pagos vive en CxC (`AbonoCaptureDrawer` en detalle general de venta).

## Test plan

- [ ] **Cliente fantasma:** crear solicitud nueva → esperar la próxima vuelta del cron (cada hora 0:00) → recibir email "Bienvenido a DILESA — ..." en el email del vendedor y el del cliente.
- [ ] **Fase 2:** abrir `/dilesa/ventas/[id]/capturar/2-asignada` → ver 4 docs requeridos (sumó solicitud_asignacion) + sección nueva "Recibos del enganche" con monto requerido vs pagado.
- [ ] **Si recibos cubren enganche:** badge verde "Cubre el enganche". Si no: ámbar "Pendiente de cubrir".

## Out of scope

- Backfill manual de `notif_hold_creado_at` para solicitudes existentes (el cron las recogerá en la siguiente hora con el `from` arreglado — el cliente fantasma actual debería recibir el email automáticamente la próxima hora).

🤖 Generated with [Claude Code](https://claude.com/claude-code)