### PR TITLE
fix(emails): resolver header_url contra bsop.io (no bucket Supabase inexistente)

### DIFF
--- a/lib/dilesa/email-branding.test.ts
+++ b/lib/dilesa/email-branding.test.ts
@@ -119,4 +119,26 @@ describe('loadEmpresaBranding', () => {
     const b = await loadEmpresaBranding(sb, 'x');
     expect(b.headerUrl).toBe('https://cdn.dilesa.mx/header.png');
   });
+
+  it('headerUrl relativa se resuelve contra el dominio de prod (Next public/)', async () => {
+    const sb = mockSupabase({
+      id: 'x',
+      slug: 'dilesa',
+      nombre: 'DILESA',
+      header_url: '/brand/dilesa/header-email.png',
+    });
+    const b = await loadEmpresaBranding(sb, 'x');
+    expect(b.headerUrl).toBe('https://bsop.io/brand/dilesa/header-email.png');
+  });
+
+  it('headerUrl sin slash inicial se normaliza con uno', async () => {
+    const sb = mockSupabase({
+      id: 'x',
+      slug: 'dilesa',
+      nombre: 'DILESA',
+      header_url: 'brand/dilesa/header-email.png',
+    });
+    const b = await loadEmpresaBranding(sb, 'x');
+    expect(b.headerUrl).toBe('https://bsop.io/brand/dilesa/header-email.png');
+  });
 });

--- a/lib/dilesa/email-branding.ts
+++ b/lib/dilesa/email-branding.ts
@@ -56,17 +56,23 @@ const FOOTER_DATA_BY_SLUG: Record<string, { sitioWeb: string; telefono: string }
 };
 
 /**
- * Base pública para servir imágenes de branding subidas al bucket
- * `brand-assets` (mismo patrón que `lib/juntas/email.ts`). Si la URL
- * de la empresa empieza con `http(s)://` o `data:`, se devuelve tal cual.
+ * Base pública para servir imágenes de branding. Los headers viven en
+ * `public/brand/<empresa>/header-email.png` y se sirven como asset
+ * estático de Next.js bajo el dominio de producción (mismo patrón que
+ * `lib/juntas/email.ts`). Si la URL en `core.empresas.header_url` ya
+ * empieza con `http(s)://` o `data:`, se devuelve tal cual.
+ *
+ * Hardcodeamos el dominio de prod porque los emails se envían siempre
+ * desde el deployment de producción — usar `NEXT_PUBLIC_SITE_URL` haría
+ * que previews de Vercel mandaran links a sí mismas (URLs efímeras que
+ * mueren al expirar el preview).
  */
-const ASSET_BASE_URL = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').replace(/\/+$/, '');
+const ASSET_BASE_URL = 'https://bsop.io';
 function resolveAssetUrl(path: string | null | undefined): string | null {
   if (!path) return null;
   if (/^(https?:|data:)/.test(path)) return path;
-  if (!ASSET_BASE_URL) return null;
   const cleaned = path.startsWith('/') ? path : `/${path}`;
-  return `${ASSET_BASE_URL}/storage/v1/object/public/brand-assets${cleaned}`;
+  return `${ASSET_BASE_URL}${cleaned}`;
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any --


### PR DESCRIPTION
## Problema

El email "Bienvenido a DILESA" llega con la imagen del header rota. La columna \`core.empresas.header_url\` para DILESA tiene \`/brand/dilesa/header-email.png\`, y \`lib/dilesa/email-branding.ts#resolveAssetUrl\` la estaba prefijando con:

\`\`\`
https://<supabase>.supabase.co/storage/v1/object/public/brand-assets/brand/dilesa/header-email.png
\`\`\`

Pero el bucket \`brand-assets\` **no existe** en este proyecto Supabase — solo está \`adjuntos\`. La imagen real vive en \`public/brand/dilesa/header-email.png\` y se sirve como asset estático de Next.js bajo el dominio de producción.

## Fix

Cambio \`ASSET_BASE_URL\` a \`https://bsop.io\` (hardcoded), siguiendo el mismo patrón que ya tiene \`lib/juntas/email.ts\`. Resultado:

\`\`\`
/brand/dilesa/header-email.png → https://bsop.io/brand/dilesa/header-email.png
\`\`\`

No uso \`NEXT_PUBLIC_SITE_URL\` porque los emails se mandan siempre desde el deployment de producción — usar el env haría que un email de un preview de Vercel apuntara a URLs efímeras que mueren cuando el preview expira.

## Impacto

Cubre los 5 emails que pasan por este helper:
- \`hold_creado\` (bienvenida)
- \`hold_promovido\`
- \`hold_4h_warning\`
- \`hold_expirada\`
- \`desasignada\`

## Tests

- ✅ \`headerUrl\` http absoluta se preserva tal cual (test existente)
- ✅ \`headerUrl\` relativa se resuelve contra \`https://bsop.io\` (test nuevo)
- ✅ \`headerUrl\` sin slash inicial se normaliza con uno (test nuevo)

## Auto-merge

Fix de backend (lib helper), no requiere revisar preview visual. Activo auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)