### PR TITLE
feat(dilesa-contratos-obra): PDF de contrato de obra de monto global (Sprint · Fase 4)

### DIFF
--- a/app/api/dilesa/construccion/contratos/[id]/pdf/route.tsx
+++ b/app/api/dilesa/construccion/contratos/[id]/pdf/route.tsx
@@ -27,6 +27,10 @@ import {
   type Anexo3Prototipo,
   type Anexo3Tarea,
 } from '@/lib/dilesa/pdf/contrato-obra';
+import {
+  ContratoObraGlobalPDF,
+  type ContratoObraGlobalData,
+} from '@/lib/dilesa/pdf/contrato-obra-global';
 import { formatMontoEnLetras } from '@/lib/format/numero-a-letras';
 
 const MESES_ES = [
@@ -69,7 +73,9 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
   const { data: contrato, error: cErr } = await sb
     .schema('dilesa')
     .from('contratos_construccion')
-    .select('id, codigo, fecha_contrato, contratista_id, proyecto_id, valor_total')
+    .select(
+      'id, codigo, fecha_contrato, contratista_id, proyecto_id, valor_total, tipo, objeto, fecha_inicio, fecha_fin, anticipo_pct, retencion_pct, fianza_pct, periodicidad_estimaciones_dias'
+    )
     .eq('id', id)
     .is('deleted_at', null)
     .maybeSingle();
@@ -107,6 +113,59 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
         .eq('contrato_id', contrato.id)
         .is('deleted_at', null),
     ]);
+
+  // ── Branch: contrato de obra de MONTO GLOBAL (no-vivienda) ──
+  // La vivienda se describe por lotes/prototipos + ANEXO 3 de precios unitarios;
+  // la obra (urbanización, cabecera, tarea menor) por su objeto descriptivo, sin
+  // lotes ni anexos. Genérico para los 3 tipos no-vivienda.
+  if ((contrato.tipo as string) !== 'vivienda') {
+    const nombreCtr =
+      [persona?.nombre, persona?.apellido_paterno, persona?.apellido_materno]
+        .filter(Boolean)
+        .join(' ')
+        .trim() || '(sin nombre)';
+    const esMoralG = /moral/i.test((datos?.persona_fisica_o_moral as string | null) ?? '');
+    const monto = Number(contrato.valor_total ?? 0);
+    const anticipoPct = Number(contrato.anticipo_pct ?? 0);
+    const anticipoMonto = Math.round(monto * anticipoPct) / 100; // pct sobre el total
+    const globalData: ContratoObraGlobalData = {
+      folio: (contrato.codigo as string) ?? id,
+      fechaFirmaTexto: fechaLarga(contrato.fecha_contrato as string | null),
+      fechaInicioTexto: fechaLarga(
+        (contrato.fecha_inicio as string | null) ?? (contrato.fecha_contrato as string | null)
+      ),
+      fechaFinTexto: fechaLarga(contrato.fecha_fin as string | null),
+      objeto: (contrato.objeto as string | null) ?? '',
+      proyectoNombre: (proyecto?.nombre as string | null) ?? '',
+      contratista: {
+        nombre: nombreCtr.toUpperCase(),
+        esMoral: esMoralG,
+        representanteLegal: (datos?.representante_legal as string | null) || null,
+        rfc: (persona?.rfc as string | null) || null,
+        repse: (datos?.repse as string | null) || null,
+        registroPatronal: (datos?.registro_patronal as string | null) || null,
+        domicilio: (datos?.domicilio as string | null) || null,
+      },
+      montoTotal: monto,
+      montoTotalEnLetra: formatMontoEnLetras(monto),
+      anticipoMonto,
+      anticipoEnLetra: formatMontoEnLetras(anticipoMonto),
+      anticipoPct,
+      retencionPct: Number(contrato.retencion_pct ?? 0),
+      fianzaPct: Number(contrato.fianza_pct ?? 0),
+      periodicidadDias: Number(contrato.periodicidad_estimaciones_dias ?? 14),
+    };
+    const bufG = await renderToBuffer(<ContratoObraGlobalPDF data={globalData} />);
+    const fnameG = `contrato-obra-${(contrato.codigo as string)?.replace(/[^\w.-]+/g, '_') || id}.pdf`;
+    return new Response(new Uint8Array(bufG), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${fnameG}"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
 
   const construccionIds = [...new Set((lotesRows ?? []).map((l) => l.construccion_id as string))];
   if (construccionIds.length === 0) {

--- a/app/dilesa/construccion/contratos/[id]/page.tsx
+++ b/app/dilesa/construccion/contratos/[id]/page.tsx
@@ -355,15 +355,15 @@ function DetailInner() {
             </p>
           ) : null}
         </div>
-        {contrato.tipo === 'vivienda' ? (
-          <a
-            href={`/api/dilesa/construccion/contratos/${contrato.id}/pdf`}
-            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-sm font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40 hover:text-[var(--text)]"
-          >
-            <Download className="h-4 w-4" />
-            Descargar contrato (PDF)
-          </a>
-        ) : null}
+        {/* Ambos tipos generan PDF: vivienda con lotes+ANEXO 3, obra de monto
+            global con objeto descriptivo (el endpoint branchea por `tipo`). */}
+        <a
+          href={`/api/dilesa/construccion/contratos/${contrato.id}/pdf`}
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-sm font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40 hover:text-[var(--text)]"
+        >
+          <Download className="h-4 w-4" />
+          Descargar contrato (PDF)
+        </a>
       </header>
 
       <Section title="Datos generales">

--- a/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
+++ b/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
@@ -52,6 +52,27 @@ const TIPO_ABREV: Record<string, string> = {
   tarea_menor: 'TAR',
 };
 
+/**
+ * Objetos de obra más comunes (frentes reales de DILESA). Al elegir uno se
+ * pre-llena el campo `objeto` (editable, p.ej. para agregar metros lineales);
+ * es la cláusula PRIMERA del contrato. Obligatorio en la captura.
+ */
+const OBJETOS_COMUNES = [
+  'Construcción de muro de contención',
+  'Construcción de barda perimetral',
+  'Electrificación de lotes (media y baja tensión y alumbrado público)',
+  'Electrificación de línea troncal',
+  'Pavimentación',
+  'Instalación de red de agua potable',
+  'Instalación de red de drenaje sanitario',
+  'Construcción de cordón y guarnición',
+  'Construcción de banquetas',
+  'Construcción de caseta de acceso',
+  'Suministro e instalación de portón y control de acceso',
+  'Fabricación e instalación de monolito y nomenclatura',
+  'Terracerías y movimiento de tierras',
+] as const;
+
 export default function Page() {
   return (
     <RequireAccess empresa="dilesa" modulo="dilesa.construccion.contratos" write>
@@ -82,9 +103,11 @@ function NuevoContratoObraBody() {
   const [tipo, setTipo] = useState<string>('urbanizacion');
   const [fechaContrato, setFechaContrato] = useState(new Date().toISOString().slice(0, 10));
   const [valorTotal, setValorTotal] = useState('');
-  const [anticipoPct, setAnticipoPct] = useState('');
-  const [retencionPct, setRetencionPct] = useState('');
-  const [fianzaPct, setFianzaPct] = useState('');
+  // Defaults: anticipo y fianza en 0 (los locales no llevan; se capturan si aplican),
+  // retención en 5 (el fondo de garantía estándar — la garantía real cuando no hay fianza).
+  const [anticipoPct, setAnticipoPct] = useState('0');
+  const [retencionPct, setRetencionPct] = useState('5');
+  const [fianzaPct, setFianzaPct] = useState('0');
   const [periodicidadDias, setPeriodicidadDias] = useState('');
   const [objeto, setObjeto] = useState('');
   const [fechaInicio, setFechaInicio] = useState('');
@@ -211,7 +234,13 @@ function NuevoContratoObraBody() {
   const codigoFinal = codigoOverride.trim() || codigoSugerido;
 
   const canSubmit =
-    !!contratistaId && !!proyectoId && !!tipo && !!fechaContrato && !!codigoFinal && valorNum > 0;
+    !!contratistaId &&
+    !!proyectoId &&
+    !!tipo &&
+    !!fechaContrato &&
+    !!codigoFinal &&
+    valorNum > 0 &&
+    !!objeto.trim();
 
   async function onSubmit() {
     if (!canSubmit || submitting) return;
@@ -231,9 +260,9 @@ function NuevoContratoObraBody() {
           valor_total: valorNum,
           anticipo_pct: anticipoPct.trim() ? Number(anticipoPct) : 0,
           retencion_pct: retencionPct.trim() ? Number(retencionPct) : 0,
-          fianza_pct: fianzaPct.trim() ? Number(fianzaPct) : null,
+          fianza_pct: fianzaPct.trim() ? Number(fianzaPct) : 0,
           periodicidad_estimaciones_dias: periodicidadDias.trim() ? Number(periodicidadDias) : null,
-          objeto: objeto.trim() || null,
+          objeto: objeto.trim(),
           fecha_inicio: fechaInicio || null,
           fecha_fin: fechaFin || null,
           notas: notas.trim() || null,
@@ -429,13 +458,32 @@ function NuevoContratoObraBody() {
       <Section title="Alcance, plazo y garantía">
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <div className="sm:col-span-2">
-            <Field label="Objeto del contrato">
+            <Field label="Objeto del contrato *">
+              <select
+                className={`${selectCls} mb-2`}
+                value=""
+                onChange={(e) => {
+                  if (e.target.value) setObjeto(e.target.value);
+                }}
+                aria-label="Objeto común"
+              >
+                <option value="">Elegir objeto común… (o escribe abajo)</option>
+                {OBJETOS_COMUNES.map((o) => (
+                  <option key={o} value={o}>
+                    {o}
+                  </option>
+                ))}
+              </select>
               <textarea
                 className="min-h-[60px] w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm"
                 value={objeto}
                 onChange={(e) => setObjeto(e.target.value)}
-                placeholder="Ej. Suministro y mano de obra de 225 m de muro de contención…"
+                placeholder="Ej. Construcción de 225 m de muro de contención…"
               />
+              <Hint>
+                Es la cláusula PRIMERA del contrato. Elige uno común y ajústalo (metros,
+                ubicación…).
+              </Hint>
             </Field>
           </div>
           <Field label="Inicio de ejecución">

--- a/lib/dilesa/pdf/contrato-obra-global.test.ts
+++ b/lib/dilesa/pdf/contrato-obra-global.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Invariantes source-level del template de contrato de obra de monto global
+ * (iniciativa dilesa-contratos-obra · Fase 4). Source-level y no render: el
+ * setup de este repo es env=node sin jsdom (ver cxc-printables.test.ts); el
+ * render real se valida con el smoke del route handler en preview.
+ *
+ * Guarda dos cosas: (1) que el cuerpo legal está completo (las 18 cláusulas del
+ * formato "servicios a precios unitarios"), y (2) que esta variante es de monto
+ * global — sin tabla de lotes ni ANEXO 3, que son exclusivos de vivienda.
+ */
+const src = readFileSync(path.resolve(__dirname, 'contrato-obra-global.tsx'), 'utf8');
+
+describe('contrato-obra-global (PDF de obra de monto global — Fase 4)', () => {
+  it('declara las 18 cláusulas en orden (PRIMERA … DÉCIMA OCTAVA)', () => {
+    const numeros = [...src.matchAll(/n="([^"]+)"/g)].map((m) => m[1]);
+    expect(numeros).toEqual([
+      'PRIMERA',
+      'SEGUNDA',
+      'TERCERA',
+      'CUARTA',
+      'QUINTA',
+      'SEXTA',
+      'SÉPTIMA',
+      'OCTAVA',
+      'NOVENA',
+      'DÉCIMA',
+      'DÉCIMA PRIMERA',
+      'DÉCIMA SEGUNDA',
+      'DÉCIMA TERCERA',
+      'DÉCIMA CUARTA',
+      'DÉCIMA QUINTA',
+      'DÉCIMA SEXTA',
+      'DÉCIMA SÉPTIMA',
+      'DÉCIMA OCTAVA',
+    ]);
+  });
+
+  it('reusa header/footer/folio y las constantes del cliente (no duplica branding/datos)', () => {
+    expect(src).toMatch(/HeaderBand/);
+    expect(src).toMatch(/FooterBand/);
+    expect(src).toContain('EL_CLIENTE_OBRA');
+    expect(src).toContain('TESTIGOS_OBRA');
+    expect(src).toContain('JURISDICCION_OBRA');
+  });
+
+  it('es de monto global: una sola página, sin tabla de lotes ni datos de anexo', () => {
+    // Vivienda monta una segunda <Page> para el ANEXO 3; el global es 1 sola.
+    expect([...src.matchAll(/<Page\b/g)]).toHaveLength(1);
+    expect(src).not.toContain('LotesTable');
+    expect(src).not.toContain('Anexo3');
+    expect(src).not.toMatch(/data\.lotes|data\.anexo3/);
+  });
+
+  it('no usa `gap` (gotcha de @react-pdf v4.5.x — usar margins)', () => {
+    expect(src).not.toMatch(/\bgap:\s/);
+  });
+
+  it('parametriza los valores variables del contrato', () => {
+    for (const campo of [
+      'objeto',
+      'montoTotal',
+      'anticipoMonto',
+      'retencionPct',
+      'fianzaPct',
+      'periodicidadDias',
+    ]) {
+      expect(src).toContain(campo);
+    }
+  });
+});

--- a/lib/dilesa/pdf/contrato-obra-global.test.ts
+++ b/lib/dilesa/pdf/contrato-obra-global.test.ts
@@ -59,6 +59,13 @@ describe('contrato-obra-global (PDF de obra de monto global — Fase 4)', () => 
     expect(src).not.toMatch(/\bgap:\s/);
   });
 
+  it('fianza y anticipo son condicionales al pct (contratistas locales sin fianza/anticipo)', () => {
+    // Si fianza_pct/anticipo_pct = 0, la cláusula no obliga lo que no se exige
+    // (la garantía pasa a ser el fondo de retención de la cláusula OCTAVA).
+    expect(src).toContain('data.fianzaPct > 0');
+    expect(src).toContain('data.anticipoPct > 0');
+  });
+
   it('parametriza los valores variables del contrato', () => {
     for (const campo of [
       'objeto',

--- a/lib/dilesa/pdf/contrato-obra-global.tsx
+++ b/lib/dilesa/pdf/contrato-obra-global.tsx
@@ -266,18 +266,26 @@ export function ContratoObraGlobalPDF({ data }: { data: ContratoObraGlobalData }
           n="SÉPTIMA"
           titulo="ANTICIPO PARA INICIO DE OBRA"
           texto={
-            <>
-              Para el inicio de la obra objeto del presente instrumento “EL CLIENTE” pagará como
-              anticipo a cuenta del valor total de la obra la cantidad de{' '}
-              <Text style={cStyles.bold}>
-                {money(data.anticipoMonto)} ({data.anticipoEnLetra})
-              </Text>
-              , impuesto al valor agregado incluido, equivalente al{' '}
-              <Text style={cStyles.bold}>{num(data.anticipoPct)}%</Text> del importe total del
-              presente contrato, obligándose “EL CONTRATISTA” a utilizarlo única y exclusivamente en
-              dichos trabajos. La amortización de los anticipos se llevará a cabo en cada estimación
-              parcial de pago de avance.
-            </>
+            data.anticipoPct > 0 ? (
+              <>
+                Para el inicio de la obra objeto del presente instrumento “EL CLIENTE” pagará como
+                anticipo a cuenta del valor total de la obra la cantidad de{' '}
+                <Text style={cStyles.bold}>
+                  {money(data.anticipoMonto)} ({data.anticipoEnLetra})
+                </Text>
+                , impuesto al valor agregado incluido, equivalente al{' '}
+                <Text style={cStyles.bold}>{num(data.anticipoPct)}%</Text> del importe total del
+                presente contrato, obligándose “EL CONTRATISTA” a utilizarlo única y exclusivamente
+                en dichos trabajos. La amortización de los anticipos se llevará a cabo en cada
+                estimación parcial de pago de avance.
+              </>
+            ) : (
+              <>
+                Las partes acuerdan que para la ejecución de la obra objeto del presente contrato no
+                se otorgará anticipo a “EL CONTRATISTA”, por lo que los trabajos se pagarán
+                íntegramente mediante las estimaciones de avance conforme a la cláusula OCTAVA.
+              </>
+            )
           }
         />
 
@@ -288,7 +296,7 @@ export function ContratoObraGlobalPDF({ data }: { data: ContratoObraGlobalData }
             <>
               Las partes convienen que los trabajos objeto del presente contrato se paguen mediante
               la formulación de estimaciones que abarcarán períodos de ejecución no mayores de{' '}
-              <Text style={cStyles.bold}>{num(data.periodicidadDias)} (catorce) días</Text>, término
+              <Text style={cStyles.bold}>{num(data.periodicidadDias)} días naturales</Text>, término
               que iniciaría a partir del inicio de la obra; las que serán presentadas a la
               supervisión para su revisión y aprobación. Las estimaciones se pagarán en un plazo no
               mayor a 5 (cinco) días hábiles, contados a partir de la fecha de entrega de la factura
@@ -307,12 +315,22 @@ export function ContratoObraGlobalPDF({ data }: { data: ContratoObraGlobalData }
           n="NOVENA"
           titulo="GARANTÍAS"
           texto={
-            <>
-              “EL CONTRATISTA” entregará a “EL CLIENTE” fianza de cumplimiento por el{' '}
-              <Text style={cStyles.bold}>{num(data.fianzaPct)}%</Text> del monto total del contrato,
-              misma que podrá ser cancelada al término de la obra y una vez que se halle amortizado
-              el total del anticipo.
-            </>
+            data.fianzaPct > 0 ? (
+              <>
+                “EL CONTRATISTA” entregará a “EL CLIENTE” fianza de cumplimiento por el{' '}
+                <Text style={cStyles.bold}>{num(data.fianzaPct)}%</Text> del monto total del
+                contrato, misma que podrá ser cancelada al término de la obra y una vez que se halle
+                amortizado el total del anticipo, sin perjuicio del fondo de garantía retenido
+                conforme a la cláusula OCTAVA.
+              </>
+            ) : (
+              <>
+                La correcta ejecución de los trabajos queda garantizada mediante el fondo de
+                garantía que “EL CLIENTE” retiene de cada estimación conforme a la cláusula OCTAVA
+                del presente contrato, el cual se devolverá a “EL CONTRATISTA” en los términos ahí
+                señalados. Las partes acuerdan que no se requiere fianza de cumplimiento adicional.
+              </>
+            )
           }
         />
 

--- a/lib/dilesa/pdf/contrato-obra-global.tsx
+++ b/lib/dilesa/pdf/contrato-obra-global.tsx
@@ -1,0 +1,578 @@
+/**
+ * Template PDF: Contrato de Servicios a Precios Unitarios y Tiempo
+ * Determinado — variante de **obra de monto global** (DILESA ↔ contratista).
+ *
+ * A diferencia de `contrato-obra.tsx` (vivienda, con tabla de lotes/prototipos
+ * y ANEXO 3 de precios unitarios derivados), esta variante es para obra
+ * descrita por su **objeto** (urbanización, cabecera, tarea menor): muro de
+ * contención, barda, electrificación, etc. El objeto reemplaza la tabla de
+ * lotes en la cláusula PRIMERA y no hay anexos de prototipo.
+ *
+ * El cuerpo legal transcribe el contrato real "Muro de contención (Maya)"
+ * (sprint dilesa-contratos-obra · Fase 4): declaraciones + 18 cláusulas + 2
+ * testigos. Los valores variables (objeto, monto, plazo, anticipo, retención,
+ * fianza, periodicidad de estimaciones) vienen del contrato; el cliente DILESA
+ * y la jurisdicción de las constantes compartidas con el template de vivienda.
+ *
+ * Estilos de texto re-declarados localmente (no se acoplan al de vivienda, que
+ * además tiene estilos de tabla que aquí no aplican). Header/footer/folio y la
+ * paleta sí se reusan. `gap` de @react-pdf/renderer v4.5.x falla bundled — se
+ * usan margins.
+ */
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand, Folio } from './header-footer';
+import { EL_CLIENTE_OBRA, JURISDICCION_OBRA, TESTIGOS_OBRA } from '../contrato/constantes-obra';
+
+export type ContratoObraGlobalContratista = {
+  nombre: string; // razón social o nombre completo
+  esMoral: boolean;
+  representanteLegal: string | null;
+  rfc: string | null;
+  repse: string | null;
+  registroPatronal: string | null;
+  domicilio: string | null;
+};
+
+export type ContratoObraGlobalData = {
+  folio: string;
+  fechaFirmaTexto: string; // "26 de Diciembre del 2022"
+  fechaInicioTexto: string; // "28 de Mayo del 2026"
+  fechaFinTexto: string; // "26 de Junio del 2026"
+  /** Objeto del contrato (cláusula PRIMERA): "Construcción de 225 metros de muro de contención…". */
+  objeto: string;
+  proyectoNombre: string;
+  contratista: ContratoObraGlobalContratista;
+  montoTotal: number;
+  montoTotalEnLetra: string; // "OCHOCIENTOS SESENTA MIL 00/100 M.N."
+  anticipoMonto: number;
+  anticipoEnLetra: string; // "Ochenta y seis mil 00/100 M.N."
+  anticipoPct: number; // 10
+  retencionPct: number; // 5
+  fianzaPct: number; // 10
+  periodicidadDias: number; // 14
+};
+
+const fmtMoney = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 2,
+});
+const money = (n: number) => fmtMoney.format(Number(n) || 0);
+const num = (n: number) => (Number.isFinite(n) ? String(Math.round(n)) : '__');
+
+export function ContratoObraGlobalPDF({ data }: { data: ContratoObraGlobalData }) {
+  const c = data.contratista;
+  const objeto = data.objeto?.trim() || 'los trabajos descritos en el presente instrumento';
+  const enProyecto = data.proyectoNombre?.trim()
+    ? ` en el fraccionamiento ${data.proyectoNombre.trim()}`
+    : '';
+  return (
+    <Document title={`Contrato de Obra — ${data.folio}`}>
+      <Page size="LETTER" style={styles.page} wrap>
+        <HeaderBand title="CONTRATO DE OBRA" fecha={data.fechaFirmaTexto} />
+
+        <Text style={cStyles.titulo}>
+          CONTRATO DE SERVICIOS A PRECIOS UNITARIOS Y TIEMPO DETERMINADO
+        </Text>
+
+        {/* ── Encabezado / comparecencia ── */}
+        <Text style={cStyles.parrafo}>
+          Contrato de Servicios a Precios Unitarios y Tiempo Determinado que celebran, por una
+          parte, <Text style={cStyles.bold}>{EL_CLIENTE_OBRA.razonSocial}</Text>, representado por
+          el <Text style={cStyles.bold}>SR. {EL_CLIENTE_OBRA.representante}</Text>, en lo sucesivo
+          se le denominará <Text style={cStyles.bold}>“EL CLIENTE”</Text>; y por la otra parte{' '}
+          <Text style={cStyles.bold}>{c.nombre}</Text>, a quien en lo sucesivo se le denominará{' '}
+          <Text style={cStyles.bold}>“EL CONTRATISTA”</Text>
+          {c.representanteLegal ? (
+            <>
+              , representada en este acto por{' '}
+              <Text style={cStyles.bold}>{c.representanteLegal}</Text> en su carácter de
+              Representante Legal
+            </>
+          ) : null}
+          , los cuales se sujetan al tenor de las siguientes Declaraciones y Cláusulas:
+        </Text>
+
+        <Text style={cStyles.seccionTitulo}>DECLARACIONES</Text>
+
+        {/* I — EL CLIENTE */}
+        <Text style={cStyles.parrafo}>
+          <Text style={cStyles.bold}>
+            I.- Manifiesta “EL CLIENTE” por conducto de sus representantes:
+          </Text>
+        </Text>
+        <Text style={cStyles.parrafo}>
+          a) Es una persona moral constituida de conformidad con las Leyes Mexicanas, acreditándolo
+          con la Escritura Constitutiva {EL_CLIENTE_OBRA.escrituraConstitutiva.numero} libro núm.{' '}
+          {EL_CLIENTE_OBRA.escrituraConstitutiva.libro} volumen{' '}
+          {EL_CLIENTE_OBRA.escrituraConstitutiva.volumen},{' '}
+          {EL_CLIENTE_OBRA.escrituraConstitutiva.notario}, Notario Público Número{' '}
+          {EL_CLIENTE_OBRA.escrituraConstitutiva.numeroNotaria} de la ciudad de{' '}
+          {EL_CLIENTE_OBRA.escrituraConstitutiva.ciudad}. Que su representante acredita su
+          personalidad y carácter de{' '}
+          <Text style={cStyles.bold}>
+            Representante Legal con poder para pleitos y cobranzas, actos de administración, actos
+            de dominio, poder cambiario, y representación patronal
+          </Text>
+          , con el documento de escritura pública número {EL_CLIENTE_OBRA.poderRepresentante.numero}
+          , bajo la fe del {EL_CLIENTE_OBRA.poderRepresentante.notario}, titular de la Notaría
+          Pública Núm. {EL_CLIENTE_OBRA.poderRepresentante.numeroNotaria}, de la ciudad de{' '}
+          {EL_CLIENTE_OBRA.poderRepresentante.ciudad}. Así mismo manifiesta bajo protesta de decir
+          verdad que a la fecha de la firma del presente contrato no le han sido revocadas las
+          facultades conferidas.
+        </Text>
+        <Text style={cStyles.parrafo}>
+          b) Tiene capacidad jurídica para contratar lo que se expresa en este documento.
+        </Text>
+        <Text style={cStyles.parrafo}>
+          c) Tiene establecido su domicilio en {EL_CLIENTE_OBRA.domicilio}, mismo que señala para
+          todos los fines y efectos legales de este contrato. Con RFC {EL_CLIENTE_OBRA.rfc}.
+        </Text>
+
+        {/* II — EL CONTRATISTA */}
+        <Text style={cStyles.parrafo}>
+          <Text style={cStyles.bold}>
+            II.- Manifiesta “EL CONTRATISTA”
+            {c.esMoral
+              ? ' por conducto de su Representante Legal.'
+              : ' por conducto de su Administrador Único.'}
+          </Text>
+        </Text>
+        <Text style={cStyles.parrafo}>
+          a) Es {c.esMoral ? 'una persona moral constituida' : 'una persona física constituida'} de
+          conformidad con las Leyes Mexicanas, legalmente constituida conforme a la legislación
+          mexicana en la materia, registrada ante la Secretaría de Hacienda y Crédito Público con
+          Cédula de Identificación Fiscal y RFC{' '}
+          <Text style={cStyles.bold}>{c.rfc ?? '__________'}</Text>, con registro ante la Secretaría
+          de Trabajo REPSE N° <Text style={cStyles.bold}>{c.repse ?? '__________'}</Text>, y
+          Registro Patronal ante el IMSS N°{' '}
+          <Text style={cStyles.bold}>{c.registroPatronal ?? '__________'}</Text>.
+        </Text>
+        <Text style={cStyles.parrafo}>
+          b) Tiene capacidad jurídica para contratar y reúne las condiciones técnicas y económicas
+          para obligarse a la ejecución de la obra objeto de este contrato.
+        </Text>
+        <Text style={cStyles.parrafo}>
+          c) Tiene establecido su domicilio en{' '}
+          <Text style={cStyles.bold}>{c.domicilio ?? '__________'}</Text>, mismo que señala para
+          todos los fines y efectos legales de este contrato.
+        </Text>
+        <Text style={cStyles.parrafo}>
+          d) Ha tomado en consideración todas las circunstancias que pudieran afectar la ejecución
+          de los trabajos y se compromete a realizarlos oportunamente.
+        </Text>
+
+        {/* III — Ambas partes */}
+        <Text style={cStyles.parrafo}>
+          <Text style={cStyles.bold}>III.- Manifiestan Ambas Partes lo siguiente:</Text> ÚNICA.- Que
+          es su deseo y libre voluntad celebrar el presente contrato ajustándose al tenor de las
+          siguientes:
+        </Text>
+
+        <Text style={cStyles.seccionTitulo}>CLÁUSULAS</Text>
+
+        <Clausula
+          n="PRIMERA"
+          titulo="OBJETO DEL CONTRATO"
+          texto={
+            <>
+              “EL CLIENTE” encomienda a “EL CONTRATISTA” la ejecución de suministros parciales y
+              mano de obra en {objeto}
+              {enProyecto}, y éste se obliga a realizarla hasta su total terminación acatando para
+              ello lo establecido por los diversos ordenamientos, normas y anexos señalados en este
+              contrato, así como las normas de construcción vigentes en el lugar donde deban
+              realizarse los trabajos, mismos que se tienen por reproducidos como parte integrante
+              de estas cláusulas.
+            </>
+          }
+        />
+
+        <Clausula
+          n="SEGUNDA"
+          titulo="MONTO TOTAL DEL CONTRATO"
+          texto={
+            <>
+              El monto total del presente contrato es por la cantidad de{' '}
+              <Text style={cStyles.bold}>
+                {money(data.montoTotal)} ({data.montoTotalEnLetra})
+              </Text>
+              . Impuesto al valor agregado incluido.
+            </>
+          }
+        />
+
+        <Clausula
+          n="TERCERA"
+          titulo="PLAZO DE EJECUCIÓN DE LOS TRABAJOS"
+          texto={
+            <>
+              “EL CONTRATISTA” se obliga a iniciar los trabajos objeto de este contrato el día{' '}
+              <Text style={cStyles.bold}>{data.fechaInicioTexto}</Text> y terminarlos el{' '}
+              <Text style={cStyles.bold}>{data.fechaFinTexto}</Text>.
+            </>
+          }
+        />
+
+        <Clausula
+          n="CUARTA"
+          titulo="VIGENCIA DEL CONTRATO"
+          texto={
+            <>
+              El presente contrato iniciará su vigencia el día de su firma, el cual se señala en la
+              cláusula tercera de este contrato, y terminará su vigencia hasta el día en que se
+              formalice el acta entrega-recepción de los trabajos y/o servicios en forma
+              satisfactoria para “EL CLIENTE”. Una vez aprobados, los programas, la propuesta de
+              presupuesto aprobada, las diferentes etapas, así como sus planos debidamente revisados
+              y aprobados por “EL CLIENTE” serán Anexos de este Contrato y formarán parte del mismo.
+            </>
+          }
+        />
+
+        <Clausula
+          n="QUINTA"
+          titulo="SOLICITUD DE PRÓRROGA POR PARTE DE “EL CONTRATISTA”"
+          texto={
+            <>
+              En los casos fortuitos o de fuerza mayor, o cuando por cualquier otra causa no
+              imputable a “EL CONTRATISTA” le fuere imposible cumplir con el programa, solicitará
+              oportunamente y por escrito la prórroga que considere necesaria, expresando los
+              motivos en que apoye su solicitud. “EL CLIENTE”, bajo su responsabilidad, resolverá
+              sobre la justificación y procedencia de la prórroga y, en su caso, concederá la que
+              haya solicitado “EL CONTRATISTA”, o la que estime conveniente, mediante un acuerdo
+              fundado y motivado por escrito, así como la posterior celebración de un convenio
+              modificatorio o adicional, según sea el caso.
+            </>
+          }
+        />
+
+        <Clausula
+          n="SEXTA"
+          titulo="DISPONIBILIDAD DEL INMUEBLE, DOCUMENTOS ADMINISTRATIVOS Y/O MATERIALES Y MAQUINARIA"
+          texto={
+            <>
+              “EL CLIENTE” se obliga a poner a disposición de “EL CONTRATISTA” el o los inmuebles
+              donde deban llevarse a cabo los trabajos materia de este contrato, así como la
+              información relativa a la obra que se va a ejecutar y los dictámenes, permisos,
+              licencias y demás autorizaciones que se requieren para su realización. “EL CLIENTE”
+              será el encargado de proporcionar a “EL CONTRATISTA” el material necesario para la
+              ejecución del presente instrumento, asignando un lugar específico de entrega y
+              recepción de dicho material.
+            </>
+          }
+        />
+
+        <Clausula
+          n="SÉPTIMA"
+          titulo="ANTICIPO PARA INICIO DE OBRA"
+          texto={
+            <>
+              Para el inicio de la obra objeto del presente instrumento “EL CLIENTE” pagará como
+              anticipo a cuenta del valor total de la obra la cantidad de{' '}
+              <Text style={cStyles.bold}>
+                {money(data.anticipoMonto)} ({data.anticipoEnLetra})
+              </Text>
+              , impuesto al valor agregado incluido, equivalente al{' '}
+              <Text style={cStyles.bold}>{num(data.anticipoPct)}%</Text> del importe total del
+              presente contrato, obligándose “EL CONTRATISTA” a utilizarlo única y exclusivamente en
+              dichos trabajos. La amortización de los anticipos se llevará a cabo en cada estimación
+              parcial de pago de avance.
+            </>
+          }
+        />
+
+        <Clausula
+          n="OCTAVA"
+          titulo="FORMA DE PAGO"
+          texto={
+            <>
+              Las partes convienen que los trabajos objeto del presente contrato se paguen mediante
+              la formulación de estimaciones que abarcarán períodos de ejecución no mayores de{' '}
+              <Text style={cStyles.bold}>{num(data.periodicidadDias)} (catorce) días</Text>, término
+              que iniciaría a partir del inicio de la obra; las que serán presentadas a la
+              supervisión para su revisión y aprobación. Las estimaciones se pagarán en un plazo no
+              mayor a 5 (cinco) días hábiles, contados a partir de la fecha de entrega de la factura
+              a “EL CLIENTE”, la que deberá reunir los requisitos fiscales que establecen las leyes
+              y contener el visto bueno de la supervisión. Acepta “EL CONTRATISTA” que “EL CLIENTE”
+              le retenga el <Text style={cStyles.bold}>{num(data.retencionPct)}%</Text> de cada
+              estimación presentada como fondo de garantía, el cual le será devuelto al presentar
+              los oficios de entrega-recepción de las obras por parte de los representantes de “EL
+              CLIENTE”. Ni las estimaciones ni las liquidaciones, aunque hayan sido pagadas, se
+              considerarán como aceptación de las obras.
+            </>
+          }
+        />
+
+        <Clausula
+          n="NOVENA"
+          titulo="GARANTÍAS"
+          texto={
+            <>
+              “EL CONTRATISTA” entregará a “EL CLIENTE” fianza de cumplimiento por el{' '}
+              <Text style={cStyles.bold}>{num(data.fianzaPct)}%</Text> del monto total del contrato,
+              misma que podrá ser cancelada al término de la obra y una vez que se halle amortizado
+              el total del anticipo.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA"
+          titulo="AJUSTE DE COSTOS"
+          texto={
+            <>
+              Las partes acuerdan la revisión de los costos que integran los precios unitarios
+              pactados cuando ocurran circunstancias de orden económico que determinen un aumento o
+              reducción conforme al programa pactado o el vigente, dentro de los 20 (veinte) días
+              hábiles siguientes a la fecha de presentación por parte de “EL CONTRATISTA”. La
+              revisión se efectuará a solicitud escrita de “EL CONTRATISTA”, acompañada de la
+              documentación comprobatoria; “EL CLIENTE”, dentro de los 15 (quince) días hábiles
+              siguientes, resolverá sobre la procedencia de la petición.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA PRIMERA"
+          titulo="RECEPCIÓN DE LOS TRABAJOS"
+          texto={
+            <>
+              “EL CLIENTE” recibirá los trabajos hasta que sean terminados en su totalidad, si
+              hubieren sido terminados de acuerdo con las especificaciones convenidas. Se efectuarán
+              recepciones parciales cuando: a) sin estar terminada la totalidad de la obra, la parte
+              ejecutada se ajuste a lo convenido y pueda ser utilizada; b) “EL CLIENTE” determine
+              suspender las obras y lo ejecutado se ajuste a lo pactado; c) de común acuerdo se
+              convenga dar por terminado anticipadamente el contrato; d) “EL CLIENTE” rescinda
+              administrativamente el contrato; e) la autoridad judicial declare rescindido el
+              contrato. “EL CLIENTE” se reserva el derecho de reclamar por trabajos faltantes o mal
+              ejecutados.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA SEGUNDA"
+          titulo="REPRESENTANTE DE “EL CONTRATISTA”"
+          texto={
+            <>
+              “EL CONTRATISTA” nombrará antes de la fecha de inicio de la obra un superintendente de
+              construcción permanente, el cual deberá tener poder amplio y suficiente para tomar
+              decisiones en todo lo relativo al cumplimiento de este contrato. “EL CLIENTE” se
+              reserva el derecho de su aceptación, el cual podrá ejercer en cualquier tiempo.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA TERCERA"
+          titulo="RELACIONES LABORALES"
+          texto={
+            <>
+              “EL CONTRATISTA” es el único responsable de las obligaciones derivadas de las
+              disposiciones legales y demás ordenamientos en materia de trabajo y de seguridad
+              social. “EL CONTRATISTA” se obliga por lo mismo a responder de todas las reclamaciones
+              que sus trabajadores presentaren en su contra o en contra de “EL CLIENTE” en relación
+              con los trabajos que ampara este contrato.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA CUARTA"
+          titulo="SUSPENSIÓN DEL CONTRATO"
+          texto={
+            <>
+              “EL CLIENTE” podrá suspender temporal o definitivamente, en todo o en parte, la obra
+              contratada en cualquier momento por causas justificadas o por razones de interés
+              general. Cuando la suspensión sea temporal, el contrato podrá continuar produciendo
+              todos sus efectos legales una vez que hayan desaparecido las causas que la motivaron.
+              Cuando la suspensión sea definitiva será rescindido el presente contrato, pagando “EL
+              CLIENTE” los trabajos ejecutados hasta el momento de la suspensión.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA QUINTA"
+          titulo="TERMINACIÓN ADMINISTRATIVA DEL CONTRATO"
+          texto={
+            <>
+              “EL CLIENTE” podrá en cualquier momento terminar administrativamente este contrato por
+              causas de interés general. La contravención a las disposiciones, lineamientos, bases,
+              procedimientos y requisitos que establece la Ley para el Estado y Municipios de
+              Coahuila en relación a la materia, o el incumplimiento de cualquiera de las
+              obligaciones de “EL CONTRATISTA”, dará motivo a su rescisión inmediata, sin
+              responsabilidad para “EL CLIENTE”, además de que se le apliquen a “EL CONTRATISTA” las
+              penas convencionales conforme a lo establecido en este contrato y se le haga efectiva
+              la garantía otorgada para el cumplimiento del mismo.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA SEXTA"
+          titulo="OTRAS ESTIPULACIONES ESPECÍFICAS"
+          texto={
+            <>
+              1. Trabajos extraordinarios: cuando a juicio de “EL CLIENTE” sea necesario llevar a
+              cabo conceptos o cantidades de trabajo no contemplados, se celebrará convenio
+              modificatorio a precios unitarios; si se requieren nuevos conceptos, “EL CONTRATISTA”
+              someterá los precios unitarios respectivos a consideración de “EL CLIENTE”, quien de
+              no optar por esta solución podrá encomendar los trabajos a tercera persona. 2.
+              Supervisión: “EL CLIENTE” tendrá derecho de supervisar en todo tiempo las obras y dará
+              instrucciones por escrito; establecerá la residencia de supervisión y llevará la
+              bitácora de la obra como único medio de comunicación oficial. 3. Modificaciones al
+              programa, planos, especificaciones y variaciones de las cantidades de trabajo podrán
+              ordenarse por escrito; si varía el importe total, las partes celebrarán convenio
+              modificatorio. 4. Rescisión: operará de pleno derecho a favor de “EL CLIENTE” conforme
+              al procedimiento pactado. 5. Procedimiento de rescisión: se comunicará a “EL
+              CONTRATISTA” en forma fehaciente para que, en un plazo no mayor de 15 (quince) días
+              hábiles, exponga lo que a su derecho convenga. 6. Personal y equipo: a cargo exclusivo
+              de “EL CONTRATISTA”. 7. Maquinaria y herramienta: por cuenta de “EL CONTRATISTA”,
+              quien retirará del lugar los elementos que no se encuentren en uso.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA SÉPTIMA"
+          titulo="JURISDICCIÓN"
+          texto={
+            <>
+              Para la interpretación y cumplimiento del presente contrato, así como para todo
+              aquello que no esté estipulado, las partes se someten a la jurisdicción de los
+              Tribunales del Estado de {JURISDICCION_OBRA.estado}, por lo que “EL CONTRATISTA”
+              renuncia al fuero que pudiera corresponderle por razón de su domicilio presente,
+              futuro o cualquier otra causa.
+            </>
+          }
+        />
+
+        <Clausula
+          n="DÉCIMA OCTAVA"
+          titulo="AUSENCIA DE VICIOS DEL CONSENTIMIENTO"
+          texto={
+            <>
+              Ambas partes reconocen que en el presente Contrato no existe error, dolo, violencia,
+              mala fe, lesión, ni ningún otro vicio de voluntad que pudiere nulificarlo o
+              invalidarlo, encontrándose de acuerdo en la forma en que se encuentra redactado. Una
+              vez que fue leído por las partes otorgantes y debidamente enteradas de su contenido y
+              alcance legal, lo firman a su entera conformidad ante la presencia de dos testigos que
+              dan fe de su celebración el día{' '}
+              <Text style={cStyles.bold}>{data.fechaFirmaTexto}</Text>, en la Ciudad de{' '}
+              {JURISDICCION_OBRA.ciudad}.
+            </>
+          }
+        />
+
+        {/* Firmas */}
+        <View style={cStyles.firmasGroup}>
+          <FirmaSlot
+            nombre={`LIC. ${EL_CLIENTE_OBRA.representante}`}
+            rol={'Representante Legal\nPOR “EL CLIENTE”'}
+          />
+          <FirmaSlot
+            nombre={c.representanteLegal ?? c.nombre}
+            rol={
+              c.representanteLegal
+                ? 'Representante Legal\nPOR “EL CONTRATISTA”'
+                : 'POR “EL CONTRATISTA”'
+            }
+          />
+          {TESTIGOS_OBRA.map((t) => (
+            <FirmaSlot key={t.nombre} nombre={t.nombre} rol="TESTIGO" />
+          ))}
+        </View>
+
+        <Folio value={data.folio} />
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+// ── Sub-componentes ───────────────────────────────────────────────────────
+
+function Clausula({ n, titulo, texto }: { n: string; titulo: string; texto: React.ReactNode }) {
+  return (
+    <Text style={cStyles.clausula}>
+      <Text style={cStyles.clausulaNumero}>
+        {n}.- {titulo}.-{' '}
+      </Text>
+      {texto}
+    </Text>
+  );
+}
+
+function FirmaSlot({ nombre, rol }: { nombre: string; rol: string }) {
+  return (
+    <View style={cStyles.firmaSlot} wrap={false}>
+      <View style={cStyles.firmaLinea} />
+      <Text style={cStyles.firmaNombre}>{nombre}</Text>
+      <Text style={cStyles.firmaRol}>{rol}</Text>
+    </View>
+  );
+}
+
+const cStyles = StyleSheet.create({
+  titulo: {
+    fontSize: 11,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'center',
+    marginTop: 4,
+    marginBottom: 8,
+    letterSpacing: 0.5,
+  },
+  parrafo: {
+    fontSize: 8.5,
+    textAlign: 'justify',
+    marginBottom: 4,
+    lineHeight: 1.35,
+  },
+  seccionTitulo: {
+    fontSize: 11,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'center',
+    marginTop: 8,
+    marginBottom: 4,
+    letterSpacing: 0.5,
+  },
+  bold: { fontFamily: 'Helvetica-Bold' },
+  clausula: {
+    fontSize: 8.5,
+    textAlign: 'justify',
+    marginBottom: 4,
+    lineHeight: 1.35,
+  },
+  clausulaNumero: { fontFamily: 'Helvetica-Bold' },
+  firmasGroup: {
+    marginTop: 22,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-around',
+  },
+  firmaSlot: {
+    width: 220,
+    alignItems: 'center',
+    marginBottom: 18,
+    marginHorizontal: 6,
+  },
+  firmaLinea: {
+    width: '100%',
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.text,
+    marginBottom: 3,
+    marginTop: 26,
+  },
+  firmaNombre: {
+    fontSize: 8.5,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'center',
+  },
+  firmaRol: {
+    fontSize: 7.5,
+    color: colors.textMuted,
+    textAlign: 'center',
+    marginTop: 1,
+  },
+});


### PR DESCRIPTION
## Qué

Cierra el sprint **Contratos → partidas + PDF**. Los contratos de obra (urbanización, cabecera, tarea menor) ya generan su **contrato en PDF** — antes solo vivienda podía (el endpoint exigía lotes y el botón se ocultaba para obra). Resuelve el punto (b) del reporte de Beto sobre Maya: "falta generar el contrato de obra en PDF".

### Template `lib/dilesa/pdf/contrato-obra-global.tsx`
Nuevo template del "Contrato de Servicios a Precios Unitarios y Tiempo Determinado" de **monto global**: declaraciones (cliente/contratista/ambas) + **18 cláusulas** + 2 testigos, **fiel al contrato legal real** (Muro de contención, Maya). El **objeto descriptivo** reemplaza la tabla de lotes en la cláusula PRIMERA; **sin ANEXO 3**. Reusa `HeaderBand`/`FooterBand`/`Folio`/`styles` + las constantes del cliente DILESA. Una sola página (vs vivienda que monta el anexo).

### Endpoint `[id]/pdf/route.tsx`
Branch por `tipo`: **vivienda** usa lotes + ANEXO 3 (flujo intacto); **no-vivienda** arma el template global con los valores del contrato (objeto, monto y anticipo en letras, plazo, retención, fianza, periodicidad de estimaciones). Genérico para los 3 tipos no-vivienda — no varía por tipo.

### Botón `[id]/page.tsx`
"Descargar contrato (PDF)" deja de estar gateado a `tipo === 'vivienda'`; ambos tipos lo muestran.

## Validación
- **Smoke render** con datos de Maya → 3 páginas, fiel al PDF legal (branding DILESA, declaraciones, 18 cláusulas con $860k / anticipo $86k 10% / retención 5% / fianza 10% / estimaciones 14 días, firmas + 2 testigos).
- Test source-level (18 cláusulas en orden, reuso de branding, sin lotes/anexo, sin `gap`).
- Checks: typecheck ✓ · test:run ✓ (1310) · lint ✓ · format:check ✓.

## Nota
Para que el PDF de un contrato salga completo, el contrato debe tener capturado su **objeto** (campo de Fase 1). Maya hoy tiene `objeto` vacío → el template usa un placeholder ("los trabajos descritos…") hasta que se capture. Independiente de Fase 3 (#711); toca archivos distintos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)