### PR TITLE
fix(dilesa-ventas): feedback visual de cliente preseleccionado en venta nueva

### DIFF
--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -307,6 +307,31 @@ function NuevaSolicitudForm() {
     }
   }, [searchParams, unidades, unidadId]);
 
+  // Pre-popular la búsqueda con el apellido del cliente preseleccionado
+  // desde `?persona=<id>` para que la lista filtre a 1-2 coincidencias y el
+  // highlight de selección quede visible sin scroll. Caso típico: usuario
+  // viene de una venta desasignada y reasigna al mismo cliente.
+  useEffect(() => {
+    if (!personaIdFromUrl || personasExistentes.length === 0) return;
+    const p = personasExistentes.find((x) => x.id === personaIdFromUrl);
+    if (p && !busquedaPersona) {
+      const seed = p.apellido_paterno?.trim() || p.nombre?.trim() || '';
+      if (seed) setBusquedaPersona(seed);
+    }
+    // Solo corre una vez cuando se carga el catálogo — no re-disparar si
+    // Beto edita la búsqueda manualmente.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [personaIdFromUrl, personasExistentes]);
+
+  // Datos de la persona seleccionada (para chip de confirmación visual).
+  const personaSeleccionadaInfo = useMemo(
+    () =>
+      personaIdSeleccionada
+        ? (personasExistentes.find((p) => p.id === personaIdSeleccionada) ?? null)
+        : null,
+    [personaIdSeleccionada, personasExistentes]
+  );
+
   // ── Recalcular precio cuando cambian inputs ─────────────────────────────────
   useEffect(() => {
     if (!unidadId) {
@@ -706,6 +731,39 @@ function NuevaSolicitudForm() {
 
         {clienteModo === 'existente' ? (
           <div className="mt-4 space-y-3">
+            {personaSeleccionadaInfo ? (
+              <div className="flex items-start justify-between gap-3 rounded-md border border-[var(--accent)]/40 bg-[var(--accent)]/10 px-3 py-2 text-sm">
+                <div className="min-w-0">
+                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Cliente seleccionado
+                  </div>
+                  <div className="font-medium">
+                    {[
+                      personaSeleccionadaInfo.nombre,
+                      personaSeleccionadaInfo.apellido_paterno,
+                      personaSeleccionadaInfo.apellido_materno,
+                    ]
+                      .filter(Boolean)
+                      .join(' ') || '(sin nombre)'}
+                  </div>
+                  {personaSeleccionadaInfo.curp ? (
+                    <div className="font-mono text-xs text-muted-foreground">
+                      {personaSeleccionadaInfo.curp}
+                    </div>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPersonaIdSeleccionada('');
+                    setBusquedaPersona('');
+                  }}
+                  className="shrink-0 text-xs text-muted-foreground underline hover:text-foreground"
+                >
+                  Cambiar
+                </button>
+              </div>
+            ) : null}
             <Input
               placeholder="Buscar por nombre, apellido o CURP…"
               value={busquedaPersona}


### PR DESCRIPTION
## Problema

Cuando Beto usa "+ Crear nueva solicitud para este cliente" desde una venta desasignada, el navegador llega a `/dilesa/ventas/nueva?persona=<id>` y el código preseleccionaba el `clienteModo='existente'` + `personaIdSeleccionada=<id>` en el estado. Pero la lista de personas tiene miles de elementos en un `max-h-64 overflow-auto`, por lo que el highlight de selección quedaba scrolled out — visualmente parecía que ningún cliente estaba seleccionado.

## Cambios

1. **Banner visual arriba del buscador** con el nombre + CURP del cliente seleccionado y botón "Cambiar" para limpiarlo. Aplica tanto al caso de `?persona=<id>` como cuando Beto selecciona manualmente de la lista — confirmación clara en ambos casos.
2. **Pre-popular `busquedaPersona`** con el `apellido_paterno` (o `nombre` como fallback) del cliente preseleccionado al cargar el catálogo. La lista filtra a 1-2 coincidencias y el item con highlight queda visible al instante sin scroll.

El useEffect que pre-popula la búsqueda solo corre una vez (al cargar el catálogo) — si Beto edita la búsqueda manualmente después, no se sobreescribe.

## UI — sin auto-merge

Cambio puramente visual del form de captura. Dejo el PR abierto sin auto-merge para que revises en preview antes de mergear.

## Test plan

- [ ] Desasignar una venta → "Crear nueva solicitud para este cliente"
- [ ] Verificar que aparece banner "Cliente seleccionado: Nombre Apellido (CURP)" arriba del buscador
- [ ] Verificar que la búsqueda viene pre-poblada con el apellido y la lista muestra al cliente con highlight
- [ ] Clic en "Cambiar" → limpia selección + búsqueda
- [ ] Seleccionar otro cliente desde la lista → banner se actualiza con el nuevo nombre

🤖 Generated with [Claude Code](https://claude.com/claude-code)