### PR TITLE
feat(dilesa-compras): Sprint 1 fase 2a — costeo sobre erp.presupuesto_partidas

### DIFF
--- a/components/dilesa/costeo-concepto-form.tsx
+++ b/components/dilesa/costeo-concepto-form.tsx
@@ -2,7 +2,8 @@
 
 /**
  * CosteoConceptoForm — alta/edición de un concepto de presupuesto de obra
- * (`dilesa.obra_presupuesto`, Capa A).
+ * (`erp.presupuesto_partidas`, modelo canónico — ADR-040; migrado desde
+ * `dilesa.obra_presupuesto` en Sprint 1 de dilesa-compras).
  *
  * Iniciativa dilesa-contratos-obra · Sprint 5 (captura de presupuesto). El
  * traspaso de los Excel (hoja RESUMEN) cargó 128 conceptos de solo-lectura;
@@ -84,32 +85,33 @@ export function CosteoConceptoForm({
 
     const payload = {
       etapa: etapa.trim() || null,
-      concepto: concepto.trim(),
+      concepto_texto: concepto.trim(),
       presupuesto_previo: toNum(presupuestoPrevio),
-      presupuesto_actualizado: toNum(presupuestoActual),
+      presupuesto_aprobado: toNum(presupuestoActual),
       gasto_real_total: toNum(gastoReal),
       proveedor_texto: proveedor.trim() || null,
       fecha_compromiso: fecha || null,
     };
 
+    // Modelo canónico erp.presupuesto_partidas (ADR-040). Aún no está en
+    // types/supabase.ts (se difiere al workflow db-types) → cast `as any`,
+    // patrón del repo para tablas nuevas.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const partidas = () => (sb.schema('erp') as any).from('presupuesto_partidas');
     const resp = editRow
-      ? await sb
-          .schema('dilesa')
-          .from('obra_presupuesto')
+      ? await partidas()
           .update({ ...payload, proyecto_id: proyectoId, updated_at: new Date().toISOString() })
           .eq('id', editRow.id)
-      : await sb
-          .schema('dilesa')
-          .from('obra_presupuesto')
-          .insert({
-            empresa_id: empresaId,
-            proyecto_id: proyectoId,
-            orden:
-              rows
-                .filter((r) => r.proyecto_id === proyectoId)
-                .reduce((m, r) => Math.max(m, r.orden), 0) + 1,
-            ...payload,
-          });
+      : await partidas().insert({
+          empresa_id: empresaId,
+          proyecto_id: proyectoId,
+          fuente: 'obra_resumen',
+          orden:
+            rows
+              .filter((r) => r.proyecto_id === proyectoId)
+              .reduce((m, r) => Math.max(m, r.orden), 0) + 1,
+          ...payload,
+        });
 
     if (resp.error) {
       toast.add({

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -135,11 +135,14 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
 
     // Capa A (presupuesto) + proyectos + Capa B (contratos + estimaciones).
     const [presupuestoRes, proyectosRes, contratosRes, estimacionesRes] = await Promise.all([
-      sb
-        .schema('dilesa')
-        .from('obra_presupuesto')
+      // Capa A migrada al modelo canónico erp.presupuesto_partidas (ADR-040).
+      // Cast `as any`: la tabla aún no está en types (se difiere al workflow
+      // db-types). concepto→concepto_texto, presupuesto_actualizado→presupuesto_aprobado.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any)
+        .from('presupuesto_partidas')
         .select(
-          'id, proyecto_id, etapa, concepto, presupuesto_actualizado, presupuesto_previo, gasto_real_total, proveedor_texto, fecha_compromiso, orden'
+          'id, proyecto_id, etapa, concepto_texto, presupuesto_aprobado, presupuesto_previo, gasto_real_total, proveedor_texto, fecha_compromiso, orden'
         )
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
@@ -197,12 +200,26 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       agg.set(pid, cur);
     }
 
-    const out: CosteoRow[] = (presupuestoRes.data ?? [])
+    // El SELECT va por cast `as any` (presupuesto_partidas no está en types aún);
+    // tipamos la fila cruda aquí para conservar el chequeo en el mapeo.
+    type PartidaRaw = {
+      id: string;
+      proyecto_id: string | null;
+      etapa: string | null;
+      concepto_texto: string | null;
+      presupuesto_aprobado: number | null;
+      presupuesto_previo: number | null;
+      gasto_real_total: number | null;
+      proveedor_texto: string | null;
+      fecha_compromiso: string | null;
+      orden: number | null;
+    };
+    const out: CosteoRow[] = ((presupuestoRes.data ?? []) as PartidaRaw[])
       .filter((r) => r.proyecto_id != null)
       .map((r) => {
         const presupuesto =
-          r.presupuesto_actualizado != null
-            ? Number(r.presupuesto_actualizado)
+          r.presupuesto_aprobado != null
+            ? Number(r.presupuesto_aprobado)
             : r.presupuesto_previo != null
               ? Number(r.presupuesto_previo)
               : null;
@@ -213,10 +230,10 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
           proyecto_id: pid,
           proyectoNombre: proyectoMap.get(pid) ?? '',
           etapa: (r.etapa as string | null) ?? null,
-          concepto: (r.concepto as string) ?? '',
+          concepto: (r.concepto_texto as string) ?? '',
           presupuestoPrevio: r.presupuesto_previo != null ? Number(r.presupuesto_previo) : null,
           presupuestoActualizado:
-            r.presupuesto_actualizado != null ? Number(r.presupuesto_actualizado) : null,
+            r.presupuesto_aprobado != null ? Number(r.presupuesto_aprobado) : null,
           presupuesto,
           gastoReal,
           proveedor: (r.proveedor_texto as string | null) ?? null,
@@ -275,9 +292,9 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   const eliminar = useCallback(
     async (row: CosteoRow) => {
       const sb = createSupabaseBrowserClient();
-      const { error: e } = await sb
-        .schema('dilesa')
-        .from('obra_presupuesto')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: e } = await (sb.schema('erp') as any)
+        .from('presupuesto_partidas')
         .update({ deleted_at: new Date().toISOString() })
         .eq('id', row.id);
       if (e) {

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -242,3 +242,14 @@ pago: rol **Dirección** (ya vigente en CxP).
   Coexistencia inerte (compras sin UI). **Próximo (fase 2, antes de Sprint 2):**
   re-apuntar `costeo` a `erp.presupuesto_partidas` con preview + retirar
   `obra_presupuesto`.
+- **2026-06-04** — **Sprint 1 fase 2a: `costeo` re-apuntado.** `costeo-module`
+  (SELECT + mapeo + soft-delete) y `costeo-concepto-form` (alta/edición) ahora
+  leen y escriben `erp.presupuesto_partidas` (`concepto`→`concepto_texto`,
+  `presupuesto_actualizado`→`presupuesto_aprobado`; altas marcan
+  `fuente='obra_resumen'`). Cast `as any` + `eslint-disable` mientras la tabla
+  no esté en `types` (se difiere al workflow). Verificado: ventana de edición =
+  0 (las dos tablas idénticas, sin re-sync); cero queries activas a
+  `obra_presupuesto` en código; 5 checks verdes (1247 tests). PR **UI-touching →
+  preview sin auto-merge** para validar que las 128 partidas se ven/editan bien
+  antes de mergear. **Fase 2b (sigue):** retirar `dilesa.obra_presupuesto` tras
+  validar en prod.


### PR DESCRIPTION
## Qué

**Sprint 1, fase 2a.** Re-apunta el módulo **Costeo** (de `dilesa-contratos-obra`) al modelo canónico `erp.presupuesto_partidas`, reemplazando `dilesa.obra_presupuesto`. Cierra la "casa limpia" que tracé en el ADR-040 (sin la vista de compat frágil).

## Cambios

- `costeo-module.tsx` — SELECT + mapeo (`concepto`→`concepto_texto`, `presupuesto_actualizado`→`presupuesto_aprobado`) + soft-delete.
- `costeo-concepto-form.tsx` — alta/edición con el payload mapeado; altas marcan `fuente='obra_resumen'`.
- Cast `as any` + `eslint-disable` mientras `presupuesto_partidas` no esté en `types` (se difiere al workflow `db-types`). Fila cruda tipada (`PartidaRaw`) para conservar el chequeo en el mapeo.

## Verificación

- **Ventana de edición a `obra_presupuesto` = 0** (las dos tablas idénticas desde la copia → sin re-sync necesario).
- **Cero queries activas a `obra_presupuesto`** en código.
- 5 checks verdes (1247 tests, incl. `costeo-module.test`). El tipo interno `CosteoRow` no cambia → test intacto.

## ⚠️ Sin auto-merge — revisar preview

Es UI-touching: cambia de dónde lee Costeo. **Antes de mergear, validar en el preview** que el tab Costeo (`/dilesa/construccion/costeo`) sigue mostrando las 128 partidas y permite editar/eliminar. `obra_presupuesto` queda **intacta de respaldo** — si algo se ve mal, revertir es trivial.

**Fase 2b (siguiente, tras validar en prod):** retirar `dilesa.obra_presupuesto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)