### PR TITLE
feat(dilesa-contratos-obra): Costeo por partida (3 capas) + backfill de contratos (Sprint · Fase 3)

### DIFF
--- a/components/dilesa/costeo-module.test.ts
+++ b/components/dilesa/costeo-module.test.ts
@@ -14,6 +14,8 @@ function r(overrides: Partial<CosteoRow>): CosteoRow {
     presupuestoActualizado: null,
     presupuesto: 0,
     gastoReal: 0,
+    comprometido: 0,
+    ejercido: 0,
     proveedorPersonaId: null,
     proveedor: null,
     fechaCompromiso: null,
@@ -148,6 +150,21 @@ describe('groupCosteo (Costeo DILESA — agrupado etapa›capítulo)', () => {
     expect(etapa?.gastoReal).toBe(500);
     expect(etapa?.capitulos[0]?.presupuesto).toBe(1000);
     expect(etapa?.capitulos[0]?.gastoReal).toBe(500);
+  });
+
+  it('suma comprometido y ejercido por capítulo y etapa (3 capas — ADR-042)', () => {
+    const grupos = groupCosteo(
+      [
+        r({ conceptoId: 'agua', comprometido: 800, ejercido: 300 }),
+        r({ conceptoId: 'agua', comprometido: 200, ejercido: 0 }),
+      ],
+      CATALOGO
+    );
+    const etapa = grupos[0];
+    expect(etapa?.comprometido).toBe(1000);
+    expect(etapa?.ejercido).toBe(300);
+    expect(etapa?.capitulos[0]?.comprometido).toBe(1000);
+    expect(etapa?.capitulos[0]?.ejercido).toBe(300);
   });
 
   it('ordena las partidas dentro del capítulo por código de concepto', () => {

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -29,6 +29,14 @@
  * Carga cross-schema con queries paralelas + lookups Map (mismo patrón que
  * contratos-module — evita embeds de PostgREST). Los KPIs son reactivos a los
  * filtros (ADR-034); el contratado/saldo refleja los proyectos visibles.
+ *
+ * Control de 3 capas por partida (ADR-042, sprint Contratos→partidas · Fase 3):
+ * cada renglón muestra Comprometido (Σ OC + contratos de obra ligados por
+ * `partida_id`) · Ejercido (recibido + facturas directas) · Disponible
+ * (presupuesto − comprometido; rojo si negativo = sobre-contratación), leídos de
+ * `erp.v_partida_control` por un lookup Map paralelo. Por eso el monto de un
+ * contrato de obra (p.ej. Maya) ya aparece dentro de su partida, no solo en el
+ * KPI agregado "Contratado".
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -66,8 +74,19 @@ export type CosteoRow = {
   presupuestoActualizado: number | null;
   /** presupuesto_actualizado ?? presupuesto_previo (numeric, c/IVA). Derivado. */
   presupuesto: number | null;
-  /** gasto_real_total (numeric, c/IVA). */
+  /** gasto_real_total (numeric, c/IVA) — captura manual del traspaso (Excel). */
   gastoReal: number | null;
+  /**
+   * Comprometido de la partida (Σ OC enviada/parcial/cerrada + Σ contratos de
+   * obra ligados por `partida_id`) — `erp.v_partida_control` (ADR-042). 0 si la
+   * partida no tiene ni OC ni contratos.
+   */
+  comprometido: number;
+  /**
+   * Ejercido/devengado de la partida (recibido de OC + facturas directas) —
+   * `erp.v_partida_control` (ADR-041). 0 si nada devengado.
+   */
+  ejercido: number;
   /** Proveedor estructurado (persona_id) — preferido sobre el texto libre. */
   proveedorPersonaId: string | null;
   /** Proveedor en texto libre (legacy del traspaso; fallback de display). */
@@ -97,6 +116,8 @@ export type CosteoCapitulo = {
   partidas: CosteoRow[];
   presupuesto: number;
   gastoReal: number;
+  comprometido: number;
+  ejercido: number;
 };
 
 /** Una etapa agrupada con sus capítulos y subtotales. */
@@ -107,6 +128,8 @@ export type CosteoEtapa = {
   capitulos: CosteoCapitulo[];
   presupuesto: number;
   gastoReal: number;
+  comprometido: number;
+  ejercido: number;
 };
 
 /**
@@ -128,6 +151,8 @@ export function groupCosteo(
     capitulos: Map<string, { cap: CosteoCapitulo; orderKey: string }>;
     presupuesto: number;
     gastoReal: number;
+    comprometido: number;
+    ejercido: number;
   };
   const etapas = new Map<string, EtapaAcc>();
 
@@ -146,6 +171,8 @@ export function groupCosteo(
         capitulos: new Map(),
         presupuesto: 0,
         gastoReal: 0,
+        comprometido: 0,
+        ejercido: 0,
       };
       etapas.set(etapaKey, e);
     }
@@ -160,6 +187,8 @@ export function groupCosteo(
           partidas: [],
           presupuesto: 0,
           gastoReal: 0,
+          comprometido: 0,
+          ejercido: 0,
         },
         orderKey: res ? res.capituloCodigo : '￿',
       };
@@ -171,8 +200,12 @@ export function groupCosteo(
     c.cap.partidas.push(r);
     c.cap.presupuesto += p;
     c.cap.gastoReal += g;
+    c.cap.comprometido += r.comprometido;
+    c.cap.ejercido += r.ejercido;
     e.presupuesto += p;
     e.gastoReal += g;
+    e.comprometido += r.comprometido;
+    e.ejercido += r.ejercido;
   }
 
   return [...etapas.values()]
@@ -183,6 +216,8 @@ export function groupCosteo(
       nombre: e.nombre,
       presupuesto: e.presupuesto,
       gastoReal: e.gastoReal,
+      comprometido: e.comprometido,
+      ejercido: e.ejercido,
       capitulos: [...e.capitulos.values()]
         .sort((a, b) => a.orderKey.localeCompare(b.orderKey))
         .map(({ cap }) => {
@@ -240,9 +275,26 @@ export function deriveKpis(
   ];
 }
 
-/** % de ejecución de un subtotal de grupo (gasto ÷ presupuesto). */
-function pctEjec(gasto: number, presupuesto: number): string {
-  return presupuesto > 0 ? formatPercent(gasto / presupuesto) : '—';
+/** Monto del costeo: '—' cuando es exactamente 0, moneda si no (ADR-034). */
+function fmtMonto(n: number): string {
+  return n === 0 ? '—' : formatCurrency(n);
+}
+
+/**
+ * Disponible de una partida/grupo = presupuesto − comprometido. Negativo =
+ * sobre-contratación (se comprometió más de lo presupuestado) → `alerta`. '—'
+ * solo cuando no hay ni presupuesto ni comprometido.
+ */
+function disponibleCell(
+  presupuesto: number,
+  comprometido: number
+): {
+  text: string;
+  alerta: boolean;
+} {
+  if (presupuesto === 0 && comprometido === 0) return { text: '—', alerta: false };
+  const d = presupuesto - comprometido;
+  return { text: formatCurrency(d), alerta: d < 0 };
 }
 
 type FetchResult = {
@@ -301,6 +353,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       estimacionesRes,
       catalogoRes,
       proveedoresRes,
+      controlRes,
     ] = await Promise.all([
       // Capa A migrada al modelo canónico erp.presupuesto_partidas (ADR-040).
       // Cast `as any`: la tabla aún no está en types (se difiere al workflow
@@ -346,6 +399,14 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
         .eq('empresa_id', empresaId)
         .eq('activo', true)
         .is('deleted_at', null),
+      // Control de 3 capas por partida (ADR-042): comprometido = Σ OC + Σ
+      // contratos de obra ligados por partida_id; ejercido = recibido + facturas
+      // directas. La vista ya filtra deleted_at y deriva por empresa.
+      sb
+        .schema('erp')
+        .from('v_partida_control')
+        .select('partida_id, comprometido, ejercido')
+        .eq('empresa_id', empresaId),
     ]);
 
     const firstErr =
@@ -354,9 +415,22 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
       contratosRes.error ??
       estimacionesRes.error ??
       catalogoRes.error ??
-      proveedoresRes.error;
+      proveedoresRes.error ??
+      controlRes.error;
     if (firstErr) {
       return { error: getSupabaseErrorMessage(firstErr, 'No se pudo cargar el costeo.') };
+    }
+
+    // Control de 3 capas por partida_id (ADR-042). Lookup Map: evita embed
+    // cross-schema (la vista vive en erp; las partidas también, pero el patrón
+    // del módulo es queries paralelas + Map).
+    const controlByPartida = new Map<string, { comprometido: number; ejercido: number }>();
+    for (const c of controlRes.data ?? []) {
+      if (!c.partida_id) continue;
+      controlByPartida.set(c.partida_id, {
+        comprometido: Number(c.comprometido ?? 0),
+        ejercido: Number(c.ejercido ?? 0),
+      });
     }
 
     // proyectoMap resuelve nombres de TODOS los proyectos (para la tabla de
@@ -444,6 +518,7 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
             : null;
       const gastoReal = r.gasto_real_total != null ? Number(r.gasto_real_total) : null;
       const pid = (r.proyecto_id as string | null) ?? null;
+      const ctrl = controlByPartida.get(r.id as string);
       return {
         id: r.id as string,
         proyecto_id: pid,
@@ -456,6 +531,8 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
           r.presupuesto_aprobado != null ? Number(r.presupuesto_aprobado) : null,
         presupuesto,
         gastoReal,
+        comprometido: ctrl?.comprometido ?? 0,
+        ejercido: ctrl?.ejercido ?? 0,
         proveedorPersonaId: (r.proveedor_persona_id as string | null) ?? null,
         proveedor: (r.proveedor_texto as string | null) ?? null,
         fechaCompromiso: (r.fecha_compromiso as string | null) ?? null,
@@ -620,17 +697,6 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
     [filtrados, catalogo.byConcepto]
   );
 
-  // Resuelve el proveedor a mostrar: estructurado → texto libre → "—".
-  const proveedorDisplay = useCallback(
-    (r: CosteoRow): string => {
-      if (r.proveedorPersonaId) {
-        return proveedorNombreById.get(r.proveedorPersonaId) ?? r.proveedor ?? '—';
-      }
-      return r.proveedor || '—';
-    },
-    [proveedorNombreById]
-  );
-
   // Al buscar, ignora el colapsado para que los matches sean visibles.
   const isSearching = q.length > 0;
   // Click en la fila abre la edición (solo si puede escribir).
@@ -757,10 +823,11 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
             <thead className="sticky top-0 z-10 bg-[var(--card)] text-xs uppercase tracking-wide text-[var(--text)]/50">
               <tr className="border-b border-[var(--border)]">
                 <th className="px-3 py-2.5 text-left">Concepto</th>
-                <th className="w-36 px-3 py-2.5 text-right">Presupuesto</th>
-                <th className="w-36 px-3 py-2.5 text-right">Gasto real</th>
-                <th className="w-20 px-3 py-2.5 text-right">% ejec.</th>
-                <th className="w-56 px-3 py-2.5 text-left">Proveedor</th>
+                <th className="w-32 px-3 py-2.5 text-right">Presupuesto</th>
+                <th className="w-32 px-3 py-2.5 text-right">Comprometido</th>
+                <th className="w-32 px-3 py-2.5 text-right">Ejercido</th>
+                <th className="w-32 px-3 py-2.5 text-right">Disponible</th>
+                <th className="w-32 px-3 py-2.5 text-right">Gasto real</th>
               </tr>
             </thead>
             <tbody>
@@ -774,7 +841,6 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
                     collapsed={collapsed}
                     isSearching={isSearching}
                     onToggle={toggleGrupo}
-                    proveedorDisplay={proveedorDisplay}
                     onRowClick={onRowClick}
                   />
                 );
@@ -787,6 +853,27 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   );
 }
 
+// ─── Celda de disponible (rojo si sobre-contratado) ─────────────────────────
+
+function DisponibleTd({
+  presupuesto,
+  comprometido,
+  pad,
+  normalColor,
+}: {
+  presupuesto: number;
+  comprometido: number;
+  pad: string;
+  normalColor: string;
+}) {
+  const { text, alerta } = disponibleCell(presupuesto, comprometido);
+  return (
+    <td className={`${pad} text-right tabular-nums ${alerta ? 'text-red-600' : normalColor}`}>
+      {text}
+    </td>
+  );
+}
+
 // ─── Fragmento de grupo (etapa + sus capítulos + partidas) ──────────────────
 
 function GrupoFragment({
@@ -795,7 +882,6 @@ function GrupoFragment({
   collapsed,
   isSearching,
   onToggle,
-  proveedorDisplay,
   onRowClick,
 }: {
   etapa: CosteoEtapa;
@@ -803,7 +889,6 @@ function GrupoFragment({
   collapsed: Set<string>;
   isSearching: boolean;
   onToggle: (key: string) => void;
-  proveedorDisplay: (r: CosteoRow) => string;
   onRowClick?: (r: CosteoRow) => void;
 }) {
   return (
@@ -821,15 +906,23 @@ function GrupoFragment({
           </button>
         </td>
         <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]">
-          {etapa.presupuesto === 0 ? '—' : formatCurrency(etapa.presupuesto)}
+          {fmtMonto(etapa.presupuesto)}
         </td>
         <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]">
-          {etapa.gastoReal === 0 ? '—' : formatCurrency(etapa.gastoReal)}
+          {fmtMonto(etapa.comprometido)}
         </td>
+        <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]">
+          {fmtMonto(etapa.ejercido)}
+        </td>
+        <DisponibleTd
+          presupuesto={etapa.presupuesto}
+          comprometido={etapa.comprometido}
+          pad="px-3 py-2 font-semibold"
+          normalColor="text-[var(--text)]"
+        />
         <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]/70">
-          {pctEjec(etapa.gastoReal, etapa.presupuesto)}
+          {fmtMonto(etapa.gastoReal)}
         </td>
-        <td className="px-3 py-2" />
       </tr>
 
       {!etapaCollapsed &&
@@ -841,7 +934,6 @@ function GrupoFragment({
               cap={cap}
               capCollapsed={capCollapsed}
               onToggle={onToggle}
-              proveedorDisplay={proveedorDisplay}
               onRowClick={onRowClick}
             />
           );
@@ -856,13 +948,11 @@ function CapituloFragment({
   cap,
   capCollapsed,
   onToggle,
-  proveedorDisplay,
   onRowClick,
 }: {
   cap: CosteoCapitulo;
   capCollapsed: boolean;
   onToggle: (key: string) => void;
-  proveedorDisplay: (r: CosteoRow) => string;
   onRowClick?: (r: CosteoRow) => void;
 }) {
   return (
@@ -883,15 +973,23 @@ function CapituloFragment({
           </button>
         </td>
         <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/80">
-          {cap.presupuesto === 0 ? '—' : formatCurrency(cap.presupuesto)}
+          {fmtMonto(cap.presupuesto)}
         </td>
         <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/80">
-          {cap.gastoReal === 0 ? '—' : formatCurrency(cap.gastoReal)}
+          {fmtMonto(cap.comprometido)}
         </td>
+        <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/80">
+          {fmtMonto(cap.ejercido)}
+        </td>
+        <DisponibleTd
+          presupuesto={cap.presupuesto}
+          comprometido={cap.comprometido}
+          pad="px-3 py-1.5"
+          normalColor="text-[var(--text)]/80"
+        />
         <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/60">
-          {pctEjec(cap.gastoReal, cap.presupuesto)}
+          {fmtMonto(cap.gastoReal)}
         </td>
-        <td className="px-3 py-1.5" />
       </tr>
 
       {!capCollapsed &&
@@ -909,12 +1007,20 @@ function CapituloFragment({
               {r.presupuesto == null ? '—' : formatCurrency(r.presupuesto)}
             </td>
             <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]">
+              {fmtMonto(r.comprometido)}
+            </td>
+            <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]">
+              {fmtMonto(r.ejercido)}
+            </td>
+            <DisponibleTd
+              presupuesto={r.presupuesto ?? 0}
+              comprometido={r.comprometido}
+              pad="px-3 py-1.5"
+              normalColor="text-[var(--text)]"
+            />
+            <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/70">
               {r.gastoReal == null ? '—' : formatCurrency(r.gastoReal)}
             </td>
-            <td className="px-3 py-1.5 text-right tabular-nums text-[var(--text)]/70">
-              {r.ratio == null ? '—' : formatPercent(r.ratio)}
-            </td>
-            <td className="px-3 py-1.5 text-[var(--text)]/80">{proveedorDisplay(r)}</td>
           </tr>
         ))}
     </>

--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -541,3 +541,26 @@ contratos de obra históricos quedaron ligados a su partida.
   disponible negativo porque varios contratos del frente se agruparon en el concepto ancla (el
   hermano queda sin comprometido) — reasignable con `<LigarPartida>` si se quiere precisión.
 - **Pendiente:** Fase 4 (PDF de contrato de obra de monto global).
+
+### 2026-06-07 — Sprint Contratos→partidas+PDF · Fase 4 (PDF de obra de monto global) — PR #712
+
+Los contratos de obra ya generan su contrato en PDF (antes solo vivienda podía). Cierra el sprint.
+
+- **Template** `lib/dilesa/pdf/contrato-obra-global.tsx`: "Contrato de Servicios a Precios Unitarios
+  y Tiempo Determinado" de monto global — declaraciones + 18 cláusulas + 2 testigos, fiel al contrato
+  legal real (Maya). El `objeto` descriptivo reemplaza la tabla de lotes (cláusula PRIMERA); sin
+  ANEXO 3. Reusa `HeaderBand`/`FooterBand`/`Folio`/`styles` + constantes del cliente DILESA. 1 página.
+- **Endpoint** `[id]/pdf/route.tsx`: branch por `tipo` — vivienda usa lotes + ANEXO 3 (intacto),
+  no-vivienda arma el template global. **Botón** "Descargar contrato (PDF)" en el detalle para ambos
+  tipos (antes gateado a vivienda).
+- **Revisión del contrato con Beto** (mismo PR): **fianza y anticipo CONDICIONALES** — si
+  `fianza_pct`/`anticipo_pct` = 0, el contrato NO los exige (la garantía pasa al fondo de retención
+  del 5%, que es lo que sí aplican con contratistas locales). Fix: la periodicidad ya no hardcodea
+  "(catorce)". **Form de alta** (`nuevo-obra/page.tsx`): defaults anticipo/fianza 0 + retención 5;
+  **objeto obligatorio** + dropdown de objetos de obra comunes (frentes DILESA) que pre-llena el campo.
+- Render verificado (smoke caso Maya + caso local sin fianza/anticipo). Test source-level (18
+  cláusulas, condicionales, sin lotes/anexo). **UI visible → preview-first** (PR #712).
+- **Decisiones de Beto cerradas:** escritura 177 + Adalberto Santos como representante de obra
+  (vigente); testigos Francisco Rivera + Nelcy Martínez (vigentes); REPSE/registro patronal siempre
+  se exigen (el blanco del PDF es solo fallback). **Pendiente menor:** capturar el `objeto` de los
+  contratos de obra existentes (Maya y demás) para que su PDF salga completo (hoy usan placeholder).

--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -14,8 +14,9 @@ backend (#651, en prod) + UI "Emitir a CxP" (#654) + **Sprint 5 captura de
 presupuesto**. **Sprint promovido 2026-06-06: Contratos → partidas + PDF de obra**
 (ejecuta ADR-042 Fases 2-3 + PDF) — el monto de contrato no se ve por partida
 (302/303 sin `partida_id`) + falta el PDF de obra de monto global; plan de 4 fases
-documentado en Bitácora, pendiente arrancar Fase 1 con OK. Próximo aparte:
-reasignar los 8 contratos placeholder.)
+documentado en Bitácora. **Fases 1-3 done** (#709 DB · #710 UI partida · #711 Costeo 3 capas +
+backfill de 30 contratos aplicado a prod 2026-06-06). Próximo: Fase 4 (PDF de obra de monto
+global). Aparte: reasignar los 8 contratos placeholder + 3 contratos de obra sin partida.)
 
 ## Problema
 
@@ -513,3 +514,30 @@ contrato-obra.tsx`) es para **vivienda** (lotes/prototipos/Anexo 3), no para obr
     del contrato cuenta como comprometido en esa partida vía `v_partida_control` (cableado en Fase
     0). 5 checks verdes (1305 tests). **Sin migración → preview-first.** Próximo: Fase 3 (Costeo
     muestra el comprometido **por partida** + backfill de los 302 con Beto) y Fase 4 (PDF de obra).
+
+### 2026-06-06 — Sprint Contratos→partidas+PDF · Fase 3 (Costeo por partida + backfill) — PR #711
+
+El Costeo de Construcción muestra el control de **3 capas por partida** (ADR-042) y los
+contratos de obra históricos quedaron ligados a su partida.
+
+- **UI** (`costeo-module.tsx`): query paralela a `erp.v_partida_control` + lookup Map por
+  `partida_id`; cada renglón (y subtotal de capítulo/etapa) muestra **Comprometido** (Σ OC +
+  contratos ligados) · **Ejercido** (recibido + facturas directas) · **Disponible** (presupuesto
+  − comprometido; **rojo si negativo** = sobre-contratación). Sustituyen las columnas "% ejec" y
+  "Proveedor"; KPIs de rollup intactos. 5 checks verdes (1306 tests). **UI visible →
+  preview-first** (PR #711, sin auto-merge).
+- **Diagnóstico que corrigió el handoff:** de los 302 contratos sin `partida_id`, **269 son
+  vivienda** (NO van a partidas de obra por diseño ADR-042 — se costean por lote/prototipo). El
+  backfill real eran **33 de obra** (22 urbanización + 10 cabecera + 1 tarea menor).
+- **Backfill `20260606190000`** (DML idempotente, **aplicado a prod + registrado en historial**):
+  liga **30** contratos por match keyword-del-frente + monto al centavo (valida proyecto). De los
+  33: 29 por match automático + **Maya** ($860k muro de contención) ligado a la partida seed
+  "Barda perimetral" de Lomas de las Delicias por decisión de Beto → disponible −$860k (alarma de
+  contratado-sin-presupuesto, hasta capturar el cuadro de Delicias). **3 quedan sin ligar**
+  (URBANIZACIÓN-C5 $617k, VANDALIZADAS-C4 $0, ESTRELLA-P3 $12k) — se ligan con `<LigarPartida>`
+  cuando se decida el concepto.
+- **Verificado en prod:** 31 obra ligados / 3 sin ligar / 269 vivienda sin ligar; SIMAS cuadra al
+  centavo (disponible $0); Maya −$860k. **Nota:** electrificación/pavimentación LDLE muestran
+  disponible negativo porque varios contratos del frente se agruparon en el concepto ancla (el
+  hermano queda sin comprometido) — reasignable con `<LigarPartida>` si se quiere precisión.
+- **Pendiente:** Fase 4 (PDF de contrato de obra de monto global).

--- a/supabase/migrations/20260606190000_backfill_contratos_obra_partida.sql
+++ b/supabase/migrations/20260606190000_backfill_contratos_obra_partida.sql
@@ -7,8 +7,9 @@
 -- 302 tenían `partida_id` NULL; pero 269 de ellos son `tipo='vivienda'`, que NO se
 -- ligan a partidas de obra por diseño (se costean por lote/prototipo — ADR-042 deja
 -- `partida_id` nullable para ellos). El backfill real son los **33 contratos de obra**
--- (urbanización/cabecera/tarea_menor). De esos 33, este script liga los **29** con
--- destino claro; los **4 restantes** quedan NULL (decisión de negocio de Beto, abajo).
+-- (urbanización/cabecera/tarea_menor). De esos 33, este script liga **30** (29 por match
+-- automático + Maya a la barda perimetral seed por decisión de Beto); los **3 restantes**
+-- quedan NULL (decisión de negocio, abajo).
 --
 -- MÉTODO DE MATCH (contrato → partida del MISMO proyecto, N:1 — ADR-042 §1):
 --   - kw+monto  : keyword del frente (del código `OBRA-<proy>-<FRENTE>-<id>`) consistente
@@ -61,7 +62,13 @@ WITH mapeo(codigo, partida_id, metodo) AS (
     ('OBRA-LDS-ESTRELLA-L3',              '6921cfd9-52f3-43e1-ab8a-a90cf5f59507'::uuid, 'solo-monto'), -- Construcción de cordón guarnición (M.O.)
     ('OBRA-LDS-PAVIMENTACION-C4',         '5b20f274-fed5-4a61-89e2-f5a526d6aaba'::uuid, 'kw+monto'),   -- Pavimentación
     ('OBRA-LDS-PORTON-I4',                '28d075d4-1c2f-48c7-beb8-1ce8ee143a78'::uuid, 'kw-ancla'),   -- Control de acceso para porton y puerta peatonal
-    ('OBRA-LDS-PORTON-C4',                '28d075d4-1c2f-48c7-beb8-1ce8ee143a78'::uuid, 'kw-ancla')    -- Control de acceso para porton y puerta peatonal
+    ('OBRA-LDS-PORTON-C4',                '28d075d4-1c2f-48c7-beb8-1ce8ee143a78'::uuid, 'kw-ancla'),   -- Control de acceso para porton y puerta peatonal
+    -- ── Lomas de las Delicias (decisión de Beto, Fase 3) ───────────────────
+    -- Muro de contención (Maya) → "Barda perimetral" seed (el muro del catálogo).
+    -- Delicias NO tiene presupuesto de obra capturado (todas sus partidas en $0) →
+    -- disponible = −$860k = alarma intencional de "contratado sin presupuesto", hasta
+    -- capturar el cuadro de Delicias. Reasignable con <LigarPartida>.
+    ('2026/1-DIE-MAYA-CAB#1',             '9dee092a-90e6-45b7-a017-316dda56b7af'::uuid, 'seed-alarma') -- Barda perimetral
 )
 UPDATE dilesa.contratos_construccion c
 SET partida_id = m.partida_id
@@ -73,12 +80,8 @@ WHERE c.codigo = m.codigo
   AND c.deleted_at IS NULL
   AND c.partida_id IS NULL;            -- idempotente: no re-liga lo ya ligado
 
--- ── 4 contratos SIN MATCH (NO se ligan aquí — decisión de Beto) ────────────
+-- ── 3 contratos SIN MATCH (NO se ligan aquí — decisión de Beto) ────────────
 --   OBRA-LDLE-URBANIZACIÓN-C5  ($617,567)  frente genérico; sin concepto evidente.
 --   OBRA-LDLE-VANDALIZADAS-C4  ($0)        reparación; al ser $0 no afecta el comprometido.
 --   OBRA-LDS-ESTRELLA-P3       ($12,042)   sin concepto del proyecto que cuadre.
---   2026/1-DIE-MAYA-CAB#1      ($860,000)  Muro de contención (Lomas de las Delicias):
---     su proyecto solo tiene el catálogo seed sin montos → necesita capturar el
---     presupuesto de obra de Delicias antes de ligar (o ligar a una partida seed y
---     que el disponible quede negativo como alarma). Se liga con <LigarPartida> una
---     vez decidido el concepto destino.
+--   (Se ligan con <LigarPartida> desde el detalle del contrato cuando se decida el destino.)

--- a/supabase/migrations/20260606190000_backfill_contratos_obra_partida.sql
+++ b/supabase/migrations/20260606190000_backfill_contratos_obra_partida.sql
@@ -1,0 +1,84 @@
+-- Iniciativa dilesa-contratos-obra · Sprint Contratos→partidas · Fase 3 · ADR-042
+-- Backfill: liga los contratos de obra históricos a su partida del presupuesto.
+--
+-- CONTEXTO. Hasta ADR-042 Fase 2, el alta de contrato no asignaba `partida_id`, así
+-- que el comprometido de los contratos de obra no aparecía por partida en el Costeo
+-- (solo en el KPI agregado "Contratado" por proyecto). De los 303 contratos DILESA,
+-- 302 tenían `partida_id` NULL; pero 269 de ellos son `tipo='vivienda'`, que NO se
+-- ligan a partidas de obra por diseño (se costean por lote/prototipo — ADR-042 deja
+-- `partida_id` nullable para ellos). El backfill real son los **33 contratos de obra**
+-- (urbanización/cabecera/tarea_menor). De esos 33, este script liga los **29** con
+-- destino claro; los **4 restantes** quedan NULL (decisión de negocio de Beto, abajo).
+--
+-- MÉTODO DE MATCH (contrato → partida del MISMO proyecto, N:1 — ADR-042 §1):
+--   - kw+monto  : keyword del frente (del código `OBRA-<proy>-<FRENTE>-<id>`) consistente
+--                 Y `valor_total` = `presupuesto_aprobado` al centavo. Máxima confianza.
+--   - kw-ancla  : keyword del frente; varios contratos del frente → la partida-concepto
+--                 principal del frente (mayor presupuesto). El comprometido del frente
+--                 queda agrupado en su partida ancla (p.ej. 6 contratos de electrificación
+--                 LDLE → "Electrificación de lotes…"). Beto puede reasignar con <LigarPartida>.
+--   - solo-monto: sin keyword (contratista, p.ej. ESTRELLA) pero `valor_total` cuadra al
+--                 centavo con un concepto. Confiable (contrato y partida salieron del mismo Excel).
+--
+-- IDEMPOTENTE: solo toca filas con `partida_id IS NULL` de DILESA. Re-correrlo no re-liga.
+-- SEGURO EN PREVIEW: el branch corre sin datos de prod (0 contratos) → 0 filas afectadas.
+-- El JOIN a presupuesto_partidas valida que la partida pertenece al mismo proyecto del
+-- contrato (defensa contra un UUID mal copiado).
+--
+-- Una vez ligado, el `valor_total` del contrato suma a `comprometido` de su partida en
+-- `erp.v_partida_control` (cableado en ADR-042 Fase 0, migración 20260605190000), y el
+-- Costeo lo muestra por renglón con su disponible (= aprobado − comprometido).
+
+WITH mapeo(codigo, partida_id, metodo) AS (
+  VALUES
+    -- ── Lomas de los Encinos ───────────────────────────────────────────────
+    ('OBRA-LDLE-AGUA_POTABLE_DRENAJE-B3', 'b8c347e2-a3de-42b5-9e1b-98cb6b13e1c7'::uuid, 'kw+monto'),   -- Instalación de red de drenaje sanitario (solo MO) 1era etapa
+    ('OBRA-LDLE-AGUA_POTABLE_DRENAJE-G3', 'b8c347e2-a3de-42b5-9e1b-98cb6b13e1c7'::uuid, 'kw-ancla'),   -- Instalación de red de drenaje sanitario (solo MO) 1era etapa
+    ('OBRA-LDLE-CORDON-C4',               '25fb4753-7d65-4697-9ebe-f462eaa74433'::uuid, 'kw+monto'),   -- Construcción de cordón guarnición (M.O.)
+    ('OBRA-LDLE-ELECTRIFICACION-I4',      'ad0f503d-e1ad-4c67-ab93-22fc0419f483'::uuid, 'kw-ancla'),   -- Electrificación de lotes media y baja tensión y alumbrado público
+    ('OBRA-LDLE-ELECTRIFICACION-C4',      'ad0f503d-e1ad-4c67-ab93-22fc0419f483'::uuid, 'kw-ancla'),   -- Electrificación de lotes media y baja tensión y alumbrado público
+    ('OBRA-LDLE-ELECTRIFICACION-B81',     'ad0f503d-e1ad-4c67-ab93-22fc0419f483'::uuid, 'kw-ancla'),   -- Electrificación de lotes media y baja tensión y alumbrado público
+    ('OBRA-LDLE-ELECTRIFICACION-C26',     'ad0f503d-e1ad-4c67-ab93-22fc0419f483'::uuid, 'kw-ancla'),   -- Electrificación de lotes media y baja tensión y alumbrado público
+    ('OBRA-LDLE-ELECTRIFICACION-I65',     'ad0f503d-e1ad-4c67-ab93-22fc0419f483'::uuid, 'kw-ancla'),   -- Electrificación de lotes media y baja tensión y alumbrado público
+    ('OBRA-LDLE-ELECTRIFICACION-C65',     'ad0f503d-e1ad-4c67-ab93-22fc0419f483'::uuid, 'kw-ancla'),   -- Electrificación de lotes media y baja tensión y alumbrado público
+    ('OBRA-LDLE-MONOLITO-C4',             '6f285c58-6c04-400f-855b-380e34e49143'::uuid, 'kw-ancla'),   -- Entrada fraccionamiento (monolito y plaza)
+    ('OBRA-LDLE-NOMENCLATURA-C5',         '562c0168-b6ef-4da9-8046-433092c0b291'::uuid, 'kw-ancla'),   -- Fabricación e instalación de nomenclaturas
+    ('OBRA-LDLE-PAVIMENTACION-S4',        '579f92dd-1513-467d-9644-c974926a8ab1'::uuid, 'kw-ancla'),   -- Pavimentación
+    ('OBRA-LDLE-PAVIMENTACION-C4',        '579f92dd-1513-467d-9644-c974926a8ab1'::uuid, 'kw-ancla'),   -- Pavimentación
+    ('OBRA-LDLE-PAVIMENTACION-I4',        '579f92dd-1513-467d-9644-c974926a8ab1'::uuid, 'kw-ancla'),   -- Pavimentación
+    ('OBRA-LDLE-PAVIMENTACION-O4',        '579f92dd-1513-467d-9644-c974926a8ab1'::uuid, 'kw-ancla'),   -- Pavimentación
+    ('OBRA-LDLE-SIMAS-B6',                '54b4bf5e-bee7-4d1d-a427-254524c14022'::uuid, 'kw+monto'),   -- Derechos de interconexión agua potable
+    -- ── Lomas del Sol ──────────────────────────────────────────────────────
+    ('OBRA-LDS-BANQUETA-B3',              '76aa6e9d-b049-491d-b6d3-67da74c2611e'::uuid, 'kw-ancla'),   -- Banquetas excedentes de áreas verdes y municipales (MO y Materiales)
+    ('OBRA-LDS-BANQUETA-K3',              '76aa6e9d-b049-491d-b6d3-67da74c2611e'::uuid, 'kw-ancla'),   -- Banquetas excedentes de áreas verdes y municipales (MO y Materiales)
+    ('OBRA-LDS-BARDA-B3',                 'd61924b0-9270-4669-a5d0-28754e4833ba'::uuid, 'kw-ancla'),   -- Construcción de barda perimetral (Mano de Obra)
+    ('OBRA-LDS-BARDA2-B3',                'd61924b0-9270-4669-a5d0-28754e4833ba'::uuid, 'kw-ancla'),   -- Construcción de barda perimetral (Mano de Obra)
+    ('OBRA-LDS-CASETA-B3',                'a074ff39-2baf-41e6-8aed-b6db71232139'::uuid, 'kw+monto'),   -- Caseta de acceso
+    ('OBRA-LDS-ELECTRIFICACION-C4',       '26b8cf99-a6df-4a2e-9e15-e04189d74c17'::uuid, 'kw+monto'),   -- Electrificación de lotes media y baja tensión y alumbrado público
+    ('OBRA-LDS-ELECTRIFICACION-H4',       '26b8cf99-a6df-4a2e-9e15-e04189d74c17'::uuid, 'kw-ancla'),   -- Electrificación de lotes media y baja tensión y alumbrado público
+    ('OBRA-LDS-ESTRELLA-B3',              'b5e0688e-ca8d-4a04-8683-e9d9c58a961f'::uuid, 'solo-monto'), -- Instalación de red de drenaje sanitario (solo MO)
+    ('OBRA-LDS-ESTRELLA-G3',              'cae0688d-9990-428b-89f5-1eef0ad25ddd'::uuid, 'solo-monto'), -- Instalación de red de agua potable (solo MO)
+    ('OBRA-LDS-ESTRELLA-L3',              '6921cfd9-52f3-43e1-ab8a-a90cf5f59507'::uuid, 'solo-monto'), -- Construcción de cordón guarnición (M.O.)
+    ('OBRA-LDS-PAVIMENTACION-C4',         '5b20f274-fed5-4a61-89e2-f5a526d6aaba'::uuid, 'kw+monto'),   -- Pavimentación
+    ('OBRA-LDS-PORTON-I4',                '28d075d4-1c2f-48c7-beb8-1ce8ee143a78'::uuid, 'kw-ancla'),   -- Control de acceso para porton y puerta peatonal
+    ('OBRA-LDS-PORTON-C4',                '28d075d4-1c2f-48c7-beb8-1ce8ee143a78'::uuid, 'kw-ancla')    -- Control de acceso para porton y puerta peatonal
+)
+UPDATE dilesa.contratos_construccion c
+SET partida_id = m.partida_id
+FROM mapeo m
+  JOIN erp.presupuesto_partidas pp ON pp.id = m.partida_id AND pp.deleted_at IS NULL
+WHERE c.codigo = m.codigo
+  AND c.empresa_id = 'f5942ed4-7a6b-4c39-af18-67b9fbf7f479'
+  AND c.proyecto_id = pp.proyecto_id   -- la partida es del mismo proyecto del contrato
+  AND c.deleted_at IS NULL
+  AND c.partida_id IS NULL;            -- idempotente: no re-liga lo ya ligado
+
+-- ── 4 contratos SIN MATCH (NO se ligan aquí — decisión de Beto) ────────────
+--   OBRA-LDLE-URBANIZACIÓN-C5  ($617,567)  frente genérico; sin concepto evidente.
+--   OBRA-LDLE-VANDALIZADAS-C4  ($0)        reparación; al ser $0 no afecta el comprometido.
+--   OBRA-LDS-ESTRELLA-P3       ($12,042)   sin concepto del proyecto que cuadre.
+--   2026/1-DIE-MAYA-CAB#1      ($860,000)  Muro de contención (Lomas de las Delicias):
+--     su proyecto solo tiene el catálogo seed sin montos → necesita capturar el
+--     presupuesto de obra de Delicias antes de ligar (o ligar a una partida seed y
+--     que el disponible quede negativo como alarma). Se liga con <LigarPartida> una
+--     vez decidido el concepto destino.


### PR DESCRIPTION
## Qué

Cierra el círculo de **ADR-042** (el contrato de obra como compromiso de una partida): el Costeo de Construcción ahora muestra el comprometido **por partida**, no solo en el KPI agregado "Contratado". Resuelve el reporte de Beto (el contrato Maya $860k aparecía en "Contratado" pero no dentro de ninguna partida).

### 1. UI — control de 3 capas por partida (`costeo-module.tsx`)
Cada renglón lee `erp.v_partida_control` (lookup Map paralelo) y despliega:
- **Comprometido** = Σ OC (enviada/parcial/cerrada) + Σ contratos de obra ligados por `partida_id`.
- **Ejercido** = recibido de OC + facturas directas (ADR-041).
- **Disponible** = presupuesto − comprometido. **Rojo si negativo** = sobre-contratación.

Sustituyen las columnas "% ejec" y "Proveedor". Subtotales por capítulo y etapa. Sin cambio en los KPIs de rollup.

### 2. Backfill `20260606190000` (DML, **pendiente de aplicar a prod con OK de Beto**)
De los 302 contratos sin `partida_id`, **269 son vivienda** (no van a partidas de obra, por diseño ADR-042). El backfill real son los **33 contratos de obra**:
- **29 ligados** por match keyword-del-frente + monto al centavo (idempotente, valida proyecto). Dry-run: 29/29 OK.
- **4 sin match** (decisión de negocio, quedan NULL): `URBANIZACIÓN-C5`, `VANDALIZADAS-C4` ($0), `ESTRELLA-P3` ($12k), y **Maya** ($860k — Lomas de las Delicias solo tiene catálogo seed sin montos).

## Por qué preview-first
Cambio de UI visible. El comprometido por partida se ve poblado **después** de aplicar el backfill a prod (el Preview branch corre sin datos de prod). Reviso el SQL del backfill contigo antes de aplicarlo.

## Checks
typecheck ✓ · test:run ✓ (1306) · lint ✓ · format:check ✓ · schema:check ✓ (sin drift; DML no toca schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)