### PR TITLE
feat(dilesa-contratos-obra): UI de partida en contratos de obra (Fase 2)

### DIFF
--- a/app/dilesa/construccion/contratos/[id]/page.tsx
+++ b/app/dilesa/construccion/contratos/[id]/page.tsx
@@ -26,11 +26,16 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Download, ExternalLink, FileText, HardHat } from 'lucide-react';
+import { ArrowLeft, Download, ExternalLink, FileText, HardHat, Loader2, Save } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/toast';
+import { usePermissions } from '@/components/providers';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { buildPartidaIndex, type PartidaGrupo } from '@/lib/compras/partidas';
 import { ObraContratoDetalle } from '@/components/dilesa/obra-contrato-detalle';
 
 type Contrato = {
@@ -380,6 +385,14 @@ function DetailInner() {
       </Section>
 
       {contrato.tipo !== 'vivienda' ? (
+        <LigarPartida
+          contratoId={contrato.id}
+          proyectoId={contrato.proyecto_id}
+          partidaIdInicial={(contrato as { partida_id?: string | null }).partida_id ?? null}
+        />
+      ) : null}
+
+      {contrato.tipo !== 'vivienda' ? (
         <ObraContratoDetalle
           contratoId={contrato.id}
           valorTotal={contrato.valor_total}
@@ -556,5 +569,121 @@ function Kpi({ label, value, accent = false }: { label: string; value: string; a
       </div>
       <div className="mt-0.5 text-lg font-semibold tabular-nums text-[var(--text)]">{value}</div>
     </div>
+  );
+}
+
+/**
+ * Liga (o desliga) el contrato a una partida del presupuesto (ADR-042). Permite
+ * el backfill de los contratos existentes: al ligarlos, su `valor_total` cuenta
+ * como comprometido en esa partida vía `erp.v_partida_control`.
+ */
+function LigarPartida({
+  contratoId,
+  proyectoId,
+  partidaIdInicial,
+}: {
+  contratoId: string;
+  proyectoId: string | null;
+  partidaIdInicial: string | null;
+}) {
+  const { permissions } = usePermissions();
+  const toast = useToast();
+  const puedeEscribir =
+    permissions.isAdmin || permissions.modulos.get('dilesa.construccion.contratos')?.write === true;
+  const [grupos, setGrupos] = useState<PartidaGrupo[]>([]);
+  const [partidaId, setPartidaId] = useState(partidaIdInicial ?? '');
+  const [guardando, setGuardando] = useState(false);
+
+  useEffect(() => {
+    if (!proyectoId) return;
+    let activo = true;
+    const sb = createSupabaseBrowserClient();
+    void (async () => {
+      const [partidasRes, catRes] = await Promise.all([
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (sb.schema('erp') as any)
+          .from('presupuesto_partidas')
+          .select('id, proyecto_id, concepto_id, concepto_texto')
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .is('deleted_at', null),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (sb.schema('erp') as any)
+          .from('conceptos_compra')
+          .select('id, padre_id, nivel, codigo, nombre')
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .is('deleted_at', null),
+      ]);
+      if (!activo) return;
+      const { gruposByProyecto } = buildPartidaIndex(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (partidasRes.data ?? []) as any[],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (catRes.data ?? []) as any[]
+      );
+      setGrupos(gruposByProyecto.get(proyectoId) ?? []);
+    })();
+    return () => {
+      activo = false;
+    };
+  }, [proyectoId]);
+
+  async function guardar() {
+    if (guardando) return;
+    setGuardando(true);
+    const sb = createSupabaseBrowserClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (sb.schema('dilesa') as any)
+      .from('contratos_construccion')
+      .update({ partida_id: partidaId || null, updated_at: new Date().toISOString() })
+      .eq('id', contratoId);
+    if (error) {
+      toast.add({
+        title: 'Error',
+        description: getSupabaseErrorMessage(error, 'No se pudo guardar la partida.'),
+        type: 'error',
+      });
+    } else {
+      toast.add({ title: partidaId ? 'Partida ligada' : 'Partida desligada', type: 'success' });
+    }
+    setGuardando(false);
+  }
+
+  if (!proyectoId) return null;
+
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <h2 className="mb-1 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+        Partida del presupuesto
+      </h2>
+      <p className="mb-3 text-xs text-muted-foreground">
+        Liga este contrato a una partida del costeo para que su monto cuente como comprometido en
+        esa partida (ADR-042).
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          className="h-9 min-w-[260px] flex-1 rounded-md border border-[var(--border)] bg-[var(--bg)] px-3 text-sm"
+          value={partidaId}
+          onChange={(e) => setPartidaId(e.target.value)}
+          disabled={!puedeEscribir}
+        >
+          <option value="">— sin ligar —</option>
+          {grupos.map((g) => (
+            <optgroup key={g.key} label={g.label}>
+              {g.partidas.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.label}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+        {puedeEscribir ? (
+          <Button onClick={guardar} disabled={guardando || partidaId === (partidaIdInicial ?? '')}>
+            {guardando ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Guardar
+          </Button>
+        ) : null}
+      </div>
+    </section>
   );
 }

--- a/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
+++ b/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
@@ -35,6 +35,7 @@ import {
   type ProyectoOption,
   type ProyectoSelectorRow,
 } from '@/lib/dilesa/proyectos-selector';
+import { buildPartidaIndex, type PartidaGrupo } from '@/lib/compras/partidas';
 
 type Contratista = { id: string; nombre: string; abreviacion: string | null };
 
@@ -69,15 +70,25 @@ function NuevoContratoObraBody() {
   const [contratistas, setContratistas] = useState<Contratista[]>([]);
   const [proyectos, setProyectos] = useState<ProyectoOption[]>([]);
   const [seqByContratista, setSeqByContratista] = useState<Map<string, number>>(new Map());
+  // Partidas del presupuesto por proyecto (etapa›capítulo) para ligar el contrato (ADR-042).
+  const [partidasByProyecto, setPartidasByProyecto] = useState<Map<string, PartidaGrupo[]>>(
+    new Map()
+  );
 
   // ── Form ───────────────────────────────────────────────────────────────
   const [contratistaId, setContratistaId] = useState('');
   const [proyectoId, setProyectoId] = useState('');
+  const [partidaId, setPartidaId] = useState('');
   const [tipo, setTipo] = useState<string>('urbanizacion');
   const [fechaContrato, setFechaContrato] = useState(new Date().toISOString().slice(0, 10));
   const [valorTotal, setValorTotal] = useState('');
   const [anticipoPct, setAnticipoPct] = useState('');
   const [retencionPct, setRetencionPct] = useState('');
+  const [fianzaPct, setFianzaPct] = useState('');
+  const [periodicidadDias, setPeriodicidadDias] = useState('');
+  const [objeto, setObjeto] = useState('');
+  const [fechaInicio, setFechaInicio] = useState('');
+  const [fechaFin, setFechaFin] = useState('');
   const [codigoOverride, setCodigoOverride] = useState('');
   const [notas, setNotas] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -87,38 +98,57 @@ function NuevoContratoObraBody() {
     setLoadingMeta(true);
     setLoadError(null);
 
-    const [contratistasRes, datosRes, proyectosRes, contratosCountRes] = await Promise.all([
-      sb
-        .schema('erp')
-        .from('personas')
-        .select('id, nombre, apellido_paterno, apellido_materno')
-        .eq('empresa_id', DILESA_EMPRESA_ID)
-        .eq('tipo', 'contratista')
-        .eq('activo', true),
-      sb
-        .schema('dilesa')
-        .from('contratistas_datos')
-        .select('persona_id, abreviacion')
-        .eq('empresa_id', DILESA_EMPRESA_ID)
-        .is('deleted_at', null),
-      sb
-        .schema('dilesa')
-        .from('proyectos')
-        .select('id, nombre, tipo, proyecto_predecesor_id')
-        .eq('empresa_id', DILESA_EMPRESA_ID)
-        .is('deleted_at', null),
-      // Conteo de contratos de obra (no-vivienda) por contratista → seq del código.
-      sb
-        .schema('dilesa')
-        .from('contratos_construccion')
-        .select('contratista_id, tipo')
-        .eq('empresa_id', DILESA_EMPRESA_ID)
-        .neq('tipo', 'vivienda')
-        .is('deleted_at', null),
-    ]);
+    const [contratistasRes, datosRes, proyectosRes, contratosCountRes, partidasRes, catalogoRes] =
+      await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('id, nombre, apellido_paterno, apellido_materno')
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .eq('tipo', 'contratista')
+          .eq('activo', true),
+        sb
+          .schema('dilesa')
+          .from('contratistas_datos')
+          .select('persona_id, abreviacion')
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .is('deleted_at', null),
+        sb
+          .schema('dilesa')
+          .from('proyectos')
+          .select('id, nombre, tipo, proyecto_predecesor_id')
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .is('deleted_at', null),
+        // Conteo de contratos de obra (no-vivienda) por contratista → seq del código.
+        sb
+          .schema('dilesa')
+          .from('contratos_construccion')
+          .select('contratista_id, tipo')
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .neq('tipo', 'vivienda')
+          .is('deleted_at', null),
+        // Partidas del presupuesto + catálogo → selector de partida (ADR-042).
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (sb.schema('erp') as any)
+          .from('presupuesto_partidas')
+          .select('id, proyecto_id, concepto_id, concepto_texto')
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .is('deleted_at', null),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (sb.schema('erp') as any)
+          .from('conceptos_compra')
+          .select('id, padre_id, nivel, codigo, nombre')
+          .eq('empresa_id', DILESA_EMPRESA_ID)
+          .is('deleted_at', null),
+      ]);
 
     const firstErr =
-      contratistasRes.error ?? datosRes.error ?? proyectosRes.error ?? contratosCountRes.error;
+      contratistasRes.error ??
+      datosRes.error ??
+      proyectosRes.error ??
+      contratosCountRes.error ??
+      partidasRes.error ??
+      catalogoRes.error;
     if (firstErr) {
       setLoadError(getSupabaseErrorMessage(firstErr, 'No se pudieron cargar los catálogos.'));
       setLoadingMeta(false);
@@ -143,6 +173,13 @@ function NuevoContratoObraBody() {
     setProyectos(
       buildProyectoOptions((proyectosRes.data ?? []) as unknown as ProyectoSelectorRow[])
     );
+    const { gruposByProyecto } = buildPartidaIndex(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (partidasRes.data ?? []) as any[],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (catalogoRes.data ?? []) as any[]
+    );
+    setPartidasByProyecto(gruposByProyecto);
 
     const seq = new Map<string, number>();
     for (const c of contratosCountRes.data ?? []) {
@@ -189,10 +226,16 @@ function NuevoContratoObraBody() {
           fecha_contrato: fechaContrato,
           contratista_id: contratistaId,
           proyecto_id: proyectoId,
+          partida_id: partidaId || null,
           tipo,
           valor_total: valorNum,
           anticipo_pct: anticipoPct.trim() ? Number(anticipoPct) : 0,
           retencion_pct: retencionPct.trim() ? Number(retencionPct) : 0,
+          fianza_pct: fianzaPct.trim() ? Number(fianzaPct) : null,
+          periodicidad_estimaciones_dias: periodicidadDias.trim() ? Number(periodicidadDias) : null,
+          objeto: objeto.trim() || null,
+          fecha_inicio: fechaInicio || null,
+          fecha_fin: fechaFin || null,
           notas: notas.trim() || null,
         })
         .select('id')
@@ -270,7 +313,10 @@ function NuevoContratoObraBody() {
             <select
               className={selectCls}
               value={proyectoId}
-              onChange={(e) => setProyectoId(e.target.value)}
+              onChange={(e) => {
+                setProyectoId(e.target.value);
+                setPartidaId('');
+              }}
             >
               <option value="">— selecciona —</option>
               {proyectos.map((p) => (
@@ -279,6 +325,30 @@ function NuevoContratoObraBody() {
                 </option>
               ))}
             </select>
+          </Field>
+          <Field label="Partida del presupuesto">
+            <select
+              className={selectCls}
+              value={partidaId}
+              onChange={(e) => setPartidaId(e.target.value)}
+              disabled={!proyectoId}
+            >
+              <option value="">
+                {proyectoId ? '— sin ligar —' : 'Selecciona proyecto primero'}
+              </option>
+              {(partidasByProyecto.get(proyectoId) ?? []).map((g) => (
+                <optgroup key={g.key} label={g.label}>
+                  {g.partidas.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.label}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+            <Hint>
+              Liga el contrato a una partida para que su monto cuente en el costeo (ADR-042).
+            </Hint>
           </Field>
           <Field label="Tipo de obra *">
             <select className={selectCls} value={tipo} onChange={(e) => setTipo(e.target.value)}>
@@ -353,6 +423,54 @@ function NuevoContratoObraBody() {
               onChange={(e) => setNotas(e.target.value)}
             />
           </Field>
+        </div>
+      </Section>
+
+      <Section title="Alcance, plazo y garantía">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div className="sm:col-span-2">
+            <Field label="Objeto del contrato">
+              <textarea
+                className="min-h-[60px] w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm"
+                value={objeto}
+                onChange={(e) => setObjeto(e.target.value)}
+                placeholder="Ej. Suministro y mano de obra de 225 m de muro de contención…"
+              />
+            </Field>
+          </div>
+          <Field label="Inicio de ejecución">
+            <Input
+              type="date"
+              value={fechaInicio}
+              onChange={(e) => setFechaInicio(e.target.value)}
+            />
+          </Field>
+          <Field label="Fin de ejecución">
+            <Input type="date" value={fechaFin} onChange={(e) => setFechaFin(e.target.value)} />
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Fianza %">
+              <Input
+                type="number"
+                step="0.01"
+                min="0"
+                max="100"
+                value={fianzaPct}
+                onChange={(e) => setFianzaPct(e.target.value)}
+                placeholder="0"
+              />
+            </Field>
+            <Field label="Estimaciones c/ N días">
+              <Input
+                type="number"
+                step="1"
+                min="0"
+                value={periodicidadDias}
+                onChange={(e) => setPeriodicidadDias(e.target.value)}
+                placeholder="14"
+              />
+            </Field>
+          </div>
         </div>
       </Section>
 

--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -500,3 +500,16 @@ contrato-obra.tsx`) es para **vivienda** (lotes/prototipos/Anexo 3), no para obr
   acumular el drift que rompe el Supabase Preview — lección de [[reference_bsop_merge_flow_multisesion]]).
   SCHEMA_REF + types regenerados (5 columnas, sin drift). Próximo: Fase 2 (UI alta/edición de
   contrato con selector de partida + estos campos).
+- **2026-06-06** — **Sprint Contratos→partidas+PDF · Fase 2 (UI alta + edición/ligado).** Dos
+  cosas: (1) **Alta** (`nuevo-obra/page.tsx`): selector de **partida del presupuesto** (agrupado
+  etapa›capítulo vía `buildPartidaIndex`, depende del proyecto; resetea al cambiar de proyecto)
+  - sección "Alcance, plazo y garantía" con los 5 campos nuevos (`objeto`, `fecha_inicio`,
+    `fecha_fin`, `fianza_pct`, `periodicidad_estimaciones_dias`); el insert los popula +
+    `partida_id`. (2) **Edición/ligado** (`[id]/page.tsx`, detalle del contrato): sub-componente
+    `<LigarPartida>` — selector de partida + Guardar (`UPDATE partida_id`) en una Section nueva,
+    para **ligar los 302 contratos existentes** (incl. Maya) a su partida → la herramienta del
+    backfill de Fase 3. Respeta `puedeEscribir` (write del sub-slug `dilesa.construccion.contratos`).
+    El detalle era solo-lectura; ahora permite el ligado puntual. Una vez ligado, el `valor_total`
+    del contrato cuenta como comprometido en esa partida vía `v_partida_control` (cableado en Fase
+    0). 5 checks verdes (1305 tests). **Sin migración → preview-first.** Próximo: Fase 3 (Costeo
+    muestra el comprometido **por partida** + backfill de los 302 con Beto) y Fase 4 (PDF de obra).


### PR DESCRIPTION
**Sprint Contratos → partidas + PDF · Fase 2 (UI).** Cierra el "monto no se ve por partida".

## Qué entra
1. **Alta de contrato de obra** (`nuevo-obra`): selector de **partida del presupuesto** (agrupado etapa›capítulo, depende del proyecto) + sección **Alcance, plazo y garantía** con los 5 campos nuevos (`objeto`, `fecha_inicio`/`fecha_fin`, `fianza_pct`, `periodicidad_estimaciones_dias`).
2. **Edición / ligado** (detalle del contrato): sub-componente **Partida del presupuesto** — selector + Guardar para **ligar contratos existentes** (incl. el de Maya) a su partida. El detalle era solo-lectura; ahora permite el ligado puntual → **la herramienta del backfill** (Fase 3).

Una vez ligado, el `valor_total` del contrato cuenta como comprometido en esa partida (vía `v_partida_control`, cableado en Fase 0). **Sin migración.**

## Revisión
**Preview-first.** Pruébalo: (a) crear un contrato de obra nuevo eligiendo partida + llenando objeto/plazo/fianza; (b) abrir el contrato de **Maya** y ligarlo a su partida con el selector nuevo.

⚠️ Sin migración → el preview usa **datos de prod**: ligar Maya en el preview **escribe a prod** (es justo lo que queremos, pero consciente). El reflejo en el Costeo por partida llega en la Fase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)