### PR TITLE
feat(rdb-ventas): comparativo semanal por categoría (4º tab)

### DIFF
--- a/components/ventas/semana-utils.test.ts
+++ b/components/ventas/semana-utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fechaEnTz,
+  hoyEnTz,
+  inicioMes,
+  indiceSemana,
+  isoSemana,
+  lunesDe,
+  etiquetaCorta,
+  etiquetaMes,
+  ventanaSemanas,
+} from './semana-utils';
+
+// Toda la suite usa TZ America/Matamoros (UTC-5 fijo, default del módulo).
+
+describe('isoSemana', () => {
+  it('jueves 1-ene-2026 cae en la semana ISO 1', () => {
+    expect(isoSemana('2026-01-01')).toBe(1);
+  });
+
+  it('lunes 11-may-2026 es semana ISO 20 (coincide con la hoja de RDB)', () => {
+    expect(isoSemana('2026-05-11')).toBe(20);
+  });
+
+  it('domingo 17-may-2026 sigue en la semana 20 (la semana ISO termina en domingo)', () => {
+    expect(isoSemana('2026-05-17')).toBe(20);
+  });
+
+  it('lunes 18-may-2026 ya es semana 21', () => {
+    expect(isoSemana('2026-05-18')).toBe(21);
+  });
+});
+
+describe('lunesDe', () => {
+  it('mapea cualquier día de la semana a su lunes ISO', () => {
+    expect(lunesDe('2026-05-11')).toBe('2026-05-11'); // ya es lunes
+    expect(lunesDe('2026-05-14')).toBe('2026-05-11'); // jueves
+    expect(lunesDe('2026-05-17')).toBe('2026-05-11'); // domingo
+    expect(lunesDe('2026-05-18')).toBe('2026-05-18'); // lunes siguiente
+  });
+});
+
+describe('ventanaSemanas', () => {
+  // Miércoles 20-may-2026 12:00Z → 07:00 en Matamoros, sigue siendo el día 20,
+  // que cae en la semana ISO 21 (18–24 may).
+  const now = new Date('2026-05-20T12:00:00Z');
+  const semanas = ventanaSemanas(now, 6);
+
+  it('devuelve 6 semanas, más vieja primero', () => {
+    expect(semanas).toHaveLength(6);
+    expect(semanas.map((s) => s.isoSemana)).toEqual([16, 17, 18, 19, 20, 21]);
+  });
+
+  it('la última es la semana en curso y las demás no', () => {
+    expect(semanas[5]).toMatchObject({ isoSemana: 21, inicio: '2026-05-18', enCurso: true });
+    expect(semanas.slice(0, 5).every((s) => !s.enCurso)).toBe(true);
+  });
+
+  it('cada bucket va de lunes a domingo', () => {
+    expect(semanas[4]).toMatchObject({ inicio: '2026-05-11', fin: '2026-05-17' });
+  });
+});
+
+describe('indiceSemana', () => {
+  const semanas = ventanaSemanas(new Date('2026-05-20T12:00:00Z'), 6);
+
+  it('ubica una fecha dentro de su bucket', () => {
+    expect(indiceSemana('2026-05-11', semanas)).toBe(4); // semana 20
+    expect(indiceSemana('2026-05-20', semanas)).toBe(5); // semana en curso
+    expect(indiceSemana('2026-04-13', semanas)).toBe(0); // semana 16
+  });
+
+  it('devuelve -1 para fechas fuera de la ventana', () => {
+    expect(indiceSemana('2026-04-12', semanas)).toBe(-1); // un día antes
+    expect(indiceSemana('2026-05-25', semanas)).toBe(-1); // un día después
+  });
+});
+
+describe('fechaEnTz', () => {
+  it('un timestamp de noche UTC cae en el día anterior en Matamoros', () => {
+    // 02:00Z del 12 = 21:00 del 11 en UTC-5.
+    expect(fechaEnTz('2026-05-12T02:00:00+00:00')).toBe('2026-05-11');
+  });
+
+  it('un timestamp de tarde se queda en el mismo día', () => {
+    expect(fechaEnTz('2026-05-11T18:30:00+00:00')).toBe('2026-05-11');
+  });
+});
+
+describe('hoyEnTz', () => {
+  it('formatea la fecha local en la TZ del club', () => {
+    expect(hoyEnTz(new Date('2026-05-20T12:00:00Z'))).toBe('2026-05-20');
+  });
+});
+
+describe('inicioMes / etiquetas', () => {
+  it('inicioMes devuelve el primer día del mes', () => {
+    expect(inicioMes('2026-05-20')).toBe('2026-05-01');
+  });
+
+  it('etiquetaMes y etiquetaCorta formatean en español corto', () => {
+    expect(etiquetaMes('2026-05-11')).toBe('may 2026');
+    expect(etiquetaCorta('2026-05-11')).toBe('11 may');
+    expect(etiquetaCorta('2026-01-04')).toBe('4 ene');
+  });
+});

--- a/components/ventas/semana-utils.ts
+++ b/components/ventas/semana-utils.ts
@@ -1,0 +1,128 @@
+/**
+ * Helpers puros para el tab "Comparativo" de Ventas RDB.
+ *
+ * Todo el bucketing por semana ISO (lunes–domingo) vive acá, separado del
+ * componente, para poder testearlo sin DOM ni red. Las fechas se manejan como
+ * strings calendario `YYYY-MM-DD` en la TZ del club (misma `TZ` que el resto
+ * del módulo de Ventas) y la aritmética de días se hace anclada a mediodía UTC
+ * para evitar drift por offset/DST.
+ */
+
+import { TZ } from './utils';
+
+export type SemanaBucket = {
+  /** Lunes de la semana, `YYYY-MM-DD` en TZ del club. */
+  inicio: string;
+  /** Domingo de la semana, `YYYY-MM-DD`. */
+  fin: string;
+  /** Número de semana ISO 8601 (1–53). */
+  isoSemana: number;
+  /** `true` para la semana en curso (la última de la ventana, parcial). */
+  enCurso: boolean;
+};
+
+const MS_DIA = 86_400_000;
+
+const MESES_ES = [
+  'ene',
+  'feb',
+  'mar',
+  'abr',
+  'may',
+  'jun',
+  'jul',
+  'ago',
+  'sep',
+  'oct',
+  'nov',
+  'dic',
+] as const;
+
+/** Fecha calendario `YYYY-MM-DD` de `now` en la TZ dada. */
+export function hoyEnTz(now: Date, tz: string = TZ): string {
+  return new Intl.DateTimeFormat('sv-SE', { timeZone: tz }).format(now);
+}
+
+/**
+ * Fecha calendario `YYYY-MM-DD` de un timestamp (timestamptz del backend) en
+ * la TZ del club. Se usa para ubicar cada pedido en su día local — un pedido a
+ * las 23:00 UTC cae en el día anterior en Matamoros (UTC-5).
+ */
+export function fechaEnTz(ts: string | Date, tz: string = TZ): string {
+  const d = typeof ts === 'string' ? new Date(ts.replace(' ', 'T')) : ts;
+  return new Intl.DateTimeFormat('sv-SE', { timeZone: tz }).format(d);
+}
+
+/** Parsea `YYYY-MM-DD` a un Date anclado a mediodía UTC (sin shift de día). */
+function parseYmd(ymd: string): Date {
+  const [y, m, d] = ymd.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d, 12));
+}
+
+function toYmd(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Lunes ISO de la semana que contiene `ymd`. */
+export function lunesDe(ymd: string): string {
+  const d = parseYmd(ymd);
+  const dow = (d.getUTCDay() + 6) % 7; // Lun=0 … Dom=6
+  d.setUTCDate(d.getUTCDate() - dow);
+  return toYmd(d);
+}
+
+/** Número de semana ISO 8601 para `ymd`. */
+export function isoSemana(ymd: string): number {
+  const d = parseYmd(ymd);
+  const dayNum = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - dayNum + 3); // jueves de esta semana
+  const primerJueves = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const primerDayNum = (primerJueves.getUTCDay() + 6) % 7;
+  primerJueves.setUTCDate(primerJueves.getUTCDate() - primerDayNum + 3);
+  return 1 + Math.round((d.getTime() - primerJueves.getTime()) / (7 * MS_DIA));
+}
+
+/**
+ * Las últimas `n` semanas ISO terminando en la semana en curso (parcial),
+ * más vieja primero. `now` se inyecta para poder testear de forma determinista.
+ */
+export function ventanaSemanas(now: Date, n = 6, tz: string = TZ): SemanaBucket[] {
+  const lunesActual = lunesDe(hoyEnTz(now, tz));
+  const base = parseYmd(lunesActual);
+  const out: SemanaBucket[] = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const lunes = new Date(base);
+    lunes.setUTCDate(lunes.getUTCDate() - i * 7);
+    const domingo = new Date(lunes);
+    domingo.setUTCDate(domingo.getUTCDate() + 6);
+    const inicio = toYmd(lunes);
+    out.push({ inicio, fin: toYmd(domingo), isoSemana: isoSemana(inicio), enCurso: i === 0 });
+  }
+  return out;
+}
+
+/** Índice (0…n-1) del bucket en que cae `fecha`, o -1 si queda fuera. */
+export function indiceSemana(fecha: string, semanas: readonly SemanaBucket[]): number {
+  for (let i = 0; i < semanas.length; i++) {
+    const s = semanas[i];
+    if (fecha >= s.inicio && fecha <= s.fin) return i;
+  }
+  return -1;
+}
+
+/** Primer día `YYYY-MM-DD` del mes calendario que contiene `ymd`. */
+export function inicioMes(ymd: string): string {
+  return `${ymd.slice(0, 7)}-01`;
+}
+
+/** Etiqueta de mes corta: `2026-05-11` → "may 2026". */
+export function etiquetaMes(ymd: string): string {
+  const [y, m] = ymd.split('-').map(Number);
+  return `${MESES_ES[m - 1]} ${y}`;
+}
+
+/** Etiqueta día+mes corta: `2026-05-11` → "11 may". */
+export function etiquetaCorta(ymd: string): string {
+  const [, m, d] = ymd.split('-').map(Number);
+  return `${d} ${MESES_ES[m - 1]}`;
+}

--- a/components/ventas/ventas-comparativo.tsx
+++ b/components/ventas/ventas-comparativo.tsx
@@ -1,0 +1,426 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { getLocalDayBoundsUtc } from '@/lib/timezone';
+import { formatCurrency } from '@/lib/format';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { ErrorBanner } from '@/components/module-page';
+import { Download } from 'lucide-react';
+import { CategoriaBadge } from './categoria-badge';
+import { TZ } from './utils';
+import {
+  etiquetaCorta,
+  etiquetaMes,
+  fechaEnTz,
+  hoyEnTz,
+  indiceSemana,
+  inicioMes,
+  ventanaSemanas,
+} from './semana-utils';
+
+// Líneas sin producto en catálogo → "Sin categoría". Mismo criterio que el
+// tab "Por categoría" para que los números reconcilien.
+const SIN_CATEGORIA_KEY = 'sin-categoria';
+const SIN_CATEGORIA_LABEL = 'Sin categoría';
+const N_SEMANAS = 6;
+// Chunk del `.in('order_id', …)` — el mismo tamaño que usa el tab "Por
+// categoría", validado contra el límite de longitud de URL de PostgREST.
+const CHUNK = 500;
+
+type Metric = 'importe' | 'unidades';
+
+type LineaCategoria = {
+  order_id: string;
+  categoria_id: string | null;
+  categoria_nombre: string | null;
+  categoria_color: string | null;
+  quantity: number | null;
+  total_price: number | null;
+};
+
+type PedidoMeta = { weekIdx: number; inMonth: boolean };
+
+type AggRow = {
+  key: string;
+  nombre: string;
+  color: string | null;
+  importeSem: number[];
+  unidadesSem: number[];
+  importeMes: number;
+  unidadesMes: number;
+};
+
+export function VentasComparativo() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [agg, setAgg] = useState<AggRow[]>([]);
+  const [metric, setMetric] = useState<Metric>('importe');
+
+  // Ventana fija: últimas 6 semanas ISO + mes en curso. Independiente del
+  // filtro global de fechas/corte de VentasView — este tab siempre mira el
+  // comportamiento reciente, sin importar qué rango haya elegido el usuario.
+  const { semanas, mesInicio, mesLabel, rangoUtc } = useMemo(() => {
+    const now = new Date();
+    const sems = ventanaSemanas(now, N_SEMANAS, TZ);
+    const hoy = hoyEnTz(now, TZ);
+    return {
+      semanas: sems,
+      mesInicio: inicioMes(hoy),
+      mesLabel: etiquetaMes(hoy),
+      rangoUtc: {
+        start: getLocalDayBoundsUtc(sems[0].inicio, TZ).start,
+        end: getLocalDayBoundsUtc(hoy, TZ).end,
+      },
+    };
+  }, []);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const supabase = createSupabaseBrowserClient();
+
+      // 1) Pedidos válidos en la ventana: misma vista canónica que "Por
+      //    categoría" (excluye fantasmas ADR-031, sólo paid=true). El
+      //    timestamp ubica cada pedido en su semana ISO y su mes calendario.
+      const { data: pedidos, error: pedErr } = await supabase
+        .schema('rdb')
+        .from('v_waitry_pedidos')
+        .select('order_id, status, timestamp')
+        .gte('timestamp', rangoUtc.start)
+        .lte('timestamp', rangoUtc.end)
+        .limit(20000);
+      if (pedErr) throw pedErr;
+
+      const meta = new Map<string, PedidoMeta>();
+      for (const p of pedidos ?? []) {
+        if (!p.order_id || !p.timestamp) continue;
+        if ((p.status ?? '').toLowerCase().includes('cancel')) continue;
+        const fecha = fechaEnTz(p.timestamp, TZ);
+        const weekIdx = indiceSemana(fecha, semanas);
+        if (weekIdx < 0) continue;
+        meta.set(p.order_id, { weekIdx, inMonth: fecha >= mesInicio });
+      }
+
+      const orderIds = [...meta.keys()];
+      if (orderIds.length === 0) {
+        setAgg([]);
+        return;
+      }
+
+      // 2) Líneas con categoría de esos pedidos, chunked por el límite de URL.
+      const lineas: LineaCategoria[] = [];
+      for (let i = 0; i < orderIds.length; i += CHUNK) {
+        const chunk = orderIds.slice(i, i + CHUNK);
+        const { data, error: linErr } = await supabase
+          .schema('rdb')
+          .from('v_waitry_productos_categoria')
+          .select(
+            'order_id, categoria_id, categoria_nombre, categoria_color, quantity, total_price'
+          )
+          .in('order_id', chunk)
+          .limit(50000);
+        if (linErr) throw linErr;
+        lineas.push(...((data ?? []) as LineaCategoria[]));
+      }
+
+      // 3) Pivote categoría × semana, acumulando importe y unidades en paralelo
+      //    para que el toggle de métrica no dispare otra query.
+      const map = new Map<string, AggRow>();
+      for (const ln of lineas) {
+        const m = meta.get(ln.order_id);
+        if (!m) continue;
+        const key = ln.categoria_id ?? SIN_CATEGORIA_KEY;
+        let row = map.get(key);
+        if (!row) {
+          row = {
+            key,
+            nombre: ln.categoria_nombre ?? SIN_CATEGORIA_LABEL,
+            color: ln.categoria_color,
+            importeSem: Array.from({ length: N_SEMANAS }, () => 0),
+            unidadesSem: Array.from({ length: N_SEMANAS }, () => 0),
+            importeMes: 0,
+            unidadesMes: 0,
+          };
+          map.set(key, row);
+        }
+        const imp = Number(ln.total_price ?? 0);
+        const uni = Number(ln.quantity ?? 0);
+        row.importeSem[m.weekIdx] += imp;
+        row.unidadesSem[m.weekIdx] += uni;
+        if (m.inMonth) {
+          row.importeMes += imp;
+          row.unidadesMes += uni;
+        }
+      }
+
+      setAgg([...map.values()]);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Error al cargar el comparativo semanal');
+    } finally {
+      setLoading(false);
+    }
+  }, [semanas, mesInicio, rangoUtc.start, rangoUtc.end]);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  // Filas en la métrica activa, sin categorías vacías, ordenadas por Σ6sem desc
+  // (mismo criterio "mayor a menor" que la hoja de RDB).
+  const rows = useMemo(() => {
+    const semKey = metric === 'importe' ? 'importeSem' : 'unidadesSem';
+    const mesKey = metric === 'importe' ? 'importeMes' : 'unidadesMes';
+    return agg
+      .map((r) => {
+        const sem = r[semKey];
+        return {
+          key: r.key,
+          nombre: r.nombre,
+          color: r.color,
+          sem,
+          sigma: sem.reduce((a, b) => a + b, 0),
+          mes: r[mesKey],
+        };
+      })
+      .filter((r) => r.sigma !== 0 || r.mes !== 0)
+      .sort((a, b) => b.sigma - a.sigma);
+  }, [agg, metric]);
+
+  const totals = useMemo(() => {
+    const sem = Array.from({ length: N_SEMANAS }, () => 0);
+    let sigma = 0;
+    let mes = 0;
+    for (const r of rows) {
+      for (let i = 0; i < N_SEMANAS; i++) sem[i] += r.sem[i];
+      sigma += r.sigma;
+      mes += r.mes;
+    }
+    return { sem, sigma, mes };
+  }, [rows]);
+
+  const fmt = (v: number) =>
+    v === 0
+      ? '—'
+      : metric === 'importe'
+        ? formatCurrency(v, { decimals: 0 })
+        : v.toLocaleString('es-MX');
+
+  const exportCsv = () => {
+    const header = [
+      'Categoría',
+      ...semanas.map((s) => `S${s.isoSemana} (${s.inicio})`),
+      'Sigma 6 sem',
+      `Acum ${mesLabel}`,
+    ];
+    const lines = [header.join(',')];
+    for (const r of rows) {
+      lines.push(
+        [
+          `"${r.nombre.replace(/"/g, '""')}"`,
+          ...r.sem.map((v) => String(v)),
+          String(r.sigma),
+          String(r.mes),
+        ].join(',')
+      );
+    }
+    lines.push(
+      [
+        '"TOTAL"',
+        ...totals.sem.map((v) => String(v)),
+        String(totals.sigma),
+        String(totals.mes),
+      ].join(',')
+    );
+    const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `rdb-comparativo-${metric}-${semanas[0].inicio}_${hoyEnTz(new Date(), TZ)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          Últimas {N_SEMANAS} semanas ISO (lun–dom) · cancha + tiendita (Waitry).{' '}
+          <span className="text-muted-foreground/70">
+            La semana {semanas[N_SEMANAS - 1].isoSemana} va en curso.
+          </span>
+        </p>
+        <div className="flex items-center gap-2">
+          <div className="inline-flex rounded-lg border p-0.5">
+            {(
+              [
+                ['importe', 'Importe'],
+                ['unidades', 'Unidades'],
+              ] as const
+            ).map(([k, label]) => (
+              <button
+                key={k}
+                type="button"
+                onClick={() => setMetric(k)}
+                className={cn(
+                  'rounded-md px-3 py-1 text-sm font-medium transition',
+                  metric === k
+                    ? 'bg-emerald-500 text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={exportCsv}
+            disabled={!rows.length}
+            className="gap-2"
+          >
+            <Download className="h-4 w-4" /> CSV
+          </Button>
+        </div>
+      </div>
+
+      {error ? <ErrorBanner error={error} onRetry={() => void fetchData()} /> : null}
+
+      {loading ? (
+        <div className="h-72 animate-pulse rounded-xl border bg-muted/30" />
+      ) : rows.length === 0 ? (
+        <div className="rounded-xl border bg-card p-10 text-center text-sm text-muted-foreground">
+          Sin ventas registradas en las últimas {N_SEMANAS} semanas.
+        </div>
+      ) : (
+        <div className="rounded-xl border bg-card">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="sticky left-0 bg-card">Categoría</TableHead>
+                {semanas.map((s) => (
+                  <TableHead key={s.inicio} className="text-right">
+                    <div className="flex flex-col items-end leading-tight">
+                      <span className={cn('font-semibold', s.enCurso && 'text-emerald-600')}>
+                        S{s.isoSemana}
+                      </span>
+                      <span className="text-[11px] font-normal text-muted-foreground">
+                        {etiquetaCorta(s.inicio)}
+                      </span>
+                    </div>
+                  </TableHead>
+                ))}
+                <TableHead className="text-right">Σ 6 sem</TableHead>
+                <TableHead className="text-right">Acum. {mesLabel}</TableHead>
+                <TableHead className="text-right">Tend.</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((r) => (
+                <TableRow key={r.key}>
+                  <TableCell className="sticky left-0 bg-card">
+                    <CategoriaBadge nombre={r.nombre} color={r.color} />
+                  </TableCell>
+                  {r.sem.map((v, i) => (
+                    <TableCell
+                      key={semanas[i].inicio}
+                      className={cn(
+                        'text-right tabular-nums',
+                        v === 0 && 'text-muted-foreground/40',
+                        semanas[i].enCurso && v !== 0 && 'text-emerald-700/90'
+                      )}
+                    >
+                      {fmt(v)}
+                    </TableCell>
+                  ))}
+                  <TableCell className="text-right font-semibold tabular-nums">
+                    {fmt(r.sigma)}
+                  </TableCell>
+                  <TableCell className="text-right font-semibold tabular-nums">
+                    {fmt(r.mes)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Sparkline values={r.sem} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell className="sticky left-0 bg-muted/50 font-semibold">TOTAL</TableCell>
+                {totals.sem.map((v, i) => (
+                  <TableCell
+                    key={semanas[i].inicio}
+                    className="text-right font-semibold tabular-nums"
+                  >
+                    {fmt(v)}
+                  </TableCell>
+                ))}
+                <TableCell className="text-right font-bold tabular-nums">
+                  {fmt(totals.sigma)}
+                </TableCell>
+                <TableCell className="text-right font-bold tabular-nums">
+                  {fmt(totals.mes)}
+                </TableCell>
+                <TableCell />
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Sparkline mínimo (polyline SVG) para la columna de tendencia. Sin librería de
+ * charts — el repo no tiene una y no la vale para 6 puntos. Verde si la última
+ * semana sube vs la anterior, rojo si baja.
+ */
+function Sparkline({ values }: { values: number[] }) {
+  const max = Math.max(...values, 0);
+  if (max <= 0) return <span className="text-muted-foreground/40">—</span>;
+  const w = 72;
+  const h = 22;
+  const pad = 2;
+  const n = values.length;
+  const points = values
+    .map((v, i) => {
+      const x = n > 1 ? pad + (i / (n - 1)) * (w - 2 * pad) : w / 2;
+      const y = h - pad - (v / max) * (h - 2 * pad);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+  const sube = n < 2 || values[n - 1] >= values[n - 2];
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      width={w}
+      height={h}
+      className={cn('inline-block', sube ? 'text-emerald-500' : 'text-rose-500')}
+      role="img"
+      aria-label="Tendencia de las últimas semanas"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/components/ventas/ventas-view.tsx
+++ b/components/ventas/ventas-view.tsx
@@ -27,10 +27,11 @@ import { VentasFilters } from './ventas-filters';
 import { VentasTable } from './ventas-table';
 import { VentasPorProducto } from './ventas-por-producto';
 import { VentasPorCategoria } from './ventas-por-categoria';
+import { VentasComparativo } from './ventas-comparativo';
 import type { CategoriaFilter, CorteOption, Pedido } from './types';
 import { TZ, rangeForPreset, todayRange } from './utils';
 
-type VentasTab = 'pedidos' | 'por-producto' | 'por-categoria';
+type VentasTab = 'pedidos' | 'por-producto' | 'por-categoria' | 'comparativo';
 
 export function VentasView() {
   const [tab, setTab] = useState<VentasTab>('pedidos');
@@ -239,6 +240,7 @@ export function VentasView() {
             ['pedidos', 'Pedidos'],
             ['por-producto', 'Por producto'],
             ['por-categoria', 'Por categoría'],
+            ['comparativo', 'Comparativo'],
           ] as const
         ).map(([key, label]) => (
           <button
@@ -260,30 +262,33 @@ export function VentasView() {
       {/* Summary stats (solo en Pedidos) */}
       {tab === 'pedidos' && !loading && !error && <SummaryBar pedidos={filtered} />}
 
-      {/* Filters */}
-      <VentasFilters
-        search={tab === 'pedidos' ? search : ''}
-        onSearchChange={(value) => setFilter('search', value)}
-        statusFilter={statusFilter}
-        onStatusFilterChange={(value) => setFilter('statusFilter', value)}
-        corteFilter={corteFilter}
-        onCorteFilterChange={(value) => setFilter('corteFilter', value)}
-        cortes={cortes}
-        dateFrom={dateFrom}
-        dateTo={dateTo}
-        onDateFromChange={(value) => setFilters({ dateFrom: value, presetKey: 'custom' })}
-        onDateToChange={(value) => setFilters({ dateTo: value, presetKey: 'custom' })}
-        presetKey={presetKey}
-        onPresetChange={handlePreset}
-        loading={loading}
-        onRefresh={() => void fetchPedidos()}
-        count={filtered.length}
-        activeCount={activeCount}
-        onClearAll={clearAll}
-        showFantasmas={showFantasmas}
-        onShowFantasmasChange={(v) => setFilter('showDuplicados', v ? 'on' : 'off')}
-        fantasmasCount={fantasmasCount}
-      />
+      {/* Filters — el comparativo usa su propia ventana fija (últimas 6
+          semanas), no el filtro global de fecha/corte. */}
+      {tab !== 'comparativo' && (
+        <VentasFilters
+          search={tab === 'pedidos' ? search : ''}
+          onSearchChange={(value) => setFilter('search', value)}
+          statusFilter={statusFilter}
+          onStatusFilterChange={(value) => setFilter('statusFilter', value)}
+          corteFilter={corteFilter}
+          onCorteFilterChange={(value) => setFilter('corteFilter', value)}
+          cortes={cortes}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
+          onDateFromChange={(value) => setFilters({ dateFrom: value, presetKey: 'custom' })}
+          onDateToChange={(value) => setFilters({ dateTo: value, presetKey: 'custom' })}
+          presetKey={presetKey}
+          onPresetChange={handlePreset}
+          loading={loading}
+          onRefresh={() => void fetchPedidos()}
+          count={filtered.length}
+          activeCount={activeCount}
+          onClearAll={clearAll}
+          showFantasmas={showFantasmas}
+          onShowFantasmasChange={(v) => setFilter('showDuplicados', v ? 'on' : 'off')}
+          fantasmasCount={fantasmasCount}
+        />
+      )}
 
       {/* Error */}
       {error ? <ErrorBanner error={error} onRetry={() => void fetchPedidos()} /> : null}
@@ -324,6 +329,7 @@ export function VentasView() {
           onCategoriaClick={handleCategoriaClick}
         />
       )}
+      {tab === 'comparativo' && <VentasComparativo />}
     </div>
   );
 }


### PR DESCRIPTION
## Qué

Nueva pestaña **"Comparativo"** en `/rdb/ventas` (4ª, junto a Pedidos · Por producto · Por categoría). Replica el reporte manual *"Ventas Canchas y Tiendita"*: pivote **categoría × últimas 6 semanas ISO** (lun–dom), con:

- Una columna por semana (`S18 · 27 abr`, …), la semana en curso marcada en verde.
- **Σ 6 sem** — suma de las semanas visibles (cuadra peso a peso con la tabla).
- **Acum. {mes}** — total del mes calendario en curso (desacoplado de las semanas, como la hoja de Beto).
- Fila **TOTAL** al pie.
- **Sparkline** de tendencia por categoría (▲ verde / ▼ rojo) — sin librería de charts, SVG a mano (decisión registrada en `rdb-ventas-por-categoria`).
- Toggle **Importe / Unidades** (sin refetch).
- Export **CSV**.

## Cómo (sin migración)

100% client-side sobre las **mismas vistas canónicas** que el tab "Por categoría":
`rdb.v_waitry_pedidos` (excluye fantasmas ADR-031, `paid=true`) + `rdb.v_waitry_productos_categoria`. Por construcción los importes **reconcilian** con el tab "Por categoría" para el mismo rango. Ventana fija de 6 semanas, independiente del filtro global de fecha/corte (que se oculta en esta pestaña).

La lógica de semanas ISO + TZ del club vive aislada en `components/ventas/semana-utils.ts` con **15 tests unitarios** (`isoSemana('2026-05-11') === 20` cuadra con la numeración de la hoja).

## Verificación local

- ✅ `typecheck` · ✅ `lint` (0 errores) · ✅ `test:run` (82 archivos / 1237 tests) · ✅ `format:check`
- Sin cambios de schema → sin `schema:check`/`db:types`.

## Nota

Cambio **UI visible** → sin auto-merge. Para eyeball en el preview con datos reales antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)