### PR TITLE
feat(p2p-cancelaciones): uniformar motivo de cancelación (Fase 4)

### DIFF
--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -36,6 +36,7 @@ import { Button } from '@/components/ui/button';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
 import { Combobox } from '@/components/ui/combobox';
 import { FileAttachments } from '@/components/file-attachments';
+import { CancelarConMotivoDialog } from '@/components/shared/cancelar-con-motivo-dialog';
 import { usePermissions } from '@/components/providers';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
@@ -138,6 +139,7 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
 
   // Captura de precios (matriz) de una RFQ existente
   const [capturaId, setCapturaId] = useState<string | null>(null);
+  const [cancelarCot, setCancelarCot] = useState<CotizacionRow | null>(null);
 
   const fetchData = useCallback(async (): Promise<FetchResult> => {
     const sb = createSupabaseBrowserClient();
@@ -477,12 +479,18 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
   }
 
   const cancelar = useCallback(
-    async (c: CotizacionRow) => {
+    async (c: CotizacionRow, motivo: string) => {
       const sb = createSupabaseBrowserClient();
+      const ahora = new Date().toISOString();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { error: e } = await (sb.schema('erp') as any)
         .from('cotizaciones')
-        .update({ estado: 'cancelada', updated_at: new Date().toISOString() })
+        .update({
+          estado: 'cancelada',
+          cancelada_at: ahora,
+          motivo_cancelacion: motivo,
+          updated_at: ahora,
+        })
         .eq('id', c.id);
       if (e) {
         toast.add({
@@ -490,7 +498,7 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
           description: getSupabaseErrorMessage(e, 'No se pudo cancelar.'),
           type: 'error',
         });
-        return;
+        throw e; // mantiene abierto el diálogo de motivo
       }
       toast.add({ title: 'Cotización cancelada', description: c.codigo, type: 'success' });
       void cargar();
@@ -556,7 +564,7 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
                   type="button"
                   onClick={(e) => {
                     e.stopPropagation();
-                    void cancelar(r);
+                    setCancelarCot(r);
                   }}
                   aria-label={`Cancelar ${r.codigo}`}
                   className="inline-flex h-7 w-7 items-center justify-center rounded text-[var(--text)]/40 hover:bg-red-50 hover:text-red-600"
@@ -852,6 +860,17 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
         emptyIcon={<ClipboardList className="h-6 w-6" />}
         maxHeight="calc(100vh - 320px)"
       />
+
+      {cancelarCot ? (
+        <CancelarConMotivoDialog
+          key={cancelarCot.id}
+          title={`¿Cancelar ${cancelarCot.codigo}?`}
+          description="La cotización quedará cancelada. Se preserva el historial para auditoría."
+          confirmLabel="Cancelar cotización"
+          onClose={() => setCancelarCot(null)}
+          onConfirm={(motivo) => cancelar(cancelarCot, motivo)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/compras/ordenes-compra-module.tsx
+++ b/components/compras/ordenes-compra-module.tsx
@@ -447,6 +447,34 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
     [toast, cargar]
   );
 
+  const cancelar = useCallback(
+    async (oc: OcRow, motivo: string) => {
+      const sb = createSupabaseBrowserClient();
+      const ahora = new Date().toISOString();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error: e } = await (sb.schema('erp') as any)
+        .from('ordenes_compra')
+        .update({
+          estado: 'cancelada',
+          cancelada_at: ahora,
+          motivo_cancelacion: motivo,
+          updated_at: ahora,
+        })
+        .eq('id', oc.id);
+      if (e) {
+        toast.add({
+          title: 'Error',
+          description: getSupabaseErrorMessage(e, 'No se pudo cancelar.'),
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({ title: 'Orden cancelada', description: oc.codigo, type: 'success' });
+      void cargar();
+    },
+    [toast, cargar]
+  );
+
   const cerrar = useCallback(
     async (oc: OcRow) => {
       const sb = createSupabaseBrowserClient();
@@ -510,12 +538,13 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
                 onDelete={
                   r.estado === 'borrador' || r.estado === 'enviada'
                     ? {
-                        onConfirm: () => cambiarEstado(r, 'cancelada', 'Orden cancelada'),
+                        onConfirm: (motivo) => cancelar(r, motivo ?? ''),
                         label: 'Cancelar OC',
                         confirmTitle: `¿Cancelar ${r.codigo}?`,
                         confirmDescription:
                           'La orden quedará cancelada y dejará de comprometer presupuesto.',
                         confirmLabel: 'Cancelar OC',
+                        requireMotivo: true,
                       }
                     : undefined
                 }

--- a/components/compras/requisiciones-module.tsx
+++ b/components/compras/requisiciones-module.tsx
@@ -454,12 +454,13 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
   );
 
   const cancelar = useCallback(
-    async (req: ReqRow) => {
+    async (req: ReqRow, motivo: string) => {
       const sb = createSupabaseBrowserClient();
+      const ahora = new Date().toISOString();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { error: e } = await (sb.schema('erp') as any)
         .from('requisiciones')
-        .update({ deleted_at: new Date().toISOString() })
+        .update({ deleted_at: ahora, cancelada_at: ahora, motivo_cancelacion: motivo })
         .eq('id', req.id);
       if (e) {
         toast.add({
@@ -602,11 +603,12 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
                   onDelete={
                     estado !== 'con_oc'
                       ? {
-                          onConfirm: () => cancelar(r),
+                          onConfirm: (motivo) => cancelar(r, motivo ?? ''),
                           label: 'Cancelar requisición',
                           confirmTitle: `¿Cancelar ${r.codigo}?`,
                           confirmDescription: 'La requisición quedará cancelada (borrado suave).',
                           confirmLabel: 'Cancelar requisición',
+                          requireMotivo: true,
                         }
                       : undefined
                   }

--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { FileUp, Link2, RefreshCw, Search, Upload, Wallet } from 'lucide-react';
+import { Ban, FileUp, Link2, RefreshCw, Search, Upload, Wallet } from 'lucide-react';
 
 import {
   ModuleFilters,
@@ -32,6 +32,8 @@ import {
 } from '@/components/module-page';
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
+import { CancelarConMotivoDialog } from '@/components/shared/cancelar-con-motivo-dialog';
+import { usePermissions } from '@/components/providers';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -539,6 +541,10 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
         onAsignar={async (partidaId) => {
           if (selected) await asignarPartida(selected.id, partidaId);
         }}
+        onCancelada={() => {
+          setDrawerOpen(false);
+          void fetchFacturas();
+        }}
       />
 
       <UploadXmlDialog
@@ -572,6 +578,7 @@ function FacturaDrawer({
   proyectoNombreMap,
   partidaProyectoMap,
   onAsignar,
+  onCancelada,
 }: {
   factura: Factura | null;
   empresa: EmpresaSlug;
@@ -584,7 +591,12 @@ function FacturaDrawer({
   proyectoNombreMap: Map<string, string>;
   partidaProyectoMap: Map<string, string>;
   onAsignar: (partidaId: string | null) => Promise<void>;
+  /** Refresca la lista + cierra el drawer tras cancelar la factura. */
+  onCancelada: () => void;
 }) {
+  const { permissions } = usePermissions();
+  const feedback = useActionFeedback();
+  const [mostrarCancelar, setMostrarCancelar] = useState(false);
   const [pagos, setPagos] = useState<PagoAplicado[]>([]);
   const [adjuntos, setAdjuntos] = useState<Adjunto[]>([]);
   const [loading, setLoading] = useState(false);
@@ -667,6 +679,30 @@ function FacturaDrawer({
   const pdfHref = factura?.pdf_url ? `/api/adjuntos/${factura.pdf_url}` : null;
 
   const b = factura ? estadoBadge(factura) : null;
+
+  // Cancelar factura (RPC con motivo, audit trail · p2p-cancelaciones D1). Solo
+  // admin (D2), y solo antes de cualquier pago aplicado (el RPC bloquea D3 si
+  // hay pagos). Cancelar revierte la cuenta por pagar.
+  const puedeCancelar =
+    permissions.isAdmin &&
+    factura != null &&
+    (factura.estado_cxp === 'borrador' || factura.estado_cxp === 'por_pagar');
+
+  const doCancelar = async (motivo: string) => {
+    if (!factura) return;
+    const sb = createSupabaseBrowserClient();
+    const { error } = await sb
+      .schema('erp')
+      .rpc('cxp_factura_cancelar', { p_factura_id: factura.id, p_motivo: motivo });
+    if (error) {
+      feedback.error(getSupabaseErrorMessage(error, 'No se pudo cancelar la factura.'), {
+        title: 'No se pudo cancelar',
+      });
+      throw error; // mantiene abierto el diálogo de motivo
+    }
+    feedback.success('Factura cancelada');
+    onCancelada();
+  };
 
   return (
     <DetailDrawer
@@ -963,9 +999,40 @@ function FacturaDrawer({
                 </section>
               </>
             )}
+
+            {/* Cancelar factura — destructivo, solo admin, antes de pagos */}
+            {puedeCancelar && (
+              <>
+                <Separator />
+                <section className="space-y-2">
+                  <Button
+                    variant="ghost"
+                    className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                    onClick={() => setMostrarCancelar(true)}
+                  >
+                    <Ban className="h-4 w-4" /> Cancelar factura
+                  </Button>
+                  <p className="text-[11px] text-muted-foreground">
+                    Revierte la cuenta por pagar. Solo disponible antes de programar pagos; queda
+                    registro del motivo para auditoría.
+                  </p>
+                </section>
+              </>
+            )}
           </div>
         )}
       </DetailDrawerContent>
+
+      {mostrarCancelar && factura && (
+        <CancelarConMotivoDialog
+          key={factura.id}
+          title={`¿Cancelar factura de ${proveedorLabel(factura)}?`}
+          description="La factura quedará cancelada y dejará de contar como cuenta por pagar. Se preserva el historial para auditoría."
+          confirmLabel="Cancelar factura"
+          onClose={() => setMostrarCancelar(false)}
+          onConfirm={doCancelar}
+        />
+      )}
     </DetailDrawer>
   );
 }

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -31,6 +31,7 @@ import { ModuleFilters, ModuleContent, ErrorBanner } from '@/components/module-p
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { CancelarConMotivoDialog } from '@/components/shared/cancelar-con-motivo-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -445,12 +446,14 @@ export function CxpPagosModule({ empresaId }: CxpPagosModuleProps) {
         confirmVariant="default"
       />
 
-      {/* Cancelar — confirmación con motivo. Se monta on-demand con key para
-          arrancar con estado fresco sin reset-effect (React: reset por key). */}
+      {/* Cancelar — confirmación con motivo (audit trail, p2p-cancelaciones D1).
+          Se monta on-demand con key para arrancar con estado fresco. */}
       {cancelarPago && (
-        <CancelarDialog
+        <CancelarConMotivoDialog
           key={cancelarPago.id}
-          pago={cancelarPago}
+          title="¿Cancelar este pago?"
+          description="Se revierten las aplicaciones a las facturas (sus saldos vuelven a abrirse). No se puede cancelar un pago ya ejecutado."
+          confirmLabel="Cancelar pago"
           onClose={() => setCancelarPago(null)}
           onConfirm={(motivo) => doCancelar(cancelarPago, motivo)}
         />
@@ -641,67 +644,6 @@ function Field({ label, value, mono = false }: { label: string; value: string; m
       <div className="text-xs text-muted-foreground">{label}</div>
       <div className={mono ? 'font-mono text-sm' : 'text-sm'}>{value}</div>
     </div>
-  );
-}
-
-// ── Dialog: cancelar (motivo) ──────────────────────────────────────────────────
-
-function CancelarDialog({
-  pago,
-  onClose,
-  onConfirm,
-}: {
-  /** Siempre presente: el padre monta este dialog on-demand con key. */
-  pago: Pago;
-  onClose: () => void;
-  onConfirm: (motivo: string) => Promise<void>;
-}) {
-  const [motivo, setMotivo] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-
-  const handleConfirm = async () => {
-    setSubmitting(true);
-    try {
-      await onConfirm(motivo);
-      onClose();
-    } catch {
-      // El error ya se mostró vía toast; deja el dialog abierto.
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <Dialog open onOpenChange={(v) => !v && !submitting && onClose()}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>¿Cancelar este pago?</DialogTitle>
-          <DialogDescription>
-            Se revierten las aplicaciones a las facturas (sus saldos vuelven a abrirse). No se puede
-            cancelar un pago ya ejecutado.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="space-y-1.5">
-          <label className="text-xs text-muted-foreground" htmlFor="motivo-cancelacion">
-            Motivo (opcional)
-          </label>
-          <Input
-            id="motivo-cancelacion"
-            value={motivo}
-            onChange={(e) => setMotivo(e.target.value)}
-            placeholder="Ej. Error de captura, duplicado…"
-          />
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={submitting}>
-            Volver
-          </Button>
-          <Button variant="destructive" onClick={() => void handleConfirm()} disabled={submitting}>
-            {submitting ? 'Cancelando…' : 'Cancelar pago'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/components/dilesa/costeo-concepto-form.tsx
+++ b/components/dilesa/costeo-concepto-form.tsx
@@ -71,8 +71,11 @@ export function CosteoConceptoForm({
   editRow: CosteoRow | null;
   onClose: () => void;
   onSaved: () => void;
-  /** Borra la partida (solo en edición). Soft-delete + cierra el form. */
-  onDelete?: () => void | Promise<void>;
+  /**
+   * Borra la partida (solo en edición). Soft-delete + cierra el form.
+   * Recibe el motivo de cancelación capturado para el audit trail.
+   */
+  onDelete?: (motivo?: string) => void | Promise<void>;
 }) {
   const toast = useToast();
   const isEdit = editRow != null;
@@ -329,6 +332,7 @@ export function CosteoConceptoForm({
           title={`¿Eliminar “${editRow?.concepto ?? 'partida'}”?`}
           description="Marcará la partida de presupuesto como eliminada. Se preserva el historial para auditoría."
           confirmLabel="Eliminar"
+          requireMotivo
         />
       ) : null}
     </div>

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -598,12 +598,13 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
   // Soft-delete de una partida. Patrón del repo: marca `deleted_at`, preserva
   // historial para auditoría. Devuelve true si borró (para cerrar el form).
   const eliminar = useCallback(
-    async (row: CosteoRow): Promise<boolean> => {
+    async (row: CosteoRow, motivo: string): Promise<boolean> => {
       const sb = createSupabaseBrowserClient();
+      const ahora = new Date().toISOString();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { error: e } = await (sb.schema('erp') as any)
         .from('presupuesto_partidas')
-        .update({ deleted_at: new Date().toISOString() })
+        .update({ deleted_at: ahora, cancelada_at: ahora, motivo_cancelacion: motivo })
         .eq('id', row.id);
       if (e) {
         toast.add({
@@ -786,8 +787,8 @@ export function CosteoModule({ empresaId }: { empresaId: string }) {
           }}
           onDelete={
             editRow && puedeEscribir
-              ? async () => {
-                  const ok = await eliminar(editRow);
+              ? async (motivo) => {
+                  const ok = await eliminar(editRow, motivo ?? '');
                   if (ok) cerrarForm();
                 }
               : undefined

--- a/components/shared/confirm-dialog.tsx
+++ b/components/shared/confirm-dialog.tsx
@@ -13,6 +13,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import type { buttonVariants } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import type { VariantProps } from 'class-variance-authority';
 
 type ConfirmButtonVariant = NonNullable<VariantProps<typeof buttonVariants>['variant']>;
@@ -24,9 +25,10 @@ export type ConfirmDialogProps = {
   onOpenChange: (open: boolean) => void;
   /**
    * Triggered when the user confirms. Can be async; the button disables
-   * itself while the promise resolves.
+   * itself while the promise resolves. Receives the captured motivo when
+   * `requireMotivo` is set (undefined otherwise).
    */
-  onConfirm: () => void | Promise<void>;
+  onConfirm: (motivo?: string) => void | Promise<void>;
   /** Dialog title. Keep it short (“¿Eliminar departamento?”). */
   title: React.ReactNode;
   /** Optional longer explanation. Supports ReactNode for formatting. */
@@ -41,6 +43,13 @@ export type ConfirmDialogProps = {
    * Use "default" for non-destructive but still-needs-confirm actions.
    */
   confirmVariant?: ConfirmButtonVariant;
+  /**
+   * Si true, pide un motivo obligatorio (audit trail) y lo pasa a `onConfirm`.
+   * Usado por la iniciativa p2p-cancelaciones para cancelar con motivo.
+   */
+  requireMotivo?: boolean;
+  /** Placeholder del campo de motivo (solo si `requireMotivo`). */
+  motivoPlaceholder?: string;
 };
 
 /**
@@ -72,18 +81,28 @@ export function ConfirmDialog({
   confirmLabel = 'Eliminar',
   cancelLabel = 'Cancelar',
   confirmVariant = 'destructive',
+  requireMotivo = false,
+  motivoPlaceholder = 'Motivo (ej. error de captura, duplicado…)',
 }: ConfirmDialogProps) {
   const [loading, setLoading] = React.useState(false);
+  const [motivo, setMotivo] = React.useState('');
+
+  // Limpia el motivo cada vez que el diálogo se reabre.
+  React.useEffect(() => {
+    if (open) setMotivo('');
+  }, [open]);
+
+  const canConfirm = !requireMotivo || motivo.trim().length > 0;
 
   const handleConfirm = React.useCallback(async () => {
     setLoading(true);
     try {
-      await onConfirm();
+      await onConfirm(requireMotivo ? motivo.trim() : undefined);
       onOpenChange(false);
     } finally {
       setLoading(false);
     }
-  }, [onConfirm, onOpenChange]);
+  }, [onConfirm, onOpenChange, requireMotivo, motivo]);
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -92,11 +111,25 @@ export function ConfirmDialog({
           <AlertDialogTitle>{title}</AlertDialogTitle>
           {description ? <AlertDialogDescription>{description}</AlertDialogDescription> : null}
         </AlertDialogHeader>
+        {requireMotivo ? (
+          <div className="space-y-1.5">
+            <label className="text-xs text-muted-foreground" htmlFor="confirm-motivo">
+              Motivo *
+            </label>
+            <Input
+              id="confirm-motivo"
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              placeholder={motivoPlaceholder}
+              autoFocus
+            />
+          </div>
+        ) : null}
         <AlertDialogFooter>
           <AlertDialogCancel disabled={loading}>{cancelLabel}</AlertDialogCancel>
           <AlertDialogAction
             variant={confirmVariant}
-            disabled={loading}
+            disabled={loading || !canConfirm}
             onClick={(event) => {
               // Prevent AlertDialog from auto-closing before the async work
               // completes. We close it manually in `handleConfirm`.

--- a/components/shared/row-actions.tsx
+++ b/components/shared/row-actions.tsx
@@ -46,8 +46,11 @@ type ToggleAction = {
  * destructive row actions in the app — do NOT wire `window.confirm`.
  */
 type DeleteAction = {
-  /** Called only after the user confirms. Can be async. */
-  onConfirm: () => void | Promise<void>;
+  /**
+   * Called only after the user confirms. Can be async. Receives the captured
+   * motivo when `requireMotivo` is set (undefined otherwise).
+   */
+  onConfirm: (motivo?: string) => void | Promise<void>;
   /** Menu item label. Defaults to "Eliminar". */
   label?: string;
   /** Dialog title. Defaults to "¿Eliminar registro?". */
@@ -59,6 +62,13 @@ type DeleteAction = {
   confirmDescription?: React.ReactNode;
   /** Confirm button label. Defaults to "Eliminar". */
   confirmLabel?: string;
+  /**
+   * Si true, el diálogo pide un motivo obligatorio (audit trail) y lo pasa
+   * a `onConfirm`. Usado por la iniciativa p2p-cancelaciones.
+   */
+  requireMotivo?: boolean;
+  /** Placeholder del campo de motivo (solo si `requireMotivo`). */
+  motivoPlaceholder?: string;
   disabled?: boolean;
 };
 
@@ -202,6 +212,8 @@ export function RowActions({
             'Esta acción marcará el registro como eliminado. Se preserva el historial para auditoría.'
           }
           confirmLabel={onDelete.confirmLabel ?? 'Eliminar'}
+          requireMotivo={onDelete.requireMotivo}
+          motivoPlaceholder={onDelete.motivoPlaceholder}
         />
       )}
     </>

--- a/supabase/migrations/20260607200000_p2p_motivo_cancelacion_uniforme.sql
+++ b/supabase/migrations/20260607200000_p2p_motivo_cancelacion_uniforme.sql
@@ -1,0 +1,34 @@
+-- Iniciativa p2p-cancelaciones · Fase 4 — uniformar el motivo de cancelación.
+--
+-- Las 6 entidades que YA se cancelan tendrán todas un motivo de cancelación
+-- (audit trail, D1). Estado por entidad antes de esta migración:
+--   · factura  → RPC cxp_factura_cancelar ya guarda motivo_cancelacion ✓
+--   · pago     → RPC cxp_pago_cancelar ya recibe motivo (lo persiste en notas) ✓
+--   · requisición / cotización / orden de compra / partida del costeo → cancelan por
+--     UPDATE directo (deleted_at o estado) SIN registrar motivo.
+--
+-- Esta migración agrega las columnas de audit a esas 4 tablas. El UPDATE de
+-- cancelación de cada módulo (UI) las popula con el motivo capturado en el
+-- <CancelarConMotivoDialog>. Aditivo puro (columnas nullable).
+
+ALTER TABLE erp.requisiciones
+  ADD COLUMN IF NOT EXISTS cancelada_at timestamptz,
+  ADD COLUMN IF NOT EXISTS cancelada_por uuid,
+  ADD COLUMN IF NOT EXISTS motivo_cancelacion text;
+
+ALTER TABLE erp.cotizaciones
+  ADD COLUMN IF NOT EXISTS cancelada_at timestamptz,
+  ADD COLUMN IF NOT EXISTS cancelada_por uuid,
+  ADD COLUMN IF NOT EXISTS motivo_cancelacion text;
+
+ALTER TABLE erp.ordenes_compra
+  ADD COLUMN IF NOT EXISTS cancelada_at timestamptz,
+  ADD COLUMN IF NOT EXISTS cancelada_por uuid,
+  ADD COLUMN IF NOT EXISTS motivo_cancelacion text;
+
+ALTER TABLE erp.presupuesto_partidas
+  ADD COLUMN IF NOT EXISTS cancelada_at timestamptz,
+  ADD COLUMN IF NOT EXISTS cancelada_por uuid,
+  ADD COLUMN IF NOT EXISTS motivo_cancelacion text;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Qué

Cierra la iniciativa **p2p-cancelaciones**. Las **6 entidades del P2P que ya se cancelaban** ahora capturan un **motivo obligatorio** (audit trail · D1), uniforme en todo el flujo: requisición, cotización, orden de compra, partida del costeo, factura y pago.

## Por qué

Antes el motivo solo se pedía en pago (y era opcional). Req/Cot/OC/partida cancelaban por UPDATE directo sin registrar nada; la factura ni siquiera tenía UI de cancelación. Esta fase deja una sola UX de "cancelar con motivo" en las 6.

## Cambios

**Primitivos compartidos**
- `ConfirmDialog` + `RowActions`: nuevo flag `requireMotivo` (input de motivo obligatorio que se pasa a `onConfirm(motivo)`). Backward-compatible — `() => void` sigue asignable.

**Las 6 entidades**
- **Requisición / OC / Cotización / Partida (costeo)**: el UPDATE de cancelación ahora popula `cancelada_at` + `motivo_cancelacion`. Cotización monta el `CancelarConMotivoDialog` compartido (antes era una X directa sin motivo).
- **Factura**: nueva acción **"Cancelar factura"** en el drawer (solo admin · D2, y solo antes de programar pagos), vía RPC `cxp_factura_cancelar` que ya existía pero **no tenía UI**. El RPC bloquea si hay pagos aplicados (D3) y escribe a `core.audit_log`.
- **Pago**: el dialog custom se reemplaza por el `CancelarConMotivoDialog` compartido — motivo ahora **obligatorio** (antes opcional), consistente con el resto. −60 líneas.

**DB**
- Migración `20260607200000`: `cancelada_at`/`cancelada_por`/`motivo_cancelacion` en `erp.requisiciones`/`cotizaciones`/`ordenes_compra`/`presupuesto_partidas`. Aditivo puro (columnas nullable). Ya aplicada a prod + registrada en `schema_migrations`; SCHEMA_REF/types ya reflejaban las columnas (regenerados por una sesión previa).

## Verificación

- ✅ typecheck · lint (0 errores) · format:check · test:run (1315) · schema:check (sin drift, las columnas ya viven en `SCHEMA_REF.md`)
- Rebased sobre `origin/main` (#725/#726).

🤖 Generated with [Claude Code](https://claude.com/claude-code)