### PR TITLE
feat(dilesa-pdf): watermark "DESASIGNADA"/"EXPIRADA" en PDFs de ventas no-activas

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -66,7 +66,7 @@ export async function GET(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, created_at, ine_numero'
+      'id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, created_at, ine_numero, estado'
     )
     .eq('id', id)
     .is('deleted_at', null)
@@ -74,6 +74,17 @@ export async function GET(
   if (vErr || !venta) {
     return NextResponse.json({ error: 'Venta no encontrada' }, { status: 404 });
   }
+
+  // Si la venta ya no está activa (desasignada o expirada), estampamos
+  // un watermark en el PDF para invalidarlo visualmente. LFPIORPI exige
+  // conservar el expediente histórico, por eso no escondemos el botón;
+  // marcamos el doc para que nadie lo use como válido por error.
+  const watermarkText: string | null =
+    venta.estado === 'desasignada'
+      ? 'DESASIGNADA'
+      : venta.estado === 'expirada'
+        ? 'EXPIRADA'
+        : null;
 
   // Persona (cliente) cross-schema — FICU + Promesa necesitan todos los KYC
   // fields que el form de Sprint 7c-2 persistió aquí (no en `dilesa.ventas`).
@@ -180,6 +191,7 @@ export async function GET(
       fechaTexto,
       clienteNombre,
       identificacionInventario,
+      watermark: watermarkText,
     };
     const buf = await renderToBuffer(<AvisoPrivacidadPDF data={data} />);
     return pdfResponse(buf, `aviso-privacidad-${identificacionInventario || id}.pdf`);
@@ -302,6 +314,7 @@ export async function GET(
         .join(
           ''
         )}-${identificacionInventario}-${ahora.toLocaleString('es-MX', { timeZone: TZ_MX })}`,
+      watermark: watermarkText,
     };
     const buf = await renderToBuffer(<PromesaCompraventaPDF data={data} />);
     return pdfResponse(buf, `promesa-compraventa-${identificacionInventario || id}.pdf`);
@@ -355,6 +368,7 @@ export async function GET(
       clasificacionRiesgo: riesgo.clasificacion,
       clienteNombre,
       identificacionInventario,
+      watermark: watermarkText,
     };
     const buf = await renderToBuffer(<FicuPDF data={data} />);
     return pdfResponse(buf, `ficu-${identificacionInventario || id}.pdf`);
@@ -410,6 +424,7 @@ export async function GET(
     frenteVerde: false,
     esquina: false,
     precioM2Excedente: 0,
+    watermark: watermarkText,
     ...pdfDataExtra,
   };
 

--- a/lib/dilesa/pdf/aviso-privacidad.tsx
+++ b/lib/dilesa/pdf/aviso-privacidad.tsx
@@ -4,12 +4,14 @@
  */
 import { Document, Link, Page, Text, View } from '@react-pdf/renderer';
 import { styles, colors } from './styles';
-import { HeaderBand, FooterBand } from './header-footer';
+import { HeaderBand, FooterBand, Watermark } from './header-footer';
 
 export type AvisoPrivacidadData = {
   fechaTexto: string; // "24 de Mayo del 2026"
   clienteNombre: string;
   identificacionInventario: string; // M3-L9-LDLE-ISC
+  /** Si la venta está desasignada/expirada, texto a estampar como watermark. */
+  watermark?: string | null;
 };
 
 export function AvisoPrivacidadPDF({ data }: { data: AvisoPrivacidadData }) {
@@ -17,6 +19,7 @@ export function AvisoPrivacidadPDF({ data }: { data: AvisoPrivacidadData }) {
     <Document title={`Aviso de Privacidad — ${data.identificacionInventario}`}>
       <Page size="LETTER" style={styles.page}>
         <HeaderBand title="AVISO DE PRIVACIDAD" fecha={data.fechaTexto} />
+        {data.watermark ? <Watermark text={data.watermark} /> : null}
 
         <Text style={paragraphStyle}>
           DILESA es una empresa respetuosa de los derechos sobre los datos personales de las

--- a/lib/dilesa/pdf/ficu.tsx
+++ b/lib/dilesa/pdf/ficu.tsx
@@ -17,7 +17,7 @@
  */
 import { Document, G, Page, Path, StyleSheet, Svg, Text, View } from '@react-pdf/renderer';
 import { styles, colors } from './styles';
-import { HeaderBand, FooterBand } from './header-footer';
+import { HeaderBand, FooterBand, Watermark } from './header-footer';
 import type { CriterioRiesgo, Nivel } from '../ficu/riesgo';
 
 export type DomicilioFicu = {
@@ -75,6 +75,9 @@ export type FicuData = {
   // Firma + folio
   clienteNombre: string;
   identificacionInventario: string;
+
+  /** Si la venta está desasignada/expirada, texto a estampar como watermark. */
+  watermark?: string | null;
 };
 
 const COLOR_SEGMENTO = ['#4f81bd', '#9bbb59', '#c0504d', '#8064a2', '#f79646'];
@@ -84,6 +87,7 @@ export function FicuPDF({ data }: { data: FicuData }) {
     <Document title={`FICU — ${data.clienteNombre} — ${data.identificacionInventario}`}>
       <Page size="LETTER" style={styles.page}>
         <HeaderBand title="FORMATO DE IDENTIFICACIÓN DE CLIENTES" fecha={data.fechaTexto} />
+        {data.watermark ? <Watermark text={data.watermark} /> : null}
 
         {/* ── Datos personales ── */}
         <DataRow label="Nombre(s):" value={data.nombres} />

--- a/lib/dilesa/pdf/header-footer.tsx
+++ b/lib/dilesa/pdf/header-footer.tsx
@@ -69,3 +69,47 @@ export function Folio({ value }: { value: string }) {
     </Text>
   );
 }
+
+/**
+ * Watermark diagonal "DESASIGNADA"/"EXPIRADA"/etc. que invalida
+ * visualmente cualquier impresión del PDF cuando la venta ya no está
+ * activa. Se renderiza en TODAS las páginas (prop `fixed`) y queda
+ * detrás del contenido por orden de inserción (debe ir DESPUÉS del
+ * Header pero ANTES del body para quedar como background).
+ *
+ * Por qué no esconder los botones: LFPIORPI exige conservar el
+ * expediente histórico. Marcamos el doc en lugar de ocultarlo, así
+ * el operador puede auditar pero nadie lo usa como válido por error.
+ */
+export function Watermark({ text }: { text: string }) {
+  if (!text) return null;
+  return (
+    <View
+      fixed
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        justifyContent: 'center',
+        alignItems: 'center',
+        // @ts-expect-error — @react-pdf permite pointerEvents
+        pointerEvents: 'none',
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 90,
+          fontWeight: 700,
+          color: '#dc2626',
+          opacity: 0.18,
+          letterSpacing: 6,
+          transform: 'rotate(-30deg)',
+        }}
+      >
+        {text}
+      </Text>
+    </View>
+  );
+}

--- a/lib/dilesa/pdf/promesa-compraventa.tsx
+++ b/lib/dilesa/pdf/promesa-compraventa.tsx
@@ -24,7 +24,7 @@
  */
 import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
 import { styles, colors } from './styles';
-import { HeaderBand, FooterBand, Folio } from './header-footer';
+import { HeaderBand, FooterBand, Folio, Watermark } from './header-footer';
 import {
   CUENTA_DILESA,
   ESCRITURAS_CONSTITUTIVAS_DILESA,
@@ -73,6 +73,9 @@ export type PromesaData = {
   };
 
   folio: string; // "CLM-M3-L16-LDLE-ISC-5/24/2026 9:35:36 AM"
+
+  /** Si la venta está desasignada/expirada, texto a estampar como watermark. */
+  watermark?: string | null;
 };
 
 const fmtMoney = new Intl.NumberFormat('es-MX', {
@@ -96,6 +99,7 @@ export function PromesaCompraventaPDF({ data }: { data: PromesaData }) {
     <Document title={`Promesa de Compraventa — ${data.inmueble.identificacionInventario}`}>
       <Page size="LETTER" style={styles.page} wrap>
         <HeaderBand title="CONTRATO DE PROMESA DE COMPRAVENTA" fecha={data.fechaTexto} />
+        {data.watermark ? <Watermark text={data.watermark} /> : null}
 
         {/* ── Header del contrato (Fix 1) ── */}
         <Text style={contratoStyles.encabezado}>
@@ -561,6 +565,7 @@ export function PromesaCompraventaPDF({ data }: { data: PromesaData }) {
       {/* ── Anexo 3: Cédula de Materiales (multi-página automático) ── */}
       <Page size="LETTER" style={styles.page} wrap>
         <HeaderBand title="ANEXO 3 — CÉDULA DE MATERIALES" fecha={data.fechaTexto} />
+        {data.watermark ? <Watermark text={data.watermark} /> : null}
         <Text style={contratoStyles.parrafo}>
           Cédula de características generales, materiales y acabados de la vivienda — referida en la
           Declaración I y en los Documentos Anexos del presente contrato. Los materiales y acabados

--- a/lib/dilesa/pdf/solicitud-asignacion.tsx
+++ b/lib/dilesa/pdf/solicitud-asignacion.tsx
@@ -18,7 +18,7 @@
  */
 import { Document, Page, Text, View } from '@react-pdf/renderer';
 import { styles, colors } from './styles';
-import { HeaderBand, FooterBand, Folio } from './header-footer';
+import { HeaderBand, FooterBand, Folio, Watermark } from './header-footer';
 
 export type SolicitudData = {
   fechaTexto: string; // "24 de Mayo del 2026"
@@ -55,6 +55,8 @@ export type SolicitudData = {
   // firma
   clienteNombre: string;
   folio: string; // ej. JHM-M3-L9-LDLE-ISC-5/24/2026 9:34:28 AM
+  /** Si la venta está desasignada/expirada, texto a estampar como watermark. */
+  watermark?: string | null;
 };
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -70,6 +72,7 @@ export function SolicitudAsignacionPDF({ data }: { data: SolicitudData }) {
     <Document title={`Solicitud de Asignación — ${data.identificacionInventario}`}>
       <Page size="LETTER" style={styles.page}>
         <HeaderBand title="SOLICITUD DE ASIGNACIÓN" fecha={data.fechaTexto} />
+        {data.watermark ? <Watermark text={data.watermark} /> : null}
 
         {/* ── Datos de la vivienda ── */}
         <Text style={styles.sectionTitle}>DATOS DE LA VIVIENDA</Text>


### PR DESCRIPTION
## Problema

Si una venta queda `desasignada` (admin la libera) o `expirada` (cron tras 2 días hábiles sin completar expediente), los 4 PDFs del expediente (Solicitud, Aviso Privacidad, FICU, Promesa) seguían descargables tal cual — sin nada que indicara que el cliente ya no está en proceso. Riesgo: alguien imprime y firma un FICU o Promesa que ya no tiene validez operativa.

## Fix

Watermark rojo diagonal "DESASIGNADA" o "EXPIRADA" en cada página de cada PDF cuando aplica.

**Por qué watermark y no esconder:** LFPIORPI exige conservar el expediente histórico — el operador necesita auditar el doc original incluso después de desasignar. Marcamos en lugar de ocultar para que nadie use el doc como válido por error.

## Implementación

- `lib/dilesa/pdf/header-footer.tsx`: nuevo componente `<Watermark text={...} />` reusable. Usa `<View fixed>` (aparece en todas las páginas), posición absoluta centrada, rotado -30°, rojo `#dc2626` con `opacity: 0.18`.
- 4 templates PDF (`solicitud-asignacion.tsx`, `aviso-privacidad.tsx`, `ficu.tsx`, `promesa-compraventa.tsx`): nuevo prop opcional `data.watermark?: string | null` + render `{data.watermark ? <Watermark text={data.watermark} /> : null}` justo después del `<HeaderBand>`. Promesa lleva watermark en sus 2 pages (contrato + Anexo 3).
- Route handler: agrega `estado` al SELECT, deriva `watermarkText = venta.estado === 'desasignada' ? 'DESASIGNADA' : venta.estado === 'expirada' ? 'EXPIRADA' : null`, lo propaga a los 4 data objects.

## UI — sin auto-merge

Es cambio visual sobre los PDFs. Dejo el PR abierto sin auto-merge para que revises preview antes:

## Test plan

- [ ] Descargar los 4 PDFs de una venta activa → sin watermark, igual que antes.
- [ ] Desasignar una venta → descargar los 4 PDFs → watermark "DESASIGNADA" en cada página.
- [ ] Dejar expirar una venta (o pedir un fantasma con `expira_at < now()`) → descargar los 4 PDFs → watermark "EXPIRADA".
- [ ] En la Promesa, ambas páginas (contrato + Anexo 3) llevan watermark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)