### PR TITLE
fix(dilesa-ventas): cron libera unidad cuando el hold expira sin cola

### DIFF
--- a/app/api/cron/dilesa-ventas-expirar/route.ts
+++ b/app/api/cron/dilesa-ventas-expirar/route.ts
@@ -213,7 +213,22 @@ export async function GET(req: NextRequest) {
       .order('posicion', { ascending: true })
       .limit(1);
     const proximo = (cola ?? [])[0] as ColaRow | undefined;
-    if (!proximo) continue;
+    if (!proximo) {
+      // Sin cola: liberar la unidad para que vuelva al inventario disponible.
+      // Sin esto, la unidad queda en `asignada` aunque ninguna venta activa
+      // la tenga apartada, y nadie puede recrear solicitud (mismo bug que
+      // arregló PR #670 en `desasignarVenta`). `.eq('estado','asignada')`
+      // hace el UPDATE idempotente — si por alguna razón la unidad ya
+      // cambió de estado, no la pisamos.
+      const { error: uErr } = await sb
+        .schema('dilesa')
+        .from('unidades')
+        .update({ estado: 'terminada' })
+        .eq('id', exp.unidad_id)
+        .eq('estado', 'asignada');
+      if (uErr) summary.errors.push(`liberar unidad ${exp.unidad_id}: ${uErr.message}`);
+      continue;
+    }
 
     // Promover: setear expira_at fresco (2 días hábiles desde ahora)
     const nuevoExpira = calcularExpiraAt(new Date());


### PR DESCRIPTION
## Problema

Cuando una venta llegaba a Fase 1 sin cliente que la completara en 2 días hábiles, el cron horario la marcaba como \`expirada\`. Pero si **no había siguiente en la cola** de esa unidad, la unidad se quedaba en \`estado='asignada'\` indefinidamente.

Síntoma: banner "Hold perdido" en el detalle de la venta decía "podés recrear la solicitud", pero al ir a \`/dilesa/ventas/nueva\` la unidad no aparecía en el inventario disponible.

Bug detectado por Beto al dejar expirar una venta fantasma (M9-L1-LDS).

## Root cause

\`app/api/cron/dilesa-ventas-expirar/route.ts\` línea 216 tenía:

\`\`\`typescript
const proximo = (cola ?? [])[0] as ColaRow | undefined;
if (!proximo) continue;  // ← sale del loop sin tocar la unidad
\`\`\`

Mismo patrón que tenía \`desasignarVenta\` antes del PR #670.

## Fix

Cuando \`proximo\` es null (sin cola), UPDATE de la unidad \`asignada\` → \`terminada\`:

\`\`\`typescript
if (!proximo) {
  const { error: uErr } = await sb
    .schema('dilesa')
    .from('unidades')
    .update({ estado: 'terminada' })
    .eq('id', exp.unidad_id)
    .eq('estado', 'asignada');  // idempotente
  if (uErr) summary.errors.push(...);
  continue;
}
\`\`\`

Si hay cola, el comportamiento no cambia (la unidad sigue asignada al promoverse el siguiente líder).

## Cleanup manual

M9-L1-LDS (única unidad en este limbo) ya liberada con UPDATE puntual.

## Auto-merge

Backend (cron route), sin componente visual a revisar. Activo auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)