### PR TITLE
fix(dilesa-ventas): pulir flujo venta desasignada (4 mejoras)

### DIFF
--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -394,7 +394,7 @@ async function desasignarVentaInner(ventaId: string, motivo: string): Promise<Ac
   const { data: v } = await admin
     .schema('dilesa')
     .from('ventas')
-    .select('id, estado, notas')
+    .select('id, estado, notas, unidad_id')
     .eq('id', ventaId)
     .maybeSingle();
   if (!v) return { ok: false, error: 'Venta no encontrada' };
@@ -402,8 +402,34 @@ async function desasignarVentaInner(ventaId: string, motivo: string): Promise<Ac
     return { ok: false, error: 'La venta ya está desasignada.' };
   }
 
+  // Resolver identificador de unidad + proyecto para incluir en la nota
+  // y dar trazabilidad de qué inventario se liberó.
+  let inventarioDesc = '';
+  if (v.unidad_id) {
+    const { data: u } = await admin
+      .schema('dilesa')
+      .from('unidades')
+      .select('identificador, proyecto_id')
+      .eq('id', v.unidad_id)
+      .maybeSingle();
+    if (u) {
+      let proyectoNombre = '';
+      if (u.proyecto_id) {
+        const { data: p } = await admin
+          .schema('dilesa')
+          .from('proyectos')
+          .select('nombre')
+          .eq('id', u.proyecto_id)
+          .maybeSingle();
+        proyectoNombre = p?.nombre ?? '';
+      }
+      inventarioDesc = [proyectoNombre, u.identificador].filter(Boolean).join(' · ');
+    }
+  }
+
   const ahora = new Date().toISOString();
-  const notaDesasignacion = `[${ahora}] Desasignada por motivo: ${motivoTrim}`;
+  const inventarioPart = inventarioDesc ? ` (${inventarioDesc})` : '';
+  const notaDesasignacion = `[${ahora}] Desasignada del inventario${inventarioPart} por motivo: ${motivoTrim}`;
   const notasNuevas = v.notas ? `${v.notas}\n${notaDesasignacion}` : notaDesasignacion;
 
   const { error: upErr } = await admin

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -629,7 +629,10 @@ function DetailInner() {
       const slugCaptura = CAPTURAR_SLUG_BY_POSICION[pos];
       const previaCerrada = pos === 1 || posicionesAlcanzadas.has(pos - 1);
       const alcanzada = !!f?.fecha;
-      const puedeCapturar = !!slugCaptura && !alcanzada && previaCerrada;
+      // Si la venta ya está desasignada, el pipeline queda como histórico
+      // — el operador no puede avanzar fases. La unidad está liberada.
+      const desasignada = venta?.estado === 'desasignada';
+      const puedeCapturar = !!slugCaptura && !alcanzada && previaCerrada && !desasignada;
       return {
         pos,
         nombre,
@@ -642,7 +645,7 @@ function DetailInner() {
         previaCerrada,
       };
     });
-  }, [fases, adjuntosPorRolMap]);
+  }, [fases, adjuntosPorRolMap, venta?.estado]);
 
   const pipelineAlcanzadas = useMemo(
     () => pipelineRows.filter((r) => r.alcanzada).length,
@@ -814,6 +817,7 @@ function DetailInner() {
         ventaId={venta.id}
         estado={venta.estado}
         fasePosicion={venta.fase_posicion}
+        personaId={venta.persona_id}
       />
 
       <Section title="Datos del cliente">
@@ -1511,10 +1515,12 @@ function MovimientosAdministrativos({
   ventaId,
   estado,
   fasePosicion,
+  personaId,
 }: {
   ventaId: string;
   estado: string;
   fasePosicion: number | null;
+  personaId: string;
 }) {
   const { permissions } = usePermissions();
   const toast = useToast();
@@ -1525,6 +1531,21 @@ function MovimientosAdministrativos({
   const puedeAutorizar =
     permissions.isAdmin || permissions.modulos.get('dilesa.ventas.autorizar')?.write === true;
   if (!puedeAutorizar) return null;
+
+  // Si está desasignada, ofrecemos crear una nueva solicitud para el
+  // mismo cliente con otra unidad — caso de uso operativo común.
+  if (estado === 'desasignada') {
+    return (
+      <div className="flex flex-wrap gap-2">
+        <Link
+          href={`/dilesa/ventas/nueva?persona=${personaId}`}
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--accent)] bg-[var(--accent)]/10 px-3 py-1.5 text-sm font-medium text-[var(--accent)] hover:bg-[var(--accent)]/20"
+        >
+          + Crear nueva solicitud para este cliente
+        </Link>
+      </div>
+    );
+  }
   if (estado !== 'activa') return null;
   const pos = fasePosicion ?? 0;
 

--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -145,9 +145,14 @@ function NuevaSolicitudForm() {
   // La fecha + hora de la solicitud la setea el servidor al guardar (now()).
   // Importante para orden FIFO en Fase 2 cuando hay inventario limitado.
 
-  // Cliente: modo (existente o nuevo)
-  const [clienteModo, setClienteModo] = useState<'existente' | 'nuevo'>('nuevo');
-  const [personaIdSeleccionada, setPersonaIdSeleccionada] = useState<string>('');
+  // Cliente: modo (existente o nuevo). Si llega `?persona=<id>` en la URL
+  // (caso típico: reasignar tras desasignación), arrancamos con cliente
+  // existente y ese persona_id pre-seleccionado.
+  const personaIdFromUrl = searchParams.get('persona') ?? '';
+  const [clienteModo, setClienteModo] = useState<'existente' | 'nuevo'>(
+    personaIdFromUrl ? 'existente' : 'nuevo'
+  );
+  const [personaIdSeleccionada, setPersonaIdSeleccionada] = useState<string>(personaIdFromUrl);
   const [busquedaPersona, setBusquedaPersona] = useState('');
 
   // Cliente nuevo — KYC completo (Sprint 7c-2: todo en Fase 1, no se difiere).

--- a/components/dilesa/ventas-module.tsx
+++ b/components/dilesa/ventas-module.tsx
@@ -334,9 +334,17 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
       key: 'fase_actual',
       label: 'Fase',
       type: 'custom',
-      accessor: (v) => v.fase_posicion ?? 0,
+      accessor: (v) => (v.estado === 'desasignada' ? -1 : (v.fase_posicion ?? 0)),
       render: (v) =>
-        v.fase_actual ? <Badge tone="neutral">{v.fase_actual}</Badge> : <span>—</span>,
+        // Si la venta está desasignada, no mostramos la fase — evita el
+        // efecto contradictorio "Asignada + Desasignada" que Beto reportó.
+        v.estado === 'desasignada' ? (
+          <span className="text-[var(--text)]/30">—</span>
+        ) : v.fase_actual ? (
+          <Badge tone="neutral">{v.fase_actual}</Badge>
+        ) : (
+          <span>—</span>
+        ),
     },
     { key: 'precio', label: 'Precio', type: 'currency' },
     {


### PR DESCRIPTION
## Summary

Beto reportó 4 issues tras desasignar fantasma. Este PR los resuelve.

| # | Issue | Fix |
|---|---|---|
| 1 | Tabla principal mostraba fase "Asignada" cuando ya está desasignada | Columna "Fase" renderiza "—" gris cuando `estado='desasignada'` |
| 2 | Notas no incluyen el inventario que se liberó | Nota ahora dice `"Desasignada del inventario (Lomas del Sol · M9-L1-LDS) por motivo: ..."` |
| 3 | Pipeline mostraba botón "Capturar fase" en venta desasignada | `puedeCapturar` ahora chequea `!desasignada` — el botón desaparece, queda como histórico read-only |
| 4 | No había forma de reasignar el mismo cliente a otra unidad | Botón "+ Crear nueva solicitud para este cliente" cuando desasignada → linkea a `/dilesa/ventas/nueva?persona=<id>`. El form lee el query param y arranca con cliente existente pre-seleccionado |

## Test plan

- [ ] Hard refresh `/dilesa/ventas` → la fantasma desasignada muestra "—" en columna Fase (no "Asignada").
- [ ] Detalle de la venta → sección "Notas" incluye el identificador de inventario.
- [ ] Pipeline en el detalle no muestra botón "Capturar fase" para Fase 3.
- [ ] Botón "+ Crear nueva solicitud para este cliente" visible → click → form de nueva con clienteModo "Existente" y persona pre-seleccionada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)