### PR TITLE
fix(dilesa-ventas): feedback visual tras regresar/desasignar + visibilidad del envío de correo

### DIFF
--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -44,7 +44,17 @@ const FASES_CANONICAS: Record<number, string> = {
   17: 'Operación Terminada',
 };
 
-export type ActionResult = { ok: true } | { ok: false; error: string };
+export type ActionResult =
+  | {
+      ok: true;
+      /** True si el email se envió con éxito. False si falló o no se intentó. */
+      emailSent?: boolean;
+      /** Destinatarios efectivos (vacío si no se envió). */
+      emailSentTo?: string[];
+      /** Mensaje de error del envío, si aplica. */
+      emailError?: string;
+    }
+  | { ok: false; error: string };
 
 async function requireAutorizar(): Promise<ActionResult & { userId?: string }> {
   const sb = await createSupabaseServerClient();
@@ -227,22 +237,33 @@ export async function regresarAFase(
   // Si regresamos a Fase 1, mandamos el email de bienvenida otra vez
   // para que el cliente sepa que su solicitud está activa con plazo nuevo.
   // (Idempotencia: ya limpiamos notif_hold_creado_at arriba.)
+  let emailSent = false;
+  let emailSentTo: string[] = [];
+  let emailError: string | undefined;
   if (faseDestino === 1) {
     const ctx = await buildEmailContext(admin, ventaId);
-    if (ctx) {
+    if (!ctx) {
+      emailError = 'No se pudo armar el contexto del email (venta no encontrada).';
+      console.warn('[regresarAFase] buildEmailContext returned null', { ventaId });
+    } else {
       const res = await sendHoldEmail('hold_creado', ctx);
+      emailSent = res.ok;
+      emailSentTo = res.sentTo;
+      emailError = res.error;
       if (res.ok) {
         await admin
           .schema('dilesa')
           .from('ventas')
           .update({ notif_hold_creado_at: new Date().toISOString() })
           .eq('id', ventaId);
+      } else {
+        console.warn('[regresarAFase] sendHoldEmail failed', { ventaId, error: res.error });
       }
     }
   }
 
   revalidatePath(`/dilesa/ventas/${ventaId}`);
-  return { ok: true };
+  return { ok: true, emailSent, emailSentTo, emailError };
 }
 
 /**
@@ -292,12 +313,29 @@ export async function desasignarVenta(ventaId: string, motivo: string): Promise<
   if (upErr) return { ok: false, error: upErr.message };
 
   // Email al cliente + vendedor.
+  let emailSent = false;
+  let emailSentTo: string[] = [];
+  let emailError: string | undefined;
   const ctx = await buildEmailContext(admin, ventaId);
-  if (ctx) {
+  if (!ctx) {
+    emailError = 'No se pudo armar el contexto del email (venta no encontrada).';
+    console.warn('[desasignarVenta] buildEmailContext returned null', { ventaId });
+  } else {
     // Sobreescribimos motivo para que llegue fresh (la query lo trajo igual).
-    await sendHoldEmail('desasignada', { ...ctx, motivo: motivoTrim });
+    const res = await sendHoldEmail('desasignada', { ...ctx, motivo: motivoTrim });
+    emailSent = res.ok;
+    emailSentTo = res.sentTo;
+    emailError = res.error;
+    if (!res.ok) {
+      console.warn('[desasignarVenta] sendHoldEmail failed', {
+        ventaId,
+        error: res.error,
+        clienteEmail: ctx.clienteEmail,
+        vendedorEmail: ctx.vendedorEmail,
+      });
+    }
   }
 
   revalidatePath(`/dilesa/ventas/${ventaId}`);
-  return { ok: true };
+  return { ok: true, emailSent, emailSentTo, emailError };
 }

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -23,7 +23,7 @@
  */
 
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import {
   ArrowLeft,
@@ -1502,6 +1502,7 @@ function MovimientosAdministrativos({
 }) {
   const { permissions } = usePermissions();
   const toast = useToast();
+  const router = useRouter();
   const [openRegresar, setOpenRegresar] = useState(false);
   const [openDesasignar, setOpenDesasignar] = useState(false);
 
@@ -1510,6 +1511,19 @@ function MovimientosAdministrativos({
   if (!puedeAutorizar) return null;
   if (estado !== 'activa') return null;
   const pos = fasePosicion ?? 0;
+
+  /**
+   * Callback común: muestra toast + refresca el detalle para que el
+   * estado nuevo (fase_actual, estado) se renderee inmediatamente.
+   * Sin esto el operador no veía feedback de que el cambio aplicó.
+   */
+  function handleDone(msg: string) {
+    toast.add({ title: 'Listo', description: msg, type: 'success' });
+    router.refresh();
+  }
+  function handleError(msg: string) {
+    toast.add({ title: 'Error', description: msg, type: 'error' });
+  }
 
   return (
     <div className="flex flex-wrap gap-2">
@@ -1527,15 +1541,15 @@ function MovimientosAdministrativos({
         faseActual={pos}
         open={openRegresar}
         onOpenChange={setOpenRegresar}
-        onDone={(msg) => toast.add({ title: 'Listo', description: msg, type: 'success' })}
-        onError={(msg) => toast.add({ title: 'Error', description: msg, type: 'error' })}
+        onDone={handleDone}
+        onError={handleError}
       />
       <DesasignarDialog
         ventaId={ventaId}
         open={openDesasignar}
         onOpenChange={setOpenDesasignar}
-        onDone={(msg) => toast.add({ title: 'Listo', description: msg, type: 'success' })}
-        onError={(msg) => toast.add({ title: 'Error', description: msg, type: 'error' })}
+        onDone={handleDone}
+        onError={handleError}
       />
     </div>
   );
@@ -1573,11 +1587,14 @@ function RegresarFaseDialog({
         onError(res.error);
         return;
       }
-      onDone(
-        `Venta regresada a Fase ${faseDestino}.${
-          faseDestino === 1 ? ' Email de bienvenida enviado al cliente.' : ''
-        }`
-      );
+      const baseMsg = `Venta regresada a Fase ${faseDestino}.`;
+      const emailMsg =
+        faseDestino === 1
+          ? res.emailSent
+            ? ` Email de bienvenida enviado a ${res.emailSentTo?.join(', ') ?? 'cliente'}.`
+            : ` ⚠️ El correo no se pudo enviar${res.emailError ? ` (${res.emailError})` : ''}.`
+          : '';
+      onDone(baseMsg + emailMsg);
       onOpenChange(false);
       setMotivo('');
     } finally {
@@ -1674,7 +1691,10 @@ function DesasignarDialog({
         onError(res.error);
         return;
       }
-      onDone('Venta desasignada. Email enviado al cliente.');
+      const emailMsg = res.emailSent
+        ? ` Email enviado a ${res.emailSentTo?.join(', ') ?? 'cliente'}.`
+        : ` ⚠️ El correo no se pudo enviar${res.emailError ? ` (${res.emailError})` : ''}.`;
+      onDone('Venta desasignada.' + emailMsg);
       onOpenChange(false);
       setMotivo('');
     } finally {


### PR DESCRIPTION
## Summary

Beto reportó 2 bugs tras desasignar su fantasma:
1. **No le llegó el correo**.
2. **No vio feedback visual** — el detalle seguía mostrando "Activa".

## Fixes

**1. Feedback visual**: `MovimientosAdministrativos` ahora llama `router.refresh()` tras éxito → el header del detalle pasa de "Activa" a "Desasignada" sin recargar.

**2. Visibilidad del correo**: `ActionResult` gana `emailSent`, `emailSentTo`, `emailError`. El toast ahora dice claramente:
- ✅ "Venta desasignada. Email enviado a beto@anorte.com, cliente@…"
- ⚠️ "Venta desasignada. ⚠️ El correo no se pudo enviar (resend 422)"

Si `buildEmailContext` retorna null o `sendHoldEmail` falla, se loguea `console.warn` con detalles (ventaId, error, emails intentados) para aparecer en Vercel logs.

## Por qué no llegó el correo de la prueba previa

No estamos seguros sin los logs. Posibles causas:
- Resend rechazó por el cliente (email del cliente fantasma podría no existir o ser inválido)
- `buildEmailContext` retornó null por algún edge case
- Race entre el UPDATE estado y el SELECT siguiente

Este PR no resuelve la causa raíz pero hace que **la próxima vez se vea claramente en el toast** + queda log en Vercel para diagnóstico.

## Test plan

- [ ] Desasignar venta fantasma → toast indica si email se envió y a quién, o el error.
- [ ] Verificar que el detalle se actualiza solo (sin reload manual) mostrando estado "Desasignada".
- [ ] Si email falló, revisar Vercel logs del endpoint `actions.ts` para ver el `console.warn` con el error específico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)