### PR TITLE
feat(dilesa-compras): rediseño UX de Costeo — agrupado etapa›capítulo + dropdowns + eliminar visible

### DIFF
--- a/app/dilesa/construccion/costeo/page.tsx
+++ b/app/dilesa/construccion/costeo/page.tsx
@@ -10,9 +10,10 @@ import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
  * @responsive desktop-only
  *
  * Tab "Costeo" del hub Construcción (iniciativa dilesa-contratos-obra,
- * Sprint 3). Vista de CapEx del desarrollo: presupuesto vs gasto real por
- * concepto/etapa (Capa A, `obra_presupuesto`) + contratado/saldo de los
- * contratos de obra (Capa B). Ver ADR-038.
+ * Sprint 3; rediseñado en dilesa-compras). Vista de CapEx del desarrollo:
+ * presupuesto vs gasto real por concepto/etapa (Capa A,
+ * `erp.presupuesto_partidas` — ADR-040) + contratado/saldo de los contratos de
+ * obra (Capa B). Ver ADR-038.
  *
  * Gate: sub-slug `dilesa.construccion.costeo` (ADR-030 SS5).
  */

--- a/components/dilesa/costeo-concepto-form.tsx
+++ b/components/dilesa/costeo-concepto-form.tsx
@@ -26,10 +26,11 @@
  */
 
 import { useState } from 'react';
-import { Loader2, Plus, Save } from 'lucide-react';
+import { Loader2, Plus, Save, Trash2 } from 'lucide-react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { proyectoOptionLabel, type ProyectoOption } from '@/lib/dilesa/proyectos-selector';
@@ -56,6 +57,7 @@ export function CosteoConceptoForm({
   editRow,
   onClose,
   onSaved,
+  onDelete,
 }: {
   empresaId: string;
   proyectos: readonly ProyectoOption[];
@@ -69,9 +71,12 @@ export function CosteoConceptoForm({
   editRow: CosteoRow | null;
   onClose: () => void;
   onSaved: () => void;
+  /** Borra la partida (solo en edición). Soft-delete + cierra el form. */
+  onDelete?: () => void | Promise<void>;
 }) {
   const toast = useToast();
   const isEdit = editRow != null;
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const [proyectoId, setProyectoId] = useState(editRow?.proyecto_id ?? '');
   const [concepto, setConcepto] = useState(editRow?.concepto ?? '');
@@ -285,21 +290,47 @@ export function CosteoConceptoForm({
         se calcula como gasto real ÷ presupuesto actualizado (o previo si no hay actualizado).
         Montos con IVA incluido.
       </p>
-      <div className="mt-3 flex items-center justify-end gap-2">
-        <Button variant="outline" onClick={onClose} disabled={submitting}>
-          Cancelar
-        </Button>
-        <Button onClick={onSubmit} disabled={!canSubmit || submitting}>
-          {submitting ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : isEdit ? (
-            <Save className="size-4" />
-          ) : (
-            <Plus className="size-4" />
-          )}
-          {isEdit ? 'Guardar' : 'Registrar'}
-        </Button>
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <div>
+          {isEdit && onDelete ? (
+            <Button
+              variant="ghost"
+              onClick={() => setConfirmDelete(true)}
+              disabled={submitting}
+              className="text-red-600 hover:bg-red-50 hover:text-red-700"
+            >
+              <Trash2 className="size-4" />
+              Eliminar
+            </Button>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
+            Cancelar
+          </Button>
+          <Button onClick={onSubmit} disabled={!canSubmit || submitting}>
+            {submitting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : isEdit ? (
+              <Save className="size-4" />
+            ) : (
+              <Plus className="size-4" />
+            )}
+            {isEdit ? 'Guardar' : 'Registrar'}
+          </Button>
+        </div>
       </div>
+
+      {isEdit && onDelete ? (
+        <ConfirmDialog
+          open={confirmDelete}
+          onOpenChange={setConfirmDelete}
+          onConfirm={onDelete}
+          title={`¿Eliminar “${editRow?.concepto ?? 'partida'}”?`}
+          description="Marcará la partida de presupuesto como eliminada. Se preserva el historial para auditoría."
+          confirmLabel="Eliminar"
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/dilesa/costeo-concepto-form.tsx
+++ b/components/dilesa/costeo-concepto-form.tsx
@@ -1,25 +1,28 @@
 'use client';
 
 /**
- * CosteoConceptoForm — alta/edición de un concepto de presupuesto de obra
+ * CosteoConceptoForm — alta/edición de una partida de presupuesto de obra
  * (`erp.presupuesto_partidas`, modelo canónico — ADR-040; migrado desde
  * `dilesa.obra_presupuesto` en Sprint 1 de dilesa-compras).
  *
- * Iniciativa dilesa-contratos-obra · Sprint 5 (captura de presupuesto). El
- * traspaso de los Excel (hoja RESUMEN) cargó 128 conceptos de solo-lectura;
- * este form deja operar el presupuesto hacia adelante: capturar conceptos
- * nuevos y corregir/editar los existentes desde el tab Costeo.
+ * Iniciativa dilesa-contratos-obra · Sprint 5 (captura), rediseñado en
+ * dilesa-compras (Sprint 1 fase 2b). El traspaso de los Excel (hoja RESUMEN)
+ * cargó 128 partidas; este form deja operar el presupuesto hacia adelante:
+ * capturar partidas nuevas y corregir/editar las existentes desde el tab Costeo.
  *
- * Calca el form inline de `obra-contrato-detalle.tsx` (captura sin drawer,
- * `useState` plano). Insert/update directo con RLS de `dilesa`; el sub-slug
- * `dilesa.construccion.costeo` ya tiene write → sin migración.
+ * Dos dropdowns clave del rediseño:
+ *   - **Concepto del catálogo** (`concepto_id`): clasifica la partida en el
+ *     catálogo jerárquico (etapa›capítulo, optgroups) — sin esto la partida cae
+ *     en "Sin clasificar". El texto libre del concepto se conserva como etiqueta.
+ *   - **Proveedor** (`proveedor_persona_id`): de `erp.proveedores`. Default "Por
+ *     definir". La opción "Otro (texto libre)" preserva el `proveedor_texto`
+ *     legacy del traspaso para no perder datos al migrar al modelo estructurado.
  *
  * Notas de modelado:
  * - `orden` se autocalcula (max del proyecto + 1) en alta y se preserva en
  *   edición — no se expone en el form (reordenar es otra feature).
  * - IVA: v1 captura `gasto_real_total` c/IVA; el desglose subtotal/iva/tasa
- *   queda null (igual que el traspaso donde el Excel no lo especifica, ver
- *   ADR-038). El % de ejecución usa el total.
+ *   queda null (igual que el traspaso, ADR-038). El % de ejecución usa el total.
  */
 
 import { useState } from 'react';
@@ -30,7 +33,8 @@ import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { proyectoOptionLabel, type ProyectoOption } from '@/lib/dilesa/proyectos-selector';
-import type { CosteoRow } from '@/components/dilesa/costeo-module';
+import type { CatalogoOptgroup } from '@/lib/dilesa/conceptos-catalogo';
+import type { CosteoRow, ProveedorOption } from '@/components/dilesa/costeo-module';
 
 /** "" o no-numérico → null; en otro caso el número. */
 function toNum(s: string): number | null {
@@ -40,9 +44,14 @@ function toNum(s: string): number | null {
   return Number.isNaN(n) ? null : n;
 }
 
+/** Valor centinela del select de proveedor para capturar texto libre. */
+const PROV_OTRO = '__otro__';
+
 export function CosteoConceptoForm({
   empresaId,
   proyectos,
+  optgroups,
+  proveedores,
   rows,
   editRow,
   onClose,
@@ -50,7 +59,11 @@ export function CosteoConceptoForm({
 }: {
   empresaId: string;
   proyectos: readonly ProyectoOption[];
-  /** Conceptos visibles — fuente del autocálculo de `orden` en alta. */
+  /** Optgroups del catálogo (etapa›capítulo) para el selector de clasificación. */
+  optgroups: readonly CatalogoOptgroup[];
+  /** Proveedores activos (persona_id + nombre) para el dropdown. */
+  proveedores: readonly ProveedorOption[];
+  /** Partidas visibles — fuente del autocálculo de `orden` en alta. */
   rows: readonly CosteoRow[];
   /** null = alta; row = edición (form pre-llenado). */
   editRow: CosteoRow | null;
@@ -62,6 +75,7 @@ export function CosteoConceptoForm({
 
   const [proyectoId, setProyectoId] = useState(editRow?.proyecto_id ?? '');
   const [concepto, setConcepto] = useState(editRow?.concepto ?? '');
+  const [conceptoId, setConceptoId] = useState(editRow?.conceptoId ?? '');
   const [etapa, setEtapa] = useState(editRow?.etapa ?? '');
   const [presupuestoPrevio, setPresupuestoPrevio] = useState(
     editRow?.presupuestoPrevio != null ? String(editRow.presupuestoPrevio) : ''
@@ -72,24 +86,50 @@ export function CosteoConceptoForm({
   const [gastoReal, setGastoReal] = useState(
     editRow?.gastoReal != null ? String(editRow.gastoReal) : ''
   );
-  const [proveedor, setProveedor] = useState(editRow?.proveedor ?? '');
+  // Proveedor: si la partida ya tiene persona_id → ese; si solo tiene texto
+  // legacy → modo "Otro"; si no → "Por definir" (default).
+  const [proveedorSel, setProveedorSel] = useState(
+    editRow?.proveedorPersonaId ? editRow.proveedorPersonaId : editRow?.proveedor ? PROV_OTRO : ''
+  );
+  const [proveedorTexto, setProveedorTexto] = useState(editRow?.proveedor ?? '');
   const [fecha, setFecha] = useState(editRow?.fechaCompromiso ?? '');
   const [submitting, setSubmitting] = useState(false);
 
   const canSubmit = proyectoId !== '' && concepto.trim().length > 0;
+
+  // Al elegir un concepto del catálogo, prellena el texto libre si está vacío
+  // (atajo para captura; en edición no pisa el texto existente).
+  function onPickConcepto(id: string) {
+    setConceptoId(id);
+    if (id && concepto.trim() === '') {
+      for (const g of optgroups) {
+        const c = g.conceptos.find((x) => x.id === id);
+        if (c) {
+          setConcepto(c.nombre);
+          break;
+        }
+      }
+    }
+  }
 
   async function onSubmit() {
     if (!canSubmit || submitting) return;
     setSubmitting(true);
     const sb = createSupabaseBrowserClient();
 
+    // Proveedor: dropdown estructurado vs texto libre (mutuamente excluyentes).
+    const proveedorPersonaId = proveedorSel && proveedorSel !== PROV_OTRO ? proveedorSel : null;
+    const proveedorTextoFinal = proveedorSel === PROV_OTRO ? proveedorTexto.trim() || null : null;
+
     const payload = {
       etapa: etapa.trim() || null,
       concepto_texto: concepto.trim(),
+      concepto_id: conceptoId || null,
       presupuesto_previo: toNum(presupuestoPrevio),
       presupuesto_aprobado: toNum(presupuestoActual),
       gasto_real_total: toNum(gastoReal),
-      proveedor_texto: proveedor.trim() || null,
+      proveedor_persona_id: proveedorPersonaId,
+      proveedor_texto: proveedorTextoFinal,
       fecha_compromiso: fecha || null,
     };
 
@@ -116,14 +156,14 @@ export function CosteoConceptoForm({
     if (resp.error) {
       toast.add({
         title: isEdit ? 'Error al guardar' : 'Error al registrar',
-        description: getSupabaseErrorMessage(resp.error, 'No se pudo guardar el concepto.'),
+        description: getSupabaseErrorMessage(resp.error, 'No se pudo guardar la partida.'),
         type: 'error',
       });
       setSubmitting(false);
       return;
     }
     toast.add({
-      title: isEdit ? 'Concepto actualizado' : 'Concepto registrado',
+      title: isEdit ? 'Partida actualizada' : 'Partida registrada',
       description: concepto.trim(),
       type: 'success',
     });
@@ -134,7 +174,7 @@ export function CosteoConceptoForm({
   return (
     <div className="rounded-md border border-[var(--border)] bg-[var(--card)] p-4">
       <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
-        {isEdit ? 'Editar concepto' : 'Nuevo concepto de presupuesto'}
+        {isEdit ? 'Editar partida' : 'Nueva partida de presupuesto'}
       </h2>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         <Field label="Proyecto *">
@@ -151,20 +191,64 @@ export function CosteoConceptoForm({
             ))}
           </select>
         </Field>
-        <Field label="Concepto *">
+        <Field label="Clasificación (catálogo)">
+          <select
+            value={conceptoId}
+            onChange={(e) => onPickConcepto(e.target.value)}
+            className="h-9 w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+          >
+            <option value="">Sin clasificar</option>
+            {optgroups.map((g) => (
+              <optgroup key={g.capituloCodigo} label={g.label}>
+                {g.conceptos.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.nombre}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </Field>
+        <Field label="Concepto (etiqueta) *">
           <Input
             value={concepto}
             onChange={(e) => setConcepto(e.target.value)}
             placeholder="Red de agua potable, Barda perimetral…"
           />
         </Field>
-        <Field label="Etapa">
+        <Field label="Etapa (texto)">
           <Input
             value={etapa}
             onChange={(e) => setEtapa(e.target.value)}
             placeholder="Urbanización, Cabecera…"
           />
         </Field>
+        <Field label="Proveedor">
+          <select
+            value={proveedorSel}
+            onChange={(e) => setProveedorSel(e.target.value)}
+            className="h-9 w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+          >
+            <option value="">Por definir</option>
+            {proveedores.map((p) => (
+              <option key={p.personaId} value={p.personaId}>
+                {p.label}
+              </option>
+            ))}
+            <option value={PROV_OTRO}>Otro (texto libre)…</option>
+          </select>
+        </Field>
+        {proveedorSel === PROV_OTRO ? (
+          <Field label="Proveedor (texto libre)">
+            <Input
+              value={proveedorTexto}
+              onChange={(e) => setProveedorTexto(e.target.value)}
+              placeholder="Nombre del proveedor no catalogado"
+            />
+          </Field>
+        ) : (
+          <div className="hidden sm:block" />
+        )}
         <Field label="Presupuesto previo (c/IVA)">
           <Input
             type="number"
@@ -192,20 +276,14 @@ export function CosteoConceptoForm({
             placeholder="0.00"
           />
         </Field>
-        <Field label="Proveedor">
-          <Input
-            value={proveedor}
-            onChange={(e) => setProveedor(e.target.value)}
-            placeholder="Electrogaza, CFE, DILESA (obra propia)…"
-          />
-        </Field>
         <Field label="Fecha compromiso">
           <Input type="date" value={fecha} onChange={(e) => setFecha(e.target.value)} />
         </Field>
       </div>
       <p className="mt-2 text-[11px] text-[var(--text)]/50">
-        El % de ejecución se calcula como gasto real ÷ presupuesto actualizado (o previo si no hay
-        actualizado). Montos con IVA incluido.
+        La clasificación agrupa y ordena la partida por el catálogo de conceptos. El % de ejecución
+        se calcula como gasto real ÷ presupuesto actualizado (o previo si no hay actualizado).
+        Montos con IVA incluido.
       </p>
       <div className="mt-3 flex items-center justify-end gap-2">
         <Button variant="outline" onClick={onClose} disabled={submitting}>

--- a/components/dilesa/costeo-module.test.ts
+++ b/components/dilesa/costeo-module.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { deriveKpis, type ContratoAgg, type CosteoRow } from './costeo-module';
+import { deriveKpis, groupCosteo, type ContratoAgg, type CosteoRow } from './costeo-module';
+import type { ConceptoResuelto } from '@/lib/dilesa/conceptos-catalogo';
 
 function r(overrides: Partial<CosteoRow>): CosteoRow {
   return {
@@ -8,10 +9,12 @@ function r(overrides: Partial<CosteoRow>): CosteoRow {
     proyectoNombre: 'Lomas',
     etapa: 'Urbanización',
     concepto: 'Drenaje',
+    conceptoId: null,
     presupuestoPrevio: null,
     presupuestoActualizado: null,
     presupuesto: 0,
     gastoReal: 0,
+    proveedorPersonaId: null,
     proveedor: null,
     fechaCompromiso: null,
     orden: 0,
@@ -75,5 +78,88 @@ describe('deriveKpis (Costeo DILESA — ADR-034)', () => {
     const k = deriveKpis([r({})], { contratado: 5_000_000, saldo: 1_200_000 });
     expect(String(k[3]?.value)).toContain('5'); // contratado
     expect(String(k[4]?.value)).toContain('1'); // saldo
+  });
+});
+
+// Catálogo mínimo: 1 concepto en Urbanización › Agua potable, 1 en
+// Anteproyecto › Topografía. Mismo shape que buildCatalogoConceptos.
+function resuelto(over: Partial<ConceptoResuelto>): ConceptoResuelto {
+  return {
+    id: 'k',
+    codigo: '2.03.01',
+    nombre: 'Red de agua potable',
+    capituloCodigo: '2.03',
+    capituloNombre: 'Agua potable',
+    etapaCodigo: '2',
+    etapaNombre: 'Urbanización',
+    ...over,
+  };
+}
+const CATALOGO = new Map<string, ConceptoResuelto>([
+  ['agua', resuelto({ id: 'agua', codigo: '2.03.01' })],
+  [
+    'topo',
+    resuelto({
+      id: 'topo',
+      codigo: '1.01.01',
+      nombre: 'Levantamiento',
+      capituloCodigo: '1.01',
+      capituloNombre: 'Topografía',
+      etapaCodigo: '1',
+      etapaNombre: 'Anteproyecto',
+    }),
+  ],
+]);
+
+describe('groupCosteo (Costeo DILESA — agrupado etapa›capítulo)', () => {
+  it('agrupa por etapa y capítulo del catálogo, ordenado por código', () => {
+    const grupos = groupCosteo([r({ conceptoId: 'agua' }), r({ conceptoId: 'topo' })], CATALOGO);
+    // Anteproyecto (etapa 1) antes que Urbanización (etapa 2).
+    expect(grupos.map((g) => g.nombre)).toEqual(['Anteproyecto', 'Urbanización']);
+    expect(grupos[0]?.capitulos[0]?.nombre).toBe('Topografía');
+    expect(grupos[1]?.capitulos[0]?.nombre).toBe('Agua potable');
+  });
+
+  it('manda las partidas sin concepto_id a "Sin clasificar" al final', () => {
+    const grupos = groupCosteo(
+      [r({ conceptoId: 'agua' }), r({ conceptoId: null, concepto: 'Huérfana' })],
+      CATALOGO
+    );
+    expect(grupos.at(-1)?.nombre).toBe('Sin clasificar');
+    expect(grupos.at(-1)?.capitulos[0]?.partidas[0]?.concepto).toBe('Huérfana');
+  });
+
+  it('un concepto_id que no resuelve en el catálogo cae en "Sin clasificar"', () => {
+    const grupos = groupCosteo([r({ conceptoId: 'no-existe' })], CATALOGO);
+    expect(grupos).toHaveLength(1);
+    expect(grupos[0]?.nombre).toBe('Sin clasificar');
+  });
+
+  it('suma subtotales por capítulo y por etapa (null-safe)', () => {
+    const grupos = groupCosteo(
+      [
+        r({ conceptoId: 'agua', presupuesto: 1000, gastoReal: 400 }),
+        r({ conceptoId: 'agua', presupuesto: null, gastoReal: 100 }),
+      ],
+      CATALOGO
+    );
+    const etapa = grupos[0];
+    expect(etapa?.presupuesto).toBe(1000);
+    expect(etapa?.gastoReal).toBe(500);
+    expect(etapa?.capitulos[0]?.presupuesto).toBe(1000);
+    expect(etapa?.capitulos[0]?.gastoReal).toBe(500);
+  });
+
+  it('ordena las partidas dentro del capítulo por código de concepto', () => {
+    const cat = new Map<string, ConceptoResuelto>([
+      ['a', resuelto({ id: 'a', codigo: '2.03.02', nombre: 'B' })],
+      ['b', resuelto({ id: 'b', codigo: '2.03.01', nombre: 'A' })],
+    ]);
+    const grupos = groupCosteo(
+      [r({ id: 'x', conceptoId: 'a' }), r({ id: 'y', conceptoId: 'b' })],
+      cat
+    );
+    // y (2.03.01) antes que x (2.03.02).
+    expect(grupos[0]?.capitulos[0]?.partidas.map((p) => p.id)).toEqual(['y', 'x']);
   });
 });

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -3,44 +3,73 @@
 /**
  * CosteoModule — costeo + rollup de CapEx por proyecto (DILESA).
  *
- * Iniciativa dilesa-contratos-obra · Sprint 3. Tab "Costeo" del hub
- * Construcción. Junta las dos capas del traspaso de obra (ADR-038):
+ * Iniciativa dilesa-contratos-obra · Sprint 3, rediseñado en dilesa-compras
+ * (Sprint 1 fase 2b). Tab "Costeo" del hub Construcción. Junta las dos capas
+ * del traspaso de obra (ADR-038):
  *
- *   - Capa A (`dilesa.obra_presupuesto`): presupuesto actualizado vs gasto
- *     real por concepto × etapa × proyecto. Es la tabla principal de esta
- *     vista (hasta Sprint 3 no tenía UI).
+ *   - Capa A (`erp.presupuesto_partidas`, modelo canónico ADR-040): presupuesto
+ *     actualizado vs gasto real por partida × etapa × proyecto. Es la tabla
+ *     principal de esta vista.
  *   - Capa B (`dilesa.contratos_construccion` + `dilesa.obra_estimaciones`):
  *     contratado y pagado por proyecto → saldo por pagar (`valor_total − Σ
  *     estimaciones`). Alimenta los KPIs de rollup.
  *
+ * El rediseño (2026-06-04, plan cerrado con Beto):
+ *   1. Tabla agrupada colapsable en 2 niveles: etapa › capítulo (del catálogo
+ *      `erp.conceptos_compra`), con subtotal por grupo.
+ *   2. Orden por el catálogo canónico (etapa→capítulo→concepto). Las partidas
+ *      sin `concepto_id` caen en un grupo "Sin clasificar" al final.
+ *   3. Un proyecto a la vez: auto-selecciona el primero al entrar.
+ *   4. El form gana 2 dropdowns: concepto del catálogo (clasifica → setea
+ *      `concepto_id`) + proveedor de `erp.proveedores` (setea
+ *      `proveedor_persona_id`).
+ *   5. Botón eliminar visible (ícono de bote directo, no en el menú ⋯).
+ *
  * Carga cross-schema con queries paralelas + lookups Map (mismo patrón que
- * contratos-module — evita embeds de PostgREST). Los KPIs son reactivos a
- * los filtros (ADR-034); el contratado/saldo refleja los proyectos visibles.
+ * contratos-module — evita embeds de PostgREST). Los KPIs son reactivos a los
+ * filtros (ADR-034); el contratado/saldo refleja los proyectos visibles.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
-import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
+import { ModuleKpiStrip, type ModuleKpi } from '@/components/module-page';
 import { Input } from '@/components/ui/input';
-import { Coins, Plus, RefreshCw, Search } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Coins,
+  Loader2,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Search,
+  Trash2,
+} from 'lucide-react';
 import { usePermissions } from '@/components/providers';
 import { useToast } from '@/components/ui/toast';
-import { RowActions } from '@/components/shared/row-actions';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 import { CosteoConceptoForm } from '@/components/dilesa/costeo-concepto-form';
 import {
   buildProyectoOptions,
   type ProyectoOption,
   type ProyectoSelectorRow,
 } from '@/lib/dilesa/proyectos-selector';
+import {
+  buildCatalogoConceptos,
+  type CatalogoConceptos,
+  type ConceptoResuelto,
+} from '@/lib/dilesa/conceptos-catalogo';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { formatCurrency, formatPercent } from '@/lib/format';
 
 export type CosteoRow = {
   id: string;
-  proyecto_id: string;
+  proyecto_id: string | null;
   proyectoNombre: string;
   etapa: string | null;
   concepto: string;
+  /** Clasificación al catálogo `erp.conceptos_compra` (drives agrupado/orden). */
+  conceptoId: string | null;
   /** presupuesto_previo crudo (numeric, c/IVA) — para la captura. */
   presupuestoPrevio: number | null;
   /** presupuesto_actualizado crudo (numeric, c/IVA) — para la captura. */
@@ -49,6 +78,9 @@ export type CosteoRow = {
   presupuesto: number | null;
   /** gasto_real_total (numeric, c/IVA). */
   gastoReal: number | null;
+  /** Proveedor estructurado (persona_id) — preferido sobre el texto libre. */
+  proveedorPersonaId: string | null;
+  /** Proveedor en texto libre (legacy del traspaso; fallback de display). */
   proveedor: string | null;
   /** fecha_compromiso (date ISO) — para la captura. */
   fechaCompromiso: string | null;
@@ -58,8 +90,123 @@ export type CosteoRow = {
   ratio: number | null;
 };
 
+/** Opción de proveedor para el dropdown del form (persona_id + nombre). */
+export type ProveedorOption = { personaId: string; label: string };
+
 /** Contratado y pagado por proyecto (Capa B), para el rollup de saldo. */
 export type ContratoAgg = { contratado: number; saldo: number };
+
+/** Clave del bucket "sin clasificar" (etapa o capítulo sin catálogo). */
+const SIN = '__sin__';
+
+/** Un capítulo agrupado con sus partidas y subtotales. */
+export type CosteoCapitulo = {
+  key: string;
+  codigo: string | null;
+  nombre: string;
+  partidas: CosteoRow[];
+  presupuesto: number;
+  gastoReal: number;
+};
+
+/** Una etapa agrupada con sus capítulos y subtotales. */
+export type CosteoEtapa = {
+  key: string;
+  codigo: string | null;
+  nombre: string;
+  capitulos: CosteoCapitulo[];
+  presupuesto: number;
+  gastoReal: number;
+};
+
+/**
+ * Agrupa las partidas en la estructura colapsable de 2 niveles (etapa →
+ * capítulo) según la clasificación del catálogo. Las partidas sin `concepto_id`
+ * (o cuyo concepto no resuelve en el catálogo) caen en "Sin clasificar", que se
+ * ordena al final. Subtotales null-safe. Orden de hojas: código de concepto →
+ * `orden` → texto. Exportado para test unitario (ADR-034 patrón deriveKpis).
+ */
+export function groupCosteo(
+  rows: readonly CosteoRow[],
+  byConcepto: ReadonlyMap<string, ConceptoResuelto>
+): CosteoEtapa[] {
+  type EtapaAcc = {
+    key: string;
+    codigo: string | null;
+    nombre: string;
+    orderKey: string;
+    capitulos: Map<string, { cap: CosteoCapitulo; orderKey: string }>;
+    presupuesto: number;
+    gastoReal: number;
+  };
+  const etapas = new Map<string, EtapaAcc>();
+
+  for (const r of rows) {
+    const res = r.conceptoId ? byConcepto.get(r.conceptoId) : undefined;
+    const etapaKey = res ? res.etapaCodigo : SIN;
+    const capKey = res ? res.capituloCodigo : SIN;
+
+    let e = etapas.get(etapaKey);
+    if (!e) {
+      e = {
+        key: etapaKey,
+        codigo: res ? res.etapaCodigo : null,
+        nombre: res ? res.etapaNombre : 'Sin clasificar',
+        orderKey: res ? res.etapaCodigo : '￿',
+        capitulos: new Map(),
+        presupuesto: 0,
+        gastoReal: 0,
+      };
+      etapas.set(etapaKey, e);
+    }
+
+    let c = e.capitulos.get(capKey);
+    if (!c) {
+      c = {
+        cap: {
+          key: `${etapaKey}/${capKey}`,
+          codigo: res ? res.capituloCodigo : null,
+          nombre: res ? res.capituloNombre : 'Sin clasificar',
+          partidas: [],
+          presupuesto: 0,
+          gastoReal: 0,
+        },
+        orderKey: res ? res.capituloCodigo : '￿',
+      };
+      e.capitulos.set(capKey, c);
+    }
+
+    const p = r.presupuesto ?? 0;
+    const g = r.gastoReal ?? 0;
+    c.cap.partidas.push(r);
+    c.cap.presupuesto += p;
+    c.cap.gastoReal += g;
+    e.presupuesto += p;
+    e.gastoReal += g;
+  }
+
+  return [...etapas.values()]
+    .sort((a, b) => a.orderKey.localeCompare(b.orderKey))
+    .map((e) => ({
+      key: e.key,
+      codigo: e.codigo,
+      nombre: e.nombre,
+      presupuesto: e.presupuesto,
+      gastoReal: e.gastoReal,
+      capitulos: [...e.capitulos.values()]
+        .sort((a, b) => a.orderKey.localeCompare(b.orderKey))
+        .map(({ cap }) => {
+          cap.partidas.sort((x, y) => {
+            const cx = x.conceptoId ? (byConcepto.get(x.conceptoId)?.codigo ?? '') : '';
+            const cy = y.conceptoId ? (byConcepto.get(y.conceptoId)?.codigo ?? '') : '';
+            if (cx !== cy) return cx.localeCompare(cy);
+            if (x.orden !== y.orden) return x.orden - y.orden;
+            return x.concepto.localeCompare(y.concepto);
+          });
+          return cap;
+        }),
+    }));
+}
 
 /**
  * KPIs reactivos a filtros (ADR-034). `rows` = renglones de presupuesto
@@ -103,6 +250,21 @@ export function deriveKpis(
   ];
 }
 
+/** % de ejecución de un subtotal de grupo (gasto ÷ presupuesto). */
+function pctEjec(gasto: number, presupuesto: number): string {
+  return presupuesto > 0 ? formatPercent(gasto / presupuesto) : '—';
+}
+
+type FetchResult = {
+  rows?: CosteoRow[];
+  agg?: Map<string, { contratado: number; pagado: number }>;
+  proyectos?: ProyectoOption[];
+  catalogo?: CatalogoConceptos;
+  proveedores?: ProveedorOption[];
+  proveedorNombreById?: Map<string, string>;
+  error?: string;
+};
+
 export function CosteoModule({ empresaId }: { empresaId: string }) {
   const { permissions } = usePermissions();
   const toast = useToast();
@@ -116,25 +278,42 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   >(new Map());
   /** Proyectos DILESA para el selector del form (desarrollos + anteproyectos no convertidos). */
   const [proyectos, setProyectos] = useState<ProyectoOption[]>([]);
+  /** Catálogo de conceptos (agrupado/orden de la tabla + optgroups del form). */
+  const [catalogo, setCatalogo] = useState<CatalogoConceptos>({
+    byConcepto: new Map(),
+    optgroups: [],
+  });
+  /** Proveedores activos para el dropdown del form. */
+  const [proveedores, setProveedores] = useState<ProveedorOption[]>([]);
+  /** persona_id → nombre, para resolver el proveedor en la tabla. */
+  const [proveedorNombreById, setProveedorNombreById] = useState<Map<string, string>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  /** '' = todos · '__sin__' = sin proyecto · else proyecto_id (un proyecto a la vez). */
   const [proyectoFiltro, setProyectoFiltro] = useState('');
-  const [etapaFiltro, setEtapaFiltro] = useState('');
-  /** Captura de presupuesto (Sprint 5). null editRow + open = alta. */
+  const autoSelectDone = useRef(false);
+  /** Captura de presupuesto. null editRow + open = alta. */
   const [formOpen, setFormOpen] = useState(false);
   const [editRow, setEditRow] = useState<CosteoRow | null>(null);
+  /** Colapsado de grupos (keys de etapa y capítulo). Default: todo expandido. */
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  /** Partida pendiente de confirmar borrado (trash visible). */
+  const [deleteTarget, setDeleteTarget] = useState<CosteoRow | null>(null);
 
-  const fetchCosteo = useCallback(async (): Promise<{
-    rows?: CosteoRow[];
-    agg?: Map<string, { contratado: number; pagado: number }>;
-    proyectos?: ProyectoOption[];
-    error?: string;
-  }> => {
+  const fetchCosteo = useCallback(async (): Promise<FetchResult> => {
     const sb = createSupabaseBrowserClient();
 
-    // Capa A (presupuesto) + proyectos + Capa B (contratos + estimaciones).
-    const [presupuestoRes, proyectosRes, contratosRes, estimacionesRes] = await Promise.all([
+    // Capa A (partidas) + proyectos + Capa B (contratos + estimaciones) +
+    // catálogo de conceptos + proveedores activos.
+    const [
+      presupuestoRes,
+      proyectosRes,
+      contratosRes,
+      estimacionesRes,
+      catalogoRes,
+      proveedoresRes,
+    ] = await Promise.all([
       // Capa A migrada al modelo canónico erp.presupuesto_partidas (ADR-040).
       // Cast `as any`: la tabla aún no está en types (se difiere al workflow
       // db-types). concepto→concepto_texto, presupuesto_actualizado→presupuesto_aprobado.
@@ -142,7 +321,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       (sb.schema('erp') as any)
         .from('presupuesto_partidas')
         .select(
-          'id, proyecto_id, etapa, concepto_texto, presupuesto_aprobado, presupuesto_previo, gasto_real_total, proveedor_texto, fecha_compromiso, orden'
+          'id, proyecto_id, etapa, concepto_texto, concepto_id, presupuesto_aprobado, presupuesto_previo, gasto_real_total, proveedor_persona_id, proveedor_texto, fecha_compromiso, orden'
         )
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
@@ -164,10 +343,30 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
         .select('contrato_id, monto_total')
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
+      // Catálogo de conceptos (ADR-040) — cast `as any` (no está en types aún).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any)
+        .from('conceptos_compra')
+        .select('id, padre_id, nivel, codigo, nombre')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      // Proveedores activos + nombre de la persona (embed intra-schema erp).
+      sb
+        .schema('erp')
+        .from('proveedores')
+        .select('persona_id, personas:persona_id(nombre, apellido_paterno, apellido_materno)')
+        .eq('empresa_id', empresaId)
+        .eq('activo', true)
+        .is('deleted_at', null),
     ]);
 
     const firstErr =
-      presupuestoRes.error ?? proyectosRes.error ?? contratosRes.error ?? estimacionesRes.error;
+      presupuestoRes.error ??
+      proyectosRes.error ??
+      contratosRes.error ??
+      estimacionesRes.error ??
+      catalogoRes.error ??
+      proveedoresRes.error;
     if (firstErr) {
       return { error: getSupabaseErrorMessage(firstErr, 'No se pudo cargar el costeo.') };
     }
@@ -200,95 +399,137 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       agg.set(pid, cur);
     }
 
-    // El SELECT va por cast `as any` (presupuesto_partidas no está en types aún);
-    // tipamos la fila cruda aquí para conservar el chequeo en el mapeo.
+    // Catálogo de conceptos (árbol etapa→capítulo→concepto).
+    const catalogo = buildCatalogoConceptos(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (catalogoRes.data ?? []) as any[]
+    );
+
+    // Proveedores: dedup por persona_id, label = nombre + apellidos.
+    type ProvRaw = {
+      persona_id: string;
+      personas: {
+        nombre: string | null;
+        apellido_paterno: string | null;
+        apellido_materno: string | null;
+      } | null;
+    };
+    const proveedorNombreById = new Map<string, string>();
+    for (const pv of (proveedoresRes.data ?? []) as unknown as ProvRaw[]) {
+      if (!pv.persona_id || proveedorNombreById.has(pv.persona_id)) continue;
+      const label = [
+        pv.personas?.nombre,
+        pv.personas?.apellido_paterno,
+        pv.personas?.apellido_materno,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .trim();
+      proveedorNombreById.set(pv.persona_id, label || '(sin nombre)');
+    }
+    const proveedores: ProveedorOption[] = [...proveedorNombreById.entries()]
+      .map(([personaId, label]) => ({ personaId, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+
+    // El SELECT va por cast `as any`; tipamos la fila cruda aquí para conservar
+    // el chequeo en el mapeo.
     type PartidaRaw = {
       id: string;
       proyecto_id: string | null;
       etapa: string | null;
       concepto_texto: string | null;
+      concepto_id: string | null;
       presupuesto_aprobado: number | null;
       presupuesto_previo: number | null;
       gasto_real_total: number | null;
+      proveedor_persona_id: string | null;
       proveedor_texto: string | null;
       fecha_compromiso: string | null;
       orden: number | null;
     };
-    const out: CosteoRow[] = ((presupuestoRes.data ?? []) as PartidaRaw[])
-      .filter((r) => r.proyecto_id != null)
-      .map((r) => {
-        const presupuesto =
-          r.presupuesto_aprobado != null
-            ? Number(r.presupuesto_aprobado)
-            : r.presupuesto_previo != null
-              ? Number(r.presupuesto_previo)
-              : null;
-        const gastoReal = r.gasto_real_total != null ? Number(r.gasto_real_total) : null;
-        const pid = r.proyecto_id as string;
-        return {
-          id: r.id as string,
-          proyecto_id: pid,
-          proyectoNombre: proyectoMap.get(pid) ?? '',
-          etapa: (r.etapa as string | null) ?? null,
-          concepto: (r.concepto_texto as string) ?? '',
-          presupuestoPrevio: r.presupuesto_previo != null ? Number(r.presupuesto_previo) : null,
-          presupuestoActualizado:
-            r.presupuesto_aprobado != null ? Number(r.presupuesto_aprobado) : null,
-          presupuesto,
-          gastoReal,
-          proveedor: (r.proveedor_texto as string | null) ?? null,
-          fechaCompromiso: (r.fecha_compromiso as string | null) ?? null,
-          orden: Number(r.orden ?? 0),
-          ratio:
-            presupuesto != null && presupuesto > 0 && gastoReal != null
-              ? gastoReal / presupuesto
-              : null,
-        };
-      });
+    const out: CosteoRow[] = ((presupuestoRes.data ?? []) as PartidaRaw[]).map((r) => {
+      const presupuesto =
+        r.presupuesto_aprobado != null
+          ? Number(r.presupuesto_aprobado)
+          : r.presupuesto_previo != null
+            ? Number(r.presupuesto_previo)
+            : null;
+      const gastoReal = r.gasto_real_total != null ? Number(r.gasto_real_total) : null;
+      const pid = (r.proyecto_id as string | null) ?? null;
+      return {
+        id: r.id as string,
+        proyecto_id: pid,
+        proyectoNombre: pid ? (proyectoMap.get(pid) ?? '') : '',
+        etapa: (r.etapa as string | null) ?? null,
+        concepto: (r.concepto_texto as string) ?? '',
+        conceptoId: (r.concepto_id as string | null) ?? null,
+        presupuestoPrevio: r.presupuesto_previo != null ? Number(r.presupuesto_previo) : null,
+        presupuestoActualizado:
+          r.presupuesto_aprobado != null ? Number(r.presupuesto_aprobado) : null,
+        presupuesto,
+        gastoReal,
+        proveedorPersonaId: (r.proveedor_persona_id as string | null) ?? null,
+        proveedor: (r.proveedor_texto as string | null) ?? null,
+        fechaCompromiso: (r.fecha_compromiso as string | null) ?? null,
+        orden: Number(r.orden ?? 0),
+        ratio:
+          presupuesto != null && presupuesto > 0 && gastoReal != null
+            ? gastoReal / presupuesto
+            : null,
+      };
+    });
 
-    return { rows: out, agg, proyectos };
+    return { rows: out, agg, proyectos, catalogo, proveedores, proveedorNombreById };
   }, [empresaId]);
 
-  const cargar = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    const { rows: data, agg, proyectos: proy, error: e } = await fetchCosteo();
-    if (e) {
-      setError(e);
+  const applyResult = useCallback((res: FetchResult) => {
+    if (res.error) {
+      setError(res.error);
       setRows([]);
       setContratoAggByProyecto(new Map());
       setProyectos([]);
+      setProveedores([]);
+      setProveedorNombreById(new Map());
+      setCatalogo({ byConcepto: new Map(), optgroups: [] });
     } else {
-      setRows(data ?? []);
-      setContratoAggByProyecto(agg ?? new Map());
-      setProyectos(proy ?? []);
+      setError(null);
+      setRows(res.rows ?? []);
+      setContratoAggByProyecto(res.agg ?? new Map());
+      setProyectos(res.proyectos ?? []);
+      setCatalogo(res.catalogo ?? { byConcepto: new Map(), optgroups: [] });
+      setProveedores(res.proveedores ?? []);
+      setProveedorNombreById(res.proveedorNombreById ?? new Map());
     }
+  }, []);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    applyResult(await fetchCosteo());
     setLoading(false);
-  }, [fetchCosteo]);
+  }, [fetchCosteo, applyResult]);
 
   useEffect(() => {
     let activo = true;
-    void fetchCosteo().then(({ rows: data, agg, proyectos: proy, error: e }) => {
+    void fetchCosteo().then((res) => {
       if (!activo) return;
-      if (e) {
-        setError(e);
-        setRows([]);
-        setContratoAggByProyecto(new Map());
-        setProyectos([]);
-      } else {
-        setRows(data ?? []);
-        setContratoAggByProyecto(agg ?? new Map());
-        setProyectos(proy ?? []);
+      applyResult(res);
+      // Un proyecto a la vez: auto-selecciona el primero (por nombre) al entrar.
+      if (!autoSelectDone.current && !res.error) {
+        const first = (res.rows ?? [])
+          .filter((r) => r.proyecto_id)
+          .sort((a, b) => a.proyectoNombre.localeCompare(b.proyectoNombre))[0];
+        if (first?.proyecto_id) setProyectoFiltro(first.proyecto_id);
+        autoSelectDone.current = true;
       }
       setLoading(false);
     });
     return () => {
       activo = false;
     };
-  }, [fetchCosteo]);
+  }, [fetchCosteo, applyResult]);
 
-  // Soft-delete de un concepto de presupuesto (Sprint 5). Patrón del repo:
-  // marca `deleted_at`, preserva historial para auditoría.
+  // Soft-delete de una partida. Patrón del repo: marca `deleted_at`, preserva
+  // historial para auditoría.
   const eliminar = useCallback(
     async (row: CosteoRow) => {
       const sb = createSupabaseBrowserClient();
@@ -300,12 +541,12 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       if (e) {
         toast.add({
           title: 'Error al eliminar',
-          description: getSupabaseErrorMessage(e, 'No se pudo eliminar el concepto.'),
+          description: getSupabaseErrorMessage(e, 'No se pudo eliminar la partida.'),
           type: 'error',
         });
         return;
       }
-      toast.add({ title: 'Concepto eliminado', description: row.concepto, type: 'success' });
+      toast.add({ title: 'Partida eliminada', description: row.concepto, type: 'success' });
       void cargar();
     },
     [toast, cargar]
@@ -324,34 +565,53 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
     setEditRow(null);
   }
 
-  const proyectosPresentes = useMemo(
-    () => [...new Set(rows.map((r) => r.proyectoNombre).filter(Boolean))].sort(),
-    [rows]
-  );
-  const etapasPresentes = useMemo(
-    () => [...new Set(rows.map((r) => r.etapa).filter((e): e is string => Boolean(e)))].sort(),
-    [rows]
-  );
+  const toggleGrupo = useCallback((key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
 
+  // Opciones del selector de proyecto: cada proyecto presente + "sin proyecto".
+  const proyectosPresentes = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const r of rows) {
+      if (r.proyecto_id) m.set(r.proyecto_id, r.proyectoNombre || '(sin nombre)');
+    }
+    return [...m.entries()]
+      .map(([id, nombre]) => ({ id, nombre }))
+      .sort((a, b) => a.nombre.localeCompare(b.nombre));
+  }, [rows]);
+  const haySinProyecto = useMemo(() => rows.some((r) => !r.proyecto_id), [rows]);
+
+  const q = search.trim().toLowerCase();
   const filtrados = useMemo(() => {
-    const q = search.trim().toLowerCase();
     return rows.filter((r) => {
-      if (proyectoFiltro && r.proyectoNombre !== proyectoFiltro) return false;
-      if (etapaFiltro && r.etapa !== etapaFiltro) return false;
+      if (proyectoFiltro === SIN) {
+        if (r.proyecto_id) return false;
+      } else if (proyectoFiltro !== '') {
+        if (r.proyecto_id !== proyectoFiltro) return false;
+      }
       if (q) {
+        const proveedorNombre = r.proveedorPersonaId
+          ? (proveedorNombreById.get(r.proveedorPersonaId) ?? '')
+          : '';
         const hay =
           r.concepto.toLowerCase().includes(q) ||
           (r.proveedor?.toLowerCase().includes(q) ?? false) ||
+          proveedorNombre.toLowerCase().includes(q) ||
           (r.etapa?.toLowerCase().includes(q) ?? false);
         if (!hay) return false;
       }
       return true;
     });
-  }, [rows, search, proyectoFiltro, etapaFiltro]);
+  }, [rows, q, proyectoFiltro, proveedorNombreById]);
 
   // Contratado/saldo de Capa B para los proyectos visibles en los filtros.
   const contratoTotals = useMemo<ContratoAgg>(() => {
-    const visibles = new Set(filtrados.map((r) => r.proyecto_id));
+    const visibles = new Set(filtrados.map((r) => r.proyecto_id).filter(Boolean) as string[]);
     let contratado = 0;
     let pagado = 0;
     for (const pid of visibles) {
@@ -366,63 +626,25 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
 
   const kpis = useMemo(() => deriveKpis(filtrados, contratoTotals), [filtrados, contratoTotals]);
 
-  const columns: Column<CosteoRow>[] = [
-    {
-      key: 'proyectoNombre',
-      label: 'Proyecto',
-      type: 'text',
-      sticky: true,
-      width: 'min-w-[180px]',
+  const grupos = useMemo(
+    () => groupCosteo(filtrados, catalogo.byConcepto),
+    [filtrados, catalogo.byConcepto]
+  );
+
+  // Resuelve el proveedor a mostrar: estructurado → texto libre → "—".
+  const proveedorDisplay = useCallback(
+    (r: CosteoRow): string => {
+      if (r.proveedorPersonaId) {
+        return proveedorNombreById.get(r.proveedorPersonaId) ?? r.proveedor ?? '—';
+      }
+      return r.proveedor || '—';
     },
-    { key: 'etapa', label: 'Etapa', type: 'text', render: (r) => r.etapa || '—' },
-    { key: 'concepto', label: 'Concepto', type: 'text', width: 'min-w-[260px]' },
-    {
-      key: 'presupuesto',
-      label: 'Presupuesto',
-      type: 'custom',
-      accessor: (r) => r.presupuesto ?? 0,
-      render: (r) => (r.presupuesto == null ? '—' : formatCurrency(r.presupuesto)),
-    },
-    {
-      key: 'gastoReal',
-      label: 'Gasto real',
-      type: 'custom',
-      accessor: (r) => r.gastoReal ?? 0,
-      render: (r) => (r.gastoReal == null ? '—' : formatCurrency(r.gastoReal)),
-    },
-    {
-      key: 'ratio',
-      label: '% ejec.',
-      type: 'custom',
-      accessor: (r) => r.ratio ?? 0,
-      render: (r) => (r.ratio == null ? '—' : formatPercent(r.ratio)),
-    },
-    { key: 'proveedor', label: 'Proveedor', type: 'text', render: (r) => r.proveedor || '—' },
-    ...(puedeEscribir
-      ? [
-          {
-            key: 'acciones',
-            label: '',
-            type: 'custom' as const,
-            sortable: false,
-            align: 'right' as const,
-            width: 'w-12',
-            render: (r: CosteoRow) => (
-              <RowActions
-                ariaLabel={`Acciones para ${r.concepto}`}
-                onEdit={{ onClick: () => abrirEdicion(r) }}
-                onDelete={{
-                  onConfirm: () => eliminar(r),
-                  confirmTitle: `¿Eliminar “${r.concepto}”?`,
-                  confirmDescription:
-                    'Marcará el concepto de presupuesto como eliminado. Se preserva el historial para auditoría.',
-                }}
-              />
-            ),
-          },
-        ]
-      : []),
-  ];
+    [proveedorNombreById]
+  );
+
+  // Al buscar, ignora el colapsado para que los matches sean visibles.
+  const isSearching = q.length > 0;
+  const colCount = puedeEscribir ? 6 : 5;
 
   return (
     <div className="space-y-6 p-6">
@@ -442,6 +664,20 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       <ModuleKpiStrip stats={kpis} cols={5} />
 
       <div className="flex flex-wrap items-center gap-3">
+        <select
+          value={proyectoFiltro}
+          onChange={(e) => setProyectoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm font-medium text-[var(--text)]"
+          aria-label="Proyecto"
+        >
+          <option value="">Todos los proyectos</option>
+          {proyectosPresentes.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.nombre}
+            </option>
+          ))}
+          {haySinProyecto ? <option value={SIN}>Sin proyecto asignado</option> : null}
+        </select>
         <div className="relative">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
           <Input
@@ -451,30 +687,6 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
             className="w-72 pl-9"
           />
         </div>
-        <select
-          value={proyectoFiltro}
-          onChange={(e) => setProyectoFiltro(e.target.value)}
-          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
-        >
-          <option value="">Todos los proyectos</option>
-          {proyectosPresentes.map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
-        <select
-          value={etapaFiltro}
-          onChange={(e) => setEtapaFiltro(e.target.value)}
-          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
-        >
-          <option value="">Todas las etapas</option>
-          {etapasPresentes.map((et) => (
-            <option key={et} value={et}>
-              {et}
-            </option>
-          ))}
-        </select>
         <button
           type="button"
           onClick={() => void cargar()}
@@ -485,7 +697,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
         </button>
         <div className="ml-auto flex items-center gap-3">
           <span className="text-sm text-[var(--text)]/60">
-            {filtrados.length} de {rows.length} conceptos
+            {filtrados.length} de {rows.length} partidas
           </span>
           {puedeEscribir ? (
             <button
@@ -494,7 +706,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
               className="inline-flex h-9 items-center gap-1.5 rounded-md bg-[var(--accent)] px-3 text-sm font-medium text-white hover:opacity-90"
             >
               <Plus className="h-3.5 w-3.5" />
-              Nuevo concepto
+              Nueva partida
             </button>
           ) : null}
         </div>
@@ -505,6 +717,8 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
           key={editRow?.id ?? 'nuevo'}
           empresaId={empresaId}
           proyectos={proyectos}
+          optgroups={catalogo.optgroups}
+          proveedores={proveedores}
           rows={rows}
           editRow={editRow}
           onClose={cerrarForm}
@@ -515,19 +729,256 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
         />
       ) : null}
 
-      <DataTable
-        data={filtrados}
-        columns={columns}
-        rowKey="id"
-        loading={loading}
-        error={error}
-        onRetry={() => void cargar()}
-        initialSort={{ key: 'gastoReal', dir: 'desc' }}
-        emptyTitle="Sin costeo"
-        emptyDescription="No hay conceptos de presupuesto que coincidan con los filtros."
-        emptyIcon={<Coins className="h-6 w-6" />}
-        maxHeight="calc(100vh - 280px)"
+      {loading ? (
+        <div className="flex items-center justify-center gap-2 rounded-md border border-[var(--border)] py-16 text-sm text-[var(--text)]/60">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Cargando costeo…
+        </div>
+      ) : error ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={() => void cargar()}
+            className="mt-2 rounded-md border border-red-300 px-3 py-1 text-xs font-medium hover:bg-red-100"
+          >
+            Reintentar
+          </button>
+        </div>
+      ) : grupos.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed border-[var(--border)] py-16 text-center">
+          <Coins className="h-6 w-6 text-[var(--text)]/30" />
+          <p className="text-sm font-medium text-[var(--text)]">Sin costeo</p>
+          <p className="text-sm text-[var(--text)]/60">
+            No hay partidas de presupuesto que coincidan con los filtros.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-[var(--border)]">
+          <table className="min-w-full text-sm">
+            <thead className="sticky top-0 z-10 bg-[var(--card)] text-xs uppercase tracking-wide text-[var(--text)]/50">
+              <tr className="border-b border-[var(--border)]">
+                <th className="px-3 py-2.5 text-left">Concepto</th>
+                <th className="w-36 px-3 py-2.5 text-right">Presupuesto</th>
+                <th className="w-36 px-3 py-2.5 text-right">Gasto real</th>
+                <th className="w-20 px-3 py-2.5 text-right">% ejec.</th>
+                <th className="w-56 px-3 py-2.5 text-left">Proveedor</th>
+                {puedeEscribir ? <th className="w-20 px-3 py-2.5 text-right" /> : null}
+              </tr>
+            </thead>
+            <tbody>
+              {grupos.map((etapa) => {
+                const etapaCollapsed = !isSearching && collapsed.has(etapa.key);
+                return (
+                  <GrupoFragment
+                    key={etapa.key}
+                    etapa={etapa}
+                    etapaCollapsed={etapaCollapsed}
+                    collapsed={collapsed}
+                    isSearching={isSearching}
+                    colCount={colCount}
+                    puedeEscribir={puedeEscribir}
+                    onToggle={toggleGrupo}
+                    proveedorDisplay={proveedorDisplay}
+                    onEdit={abrirEdicion}
+                    onDelete={setDeleteTarget}
+                  />
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={deleteTarget != null}
+        onOpenChange={(o) => {
+          if (!o) setDeleteTarget(null);
+        }}
+        onConfirm={async () => {
+          if (deleteTarget) await eliminar(deleteTarget);
+          setDeleteTarget(null);
+        }}
+        title={deleteTarget ? `¿Eliminar “${deleteTarget.concepto}”?` : '¿Eliminar partida?'}
+        description="Marcará la partida de presupuesto como eliminada. Se preserva el historial para auditoría."
+        confirmLabel="Eliminar"
       />
     </div>
+  );
+}
+
+// ─── Fragmento de grupo (etapa + sus capítulos + partidas) ──────────────────
+
+function GrupoFragment({
+  etapa,
+  etapaCollapsed,
+  collapsed,
+  isSearching,
+  colCount,
+  puedeEscribir,
+  onToggle,
+  proveedorDisplay,
+  onEdit,
+  onDelete,
+}: {
+  etapa: CosteoEtapa;
+  etapaCollapsed: boolean;
+  collapsed: Set<string>;
+  isSearching: boolean;
+  colCount: number;
+  puedeEscribir: boolean;
+  onToggle: (key: string) => void;
+  proveedorDisplay: (r: CosteoRow) => string;
+  onEdit: (r: CosteoRow) => void;
+  onDelete: (r: CosteoRow) => void;
+}) {
+  return (
+    <>
+      {/* Nivel 1 · Etapa */}
+      <tr className="border-b border-[var(--border)] bg-[var(--card)]/70">
+        <td className="px-3 py-2">
+          <button
+            type="button"
+            onClick={() => onToggle(etapa.key)}
+            className="-mx-1 flex items-center gap-1.5 rounded px-1 py-0.5 text-left font-semibold text-[var(--text)] hover:bg-[var(--card)]"
+          >
+            <Chevron open={!etapaCollapsed} />
+            {etapa.nombre}
+          </button>
+        </td>
+        <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]">
+          {etapa.presupuesto === 0 ? '—' : formatCurrency(etapa.presupuesto)}
+        </td>
+        <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]">
+          {etapa.gastoReal === 0 ? '—' : formatCurrency(etapa.gastoReal)}
+        </td>
+        <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]/70">
+          {pctEjec(etapa.gastoReal, etapa.presupuesto)}
+        </td>
+        <td className="px-3 py-2" colSpan={colCount - 4} />
+      </tr>
+
+      {!etapaCollapsed &&
+        etapa.capitulos.map((cap) => {
+          const capCollapsed = !isSearching && collapsed.has(cap.key);
+          return (
+            <CapituloFragment
+              key={cap.key}
+              cap={cap}
+              capCollapsed={capCollapsed}
+              colCount={colCount}
+              puedeEscribir={puedeEscribir}
+              onToggle={onToggle}
+              proveedorDisplay={proveedorDisplay}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          );
+        })}
+    </>
+  );
+}
+
+// ─── Fragmento de capítulo (capítulo + sus partidas) ────────────────────────
+
+function CapituloFragment({
+  cap,
+  capCollapsed,
+  colCount,
+  puedeEscribir,
+  onToggle,
+  proveedorDisplay,
+  onEdit,
+  onDelete,
+}: {
+  cap: CosteoCapitulo;
+  capCollapsed: boolean;
+  colCount: number;
+  puedeEscribir: boolean;
+  onToggle: (key: string) => void;
+  proveedorDisplay: (r: CosteoRow) => string;
+  onEdit: (r: CosteoRow) => void;
+  onDelete: (r: CosteoRow) => void;
+}) {
+  return (
+    <>
+      {/* Nivel 2 · Capítulo */}
+      <tr className="border-b border-[var(--border)]/60 bg-[var(--card)]/30">
+        <td className="px-3 py-1.5 pl-7">
+          <button
+            type="button"
+            onClick={() => onToggle(cap.key)}
+            className="-mx-1 flex items-center gap-1.5 rounded px-1 py-0.5 text-left font-medium text-[var(--text)]/90 hover:bg-[var(--card)]"
+          >
+            <Chevron open={!capCollapsed} small />
+            {cap.nombre}
+            <span className="text-xs font-normal text-[var(--text)]/40">
+              ({cap.partidas.length})
+            </span>
+          </button>
+        </td>
+        <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/80">
+          {cap.presupuesto === 0 ? '—' : formatCurrency(cap.presupuesto)}
+        </td>
+        <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/80">
+          {cap.gastoReal === 0 ? '—' : formatCurrency(cap.gastoReal)}
+        </td>
+        <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/60">
+          {pctEjec(cap.gastoReal, cap.presupuesto)}
+        </td>
+        <td className="px-3 py-1.5" colSpan={colCount - 4} />
+      </tr>
+
+      {!capCollapsed &&
+        cap.partidas.map((r) => (
+          <tr
+            key={r.id}
+            className="border-b border-[var(--border)]/40 transition-colors hover:bg-[var(--card)]/40"
+          >
+            <td className="px-3 py-1.5 pl-12 text-[var(--text)]">{r.concepto || '—'}</td>
+            <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]">
+              {r.presupuesto == null ? '—' : formatCurrency(r.presupuesto)}
+            </td>
+            <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]">
+              {r.gastoReal == null ? '—' : formatCurrency(r.gastoReal)}
+            </td>
+            <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/70">
+              {r.ratio == null ? '—' : formatPercent(r.ratio)}
+            </td>
+            <td className="px-3 py-1.5 text-[var(--text)]/80">{proveedorDisplay(r)}</td>
+            {puedeEscribir ? (
+              <td className="px-3 py-1.5">
+                <div className="flex items-center justify-end gap-1">
+                  <button
+                    type="button"
+                    onClick={() => onEdit(r)}
+                    aria-label={`Editar ${r.concepto}`}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/50 hover:bg-[var(--card)] hover:text-[var(--text)]"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(r)}
+                    aria-label={`Eliminar ${r.concepto}`}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/50 hover:bg-red-50 hover:text-red-600"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </td>
+            ) : null}
+          </tr>
+        ))}
+    </>
+  );
+}
+
+function Chevron({ open, small = false }: { open: boolean; small?: boolean }) {
+  const cls = small ? 'h-3.5 w-3.5' : 'h-4 w-4';
+  return open ? (
+    <ChevronDown className={`${cls} text-[var(--text)]/40`} />
+  ) : (
+    <ChevronRight className={`${cls} text-[var(--text)]/40`} />
   );
 }

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -23,7 +23,8 @@
  *   4. El form gana 2 dropdowns: concepto del catálogo (clasifica → setea
  *      `concepto_id`) + proveedor de `erp.proveedores` (setea
  *      `proveedor_persona_id`).
- *   5. Botón eliminar visible (ícono de bote directo, no en el menú ⋯).
+ *   5. Edición por click en la fila; el botón eliminar vive dentro del cuadro
+ *      de edición (no íconos en la orilla de la fila).
  *
  * Carga cross-schema con queries paralelas + lookups Map (mismo patrón que
  * contratos-module — evita embeds de PostgREST). Los KPIs son reactivos a los
@@ -34,20 +35,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { ModuleKpiStrip, type ModuleKpi } from '@/components/module-page';
 import { Input } from '@/components/ui/input';
-import {
-  ChevronDown,
-  ChevronRight,
-  Coins,
-  Loader2,
-  Pencil,
-  Plus,
-  RefreshCw,
-  Search,
-  Trash2,
-} from 'lucide-react';
+import { ChevronDown, ChevronRight, Coins, Loader2, Plus, RefreshCw, Search } from 'lucide-react';
 import { usePermissions } from '@/components/providers';
 import { useToast } from '@/components/ui/toast';
-import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 import { CosteoConceptoForm } from '@/components/dilesa/costeo-concepto-form';
 import {
   buildProyectoOptions,
@@ -298,8 +288,6 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   const [editRow, setEditRow] = useState<CosteoRow | null>(null);
   /** Colapsado de grupos (keys de etapa y capítulo). Default: todo expandido. */
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
-  /** Partida pendiente de confirmar borrado (trash visible). */
-  const [deleteTarget, setDeleteTarget] = useState<CosteoRow | null>(null);
 
   const fetchCosteo = useCallback(async (): Promise<FetchResult> => {
     const sb = createSupabaseBrowserClient();
@@ -529,9 +517,9 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   }, [fetchCosteo, applyResult]);
 
   // Soft-delete de una partida. Patrón del repo: marca `deleted_at`, preserva
-  // historial para auditoría.
+  // historial para auditoría. Devuelve true si borró (para cerrar el form).
   const eliminar = useCallback(
-    async (row: CosteoRow) => {
+    async (row: CosteoRow): Promise<boolean> => {
       const sb = createSupabaseBrowserClient();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { error: e } = await (sb.schema('erp') as any)
@@ -544,10 +532,11 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
           description: getSupabaseErrorMessage(e, 'No se pudo eliminar la partida.'),
           type: 'error',
         });
-        return;
+        return false;
       }
       toast.add({ title: 'Partida eliminada', description: row.concepto, type: 'success' });
       void cargar();
+      return true;
     },
     [toast, cargar]
   );
@@ -644,7 +633,8 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
 
   // Al buscar, ignora el colapsado para que los matches sean visibles.
   const isSearching = q.length > 0;
-  const colCount = puedeEscribir ? 6 : 5;
+  // Click en la fila abre la edición (solo si puede escribir).
+  const onRowClick = puedeEscribir ? abrirEdicion : undefined;
 
   return (
     <div className="space-y-6 p-6">
@@ -726,6 +716,14 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
             cerrarForm();
             void cargar();
           }}
+          onDelete={
+            editRow && puedeEscribir
+              ? async () => {
+                  const ok = await eliminar(editRow);
+                  if (ok) cerrarForm();
+                }
+              : undefined
+          }
         />
       ) : null}
 
@@ -763,7 +761,6 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
                 <th className="w-36 px-3 py-2.5 text-right">Gasto real</th>
                 <th className="w-20 px-3 py-2.5 text-right">% ejec.</th>
                 <th className="w-56 px-3 py-2.5 text-left">Proveedor</th>
-                {puedeEscribir ? <th className="w-20 px-3 py-2.5 text-right" /> : null}
               </tr>
             </thead>
             <tbody>
@@ -776,12 +773,9 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
                     etapaCollapsed={etapaCollapsed}
                     collapsed={collapsed}
                     isSearching={isSearching}
-                    colCount={colCount}
-                    puedeEscribir={puedeEscribir}
                     onToggle={toggleGrupo}
                     proveedorDisplay={proveedorDisplay}
-                    onEdit={abrirEdicion}
-                    onDelete={setDeleteTarget}
+                    onRowClick={onRowClick}
                   />
                 );
               })}
@@ -789,20 +783,6 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
           </table>
         </div>
       )}
-
-      <ConfirmDialog
-        open={deleteTarget != null}
-        onOpenChange={(o) => {
-          if (!o) setDeleteTarget(null);
-        }}
-        onConfirm={async () => {
-          if (deleteTarget) await eliminar(deleteTarget);
-          setDeleteTarget(null);
-        }}
-        title={deleteTarget ? `¿Eliminar “${deleteTarget.concepto}”?` : '¿Eliminar partida?'}
-        description="Marcará la partida de presupuesto como eliminada. Se preserva el historial para auditoría."
-        confirmLabel="Eliminar"
-      />
     </div>
   );
 }
@@ -814,23 +794,17 @@ function GrupoFragment({
   etapaCollapsed,
   collapsed,
   isSearching,
-  colCount,
-  puedeEscribir,
   onToggle,
   proveedorDisplay,
-  onEdit,
-  onDelete,
+  onRowClick,
 }: {
   etapa: CosteoEtapa;
   etapaCollapsed: boolean;
   collapsed: Set<string>;
   isSearching: boolean;
-  colCount: number;
-  puedeEscribir: boolean;
   onToggle: (key: string) => void;
   proveedorDisplay: (r: CosteoRow) => string;
-  onEdit: (r: CosteoRow) => void;
-  onDelete: (r: CosteoRow) => void;
+  onRowClick?: (r: CosteoRow) => void;
 }) {
   return (
     <>
@@ -855,7 +829,7 @@ function GrupoFragment({
         <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]/70">
           {pctEjec(etapa.gastoReal, etapa.presupuesto)}
         </td>
-        <td className="px-3 py-2" colSpan={colCount - 4} />
+        <td className="px-3 py-2" />
       </tr>
 
       {!etapaCollapsed &&
@@ -866,12 +840,9 @@ function GrupoFragment({
               key={cap.key}
               cap={cap}
               capCollapsed={capCollapsed}
-              colCount={colCount}
-              puedeEscribir={puedeEscribir}
               onToggle={onToggle}
               proveedorDisplay={proveedorDisplay}
-              onEdit={onEdit}
-              onDelete={onDelete}
+              onRowClick={onRowClick}
             />
           );
         })}
@@ -884,21 +855,15 @@ function GrupoFragment({
 function CapituloFragment({
   cap,
   capCollapsed,
-  colCount,
-  puedeEscribir,
   onToggle,
   proveedorDisplay,
-  onEdit,
-  onDelete,
+  onRowClick,
 }: {
   cap: CosteoCapitulo;
   capCollapsed: boolean;
-  colCount: number;
-  puedeEscribir: boolean;
   onToggle: (key: string) => void;
   proveedorDisplay: (r: CosteoRow) => string;
-  onEdit: (r: CosteoRow) => void;
-  onDelete: (r: CosteoRow) => void;
+  onRowClick?: (r: CosteoRow) => void;
 }) {
   return (
     <>
@@ -926,14 +891,18 @@ function CapituloFragment({
         <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/60">
           {pctEjec(cap.gastoReal, cap.presupuesto)}
         </td>
-        <td className="px-3 py-1.5" colSpan={colCount - 4} />
+        <td className="px-3 py-1.5" />
       </tr>
 
       {!capCollapsed &&
         cap.partidas.map((r) => (
           <tr
             key={r.id}
-            className="border-b border-[var(--border)]/40 transition-colors hover:bg-[var(--card)]/40"
+            onClick={onRowClick ? () => onRowClick(r) : undefined}
+            title={onRowClick ? 'Editar partida' : undefined}
+            className={`border-b border-[var(--border)]/40 transition-colors hover:bg-[var(--card)]/40 ${
+              onRowClick ? 'cursor-pointer' : ''
+            }`}
           >
             <td className="px-3 py-1.5 pl-12 text-[var(--text)]">{r.concepto || '—'}</td>
             <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]">
@@ -946,28 +915,6 @@ function CapituloFragment({
               {r.ratio == null ? '—' : formatPercent(r.ratio)}
             </td>
             <td className="px-3 py-1.5 text-[var(--text)]/80">{proveedorDisplay(r)}</td>
-            {puedeEscribir ? (
-              <td className="px-3 py-1.5">
-                <div className="flex items-center justify-end gap-1">
-                  <button
-                    type="button"
-                    onClick={() => onEdit(r)}
-                    aria-label={`Editar ${r.concepto}`}
-                    className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/50 hover:bg-[var(--card)] hover:text-[var(--text)]"
-                  >
-                    <Pencil className="h-3.5 w-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onDelete(r)}
-                    aria-label={`Eliminar ${r.concepto}`}
-                    className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/50 hover:bg-red-50 hover:text-red-600"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              </td>
-            ) : null}
           </tr>
         ))}
     </>

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -276,3 +276,15 @@ pago: rol **Dirección** (ya vigente en CxP).
   pendiente del OK de Beto** (paridad verificada 128 legacy ↔ 129 canónico; cero
   referencias runtime en código, solo JSDoc viejo + script de import histórico +
   `types` generados).
+- **2026-06-04** — **Clasificación masiva de partidas (backfill de `concepto_id`).**
+  Beto pidió clasificar todo lo pendiente. Match `partida → concepto` por
+  similitud de nombre (la mayoría casi idéntico) + etapa como tiebreaker para
+  vialidades vs plataformas; 9 decisiones difíciles confirmadas con Beto (trío de
+  lotificación → `1.04.05`; "1era etapa" sin marcador → plataformas etapa 3; "Maq
+  2da/3era" → `2.01.10`; UID agua-drenaje-cordones → `2.04.02`). Aplicado vía MCP
+  en transacción con guarda `concepto_id IS NULL` (no pisa lo ya clasificado) +
+  el FK valida cada concepto (typo = rollback, no escritura mala). Fila de prueba
+  "Prueba" ($215k sin gasto) soft-deleted. **Resultado: 128/128 partidas vivas
+  clasificadas, 0 sin clasificar.** La tabla agrupada del rediseño ya muestra
+  todo bajo su etapa › capítulo correcto (cero "Sin clasificar"). Reversible vía
+  el dropdown del form.

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -264,8 +264,9 @@ pago: rol **Dirección** (ya vigente en CxP).
   (`<optgroup>` etapa›capítulo → `concepto_id`, prellena la etiqueta) +
   proveedor de `erp.proveedores` (→ `proveedor_persona_id`, default "Por
   definir", opción "Otro (texto libre)" que **preserva el `proveedor_texto`
-  legacy** sin pérdida); (5) **botón eliminar visible** (ícono de bote directo en
-  la fila + lápiz para editar, fuera del menú `⋯`). Nuevo helper puro
+  legacy** sin pérdida); (5) **edición por click en la fila** + botón **Eliminar
+  dentro del cuadro de edición** (sin íconos en la orilla — ajuste pedido por
+  Beto al revisar el preview). Nuevo helper puro
   `lib/dilesa/conceptos-catalogo.ts` (`buildCatalogoConceptos`: árbol +
   optgroups) y `groupCosteo` exportado, ambos con test unitario (17 tests
   nuevos). Estado: **129 partidas, 47 clasificadas** (82 a reclasificar con el

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-06-04
-**Última actualización:** 2026-06-04 (Sprint 0 aplicado a prod: ADR-040 + `erp.conceptos_compra` con 3 etapas / 18 capítulos / 71 conceptos, seed normalizado de `dilesa.obra_presupuesto`. Estado → `in_progress`. Próximo: Sprint 1 — cerrar D9 (unificación de presupuesto en `erp`) + binding `partida_id` + vista `v_partida_control`.)
+**Última actualización:** 2026-06-04 (Sprint 1 fase 2b: rediseño UX de Costeo — tabla agrupada colapsable etapa › capítulo, orden por catálogo canónico, un-proyecto-a-la-vez, dropdowns de clasificación/proveedor en el form, eliminar visible. Helper `lib/dilesa/conceptos-catalogo.ts` + `groupCosteo` con 17 tests. 5 checks verdes. PR a preview sin auto-merge. Retiro de `dilesa.obra_presupuesto` pendiente del OK de Beto.)
 
 ## Problema
 
@@ -253,3 +253,25 @@ pago: rol **Dirección** (ya vigente en CxP).
   preview sin auto-merge** para validar que las 128 partidas se ven/editan bien
   antes de mergear. **Fase 2b (sigue):** retirar `dilesa.obra_presupuesto` tras
   validar en prod.
+- **2026-06-04** — **Sprint 1 fase 2b: rediseño UX de Costeo.** Plan cerrado con
+  Beto y ejecutado como PR dedicado. 5 mejoras: (1) **tabla agrupada colapsable
+  en 2 niveles etapa › capítulo** con subtotal por grupo (reemplaza el
+  `<DataTable>` plano); (2) **orden por el catálogo canónico** `erp.conceptos_compra`
+  (etapa→capítulo→concepto vía `codigo`), partidas sin `concepto_id` en grupo
+  **"Sin clasificar" al final**; (3) **un proyecto a la vez** — auto-selecciona
+  el primer proyecto al entrar; selector lista cada proyecto + "Todos" + "Sin
+  proyecto asignado"; (4) **form + 2 dropdowns**: clasificación al catálogo
+  (`<optgroup>` etapa›capítulo → `concepto_id`, prellena la etiqueta) +
+  proveedor de `erp.proveedores` (→ `proveedor_persona_id`, default "Por
+  definir", opción "Otro (texto libre)" que **preserva el `proveedor_texto`
+  legacy** sin pérdida); (5) **botón eliminar visible** (ícono de bote directo en
+  la fila + lápiz para editar, fuera del menú `⋯`). Nuevo helper puro
+  `lib/dilesa/conceptos-catalogo.ts` (`buildCatalogoConceptos`: árbol +
+  optgroups) y `groupCosteo` exportado, ambos con test unitario (17 tests
+  nuevos). Estado: **129 partidas, 47 clasificadas** (82 a reclasificar con el
+  dropdown nuevo), **0 con proveedor estructurado** (217 proveedores activos
+  disponibles). 5 checks verdes (typecheck, **1257 tests**, lint 0-err, format).
+  PR **UI-touching → preview sin auto-merge**. **Retiro de `dilesa.obra_presupuesto`
+  pendiente del OK de Beto** (paridad verificada 128 legacy ↔ 129 canónico; cero
+  referencias runtime en código, solo JSDoc viejo + script de import histórico +
+  `types` generados).

--- a/lib/dilesa/conceptos-catalogo.test.ts
+++ b/lib/dilesa/conceptos-catalogo.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { buildCatalogoConceptos, type ConceptoCompraRaw } from './conceptos-catalogo';
+
+// Mini catálogo de 2 etapas para los tests. Mismo shape que el seed ADR-040:
+// codigo con padding 2-díg, padre = código sin el último segmento.
+const ROWS: ConceptoCompraRaw[] = [
+  { id: 'e1', padre_id: null, nivel: 'etapa', codigo: '1', nombre: 'Anteproyecto' },
+  { id: 'c1', padre_id: 'e1', nivel: 'capitulo', codigo: '1.01', nombre: 'Topografía' },
+  { id: 'k1', padre_id: 'c1', nivel: 'concepto', codigo: '1.01.02', nombre: 'Mecánica de suelos' },
+  { id: 'k2', padre_id: 'c1', nivel: 'concepto', codigo: '1.01.01', nombre: 'Levantamiento' },
+  { id: 'e2', padre_id: null, nivel: 'etapa', codigo: '2', nombre: 'Urbanización' },
+  { id: 'c2', padre_id: 'e2', nivel: 'capitulo', codigo: '2.03', nombre: 'Agua potable' },
+  { id: 'k3', padre_id: 'c2', nivel: 'concepto', codigo: '2.03.01', nombre: 'Red de agua potable' },
+];
+
+describe('buildCatalogoConceptos (ADR-040)', () => {
+  it('resuelve la jerarquía completa de un concepto hoja', () => {
+    const { byConcepto } = buildCatalogoConceptos(ROWS);
+    const res = byConcepto.get('k3');
+    expect(res).toMatchObject({
+      codigo: '2.03.01',
+      nombre: 'Red de agua potable',
+      capituloCodigo: '2.03',
+      capituloNombre: 'Agua potable',
+      etapaCodigo: '2',
+      etapaNombre: 'Urbanización',
+    });
+  });
+
+  it('solo indexa conceptos hoja (no etapas ni capítulos)', () => {
+    const { byConcepto } = buildCatalogoConceptos(ROWS);
+    expect(byConcepto.has('e1')).toBe(false);
+    expect(byConcepto.has('c1')).toBe(false);
+    expect(byConcepto.size).toBe(3);
+  });
+
+  it('arma un optgroup por capítulo, ordenados por código', () => {
+    const { optgroups } = buildCatalogoConceptos(ROWS);
+    expect(optgroups.map((g) => g.capituloCodigo)).toEqual(['1.01', '2.03']);
+    expect(optgroups[0]?.label).toBe('Anteproyecto › Topografía');
+  });
+
+  it('ordena los conceptos dentro del optgroup por código (no por inserción)', () => {
+    const { optgroups } = buildCatalogoConceptos(ROWS);
+    // k2 (1.01.01) antes que k1 (1.01.02) aunque k1 venga primero en el array.
+    expect(optgroups[0]?.conceptos.map((c) => c.codigo)).toEqual(['1.01.01', '1.01.02']);
+  });
+
+  it('omite conceptos huérfanos (capítulo o etapa ausente)', () => {
+    const huerfano: ConceptoCompraRaw[] = [
+      { id: 'x', padre_id: 'no-existe', nivel: 'concepto', codigo: '9.99.99', nombre: 'Huérfano' },
+    ];
+    const { byConcepto, optgroups } = buildCatalogoConceptos(huerfano);
+    expect(byConcepto.size).toBe(0);
+    expect(optgroups).toHaveLength(0);
+  });
+});

--- a/lib/dilesa/conceptos-catalogo.ts
+++ b/lib/dilesa/conceptos-catalogo.ts
@@ -1,0 +1,106 @@
+/**
+ * Catálogo jerárquico de conceptos de compra (`erp.conceptos_compra`, ADR-040).
+ *
+ * 3 niveles vía `padre_id` self-FK: etapa → capítulo → concepto. Helpers puros
+ * (testeables) para:
+ *   (a) resolver la jerarquía completa de un concepto hoja, y
+ *   (b) armar los `<optgroup>` ordenados del selector de clasificación del form
+ *       de Costeo (un grupo por capítulo, label "Etapa › Capítulo").
+ *
+ * El `codigo` lleva padding 2-díg ('2.03.01'), así que el orden lexicográfico
+ * coincide con el orden natural del catálogo — ordenamos por `codigo`.
+ *
+ * Reusable más allá de Costeo (la iniciativa `dilesa-compras` consume el mismo
+ * catálogo para clasificar líneas de compra).
+ */
+
+/** Fila cruda del catálogo (los 4 campos que necesita el árbol). */
+export type ConceptoCompraRaw = {
+  id: string;
+  padre_id: string | null;
+  nivel: string; // 'etapa' | 'capitulo' | 'concepto'
+  codigo: string;
+  nombre: string;
+};
+
+/** Jerarquía resuelta de un concepto hoja (nivel = 'concepto'). */
+export type ConceptoResuelto = {
+  id: string;
+  codigo: string;
+  nombre: string;
+  capituloCodigo: string;
+  capituloNombre: string;
+  etapaCodigo: string;
+  etapaNombre: string;
+};
+
+/** Un capítulo con sus conceptos hoja, para el `<optgroup>` del selector. */
+export type CatalogoOptgroup = {
+  etapaCodigo: string;
+  etapaNombre: string;
+  capituloCodigo: string;
+  capituloNombre: string;
+  /** Label compuesto del optgroup: "Urbanización › Agua potable". */
+  label: string;
+  conceptos: { id: string; codigo: string; nombre: string }[];
+};
+
+export type CatalogoConceptos = {
+  /** conceptoId → jerarquía resuelta. Solo conceptos hoja resolubles. */
+  byConcepto: Map<string, ConceptoResuelto>;
+  /** Optgroups ordenados (etapa→capítulo) para el `<select>` del form. */
+  optgroups: CatalogoOptgroup[];
+};
+
+/**
+ * Construye el índice del catálogo a partir de las filas crudas.
+ * Tolerante a datos parciales: un concepto cuyo capítulo o etapa no esté en el
+ * set simplemente se omite del índice (queda como "sin clasificar" aguas abajo).
+ */
+export function buildCatalogoConceptos(rows: readonly ConceptoCompraRaw[]): CatalogoConceptos {
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const byConcepto = new Map<string, ConceptoResuelto>();
+
+  for (const concepto of rows) {
+    if (concepto.nivel !== 'concepto') continue;
+    const capitulo = concepto.padre_id ? byId.get(concepto.padre_id) : undefined;
+    const etapa = capitulo?.padre_id ? byId.get(capitulo.padre_id) : undefined;
+    if (!capitulo || !etapa) continue;
+    byConcepto.set(concepto.id, {
+      id: concepto.id,
+      codigo: concepto.codigo,
+      nombre: concepto.nombre,
+      capituloCodigo: capitulo.codigo,
+      capituloNombre: capitulo.nombre,
+      etapaCodigo: etapa.codigo,
+      etapaNombre: etapa.nombre,
+    });
+  }
+
+  // Agrupar conceptos por capítulo → optgroups ordenados por código.
+  const grupos = new Map<string, CatalogoOptgroup>();
+  for (const res of byConcepto.values()) {
+    let g = grupos.get(res.capituloCodigo);
+    if (!g) {
+      g = {
+        etapaCodigo: res.etapaCodigo,
+        etapaNombre: res.etapaNombre,
+        capituloCodigo: res.capituloCodigo,
+        capituloNombre: res.capituloNombre,
+        label: `${res.etapaNombre} › ${res.capituloNombre}`,
+        conceptos: [],
+      };
+      grupos.set(res.capituloCodigo, g);
+    }
+    g.conceptos.push({ id: res.id, codigo: res.codigo, nombre: res.nombre });
+  }
+
+  const optgroups = [...grupos.values()].sort((a, b) =>
+    a.capituloCodigo.localeCompare(b.capituloCodigo)
+  );
+  for (const g of optgroups) {
+    g.conceptos.sort((a, b) => a.codigo.localeCompare(b.codigo));
+  }
+
+  return { byConcepto, optgroups };
+}


### PR DESCRIPTION
## Qué

Rediseño del módulo **Costeo** de DILESA (`erp.presupuesto_partidas`, ADR-040) con el plan cerrado con Beto. Sprint 1 fase 2b de `dilesa-compras`.

### Las 5 mejoras
1. **Tabla agrupada colapsable en 2 niveles: etapa › capítulo** (del catálogo `erp.conceptos_compra`) con subtotal por grupo — reemplaza el `<DataTable>` plano.
2. **Orden por el catálogo canónico** (etapa→capítulo→concepto vía `codigo`). Las partidas sin `concepto_id` caen en un grupo **"Sin clasificar" al final**.
3. **Un proyecto a la vez**: auto-selecciona el primer proyecto al entrar; selector con cada proyecto + "Todos los proyectos" + "Sin proyecto asignado".
4. **Form gana 2 dropdowns**:
   - **Clasificación (catálogo)** → `concepto_id`, con `<optgroup>` por etapa›capítulo; prellena la etiqueta de texto. _Hoy solo 47/129 partidas están clasificadas_ — este dropdown es la herramienta para reclasificar las 82 restantes.
   - **Proveedor** de `erp.proveedores` → `proveedor_persona_id`, default "Por definir". La opción **"Otro (texto libre)" preserva el `proveedor_texto` legacy sin pérdida** (hoy 0/129 usan el campo estructurado; 217 proveedores activos disponibles).
5. **Botón eliminar visible**: ícono de bote directo en la fila (+ lápiz para editar), fuera del menú `⋯`.

## Cómo
- Nuevo helper puro [`lib/dilesa/conceptos-catalogo.ts`](lib/dilesa/conceptos-catalogo.ts) (`buildCatalogoConceptos`: árbol etapa→capítulo→concepto + optgroups) — reusable por el resto de `dilesa-compras`.
- `groupCosteo` exportado del módulo (agrupa partidas + subtotales null-safe).
- **17 tests nuevos** (catálogo + agrupado), `deriveKpis` intacto.
- **Cero cambios de schema** — el sub-slug `dilesa.construccion.costeo` ya tiene write.

## Verificación
✅ typecheck · ✅ **1257 tests** (84 archivos) · ✅ lint (0 errores) · ✅ format:check

## ⚠️ Preview-first (sin auto-merge)
Cambio de UI visible → dejo el PR abierto para que **Beto revise el preview de Vercel** antes de mergear.

## Pendiente hermano (requiere tu OK, Beto)
Retirar `dilesa.obra_presupuesto` (renombrar a `_deprecated`, no drop). Verificado: paridad **128 legacy ↔ 129 canónico**, **cero referencias runtime** en código (solo JSDoc viejo + el script de import histórico + `types` generados). Es un cambio de schema en prod, así que no lo aplico sin tu confirmación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)