### PR TITLE
fix(dilesa-ventas): liberar unidad al desasignar (estado asignada → terminada)

### DIFF
--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -443,6 +443,31 @@ async function desasignarVentaInner(ventaId: string, motivo: string): Promise<Ac
     .eq('id', ventaId);
   if (upErr) return { ok: false, error: upErr.message };
 
+  // Liberar la unidad: cuando se autoriza Fase 2 (Asignada), la unidad
+  // pasa a estado='asignada'. Al desasignar, debemos regresarla a
+  // 'terminada' para que vuelva a aparecer en el form de nueva venta
+  // (que filtra por `estado IN ('en_construccion','terminada')`).
+  //
+  // Solo tocamos si el estado actual es 'asignada' — estados posteriores
+  // (escriturada, entregada) no se revierten porque implican que el
+  // proceso siguió avanzando antes del desasignar (caso operativo raro,
+  // pero Dirección puede manejarlo manual).
+  if (v.unidad_id) {
+    const { data: unidadActual } = await admin
+      .schema('dilesa')
+      .from('unidades')
+      .select('estado')
+      .eq('id', v.unidad_id)
+      .maybeSingle();
+    if (unidadActual?.estado === 'asignada') {
+      await admin
+        .schema('dilesa')
+        .from('unidades')
+        .update({ estado: 'terminada' })
+        .eq('id', v.unidad_id);
+    }
+  }
+
   // Email al cliente + vendedor.
   let emailSent = false;
   let emailSentTo: string[] = [];


### PR DESCRIPTION
## Summary

Beto: tras desasignar fantasma, intentó crear nueva solicitud, eligió Lomas del Sol y la unidad M9-L1-LDS **no aparecía disponible**.

**Causa raíz:** al autorizar Fase 2 (Asignada), `dilesa.unidades.estado` pasa de `'terminada'` a `'asignada'`. Mi `desasignarVenta` no regresaba el estado físico de la unidad — solo el de la venta. El form de venta nueva filtra por `estado IN ('en_construccion','terminada')` → unidad atascada.

## Fix

- `desasignarVenta` ahora verifica el estado actual de la unidad y si está en `'asignada'` la regresa a `'terminada'`.
- Estados posteriores (`escriturada`, `entregada`) NO se revierten porque implican que el proceso avanzó más allá de la asignación.
- Backfill DB: M9-L1-LDS liberada por UPDATE puntual aprobado por classifier.

## Pendiente — 7 unidades históricas en el mismo limbo

Detectadas durante la investigación:
M10-L25-LDLE, M10-L27-LDLE, M11-L19-LDLE, M12-L29-LDLE, M22-L3-LDLE, M3-L2-LDLE, M4-L29-LDLE.

Todas con venta `desasignada` pero unidad atascada en `'asignada'`. Esperan OK explícito de Beto para `UPDATE` masivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)