### PR TITLE
fix(dilesa-ventas): capturar throws silenciosos de regresar/desasignar

### DIFF
--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -172,6 +172,20 @@ export async function regresarAFase(
   faseDestino: number,
   motivo: string
 ): Promise<ActionResult> {
+  try {
+    return await regresarAFaseInner(ventaId, faseDestino, motivo);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn('[regresarAFase] uncaught error', { ventaId, error: msg });
+    return { ok: false, error: `Error inesperado: ${msg}` };
+  }
+}
+
+async function regresarAFaseInner(
+  ventaId: string,
+  faseDestino: number,
+  motivo: string
+): Promise<ActionResult> {
   const gate = await requireAutorizar();
   if (!gate.ok) return gate;
 
@@ -275,6 +289,16 @@ export async function regresarAFase(
  * decisión gerencial, no una expiración natural.
  */
 export async function desasignarVenta(ventaId: string, motivo: string): Promise<ActionResult> {
+  try {
+    return await desasignarVentaInner(ventaId, motivo);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn('[desasignarVenta] uncaught error', { ventaId, error: msg });
+    return { ok: false, error: `Error inesperado: ${msg}` };
+  }
+}
+
+async function desasignarVentaInner(ventaId: string, motivo: string): Promise<ActionResult> {
   const gate = await requireAutorizar();
   if (!gate.ok) return gate;
 

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -1597,6 +1597,12 @@ function RegresarFaseDialog({
       onDone(baseMsg + emailMsg);
       onOpenChange(false);
       setMotivo('');
+    } catch (e) {
+      // Server action arrojó excepción sin manejarse — la mostramos al
+      // operador en vez de dejarla pasar silenciosa (era el bug del PR #664).
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error('[RegresarFaseDialog] uncaught', e);
+      onError(`No se pudo regresar la venta: ${msg}`);
     } finally {
       setSubmitting(false);
     }
@@ -1697,6 +1703,12 @@ function DesasignarDialog({
       onDone('Venta desasignada.' + emailMsg);
       onOpenChange(false);
       setMotivo('');
+    } catch (e) {
+      // Server action arrojó excepción sin manejarse — la mostramos al
+      // operador en vez de dejarla pasar silenciosa (era el bug del PR #664).
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error('[DesasignarDialog] uncaught', e);
+      onError(`No se pudo desasignar la venta: ${msg}`);
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Summary

Beto: _"ni el boton de regresar fase ni el de desasigna hace nada"_.

**Causa raíz:** si las server actions arrojan una excepción (cookies rotas, admin client null, error en buildEmailContext, etc.), el dialog tenía `try` sin `catch`. La promesa se rechazaba silenciosa — operador no veía nada.

## Fix

1. **Server actions wrap externo**: `regresarAFase` y `desasignarVenta` delegan a `*Inner` y atrapan throws con `try/catch` que loguea + retorna `{ok: false, error: 'Error inesperado: ...'}`. Garantiza nunca arrojan.
2. **Dialogs UI catch**: `catch (e)` agregado que muestra el mensaje al usuario via `onError` + `console.error` para debugging en browser DevTools.

Combinado: el operador siempre verá un toast — o ✅ "Listo, ..." o ⚠️ "Error: ...". Sin más caso "no pasa nada".

## Cómo diagnosticar después del merge

1. Pulsa el botón → toast aparece.
2. Si toast dice **"Error inesperado: X"** → revisa Vercel logs del action (`[regresarAFase] uncaught` o `[desasignarVenta] uncaught`).
3. Si toast dice **"Venta desasignada"** pero email no llega → mira el campo de email en el toast ("Email enviado a ..." vs "⚠️ no se pudo enviar (...)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)