### PR TITLE
fix(sanren-peptides): la bitácora no refrescaba tras registrar

### DIFF
--- a/app/health/actions.ts
+++ b/app/health/actions.ts
@@ -108,6 +108,7 @@ export async function registrarToma(input: RegistrarTomaInput): Promise<ActionRe
     }
 
     revalidatePath('/health');
+    revalidatePath('/peptides');
     return { ok: true };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : 'Error desconocido.' };
@@ -162,6 +163,7 @@ export async function crearCompuesto(input: CrearCompuestoInput): Promise<Action
     }
 
     revalidatePath('/health');
+    revalidatePath('/peptides');
     return { ok: true };
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : 'Error desconocido.' };

--- a/app/peptides/page.tsx
+++ b/app/peptides/page.tsx
@@ -6,6 +6,11 @@ import { getPeptidesData } from '@/lib/peptides';
 import { getProtocoloData } from '@/lib/protocolo';
 import { PeptidesView } from '@/components/peptides/peptides-view';
 
+// Datos personales leídos server-side con service-role — siempre frescos. Sin
+// esto la página se renderiza estática y `router.refresh()` tras registrar una
+// toma no re-jala los datos nuevos (bug de la bitácora, 2026-06-04).
+export const dynamic = 'force-dynamic';
+
 /**
  * Base de info de sourcing de péptidos (iniciativa sanren-peptides).
  * SANREN → Péptidos. Lectura server-side con service-role (RLS deny-all);


### PR DESCRIPTION
**Bug:** registrar una toma en la bitácora no actualizaba la UI. La escritura SÍ ocurría (2 tomas de prueba quedaron en `health.protocolo_tomas`); el problema era que `/peptides` se renderizaba **estática** (no lee dynamic APIs) → `router.refresh()` servía la versión cacheada.

**Fix:**
- `export const dynamic = 'force-dynamic'` en `app/peptides/page.tsx` (datos personales server-side, siempre frescos).
- `revalidatePath('/peptides')` en `registrarToma` / `crearCompuesto` (antes solo revalidaban `/health`).

Sigue Sprint 6: calculadora de reconstitución al registrar + abrir/editar/borrar cada toma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)