### PR TITLE
feat(sanren-peptides): Sprint 5 (parcial) — Notas curadas del doc/wiki + GLP-1 enriquecidos

### DIFF
--- a/docs/planning/sanren-peptides.md
+++ b/docs/planning/sanren-peptides.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-06-03
-**Última actualización:** 2026-06-03 (promovida a `in_progress`; Sprint 0 — planning doc + fila en INITIATIVES)
+**Última actualización:** 2026-06-04 (Sprints 1-5 entregados — módulo en prod con score de vendor + bitácora + 12 notas curadas; **próximo:** digest del Telegram cuando Beto pase el export)
 
 ## Problema
 
@@ -185,6 +185,18 @@ Semax + 13 tomas) vía las server actions de `app/health/actions.ts`.
   export del Telegram entró en cooldown de 24h. Alcance v1 cerrado con D1+D2+D3.
   Confirmado por Explore: SANREN gatea por empresa (sin `core.modulos`), y la UI
   debe leer server-side con service-role (RLS deny-all) + filtrar client-side.
+- **2026-06-04** — Sprints 1-5 entregados. PR #674 mergeado: schema `peptides`
+  (5 tablas) en prod + importer de las 3 sheets (1,441 COAs / 29 vendors / 15
+  insumos / 59 péptidos) + UI `/peptides` (filtro estrella COA, **score de
+  vendor**, filtros región/estado, catálogo, insumos, notas) + bitácora simple
+  reusando `health.protocolo_*` (Health pasó a read-only, captura movida). Beto
+  pidió el score de vendor + filtros USA/China a media construcción (se agregó
+  antes de la bitácora). Sprint 5 (doc+wiki): el Doc de Google "Guides" entró
+  con el link corregido por Beto (OCR confundió `l`↔`I`); curé **12 notas**
+  (seguridad, reconstitución, testing, dosis, almacenamiento, labs, crypto,
+  diccionario, alerta de endotoxina) + enriquecí 5 GLP-1 vía
+  `scripts/seed_peptides_notas.ts`. **Pendiente:** digest del Telegram → notas
+  cuando Beto pase el `result.json` (export seguía en cooldown).
 
 ## Decisiones registradas
 
@@ -206,3 +218,9 @@ Semax + 13 tomas) vía las server actions de `app/health/actions.ts`.
 - **2026-06-03** — RLS **deny-all + service-role** (igual que `health.protocolo_*`).
   _Razón:_ consistencia + data de sourcing no debe ser legible por API directa;
   la app lee/escribe server-side. _Aplica a:_ las 5 tablas `peptides.*`.
+- **2026-06-04** — **Score de vendor** (`lib/peptides-score.ts`): resultados/calidad
+  40% · precio 25% · evidencia (# COAs, log-escalado) 20% · endotoxina 15%, con
+  `estado` como multiplicador (activo 1 / warning 0.75 / removido 0.4). Match
+  blando vendor↔COA por código normalizado (BFF ↔ BFF/AMO). _Razón:_ Beto pidió
+  puntuar para decidir dónde comprar; transparente y recalibrable (pesos
+  documentados + desglose en el drawer), no caja negra. _Aplica a:_ pestaña Vendors.

--- a/scripts/seed_peptides_notas.ts
+++ b/scripts/seed_peptides_notas.ts
@@ -1,0 +1,254 @@
+/**
+ * Seed idempotente — Notas curadas + enriquecimiento de catálogo (sanren-peptides, Sprint 5).
+ *
+ * Cura las guías de STG (Google Doc "Guides" + wiki stairwaytogray.com) a
+ * peptides.notas y enriquece peptides.peptidos para los GLP-1. NO toca el
+ * Telegram (ese digest se agrega cuando libere el export).
+ *
+ * Idempotente: borra las notas con fuente 'STG%' y las re-inserta; el catálogo
+ * se UPDATEA por nombre (no crea filas — el importer ya cargó los nombres).
+ * Data personal/curada, fuera de migraciones versionadas (no corre en preview/CI).
+ *
+ *   DRY_RUN=1 npx tsx --env-file=.env.local scripts/seed_peptides_notas.ts
+ *   npx tsx --env-file=.env.local scripts/seed_peptides_notas.ts
+ *
+ * No es consejo médico. Resume material comunitario con su fuente; encuadrar en UI.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Faltan NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+}
+
+const DOC = 'STG Guides (doc)';
+const WIKI = 'STG Wiki';
+const F = '2026-05-06T00:00:00Z'; // fecha del doc "Guides"
+
+interface NotaSeed {
+  titulo: string;
+  cuerpo: string;
+  tipo: 'alerta' | 'protocolo' | 'nota';
+  tags: string[];
+  fuente: string;
+  fecha: string;
+}
+
+const NOTAS: NotaSeed[] = [
+  {
+    titulo: 'Seguridad básica del mercado gris (10 reglas)',
+    tipo: 'protocolo',
+    tags: ['seguridad'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      '1) No confíes en nadie en internet. 2) Solo agua bacteriostática Pfizer Hospira (no la del vendor). 3) No confíes en el COA del vendor (pureza/cantidad/esterilidad). 4) MOQ = 10 viales; desconfía de quien venda viales sueltos o "group buys" de terceros. 5) Evita cripto en tu 1er pedido si puedes. 6) Si no puedes testear todo, únete a un group test. 7) Pide warehouse doméstico cuando exista. 8) Los vendors de USA tienen el MISMO riesgo (o más) que los de China — trátalos igual. 9) Quédate en Tirzepatide o Semaglutide antes de explorar otros. 10) Nunca vendas a nadie; no gastes más de lo que estás dispuesto a perder.',
+  },
+  {
+    titulo: 'Reconstitución con filtro — pasos',
+    tipo: 'protocolo',
+    tags: ['reconstitucion', 'esterilidad'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Material: alcohol isopropílico 70%, guantes, vial liofilizado, jeringa luer-lock 3 mL + agujas, vial estéril vacío, agua Hospira, filtro PES 0.22µm (4 o 13 mm), contenedor de sharps. Pasos: lavar/desinfectar área y puertos; cargar agua Hospira; inyectar al vial liofilizado; girar suave y dejar disolver 5+ min; aspirar todo; quitar aguja, instalar filtro PES, nueva aguja, empujar a vial estéril nuevo. El filtro remueve bacterias/mold ya presentes; el agua Hospira evita que crezcan pero no remueve lo que ya hay.',
+  },
+  {
+    titulo: 'Cálculo de dosis y concentración',
+    tipo: 'nota',
+    tags: ['dosis'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Units = volumen en la jeringa. La masa de péptido en el vial es fija; el agua que agregas define la CONCENTRACIÓN (mg/mL). Regla fácil: 1 mL por cada 10 mg (1 mL→10 mg, 25 u = 2.5 mg). Viales suelen ser de 3 mL, así que en dosis grandes (30/40/60 mg) usa 0.5 mL por 10 mg. Anota SIEMPRE la concentración usada. Calculadoras: compoundpal.com, reverse.peprecon.com (ojo: muchas usan mcg, 1 mg = 1000 mcg).',
+  },
+  {
+    titulo: 'Almacenamiento y BUD (vida útil)',
+    tipo: 'nota',
+    tags: ['almacenamiento'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Powder liofilizado → freezer hasta reconstituir (2-3 años en freezer estándar -18°C; 5+ años en ultracold -60/-80°C). Reconstituido → refrigerador. Agua Hospira → lugar fresco/oscuro, NO en fridge; BUD 28 días desde la 1ª punción. USP marca 28 días tras puncionar un vial multidosis; método aséptico + filtrado ayudan a extenderlo. Cada punción es una oportunidad de contaminación.',
+  },
+  {
+    titulo: 'Group testing — qué buscar',
+    tipo: 'protocolo',
+    tags: ['testing'],
+    fuente: `${DOC} + ${WIKI} (Testing 101)`,
+    fecha: F,
+    cuerpo:
+      'Test primario: HPLC (presencia del péptido, pureza, masa real en mg). Objetivo: ≥98% de pureza y ±15% de masa vs la etiqueta. Janoshik = gold standard internacional; muchos vendors solo honran garantía con reporte Janoshik (pregunta su política antes de comprar). Endotoxina y esterilidad: córrelos por la DATA, no porque el vendor del mercado gris vaya a reembolsar. Más vials testeados del mismo batch = mejor promedio (ley de los grandes números). Detalle: stairwaytogray.com/posts/testing/testing-101/',
+  },
+  {
+    titulo: 'Endotoxina y esterilidad — por qué importan',
+    tipo: 'alerta',
+    tags: ['seguridad', 'endotoxina'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Endotoxina = toxinas bacterianas que NO se filtran (más pequeñas que el poro del filtro). El test de esterilidad (TAMC/TYMC en Janoshik, USP71 en PeptideTest) cultiva para ver si crece bacteria. Son suplementos al COA y rara vez tienen garantía de reembolso/reship. Un batch con endotoxina alta es un riesgo agudo — por eso el filtro de endotoxina del módulo está al frente.',
+  },
+  {
+    titulo: 'Notación de kits',
+    tipo: 'nota',
+    tags: ['basics'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Kit = 10 viales. T30 = Tirz 300 mg (10×30 mg). R10 = Reta 100 mg (10×10 mg). C10 = Cagri 100 mg. S10 = Sema 100 mg. Ej: T30 da 6 dosis de 5 mg, 4 de 7.5 mg o 3 de 10 mg por vial. Todo llega como powder liofilizado en vial de 3 mL — NO comprar líquido ni "raw".',
+  },
+  {
+    titulo: 'Vendors vs group buys',
+    tipo: 'nota',
+    tags: ['sourcing'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Vendor Promo = venta directa del vendor (con su rep). Aunque listen COAs, NO se confían los tests del vendor; testea tú o en grupo tras recibir (batch/cap color/fecha). "Group buy" de terceros (alguien que junta MOQ) = mucho más riesgoso, NO para newbies — la mayoría de scams vienen de ahí. No hay "mejor vendor": todos tienen pros/contras y un buen vendor hoy puede fallar mañana; lee el historial de la hoja de vendors.',
+  },
+  {
+    titulo: 'Pagos / Crypto 1-2-3',
+    tipo: 'nota',
+    tags: ['pago', 'crypto'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Nunca pagues al vendor directo desde Coinbase/Cashapp/Zelle (riesgo de baneo de cuenta) — envía desde tu wallet personal (Trust Wallet). Compra USDC/USDT + un poco de gas (SOL/ETH baratos; TRON es el más caro). Siempre haz una transacción de prueba ($5-20) y que el vendor confirme. Los DMs con info de pago son 99% scam: usa solo el contacto del Vendor Promo.',
+  },
+  {
+    titulo: 'Labs de sangre recomendados',
+    tipo: 'nota',
+    tags: ['salud', 'labs'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Idealmente: una vez antes de empezar y luego cada 6 meses (opcional durante un stall). Panel: Metabólico completo (CBC, CMP, lípidos, ALT/AST, bilirrubina, fosfatasa alc.), Tiroides (TSH/T3/T4), A1C (diabetes/prediabetes), Lipasa (páncreas). Útil también: DEXA (músculo/grasa) y monitor de presión. Se pueden ordenar sin doctor (privatemdlabs, ultalabtests, ownyourlabs, functionhealth…).',
+  },
+  {
+    titulo: 'Insumos clave',
+    tipo: 'nota',
+    tags: ['insumos'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Agua bacteriostática: SOLO Hospira (0.9% benzyl alcohol); BUD 28 días post-punción. Viales estériles (no confiar en "esterilidad" de Amazon). Jeringas luer-lock 3 mL 25-27g para reconstituir; jeringas de insulina (0.5/1 mL) para inyectar (aguja 5/16"). Filtros PES 0.22µm de 4 o 13 mm. Proveedores en la pestaña Insumos.',
+  },
+  {
+    titulo: 'Diccionario de términos',
+    tipo: 'nota',
+    tags: ['glosario'],
+    fuente: DOC,
+    fecha: F,
+    cuerpo:
+      'Lyophilized: powder liofilizado. COA: Certificate of Analysis (pureza/cantidad por HPLC). Sterility test: cultivo para detectar bacteria. Endotoxin test: toxinas bacterianas no filtrables. TAMC/TYMC: conteos de esterilidad (Janoshik). USP71: esterilidad (PeptideTest). MOQ: pedido mínimo. Domestic warehouse: envía desde USA (ya pasó aduana). International: envía de China (pasa aduana). Pinning: inyectar. BAC water: agua con 0.9% benzyl alcohol.',
+  },
+];
+
+interface CatalogoSeed {
+  nombre: string;
+  clase: string;
+  descripcion: string;
+  reconstitucion: string;
+  cautelas: string;
+}
+
+const CATALOGO: CatalogoSeed[] = [
+  {
+    nombre: 'Tirzepatide',
+    clase: 'glp1',
+    descripcion:
+      'Agonista dual GIP/GLP-1. El péptido más usado y con más data clínica del espacio (>10M usuarios en USA, FDA-approved como Mounjaro/Zepbound). API producida en China (algunos en India).',
+    reconstitucion:
+      'Liofilizado; reconstituir con agua Hospira (1 mL por 10 mg = 100 u; 0.5 mL/10 mg en viales grandes). Filtro PES 0.22µm opcional. Powder→freezer, líquido→fridge.',
+    cautelas:
+      'No comprar líquido ni "raw". Gray-grade: confirma pureza/masa por testing independiente. Investiga efectos/interacciones antes de iniciar.',
+  },
+  {
+    nombre: 'Semaglutide',
+    clase: 'glp1',
+    descripcion:
+      'Agonista GLP-1. FDA-approved (Ozempic/Wegovy), amplia data clínica de seguridad y eficacia.',
+    reconstitucion: 'Igual que Tirz: liofilizado, agua Hospira, 1 mL por 10 mg.',
+    cautelas: 'Investiga perfil antes de iniciar; confirma por testing independiente.',
+  },
+  {
+    nombre: 'Retatrutide',
+    clase: 'glp1',
+    descripcion:
+      'Triple agonista GLP-1 / GIP / glucagón. En ensayos clínicos (aún no aprobado por FDA).',
+    reconstitucion: 'Liofilizado; agua Hospira. Confirmar concentración y anotarla.',
+    cautelas:
+      'Mueve frecuencia cardiaca en reposo, presión y peso — relevante con historia cardiovascular; coordina con tu seguimiento médico. Perfil de seguridad aún en estudio.',
+  },
+  {
+    nombre: 'Cagrilintide',
+    clase: 'glp1',
+    descripcion:
+      'Análogo de amilina de acción larga; se estudia solo y combinado con Semaglutide (CagriSema).',
+    reconstitucion: 'Liofilizado; agua Hospira.',
+    cautelas: 'En investigación; confirma por testing independiente.',
+  },
+  {
+    nombre: 'Mazdutide',
+    clase: 'glp1',
+    descripcion: 'Agonista dual GLP-1 / glucagón; en ensayos clínicos.',
+    reconstitucion: 'Liofilizado; agua Hospira.',
+    cautelas: 'En investigación; confirma por testing independiente.',
+  },
+];
+
+async function main() {
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+  const sbp = (sb as { schema: (s: string) => ReturnType<typeof sb.schema> }).schema('peptides');
+
+  console.log(`Curado: ${NOTAS.length} notas · ${CATALOGO.length} péptidos a enriquecer`);
+  if (DRY_RUN) {
+    console.log(
+      '[DRY_RUN] notas:',
+      NOTAS.map((n) => `${n.tipo}: ${n.titulo}`)
+    );
+    console.log(
+      '[DRY_RUN] catálogo:',
+      CATALOGO.map((c) => c.nombre)
+    );
+    return;
+  }
+
+  // Notas: idempotente (borra las STG-sourced y re-inserta).
+  const { error: delErr } = await sbp.from('notas').delete().like('fuente', 'STG%');
+  if (delErr) throw new Error(`delete notas: ${delErr.message}`);
+  const { error: insErr } = await sbp
+    .from('notas')
+    .insert(NOTAS.map((n) => ({ ...n, peptido: null, vendor_codigo: null })));
+  if (insErr) throw new Error(`insert notas: ${insErr.message}`);
+
+  // Catálogo: UPDATE por nombre (no crea filas).
+  let enriquecidos = 0;
+  for (const c of CATALOGO) {
+    const { error, count } = await sbp
+      .from('peptidos')
+      .update(
+        {
+          clase: c.clase,
+          descripcion: c.descripcion,
+          reconstitucion: c.reconstitucion,
+          cautelas: c.cautelas,
+          fuente: 'STG Guides + Wiki',
+        },
+        { count: 'exact' }
+      )
+      .eq('nombre', c.nombre);
+    if (error) throw new Error(`update ${c.nombre}: ${error.message}`);
+    enriquecidos += count ?? 0;
+  }
+
+  console.log(`✓ ${NOTAS.length} notas insertadas · ${enriquecidos} péptidos enriquecidos.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Qué es
Sprint 5 (parte doc + wiki) de `sanren-peptides`. Cura la guía de STG (el Google Doc "Guides" que Beto desbloqueó + el wiki) a la pestaña **Notas**, ya poblada en prod.

## Cambios
- **`scripts/seed_peptides_notas.ts`** (idempotente) — 12 notas curadas: seguridad del mercado gris, reconstitución con filtro, testing/HPLC (≥98% pureza, ±15% masa, Janoshik), dosis/concentración, almacenamiento/BUD, labs de sangre, crypto, vendors vs group buys, insumos, diccionario, **alerta de endotoxina** + enriquece 5 GLP-1 (Tirz/Sema/Reta/Cagri/Mazdutide).
- Planning doc: bitácora + decisiones (incl. score de vendor) al día.

Corrido a prod (data personal, fuera de migraciones). Sin cambios de UI — la pestaña Notas ya shippeó en #674.

## Pendiente
Digest del **Telegram** → Notas cuando libere el export (cooldown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)