### PR TITLE
feat(dilesa-compras): Sprint 2 Fase C — Recepciones (devenga ejercido sin inventario)

### DIFF
--- a/app/dilesa/compras/recepciones/page.tsx
+++ b/app/dilesa/compras/recepciones/page.tsx
@@ -2,28 +2,24 @@
 
 import { RequireAccess } from '@/components/require-access';
 import { DesktopOnlyNotice } from '@/components/responsive';
-import { ComprasProximamente } from '@/components/compras/compras-proximamente';
+import { RecepcionesModule } from '@/components/compras/recepciones-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
 /**
  * @module Compras · Recepciones (DILESA)
  * @responsive desktop-only
  *
- * Tab "Recepciones" del hub Compras (iniciativa dilesa-compras · Sprint 2).
- * Recibir lo comprado devenga (`ejercido`) contra la partida sin mover
- * inventario (vía `oc_recibir_linea_partida`). Gate: sub-slug
+ * Tab "Recepciones" del hub Compras (iniciativa dilesa-compras · Sprint 2
+ * Fase C). Recibir lo comprado devenga (`ejercido`) contra la partida sin
+ * mover inventario (vía `oc_recibir_linea_partida`). Gate: sub-slug
  * `dilesa.compras.recepciones` (ADR-030 SS5).
- *
- * Placeholder de Fase A — la recepción llega en Fase C (con la RPC nueva).
  */
 export default function Page() {
   return (
     <RequireAccess empresa="dilesa" modulo="dilesa.compras.recepciones">
       <DesktopOnlyNotice module="Recepciones" />
       <div className="hidden sm:block">
-        <ComprasProximamente
-          titulo="Recepciones"
-          descripcion="Recepción de lo comprado: devenga el ejercido contra la partida del presupuesto, sin mover inventario. Llega en la Fase C del Sprint 2."
-        />
+        <RecepcionesModule empresaId={DILESA_EMPRESA_ID} />
       </div>
     </RequireAccess>
   );

--- a/components/compras/recepciones-module.tsx
+++ b/components/compras/recepciones-module.tsx
@@ -1,0 +1,597 @@
+'use client';
+
+/**
+ * RecepcionesModule — recepción de órdenes de compra (DILESA, constructora).
+ *
+ * Iniciativa `dilesa-compras` · Sprint 2 Fase C. Tab "Recepciones" del hub
+ * Compras. Bandeja de OCs en estado `enviada`/`parcial`; recibir N por línea
+ * **devenga contra la partida** (`erp.v_partida_control.ejercido`) vía la RPC
+ * `oc_recibir_linea_partida` — sin mover inventario (D11/D13).
+ *
+ * Recepción ligera (D11): no hay documento de recepción con folio; el estado
+ * vive en `ordenes_compra_detalle.cantidad_recibida`. Un proyecto a la vez.
+ */
+
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronRight, Loader2, PackageCheck, RefreshCw, Search } from 'lucide-react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge, type BadgeTone } from '@/components/ui/badge';
+import { usePermissions } from '@/components/providers';
+import { useToast } from '@/components/ui/toast';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { formatCurrency } from '@/lib/format';
+import {
+  buildProyectoOptions,
+  type ProyectoOption,
+  type ProyectoSelectorRow,
+} from '@/lib/dilesa/proyectos-selector';
+import {
+  lineaPendiente,
+  lineaTotal,
+  type OcEstado,
+  type OcLinea,
+  type OcRow,
+} from '@/lib/compras/ordenes';
+
+const ESTADO_TONE: Record<string, BadgeTone> = { enviada: 'info', parcial: 'warning' };
+const ESTADO_LABEL: Record<string, string> = { enviada: 'Enviada', parcial: 'Parcial' };
+
+type ProvName = Map<string, string>;
+type FetchResult = {
+  rows?: OcRow[];
+  proyectos?: ProyectoOption[];
+  error?: string;
+};
+
+function toNum(s: string): number {
+  const n = Number(s.trim());
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function RecepcionesModule({ empresaId }: { empresaId: string }) {
+  const { permissions } = usePermissions();
+  const toast = useToast();
+  const puedeRecibir =
+    permissions.isAdmin || permissions.modulos.get('dilesa.compras.recepciones')?.write === true;
+
+  const [rows, setRows] = useState<OcRow[]>([]);
+  const [proyectos, setProyectos] = useState<ProyectoOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [proyectoFiltro, setProyectoFiltro] = useState('');
+  const autoSelectDone = useRef(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  /** detalleId → cantidad recibida (total) en captura. */
+  const [recibos, setRecibos] = useState<Record<string, string>>({});
+  const [savingId, setSavingId] = useState<string | null>(null);
+
+  const fetchData = useCallback(async (): Promise<FetchResult> => {
+    const sb = createSupabaseBrowserClient();
+    const [ocRes, proyectosRes, proveedoresRes, partidasRes] = await Promise.all([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any)
+        .from('ordenes_compra')
+        .select(
+          'id, codigo, proveedor_id, estado, fecha_entrega, created_at, ordenes_compra_detalle(id, partida_id, descripcion, unidad, cantidad, cantidad_recibida, cantidad_cancelada, precio_unitario, precio_real)'
+        )
+        .eq('empresa_id', empresaId)
+        .in('estado', ['enviada', 'parcial'])
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, nombre, tipo, proyecto_predecesor_id')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('erp')
+        .from('proveedores')
+        .select('id, personas:persona_id(nombre, apellido_paterno, apellido_materno)')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any)
+        .from('presupuesto_partidas')
+        .select('id, proyecto_id, concepto_texto')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr = ocRes.error ?? proyectosRes.error ?? proveedoresRes.error ?? partidasRes.error;
+    if (firstErr) return { error: getSupabaseErrorMessage(firstErr, 'No se pudo cargar.') };
+
+    const proyectoMap = new Map<string, string>();
+    for (const p of proyectosRes.data ?? []) proyectoMap.set(p.id as string, p.nombre as string);
+    const proyectos = buildProyectoOptions(
+      (proyectosRes.data ?? []) as unknown as ProyectoSelectorRow[]
+    );
+
+    type ProvRaw = {
+      id: string;
+      personas: {
+        nombre: string | null;
+        apellido_paterno: string | null;
+        apellido_materno: string | null;
+      } | null;
+    };
+    const provName: ProvName = new Map();
+    for (const pv of (proveedoresRes.data ?? []) as unknown as ProvRaw[]) {
+      provName.set(
+        pv.id,
+        [pv.personas?.nombre, pv.personas?.apellido_paterno, pv.personas?.apellido_materno]
+          .filter(Boolean)
+          .join(' ')
+          .trim() || '(sin nombre)'
+      );
+    }
+
+    type PartidaRaw = { id: string; proyecto_id: string | null; concepto_texto: string | null };
+    const partidaLabel = new Map<string, string>();
+    const partidaProyecto = new Map<string, string>();
+    for (const p of (partidasRes.data ?? []) as PartidaRaw[]) {
+      partidaLabel.set(p.id, p.concepto_texto ?? '(sin concepto)');
+      if (p.proyecto_id) partidaProyecto.set(p.id, p.proyecto_id);
+    }
+
+    type OcRaw = {
+      id: string;
+      codigo: string | null;
+      proveedor_id: string | null;
+      estado: string;
+      fecha_entrega: string | null;
+      created_at: string;
+      ordenes_compra_detalle: Array<{
+        id: string;
+        partida_id: string | null;
+        descripcion: string | null;
+        unidad: string | null;
+        cantidad: number | null;
+        cantidad_recibida: number | null;
+        cantidad_cancelada: number | null;
+        precio_unitario: number | null;
+        precio_real: number | null;
+      }> | null;
+    };
+    const out: OcRow[] = ((ocRes.data ?? []) as OcRaw[]).map((o) => {
+      const lineas: OcLinea[] = (o.ordenes_compra_detalle ?? []).map((d) => ({
+        id: d.id,
+        partidaId: d.partida_id,
+        partidaLabel: d.partida_id ? (partidaLabel.get(d.partida_id) ?? '—') : '—',
+        descripcion: d.descripcion ?? '',
+        unidad: d.unidad,
+        cantidad: Number(d.cantidad ?? 0),
+        cantidadRecibida: Number(d.cantidad_recibida ?? 0),
+        cantidadCancelada: Number(d.cantidad_cancelada ?? 0),
+        precioUnitario: Number(d.precio_real ?? d.precio_unitario ?? 0),
+      }));
+      const proyectoId =
+        lineas
+          .map((l) => l.partidaId)
+          .filter(Boolean)
+          .map((pid) => partidaProyecto.get(pid!))[0] ?? null;
+      return {
+        id: o.id,
+        codigo: o.codigo ?? '—',
+        proyectoId,
+        proyectoNombre: proyectoId ? (proyectoMap.get(proyectoId) ?? '') : '',
+        proveedorId: o.proveedor_id,
+        proveedorNombre: o.proveedor_id ? (provName.get(o.proveedor_id) ?? '—') : '—',
+        estado: (o.estado as OcEstado) ?? 'enviada',
+        fecha: o.fecha_entrega ?? o.created_at?.slice(0, 10) ?? null,
+        lineas,
+      };
+    });
+
+    return { rows: out, proyectos };
+  }, [empresaId]);
+
+  const apply = useCallback((res: FetchResult) => {
+    if (res.error) {
+      setError(res.error);
+      setRows([]);
+    } else {
+      setError(null);
+      setRows(res.rows ?? []);
+      setProyectos(res.proyectos ?? []);
+    }
+  }, []);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    apply(await fetchData());
+    setLoading(false);
+  }, [fetchData, apply]);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchData().then((res) => {
+      if (!activo) return;
+      apply(res);
+      if (!autoSelectDone.current && !res.error) {
+        const first = (res.rows ?? [])
+          .filter((r) => r.proyectoId)
+          .sort((a, b) => a.proyectoNombre.localeCompare(b.proyectoNombre))[0];
+        if (first?.proyectoId) setProyectoFiltro(first.proyectoId);
+        autoSelectDone.current = true;
+      }
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchData, apply]);
+
+  const proyectosPresentes = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of proyectos) m.set(p.id, p.nombre);
+    return [...m.entries()]
+      .map(([id, nombre]) => ({ id, nombre }))
+      .sort((a, b) => a.nombre.localeCompare(b.nombre));
+  }, [proyectos]);
+
+  const q = search.trim().toLowerCase();
+  const filtrados = useMemo(() => {
+    return rows.filter((r) => {
+      if (proyectoFiltro && r.proyectoId !== proyectoFiltro) return false;
+      if (q) {
+        const hay =
+          r.codigo.toLowerCase().includes(q) ||
+          r.proveedorNombre.toLowerCase().includes(q) ||
+          r.lineas.some((l) => l.partidaLabel.toLowerCase().includes(q));
+        if (!hay) return false;
+      }
+      return true;
+    });
+  }, [rows, q, proyectoFiltro]);
+
+  const kpis: ModuleKpi[] = useMemo(() => {
+    const enviadas = filtrados.filter((r) => r.estado === 'enviada').length;
+    const parciales = filtrados.filter((r) => r.estado === 'parcial').length;
+    const pendienteValor = filtrados.reduce(
+      (acc, r) => acc + r.lineas.reduce((a, l) => a + lineaPendiente(l) * l.precioUnitario, 0),
+      0
+    );
+    return [
+      { key: 'porRecibir', label: 'Por recibir', value: enviadas === 0 ? '—' : String(enviadas) },
+      { key: 'parciales', label: 'Parciales', value: parciales === 0 ? '—' : String(parciales) },
+      {
+        key: 'pendiente',
+        label: 'Valor pendiente',
+        value: pendienteValor === 0 ? '—' : formatCurrency(pendienteValor, { compact: true }),
+      },
+    ];
+  }, [filtrados]);
+
+  const toggleExpand = useCallback((oc: OcRow) => {
+    setExpandedId((prev) => {
+      if (prev === oc.id) return null;
+      // Prefill recibos con la cantidad recibida actual de cada línea.
+      setRecibos((r) => {
+        const next = { ...r };
+        for (const l of oc.lineas) next[l.id] = String(l.cantidadRecibida);
+        return next;
+      });
+      return oc.id;
+    });
+  }, []);
+
+  const recibirTodo = useCallback((oc: OcRow) => {
+    setRecibos((r) => {
+      const next = { ...r };
+      for (const l of oc.lineas) {
+        next[l.id] = String(l.cantidad - l.cantidadCancelada);
+      }
+      return next;
+    });
+  }, []);
+
+  const guardar = useCallback(
+    async (oc: OcRow) => {
+      setSavingId(oc.id);
+      const sb = createSupabaseBrowserClient();
+      // Solo las líneas cuyo total recibido cambió.
+      const cambios = oc.lineas.filter((l) => {
+        const v = recibos[l.id];
+        return v != null && toNum(v) !== l.cantidadRecibida;
+      });
+      if (cambios.length === 0) {
+        toast.add({
+          title: 'Sin cambios',
+          description: 'No modificaste cantidades.',
+          type: 'info',
+        });
+        setSavingId(null);
+        return;
+      }
+      for (const l of cambios) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { error: e } = await (sb.schema('erp') as any).rpc('oc_recibir_linea_partida', {
+          p_detalle_id: l.id,
+          p_cantidad_recibida_total: toNum(recibos[l.id]),
+          p_costo_unitario: null,
+        });
+        if (e) {
+          toast.add({
+            title: 'Error al recibir',
+            description: getSupabaseErrorMessage(e, `Falló la línea "${l.partidaLabel}".`),
+            type: 'error',
+          });
+          setSavingId(null);
+          void cargar();
+          return;
+        }
+      }
+      toast.add({
+        title: 'Recepción registrada',
+        description: `${oc.codigo} · ${cambios.length} línea(s)`,
+        type: 'success',
+      });
+      setSavingId(null);
+      setExpandedId(null);
+      void cargar();
+    },
+    [recibos, toast, cargar]
+  );
+
+  const columns: Column<OcRow>[] = [
+    {
+      key: 'expand',
+      label: '',
+      type: 'custom',
+      sortable: false,
+      width: 'w-8',
+      render: (r) => (
+        <ChevronRight
+          className={`h-4 w-4 text-[var(--text)]/40 transition-transform ${expandedId === r.id ? 'rotate-90' : ''}`}
+        />
+      ),
+    },
+    { key: 'codigo', label: 'Folio', type: 'text', width: 'min-w-[120px]' },
+    { key: 'proveedorNombre', label: 'Proveedor', type: 'text', width: 'min-w-[200px]' },
+    {
+      key: 'estado',
+      label: 'Estado',
+      type: 'custom',
+      render: (r) => (
+        <Badge tone={ESTADO_TONE[r.estado] ?? 'neutral'}>
+          {ESTADO_LABEL[r.estado] ?? r.estado}
+        </Badge>
+      ),
+    },
+    {
+      key: 'pendiente',
+      label: 'Líneas pend.',
+      type: 'custom',
+      align: 'right',
+      accessor: (r) => r.lineas.filter((l) => lineaPendiente(l) > 0).length,
+      render: (r) => String(r.lineas.filter((l) => lineaPendiente(l) > 0).length),
+    },
+    { key: 'fecha', label: 'Fecha', type: 'text', render: (r) => r.fecha || '—' },
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <PackageCheck className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Recepciones</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Recibe lo comprado contra la partida del presupuesto. Cada recepción mueve el “ejercido”
+            de la partida, sin tocar inventario.
+          </p>
+        </div>
+      </header>
+
+      <ModuleKpiStrip stats={kpis} cols={3} />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <select
+          value={proyectoFiltro}
+          onChange={(e) => setProyectoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm font-medium text-[var(--text)]"
+          aria-label="Proyecto"
+        >
+          <option value="">Todos los proyectos</option>
+          {proyectosPresentes.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.nombre}
+            </option>
+          ))}
+        </select>
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar folio, proveedor o partida…"
+            className="w-72 pl-9"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Refrescar
+        </button>
+        <span className="ml-auto text-sm text-[var(--text)]/60">
+          {filtrados.length} {filtrados.length === 1 ? 'orden' : 'órdenes'} por recibir
+        </span>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center gap-2 rounded-md border border-[var(--border)] py-16 text-sm text-[var(--text)]/60">
+          <Loader2 className="h-4 w-4 animate-spin" /> Cargando…
+        </div>
+      ) : error ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={() => void cargar()}
+            className="mt-2 rounded-md border border-red-300 px-3 py-1 text-xs font-medium hover:bg-red-100"
+          >
+            Reintentar
+          </button>
+        </div>
+      ) : filtrados.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed border-[var(--border)] py-16 text-center">
+          <PackageCheck className="h-6 w-6 text-[var(--text)]/30" />
+          <p className="text-sm font-medium text-[var(--text)]">Nada por recibir</p>
+          <p className="text-sm text-[var(--text)]/60">
+            No hay órdenes enviadas o parciales en este filtro.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-[var(--border)]">
+          <table className="min-w-full text-sm">
+            <thead className="bg-[var(--card)] text-xs uppercase tracking-wide text-[var(--text)]/50">
+              <tr className="border-b border-[var(--border)]">
+                {columns.map((c) => (
+                  <th
+                    key={c.key}
+                    className={`px-3 py-2.5 ${c.align === 'right' ? 'text-right' : 'text-left'} ${c.width ?? ''}`}
+                  >
+                    {c.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {filtrados.map((oc) => (
+                <Fragment key={oc.id}>
+                  <tr
+                    onClick={() => toggleExpand(oc)}
+                    className="cursor-pointer border-b border-[var(--border)]/60 transition-colors hover:bg-[var(--card)]/50"
+                  >
+                    {columns.map((c) => (
+                      <td
+                        key={c.key}
+                        className={`px-3 py-2 ${c.align === 'right' ? 'text-right tabular-nums' : ''}`}
+                      >
+                        {c.render
+                          ? c.render(oc)
+                          : String((oc as unknown as Record<string, unknown>)[c.key] ?? '')}
+                      </td>
+                    ))}
+                  </tr>
+                  {expandedId === oc.id ? (
+                    <tr className="border-b border-[var(--border)] bg-[var(--card)]/30">
+                      <td colSpan={columns.length} className="px-4 py-3">
+                        <ReceivePanel
+                          oc={oc}
+                          recibos={recibos}
+                          setRecibos={setRecibos}
+                          puedeRecibir={puedeRecibir}
+                          saving={savingId === oc.id}
+                          onRecibirTodo={() => recibirTodo(oc)}
+                          onGuardar={() => void guardar(oc)}
+                        />
+                      </td>
+                    </tr>
+                  ) : null}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReceivePanel({
+  oc,
+  recibos,
+  setRecibos,
+  puedeRecibir,
+  saving,
+  onRecibirTodo,
+  onGuardar,
+}: {
+  oc: OcRow;
+  recibos: Record<string, string>;
+  setRecibos: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  puedeRecibir: boolean;
+  saving: boolean;
+  onRecibirTodo: () => void;
+  onGuardar: () => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <table className="min-w-full text-sm">
+        <thead className="text-xs uppercase tracking-wide text-[var(--text)]/50">
+          <tr>
+            <th className="py-1 pr-3 text-left">Partida</th>
+            <th className="px-2 py-1 text-right">Pedida</th>
+            <th className="px-2 py-1 text-right">Recibida</th>
+            <th className="px-2 py-1 text-right">Pendiente</th>
+            <th className="px-2 py-1 text-right">Recibir (total)</th>
+            <th className="px-2 py-1 text-right">Importe</th>
+          </tr>
+        </thead>
+        <tbody>
+          {oc.lineas.map((l) => {
+            const pend = lineaPendiente(l);
+            return (
+              <tr key={l.id} className="border-t border-[var(--border)]/40">
+                <td className="py-1.5 pr-3">
+                  <span className="text-[var(--text)]">{l.partidaLabel}</span>
+                  {l.descripcion ? (
+                    <span className="text-[var(--text)]/50"> · {l.descripcion}</span>
+                  ) : null}
+                </td>
+                <td className="px-2 py-1.5 text-right tabular-nums">{l.cantidad}</td>
+                <td className="px-2 py-1.5 text-right tabular-nums text-[var(--text)]/70">
+                  {l.cantidadRecibida}
+                </td>
+                <td className="px-2 py-1.5 text-right tabular-nums">
+                  {pend > 0 ? pend : <span className="text-[var(--text)]/30">0</span>}
+                </td>
+                <td className="px-2 py-1.5 text-right">
+                  <Input
+                    type="number"
+                    step="0.01"
+                    value={recibos[l.id] ?? String(l.cantidadRecibida)}
+                    onChange={(e) => setRecibos((r) => ({ ...r, [l.id]: e.target.value }))}
+                    disabled={!puedeRecibir || saving}
+                    className="ml-auto w-24 text-right"
+                    aria-label={`Recibir ${l.partidaLabel}`}
+                  />
+                </td>
+                <td className="px-2 py-1.5 text-right tabular-nums">
+                  {formatCurrency(lineaTotal(l))}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {puedeRecibir ? (
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <Button variant="outline" onClick={onRecibirTodo} disabled={saving}>
+            Recibir todo
+          </Button>
+          <Button onClick={onGuardar} disabled={saving}>
+            {saving ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <PackageCheck className="size-4" />
+            )}
+            Guardar recepción
+          </Button>
+        </div>
+      ) : (
+        <p className="pt-1 text-right text-xs text-[var(--text)]/50">
+          Sin permiso de escritura en Recepciones.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -345,3 +345,17 @@ pago: rol **Dirección** (ya vigente en CxP).
   a la vez. 1264 tests verdes. Pendiente Fase B: editar OC borrador + drawer de
   detalle con histórico (v1 es alta + acciones; sin edición de líneas existentes).
   Próximo: Fase C (recepción, RPC nueva).
+- **2026-06-05** — **`obra_presupuesto` retirada (PR #691) + Fase C construida.**
+  `dilesa.obra_presupuesto` → `_deprecated` (rename, no drop) con OK de Beto;
+  verificado seguro (cero refs runtime, cero vistas/FKs, paridad 128↔128);
+  SCHEMA_REF + types regenerados (types absorbió las tablas diferidas de S0/S1).
+  **Fase C** (recepción, este PR): RPC nueva `erp.oc_recibir_linea_partida`
+  (variante de `oc_recibir_linea` sin producto/almacén/inventario — solo actualiza
+  `cantidad_recibida` + recalcula estado + audita → mueve `ejercido`) en archivo,
+  **pendiente de aplicar a prod con OK de Beto** (en el preview se aplica al branch
+  aislado). `components/compras/recepciones-module.tsx`: bandeja de OCs
+  enviada/parcial + recibir N por línea (inline expand, "Recibir todo" + guardar)
+  contra la partida; helpers `lineaPendiente`/`ocTienePendiente` + 4 tests.
+  Recepción ligera (D11, sin documento/folio). 1268 tests verdes. Próximo:
+  Fase D (requisiciones) + extraer componente compartido + (follow-up) ajuste F4
+  de la vista si se confirma la semántica de `ejercido` con OCs canceladas.

--- a/lib/compras/ordenes.test.ts
+++ b/lib/compras/ordenes.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   comprometeOc,
   deriveOcKpis,
+  lineaPendiente,
   lineaTotal,
+  ocTienePendiente,
   ocTotal,
   type OcLinea,
   type OcRow,
@@ -55,6 +57,32 @@ describe('lineaTotal / ocTotal', () => {
     expect(
       lineaTotal(linea({ cantidad: undefined as unknown as number, precioUnitario: 10 }))
     ).toBe(0);
+  });
+});
+
+describe('lineaPendiente / ocTienePendiente', () => {
+  it('pendiente = pedida − recibida − cancelada', () => {
+    expect(lineaPendiente(linea({ cantidad: 10, cantidadRecibida: 3, cantidadCancelada: 2 }))).toBe(
+      5
+    );
+  });
+  it('nunca negativo', () => {
+    expect(lineaPendiente(linea({ cantidad: 5, cantidadRecibida: 5, cantidadCancelada: 1 }))).toBe(
+      0
+    );
+  });
+  it('ocTienePendiente true si alguna línea tiene pendiente', () => {
+    const o = oc({
+      lineas: [
+        linea({ cantidad: 2, cantidadRecibida: 2 }),
+        linea({ cantidad: 3, cantidadRecibida: 1 }),
+      ],
+    });
+    expect(ocTienePendiente(o)).toBe(true);
+  });
+  it('ocTienePendiente false si todo recibido/cancelado', () => {
+    const o = oc({ lineas: [linea({ cantidad: 2, cantidadRecibida: 2 })] });
+    expect(ocTienePendiente(o)).toBe(false);
   });
 });
 

--- a/lib/compras/ordenes.ts
+++ b/lib/compras/ordenes.ts
@@ -61,6 +61,18 @@ export function ocTotal(oc: Pick<OcRow, 'lineas'>): number {
   return oc.lineas.reduce((acc, l) => acc + lineaTotal(l), 0);
 }
 
+/** Cantidad aún por recibir de una línea: pedida − recibida − cancelada (≥ 0). */
+export function lineaPendiente(
+  l: Pick<OcLinea, 'cantidad' | 'cantidadRecibida' | 'cantidadCancelada'>
+): number {
+  return Math.max(0, (l.cantidad ?? 0) - (l.cantidadRecibida ?? 0) - (l.cantidadCancelada ?? 0));
+}
+
+/** ¿La OC tiene algo pendiente de recibir? (alguna línea con pendiente > 0). */
+export function ocTienePendiente(oc: Pick<OcRow, 'lineas'>): boolean {
+  return oc.lineas.some((l) => lineaPendiente(l) > 0);
+}
+
 /** ¿La OC compromete presupuesto? (estado enviada/parcial/cerrada). */
 export function comprometeOc(estado: OcEstado): boolean {
   return OC_ESTADOS_COMPROMETEN.includes(estado);

--- a/supabase/migrations/20260605160000_erp_oc_recibir_linea_partida.sql
+++ b/supabase/migrations/20260605160000_erp_oc_recibir_linea_partida.sql
@@ -1,0 +1,128 @@
+-- RPC de recepción constructora-first: `erp.oc_recibir_linea_partida`.
+--
+-- Iniciativa `dilesa-compras` · Sprint 2 Fase C. Variante de
+-- `erp.oc_recibir_linea` (que usa RDB) para el modelo constructora (D7/D11/D13):
+-- la línea se ancla a una **partida** (no a producto) y la recepción **devenga
+-- contra la partida** — solo actualiza `cantidad_recibida` (lo que alimenta
+-- `ejercido` en `erp.v_partida_control`) + recalcula estado + audita. NO toca
+-- inventario (`movimientos_inventario`) ni requiere almacén.
+--
+-- RPC NUEVA (no se modifica `oc_recibir_linea`) para aislar el riesgo del
+-- inventario de RDB en prod (D13). Mismos guards de permiso/estado/cantidad e
+-- idempotencia que la original. Reversible: `DROP FUNCTION ...`.
+
+CREATE OR REPLACE FUNCTION erp.oc_recibir_linea_partida(
+  p_detalle_id uuid,
+  p_cantidad_recibida_total numeric,
+  p_costo_unitario numeric DEFAULT NULL::numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $function$
+DECLARE
+  v_empresa_id uuid;
+  v_orden_id uuid;
+  v_partida_id uuid;
+  v_cantidad_pedida numeric;
+  v_cantidad_recibida_actual numeric;
+  v_cantidad_cancelada numeric;
+  v_precio_real numeric;
+  v_precio_unitario numeric;
+  v_delta numeric;
+  v_costo numeric;
+  v_estado_oc text;
+BEGIN
+  IF p_cantidad_recibida_total IS NULL OR p_cantidad_recibida_total < 0 THEN
+    RAISE EXCEPTION 'cantidad_recibida_total debe ser >= 0 (recibido: %)', p_cantidad_recibida_total
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT
+    d.empresa_id, d.orden_compra_id, d.partida_id,
+    d.cantidad, d.cantidad_recibida, d.cantidad_cancelada,
+    d.precio_real, d.precio_unitario,
+    o.estado
+    INTO
+    v_empresa_id, v_orden_id, v_partida_id,
+    v_cantidad_pedida, v_cantidad_recibida_actual, v_cantidad_cancelada,
+    v_precio_real, v_precio_unitario,
+    v_estado_oc
+  FROM erp.ordenes_compra_detalle d
+  JOIN erp.ordenes_compra o ON o.id = d.orden_compra_id
+  WHERE d.id = p_detalle_id
+  FOR UPDATE OF d;
+
+  IF v_empresa_id IS NULL THEN
+    RAISE EXCEPTION 'Línea de OC % no encontrada', p_detalle_id USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT core.fn_has_empresa(v_empresa_id) THEN
+    RAISE EXCEPTION 'Sin permiso para empresa %', v_empresa_id USING ERRCODE = '42501';
+  END IF;
+
+  IF v_estado_oc IN ('cerrada', 'cancelada') THEN
+    RAISE EXCEPTION 'OC % está en estado terminal % — no se pueden registrar más recepciones', v_orden_id, v_estado_oc
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Constructora (D12): la línea se ancla a partida, NO a producto.
+  IF v_partida_id IS NULL THEN
+    RAISE EXCEPTION 'Línea % no está ligada a una partida de presupuesto.', p_detalle_id
+      USING ERRCODE = '22023',
+            HINT = 'Edita la OC para anclar la línea a una partida del presupuesto.';
+  END IF;
+
+  IF p_cantidad_recibida_total + v_cantidad_cancelada > v_cantidad_pedida THEN
+    RAISE EXCEPTION 'cantidad_recibida_total (%) + cantidad_cancelada (%) excede cantidad pedida (%)',
+      p_cantidad_recibida_total, v_cantidad_cancelada, v_cantidad_pedida
+      USING ERRCODE = '22023';
+  END IF;
+
+  v_delta := p_cantidad_recibida_total - v_cantidad_recibida_actual;
+
+  IF v_delta = 0 THEN
+    RETURN jsonb_build_object(
+      'detalle_id', p_detalle_id,
+      'cantidad_recibida_total', p_cantidad_recibida_total,
+      'delta_aplicado', 0,
+      'mensaje', 'sin cambio (idempotente)'
+    );
+  END IF;
+
+  v_costo := COALESCE(p_costo_unitario, v_precio_real, v_precio_unitario);
+
+  -- Devenga contra la partida: solo actualiza cantidad_recibida (alimenta
+  -- erp.v_partida_control.ejercido). SIN movimientos_inventario, sin almacén.
+  UPDATE erp.ordenes_compra_detalle
+     SET cantidad_recibida = p_cantidad_recibida_total
+   WHERE id = p_detalle_id;
+
+  PERFORM erp.fn_oc_recalcular_estado(v_orden_id);
+
+  PERFORM erp.fn_oc_audit(
+    v_empresa_id,
+    'oc_recibir_linea_partida',
+    'erp.ordenes_compra_detalle',
+    p_detalle_id,
+    jsonb_build_object('cantidad_recibida', v_cantidad_recibida_actual),
+    jsonb_build_object(
+      'cantidad_recibida', p_cantidad_recibida_total,
+      'delta', v_delta,
+      'costo_unitario', v_costo
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'detalle_id', p_detalle_id,
+    'orden_compra_id', v_orden_id,
+    'partida_id', v_partida_id,
+    'cantidad_recibida_total', p_cantidad_recibida_total,
+    'delta_aplicado', v_delta,
+    'costo_unitario_aplicado', v_costo
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION erp.oc_recibir_linea_partida(uuid, numeric, numeric) TO authenticated;


### PR DESCRIPTION
## Qué (Sprint 2 · Fase C)

El tab **Recepciones** del hub Compras — constructora-first. Recibir lo comprado **devenga el `ejercido`** contra la partida del presupuesto, **sin tocar inventario**.

- **RPC nueva `erp.oc_recibir_linea_partida`** ([migración 20260605160000](supabase/migrations/20260605160000_erp_oc_recibir_linea_partida.sql)): variante de `oc_recibir_linea` (la de RDB) que quita el requisito de `producto_id` + almacén + `movimientos_inventario`; solo actualiza `cantidad_recibida` → `fn_oc_recalcular_estado` → `fn_oc_audit`. Mismos guards (permiso/estado/cantidad/idempotencia). **RPC nueva, no toca la de RDB (D13).**
- **`components/compras/recepciones-module.tsx`**: bandeja de OCs `enviada`/`parcial`, expand por orden → recibir N por línea ("Recibir todo" + Guardar) contra la partida. **Recepción ligera (D11)**: sin documento/folio.
- Helpers `lineaPendiente`/`ocTienePendiente` + 4 tests. **1268 tests verdes.**

## ⚠️ Migración pendiente de TU OK (no aplicada a prod)
La RPC está en el archivo pero **no la apliqué a prod** (sigo el protocolo: migración de prod = tu OK puntual). En el **preview** sí se aplica (branch aislado).

## Nota sobre el preview
Como este PR trae migración, Supabase crea un **branch aislado sin datos de prod** → la bandeja de Recepciones se verá **vacía** (no hay OCs en el branch). Sirve para revisar la **estructura/UI**; el flujo real (crear OC → recibir) se prueba tras aplicar la RPC a prod. Para verlo con datos, lo más fácil es: aplicar la RPC a prod + probar en prod con una OC real.

## Preview-first (sin auto-merge)
UI + mutación financiera → abierto para tu revisión.

## Siguiente (Fase D)
Requisiciones + extraer el componente compartido `components/compras/`. Y un follow-up opcional: ajuste F4 de `v_partida_control` (¿`ejercido` debe excluir recepciones de OCs canceladas?) — lo confirmamos cuando lo veas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)