### PR TITLE
feat(dilesa-contratos-obra): editar datos del contrato de obra desde el detalle (Sprint UI)

### DIFF
--- a/app/dilesa/construccion/contratos/[id]/page.tsx
+++ b/app/dilesa/construccion/contratos/[id]/page.tsx
@@ -31,11 +31,13 @@ import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/toast';
 import { usePermissions } from '@/components/providers';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { buildPartidaIndex, type PartidaGrupo } from '@/lib/compras/partidas';
+import { OBJETOS_COMUNES } from '@/lib/dilesa/objetos-obra';
 import { ObraContratoDetalle } from '@/components/dilesa/obra-contrato-detalle';
 
 type Contrato = {
@@ -50,6 +52,12 @@ type Contrato = {
   tipo: string;
   anticipo_pct: number | null;
   retencion_pct: number | null;
+  partida_id: string | null;
+  objeto: string | null;
+  fecha_inicio: string | null;
+  fecha_fin: string | null;
+  fianza_pct: number | null;
+  periodicidad_estimaciones_dias: number | null;
 };
 
 type Lote = {
@@ -385,10 +393,17 @@ function DetailInner() {
       </Section>
 
       {contrato.tipo !== 'vivienda' ? (
+        <EditarDatosContrato
+          contrato={contrato}
+          onSaved={(patch) => setContrato((prev) => (prev ? { ...prev, ...patch } : prev))}
+        />
+      ) : null}
+
+      {contrato.tipo !== 'vivienda' ? (
         <LigarPartida
           contratoId={contrato.id}
           proyectoId={contrato.proyecto_id}
-          partidaIdInicial={(contrato as { partida_id?: string | null }).partida_id ?? null}
+          partidaIdInicial={contrato.partida_id}
         />
       ) : null}
 
@@ -685,5 +700,269 @@ function LigarPartida({
         ) : null}
       </div>
     </section>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-[var(--text)]/50">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return <p className="mt-1 text-[11px] text-[var(--text)]/50">{children}</p>;
+}
+
+/**
+ * Editar los datos de un contrato de obra (no-vivienda) con UPDATE directo
+ * (mismo patrón que <LigarPartida>). Los contratos históricos importados de
+ * Excel llegaron sin objeto/plazo/fianza/periodicidad, así que su PDF de obra
+ * (Fase 4) salía incompleto y había que corregirlos por SQL. Esta sección los
+ * captura desde la UI. Gated por write del sub-slug `dilesa.construccion.contratos`.
+ * Tras guardar sube el patch al detalle (onSaved) para que la ficha y el saldo
+ * de obra reflejen los cambios sin recargar.
+ */
+function EditarDatosContrato({
+  contrato,
+  onSaved,
+}: {
+  contrato: Contrato;
+  onSaved: (patch: Partial<Contrato>) => void;
+}) {
+  const { permissions } = usePermissions();
+  const toast = useToast();
+  const puedeEscribir =
+    permissions.isAdmin || permissions.modulos.get('dilesa.construccion.contratos')?.write === true;
+
+  const [objeto, setObjeto] = useState(contrato.objeto ?? '');
+  const [fechaInicio, setFechaInicio] = useState(contrato.fecha_inicio ?? '');
+  const [fechaFin, setFechaFin] = useState(contrato.fecha_fin ?? '');
+  const [valorTotal, setValorTotal] = useState(
+    contrato.valor_total == null ? '' : String(contrato.valor_total)
+  );
+  const [anticipoPct, setAnticipoPct] = useState(
+    contrato.anticipo_pct == null ? '' : String(contrato.anticipo_pct)
+  );
+  const [retencionPct, setRetencionPct] = useState(
+    contrato.retencion_pct == null ? '' : String(contrato.retencion_pct)
+  );
+  const [fianzaPct, setFianzaPct] = useState(
+    contrato.fianza_pct == null ? '' : String(contrato.fianza_pct)
+  );
+  const [periodicidadDias, setPeriodicidadDias] = useState(
+    contrato.periodicidad_estimaciones_dias == null
+      ? ''
+      : String(contrato.periodicidad_estimaciones_dias)
+  );
+  const [notas, setNotas] = useState(contrato.notas ?? '');
+  const [guardando, setGuardando] = useState(false);
+
+  const patch = useMemo(
+    () => ({
+      objeto: objeto.trim() || null,
+      fecha_inicio: fechaInicio || null,
+      fecha_fin: fechaFin || null,
+      anticipo_pct: anticipoPct.trim() === '' ? 0 : Number(anticipoPct),
+      retencion_pct: retencionPct.trim() === '' ? 0 : Number(retencionPct),
+      fianza_pct: fianzaPct.trim() === '' ? null : Number(fianzaPct),
+      periodicidad_estimaciones_dias:
+        periodicidadDias.trim() === '' ? null : Math.round(Number(periodicidadDias)),
+      valor_total: valorTotal.trim() === '' ? 0 : Number(valorTotal),
+      notas: notas.trim() || null,
+    }),
+    [
+      objeto,
+      fechaInicio,
+      fechaFin,
+      anticipoPct,
+      retencionPct,
+      fianzaPct,
+      periodicidadDias,
+      valorTotal,
+      notas,
+    ]
+  );
+
+  // Snapshot normalizado del contrato actual para detectar cambios (dirty). Tras
+  // guardar, onSaved actualiza el prop `contrato` → snapshot == patch → dirty false.
+  const snapshot = useMemo(
+    () => ({
+      objeto: contrato.objeto?.trim() || null,
+      fecha_inicio: contrato.fecha_inicio || null,
+      fecha_fin: contrato.fecha_fin || null,
+      anticipo_pct: Number(contrato.anticipo_pct ?? 0),
+      retencion_pct: Number(contrato.retencion_pct ?? 0),
+      fianza_pct: contrato.fianza_pct == null ? null : Number(contrato.fianza_pct),
+      periodicidad_estimaciones_dias:
+        contrato.periodicidad_estimaciones_dias == null
+          ? null
+          : Number(contrato.periodicidad_estimaciones_dias),
+      valor_total: Number(contrato.valor_total ?? 0),
+      notas: contrato.notas?.trim() || null,
+    }),
+    [contrato]
+  );
+
+  const valido =
+    [patch.anticipo_pct, patch.retencion_pct, patch.valor_total].every((n) => Number.isFinite(n)) &&
+    (patch.fianza_pct == null || Number.isFinite(patch.fianza_pct)) &&
+    (patch.periodicidad_estimaciones_dias == null ||
+      Number.isFinite(patch.periodicidad_estimaciones_dias)) &&
+    patch.valor_total > 0;
+  const dirty = JSON.stringify(patch) !== JSON.stringify(snapshot);
+
+  async function guardar() {
+    if (guardando || !dirty || !valido) return;
+    setGuardando(true);
+    const sb = createSupabaseBrowserClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (sb.schema('dilesa') as any)
+      .from('contratos_construccion')
+      .update({ ...patch, updated_at: new Date().toISOString() })
+      .eq('id', contrato.id);
+    if (error) {
+      toast.add({
+        title: 'Error',
+        description: getSupabaseErrorMessage(error, 'No se pudieron guardar los datos.'),
+        type: 'error',
+      });
+    } else {
+      toast.add({ title: 'Datos del contrato guardados', type: 'success' });
+      onSaved(patch);
+    }
+    setGuardando(false);
+  }
+
+  if (!puedeEscribir) return null;
+
+  const selectCls =
+    'h-9 w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm';
+
+  return (
+    <Section title="Editar datos del contrato">
+      <p className="-mt-2 mb-4 text-xs text-[var(--text)]/50">
+        Completa el alcance, plazo, montos y garantía del contrato de obra. Estos datos alimentan el
+        PDF del contrato (objeto, fechas, anticipo, retención y fianza).
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <Field label="Objeto del contrato">
+            <select
+              className={`${selectCls} mb-2`}
+              value=""
+              onChange={(e) => {
+                if (e.target.value) setObjeto(e.target.value);
+              }}
+              aria-label="Objeto común"
+            >
+              <option value="">Elegir objeto común… (o escribe abajo)</option>
+              {OBJETOS_COMUNES.map((o) => (
+                <option key={o} value={o}>
+                  {o}
+                </option>
+              ))}
+            </select>
+            <textarea
+              className="min-h-[60px] w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm"
+              value={objeto}
+              onChange={(e) => setObjeto(e.target.value)}
+              placeholder="Ej. Construcción de 225 m de muro de contención…"
+            />
+            <Hint>
+              Es la cláusula PRIMERA del contrato. Elige uno común y ajústalo (metros, ubicación…).
+            </Hint>
+          </Field>
+        </div>
+        <Field label="Inicio de ejecución">
+          <Input type="date" value={fechaInicio} onChange={(e) => setFechaInicio(e.target.value)} />
+        </Field>
+        <Field label="Fin de ejecución">
+          <Input type="date" value={fechaFin} onChange={(e) => setFechaFin(e.target.value)} />
+        </Field>
+        <Field label="Valor total (c/IVA)">
+          <Input
+            type="number"
+            step="0.01"
+            min="0"
+            value={valorTotal}
+            onChange={(e) => setValorTotal(e.target.value)}
+            placeholder="0.00"
+          />
+          <Hint>
+            {patch.valor_total > 0
+              ? moneyFmt.format(patch.valor_total)
+              : 'Monto total del contrato.'}
+          </Hint>
+        </Field>
+        <div className="grid grid-cols-2 gap-3 sm:col-span-2 sm:grid-cols-4">
+          <Field label="Anticipo %">
+            <Input
+              type="number"
+              step="0.01"
+              min="0"
+              max="100"
+              value={anticipoPct}
+              onChange={(e) => setAnticipoPct(e.target.value)}
+              placeholder="0"
+            />
+          </Field>
+          <Field label="Retención %">
+            <Input
+              type="number"
+              step="0.01"
+              min="0"
+              max="100"
+              value={retencionPct}
+              onChange={(e) => setRetencionPct(e.target.value)}
+              placeholder="0"
+            />
+          </Field>
+          <Field label="Fianza %">
+            <Input
+              type="number"
+              step="0.01"
+              min="0"
+              max="100"
+              value={fianzaPct}
+              onChange={(e) => setFianzaPct(e.target.value)}
+              placeholder="0"
+            />
+          </Field>
+          <Field label="Estimaciones c/ N días">
+            <Input
+              type="number"
+              step="1"
+              min="0"
+              value={periodicidadDias}
+              onChange={(e) => setPeriodicidadDias(e.target.value)}
+              placeholder="14"
+            />
+          </Field>
+        </div>
+        <div className="sm:col-span-2">
+          <Field label="Notas">
+            <textarea
+              className="min-h-[60px] w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm"
+              value={notas}
+              onChange={(e) => setNotas(e.target.value)}
+            />
+          </Field>
+        </div>
+      </div>
+      <div className="mt-4 flex items-center justify-end gap-3">
+        {patch.valor_total <= 0 ? (
+          <span className="text-xs text-[var(--text)]/50">El valor total debe ser mayor a 0.</span>
+        ) : null}
+        <Button onClick={guardar} disabled={guardando || !dirty || !valido}>
+          {guardando ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+          Guardar cambios
+        </Button>
+      </div>
+    </Section>
   );
 }

--- a/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
+++ b/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
@@ -36,6 +36,7 @@ import {
   type ProyectoSelectorRow,
 } from '@/lib/dilesa/proyectos-selector';
 import { buildPartidaIndex, type PartidaGrupo } from '@/lib/compras/partidas';
+import { OBJETOS_COMUNES } from '@/lib/dilesa/objetos-obra';
 
 type Contratista = { id: string; nombre: string; abreviacion: string | null };
 
@@ -51,27 +52,6 @@ const TIPO_ABREV: Record<string, string> = {
   obra_cabecera: 'CAB',
   tarea_menor: 'TAR',
 };
-
-/**
- * Objetos de obra más comunes (frentes reales de DILESA). Al elegir uno se
- * pre-llena el campo `objeto` (editable, p.ej. para agregar metros lineales);
- * es la cláusula PRIMERA del contrato. Obligatorio en la captura.
- */
-const OBJETOS_COMUNES = [
-  'Construcción de muro de contención',
-  'Construcción de barda perimetral',
-  'Electrificación de lotes (media y baja tensión y alumbrado público)',
-  'Electrificación de línea troncal',
-  'Pavimentación',
-  'Instalación de red de agua potable',
-  'Instalación de red de drenaje sanitario',
-  'Construcción de cordón y guarnición',
-  'Construcción de banquetas',
-  'Construcción de caseta de acceso',
-  'Suministro e instalación de portón y control de acceso',
-  'Fabricación e instalación de monolito y nomenclatura',
-  'Terracerías y movimiento de tierras',
-] as const;
 
 export default function Page() {
   return (

--- a/docs/planning/dilesa-contratos-obra.md
+++ b/docs/planning/dilesa-contratos-obra.md
@@ -8,15 +8,17 @@ proveedores/contratistas; futura emisión a CxP)
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-06-01
-**Última actualización:** 2026-06-06 (Ciclo de obra end-to-end: Capa A (#617) +
+**Última actualización:** 2026-06-07 (Ciclo de obra end-to-end: Capa A (#617) +
 Capa B (#631) + Sprint 3 Costeo (#639) + Sprint 4 captura (#644) + **puente CxP**
 backend (#651, en prod) + UI "Emitir a CxP" (#654) + **Sprint 5 captura de
 presupuesto**. **Sprint promovido 2026-06-06: Contratos → partidas + PDF de obra**
 (ejecuta ADR-042 Fases 2-3 + PDF) — el monto de contrato no se ve por partida
 (302/303 sin `partida_id`) + falta el PDF de obra de monto global; plan de 4 fases
-documentado en Bitácora. **Fases 1-3 done** (#709 DB · #710 UI partida · #711 Costeo 3 capas +
-backfill de 30 contratos aplicado a prod 2026-06-06). Próximo: Fase 4 (PDF de obra de monto
-global). Aparte: reasignar los 8 contratos placeholder + 3 contratos de obra sin partida.)
+documentado en Bitácora. **Fases 1-4 done** (#709 DB · #710 UI partida · #711 Costeo 3 capas +
+backfill · #712 PDF de obra). **Sprint UI: edición de datos del contrato** desde el detalle
+(sección "Editar datos del contrato", solo obra) para no depender de SQL. Aparte: reasignar los 8
+contratos placeholder + 3 contratos de obra sin partida; capturar `objeto`/plazo de los contratos
+de obra existentes.)
 
 ## Problema
 
@@ -564,3 +566,26 @@ Los contratos de obra ya generan su contrato en PDF (antes solo vivienda podía)
   (vigente); testigos Francisco Rivera + Nelcy Martínez (vigentes); REPSE/registro patronal siempre
   se exigen (el blanco del PDF es solo fallback). **Pendiente menor:** capturar el `objeto` de los
   contratos de obra existentes (Maya y demás) para que su PDF salga completo (hoy usan placeholder).
+
+### 2026-06-07 — Sprint UI: edición de datos del contrato de obra — PR #714
+
+Los contratos de obra (no-vivienda) ya se editan desde la UI; antes el detalle era read-only salvo
+`<LigarPartida>` y los ~33 contratos históricos (objeto/plazo/fianza/periodicidad vacíos) había que
+corregirlos por SQL para que su PDF de obra (Fase 4) saliera completo. Resuelve el **Pendiente
+menor** que dejó abierto la Fase 4.
+
+- **Sección "Editar datos del contrato"** (`[id]/page.tsx`, sub-componente `<EditarDatosContrato>`):
+  solo para `tipo != 'vivienda'`, gated por **write** de `dilesa.construccion.contratos`. Calca
+  `<LigarPartida>` (useState + UPDATE directo) y el form de alta. Edita `objeto` (dropdown
+  `OBJETOS_COMUNES` + textarea), `fecha_inicio`/`fecha_fin`, `anticipo_pct`/`retencion_pct`/
+  `fianza_pct`, `periodicidad_estimaciones_dias`, `valor_total` y `notas`.
+- **Dirty-check** por snapshot normalizado (robusto al numeric-as-string de PostgREST); Guardar se
+  deshabilita sin cambios o con `valor_total <= 0`. Tras guardar sube el patch al detalle
+  (`onSaved`) → la ficha "Datos generales" y el saldo de `<ObraContratoDetalle>` se refrescan sin
+  recargar.
+- **Refactor:** `OBJETOS_COMUNES` extraído de `nuevo-obra/page.tsx` a `lib/dilesa/objetos-obra.ts`
+  (`.ts` plano compartido por alta + edición; sin duplicar). Decisión de secuencia: se mergeó la
+  Fase 4 (#712) **antes** de este sprint para reusar `OBJETOS_COMUNES` desde main sin choque en
+  `[id]/page.tsx`.
+- **Sin migración** (las 9 columnas ya existían desde Fase 1, #709). 5 checks verdes (1312 tests).
+  **UI visible → preview-first** (#714, sin auto-merge).

--- a/lib/dilesa/objetos-obra.ts
+++ b/lib/dilesa/objetos-obra.ts
@@ -1,0 +1,26 @@
+/**
+ * Objetos de obra más comunes (frentes reales de DILESA). Al elegir uno se
+ * pre-llena el campo `objeto` del contrato de obra (editable, p.ej. para
+ * agregar metros lineales); es la cláusula PRIMERA del contrato y el texto
+ * que usa el PDF de obra de monto global (Fase 4).
+ *
+ * Compartido entre el alta (`app/dilesa/construccion/contratos/nuevo-obra`) y
+ * la edición (`app/dilesa/construccion/contratos/[id]`). Vive en un `.ts` plano
+ * (no en el page client) para no arrastrar el árbol de la página al importarlo
+ * desde otro componente. Iniciativa dilesa-contratos-obra.
+ */
+export const OBJETOS_COMUNES = [
+  'Construcción de muro de contención',
+  'Construcción de barda perimetral',
+  'Electrificación de lotes (media y baja tensión y alumbrado público)',
+  'Electrificación de línea troncal',
+  'Pavimentación',
+  'Instalación de red de agua potable',
+  'Instalación de red de drenaje sanitario',
+  'Construcción de cordón y guarnición',
+  'Construcción de banquetas',
+  'Construcción de caseta de acceso',
+  'Suministro e instalación de portón y control de acceso',
+  'Fabricación e instalación de monolito y nomenclatura',
+  'Terracerías y movimiento de tierras',
+] as const;


### PR DESCRIPTION
## Qué

Agrega una sección **"Editar datos del contrato"** en el detalle de contratos de obra (`tipo != 'vivienda'`), para editar desde la UI los campos que antes solo se cambiaban por SQL. Cierra el hueco que dejaba **incompletos los PDFs** de los ~33 contratos de obra históricos (importados de Excel sin `objeto`/plazo/fianza/periodicidad).

## Por qué

El detalle era read-only salvo `<LigarPartida>`. Beto tuvo que corregir contratos (p.ej. "Muro Maya") por SQL para que su PDF de obra (Fase 4, #712) saliera completo.

## Cómo

- **`<EditarDatosContrato>`** (`contratos/[id]/page.tsx`): solo obra, gated por **write** de `dilesa.construccion.contratos`. Calca `<LigarPartida>` (useState + UPDATE directo) y el form de alta. Edita `objeto` (dropdown `OBJETOS_COMUNES` + textarea), `fecha_inicio`/`fecha_fin`, `anticipo_pct`/`retencion_pct`/`fianza_pct`, `periodicidad_estimaciones_dias`, `valor_total`, `notas`.
- Dirty-check por snapshot normalizado (robusto a numeric-as-string de PostgREST); **Guardar** deshabilitado sin cambios o con `valor_total <= 0`. Tras guardar, sube el patch al detalle (`onSaved`) → la ficha y el saldo de obra (`<ObraContratoDetalle>`) se refrescan sin recargar.
- **Refactor**: `OBJETOS_COMUNES` extraído de `nuevo-obra` a `lib/dilesa/objetos-obra.ts` (`.ts` plano, compartido por alta + edición; sin duplicar).
- **Sin migración** — las 9 columnas ya existían (Fase 1, #709).

## Checks

typecheck · test:run (1312) · lint (0 err) · format:check · schema:check (sin drift) — todos verdes localmente.

## Nota de revisión

**Preview-first, sin auto-merge** (UI visible). Revisar en el detalle de un contrato de obra (no-vivienda): la sección aparece solo con permiso de escritura; elegir un objeto común, ajustar montos/fechas, Guardar, y confirmar que la ficha de arriba refleja el nuevo valor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)