### PR TITLE
feat(dilesa-compras): Sprint 2 Fase A — hub Compras (tabs + RBAC scaffold)

### DIFF
--- a/app/dilesa/compras/layout.tsx
+++ b/app/dilesa/compras/layout.tsx
@@ -1,0 +1,52 @@
+import { type ReactNode } from 'react';
+import { RoutedModuleTabs } from '@/components/module-page';
+
+/**
+ * Layout compartido del hub Compras (DILESA) — ciclo P2P constructora-first.
+ *
+ * Patrón "module with submodules / routed tabs" (ADR-005) + sub-slugs por tab
+ * (ADR-030). Iniciativa `dilesa-compras` · Sprint 2.
+ *
+ *   /dilesa/compras                → tab "Órdenes" (default landing).
+ *   /dilesa/compras/requisiciones  → tab "Requisiciones".
+ *   /dilesa/compras/recepciones    → tab "Recepciones".
+ *
+ * El ciclo se ancla al presupuesto por partidas (D7/D12): cada línea va a un
+ * concepto + partida de `erp.presupuesto_partidas`, la OC al enviarse mueve
+ * `comprometido` y la recepción devenga `ejercido` en `erp.v_partida_control`,
+ * sin tocar inventario. Las RPCs de OC (`oc_cerrar_orden`,
+ * `oc_cancelar_pendiente_linea`, `fn_oc_recalcular_estado`) se reusan de `erp`;
+ * la recepción usa una variante sin inventario (`oc_recibir_linea_partida`).
+ *
+ * Cada `module` es un sub-slug que `<RoutedModuleTabs>` filtra por permiso;
+ * los gates de acceso viven en cada sub-page (ADR-030 SS5), no en el layout.
+ */
+const TABS = [
+  {
+    label: 'Órdenes',
+    href: '/dilesa/compras',
+    exact: true,
+    module: 'dilesa.compras.ordenes',
+  },
+  {
+    label: 'Requisiciones',
+    href: '/dilesa/compras/requisiciones',
+    module: 'dilesa.compras.requisiciones',
+  },
+  {
+    label: 'Recepciones',
+    href: '/dilesa/compras/recepciones',
+    module: 'dilesa.compras.recepciones',
+  },
+] as const;
+
+export default function ComprasLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <div className="px-4 pt-4 sm:px-6 sm:pt-6">
+        <RoutedModuleTabs tabs={TABS} />
+      </div>
+      {children}
+    </>
+  );
+}

--- a/app/dilesa/compras/page.tsx
+++ b/app/dilesa/compras/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { ComprasProximamente } from '@/components/compras/compras-proximamente';
+
+/**
+ * @module Compras · Órdenes (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Órdenes" (default landing) del hub Compras (iniciativa dilesa-compras ·
+ * Sprint 2). Órdenes de compra ancladas a concepto + partida; al enviarse
+ * mueven `comprometido` en `erp.v_partida_control`. Reusa las RPCs de OC de
+ * `erp` (`oc_cerrar_orden`, `oc_cancelar_pendiente_linea`,
+ * `fn_oc_recalcular_estado`). Gate: sub-slug `dilesa.compras.ordenes`
+ * (ADR-030 SS5).
+ *
+ * Placeholder de Fase A — el módulo de OC funcional llega en Fase B (tras
+ * aplicar la migración de sub-slugs y validar la estructura).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.compras.ordenes">
+      <DesktopOnlyNotice module="Órdenes de compra" />
+      <div className="hidden sm:block">
+        <ComprasProximamente
+          titulo="Órdenes de compra"
+          descripcion="Órdenes ancladas a concepto + partida del presupuesto; al enviarse comprometen el presupuesto de la partida. Llega en la Fase B del Sprint 2."
+        />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/compras/recepciones/page.tsx
+++ b/app/dilesa/compras/recepciones/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { ComprasProximamente } from '@/components/compras/compras-proximamente';
+
+/**
+ * @module Compras · Recepciones (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Recepciones" del hub Compras (iniciativa dilesa-compras · Sprint 2).
+ * Recibir lo comprado devenga (`ejercido`) contra la partida sin mover
+ * inventario (vía `oc_recibir_linea_partida`). Gate: sub-slug
+ * `dilesa.compras.recepciones` (ADR-030 SS5).
+ *
+ * Placeholder de Fase A — la recepción llega en Fase C (con la RPC nueva).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.compras.recepciones">
+      <DesktopOnlyNotice module="Recepciones" />
+      <div className="hidden sm:block">
+        <ComprasProximamente
+          titulo="Recepciones"
+          descripcion="Recepción de lo comprado: devenga el ejercido contra la partida del presupuesto, sin mover inventario. Llega en la Fase C del Sprint 2."
+        />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/compras/requisiciones/page.tsx
+++ b/app/dilesa/compras/requisiciones/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { ComprasProximamente } from '@/components/compras/compras-proximamente';
+
+/**
+ * @module Compras · Requisiciones (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Requisiciones" del hub Compras (iniciativa dilesa-compras · Sprint 2).
+ * Solicitudes de compra previas a la orden, ancladas a concepto + partida.
+ * Gate: sub-slug `dilesa.compras.requisiciones` (ADR-030 SS5).
+ *
+ * Placeholder de Fase A — la captura llega en Fase D (después de OC y Recepción).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.compras.requisiciones">
+      <DesktopOnlyNotice module="Requisiciones" />
+      <div className="hidden sm:block">
+        <ComprasProximamente
+          titulo="Requisiciones"
+          descripcion="Solicitudes de compra previas a la orden, ancladas a concepto + partida del presupuesto. Llega en la Fase D del Sprint 2."
+        />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -72,7 +72,12 @@ export const NAV_ITEMS: NavItem[] = [
       },
       {
         label: 'Compras',
-        children: [{ label: 'Proveedores', href: '/dilesa/proveedores' }],
+        children: [
+          { label: 'Proveedores', href: '/dilesa/proveedores' },
+          // Hub P2P con tabs (Órdenes / Requisiciones / Recepciones) — ADR-030.
+          // Sidebar muestra solo el padre; la URL default cae al tab Órdenes.
+          { label: 'Órdenes de compra', href: '/dilesa/compras' },
+        ],
       },
       {
         label: 'Inmobiliario',

--- a/components/compras/compras-proximamente.tsx
+++ b/components/compras/compras-proximamente.tsx
@@ -1,0 +1,32 @@
+import { Hammer } from 'lucide-react';
+
+/**
+ * Placeholder "en construcción" para tabs del hub Compras (DILESA) que aún no
+ * tienen su módulo funcional. Iniciativa `dilesa-compras` · Sprint 2 (se va
+ * reemplazando por el módulo real conforme avanzan las fases B/C/D).
+ *
+ * Vive en `components/compras/` (D4: el componente compartido de compras
+ * constructora-first se construye aquí; RDB no se toca en v1).
+ */
+export function ComprasProximamente({
+  titulo,
+  descripcion,
+}: {
+  titulo: string;
+  descripcion: string;
+}) {
+  return (
+    <div className="p-6">
+      <div className="flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-[var(--border)] py-20 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <Hammer className="h-6 w-6" />
+        </div>
+        <h2 className="text-lg font-semibold text-[var(--text)]">{titulo}</h2>
+        <p className="max-w-md text-sm text-[var(--text)]/60">{descripcion}</p>
+        <span className="rounded-full bg-[var(--card)] px-3 py-1 text-xs font-medium text-[var(--text)]/50">
+          En construcción
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -6,7 +6,7 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-06-04
-**Última actualización:** 2026-06-04 (Sprint 1 fase 2b: rediseño UX de Costeo — tabla agrupada colapsable etapa › capítulo, orden por catálogo canónico, un-proyecto-a-la-vez, dropdowns de clasificación/proveedor en el form, eliminar visible. Helper `lib/dilesa/conceptos-catalogo.ts` + `groupCosteo` con 17 tests. 5 checks verdes. PR a preview sin auto-merge. Retiro de `dilesa.obra_presupuesto` pendiente del OK de Beto.)
+**Última actualización:** 2026-06-05 (Sprint 1 **cerrado** —PR #688 mergeado: rediseño Costeo + clasificación 128/128. **Sprint 2 planeado**: hub `/dilesa/compras` con tabs, modelo constructora-first; discovery hecho + 4 decisiones D10–D13. Plan de 4 fases [A hub+RBAC · B OC · C recepción · D requisiciones+componente compartido]; schema mínimo = INSERT sub-slugs + 1 RPC de recepción. Próximo: Fase A. Pendiente aparte: retiro de `dilesa.obra_presupuesto` con OK de Beto.)
 
 ## Problema
 
@@ -103,6 +103,27 @@ presupuesto, cuánto va comprometido vs ejercido vs pagado".
   limpio, migrando con cuidado lo que creó `dilesa-proyectos-anteproyectos`.
   **Alternativa:** puente polimórfico en `dilesa` (mantiene `erp` puro). Se
   decide en el ADR antes de tocar schema.
+- **D10 — UI = hub `/dilesa/compras` con tabs routed (ADR-030)**, NO 3 módulos
+  separados (cerrada 2026-06-05). Consistente con Ventas/Construcción. Sub-slugs:
+  umbrella `dilesa.compras` + `dilesa.compras.requisiciones` /
+  `dilesa.compras.ordenes` / `dilesa.compras.recepciones`. Proveedores se queda
+  como entry aparte en la sección Compras.
+- **D11 — Recepción ligera, sin documento formal** (cerrada 2026-06-05). Recibir
+  contra la partida = `UPDATE ordenes_compra_detalle.cantidad_recibida` (eso
+  alimenta `ejercido` en `v_partida_control`), SIN encabezado folio/fecha/firma y
+  SIN tocar inventario. Las tablas `erp.recepciones`/`recepciones_detalle` (hoy
+  vacías, no usadas por RDB) NO se adoptan en v1. Subir a documento formal queda
+  como salida futura si obra lo pide.
+- **D12 — Siempre hay partida** (cerrada 2026-06-05). Toda línea de
+  requisición/OC se ancla a una partida existente del presupuesto del proyecto;
+  si falta, se crea primero en Costeo. NO se agrega `concepto_id` a los detalles
+  (el concepto se alcanza vía `partida_id → presupuesto_partidas.concepto_id`).
+  El control de 3 capas siempre cuadra.
+- **D13 — RPC de recepción nueva, no branch en la de RDB** (cerrada 2026-06-05).
+  `oc_recibir_linea` mueve inventario de RDB en prod; en vez de meterle un branch
+  riesgoso, se crea `erp.oc_recibir_linea_partida` (mismos guards de
+  permiso/estado/cantidad, pero solo actualiza `cantidad_recibida` + recalcula
+  estado + audit; cero inventario). Aísla el riesgo a RDB.
 
 ## Alcance v1
 
@@ -287,4 +308,25 @@ pago: rol **Dirección** (ya vigente en CxP).
   "Prueba" ($215k sin gasto) soft-deleted. **Resultado: 128/128 partidas vivas
   clasificadas, 0 sin clasificar.** La tabla agrupada del rediseño ya muestra
   todo bajo su etapa › capítulo correcto (cero "Sin clasificar"). Reversible vía
-  el dropdown del form.
+  el dropdown del form. PR #688 mergeado (squash) el 2026-06-05; **Sprint 1
+  cerrado** (binding `partida_id` + `v_partida_control` + re-apunte + rediseño +
+  clasificación).
+- **2026-06-05** — **Sprint 2 planeado (discovery + 4 decisiones).** Discovery
+  read-only del fit constructora de la maquinaria `erp.*` (hecha restaurante-first
+  para RDB). Hallazgos: requisiciones/OC + RPCs `oc_cerrar_orden`/
+  `oc_cancelar_pendiente_linea`/`fn_oc_recalcular_estado` reusan limpio
+  (`producto_id` ya nullable, `partida_id` ya existe); **único bloqueo** =
+  `oc_recibir_linea` exige `producto_id` + escribe a `movimientos_inventario` con
+  almacén → necesita variante sin inventario. Mapa de `v_partida_control`:
+  `comprometido`=Σ línea OC×precio (estado enviada/parcial/cerrada), `ejercido`=Σ
+  `cantidad_recibida`×precio (sin filtro de estado — posible ajuste, ver F4 del
+  discovery), `pagado`=Σ aplicaciones vía `facturas.partida_id`. **Sorpresa
+  crítica:** `partida_id` existe pero el código (`generarOrdenCompra`,
+  `guardarRequisicion`) NO lo copia aún → `comprometido`/`ejercido` en $0 hasta
+  cablearlo end-to-end. Decisiones D10–D13 cerradas con Beto (hub con tabs,
+  recepción ligera, siempre-hay-partida, RPC nueva). Plan de 4 fases: A (hub +
+  RBAC migración sub-slugs), B (OC, mueve comprometido), C (recepción vía
+  `oc_recibir_linea_partida`, mueve ejercido), D (requisiciones + extraer
+  `components/compras/`). Schema total del sprint = INSERT sub-slugs (A) + 1 RPC
+  (C). Gates a respetar: rol Dirección (no `rol='admin'`), filtrado `empresa_id`
+  por query, scope un-proyecto-a-la-vez.

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -249,6 +249,13 @@ const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   // Vista de CapEx: presupuesto vs gasto real (obra_presupuesto) + saldo de
   // contratos de obra. Migración 20260602030000_modulos_dilesa_construccion_costeo.sql.
   'dilesa.construccion.costeo',
+  // Hub de Compras (P2P) — umbrella + 3 sub-slugs por tab (iniciativa
+  // dilesa-compras · Sprint 2, ADR-030). Modelo constructora-first.
+  // Migración 20260605040000_modulos_dilesa_compras.sql.
+  'dilesa.compras',
+  'dilesa.compras.ordenes',
+  'dilesa.compras.requisiciones',
+  'dilesa.compras.recepciones',
   // Sub-slugs por fase del pipeline (Sprint 7a captura por fase)
   'dilesa.ventas.fase01_solicitud',
   'dilesa.ventas.fase02_asignada',

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -87,6 +87,14 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   // la página /registrar-tarea fue removida en favor del click directo).
   '/dilesa/construccion/contratos/nuevo': 'dilesa.construccion.contratos',
   '/dilesa/construccion/contratos/nuevo-obra': 'dilesa.construccion.contratos',
+  // Compras es un hub con 3 tabs (Sprint 2 `dilesa-compras`). El padre
+  // `dilesa.compras` es umbrella del sidebar; cada tab tiene su sub-slug
+  // (ADR-030). La URL default mapea al sub-slug del primer tab (Órdenes).
+  // Modelo constructora-first: la línea ancla concepto+partida y la recepción
+  // devenga contra la partida. Ver docs/planning/dilesa-compras.md.
+  '/dilesa/compras': 'dilesa.compras.ordenes',
+  '/dilesa/compras/requisiciones': 'dilesa.compras.requisiciones',
+  '/dilesa/compras/recepciones': 'dilesa.compras.recepciones',
 
   // RDB — home + operaciones
   '/rdb/home': 'rdb.home',

--- a/supabase/migrations/20260605040000_modulos_dilesa_compras.sql
+++ b/supabase/migrations/20260605040000_modulos_dilesa_compras.sql
@@ -1,0 +1,67 @@
+-- Hub de Compras (P2P) para DILESA: umbrella `dilesa.compras` + 3 sub-slugs por
+-- tab (ADR-030). Sprint 2 fase A de la iniciativa `dilesa-compras`.
+--
+-- El hub /dilesa/compras tiene 3 tabs routed (Órdenes / Requisiciones /
+-- Recepciones). El umbrella es la entry del sidebar (ADR-030 D3); cada sub-slug
+-- gobierna el acceso real a su tab (RoutedModuleTabs filtra las que no tienen
+-- permiso; cada sub-page monta su <RequireAccess modulo="...">).
+--
+-- Modelo constructora-first (D7/D10–D13): las líneas se anclan a concepto +
+-- partida de presupuesto (`erp.conceptos_compra` / `erp.presupuesto_partidas`),
+-- NO a producto/almacén; la recepción devenga contra la partida sin inventario.
+--
+-- Backfill defensivo: como el umbrella es NUEVO (no hay permisos del padre que
+-- clonar), se clonan los permisos de un módulo DILESA existente y adyacente
+-- (`dilesa.construccion.costeo` — el lado de presupuesto del mismo dominio) a
+-- los 4 slugs nuevos, por cada rol. Así quien hoy opera Costeo ve Compras y
+-- nadie pierde acceso; el ajuste fino por rol lo hace Beto después
+-- (ver memoria reference_roles_por_empresa: gates operativos por rol Dirección).
+
+BEGIN;
+
+-- 1. Slugs nuevos (umbrella + 3 tabs). `seccion='operaciones'` como construcción.
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT v.slug, v.nombre, v.descripcion, d.id, 'operaciones'
+FROM (SELECT id FROM core.empresas WHERE slug = 'dilesa') d
+CROSS JOIN (
+  VALUES
+    (
+      'dilesa.compras',
+      'Compras',
+      'Ciclo de compras P2P (requisición → orden de compra → recepción) anclado al presupuesto por partidas'
+    ),
+    (
+      'dilesa.compras.ordenes',
+      'Compras · Órdenes',
+      'Órdenes de compra ancladas a concepto + partida; al enviarse comprometen el presupuesto'
+    ),
+    (
+      'dilesa.compras.requisiciones',
+      'Compras · Requisiciones',
+      'Solicitudes de compra previas a la orden'
+    ),
+    (
+      'dilesa.compras.recepciones',
+      'Compras · Recepciones',
+      'Recepción de lo comprado; devenga (ejercido) contra la partida sin mover inventario'
+    )
+) AS v (slug, nombre, descripcion)
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+-- 2. Backfill defensivo de permisos: clonar de `dilesa.construccion.costeo`.
+INSERT INTO core.permisos_rol (rol_id, modulo_id, acceso_lectura, acceso_escritura)
+SELECT pr.rol_id, nuevo.id, pr.acceso_lectura, pr.acceso_escritura
+FROM core.permisos_rol pr
+JOIN core.modulos src ON src.id = pr.modulo_id AND src.slug = 'dilesa.construccion.costeo'
+JOIN core.modulos nuevo ON nuevo.empresa_id = src.empresa_id
+  AND nuevo.slug IN (
+    'dilesa.compras',
+    'dilesa.compras.ordenes',
+    'dilesa.compras.requisiciones',
+    'dilesa.compras.recepciones'
+  )
+ON CONFLICT (rol_id, modulo_id) DO NOTHING;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Qué (Sprint 2 · Fase A)

Andamiaje del **hub `/dilesa/compras`** con tabs routed (ADR-030), modelo constructora-first. Es la base sobre la que montan las fases funcionales. Construido en modo autónomo anoche.

- **Layout con tabs** (`RoutedModuleTabs`): **Órdenes** (default) · Requisiciones · Recepciones.
- **RBAC**: sub-slugs `dilesa.compras` (umbrella) + `.ordenes` / `.requisiciones` / `.recepciones` en `ROUTE_TO_MODULE` + `EXPECTED_DB_MODULE_SLUGS`; entry en el sidebar (sección **Compras**, junto a Proveedores).
- **3 tabs como placeholders** (`<ComprasProximamente>` en `components/compras/`, per D4) — los módulos funcionales llegan en B/C/D.
- **Decisiones D10–D13** + bitácora del discovery registradas en `docs/planning/dilesa-compras.md`.

## ⚠️ Migración pendiente de TU OK (no aplicada)

[`20260605040000_modulos_dilesa_compras.sql`](supabase/migrations/20260605040000_modulos_dilesa_compras.sql) — INSERT del umbrella + 3 sub-slugs en `core.modulos` + **backfill defensivo de permisos** clonando de `dilesa.construccion.costeo`.

**No la apliqué**: el clasificador de modo autónomo la bloqueó (correcto — es una migración de **permisos en prod** y tu regla pide tu OK explícito, no solo "avanza"). Queda lista para que la apliques (o me des el OK). Mientras tanto, **tú la ves en el preview como admin** (el bypass de admin no depende del slug).

## Verificación
✅ typecheck · ✅ **1257 tests** · ✅ lint · ✅ format · sync test `ROUTE_TO_MODULE ↔ EXPECTED` al día. (schema:check N/A — sin cambio de estructura ni `SCHEMA_REF`.)

## Preview-first (sin auto-merge)
Es UI visible (entry nueva + hub) → lo dejo abierto para tu revisión. **No auto-merge.**

## Siguiente (cuando despiertes)
Aplicas/oks la migración + revisas la estructura → construyo **Fase B (Órdenes de Compra)** como el módulo-molde a validar (C y D lo espejean). Los dejé sin construir a propósito: son módulos de **mutación financiera** que no puedo probar en vivo sin la migración, y preferí que valides el approach de uno antes de hacer los tres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)