### PR TITLE
feat(dilesa-ventas): botón regresar a fase + desasignar venta (Dirección)

### DIFF
--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -1,0 +1,290 @@
+'use server';
+
+/**
+ * Server actions de movimientos administrativos en una venta DILESA.
+ *
+ *  - `regresarAFase(ventaId, faseDestino, motivo)`: regresa la venta a
+ *    una fase anterior. Conserva docs cargados. Si fase destino = 1,
+ *    limpia notif_hold_creado_at + dispara email de bienvenida.
+ *  - `desasignarVenta(ventaId, motivo)`: marca estado=desasignada,
+ *    persiste motivo, manda email al cliente + vendedor.
+ *
+ * Gate: el caller debe tener escritura sobre `dilesa.ventas.autorizar`
+ * (mismo sub-slug que la autorización Fase 2). Validado server-side
+ * leyendo permisos del usuario en `core` schema.
+ *
+ * Cambios persistidos:
+ *  - `dilesa.ventas` (UPDATE)
+ *  - Llamada a hold-emails para enviar correo (fire-and-forget en error)
+ */
+
+import { revalidatePath } from 'next/cache';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import { sendHoldEmail, type HoldEmailContext } from '@/lib/dilesa/hold-emails';
+import { fetchUserPermissions } from '@/lib/permissions';
+
+const FASES_CANONICAS: Record<number, string> = {
+  1: 'Solicitud de Asignación',
+  2: 'Asignada',
+  3: 'Formalizada',
+  4: 'Solicitud de Avalúo',
+  5: 'Avalúo Cerrado',
+  6: 'Inscrita',
+  7: 'Solicitud de Dictaminación',
+  8: 'Dictaminada',
+  9: 'Validación Patronal',
+  10: 'Firmas Programadas',
+  11: 'Escriturada',
+  12: 'Detonada',
+  13: 'Facturada',
+  14: 'Preparada para Entrega',
+  15: 'Entregada',
+  16: 'Comisión Pagada',
+  17: 'Operación Terminada',
+};
+
+export type ActionResult = { ok: true } | { ok: false; error: string };
+
+async function requireAutorizar(): Promise<ActionResult & { userId?: string }> {
+  const sb = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (!user) return { ok: false, error: 'No autenticado' };
+  const perms = await fetchUserPermissions(sb);
+  const tienePermiso =
+    perms.isAdmin || perms.modulos.get('dilesa.ventas.autorizar')?.write === true;
+  if (!tienePermiso) {
+    return { ok: false, error: 'No tienes permisos para esta acción (requiere autorización).' };
+  }
+  return { ok: true, userId: user.id };
+}
+
+/**
+ * Construye el contexto cross-schema para mandar email del hold sin
+ * depender de RLS del caller. Mismo patrón que el endpoint
+ * `/api/dilesa/ventas/[id]/notify-hold-creado`.
+ */
+async function buildEmailContext(
+  admin: NonNullable<ReturnType<typeof getSupabaseAdminClient>>,
+  ventaId: string
+): Promise<HoldEmailContext | null> {
+  const { data: v } = await admin
+    .schema('dilesa')
+    .from('ventas')
+    .select(
+      'id, empresa_id, unidad_id, persona_id, vendedor_usuario_id, vendedor, expira_at, motivo_desasignacion'
+    )
+    .eq('id', ventaId)
+    .maybeSingle();
+  if (!v) return null;
+
+  const [{ data: persona }, { data: usuario }, { data: unidad }] = await Promise.all([
+    admin
+      .schema('erp')
+      .from('personas')
+      .select('nombre, apellido_paterno, apellido_materno, email')
+      .eq('id', v.persona_id)
+      .maybeSingle(),
+    v.vendedor_usuario_id
+      ? admin
+          .schema('core')
+          .from('usuarios')
+          .select('first_name, last_name, email')
+          .eq('id', v.vendedor_usuario_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    v.unidad_id
+      ? admin
+          .schema('dilesa')
+          .from('unidades')
+          .select('identificador, proyecto_id')
+          .eq('id', v.unidad_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+  ]);
+
+  let proyectoNombre = '';
+  if (unidad?.proyecto_id) {
+    const { data: p } = await admin
+      .schema('dilesa')
+      .from('proyectos')
+      .select('nombre')
+      .eq('id', unidad.proyecto_id)
+      .maybeSingle();
+    proyectoNombre = p?.nombre ?? '';
+  }
+
+  const clienteNombre =
+    [persona?.nombre, persona?.apellido_paterno, persona?.apellido_materno]
+      .filter(Boolean)
+      .join(' ') || '(sin nombre)';
+  const vendedorNombre =
+    [usuario?.first_name, usuario?.last_name].filter(Boolean).join(' ').trim() ||
+    v.vendedor ||
+    null;
+
+  return {
+    ventaId: v.id,
+    empresaId: v.empresa_id,
+    vendedorEmail: usuario?.email ?? null,
+    vendedorNombre,
+    clienteEmail: persona?.email ?? null,
+    clienteNombre,
+    unidadIdentificador: unidad?.identificador ?? '(sin unidad)',
+    proyectoNombre,
+    expiraAt: v.expira_at ? new Date(v.expira_at) : null,
+    motivo: v.motivo_desasignacion ?? null,
+  };
+}
+
+/**
+ * Regresa la venta a una fase anterior. Conserva docs cargados.
+ * Si la fase destino = 1, limpia notif_hold_creado_at y dispara
+ * email de bienvenida nuevo.
+ */
+export async function regresarAFase(
+  ventaId: string,
+  faseDestino: number,
+  motivo: string
+): Promise<ActionResult> {
+  const gate = await requireAutorizar();
+  if (!gate.ok) return gate;
+
+  const motivoTrim = motivo.trim();
+  if (motivoTrim.length < 5) {
+    return { ok: false, error: 'El motivo es obligatorio (mínimo 5 caracteres).' };
+  }
+  const faseNombre = FASES_CANONICAS[faseDestino];
+  if (!faseNombre) {
+    return { ok: false, error: `Fase destino inválida: ${faseDestino}` };
+  }
+
+  const admin = getSupabaseAdminClient();
+  if (!admin) return { ok: false, error: 'Admin client no disponible' };
+
+  // Validar que la fase destino sea ANTERIOR a la actual.
+  const { data: v } = await admin
+    .schema('dilesa')
+    .from('ventas')
+    .select('id, fase_posicion, estado, notas, persona_id, vendedor_usuario_id, unidad_id')
+    .eq('id', ventaId)
+    .maybeSingle();
+  if (!v) return { ok: false, error: 'Venta no encontrada' };
+  if (v.estado !== 'activa') {
+    return { ok: false, error: `La venta está en estado "${v.estado}" — no se puede regresar.` };
+  }
+  if (faseDestino >= (v.fase_posicion ?? 0)) {
+    return {
+      ok: false,
+      error: 'Solo se puede regresar a una fase anterior a la actual.',
+    };
+  }
+
+  // Patch: actualizar fase + agregar log al campo `notas` (queda
+  // como bitácora simple sin necesidad de tabla nueva). Si fase=1,
+  // limpiamos notif_hold_creado_at para que el ciclo del hold arranque
+  // de nuevo (cron o endpoint instantáneo lo recoge).
+  const ahora = new Date().toISOString();
+  const notaRegresion = `[${ahora}] Regresada a Fase ${faseDestino} (${faseNombre}) por motivo: ${motivoTrim}`;
+  const notasNuevas = v.notas ? `${v.notas}\n${notaRegresion}` : notaRegresion;
+  const update: {
+    fase_actual: string;
+    fase_posicion: number;
+    notas: string;
+    notif_hold_creado_at?: string | null;
+    notif_hold_4h_at?: string | null;
+  } = {
+    fase_actual: faseNombre,
+    fase_posicion: faseDestino,
+    notas: notasNuevas,
+  };
+  if (faseDestino === 1) {
+    update.notif_hold_creado_at = null;
+    update.notif_hold_4h_at = null;
+  }
+  const { error: upErr } = await admin
+    .schema('dilesa')
+    .from('ventas')
+    .update(update)
+    .eq('id', ventaId);
+  if (upErr) return { ok: false, error: upErr.message };
+
+  // Si regresamos a Fase 1, mandamos el email de bienvenida otra vez
+  // para que el cliente sepa que su solicitud está activa con plazo nuevo.
+  // (Idempotencia: ya limpiamos notif_hold_creado_at arriba.)
+  if (faseDestino === 1) {
+    const ctx = await buildEmailContext(admin, ventaId);
+    if (ctx) {
+      const res = await sendHoldEmail('hold_creado', ctx);
+      if (res.ok) {
+        await admin
+          .schema('dilesa')
+          .from('ventas')
+          .update({ notif_hold_creado_at: new Date().toISOString() })
+          .eq('id', ventaId);
+      }
+    }
+  }
+
+  revalidatePath(`/dilesa/ventas/${ventaId}`);
+  return { ok: true };
+}
+
+/**
+ * Desasigna la venta. Marca estado=desasignada, persiste motivo,
+ * y manda email al cliente + vendedor con el motivo.
+ *
+ * La unidad queda disponible para nuevas solicitudes. NO se promueve
+ * automáticamente al siguiente en la cola — la desasignación es una
+ * decisión gerencial, no una expiración natural.
+ */
+export async function desasignarVenta(ventaId: string, motivo: string): Promise<ActionResult> {
+  const gate = await requireAutorizar();
+  if (!gate.ok) return gate;
+
+  const motivoTrim = motivo.trim();
+  if (motivoTrim.length < 5) {
+    return { ok: false, error: 'El motivo es obligatorio (mínimo 5 caracteres).' };
+  }
+
+  const admin = getSupabaseAdminClient();
+  if (!admin) return { ok: false, error: 'Admin client no disponible' };
+
+  const { data: v } = await admin
+    .schema('dilesa')
+    .from('ventas')
+    .select('id, estado, notas')
+    .eq('id', ventaId)
+    .maybeSingle();
+  if (!v) return { ok: false, error: 'Venta no encontrada' };
+  if (v.estado === 'desasignada') {
+    return { ok: false, error: 'La venta ya está desasignada.' };
+  }
+
+  const ahora = new Date().toISOString();
+  const notaDesasignacion = `[${ahora}] Desasignada por motivo: ${motivoTrim}`;
+  const notasNuevas = v.notas ? `${v.notas}\n${notaDesasignacion}` : notaDesasignacion;
+
+  const { error: upErr } = await admin
+    .schema('dilesa')
+    .from('ventas')
+    .update({
+      estado: 'desasignada',
+      motivo_desasignacion: motivoTrim,
+      notas: notasNuevas,
+    })
+    .eq('id', ventaId);
+  if (upErr) return { ok: false, error: upErr.message };
+
+  // Email al cliente + vendedor.
+  const ctx = await buildEmailContext(admin, ventaId);
+  if (ctx) {
+    // Sobreescribimos motivo para que llegue fresh (la query lo trajo igual).
+    await sendHoldEmail('desasignada', { ...ctx, motivo: motivoTrim });
+  }
+
+  revalidatePath(`/dilesa/ventas/${ventaId}`);
+  return { ok: true };
+}

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -55,6 +55,16 @@ import {
   type ColaItem,
   type HoldSnapshot,
 } from '@/lib/dilesa/hold-cola';
+import { usePermissions } from '@/components/providers';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { regresarAFase, desasignarVenta } from './actions';
 
 type Venta = {
   id: string;
@@ -784,6 +794,12 @@ function DetailInner() {
         />
       </div>
 
+      <MovimientosAdministrativos
+        ventaId={venta.id}
+        estado={venta.estado}
+        fasePosicion={venta.fase_posicion}
+      />
+
       <Section title="Datos del cliente">
         {fichaPersona.length === 0 ? (
           <p className="text-sm text-[var(--text)]/60">Sin datos del cliente.</p>
@@ -1463,5 +1479,246 @@ function AdjuntoLink({ a, compact = false }: { a: Adjunto; compact?: boolean }) 
       <span className="max-w-[220px] truncate">{a.nombre}</span>
       <ExternalLink className={compact ? 'h-2.5 w-2.5' : 'h-3 w-3'} />
     </a>
+  );
+}
+
+/**
+ * Movimientos administrativos sobre la venta — solo visibles para roles
+ * con escritura sobre `dilesa.ventas.autorizar` (Dirección + Nelcy).
+ *
+ *  - Regresar a fase: dialog con selector de fase destino + motivo.
+ *  - Desasignar: dialog con motivo. Manda email al cliente + vendedor.
+ *
+ * Si la venta ya está desasignada o en fase 17, no se muestran botones.
+ */
+function MovimientosAdministrativos({
+  ventaId,
+  estado,
+  fasePosicion,
+}: {
+  ventaId: string;
+  estado: string;
+  fasePosicion: number | null;
+}) {
+  const { permissions } = usePermissions();
+  const toast = useToast();
+  const [openRegresar, setOpenRegresar] = useState(false);
+  const [openDesasignar, setOpenDesasignar] = useState(false);
+
+  const puedeAutorizar =
+    permissions.isAdmin || permissions.modulos.get('dilesa.ventas.autorizar')?.write === true;
+  if (!puedeAutorizar) return null;
+  if (estado !== 'activa') return null;
+  const pos = fasePosicion ?? 0;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {pos > 1 ? (
+        <Button variant="outline" size="sm" onClick={() => setOpenRegresar(true)}>
+          Regresar a fase…
+        </Button>
+      ) : null}
+      <Button variant="outline" size="sm" onClick={() => setOpenDesasignar(true)}>
+        Desasignar venta…
+      </Button>
+
+      <RegresarFaseDialog
+        ventaId={ventaId}
+        faseActual={pos}
+        open={openRegresar}
+        onOpenChange={setOpenRegresar}
+        onDone={(msg) => toast.add({ title: 'Listo', description: msg, type: 'success' })}
+        onError={(msg) => toast.add({ title: 'Error', description: msg, type: 'error' })}
+      />
+      <DesasignarDialog
+        ventaId={ventaId}
+        open={openDesasignar}
+        onOpenChange={setOpenDesasignar}
+        onDone={(msg) => toast.add({ title: 'Listo', description: msg, type: 'success' })}
+        onError={(msg) => toast.add({ title: 'Error', description: msg, type: 'error' })}
+      />
+    </div>
+  );
+}
+
+function RegresarFaseDialog({
+  ventaId,
+  faseActual,
+  open,
+  onOpenChange,
+  onDone,
+  onError,
+}: {
+  ventaId: string;
+  faseActual: number;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onDone: (msg: string) => void;
+  onError: (msg: string) => void;
+}) {
+  const [faseDestino, setFaseDestino] = useState<number>(1);
+  const [motivo, setMotivo] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const opciones = Array.from({ length: Math.max(0, faseActual - 1) }, (_, i) => i + 1);
+
+  async function onSubmit() {
+    if (motivo.trim().length < 5) {
+      onError('El motivo es obligatorio (mínimo 5 caracteres).');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await regresarAFase(ventaId, faseDestino, motivo);
+      if (!res.ok) {
+        onError(res.error);
+        return;
+      }
+      onDone(
+        `Venta regresada a Fase ${faseDestino}.${
+          faseDestino === 1 ? ' Email de bienvenida enviado al cliente.' : ''
+        }`
+      );
+      onOpenChange(false);
+      setMotivo('');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleOpenChange(v: boolean) {
+    if (!v) {
+      setMotivo('');
+      setFaseDestino(1);
+    }
+    onOpenChange(v);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Regresar venta a fase anterior</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <div>
+            <label className="mb-1 block text-xs text-[var(--text)]/60">Fase destino</label>
+            <select
+              value={faseDestino}
+              onChange={(e) => setFaseDestino(Number(e.target.value))}
+              className="h-9 w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm"
+              disabled={submitting}
+            >
+              {opciones.map((p) => (
+                <option key={p} value={p}>
+                  Fase {p}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs text-[var(--text)]/60">Motivo (obligatorio)</label>
+            <textarea
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              rows={3}
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm"
+              disabled={submitting}
+              placeholder="Ej. Cliente solicita corregir CURP del expediente digital."
+            />
+          </div>
+          {faseDestino === 1 ? (
+            <p className="text-xs text-amber-700 dark:text-amber-400">
+              Al regresar a Fase 1 se enviará un email de bienvenida nuevo al cliente con plazo
+              fresco de 2 días hábiles.
+            </p>
+          ) : null}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={submitting}>
+            Cancelar
+          </Button>
+          <Button onClick={onSubmit} disabled={submitting || opciones.length === 0}>
+            {submitting ? 'Regresando…' : 'Regresar venta'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DesasignarDialog({
+  ventaId,
+  open,
+  onOpenChange,
+  onDone,
+  onError,
+}: {
+  ventaId: string;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onDone: (msg: string) => void;
+  onError: (msg: string) => void;
+}) {
+  const [motivo, setMotivo] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit() {
+    if (motivo.trim().length < 5) {
+      onError('El motivo es obligatorio (mínimo 5 caracteres).');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await desasignarVenta(ventaId, motivo);
+      if (!res.ok) {
+        onError(res.error);
+        return;
+      }
+      onDone('Venta desasignada. Email enviado al cliente.');
+      onOpenChange(false);
+      setMotivo('');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleOpenChange(v: boolean) {
+    if (!v) setMotivo('');
+    onOpenChange(v);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Desasignar venta</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <p className="text-sm text-[var(--text)]/70">
+            La venta pasará a estado <b>desasignada</b>. La unidad quedará disponible para nuevas
+            solicitudes. El cliente y el vendedor recibirán un correo con el motivo.
+          </p>
+          <div>
+            <label className="mb-1 block text-xs text-[var(--text)]/60">Motivo (obligatorio)</label>
+            <textarea
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              rows={3}
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm"
+              disabled={submitting}
+              placeholder="Ej. Cliente decidió cancelar la compra por motivos personales."
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={submitting}>
+            Cancelar
+          </Button>
+          <Button onClick={onSubmit} disabled={submitting}>
+            {submitting ? 'Desasignando…' : 'Desasignar venta'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/lib/dilesa/hold-emails.ts
+++ b/lib/dilesa/hold-emails.ts
@@ -31,7 +31,12 @@ import { formatearVencimiento } from './hold-cola';
 const RESEND_FROM = 'DILESA <noreply@bsop.io>';
 const URL_BSOP = 'https://bsop.io';
 
-export type HoldEventType = 'hold_creado' | 'hold_promovido' | 'hold_4h_warning' | 'hold_expirada';
+export type HoldEventType =
+  | 'hold_creado'
+  | 'hold_promovido'
+  | 'hold_4h_warning'
+  | 'hold_expirada'
+  | 'desasignada';
 
 export interface HoldEmailContext {
   ventaId: string;
@@ -45,6 +50,8 @@ export interface HoldEmailContext {
   expiraAt: Date | null;
   /** Lista de adjuntos que faltan para completar expediente. */
   faltantes?: string[];
+  /** Motivo de la desasignación (solo aplica para evento `desasignada`). */
+  motivo?: string | null;
 }
 
 interface SendResult {
@@ -176,6 +183,28 @@ function renderTemplate(
           <p>— DILESA</p>
         `.trim(),
       };
+    case 'desasignada': {
+      const motivoHtml = ctx.motivo ? `<p><b>Motivo:</b> ${escapeHtml(ctx.motivo)}</p>` : '';
+      return {
+        subject: `Desasignación de la unidad ${ref}`,
+        html: `
+          <p>Estimado/a <b>${escapeHtml(ctx.clienteNombre)}</b>,</p>
+          <p>Te escribimos para informarte que la asignación de la unidad
+             <b>${escapeHtml(ref)}</b> que estaba a tu nombre fue cancelada
+             por nuestra dirección.</p>
+          ${motivoHtml}
+          <p>Sabemos que es una noticia que no esperabas y lamentamos las
+             molestias que esto pueda causar. Si quieres entender mejor la
+             situación o explorar otra unidad disponible, tu asesor de ventas
+             <b>${escapeHtml(ctx.vendedorNombre ?? 'asignado')}</b> está a tus
+             órdenes para acompañarte.</p>
+          <p>Agradecemos sinceramente la confianza que depositaste en
+             DILESA. Quedamos a tus órdenes para cualquier siguiente paso
+             que decidas dar.</p>
+          <p>Atentamente,<br/>— Equipo DILESA</p>
+        `.trim(),
+      };
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

2 movimientos administrativos sobre la venta, ambos gated por `dilesa.ventas.autorizar` (Dirección + Nelcy):

**1. Regresar a fase anterior** — caso de uso: modificaciones de docs que obligan a re-correr el proceso. Selector de fase destino + motivo. Docs cargados se conservan. Si fase=1, limpia `notif_hold_creado_at` y dispara email "Bienvenido" fresco (útil para volver a probar con tu fantasma).

**2. Desasignar venta** — la venta se cae. Motivo obligatorio. Estado=desasignada + email empático al cliente con el motivo + unidad disponible para nuevas solicitudes.

## Decisiones tomadas con defaults razonables

| # | Decisión | Default aplicado |
|---|---|---|
| RBAC | Mismo sub-slug `dilesa.ventas.autorizar` para ambos | reusado |
| Regresar a | Cualquier fase anterior, no solo la inmediata | selector libre |
| Docs cargados | Se conservan al regresar | sí |
| Email regresión | Solo si destino = Fase 1 (resetea ciclo del hold) | sí |
| Cola tras desasignación | Unidad disponible pero NO promoción automática | sí |

## Test plan

- [ ] Settings → Acceso: confirmar que tu rol tiene escritura sobre `dilesa.ventas.autorizar`.
- [ ] Abrir `/dilesa/ventas/[id]` de tu fantasma (Fase 2 actual) → ver 2 botones "Regresar a fase…" y "Desasignar venta…".
- [ ] Click "Regresar a fase…" → seleccionar Fase 1, motivo "Prueba del email de bienvenida desde regresión", confirmar → toast verde + email de bienvenida en tu inbox en segundos.
- [ ] Avanzar fantasma a Fase 2 otra vez, luego click "Desasignar venta…" → motivo "Prueba del email de desasignación", confirmar → email "Desasignación de la unidad..." en el inbox del cliente + vendedor.
- [ ] Confirmar que la unidad desasignada vuelve a estar disponible en `/dilesa/ventas/inventario`.

## Out of scope

- Tabla dedicada de movimientos administrativos (log vive en `venta.notas`).
- Granularidad RBAC distinta para regresar vs desasignar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)