### PR TITLE
feat(dilesa-compras): UI de captura de cotizaciones RFQ (Sprint Cotizaciones · Fase 2)

### DIFF
--- a/app/api/dilesa/cotizaciones/[id]/solicitud/route.tsx
+++ b/app/api/dilesa/cotizaciones/[id]/solicitud/route.tsx
@@ -1,0 +1,290 @@
+/**
+ * GET  /api/dilesa/cotizaciones/[id]/solicitud?proveedor=<cotProveedorId>
+ *        → descarga el PDF de la Solicitud de Cotización (dirigido a ese proveedor).
+ * POST /api/dilesa/cotizaciones/[id]/solicitud
+ *        body { cotProveedorId: string; to?: string }
+ *        → envía el PDF por email al proveedor (erp.personas.email) vía Resend.
+ *
+ * Iniciativa dilesa-compras · Sprint Cotizaciones. Auth: sesión Supabase; la RLS
+ * de `erp.cotizaciones` decide si el usuario puede leer la fila.
+ */
+
+import { NextResponse } from 'next/server';
+import { renderToBuffer } from '@react-pdf/renderer';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import {
+  SolicitudCotizacionPDF,
+  type SolicitudCotizacionData,
+} from '@/lib/dilesa/pdf/solicitud-cotizacion';
+import { getDefinitionBySlug, writeNotificationLog } from '@/lib/notifications';
+
+const MESES_ES = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+];
+
+function fmtFecha(s: string | null | undefined): string {
+  if (!s) return '—';
+  const d = new Date(`${s}T00:00:00`);
+  if (isNaN(d.getTime())) return s;
+  return `${d.getDate()} de ${MESES_ES[d.getMonth()]} de ${d.getFullYear()}`;
+}
+
+type Sb = Awaited<ReturnType<typeof createSupabaseServerClient>>;
+
+async function buildPdfData(
+  sb: Sb,
+  cotizacionId: string,
+  cotProveedorId: string | null
+): Promise<{ data?: SolicitudCotizacionData; proveedorEmail?: string | null; error?: string }> {
+  const { data: cot, error: cErr } = await sb
+    .schema('erp')
+    .from('cotizaciones')
+    .select('id, codigo, tipo, fecha_limite, descripcion, created_at')
+    .eq('id', cotizacionId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (cErr || !cot) return { error: 'Cotización no encontrada' };
+
+  const { data: lineasRaw } = await sb
+    .schema('erp')
+    .from('cotizacion_lineas')
+    .select('id, partida_id, descripcion, cantidad, unidad')
+    .eq('cotizacion_id', cotizacionId);
+  const lineas = lineasRaw ?? [];
+
+  // Partidas → concepto_texto + proyecto_id.
+  const partidaIds = [...new Set(lineas.map((l) => l.partida_id).filter(Boolean) as string[])];
+  const { data: partidasRaw } = partidaIds.length
+    ? await sb
+        .schema('erp')
+        .from('presupuesto_partidas')
+        .select('id, concepto_texto, proyecto_id')
+        .in('id', partidaIds)
+    : { data: [] };
+  const partidaMap = new Map<string, { concepto: string; proyectoId: string | null }>();
+  for (const p of partidasRaw ?? []) {
+    partidaMap.set(p.id as string, {
+      concepto: (p.concepto_texto as string | null) ?? '—',
+      proyectoId: (p.proyecto_id as string | null) ?? null,
+    });
+  }
+
+  const proyectoId = [...partidaMap.values()].map((p) => p.proyectoId).filter(Boolean)[0] ?? null;
+  const { data: proyecto } = proyectoId
+    ? await sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('nombre')
+        .eq('id', proyectoId)
+        .maybeSingle()
+    : { data: null };
+
+  // Proveedor destinatario (opcional).
+  let proveedorNombre = '(general)';
+  let proveedorEmail: string | null = null;
+  if (cotProveedorId) {
+    const { data: cp } = await sb
+      .schema('erp')
+      .from('cotizacion_proveedores')
+      .select('proveedor_id')
+      .eq('id', cotProveedorId)
+      .maybeSingle();
+    if (cp?.proveedor_id) {
+      const { data: prov } = await sb
+        .schema('erp')
+        .from('proveedores')
+        .select('persona_id')
+        .eq('id', cp.proveedor_id as string)
+        .maybeSingle();
+      if (prov?.persona_id) {
+        const { data: per } = await sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno, email')
+          .eq('id', prov.persona_id as string)
+          .maybeSingle();
+        proveedorNombre =
+          [per?.nombre, per?.apellido_paterno, per?.apellido_materno]
+            .filter(Boolean)
+            .join(' ')
+            .trim() || '(sin nombre)';
+        proveedorEmail = (per?.email as string | null) ?? null;
+      }
+    }
+  }
+
+  const data: SolicitudCotizacionData = {
+    folio: (cot.codigo as string | null) ?? '—',
+    fechaTexto: fmtFecha((cot.created_at as string | null)?.slice(0, 10)),
+    proyecto: (proyecto?.nombre as string | null) ?? '—',
+    tipoLabel: cot.tipo === 'obra' ? 'Obra (mano de obra)' : 'Materiales / servicios',
+    fechaLimiteTexto: fmtFecha(cot.fecha_limite as string | null),
+    proveedorNombre,
+    descripcion: (cot.descripcion as string | null) ?? null,
+    lineas: lineas.map((l) => ({
+      concepto: l.partida_id
+        ? (partidaMap.get(l.partida_id as string)?.concepto ?? '—')
+        : ((l.descripcion as string | null) ?? 'Concepto libre'),
+      descripcion: (l.descripcion as string | null) ?? '',
+      cantidad: String(l.cantidad ?? ''),
+      unidad: (l.unidad as string | null) ?? '',
+    })),
+  };
+
+  return { data, proveedorEmail };
+}
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const cotProveedorId = new URL(req.url).searchParams.get('proveedor');
+  const sb = await createSupabaseServerClient();
+  const result = await buildPdfData(sb, id, cotProveedorId);
+  if (result.error || !result.data) {
+    return NextResponse.json({ error: result.error ?? 'Error' }, { status: 404 });
+  }
+  const buf = await renderToBuffer(<SolicitudCotizacionPDF data={result.data} />);
+  return new Response(new Uint8Array(buf), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="solicitud-cotizacion-${result.data.folio}.pdf"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const body = (await req.json().catch(() => ({}))) as { cotProveedorId?: string; to?: string };
+  if (!body.cotProveedorId) {
+    return NextResponse.json({ error: 'Falta cotProveedorId' }, { status: 400 });
+  }
+
+  const sb = await createSupabaseServerClient();
+  const result = await buildPdfData(sb, id, body.cotProveedorId);
+  if (result.error || !result.data) {
+    return NextResponse.json({ error: result.error ?? 'Error' }, { status: 404 });
+  }
+  const data = result.data;
+
+  const to = body.to?.trim() || result.proveedorEmail;
+  if (!to) {
+    return NextResponse.json(
+      {
+        error:
+          'El proveedor no tiene email registrado. Captúralo en el proveedor o pasa { "to": "email@..." }.',
+      },
+      { status: 400 }
+    );
+  }
+
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!resendKey) {
+    return NextResponse.json({ error: 'RESEND_API_KEY no configurada' }, { status: 500 });
+  }
+
+  // Catálogo de notificaciones (fail-open: sin definición usa defaults).
+  const def = await getDefinitionBySlug(sb, 'dilesa_cotizacion');
+  let fromAddress = 'DILESA Compras <noreply@bsop.io>';
+  let replyTo: string | null = 'compras@dilesa.mx';
+  const toList = [to];
+  if (def) {
+    if (!def.activo) {
+      await writeNotificationLog(sb, {
+        definitionId: def.id,
+        status: 'skipped',
+        recipients: { to: toList },
+        subject: `dilesa_cotizacion ${data.folio} — kill switch`,
+        context: { cotizacionId: id },
+      });
+      return NextResponse.json({ ok: true, skipped: true, reason: 'kill_switch' });
+    }
+    fromAddress = def.from_name ? `${def.from_name} <${def.from_email}>` : def.from_email;
+    replyTo = def.reply_to;
+  }
+
+  const buf = await renderToBuffer(<SolicitudCotizacionPDF data={data} />);
+  const base64 = buf.toString('base64');
+  const subject = `Solicitud de cotización ${data.folio} — DILESA`;
+
+  const html = `
+<div style="font-family: -apple-system, sans-serif; color: #222; max-width: 600px;">
+  <h2 style="color: #7d8043;">Solicitud de cotización ${data.folio}</h2>
+  <p>Estimado proveedor (${data.proveedorNombre}),</p>
+  <p>
+    Por medio del presente le solicitamos su cotización para el proyecto
+    <strong>${data.proyecto}</strong>. En el PDF adjunto encontrará el listado de conceptos a
+    cotizar.
+  </p>
+  <p>
+    Favor de indicar precio unitario, tiempo de entrega y condiciones de pago, y enviar su
+    propuesta antes del <strong>${data.fechaLimiteTexto}</strong>.
+  </p>
+  <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
+  <p style="color: #888; font-size: 11px;">
+    DILESA · Desarrollo Inmobiliario Los Encinos<br/>
+    dilesa.mx · (878) 791-1818
+  </p>
+</div>`.trim();
+
+  const resendBody: Record<string, unknown> = {
+    from: fromAddress,
+    to: toList,
+    subject,
+    html,
+    attachments: [{ filename: `solicitud-cotizacion-${data.folio}.pdf`, content: base64 }],
+  };
+  if (replyTo) resendBody.reply_to = replyTo;
+
+  const emailRes = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${resendKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(resendBody),
+  });
+  const resJson = (await emailRes.json()) as { id?: string; message?: string };
+
+  if (!emailRes.ok) {
+    console.error('[cotizaciones/solicitud POST] Resend rechazó el envío', {
+      cotizacionId: id,
+      to,
+      status: emailRes.status,
+      resendError: resJson,
+    });
+    await writeNotificationLog(sb, {
+      definitionId: def?.id ?? null,
+      status: 'failed',
+      recipients: { to: toList },
+      subject,
+      errorMessage: `Resend ${emailRes.status}: ${JSON.stringify(resJson).slice(0, 800)}`,
+      context: { cotizacionId: id, folio: data.folio },
+    });
+    return NextResponse.json(
+      { error: resJson.message ?? 'Error al enviar email', detail: resJson },
+      { status: 500 }
+    );
+  }
+
+  await writeNotificationLog(sb, {
+    definitionId: def?.id ?? null,
+    status: 'sent',
+    recipients: { to: toList },
+    subject,
+    resendId: resJson.id ?? null,
+    context: { cotizacionId: id, folio: data.folio, cotProveedorId: body.cotProveedorId },
+  });
+
+  return NextResponse.json({ ok: true, emailId: resJson.id, sentTo: to });
+}
+
+export const runtime = 'nodejs';

--- a/app/dilesa/compras/cotizaciones/page.tsx
+++ b/app/dilesa/compras/cotizaciones/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { CotizacionesModule } from '@/components/compras/cotizaciones-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Compras · Cotizaciones (DILESA)
+ * @responsive desktop-only
+ *
+ * Tab "Cotizaciones" del hub Compras (iniciativa dilesa-compras · Sprint
+ * Cotizaciones). RFQ formal multi-proveedor: se pide precio a N proveedores
+ * por las líneas (ancladas a partida), se captura la matriz precio×proveedor,
+ * y en Fase 3 se compara y adjudica a OC (materiales) o contrato (obra).
+ * Gate: sub-slug `dilesa.compras.cotizaciones` (ADR-030 SS5).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.compras.cotizaciones">
+      <DesktopOnlyNotice module="Cotizaciones" />
+      <div className="hidden sm:block">
+        <CotizacionesModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/compras/layout.tsx
+++ b/app/dilesa/compras/layout.tsx
@@ -34,6 +34,11 @@ const TABS = [
     module: 'dilesa.compras.requisiciones',
   },
   {
+    label: 'Cotizaciones',
+    href: '/dilesa/compras/cotizaciones',
+    module: 'dilesa.compras.cotizaciones',
+  },
+  {
     label: 'Recepciones',
     href: '/dilesa/compras/recepciones',
     module: 'dilesa.compras.recepciones',

--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -1,0 +1,1065 @@
+'use client';
+
+/**
+ * CotizacionesModule — RFQ formal multi-proveedor (DILESA).
+ *
+ * Iniciativa `dilesa-compras` · Sprint Cotizaciones · Fase 2 (captura). Tab
+ * "Cotizaciones" del hub Compras. La RFQ es una **matriz**: N líneas (ancladas a
+ * partida, D12) × M proveedores invitados, con un precio por celda. Aquí se
+ * crea la RFQ, se invita a proveedores y se captura su respuesta + la matriz de
+ * precios. La comparativa lado a lado y la adjudicación (→ OC o contrato) viven
+ * en la Fase 3.
+ *
+ * Patrón del repo (igual que OrdenesCompraModule): client-side directo, fetch
+ * paralelo + Map lookups, un proyecto a la vez, selector solo-con-presupuesto.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ClipboardList, Loader2, Plus, RefreshCw, Save, Search, Trash2, X } from 'lucide-react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge, type BadgeTone } from '@/components/ui/badge';
+import { usePermissions } from '@/components/providers';
+import { useToast } from '@/components/ui/toast';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { formatCurrency } from '@/lib/format';
+import {
+  buildProyectoOptions,
+  type ProyectoOption,
+  type ProyectoSelectorRow,
+} from '@/lib/dilesa/proyectos-selector';
+import { buildPartidaIndex, type PartidaGrupo } from '@/lib/compras/partidas';
+import {
+  deriveCotizacionKpis,
+  mejorProveedorLinea,
+  type CotizacionEstado,
+  type CotizacionRow,
+  type CotizacionTipo,
+  type CotLinea,
+  type CotPrecio,
+  type CotProveedor,
+} from '@/lib/compras/cotizaciones';
+
+const ESTADO_TONE: Record<CotizacionEstado, BadgeTone> = {
+  abierta: 'info',
+  comparada: 'warning',
+  adjudicada: 'success',
+  cancelada: 'danger',
+};
+const ESTADO_LABEL: Record<CotizacionEstado, string> = {
+  abierta: 'Abierta',
+  comparada: 'Comparada',
+  adjudicada: 'Adjudicada',
+  cancelada: 'Cancelada',
+};
+const TIPO_LABEL: Record<CotizacionTipo, string> = {
+  compra: 'Compra (→ OC)',
+  obra: 'Obra (→ contrato)',
+};
+
+type ProveedorOption = { id: string; label: string };
+
+/** Fila con el proyecto inferido de las partidas de sus líneas (para filtrar). */
+type CotizacionRowUI = CotizacionRow & { proyectoId: string | null };
+
+type FetchResult = {
+  rows?: CotizacionRowUI[];
+  proyectos?: ProyectoOption[];
+  proveedores?: ProveedorOption[];
+  partidasByProyecto?: Map<string, PartidaGrupo[]>;
+  error?: string;
+};
+
+/** Línea en captura (alta de RFQ). */
+type DraftLinea = {
+  key: string;
+  partidaId: string;
+  descripcion: string;
+  unidad: string;
+  cantidad: string;
+};
+function emptyLinea(): DraftLinea {
+  return { key: crypto.randomUUID(), partidaId: '', descripcion: '', unidad: '', cantidad: '' };
+}
+function toNum(s: string): number {
+  const n = Number(s.trim());
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function CotizacionesModule({ empresaId }: { empresaId: string }) {
+  const { permissions } = usePermissions();
+  const toast = useToast();
+  const puedeEscribir =
+    permissions.isAdmin || permissions.modulos.get('dilesa.compras.cotizaciones')?.write === true;
+
+  const [rows, setRows] = useState<CotizacionRowUI[]>([]);
+  const [proyectos, setProyectos] = useState<ProyectoOption[]>([]);
+  const [proveedores, setProveedores] = useState<ProveedorOption[]>([]);
+  const [partidasByProyecto, setPartidasByProyecto] = useState<Map<string, PartidaGrupo[]>>(
+    new Map()
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [proyectoFiltro, setProyectoFiltro] = useState('');
+  const autoSelectDone = useRef(false);
+
+  // Alta de RFQ
+  const [formOpen, setFormOpen] = useState(false);
+  const [tipo, setTipo] = useState<CotizacionTipo>('compra');
+  const [descripcion, setDescripcion] = useState('');
+  const [fechaLimite, setFechaLimite] = useState('');
+  const [lineas, setLineas] = useState<DraftLinea[]>([emptyLinea()]);
+  const [proveedoresSel, setProveedoresSel] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+
+  // Captura de precios (matriz) de una RFQ existente
+  const [capturaId, setCapturaId] = useState<string | null>(null);
+
+  const fetchData = useCallback(async (): Promise<FetchResult> => {
+    const sb = createSupabaseBrowserClient();
+    const [cotRes, proyectosRes, proveedoresRes, catalogoRes, partidasRes] = await Promise.all([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any)
+        .from('cotizaciones')
+        .select(
+          'id, codigo, tipo, estado, descripcion, fecha_limite, adjudicado_proveedor_id, created_at, ' +
+            'cotizacion_lineas(id, partida_id, descripcion, unidad, cantidad), ' +
+            'cotizacion_proveedores(id, proveedor_id, estado, monto_total, tiempo_entrega, condiciones, notas, ' +
+            'cotizacion_proveedor_precios(id, cotizacion_linea_id, precio_unitario))'
+        )
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, nombre, tipo, proyecto_predecesor_id')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      sb
+        .schema('erp')
+        .from('proveedores')
+        .select('id, personas:persona_id(nombre, apellido_paterno, apellido_materno)')
+        .eq('empresa_id', empresaId)
+        .eq('activo', true)
+        .is('deleted_at', null),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any)
+        .from('conceptos_compra')
+        .select('id, padre_id, nivel, codigo, nombre')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any)
+        .from('presupuesto_partidas')
+        .select('id, proyecto_id, concepto_id, concepto_texto')
+        .eq('empresa_id', empresaId)
+        .is('deleted_at', null),
+    ]);
+
+    const firstErr =
+      cotRes.error ??
+      proyectosRes.error ??
+      proveedoresRes.error ??
+      catalogoRes.error ??
+      partidasRes.error;
+    if (firstErr) return { error: getSupabaseErrorMessage(firstErr, 'No se pudo cargar.') };
+
+    const proyectoMap = new Map<string, string>();
+    for (const p of proyectosRes.data ?? []) proyectoMap.set(p.id as string, p.nombre as string);
+    const proyectos = buildProyectoOptions(
+      (proyectosRes.data ?? []) as unknown as ProyectoSelectorRow[]
+    );
+
+    type ProvRaw = {
+      id: string;
+      personas: {
+        nombre: string | null;
+        apellido_paterno: string | null;
+        apellido_materno: string | null;
+      } | null;
+    };
+    const proveedores: ProveedorOption[] = ((proveedoresRes.data ?? []) as unknown as ProvRaw[])
+      .map((pv) => ({
+        id: pv.id,
+        label:
+          [pv.personas?.nombre, pv.personas?.apellido_paterno, pv.personas?.apellido_materno]
+            .filter(Boolean)
+            .join(' ')
+            .trim() || '(sin nombre)',
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+    const proveedorLabel = new Map(proveedores.map((p) => [p.id, p.label]));
+
+    const {
+      partidaLabel,
+      partidaProyecto,
+      gruposByProyecto: partidasByProyecto,
+    } = buildPartidaIndex(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (partidasRes.data ?? []) as any[],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (catalogoRes.data ?? []) as any[]
+    );
+
+    type CotRaw = {
+      id: string;
+      codigo: string | null;
+      tipo: string;
+      estado: string;
+      descripcion: string | null;
+      fecha_limite: string | null;
+      adjudicado_proveedor_id: string | null;
+      created_at: string;
+      cotizacion_lineas: Array<{
+        id: string;
+        partida_id: string | null;
+        descripcion: string | null;
+        unidad: string | null;
+        cantidad: number | null;
+      }> | null;
+      cotizacion_proveedores: Array<{
+        id: string;
+        proveedor_id: string;
+        estado: string;
+        monto_total: number | null;
+        tiempo_entrega: string | null;
+        condiciones: string | null;
+        notas: string | null;
+        cotizacion_proveedor_precios: Array<{
+          id: string;
+          cotizacion_linea_id: string;
+          precio_unitario: number | null;
+        }> | null;
+      }> | null;
+    };
+
+    const out: CotizacionRowUI[] = ((cotRes.data ?? []) as CotRaw[]).map((c) => {
+      const cotLineas: CotLinea[] = (c.cotizacion_lineas ?? []).map((l) => ({
+        id: l.id,
+        partidaId: l.partida_id,
+        partidaLabel: l.partida_id ? (partidaLabel.get(l.partida_id) ?? '—') : '—',
+        descripcion: l.descripcion ?? '',
+        unidad: l.unidad,
+        cantidad: Number(l.cantidad ?? 0),
+      }));
+      const cotProveedores: CotProveedor[] = (c.cotizacion_proveedores ?? []).map((p) => ({
+        id: p.id,
+        proveedorId: p.proveedor_id,
+        proveedorNombre: proveedorLabel.get(p.proveedor_id) ?? '—',
+        estado: p.estado as CotProveedor['estado'],
+        montoTotal: p.monto_total != null ? Number(p.monto_total) : null,
+        tiempoEntrega: p.tiempo_entrega,
+        condiciones: p.condiciones,
+        notas: p.notas,
+      }));
+      const precios: CotPrecio[] = (c.cotizacion_proveedores ?? []).flatMap((p) =>
+        (p.cotizacion_proveedor_precios ?? []).map((pr) => ({
+          cotProveedorId: p.id,
+          lineaId: pr.cotizacion_linea_id,
+          precioUnitario: Number(pr.precio_unitario ?? 0),
+        }))
+      );
+      const proyectoId =
+        cotLineas
+          .map((l) => l.partidaId)
+          .filter(Boolean)
+          .map((pid) => partidaProyecto.get(pid!))[0] ?? null;
+      return {
+        id: c.id,
+        codigo: c.codigo ?? '—',
+        tipo: (c.tipo as CotizacionTipo) ?? 'compra',
+        estado: (c.estado as CotizacionEstado) ?? 'abierta',
+        descripcion: c.descripcion ?? '',
+        fechaLimite: c.fecha_limite ?? c.created_at?.slice(0, 10) ?? null,
+        proyectoNombre: proyectoId ? (proyectoMap.get(proyectoId) ?? '') : '',
+        adjudicadoProveedorId: c.adjudicado_proveedor_id,
+        lineas: cotLineas,
+        proveedores: cotProveedores,
+        precios,
+        proyectoId,
+      };
+    });
+
+    return { rows: out, proyectos, proveedores, partidasByProyecto };
+  }, [empresaId]);
+
+  const apply = useCallback((res: FetchResult) => {
+    if (res.error) {
+      setError(res.error);
+      setRows([]);
+    } else {
+      setError(null);
+      setRows(res.rows ?? []);
+      setProyectos(res.proyectos ?? []);
+      setProveedores(res.proveedores ?? []);
+      setPartidasByProyecto(res.partidasByProyecto ?? new Map());
+    }
+  }, []);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    apply(await fetchData());
+    setLoading(false);
+  }, [fetchData, apply]);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchData().then((res) => {
+      if (!activo) return;
+      apply(res);
+      if (!autoSelectDone.current && !res.error) {
+        const firstByPartida = [...(res.partidasByProyecto ?? new Map()).keys()][0];
+        if (firstByPartida) setProyectoFiltro(firstByPartida);
+        autoSelectDone.current = true;
+      }
+      setLoading(false);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchData, apply]);
+
+  // Solo proyectos con presupuesto (partidas) o que ya tienen RFQs.
+  const proyectosPresentes = useMemo(() => {
+    const conPresupuesto = new Set(partidasByProyecto.keys());
+    const enRows = new Set(rows.map((r) => r.proyectoId).filter(Boolean) as string[]);
+    const m = new Map<string, string>();
+    for (const p of proyectos) {
+      if (conPresupuesto.has(p.id) || enRows.has(p.id)) m.set(p.id, p.nombre);
+    }
+    return [...m.entries()]
+      .map(([id, nombre]) => ({ id, nombre }))
+      .sort((a, b) => a.nombre.localeCompare(b.nombre));
+  }, [proyectos, partidasByProyecto, rows]);
+
+  const q = search.trim().toLowerCase();
+  const filtrados = useMemo(() => {
+    return rows.filter((r) => {
+      if (proyectoFiltro && r.proyectoId !== proyectoFiltro) return false;
+      if (q) {
+        const hay =
+          r.codigo.toLowerCase().includes(q) ||
+          r.descripcion.toLowerCase().includes(q) ||
+          r.proveedores.some((p) => p.proveedorNombre.toLowerCase().includes(q));
+        if (!hay) return false;
+      }
+      return true;
+    });
+  }, [rows, q, proyectoFiltro]);
+
+  const kpisData = useMemo(() => deriveCotizacionKpis(filtrados), [filtrados]);
+  const kpis: ModuleKpi[] = [
+    { key: 'total', label: 'RFQ', value: kpisData.total === 0 ? '—' : String(kpisData.total) },
+    {
+      key: 'abiertas',
+      label: 'Abiertas',
+      value: kpisData.abiertas === 0 ? '—' : String(kpisData.abiertas),
+    },
+    {
+      key: 'adjudicadas',
+      label: 'Adjudicadas',
+      value: kpisData.adjudicadas === 0 ? '—' : String(kpisData.adjudicadas),
+    },
+    {
+      key: 'montoAdjudicado',
+      label: 'Adjudicado',
+      value:
+        kpisData.montoAdjudicado === 0
+          ? '—'
+          : formatCurrency(kpisData.montoAdjudicado, { compact: true }),
+    },
+  ];
+
+  const proyectoActivo = proyectoFiltro || '';
+  const partidaGrupos = proyectoActivo ? (partidasByProyecto.get(proyectoActivo) ?? []) : [];
+
+  function abrirAlta() {
+    setTipo('compra');
+    setDescripcion('');
+    setFechaLimite('');
+    setLineas([emptyLinea()]);
+    setProveedoresSel(new Set());
+    setFormOpen(true);
+  }
+
+  const canSubmit =
+    proyectoActivo !== '' &&
+    lineas.some((l) => l.partidaId !== '' && toNum(l.cantidad) > 0) &&
+    proveedoresSel.size > 0;
+
+  async function onSubmit() {
+    if (!canSubmit || submitting) return;
+    setSubmitting(true);
+    const sb = createSupabaseBrowserClient();
+    const validas = lineas.filter((l) => l.partidaId !== '' && toNum(l.cantidad) > 0);
+    const folio = `RFQ-${Date.now().toString(36).toUpperCase()}`;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cotResp = await (sb.schema('erp') as any)
+      .from('cotizaciones')
+      .insert({
+        empresa_id: empresaId,
+        codigo: folio,
+        tipo,
+        estado: 'abierta',
+        descripcion: descripcion.trim() || null,
+        fecha_limite: fechaLimite || null,
+      })
+      .select('id')
+      .single();
+    if (cotResp.error || !cotResp.data) {
+      toast.add({
+        title: 'Error',
+        description: getSupabaseErrorMessage(cotResp.error, 'No se pudo crear la cotización.'),
+        type: 'error',
+      });
+      setSubmitting(false);
+      return;
+    }
+    const cotId = cotResp.data.id as string;
+    const detalle = validas.map((l) => ({
+      empresa_id: empresaId,
+      cotizacion_id: cotId,
+      partida_id: l.partidaId,
+      descripcion: l.descripcion.trim() || null,
+      unidad: l.unidad.trim() || null,
+      cantidad: toNum(l.cantidad),
+    }));
+    const invitados = [...proveedoresSel].map((pid) => ({
+      empresa_id: empresaId,
+      cotizacion_id: cotId,
+      proveedor_id: pid,
+      estado: 'invitado',
+    }));
+    const [lineasResp, provResp] = await Promise.all([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any).from('cotizacion_lineas').insert(detalle),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sb.schema('erp') as any).from('cotizacion_proveedores').insert(invitados),
+    ]);
+    const insErr = lineasResp.error ?? provResp.error;
+    if (insErr) {
+      toast.add({
+        title: 'Error',
+        description: getSupabaseErrorMessage(insErr, 'Cotización creada pero faltaron datos.'),
+        type: 'error',
+      });
+      setSubmitting(false);
+      return;
+    }
+    toast.add({ title: 'Cotización creada', description: folio, type: 'success' });
+    setSubmitting(false);
+    setFormOpen(false);
+    void cargar();
+  }
+
+  const cancelar = useCallback(
+    async (c: CotizacionRow) => {
+      const sb = createSupabaseBrowserClient();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: e } = await (sb.schema('erp') as any)
+        .from('cotizaciones')
+        .update({ estado: 'cancelada', updated_at: new Date().toISOString() })
+        .eq('id', c.id);
+      if (e) {
+        toast.add({
+          title: 'Error',
+          description: getSupabaseErrorMessage(e, 'No se pudo cancelar.'),
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({ title: 'Cotización cancelada', description: c.codigo, type: 'success' });
+      void cargar();
+    },
+    [toast, cargar]
+  );
+
+  const enCaptura = useMemo(() => rows.find((r) => r.id === capturaId) ?? null, [rows, capturaId]);
+
+  const columns: Column<CotizacionRow>[] = [
+    { key: 'codigo', label: 'Folio', type: 'text', sticky: true, width: 'min-w-[130px]' },
+    {
+      key: 'tipo',
+      label: 'Tipo',
+      type: 'custom',
+      render: (r) => <span className="text-sm">{TIPO_LABEL[r.tipo]}</span>,
+    },
+    {
+      key: 'descripcion',
+      label: 'Descripción',
+      type: 'text',
+      width: 'min-w-[200px]',
+      render: (r) => r.descripcion || '—',
+    },
+    {
+      key: 'estado',
+      label: 'Estado',
+      type: 'custom',
+      render: (r) => <Badge tone={ESTADO_TONE[r.estado]}>{ESTADO_LABEL[r.estado]}</Badge>,
+    },
+    {
+      key: 'lineasCount',
+      label: 'Líneas',
+      type: 'custom',
+      align: 'right',
+      accessor: (r) => r.lineas.length,
+      render: (r) => String(r.lineas.length),
+    },
+    {
+      key: 'provCount',
+      label: 'Proveedores',
+      type: 'custom',
+      align: 'right',
+      accessor: (r) => r.proveedores.length,
+      render: (r) => String(r.proveedores.length),
+    },
+    { key: 'fechaLimite', label: 'Límite', type: 'text', render: (r) => r.fechaLimite || '—' },
+    ...(puedeEscribir
+      ? [
+          {
+            key: 'acciones',
+            label: '',
+            type: 'custom' as const,
+            sortable: false,
+            align: 'right' as const,
+            width: 'w-40',
+            render: (r: CotizacionRow) =>
+              r.estado === 'abierta' || r.estado === 'comparada' ? (
+                <div className="flex items-center justify-end gap-1">
+                  <button
+                    type="button"
+                    onClick={() => setCapturaId(r.id)}
+                    className="rounded border border-[var(--border)] px-2 py-1 text-xs text-[var(--text)]/80 hover:bg-[var(--card)]"
+                  >
+                    Capturar precios
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void cancelar(r)}
+                    aria-label={`Cancelar ${r.codigo}`}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/40 hover:bg-red-50 hover:text-red-600"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ) : null,
+          },
+        ]
+      : []),
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <ClipboardList className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Cotizaciones</h1>
+          <p className="text-sm text-[var(--text)]/60">
+            RFQ formal multi-proveedor: pide precio a N por las líneas (ancladas a partida), captura
+            la matriz y adjudica a OC o contrato (comparativa y adjudicación en la siguiente fase).
+          </p>
+        </div>
+      </header>
+
+      <ModuleKpiStrip stats={kpis} cols={4} />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <select
+          value={proyectoFiltro}
+          onChange={(e) => setProyectoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm font-medium text-[var(--text)]"
+          aria-label="Proyecto"
+        >
+          <option value="">Todos los proyectos</option>
+          {proyectosPresentes.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.nombre}
+            </option>
+          ))}
+        </select>
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text)]/40" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar folio, descripción o proveedor…"
+            className="w-72 pl-9"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" /> Refrescar
+        </button>
+        <div className="ml-auto flex items-center gap-3">
+          <span className="text-sm text-[var(--text)]/60">
+            {filtrados.length} de {rows.length} cotizaciones
+          </span>
+          {puedeEscribir ? (
+            <button
+              type="button"
+              onClick={abrirAlta}
+              disabled={proyectoActivo === ''}
+              title={
+                proyectoActivo === '' ? 'Selecciona un proyecto para crear una RFQ' : undefined
+              }
+              className="inline-flex h-9 items-center gap-1.5 rounded-md bg-[var(--accent)] px-3 text-sm font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Plus className="h-3.5 w-3.5" /> Nueva cotización
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {formOpen ? (
+        <div className="rounded-md border border-[var(--border)] bg-[var(--card)] p-4">
+          <div className="mb-3 flex flex-wrap items-center gap-3">
+            <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+              Nueva RFQ ·{' '}
+              {proyectosPresentes.find((p) => p.id === proyectoActivo)?.nombre ?? 'Proyecto'}
+            </h2>
+            <select
+              value={tipo}
+              onChange={(e) => setTipo(e.target.value as CotizacionTipo)}
+              className="h-9 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 text-sm text-[var(--text)]"
+              aria-label="Tipo de cotización"
+            >
+              <option value="compra">{TIPO_LABEL.compra}</option>
+              <option value="obra">{TIPO_LABEL.obra}</option>
+            </select>
+            <Input
+              value={descripcion}
+              onChange={(e) => setDescripcion(e.target.value)}
+              placeholder="Descripción (opcional)"
+              className="w-64"
+            />
+            <label className="flex items-center gap-1.5 text-sm text-[var(--text)]/60">
+              Límite
+              <Input
+                value={fechaLimite}
+                onChange={(e) => setFechaLimite(e.target.value)}
+                type="date"
+                className="w-40"
+              />
+            </label>
+          </div>
+
+          {/* Líneas a cotizar */}
+          <div className="space-y-2">
+            {lineas.map((l, idx) => (
+              <div key={l.key} className="flex flex-wrap items-center gap-2">
+                <select
+                  value={l.partidaId}
+                  onChange={(e) =>
+                    setLineas((prev) =>
+                      prev.map((x) => (x.key === l.key ? { ...x, partidaId: e.target.value } : x))
+                    )
+                  }
+                  className="h-9 min-w-[260px] flex-1 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 text-sm text-[var(--text)]"
+                >
+                  <option value="">Partida…</option>
+                  {partidaGrupos.map((g) => (
+                    <optgroup key={g.key} label={g.label}>
+                      {g.partidas.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.label}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+                </select>
+                <Input
+                  value={l.descripcion}
+                  onChange={(e) =>
+                    setLineas((prev) =>
+                      prev.map((x) => (x.key === l.key ? { ...x, descripcion: e.target.value } : x))
+                    )
+                  }
+                  placeholder="Detalle (opcional)"
+                  className="w-44"
+                />
+                <Input
+                  value={l.cantidad}
+                  onChange={(e) =>
+                    setLineas((prev) =>
+                      prev.map((x) => (x.key === l.key ? { ...x, cantidad: e.target.value } : x))
+                    )
+                  }
+                  type="number"
+                  step="0.01"
+                  placeholder="Cant."
+                  className="w-20"
+                />
+                <Input
+                  value={l.unidad}
+                  onChange={(e) =>
+                    setLineas((prev) =>
+                      prev.map((x) => (x.key === l.key ? { ...x, unidad: e.target.value } : x))
+                    )
+                  }
+                  placeholder="Unidad"
+                  className="w-24"
+                />
+                <button
+                  type="button"
+                  onClick={() =>
+                    setLineas((prev) =>
+                      prev.length > 1 ? prev.filter((x) => x.key !== l.key) : prev
+                    )
+                  }
+                  aria-label={`Quitar línea ${idx + 1}`}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/40 hover:bg-red-50 hover:text-red-600"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => setLineas((prev) => [...prev, emptyLinea()])}
+            className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] px-3 py-1.5 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+          >
+            <Plus className="h-3.5 w-3.5" /> Agregar línea
+          </button>
+
+          {/* Proveedores a invitar */}
+          <div className="mt-4">
+            <p className="mb-2 text-sm font-medium text-[var(--text)]/70">
+              Invitar proveedores ({proveedoresSel.size})
+            </p>
+            <div className="flex max-h-32 flex-wrap gap-2 overflow-y-auto">
+              {proveedores.map((p) => {
+                const sel = proveedoresSel.has(p.id);
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() =>
+                      setProveedoresSel((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(p.id)) next.delete(p.id);
+                        else next.add(p.id);
+                        return next;
+                      })
+                    }
+                    className={`rounded-full border px-3 py-1 text-xs ${
+                      sel
+                        ? 'border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--accent)]'
+                        : 'border-[var(--border)] text-[var(--text)]/70 hover:bg-[var(--card)]'
+                    }`}
+                  >
+                    {p.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <Button variant="outline" onClick={() => setFormOpen(false)} disabled={submitting}>
+              Cancelar
+            </Button>
+            <Button onClick={onSubmit} disabled={!canSubmit || submitting}>
+              {submitting ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Plus className="size-4" />
+              )}
+              Crear RFQ
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {enCaptura ? (
+        <CapturaPrecios
+          key={enCaptura.id}
+          cotizacion={enCaptura}
+          empresaId={empresaId}
+          onClose={() => setCapturaId(null)}
+          onSaved={() => {
+            setCapturaId(null);
+            void cargar();
+          }}
+        />
+      ) : null}
+
+      <DataTable
+        data={filtrados}
+        columns={columns}
+        rowKey="id"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        initialSort={{ key: 'fechaLimite', dir: 'desc' }}
+        emptyTitle="Sin cotizaciones"
+        emptyDescription="No hay RFQ que coincidan. Crea una con “Nueva cotización”."
+        emptyIcon={<ClipboardList className="h-6 w-6" />}
+        maxHeight="calc(100vh - 320px)"
+      />
+    </div>
+  );
+}
+
+/**
+ * Panel de captura de la matriz de precios (precio por línea por proveedor) +
+ * datos de respuesta de cada proveedor. Guarda upsert de
+ * `cotizacion_proveedor_precios` + update de `cotizacion_proveedores`.
+ */
+function CapturaPrecios({
+  cotizacion,
+  empresaId,
+  onClose,
+  onSaved,
+}: {
+  cotizacion: CotizacionRow;
+  empresaId: string;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const toast = useToast();
+  const [saving, setSaving] = useState(false);
+  // Matriz local: `${cotProveedorId}|${lineaId}` → precio (string).
+  const [precios, setPrecios] = useState<Record<string, string>>(() => {
+    const seed: Record<string, string> = {};
+    for (const p of cotizacion.precios) {
+      seed[`${p.cotProveedorId}|${p.lineaId}`] = p.precioUnitario ? String(p.precioUnitario) : '';
+    }
+    return seed;
+  });
+  // Datos de respuesta por proveedor.
+  const [respuesta, setRespuesta] = useState<
+    Record<string, { tiempoEntrega: string; condiciones: string; notas: string }>
+  >(() => {
+    const seed: Record<string, { tiempoEntrega: string; condiciones: string; notas: string }> = {};
+    for (const p of cotizacion.proveedores) {
+      seed[p.id] = {
+        tiempoEntrega: p.tiempoEntrega ?? '',
+        condiciones: p.condiciones ?? '',
+        notas: p.notas ?? '',
+      };
+    }
+    return seed;
+  });
+
+  const setCelda = (cotProvId: string, lineaId: string, val: string) =>
+    setPrecios((prev) => ({ ...prev, [`${cotProvId}|${lineaId}`]: val }));
+
+  // Total por proveedor con la matriz local (en edición).
+  const totalLocal = (cotProvId: string): number =>
+    cotizacion.lineas.reduce((acc, l) => {
+      const v = Number((precios[`${cotProvId}|${l.id}`] ?? '').trim());
+      return acc + (l.cantidad ?? 0) * (Number.isFinite(v) ? v : 0);
+    }, 0);
+
+  async function guardar() {
+    if (saving) return;
+    setSaving(true);
+    const sb = createSupabaseBrowserClient();
+    // Upsert de precios (uno por celda con valor > 0) + update de respuesta/estado por proveedor.
+    const filasPrecio: Array<{
+      empresa_id: string;
+      cotizacion_proveedor_id: string;
+      cotizacion_linea_id: string;
+      precio_unitario: number;
+    }> = [];
+    for (const p of cotizacion.proveedores) {
+      for (const l of cotizacion.lineas) {
+        const raw = (precios[`${p.id}|${l.id}`] ?? '').trim();
+        if (raw === '') continue;
+        const val = Number(raw);
+        if (!Number.isFinite(val) || val <= 0) continue;
+        filasPrecio.push({
+          empresa_id: empresaId,
+          cotizacion_proveedor_id: p.id,
+          cotizacion_linea_id: l.id,
+          precio_unitario: val,
+        });
+      }
+    }
+    // Proveedor pasa a "respondida" si capturó al menos un precio; su monto_total se deriva.
+    const updates = cotizacion.proveedores.map((p) => {
+      const t = totalLocal(p.id);
+      const r = respuesta[p.id] ?? { tiempoEntrega: '', condiciones: '', notas: '' };
+      return {
+        id: p.id,
+        estado: t > 0 ? ('respondida' as const) : ('invitado' as const),
+        monto_total: t > 0 ? t : null,
+        tiempo_entrega: r.tiempoEntrega.trim() || null,
+        condiciones: r.condiciones.trim() || null,
+        notas: r.notas.trim() || null,
+      };
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const precioResp = await (sb.schema('erp') as any)
+      .from('cotizacion_proveedor_precios')
+      .upsert(filasPrecio, { onConflict: 'cotizacion_proveedor_id,cotizacion_linea_id' });
+    if (precioResp.error) {
+      toast.add({
+        title: 'Error',
+        description: getSupabaseErrorMessage(
+          precioResp.error,
+          'No se pudieron guardar los precios.'
+        ),
+        type: 'error',
+      });
+      setSaving(false);
+      return;
+    }
+    for (const u of updates) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: e } = await (sb.schema('erp') as any)
+        .from('cotizacion_proveedores')
+        .update({
+          estado: u.estado,
+          monto_total: u.monto_total,
+          tiempo_entrega: u.tiempo_entrega,
+          condiciones: u.condiciones,
+          notas: u.notas,
+        })
+        .eq('id', u.id);
+      if (e) {
+        toast.add({
+          title: 'Error',
+          description: getSupabaseErrorMessage(e, 'No se pudo actualizar un proveedor.'),
+          type: 'error',
+        });
+        setSaving(false);
+        return;
+      }
+    }
+    toast.add({ title: 'Precios guardados', description: cotizacion.codigo, type: 'success' });
+    setSaving(false);
+    onSaved();
+  }
+
+  return (
+    <div className="rounded-md border border-[var(--accent)]/40 bg-[var(--card)] p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          Capturar precios · {cotizacion.codigo}
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Cerrar captura"
+          className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/40 hover:bg-[var(--bg)]"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-[var(--border)] text-left text-xs uppercase text-[var(--text)]/50">
+              <th className="py-2 pr-3 font-medium">Partida</th>
+              <th className="px-2 py-2 text-right font-medium">Cant.</th>
+              {cotizacion.proveedores.map((p) => (
+                <th key={p.id} className="px-2 py-2 text-right font-medium">
+                  {p.proveedorNombre}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {cotizacion.lineas.map((l) => (
+              <tr key={l.id} className="border-b border-[var(--border)]/50">
+                <td className="py-2 pr-3">
+                  <span className="text-[var(--text)]">{l.partidaLabel}</span>
+                  {l.descripcion ? (
+                    <span className="block text-xs text-[var(--text)]/50">{l.descripcion}</span>
+                  ) : null}
+                </td>
+                <td className="px-2 py-2 text-right tabular-nums text-[var(--text)]/70">
+                  {l.cantidad} {l.unidad ?? ''}
+                </td>
+                {cotizacion.proveedores.map((p) => {
+                  const mejor = mejorProveedorLinea(cotizacion.precios, l.id);
+                  const esMejor = mejor === p.id;
+                  return (
+                    <td key={p.id} className="px-2 py-1.5 text-right">
+                      <Input
+                        value={precios[`${p.id}|${l.id}`] ?? ''}
+                        onChange={(e) => setCelda(p.id, l.id, e.target.value)}
+                        type="number"
+                        step="0.01"
+                        placeholder="—"
+                        className={`w-28 text-right ${esMejor ? 'border-[var(--accent)]' : ''}`}
+                      />
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+            <tr className="font-medium">
+              <td
+                className="py-2 pr-3 text-right text-xs uppercase text-[var(--text)]/50"
+                colSpan={2}
+              >
+                Total
+              </td>
+              {cotizacion.proveedores.map((p) => (
+                <td key={p.id} className="px-2 py-2 text-right tabular-nums">
+                  {formatCurrency(totalLocal(p.id))}
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      {/* Datos de respuesta por proveedor */}
+      <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {cotizacion.proveedores.map((p) => (
+          <div key={p.id} className="rounded border border-[var(--border)] p-2">
+            <p className="mb-1.5 text-xs font-medium text-[var(--text)]">{p.proveedorNombre}</p>
+            <div className="flex flex-wrap gap-1.5">
+              <Input
+                value={respuesta[p.id]?.tiempoEntrega ?? ''}
+                onChange={(e) =>
+                  setRespuesta((prev) => ({
+                    ...prev,
+                    [p.id]: { ...prev[p.id], tiempoEntrega: e.target.value },
+                  }))
+                }
+                placeholder="Entrega"
+                className="w-28"
+              />
+              <Input
+                value={respuesta[p.id]?.condiciones ?? ''}
+                onChange={(e) =>
+                  setRespuesta((prev) => ({
+                    ...prev,
+                    [p.id]: { ...prev[p.id], condiciones: e.target.value },
+                  }))
+                }
+                placeholder="Condiciones"
+                className="w-32"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        <Button variant="outline" onClick={onClose} disabled={saving}>
+          Cerrar
+        </Button>
+        <Button onClick={guardar} disabled={saving}>
+          {saving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+          Guardar precios
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -21,6 +21,7 @@ import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/compon
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
+import { Combobox } from '@/components/ui/combobox';
 import { usePermissions } from '@/components/providers';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
@@ -730,37 +731,59 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
             <Plus className="h-3.5 w-3.5" /> Agregar línea
           </button>
 
-          {/* Proveedores a invitar */}
+          {/* Proveedores a invitar — buscar y agregar (combobox con búsqueda) */}
           <div className="mt-4">
             <p className="mb-2 text-sm font-medium text-[var(--text)]/70">
               Invitar proveedores ({proveedoresSel.size})
             </p>
-            <div className="flex max-h-32 flex-wrap gap-2 overflow-y-auto">
-              {proveedores.map((p) => {
-                const sel = proveedoresSel.has(p.id);
-                return (
-                  <button
-                    key={p.id}
-                    type="button"
-                    onClick={() =>
-                      setProveedoresSel((prev) => {
-                        const next = new Set(prev);
-                        if (next.has(p.id)) next.delete(p.id);
-                        else next.add(p.id);
-                        return next;
-                      })
-                    }
-                    className={`rounded-full border px-3 py-1 text-xs ${
-                      sel
-                        ? 'border-[var(--accent)] bg-[var(--accent)]/10 text-[var(--accent)]'
-                        : 'border-[var(--border)] text-[var(--text)]/70 hover:bg-[var(--card)]'
-                    }`}
-                  >
-                    {p.label}
-                  </button>
-                );
-              })}
-            </div>
+            <Combobox
+              value={null}
+              onChange={(id) => {
+                if (!id) return;
+                setProveedoresSel((prev) => {
+                  const next = new Set(prev);
+                  next.add(id);
+                  return next;
+                });
+              }}
+              options={proveedores
+                .filter((p) => !proveedoresSel.has(p.id))
+                .map((p) => ({ value: p.id, label: p.label }))}
+              placeholder="Buscar y agregar proveedor…"
+              searchPlaceholder="Buscar proveedor…"
+              emptyText="Sin proveedores disponibles"
+              className="w-80"
+              aria-label="Agregar proveedor a la cotización"
+            />
+            {proveedoresSel.size > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {[...proveedoresSel].map((id) => {
+                  const label = proveedores.find((p) => p.id === id)?.label ?? '—';
+                  return (
+                    <span
+                      key={id}
+                      className="inline-flex items-center gap-1 rounded-full border border-[var(--accent)] bg-[var(--accent)]/10 px-2.5 py-1 text-xs text-[var(--accent)]"
+                    >
+                      {label}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setProveedoresSel((prev) => {
+                            const next = new Set(prev);
+                            next.delete(id);
+                            return next;
+                          })
+                        }
+                        aria-label={`Quitar ${label}`}
+                        className="text-[var(--accent)]/70 hover:text-[var(--accent)]"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
+            ) : null}
           </div>
 
           <div className="mt-4 flex items-center justify-end gap-2">

--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -22,6 +22,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
 import { Combobox } from '@/components/ui/combobox';
+import { FileAttachments } from '@/components/file-attachments';
 import { usePermissions } from '@/components/providers';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
@@ -42,6 +43,7 @@ import {
   type CotPrecio,
   type CotProveedor,
 } from '@/lib/compras/cotizaciones';
+import type { EmpresaSlug } from '@/lib/storage';
 
 const ESTADO_TONE: Record<CotizacionEstado, BadgeTone> = {
   abierta: 'info',
@@ -511,11 +513,14 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
     },
     {
       key: 'provCount',
-      label: 'Proveedores',
+      label: 'Respuestas',
       type: 'custom',
       align: 'right',
-      accessor: (r) => r.proveedores.length,
-      render: (r) => String(r.proveedores.length),
+      accessor: (r) => r.proveedores.filter((p) => p.estado !== 'invitado').length,
+      render: (r) => {
+        const resp = r.proveedores.filter((p) => p.estado !== 'invitado').length;
+        return `${resp}/${r.proveedores.length}`;
+      },
     },
     { key: 'fechaLimite', label: 'Límite', type: 'text', render: (r) => r.fechaLimite || '—' },
     ...(puedeEscribir
@@ -526,26 +531,20 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
             type: 'custom' as const,
             sortable: false,
             align: 'right' as const,
-            width: 'w-40',
+            width: 'w-12',
             render: (r: CotizacionRow) =>
               r.estado === 'abierta' || r.estado === 'comparada' ? (
-                <div className="flex items-center justify-end gap-1">
-                  <button
-                    type="button"
-                    onClick={() => setCapturaId(r.id)}
-                    className="rounded border border-[var(--border)] px-2 py-1 text-xs text-[var(--text)]/80 hover:bg-[var(--card)]"
-                  >
-                    Capturar precios
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void cancelar(r)}
-                    aria-label={`Cancelar ${r.codigo}`}
-                    className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/40 hover:bg-red-50 hover:text-red-600"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                </div>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void cancelar(r);
+                  }}
+                  aria-label={`Cancelar ${r.codigo}`}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/40 hover:bg-red-50 hover:text-red-600"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
               ) : null,
           },
         ]
@@ -561,8 +560,10 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">Cotizaciones</h1>
           <p className="text-sm text-[var(--text)]/60">
-            RFQ formal multi-proveedor: pide precio a N por las líneas (ancladas a partida), captura
-            la matriz y adjudica a OC o contrato (comparativa y adjudicación en la siguiente fase).
+            Solicita precio a varios proveedores y compara. Crea la RFQ con sus líneas, invita
+            proveedores, y <strong className="font-medium">haz clic en una cotización</strong> para
+            capturar lo que te cotizaron: precios por línea, archivo y condiciones. La adjudicación
+            (→ OC o contrato) llega en la siguiente fase.
           </p>
         </div>
       </header>
@@ -807,6 +808,8 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
           key={enCaptura.id}
           cotizacion={enCaptura}
           empresaId={empresaId}
+          empresaSlug="dilesa"
+          puedeEscribir={puedeEscribir}
           onClose={() => setCapturaId(null)}
           onSaved={() => {
             setCapturaId(null);
@@ -822,6 +825,7 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
         loading={loading}
         error={error}
         onRetry={() => void cargar()}
+        onRowClick={(r) => setCapturaId(r.id === capturaId ? null : r.id)}
         initialSort={{ key: 'fechaLimite', dir: 'desc' }}
         emptyTitle="Sin cotizaciones"
         emptyDescription="No hay RFQ que coincidan. Crea una con “Nueva cotización”."
@@ -840,11 +844,15 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
 function CapturaPrecios({
   cotizacion,
   empresaId,
+  empresaSlug,
+  puedeEscribir,
   onClose,
   onSaved,
 }: {
   cotizacion: CotizacionRow;
   empresaId: string;
+  empresaSlug: EmpresaSlug;
+  puedeEscribir: boolean;
   onClose: () => void;
   onSaved: () => void;
 }) {
@@ -968,9 +976,15 @@ function CapturaPrecios({
   return (
     <div className="rounded-md border border-[var(--accent)]/40 bg-[var(--card)] p-4">
       <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
-          Capturar precios · {cotizacion.codigo}
-        </h2>
+        <div>
+          <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+            Capturar y comparar · {cotizacion.codigo}
+          </h2>
+          <p className="mt-0.5 text-xs text-[var(--text)]/50">
+            Captura el precio de cada proveedor por línea (el mejor por renglón se resalta); sube su
+            archivo de cotización y condiciones abajo.
+          </p>
+        </div>
         <button
           type="button"
           onClick={onClose}
@@ -1041,44 +1055,58 @@ function CapturaPrecios({
         </table>
       </div>
 
-      {/* Datos de respuesta por proveedor */}
-      <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-        {cotizacion.proveedores.map((p) => (
-          <div key={p.id} className="rounded border border-[var(--border)] p-2">
-            <p className="mb-1.5 text-xs font-medium text-[var(--text)]">{p.proveedorNombre}</p>
-            <div className="flex flex-wrap gap-1.5">
-              <Input
-                value={respuesta[p.id]?.tiempoEntrega ?? ''}
-                onChange={(e) =>
-                  setRespuesta((prev) => ({
-                    ...prev,
-                    [p.id]: { ...prev[p.id], tiempoEntrega: e.target.value },
-                  }))
-                }
-                placeholder="Entrega"
-                className="w-28"
-              />
-              <Input
-                value={respuesta[p.id]?.condiciones ?? ''}
-                onChange={(e) =>
-                  setRespuesta((prev) => ({
-                    ...prev,
-                    [p.id]: { ...prev[p.id], condiciones: e.target.value },
-                  }))
-                }
-                placeholder="Condiciones"
-                className="w-32"
+      {/* Cotización recibida por proveedor: archivo (PDF/Excel) + condiciones */}
+      <div className="mt-5">
+        <p className="mb-2 text-sm font-medium text-[var(--text)]/70">
+          Cotización recibida por proveedor (archivo + condiciones)
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {cotizacion.proveedores.map((p) => (
+            <div key={p.id} className="rounded-md border border-[var(--border)] p-3">
+              <p className="mb-2 text-xs font-medium text-[var(--text)]">{p.proveedorNombre}</p>
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                <Input
+                  value={respuesta[p.id]?.tiempoEntrega ?? ''}
+                  onChange={(e) =>
+                    setRespuesta((prev) => ({
+                      ...prev,
+                      [p.id]: { ...prev[p.id], tiempoEntrega: e.target.value },
+                    }))
+                  }
+                  placeholder="Tiempo de entrega"
+                  className="w-32"
+                />
+                <Input
+                  value={respuesta[p.id]?.condiciones ?? ''}
+                  onChange={(e) =>
+                    setRespuesta((prev) => ({
+                      ...prev,
+                      [p.id]: { ...prev[p.id], condiciones: e.target.value },
+                    }))
+                  }
+                  placeholder="Condiciones de pago"
+                  className="w-36"
+                />
+              </div>
+              <FileAttachments
+                empresaId={empresaId}
+                empresaSlug={empresaSlug}
+                entidad="cotizaciones"
+                entidadId={p.id}
+                roles={[{ id: 'cotizacion', label: 'Archivo de cotización' }]}
+                variant="flat"
+                readOnly={!puedeEscribir}
               />
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
 
       <div className="mt-4 flex items-center justify-end gap-2">
         <Button variant="outline" onClick={onClose} disabled={saving}>
           Cerrar
         </Button>
-        <Button onClick={guardar} disabled={saving}>
+        <Button onClick={guardar} disabled={saving || !puedeEscribir}>
           {saving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
           Guardar precios
         </Button>

--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -810,11 +810,13 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
           empresaId={empresaId}
           empresaSlug="dilesa"
           puedeEscribir={puedeEscribir}
+          proveedoresDisponibles={proveedores}
           onClose={() => setCapturaId(null)}
           onSaved={() => {
             setCapturaId(null);
             void cargar();
           }}
+          onRefresh={() => void cargar()}
         />
       ) : null}
 
@@ -846,15 +848,19 @@ function CapturaPrecios({
   empresaId,
   empresaSlug,
   puedeEscribir,
+  proveedoresDisponibles,
   onClose,
   onSaved,
+  onRefresh,
 }: {
   cotizacion: CotizacionRow;
   empresaId: string;
   empresaSlug: EmpresaSlug;
   puedeEscribir: boolean;
+  proveedoresDisponibles: ProveedorOption[];
   onClose: () => void;
   onSaved: () => void;
+  onRefresh: () => void;
 }) {
   const toast = useToast();
   const [saving, setSaving] = useState(false);
@@ -973,6 +979,28 @@ function CapturaPrecios({
     onSaved();
   }
 
+  // Invitar otro proveedor a una RFQ ya creada (agrega una columna a la matriz).
+  async function invitarProveedor(proveedorId: string) {
+    const sb = createSupabaseBrowserClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: e } = await (sb.schema('erp') as any).from('cotizacion_proveedores').insert({
+      empresa_id: empresaId,
+      cotizacion_id: cotizacion.id,
+      proveedor_id: proveedorId,
+      estado: 'invitado',
+    });
+    if (e) {
+      toast.add({
+        title: 'Error',
+        description: getSupabaseErrorMessage(e, 'No se pudo invitar al proveedor.'),
+        type: 'error',
+      });
+      return;
+    }
+    toast.add({ title: 'Proveedor agregado', type: 'success' });
+    onRefresh();
+  }
+
   return (
     <div className="rounded-md border border-[var(--accent)]/40 bg-[var(--card)] p-4">
       <div className="mb-3 flex items-center justify-between">
@@ -994,6 +1022,25 @@ function CapturaPrecios({
           <X className="h-4 w-4" />
         </button>
       </div>
+
+      {puedeEscribir ? (
+        <div className="mb-3">
+          <Combobox
+            value={null}
+            onChange={(id) => {
+              if (id) void invitarProveedor(id);
+            }}
+            options={proveedoresDisponibles
+              .filter((p) => !cotizacion.proveedores.some((cp) => cp.proveedorId === p.id))
+              .map((p) => ({ value: p.id, label: p.label }))}
+            placeholder="Agregar otro proveedor a esta cotización…"
+            searchPlaceholder="Buscar proveedor…"
+            emptyText="Sin proveedores disponibles"
+            className="w-80"
+            aria-label="Agregar proveedor a la cotización"
+          />
+        </div>
+      ) : null}
 
       <div className="overflow-x-auto">
         <table className="w-full border-collapse text-sm">

--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -15,7 +15,18 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ClipboardList, Loader2, Plus, RefreshCw, Save, Search, Trash2, X } from 'lucide-react';
+import {
+  ClipboardList,
+  FileDown,
+  Loader2,
+  Mail,
+  Plus,
+  RefreshCw,
+  Save,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
 import { Input } from '@/components/ui/input';
@@ -887,8 +898,43 @@ function CapturaPrecios({
     return seed;
   });
 
+  // Confirmación de envío por email (acción externa) + estado de envío.
+  const [confirmEnvioId, setConfirmEnvioId] = useState<string | null>(null);
+  const [enviandoId, setEnviandoId] = useState<string | null>(null);
+
   const setCelda = (cotProvId: string, lineaId: string, val: string) =>
     setPrecios((prev) => ({ ...prev, [`${cotProvId}|${lineaId}`]: val }));
+
+  // Enviar la Solicitud de Cotización en PDF al email del proveedor (vía endpoint Resend).
+  async function enviarSolicitud(cotProveedorId: string) {
+    setConfirmEnvioId(null);
+    setEnviandoId(cotProveedorId);
+    try {
+      const res = await fetch(`/api/dilesa/cotizaciones/${cotizacion.id}/solicitud`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cotProveedorId }),
+      });
+      const json = (await res.json()) as { sentTo?: string; error?: string };
+      if (!res.ok) {
+        toast.add({
+          title: 'No se envió',
+          description: json.error ?? 'Error al enviar la solicitud.',
+          type: 'error',
+        });
+      } else {
+        toast.add({
+          title: 'Solicitud enviada',
+          description: json.sentTo ? `A ${json.sentTo}` : undefined,
+          type: 'success',
+        });
+      }
+    } catch {
+      toast.add({ title: 'Error', description: 'No se pudo enviar.', type: 'error' });
+    } finally {
+      setEnviandoId(null);
+    }
+  }
 
   // Total por proveedor con la matriz local (en edición).
   const totalLocal = (cotProvId: string): number =>
@@ -1144,6 +1190,52 @@ function CapturaPrecios({
                 variant="flat"
                 readOnly={!puedeEscribir}
               />
+              {/* Enviar la solicitud (PDF) al proveedor: descargar o por email */}
+              <div className="mt-2 flex items-center gap-1.5">
+                <a
+                  href={`/api/dilesa/cotizaciones/${cotizacion.id}/solicitud?proveedor=${p.id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 rounded border border-[var(--border)] px-2 py-1 text-xs text-[var(--text)]/80 hover:bg-[var(--bg)]"
+                >
+                  <FileDown className="h-3 w-3" /> PDF
+                </a>
+                {puedeEscribir ? (
+                  confirmEnvioId === p.id ? (
+                    <span className="inline-flex items-center gap-1 text-xs text-[var(--text)]/70">
+                      ¿Enviar por email?
+                      <button
+                        type="button"
+                        onClick={() => void enviarSolicitud(p.id)}
+                        className="rounded bg-[var(--accent)] px-1.5 py-0.5 text-white"
+                      >
+                        Sí
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConfirmEnvioId(null)}
+                        className="rounded border border-[var(--border)] px-1.5 py-0.5"
+                      >
+                        No
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setConfirmEnvioId(p.id)}
+                      disabled={enviandoId === p.id}
+                      className="inline-flex items-center gap-1 rounded border border-[var(--border)] px-2 py-1 text-xs text-[var(--text)]/80 hover:bg-[var(--bg)] disabled:opacity-50"
+                    >
+                      {enviandoId === p.id ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Mail className="h-3 w-3" />
+                      )}
+                      Enviar
+                    </button>
+                  )
+                ) : null}
+              </div>
             </div>
           ))}
         </div>

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -542,3 +542,18 @@ Próximo: Fase 2 = UI de captura (`components/compras/cotizaciones-module.tsx` +
   format, schema). **Sin migración → preview-first sin auto-merge** (Beto revisa el preview
   visual). Próximo: Fase 3 = comparativa lado a lado + adjudicación → OC (`cotizacion_id` +
   herencia de precios) o contrato de obra (`partida_id` + `cotizacion_id`).
+- **2026-06-06** — **Ajustes UX de Fase 2 (feedback de Beto en el preview, mismo PR #706).**
+  Dos cambios pedidos: (1) **selector de proveedores con búsqueda** — reemplazado el grid de
+  chips toggle (no escala con 200+ proveedores) por el `Combobox` searchable del repo (buscar
+  y agregar uno a uno; invitados como chips removibles; el dropdown excluye a los ya
+  agregados). (2) **flujo de captura claro + recepción de archivos** — Beto no encontraba
+  dónde se "recibe/captura" la cotización. La captura dejó de estar escondida en un botón:
+  ahora **clic en la fila** de la RFQ expande el panel "Capturar y comparar" (patrón
+  `onRowClick` + panel inline en la página, como `tareas-checklist`); la columna muestra
+  **Respuestas X/N**; y cada proveedor tiene su **`<FileAttachments>`** (ADR-022, bucket
+  `adjuntos` + `erp.adjuntos`) para subir el PDF/Excel de su cotización — se agregó
+  `'cotizaciones'` a `AdjuntoEntidad` (`lib/storage/path.ts`), `entidadId` = la fila del
+  proveedor invitado. El campo `cotizacion_proveedores.adjunto_url` de la Fase 1 queda sin uso
+  (los adjuntos viven en `erp.adjuntos` por política; el campo se retira en un cleanup futuro).
+  Gate de escritura: el guardado de precios y el upload respetan `puedeEscribir`. 5 checks
+  verdes (1305 tests).

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -524,3 +524,21 @@ contratos activos por partida_id` (join filtrado por `empresa_id`, activo =
     waitry** `20260605180000*…`→`20260605184000\_…`para resolver la colisión en`main`.
 Próximo: Fase 2 = UI de captura (`components/compras/cotizaciones-module.tsx` + page +
     TAB + ROUTE_TO_MODULE).
+- **2026-06-05** — **Sprint Cotizaciones · Fase 2 (UI de captura).** Tab "Cotizaciones"
+  del hub `/dilesa/compras` (4° tab, entre Requisiciones y Recepciones). Liberación del
+  sub-slug (4 lugares completados: ROUTE_TO_MODULE + page + TAB; el slug en `core.modulos`
+  y EXPECTED_DB_MODULE_SLUGS entraron en Fase 1). `components/compras/cotizaciones-module.tsx`
+  (molde de `ordenes-compra-module.tsx`): lista + KPIs (`deriveCotizacionKpis`), **alta de
+  RFQ** (proyecto solo-con-presupuesto · tipo compra|obra · descripción · fecha límite ·
+  líneas ancladas a partida con selector agrupado etapa›capítulo vía `buildPartidaIndex` ·
+  invitar N proveedores de `erp.proveedores` por chips) → insert `cotizaciones` +
+  `cotizacion_lineas` + `cotizacion_proveedores` (estado `invitado`); y **captura de la
+  matriz** (sub-componente `CapturaPrecios`): tabla líneas×proveedores con un input de
+  precio por celda (resalta el mejor precio por renglón vía `mejorProveedorLinea`), total
+  por proveedor en vivo, + datos de respuesta (entrega/condiciones) → upsert
+  `cotizacion_proveedor_precios` (onConflict proveedor+línea) + update
+  `cotizacion_proveedores` (pasa a `respondida`, `monto_total` derivado de la matriz).
+  Client-side directo, un proyecto a la vez. 5 checks verdes (typecheck, 1305 tests, lint,
+  format, schema). **Sin migración → preview-first sin auto-merge** (Beto revisa el preview
+  visual). Próximo: Fase 3 = comparativa lado a lado + adjudicación → OC (`cotizacion_id` +
+  herencia de precios) o contrato de obra (`partida_id` + `cotizacion_id`).

--- a/docs/planning/dilesa-compras.md
+++ b/docs/planning/dilesa-compras.md
@@ -557,3 +557,19 @@ Próximo: Fase 2 = UI de captura (`components/compras/cotizaciones-module.tsx` +
   (los adjuntos viven en `erp.adjuntos` por política; el campo se retira en un cleanup futuro).
   Gate de escritura: el guardado de precios y el upload respetan `puedeEscribir`. 5 checks
   verdes (1305 tests).
+- **2026-06-06** — **Fase 2: envío de la solicitud al proveedor (feedback de Beto, mismo
+  PR #706).** Tres pedidos más: (1) **agregar proveedores a una RFQ ya creada** — combobox
+  en el panel de captura que invita otro proveedor (insert + refresh sin cerrar). (2) **PDF
+  de Solicitud de Cotización** — componente `lib/dilesa/pdf/solicitud-cotizacion.tsx`
+  (reusa branding DILESA `HeaderBand`/`FooterBand`/`styles`); lleva **solo el listado** de
+  conceptos a cotizar (concepto/partida, descripción, cantidad, unidad — sin precios, el
+  proveedor responde en su formato) + folio/proyecto/fecha límite/destinatario + nota. (3)
+  **Envío por email** — endpoint `app/api/dilesa/cotizaciones/[id]/solicitud/route.tsx`:
+  GET `?proveedor=` descarga el PDF; POST `{cotProveedorId}` lo manda al `erp.personas.email`
+  del proveedor vía Resend (mismo patrón que estimaciones: `renderToBuffer` + adjunto base64
+  - `from` DILESA + `writeNotificationLog` con slug `dilesa_cotizacion`, fail-open sin
+    definición). UI: botones **PDF** y **Enviar** por proveedor en su tarjeta; el envío
+    (acción externa) pide **confirmación inline** y respeta `puedeEscribir`. Pendiente fino:
+    el `from`/`reply_to` usa defaults (`noreply@bsop.io` / `compras@dilesa.mx`) — afinar
+    cuando Beto defina el buzón; idealmente crear la definición `dilesa_cotizacion` en el
+    catálogo de notificaciones. 5 checks verdes (1305 tests). Sigue preview-first.

--- a/lib/dilesa/pdf/solicitud-cotizacion.tsx
+++ b/lib/dilesa/pdf/solicitud-cotizacion.tsx
@@ -1,0 +1,104 @@
+/**
+ * Template PDF: Solicitud de Cotización (RFQ) — iniciativa dilesa-compras.
+ *
+ * Documento que DILESA envía a un proveedor para pedirle que cotice un conjunto
+ * de conceptos. Lleva SÓLO el listado de lo solicitado (concepto, descripción,
+ * cantidad, unidad) — el proveedor responde con su propio formato/precios.
+ *
+ * Layout: 1 página (crece a varias si hay muchas líneas; el header/footer band
+ * van fixed). Reusa el branding DILESA (HeaderBand/FooterBand/styles).
+ */
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand, Folio } from './header-footer';
+
+export type SolicitudCotizacionData = {
+  folio: string;
+  fechaTexto: string;
+  proyecto: string;
+  tipoLabel: string;
+  fechaLimiteTexto: string;
+  proveedorNombre: string;
+  descripcion: string | null;
+  lineas: Array<{ concepto: string; descripcion: string; cantidad: string; unidad: string }>;
+};
+
+const t = StyleSheet.create({
+  headerRow: {
+    flexDirection: 'row',
+    backgroundColor: colors.bgSoft,
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.border,
+    paddingVertical: 4,
+    marginTop: 3,
+  },
+  dataRow: {
+    flexDirection: 'row',
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.borderSoft,
+    paddingVertical: 3,
+  },
+  cell: { fontSize: 8, paddingHorizontal: 4 },
+  cellHead: { fontSize: 8, fontFamily: 'Helvetica-Bold', paddingHorizontal: 4 },
+  colNum: { width: 22, textAlign: 'right' },
+  colConcepto: { flex: 2 },
+  colDesc: { flex: 3 },
+  colCant: { width: 54, textAlign: 'right' },
+  colUnidad: { width: 54 },
+});
+
+export function SolicitudCotizacionPDF({ data }: { data: SolicitudCotizacionData }) {
+  return (
+    <Document title={`Solicitud de Cotización — ${data.folio}`}>
+      <Page size="LETTER" style={styles.page}>
+        <HeaderBand title="SOLICITUD DE COTIZACIÓN" fecha={data.fechaTexto} />
+
+        <Text style={styles.sectionTitle}>DATOS DE LA SOLICITUD</Text>
+        <DataRow label="FOLIO:" value={data.folio} />
+        <DataRow label="PROYECTO:" value={data.proyecto} />
+        <DataRow label="TIPO:" value={data.tipoLabel} />
+        <DataRow label="FECHA LÍMITE DE RESPUESTA:" value={data.fechaLimiteTexto} />
+        {data.descripcion ? <DataRow label="DESCRIPCIÓN:" value={data.descripcion} /> : null}
+
+        <Text style={styles.sectionTitle}>DIRIGIDO A</Text>
+        <DataRow label="PROVEEDOR:" value={data.proveedorNombre} />
+
+        <Text style={styles.sectionTitle}>CONCEPTOS A COTIZAR</Text>
+        <View style={t.headerRow}>
+          <Text style={[t.cellHead, t.colNum]}>#</Text>
+          <Text style={[t.cellHead, t.colConcepto]}>Concepto</Text>
+          <Text style={[t.cellHead, t.colDesc]}>Descripción</Text>
+          <Text style={[t.cellHead, t.colCant]}>Cantidad</Text>
+          <Text style={[t.cellHead, t.colUnidad]}>Unidad</Text>
+        </View>
+        {data.lineas.map((l, i) => (
+          <View key={i} style={t.dataRow} wrap={false}>
+            <Text style={[t.cell, t.colNum]}>{i + 1}</Text>
+            <Text style={[t.cell, t.colConcepto]}>{l.concepto}</Text>
+            <Text style={[t.cell, t.colDesc]}>{l.descripcion || '—'}</Text>
+            <Text style={[t.cell, t.colCant]}>{l.cantidad}</Text>
+            <Text style={[t.cell, t.colUnidad]}>{l.unidad || '—'}</Text>
+          </View>
+        ))}
+
+        <Text style={styles.legalText}>
+          Favor de cotizar los conceptos listados, indicando precio unitario, tiempo de entrega y
+          condiciones de pago, y enviar su propuesta antes del {data.fechaLimiteTexto}. Esta
+          solicitud no constituye una orden de compra ni compromiso de adquisición.
+        </Text>
+
+        <Folio value={data.folio} />
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+function DataRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.label}>{label} </Text>
+      <Text style={styles.labelStrong}>{value}</Text>
+    </View>
+  );
+}

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -87,13 +87,14 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   // la página /registrar-tarea fue removida en favor del click directo).
   '/dilesa/construccion/contratos/nuevo': 'dilesa.construccion.contratos',
   '/dilesa/construccion/contratos/nuevo-obra': 'dilesa.construccion.contratos',
-  // Compras es un hub con 3 tabs (Sprint 2 `dilesa-compras`). El padre
+  // Compras es un hub con 4 tabs (`dilesa-compras`). El padre
   // `dilesa.compras` es umbrella del sidebar; cada tab tiene su sub-slug
   // (ADR-030). La URL default mapea al sub-slug del primer tab (Órdenes).
   // Modelo constructora-first: la línea ancla concepto+partida y la recepción
   // devenga contra la partida. Ver docs/planning/dilesa-compras.md.
   '/dilesa/compras': 'dilesa.compras.ordenes',
   '/dilesa/compras/requisiciones': 'dilesa.compras.requisiciones',
+  '/dilesa/compras/cotizaciones': 'dilesa.compras.cotizaciones',
   '/dilesa/compras/recepciones': 'dilesa.compras.recepciones',
 
   // RDB — home + operaciones

--- a/lib/storage/path.ts
+++ b/lib/storage/path.ts
@@ -40,7 +40,8 @@ export type AdjuntoEntidad =
   | 'facturas'
   | 'proyecto_tareas'
   | 'proyecto_tarea_pasos'
-  | 'proyecto_planos';
+  | 'proyecto_planos'
+  | 'cotizaciones';
 
 export type BuildAdjuntoPathOpts = {
   empresa: EmpresaSlug;


### PR DESCRIPTION
**Sprint Cotizaciones (RFQ) · Fase 2 — UI de captura.** Enciende el tab **Cotizaciones** en `/dilesa/compras` (4° tab, entre Requisiciones y Recepciones).

## Qué entra
- **Plumbing RBAC** (libera la URL del sub-slug `dilesa.compras.cotizaciones`): `ROUTE_TO_MODULE` + page (`<RequireAccess>`) + TAB del layout. (El slug en `core.modulos` + `EXPECTED_DB_MODULE_SLUGS` ya entraron en Fase 1.)
- **`components/compras/cotizaciones-module.tsx`** (molde de `ordenes-compra-module`):
  - Lista + KPIs (RFQ / abiertas / adjudicadas / monto adjudicado).
  - **Alta de RFQ**: proyecto (solo-con-presupuesto) · tipo **compra** (→ OC) o **obra** (→ contrato) · descripción · fecha límite · líneas ancladas a partida (selector agrupado etapa›capítulo) · invitar N proveedores por chips.
  - **Captura de la matriz** (`CapturaPrecios`): tabla líneas × proveedores con un input de precio por celda (resalta el mejor precio por renglón), total por proveedor en vivo, y datos de respuesta (entrega/condiciones). Guarda upsert de precios + marca al proveedor `respondida` con su `monto_total` derivado.

Client-side directo, un proyecto a la vez. **Sin migración.**

## Qué falta (Fase 3)
Comparativa lado a lado + **adjudicación** → OC (con `cotizacion_id` + herencia de precios) o contrato de obra (con `partida_id` + `cotizacion_id`).

## Revisión
**Preview-first** (no auto-merge): revisa el Vercel Preview — crear una RFQ, invitar proveedores, capturar precios. Como no hay migración, el preview corre contra **datos de prod**: las RFQ de prueba escriben a prod, conviene borrarlas tras revisar (o las cancelo yo). Dame el OK y lo mergeo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)