### PR TITLE
feat(emails): branding por empresa desde core.empresas (colores + header_url)

### DIFF
--- a/app/api/cron/dilesa-ventas-expirar/route.ts
+++ b/app/api/cron/dilesa-ventas-expirar/route.ts
@@ -24,6 +24,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { AVISO_HOLD_4H_MS, calcularExpiraAt } from '@/lib/dilesa/hold-cola';
 import { sendHoldEmail, type HoldEmailContext } from '@/lib/dilesa/hold-emails';
+import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -115,7 +116,9 @@ async function buildEmailContext(
     prototipoSufijo = producto?.nombre ? (producto.nombre.split('-').pop() ?? null) : null;
   }
 
+  const branding = await loadEmpresaBranding(sb, venta.empresa_id);
   return {
+    branding,
     ventaId: venta.id,
     empresaId: venta.empresa_id,
     vendedorEmail: usuario?.email ?? null,

--- a/app/api/dilesa/ventas/[id]/notify-hold-creado/route.ts
+++ b/app/api/dilesa/ventas/[id]/notify-hold-creado/route.ts
@@ -26,6 +26,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { sendHoldEmail, type HoldEmailContext } from '@/lib/dilesa/hold-emails';
+import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -137,7 +138,9 @@ export async function POST(_req: NextRequest, ctx: { params: Promise<{ id: strin
     venta.vendedor ||
     null;
 
+  const branding = await loadEmpresaBranding(admin, venta.empresa_id);
   const emailCtx: HoldEmailContext = {
+    branding,
     ventaId: venta.id,
     empresaId: venta.empresa_id,
     vendedorEmail: usuario?.email ?? null,

--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -22,6 +22,7 @@ import { revalidatePath } from 'next/cache';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { sendHoldEmail, type HoldEmailContext } from '@/lib/dilesa/hold-emails';
+import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
 
 const FASES_CANONICAS: Record<number, string> = {
   1: 'Solicitud de Asignación',
@@ -223,7 +224,9 @@ async function buildEmailContext(
     v.vendedor ||
     null;
 
+  const branding = await loadEmpresaBranding(admin, v.empresa_id);
   return {
+    branding,
     ventaId: v.id,
     empresaId: v.empresa_id,
     vendedorEmail: usuario?.email ?? null,

--- a/lib/dilesa/email-branding.test.ts
+++ b/lib/dilesa/email-branding.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { loadEmpresaBranding } from './email-branding';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Mock minimal Supabase client que solo cubre la cadena
+ * `.schema('core').from('empresas').select().eq().maybeSingle()` que usa
+ * `loadEmpresaBranding`. Devuelve la fila configurada o `null`.
+ */
+function mockSupabase(row: Record<string, unknown> | null): SupabaseClient {
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle: () => Promise.resolve({ data: row, error: null }),
+    from: () => chain,
+  };
+  return { schema: () => ({ from: () => chain }) } as unknown as SupabaseClient;
+}
+
+describe('loadEmpresaBranding', () => {
+  it('retorna defaults cuando empresaId es null', async () => {
+    const sb = mockSupabase(null);
+    const b = await loadEmpresaBranding(sb, null);
+    expect(b.empresaId).toBeNull();
+    expect(b.nombreComercial).toBe('BSOP');
+    expect(b.colorPrimario).toMatch(/^#/);
+    expect(b.colorPrimarioDark).toMatch(/^#/);
+  });
+
+  it('retorna defaults con empresaId cuando la empresa no existe', async () => {
+    const sb = mockSupabase(null);
+    const b = await loadEmpresaBranding(sb, 'no-existe');
+    expect(b.empresaId).toBe('no-existe');
+    expect(b.nombreComercial).toBe('BSOP');
+  });
+
+  it('lee colores y nombre comercial de la fila', async () => {
+    const sb = mockSupabase({
+      id: 'dilesa-id',
+      slug: 'dilesa',
+      nombre: 'DILESA',
+      nombre_comercial: 'DILESA',
+      header_url: '/brand/dilesa/header-email.png',
+      color_primario: '#7D812E',
+      color_primario_dark: '#646725',
+      color_secundario: '#4F4C4D',
+      color_texto_titulo: '#1F1F1F',
+      color_fondo_brand: '#FAF7EE',
+      color_inverso: '#FFFFFF',
+    });
+    const b = await loadEmpresaBranding(sb, 'dilesa-id');
+    expect(b.empresaId).toBe('dilesa-id');
+    expect(b.nombreComercial).toBe('DILESA');
+    expect(b.colorPrimario).toBe('#7D812E');
+    expect(b.colorPrimarioDark).toBe('#646725');
+    expect(b.colorSecundario).toBe('#4F4C4D');
+    expect(b.colorTextoTitulo).toBe('#1F1F1F');
+    expect(b.colorFondoBrand).toBe('#FAF7EE');
+    expect(b.colorInverso).toBe('#FFFFFF');
+  });
+
+  it('hidrata contacto del footer desde el mapping por slug (dilesa)', async () => {
+    const sb = mockSupabase({
+      id: 'x',
+      slug: 'dilesa',
+      nombre: 'DILESA',
+      nombre_comercial: null,
+      header_url: null,
+    });
+    const b = await loadEmpresaBranding(sb, 'x');
+    expect(b.sitioWeb).toBe('dilesa.mx');
+    expect(b.telefono).toBe('(878) 791-1818');
+  });
+
+  it('rdb tiene contacto distinto a dilesa', async () => {
+    const sb = mockSupabase({
+      id: 'rdb-id',
+      slug: 'rdb',
+      nombre: 'Rincón del Bosque',
+      nombre_comercial: 'RDB',
+    });
+    const b = await loadEmpresaBranding(sb, 'rdb-id');
+    expect(b.sitioWeb).toBe('deportivorincondelbosque.com');
+    expect(b.telefono).toBe('(878) 782-4111');
+  });
+
+  it('fallback a nombre cuando nombre_comercial es null', async () => {
+    const sb = mockSupabase({
+      id: 'x',
+      slug: 'dilesa',
+      nombre: 'DILESA Inmobiliaria',
+      nombre_comercial: null,
+    });
+    const b = await loadEmpresaBranding(sb, 'x');
+    expect(b.nombreComercial).toBe('DILESA Inmobiliaria');
+  });
+
+  it('fallback de colores cuando faltan en la fila', async () => {
+    const sb = mockSupabase({
+      id: 'x',
+      slug: 'dilesa',
+      nombre: 'X',
+      nombre_comercial: null,
+      color_primario: null,
+      color_secundario: null,
+    });
+    const b = await loadEmpresaBranding(sb, 'x');
+    expect(b.colorPrimario).toMatch(/^#/);
+    expect(b.colorSecundario).toMatch(/^#/);
+  });
+
+  it('headerUrl como http absoluta se preserva tal cual', async () => {
+    const sb = mockSupabase({
+      id: 'x',
+      slug: 'dilesa',
+      nombre: 'DILESA',
+      header_url: 'https://cdn.dilesa.mx/header.png',
+    });
+    const b = await loadEmpresaBranding(sb, 'x');
+    expect(b.headerUrl).toBe('https://cdn.dilesa.mx/header.png');
+  });
+});

--- a/lib/dilesa/email-branding.ts
+++ b/lib/dilesa/email-branding.ts
@@ -1,0 +1,114 @@
+/**
+ * Branding por empresa para emails transaccionales.
+ *
+ * Lee `core.empresas` para obtener header_url, colores y datos de
+ * contacto. Si la empresa no tiene los campos cargados, devuelve
+ * defaults razonables (verde olivo DILESA, sin imagen).
+ *
+ * Diseño: TODOS los emails del repo deberían usar este helper para
+ * mantener consistencia visual entre RDB, DILESA, ANSA, COAGAN.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface EmpresaBranding {
+  empresaId: string | null;
+  nombreComercial: string;
+  /** URL absoluta de la imagen del header (banner top del email). */
+  headerUrl: string | null;
+  /** Color principal de los acentos (header bottom strip, footer band). */
+  colorPrimario: string;
+  /** Variante oscura del primario (bordes, acentos). */
+  colorPrimarioDark: string;
+  /** Color para labels y subtítulos secundarios. */
+  colorSecundario: string;
+  /** Color del texto principal del body. */
+  colorTextoTitulo: string;
+  /** Color del fondo de bloques destacados (motivos, callouts). */
+  colorFondoBrand: string;
+  /** Color para texto sobre fondos oscuros (header/footer). */
+  colorInverso: string;
+  /** Sitio web visible en el footer (sin protocolo). */
+  sitioWeb: string;
+  /** Teléfono visible en el footer. */
+  telefono: string;
+}
+
+/** Defaults para empresas sin branding cargado — verde olivo DILESA. */
+const DEFAULT_BRANDING: Omit<EmpresaBranding, 'empresaId' | 'nombreComercial'> = {
+  headerUrl: null,
+  colorPrimario: '#7D812E',
+  colorPrimarioDark: '#646725',
+  colorSecundario: '#4F4C4D',
+  colorTextoTitulo: '#1F1F1F',
+  colorFondoBrand: '#FAF7EE',
+  colorInverso: '#FFFFFF',
+  sitioWeb: 'bsop.io',
+  telefono: '',
+};
+
+/** Datos de contacto del footer por empresa slug (mientras no haya columna). */
+const FOOTER_DATA_BY_SLUG: Record<string, { sitioWeb: string; telefono: string }> = {
+  dilesa: { sitioWeb: 'dilesa.mx', telefono: '(878) 791-1818' },
+  rdb: { sitioWeb: 'deportivorincondelbosque.com', telefono: '(878) 782-4111' },
+  ansa: { sitioWeb: 'ansa.mx', telefono: '' },
+  coagan: { sitioWeb: '', telefono: '' },
+};
+
+/**
+ * Base pública para servir imágenes de branding subidas al bucket
+ * `brand-assets` (mismo patrón que `lib/juntas/email.ts`). Si la URL
+ * de la empresa empieza con `http(s)://` o `data:`, se devuelve tal cual.
+ */
+const ASSET_BASE_URL = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').replace(/\/+$/, '');
+function resolveAssetUrl(path: string | null | undefined): string | null {
+  if (!path) return null;
+  if (/^(https?:|data:)/.test(path)) return path;
+  if (!ASSET_BASE_URL) return null;
+  const cleaned = path.startsWith('/') ? path : `/${path}`;
+  return `${ASSET_BASE_URL}/storage/v1/object/public/brand-assets${cleaned}`;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any --
+ * supabase-js solo tipa el schema `public` por default; para `core.*`
+ * casteamos. Mismo patrón que `lib/empresas/admin-guard.ts`.
+ */
+export async function loadEmpresaBranding(
+  client: SupabaseClient,
+  empresaId: string | null
+): Promise<EmpresaBranding> {
+  if (!empresaId) {
+    return { ...DEFAULT_BRANDING, empresaId: null, nombreComercial: 'BSOP' };
+  }
+  const { data } = await (client.schema('core') as any)
+    .from('empresas')
+    .select(
+      'id, slug, nombre, nombre_comercial, header_url, color_primario, color_primario_dark, color_secundario, color_texto_titulo, color_fondo_brand, color_inverso'
+    )
+    .eq('id', empresaId)
+    .maybeSingle();
+  if (!data) {
+    return { ...DEFAULT_BRANDING, empresaId, nombreComercial: 'BSOP' };
+  }
+  const slug = (data.slug as string | undefined) ?? '';
+  const footer = FOOTER_DATA_BY_SLUG[slug] ?? {
+    sitioWeb: DEFAULT_BRANDING.sitioWeb,
+    telefono: DEFAULT_BRANDING.telefono,
+  };
+  return {
+    empresaId: data.id as string,
+    nombreComercial:
+      (data.nombre_comercial as string | null)?.trim() || (data.nombre as string) || 'BSOP',
+    headerUrl: resolveAssetUrl(data.header_url as string | null),
+    colorPrimario: (data.color_primario as string | null) ?? DEFAULT_BRANDING.colorPrimario,
+    colorPrimarioDark:
+      (data.color_primario_dark as string | null) ?? DEFAULT_BRANDING.colorPrimarioDark,
+    colorSecundario: (data.color_secundario as string | null) ?? DEFAULT_BRANDING.colorSecundario,
+    colorTextoTitulo:
+      (data.color_texto_titulo as string | null) ?? DEFAULT_BRANDING.colorTextoTitulo,
+    colorFondoBrand: (data.color_fondo_brand as string | null) ?? DEFAULT_BRANDING.colorFondoBrand,
+    colorInverso: (data.color_inverso as string | null) ?? DEFAULT_BRANDING.colorInverso,
+    sitioWeb: footer.sitioWeb,
+    telefono: footer.telefono,
+  };
+}

--- a/lib/dilesa/email-layout.ts
+++ b/lib/dilesa/email-layout.ts
@@ -1,23 +1,26 @@
 /**
- * Layout reusable para los emails transaccionales de DILESA.
+ * Layout reusable para los emails transaccionales de DILESA (y, por
+ * extensión, cualquier empresa BSOP).
  *
- * Replica el diseño de los templates Coda:
- *  - Header band verde olivo con texto "DILESA" + título del documento.
- *  - Fecha alineada a la derecha.
- *  - Cuerpo libre (`bodyHtml`).
- *  - Footer band verde olivo con "DESARROLLO INMOBILIARIO LOS ENCINOS",
- *    sitio web y teléfono.
+ * Toma el branding de la empresa (`EmpresaBranding`) y arma el layout
+ * estándar:
+ *   - Header band con la imagen `header_url` de la empresa (si existe),
+ *     y debajo una barra del color primario con el título centrado.
+ *   - Fecha alineada a la derecha.
+ *   - Cuerpo libre (`bodyHtml`).
+ *   - Footer band con el color primario, nombre comercial, sitio web y
+ *     teléfono.
  *
- * Implementado con tablas + inline CSS porque es el único patrón que
- * renderea consistente en Gmail, Outlook web, Apple Mail e iOS Mail.
- * Nada de Tailwind ni de @media queries fuera del cliente — todo
- * inline para compatibilidad máxima.
+ * Implementado con tablas + inline CSS para compatibilidad con todos
+ * los clientes de email (Gmail, Outlook web, Apple Mail, iOS Mail).
+ * Nada de Tailwind ni de @media queries fuera del cliente.
  */
 
-const VERDE_DILESA = '#7C8A3F';
-const VERDE_DILESA_DARK = '#5E6A2D';
+import type { EmpresaBranding } from './email-branding';
 
 export interface EmailLayoutInput {
+  /** Branding cargado de `core.empresas` (ver `loadEmpresaBranding`). */
+  branding: EmpresaBranding;
   /** Texto grande del header band — ej. "BIENVENIDA", "DESASIGNACIÓN". */
   titulo: string;
   /** Fecha en es-MX, ej. "1 de Junio del 2026". */
@@ -26,7 +29,12 @@ export interface EmailLayoutInput {
   bodyHtml: string;
 }
 
-export function renderEmailLayout({ titulo, fechaTexto, bodyHtml }: EmailLayoutInput): string {
+export function renderEmailLayout({
+  branding,
+  titulo,
+  fechaTexto,
+  bodyHtml,
+}: EmailLayoutInput): string {
   return `<!DOCTYPE html>
 <html lang="es">
 <head>
@@ -34,19 +42,19 @@ export function renderEmailLayout({ titulo, fechaTexto, bodyHtml }: EmailLayoutI
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${escapeHtml(titulo)}</title>
 </head>
-<body style="margin:0; padding:0; background:#f4f4f4; font-family: Arial, Helvetica, sans-serif; color:#333;">
+<body style="margin:0; padding:0; background:#f4f4f4; font-family: Arial, Helvetica, sans-serif; color:${branding.colorTextoTitulo};">
   <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background:#f4f4f4;">
     <tr>
       <td align="center" style="padding: 24px 12px;">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="background:#ffffff; max-width:600px; width:100%;">
-          ${renderHeader(titulo)}
-          ${renderFecha(fechaTexto)}
+          ${renderHeader(branding, titulo)}
+          ${renderFecha(branding, fechaTexto)}
           <tr>
             <td style="padding: 12px 32px 32px;">
               ${bodyHtml}
             </td>
           </tr>
-          ${renderFooter()}
+          ${renderFooter(branding)}
         </table>
       </td>
     </tr>
@@ -55,53 +63,62 @@ export function renderEmailLayout({ titulo, fechaTexto, bodyHtml }: EmailLayoutI
 </html>`.trim();
 }
 
-function renderHeader(titulo: string): string {
-  return `
+function renderHeader(branding: EmpresaBranding, titulo: string): string {
+  // Si hay imagen del header, la usamos a width completo. Debajo va una
+  // barra de color primario con el título centrado para que el operador
+  // identifique de qué tipo de email se trata. Si no hay imagen, fallback
+  // al header de solo barra de color con el nombre comercial.
+  const headerImage = branding.headerUrl
+    ? `
+      <tr>
+        <td style="padding: 0;">
+          <img
+            src="${escapeAttr(branding.headerUrl)}"
+            alt="${escapeAttr(branding.nombreComercial)}"
+            width="600"
+            style="display:block; width:100%; max-width:600px; height:auto;"
+          />
+        </td>
+      </tr>`
+    : `
+      <tr>
+        <td style="background:${branding.colorPrimario}; padding: 24px 32px;">
+          <span style="font-size: 24px; font-weight: 700; letter-spacing: 1.5px; color:${branding.colorInverso}; font-family: Georgia, serif;">${escapeHtml(branding.nombreComercial)}</span>
+        </td>
+      </tr>`;
+
+  return `${headerImage}
     <tr>
-      <td style="background:${VERDE_DILESA}; padding: 20px 32px;">
-        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-          <tr>
-            <td style="vertical-align: middle; width: 100px;">
-              <div style="display:inline-block; background:#ffffff; padding:8px 12px; border-radius:4px; border:2px solid ${VERDE_DILESA_DARK};">
-                <span style="font-size: 22px; font-weight: 700; letter-spacing: 1px; color:${VERDE_DILESA}; font-family: Georgia, serif;">DILESA</span>
-              </div>
-            </td>
-            <td align="right" style="vertical-align: middle;">
-              <h1 style="color:#ffffff; font-size: 28px; font-weight: 700; margin: 0; letter-spacing: 1px;">${escapeHtml(
-                titulo
-              )}</h1>
-            </td>
-          </tr>
-        </table>
+      <td style="background:${branding.colorPrimarioDark}; padding: 12px 32px;">
+        <h1 style="color:${branding.colorInverso}; font-size: 20px; font-weight: 700; margin: 0; letter-spacing: 2px; text-align: center;">${escapeHtml(titulo)}</h1>
       </td>
     </tr>
   `;
 }
 
-function renderFecha(fechaTexto: string): string {
+function renderFecha(branding: EmpresaBranding, fechaTexto: string): string {
   return `
     <tr>
-      <td align="right" style="padding: 16px 32px 0; color: #888; font-size: 13px;">
+      <td align="right" style="padding: 16px 32px 0; color: ${branding.colorSecundario}; font-size: 13px;">
         ${escapeHtml(fechaTexto)}
       </td>
     </tr>
   `;
 }
 
-function renderFooter(): string {
+function renderFooter(branding: EmpresaBranding): string {
+  const contactoLine = [branding.sitioWeb, branding.telefono].filter(Boolean).join(' · ');
   return `
     <tr>
-      <td style="background:${VERDE_DILESA}; padding: 20px 32px;">
+      <td style="background:${branding.colorPrimario}; padding: 20px 32px;">
         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
           <tr>
-            <td style="color:#ffffff; font-size: 13px; vertical-align: middle;">
-              <strong style="font-size: 15px; letter-spacing: 0.5px;">DESARROLLO INMOBILIARIO LOS ENCINOS</strong><br/>
-              <span style="opacity: 0.95;">dilesa.mx &nbsp;&middot;&nbsp; (878) 791-1818</span>
-            </td>
-            <td align="right" style="vertical-align: middle; width: 100px;">
-              <div style="display:inline-block; background:#ffffff; padding:6px 10px; border-radius:4px; border:2px solid ${VERDE_DILESA_DARK};">
-                <span style="font-size: 16px; font-weight: 700; letter-spacing: 1px; color:${VERDE_DILESA}; font-family: Georgia, serif;">DILESA</span>
-              </div>
+            <td style="color:${branding.colorInverso}; font-size: 13px; vertical-align: middle;">
+              <strong style="font-size: 15px; letter-spacing: 0.5px;">${escapeHtml(branding.nombreComercial)}</strong>${
+                contactoLine
+                  ? `<br/><span style="opacity: 0.95;">${escapeHtml(contactoLine)}</span>`
+                  : ''
+              }
             </td>
           </tr>
         </table>
@@ -115,20 +132,21 @@ function renderFooter(): string {
  * pares label/value en formato tabla (compat email clients).
  */
 export interface SeccionDatos {
+  branding: EmpresaBranding;
   titulo: string;
   filas: Array<{ label: string; value: string | null | undefined }>;
 }
 
-export function renderSeccionDatos({ titulo, filas }: SeccionDatos): string {
+export function renderSeccionDatos({ branding, titulo, filas }: SeccionDatos): string {
   const filasHtml = filas
     .filter((f) => f.value != null && f.value !== '')
     .map(
       (f) => `
         <tr>
-          <td style="padding: 4px 0; color: ${VERDE_DILESA_DARK}; font-weight: 600; font-size: 13px; letter-spacing: 0.5px; vertical-align: top; white-space: nowrap;">
+          <td style="padding: 4px 0; color: ${branding.colorPrimarioDark}; font-weight: 600; font-size: 13px; letter-spacing: 0.5px; vertical-align: top; white-space: nowrap;">
             ${escapeHtml(f.label)}:
           </td>
-          <td style="padding: 4px 0 4px 12px; color: #333; font-weight: 600; font-size: 14px;">
+          <td style="padding: 4px 0 4px 12px; color: ${branding.colorTextoTitulo}; font-weight: 600; font-size: 14px;">
             ${escapeHtml(String(f.value))}
           </td>
         </tr>
@@ -137,7 +155,7 @@ export function renderSeccionDatos({ titulo, filas }: SeccionDatos): string {
     .join('');
 
   return `
-    <h2 style="color: ${VERDE_DILESA_DARK}; font-size: 14px; font-weight: 700; letter-spacing: 1.5px; margin: 16px 0 8px; text-transform: uppercase;">
+    <h2 style="color: ${branding.colorPrimarioDark}; font-size: 14px; font-weight: 700; letter-spacing: 1.5px; margin: 16px 0 8px; text-transform: uppercase;">
       ${escapeHtml(titulo)}
     </h2>
     <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
@@ -150,10 +168,24 @@ export function renderSeccionDatos({ titulo, filas }: SeccionDatos): string {
  * Pill / chip estilo Coda — fondo gris claro con borde y texto monospaced.
  * Útil para identificadores de inventario (M11-L19-LDLE-ISC).
  */
-export function pillIdentificador(value: string): string {
-  return `<span style="display:inline-block; background:#f5f5f0; border:1px solid #d4d4c8; padding:2px 8px; border-radius:3px; font-family:'Courier New', monospace; font-size: 13px; font-weight: 600; color: #333;">${escapeHtml(
+export function pillIdentificador(branding: EmpresaBranding, value: string): string {
+  return `<span style="display:inline-block; background:${branding.colorFondoBrand}; border:1px solid ${branding.colorPrimario}; padding:2px 8px; border-radius:3px; font-family:'Courier New', monospace; font-size: 13px; font-weight: 600; color: ${branding.colorTextoTitulo};">${escapeHtml(
     value
   )}</span>`;
+}
+
+/**
+ * Bloque destacado para el motivo de desasignación / cancelación.
+ */
+export function renderMotivoBloque(branding: EmpresaBranding, motivo: string): string {
+  return `
+    <h2 style="color: ${branding.colorPrimarioDark}; font-size: 14px; font-weight: 700; letter-spacing: 1.5px; margin: 20px 0 8px; text-transform: uppercase;">
+      Motivo de desasignación
+    </h2>
+    <p style="margin: 4px 0 16px; padding: 12px; background: ${branding.colorFondoBrand}; border-left: 4px solid ${branding.colorPrimario}; font-size: 14px; color: ${branding.colorTextoTitulo};">
+      ${escapeHtml(motivo)}
+    </p>
+  `;
 }
 
 export function escapeHtml(s: string): string {
@@ -163,4 +195,8 @@ export function escapeHtml(s: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+function escapeAttr(s: string): string {
+  return escapeHtml(s);
 }

--- a/lib/dilesa/hold-emails.ts
+++ b/lib/dilesa/hold-emails.ts
@@ -29,8 +29,10 @@ import {
   renderEmailLayout,
   renderSeccionDatos,
   pillIdentificador,
+  renderMotivoBloque,
   escapeHtml,
 } from './email-layout';
+import type { EmpresaBranding } from './email-branding';
 
 /**
  * `From` para Resend. Usa `noreply@bsop.io` porque es el dominio que el
@@ -68,6 +70,8 @@ export interface HoldEmailContext {
   faltantes?: string[];
   /** Motivo de la desasignación (solo aplica para evento `desasignada`). */
   motivo?: string | null;
+  /** Branding de la empresa para el layout del email. */
+  branding: EmpresaBranding;
 }
 
 interface SendResult {
@@ -137,6 +141,7 @@ function fechaTextoMx(): string {
 
 function seccionDatosVivienda(ctx: HoldEmailContext, tituloSeccion: string): string {
   return renderSeccionDatos({
+    branding: ctx.branding,
     titulo: tituloSeccion,
     filas: [
       { label: 'FRACCIONAMIENTO', value: ctx.proyectoNombre || null },
@@ -173,7 +178,7 @@ function renderTemplate(
         <p style="font-size: 15px;">Hola <b>${escapeHtml(ctx.clienteNombre)}</b>,</p>
         <p>En DILESA estamos felices de acompañarte en el proceso de compra de tu nueva vivienda.
            Te damos la bienvenida y te confirmamos que se registró tu <b>solicitud de asignación</b>
-           para la unidad ${pillIdentificador(ctx.unidadIdentificador)}.</p>
+           para la unidad ${pillIdentificador(ctx.branding, ctx.unidadIdentificador)}.</p>
         ${seccionDatosVivienda(ctx, 'Datos de la vivienda apartada')}
         <p style="margin-top: 20px;">A partir de hoy te <b>llevaremos de la mano</b> paso a paso por todo el proceso —
            desde la firma del contrato de promesa, el avalúo del banco, la dictaminación del
@@ -192,13 +197,18 @@ function renderTemplate(
       `.trim();
       return {
         subject: `Bienvenido a DILESA — Tu solicitud por ${ref}`,
-        html: renderEmailLayout({ titulo: 'BIENVENIDA', fechaTexto: fecha, bodyHtml: body }),
+        html: renderEmailLayout({
+          branding: ctx.branding,
+          titulo: 'BIENVENIDA',
+          fechaTexto: fecha,
+          bodyHtml: body,
+        }),
       };
     }
     case 'hold_promovido': {
       const body = `
         <p style="font-size: 15px;">Estimad@ <b>${escapeHtml(ctx.clienteNombre)}</b>,</p>
-        <p>La solicitud anterior para la unidad ${pillIdentificador(ctx.unidadIdentificador)}
+        <p>La solicitud anterior para la unidad ${pillIdentificador(ctx.branding, ctx.unidadIdentificador)}
            expiró sin completar expediente. Tu solicitud sube a <b>líder de la fila</b>.</p>
         ${seccionDatosVivienda(ctx, 'Datos de la vivienda apartada')}
         <p style="margin-top: 20px;">Tienes hasta <b>${escapeHtml(fechaDeadline ?? 'el plazo definido')}</b>
@@ -212,6 +222,7 @@ function renderTemplate(
       return {
         subject: `Subes a líder de la fila — ${ref}`,
         html: renderEmailLayout({
+          branding: ctx.branding,
           titulo: 'NUEVO LÍDER DE LA FILA',
           fechaTexto: fecha,
           bodyHtml: body,
@@ -221,7 +232,7 @@ function renderTemplate(
     case 'hold_4h_warning': {
       const body = `
         <p style="font-size: 15px;">Estimad@ <b>${escapeHtml(ctx.clienteNombre)}</b>,</p>
-        <p>El apartado de tu unidad ${pillIdentificador(ctx.unidadIdentificador)}
+        <p>El apartado de tu unidad ${pillIdentificador(ctx.branding, ctx.unidadIdentificador)}
            <b>expira en menos de 4 horas</b> (${escapeHtml(fechaDeadline ?? 'pronto')}).</p>
         ${seccionDatosVivienda(ctx, 'Datos de la vivienda apartada')}
         <p style="margin-top: 20px;">Si no completas el expediente antes de esa hora, el apartado pasa
@@ -234,6 +245,7 @@ function renderTemplate(
       return {
         subject: `Tu apartado expira en menos de 4 horas — ${ref}`,
         html: renderEmailLayout({
+          branding: ctx.branding,
           titulo: 'EXPIRACIÓN PRÓXIMA',
           fechaTexto: fecha,
           bodyHtml: body,
@@ -243,7 +255,7 @@ function renderTemplate(
     case 'hold_expirada': {
       const body = `
         <p style="font-size: 15px;">Estimad@ <b>${escapeHtml(ctx.clienteNombre)}</b>,</p>
-        <p>El apartado de la unidad ${pillIdentificador(ctx.unidadIdentificador)} expiró porque el
+        <p>El apartado de la unidad ${pillIdentificador(ctx.branding, ctx.unidadIdentificador)} expiró porque el
            expediente no quedó completo en el plazo de 2 días hábiles.</p>
         ${seccionDatosVivienda(ctx, 'Datos de la vivienda apartada')}
         <p style="margin-top: 20px;">La unidad pasó a la siguiente persona en la fila. Si sigues
@@ -255,6 +267,7 @@ function renderTemplate(
       return {
         subject: `Apartado expirado — ${ref}`,
         html: renderEmailLayout({
+          branding: ctx.branding,
           titulo: 'APARTADO EXPIRADO',
           fechaTexto: fecha,
           bodyHtml: body,
@@ -262,15 +275,7 @@ function renderTemplate(
       };
     }
     case 'desasignada': {
-      const motivoBloque = ctx.motivo
-        ? `
-          <h2 style="color: #5E6A2D; font-size: 14px; font-weight: 700; letter-spacing: 1.5px; margin: 20px 0 8px; text-transform: uppercase;">
-            Motivo de desasignación
-          </h2>
-          <p style="margin: 4px 0 16px; padding: 12px; background: #f5f5f0; border-left: 4px solid #7C8A3F; font-size: 14px;">
-            ${escapeHtml(ctx.motivo)}
-          </p>`
-        : '';
+      const motivoBloque = ctx.motivo ? renderMotivoBloque(ctx.branding, ctx.motivo) : '';
       const body = `
         <p style="font-size: 15px;">ESTIMAD@ <b>${escapeHtml(ctx.clienteNombre)}</b>,</p>
         <p>Por medio del presente le informamos que nos vimos en la necesidad de desasignar la
@@ -286,6 +291,7 @@ function renderTemplate(
       return {
         subject: `Desasignación de la unidad ${ref}`,
         html: renderEmailLayout({
+          branding: ctx.branding,
           titulo: 'DESASIGNACIÓN',
           fechaTexto: fecha,
           bodyHtml: body,


### PR DESCRIPTION
## Summary

Beto: _"hay que utilizar los datos de branding que tenemos en empresas, creo ya los habias estado utilizando para otros correos. Revisa los otros correos que ya tenemos y tal vez es momento para estandarizar"_.

Los emails del hold inventaban el color verde hardcoded. Este PR los unifica para que lean del branding de `core.empresas` (lo mismo que ya hace `lib/juntas/email.ts`).

## Helper nuevo `lib/dilesa/email-branding.ts`

`loadEmpresaBranding(client, empresaId)` lee `core.empresas` y devuelve:
- `headerUrl` (imagen real del banner — resuelto a URL pública de Supabase Storage)
- 6 colores brand (`color_primario`, `color_primario_dark`, `color_secundario`, `color_texto_titulo`, `color_fondo_brand`, `color_inverso`)
- `nombreComercial`, `sitioWeb`, `telefono`

Con fallbacks razonables si la empresa no tiene el campo.

## Layout refactor

- Header: imagen del `header_url` full-width arriba + barra de `colorPrimarioDark` con el título.
- Footer: `colorPrimario` + nombre comercial + dilesa.mx + (878) 791-1818.
- Pills, secciones de datos, bloques de motivo — todo usa los colores del branding.

## Test plan

- [ ] Hard refresh tu fantasma → "Desasignar venta…" → motivo → confirmar.
- [ ] Email "DESASIGNACIÓN" llega con la imagen real del header `/brand/dilesa/header-email.png` en lugar del texto Georgia que armé yo.
- [ ] Colores del header/footer son los olivos reales (#7D812E / #646725) de DILESA, no los inventados.

## Out of scope

- Refactorizar `lib/juntas/email.ts` para usar el mismo helper. Por ahora coexisten.
- Columnas `email_footer_url`, `email_telefono`, `email_sitio_web` en `core.empresas` (hardcoded por slug por ahora).

🤖 Generated with [Claude Code](https://claude.com/claude-code)