### PR TITLE
fix(dilesa-ventas): UX header venta desasignada (quitar fase + marcar unidad liberada)

### DIFF
--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -756,13 +756,29 @@ function DetailInner() {
             {clienteNombre || '(sin nombre)'}
           </h1>
           {proyectoNombre && unidad?.identificador ? (
-            <p className="mt-1 text-sm text-[var(--text)]/60">
+            <p
+              className={`mt-1 text-sm ${
+                venta.estado === 'desasignada'
+                  ? 'text-[var(--text)]/35 line-through decoration-[var(--text)]/35'
+                  : 'text-[var(--text)]/60'
+              }`}
+              title={
+                venta.estado === 'desasignada'
+                  ? 'Unidad liberada — la venta fue desasignada'
+                  : undefined
+              }
+            >
               {proyectoNombre} · {unidad.identificador}
+              {venta.estado === 'desasignada' ? (
+                <span className="ml-2 text-xs not-italic no-underline">(liberada)</span>
+              ) : null}
             </p>
           ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
-          {venta.fase_actual ? (
+          {/* Si la venta está desasignada, NO mostramos el badge de fase —
+              evita el efecto contradictorio "2. Asignada · Desasignada". */}
+          {venta.fase_actual && venta.estado !== 'desasignada' ? (
             <Badge tone="neutral">
               {venta.fase_posicion ? `${venta.fase_posicion}. ` : ''}
               {venta.fase_actual}


### PR DESCRIPTION
## Summary

Tras desasignar la venta fantasma, Beto reportó:
1. Header derecha mostraba "2. Asignada" Y "Desasignada" al mismo tiempo → confuso.
2. La línea "Lomas del Sol · M9-L1-LDS" bajo el nombre seguía como si fuera del cliente.

## Fix UX

- **Badge de fase** ahora se oculta si `estado='desasignada'`. Solo queda "Desasignada" + tipo de crédito.
- **Línea proyecto/unidad** se ve gris claro + tachado + sufijo " (liberada)" + tooltip explícito cuando desasignada.

## Sobre inventario

Investigué: la desasignación SÍ libera operativamente la unidad sin DDL adicional.

- `dilesa.unidades.estado` NO se toca (sigue 'en_construccion' / 'terminada' — reflejan la física, no asignación).
- `v_unidad_hold_queue` filtra por `ventas.estado='activa'` → venta desasignada sale automáticamente.
- Form de venta nueva filtra por estado físico → la unidad sigue apareciendo disponible para nuevas solicitudes (correcto).

**No hay leak de inventario.** La unidad está libre para que otro vendedor la solicite.

## Sobre el email

Beto mencionó que el email "se ve muy diferente a los formatos que hemos estado utilizando". No sé qué vio exactamente. **¿Puedes pegarme un screenshot del email actual?** Si el render se rompió, lo arreglamos en otro PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)