### PR TITLE
fix(cxp): upload-xml rechazaba a todo no-admin (Michelle bloqueada)

### DIFF
--- a/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
+++ b/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
@@ -78,7 +78,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     admin
       .schema('core')
       .from('usuarios_empresas')
-      .select('id')
+      .select('usuario_id')
       .eq('usuario_id', user.id)
       .eq('empresa_id', emp.id)
       .eq('activo', true)


### PR DESCRIPTION
## Bug

Michelle (rol global `viewer`, con membership **activo** en DILESA) recibía **"Sin acceso a esta empresa." (403)** al cargar un XML en `/dilesa/cxp`.

## Causa raíz

El gate de `POST /api/<empresa>/cxp/facturas/upload-xml` hacía:
```ts
.from('usuarios_empresas').select('id')
```
Pero `core.usuarios_empresas` **no tiene columna `id`** (PK compuesta `usuario_id + empresa_id + rol_id`). La query fallaba → `mem` quedaba `null` → la condición `if (!mem && rol !== 'admin')` rechazaba a **todo usuario sin rol global `admin`**, aunque tuviera membership activo. Beto pasaba solo por ser admin global, por eso no se había detectado (bug latente desde que se creó el endpoint en la iniciativa `cxp`).

## Fix

`.select('usuario_id')` (columna existente) → la fila de membership se resuelve y los miembros activos pasan. 1 línea.

## Verificación

Confirmado en prod: Michelle (`michelle.sd@dilesa.mx`) tiene `usuarios_empresas` activo en DILESA. typecheck ✓ · tests ✓ · lint ✓ · format ✓.

Único endpoint con el patrón (los otros usos de `usuarios_empresas` seleccionan `rol_id`/`empresa_id`, correctos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)