### PR TITLE
fix(dilesa-ventas): regresarAFase limpia pipeline + libera unidad al volver a Fase 1

### DIFF
--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -329,6 +329,45 @@ async function regresarAFaseInner(
     .eq('id', ventaId);
   if (upErr) return { ok: false, error: upErr.message };
 
+  // Limpiar el pipeline visual: borrar las filas de `venta_fases` con
+  // posición > faseDestino. Sin esto, el detalle sigue mostrando las
+  // fases posteriores como completadas y el botón "Capturar Fase N"
+  // no aparece (porque `alcanzada=true` deshabilita `puedeCapturar`).
+  // Soft-delete para preservar bitácora histórica.
+  const { error: fasesErr } = await admin
+    .schema('dilesa')
+    .from('venta_fases')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('venta_id', ventaId)
+    .gt('posicion', faseDestino)
+    .is('deleted_at', null);
+  if (fasesErr) {
+    console.warn('[regresarAFase] no se pudieron limpiar venta_fases', {
+      ventaId,
+      error: fasesErr.message,
+    });
+  }
+
+  // Si regresamos a Fase 1 y la unidad estaba `asignada`, liberarla.
+  // Beto: regresar 2→1 funcionalmente es "soltar la asignación para
+  // poder re-asignar" (a la misma unidad u otra desde "+ Crear nueva
+  // solicitud para este cliente"). Idempotente (.eq('estado','asignada')).
+  if (faseDestino === 1 && v.unidad_id) {
+    const { error: unidadErr } = await admin
+      .schema('dilesa')
+      .from('unidades')
+      .update({ estado: 'terminada' })
+      .eq('id', v.unidad_id)
+      .eq('estado', 'asignada');
+    if (unidadErr) {
+      console.warn('[regresarAFase] no se pudo liberar unidad', {
+        ventaId,
+        unidadId: v.unidad_id,
+        error: unidadErr.message,
+      });
+    }
+  }
+
   // Si regresamos a Fase 1, mandamos el email de bienvenida otra vez
   // para que el cliente sepa que su solicitud está activa con plazo nuevo.
   // (Idempotencia: ya limpiamos notif_hold_creado_at arriba.)


### PR DESCRIPTION
## Problema

Visto por Beto al regresar una venta de Fase 2 (Asignada) a Fase 1 (Solicitud):
1. El pipeline visual seguía mostrando Fase 2 como completada (con la fecha original).
2. El botón "Capturar Fase 2" / "Autorizar asignación" no reaparecía.
3. La unidad seguía como `asignada` → no podía "volver a asignar".

## Root cause

`regresarAFaseInner` (`app/dilesa/ventas/[id]/actions.ts`):
- Solo actualizaba `ventas.fase_actual` + `fase_posicion`.
- NO tocaba las filas de `dilesa.venta_fases` con `posicion > faseDestino`.
- NO liberaba la unidad cuando `faseDestino === 1`.

El detalle deriva `alcanzada = !!f?.fecha` desde `venta_fases`. Como la fila de Fase 2 seguía ahí con su fecha de cierre original, el pipeline la pintaba completada y `puedeCapturar = !alcanzada && ...` quedaba en `false`.

## Fix

Dos cambios mínimos en `regresarAFaseInner`:

- Soft-delete (`deleted_at = now()`) de las filas de `venta_fases` con `posicion > faseDestino`. Mantiene bitácora histórica.
- Si `faseDestino === 1` y la unidad estaba `asignada`, pasa a `terminada` (idempotente con `.eq('estado','asignada')`).

Beto eligió "Liberar unidad + permitir re-asignar a otra" — el operador puede crear nueva solicitud para el mismo cliente (misma unidad u otra), o cualquier otro cliente puede tomar esa unidad. Patrón consistente con `desasignarVenta` (PR #670) y el cron de expiración (PR #713).

## Cleanup manual de venta ya en limbo

Hay 1 venta (`e427be56-d630-44da-88f2-2872b8cf1740`, M9-L1-LDS) que ya está en este limbo de antes del fix. Cuando autorices, corro el cleanup manual (soft-delete del pipeline > 1 + liberar la unidad). Post-merge, las ventas que se regresen usarán la lógica nueva automáticamente.

## Auto-merge

Backend fix (server action). Activo auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)