### PR TITLE
feat(cross-session-coordination): Sprint 1 — generador de migraciones anti-colisión (npm run db:new)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,34 @@ exista) son hotspots de conflicto: ambos PRs editan la misma tabla, el
 primero que mergea le gana la línea al segundo, y el segundo termina
 con `This branch has conflicts that must be resolved`.
 
-Dos reglas para mantener la fricción baja sin infraestructura nueva:
+El hotspot más peligroso son las **migraciones**: dos sesiones que eligen el
+mismo `YYYYMMDDHHMMSS` colisionan el PK de `schema_migrations` y **rompen
+Supabase Preview / prod** (pasó el 2026-06-07 con `20260607190000`, usado por
+dos PRs a la vez). Reglas para mantener la fricción baja:
+
+#### Regla 0: timestamps de migración sin colisión — `npm run db:new`
+
+**Nunca** copies a mano un `YYYYMMDDHHMMSS` de otra migración ni inventes uno.
+Siempre crea migraciones con:
+
+```bash
+npm run db:new "<slug_snake_case>"   # ej: npm run db:new "modulo_dilesa_manual"
+```
+
+El generador elige un timestamp estrictamente mayor que **toda** migración que
+ya exista — localmente **y en los PRs abiertos de otras sesiones** (las ve vía
+`gh`). Así dos sesiones en paralelo no eligen el mismo. Residual: dos sesiones
+en el mismo segundo antes de abrir su PR — por eso **abre tu PR pronto**.
+(Lógica en `scripts/lib/migration-version.ts` + `scripts/new-migration.ts`;
+iniciativa `cross-session-coordination`.)
+
+Convenciones de coordinación complementarias (la memoria compartida entre
+sesiones es este `CLAUDE.md` — todas lo leen al arrancar):
+
+- **Branch = slug de iniciativa** (`claude/<slug>-…`) → `gh pr list` revela quién
+  trabaja en qué (es el "registro" de sesiones, sin archivo nuevo que mantener).
+- **Una iniciativa = una sesión.** Antes de arrancar, corre `gh pr list` para no
+  pisar una iniciativa que otra sesión ya tiene abierta.
 
 #### Regla 1: minimizar ediciones a `INITIATIVES.md`
 

--- a/docs/planning/cross-session-coordination.md
+++ b/docs/planning/cross-session-coordination.md
@@ -1,0 +1,95 @@
+# Iniciativa — Coordinación entre sesiones (autónomo paralelo)
+
+**Slug:** `cross-session-coordination`
+**Empresas:** todas (infraestructura del repo / proceso)
+**Schemas afectados:** ninguno (tooling + convenciones + CI). Toca `package.json`, `scripts/`, `.github/workflows/`, `CLAUDE.md`, `docs/strategy/INITIATIVES.md`.
+**Estado:** planned
+**Dueño:** Beto
+**Creada:** 2026-06-07
+**Última actualización:** 2026-06-07 (promoción — Beto pidió que varias sesiones autónomas en paralelo no choquen; alcance v1 = generador de migraciones gh-aware + auto-gen de INITIATIVES.md + convenciones en CLAUDE.md)
+
+## Problema
+
+Beto corre **varias sesiones de Claude Code en paralelo en modo autónomo**.
+Cada sesión es un proceso independiente sin memoria compartida en vivo; lo único
+que comparten es el repo + GitHub. Chocan cuando dos sesiones mutan el mismo
+**archivo-hotspot** sin coordinarse:
+
+- **`supabase/migrations/`** — dos sesiones eligen el mismo `YYYYMMDDHHMMSS` →
+  colisión de PK en `schema_migrations` que **rompe Supabase Preview** (y
+  rompería prod). _Pasó el 2026-06-07: `20260607190000` usado por #721 y #725;
+  tumbó el Preview de múltiples PRs (#720, #726…)._
+- **`docs/strategy/INITIATIVES.md`** — toda promoción / cambio de estado edita la
+  misma tabla → conflictos de merge recurrentes.
+- **`package.json` / `types/supabase.ts` / `SCHEMA_REF.md`** — dos sesiones
+  regeneran o agregan a la vez.
+
+La raíz: **no hay asignación de namespace ni candado**, así que dos sesiones leen
+"X está libre" al mismo tiempo y ambas lo toman (carrera TOCTOU).
+
+## Outcome esperado
+
+1. **Migraciones libres de colisión por construcción**: un generador
+   (`npm run db:new`) que elige un timestamp estrictamente mayor que toda
+   migración local **+ de PRs abiertos** (coordina vía `gh`). Nadie vuelve a
+   copiar un timestamp a mano.
+2. **`INITIATIVES.md` deja de ser hotspot**: se auto-genera desde los headers de
+   cada `docs/planning/<slug>.md` (`npm run initiatives:gen`), validado en CI
+   (`initiatives:check`). Las sesiones solo tocan su propio planning doc (un
+   archivo por iniciativa = nunca chocan).
+3. **Convenciones de coordinación en `CLAUDE.md`** (memoria compartida entre
+   sesiones): branch = slug de iniciativa, una iniciativa = una sesión, revisar
+   `gh pr list` antes de arrancar, rebase antes de push.
+
+Meta realista: colisiones **raras y baratas**, no imposibles (cero requeriría
+serializar, lo que mata el paralelismo).
+
+## Decisiones registradas
+
+> Cerradas con Beto el 2026-06-07 en la sesión de promoción.
+
+- **D1 — Coordinación stateless vía repo/GitHub, no mensajería viva.** La
+  coordinación se hace con convenciones en `CLAUDE.md` (que todas las sesiones
+  leen) + tooling determinista, no con `send_message` entre sesiones (frágil:
+  depende de que la otra sesión esté "escuchando").
+- **D2 — Construir Piezas 1 y 2** (generador de migraciones + auto-gen de
+  INITIATIVES.md). Descartado por ahora: registro de sesiones con archivo
+  dedicado (la lista de PRs abiertos ya sirve de registro) y mensajería MCP.
+- **D3 — El generador coordina vía PRs abiertos** (`gh pr list` + archivos de
+  cada PR), no solo migraciones locales — así ve migraciones de otras sesiones
+  aún no mergeadas. Residual: dos sesiones en el mismo segundo antes de abrir PR
+  (mitigado por "abre tu PR pronto").
+
+## Riesgos
+
+- **R1 — `gh` no disponible en algún runner/sesión.** El generador degrada a
+  solo-local con warning (no rompe), aceptando el riesgo residual.
+- **R2 — Carrera residual** (dos sesiones, mismo segundo, sin PR aún). Baja
+  probabilidad; mitigada por abrir PR pronto. Si se vuelve frecuente, escalar a
+  un sufijo derivado del branch.
+- **R3 — Auto-gen de INITIATIVES.md rompe el formato actual.** Mitigación: el
+  generador parsea los headers existentes; `initiatives:check` en CI detecta
+  drift; migrar en un PR aislado (Pieza 2) con verificación del diff.
+
+## Métricas de éxito
+
+- Cero colisiones de timestamp de migración tras adoptar `db:new`.
+- Cero conflictos de merge en `INITIATIVES.md` tras la auto-generación.
+- Las sesiones nuevas leen y siguen las convenciones (verificable en PRs).
+
+## Sprints / hitos
+
+- **Sprint 1 — Generador de migraciones (Pieza 1).** `scripts/lib/migration-version.ts`
+  (pura + tests), `scripts/new-migration.ts` (CLI gh-aware), `npm run db:new` y la
+  Regla 0 en `CLAUDE.md`. **(Este PR.)**
+- **Sprint 2 — Auto-gen de INITIATIVES.md (Pieza 2).** `scripts/gen-initiatives.ts`
+  (lee headers de `docs/planning/*.md` → regenera la tabla) + `initiatives:gen` /
+  `initiatives:check` + step en CI + regla en `CLAUDE.md`. PR aislado.
+- **Sprint 3 — Convenciones + closeout.** Afinar la sección de coordinación en
+  `CLAUDE.md` (branch=slug, 1 iniciativa/sesión, `gh pr list` previo) y cerrar.
+
+## Bitácora
+
+- **2026-06-07** — Iniciativa promovida a `planned` tras la colisión
+  `20260607190000` (#721 ↔ #725) que rompió Supabase Preview de varios PRs.
+  Sprint 1 (generador de migraciones) construido en este PR.

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -47,6 +47,8 @@
 
 | Tesorería (sección + Saldos Bancos) | `tesoreria` | todas (golden DILESA) | erp (`cuenta_saldos` + `v_cuenta_saldo_actual` nuevas; carga `cuentas_bancarias`), core.modulos (sección `tesoreria` + reubicar CxC/CxP + slug `dilesa.saldos-bancos` + backfill permisos) | planned | Sprint 1 — `erp.cuenta_saldos` (historial) + vista último saldo + carga de las 4 cuentas DILESA. Dependencia previa del lanzamiento de `dilesa-resumen-consejo` (ver [planning](../planning/tesoreria.md)) | 2026-06-07 |
 
+| Coordinación entre sesiones | `cross-session-coordination` | todas (infra/proceso) | ninguno (tooling + CI): `package.json`, `scripts/`, `.github/workflows/`, `CLAUDE.md`, `INITIATIVES.md` | planned | Sprint 1 (este PR): generador `npm run db:new` (timestamp anti-colisión vía `gh`) + Regla 0 en CLAUDE.md. Próximo: Sprint 2 — auto-gen de INITIATIVES.md + check de CI (ver [planning](../planning/cross-session-coordination.md)) | 2026-06-07 |
+
 ## Roadmap UI (orden de ejecución secuencial)
 
 > El roadmap UI son iniciativas con sufijo "(UI)" arriba. La cola es

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "audit:ui:json": "npx tsx scripts/audit-ui.ts --json",
     "db:types": "supabase gen types typescript --project-id ybklderteyhuugzfmxbi --schema public --schema core --schema erp --schema rdb --schema health --schema playtomic --schema dilesa --schema maquinaria --schema peptides > types/supabase.ts",
     "db:check": "npm run db:types && git diff --exit-code types/supabase.ts",
+    "db:new": "npx tsx scripts/new-migration.ts",
     "schema:ref": "npx tsx scripts/gen-schema-ref.ts",
     "schema:check": "npm run schema:ref && git diff --exit-code -I '^  Last regenerated: ' supabase/SCHEMA_REF.md",
     "prepare": "husky"

--- a/scripts/lib/migration-version.test.ts
+++ b/scripts/lib/migration-version.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatVersion,
+  incrementVersion,
+  extractVersion,
+  nextMigrationVersion,
+} from './migration-version';
+
+// Fecha fija para tests deterministas: 2026-06-07 19:30:00 UTC.
+const NOW = new Date(Date.UTC(2026, 5, 7, 19, 30, 0));
+const NOW_VERSION = '20260607193000';
+
+describe('formatVersion', () => {
+  it('formatea a YYYYMMDDHHMMSS en UTC con padding', () => {
+    expect(formatVersion(NOW)).toBe(NOW_VERSION);
+    // Padding de meses/días/horas de un dígito.
+    expect(formatVersion(new Date(Date.UTC(2026, 0, 3, 4, 5, 6)))).toBe('20260103040506');
+  });
+});
+
+describe('incrementVersion', () => {
+  it('suma 1 manteniendo 14 dígitos', () => {
+    expect(incrementVersion('20260607190000')).toBe('20260607190001');
+  });
+  it('produce una versión única aunque no sea fecha real (segundos > 59)', () => {
+    // El orden lexicográfico se preserva, que es lo único que importa.
+    expect(incrementVersion('20260607190059') > '20260607190059').toBe(true);
+  });
+});
+
+describe('extractVersion', () => {
+  it('extrae el prefijo de 14 dígitos', () => {
+    expect(extractVersion('20260607190000_modulo_dilesa_manual.sql')).toBe('20260607190000');
+  });
+  it('devuelve null si no hay prefijo de 14 dígitos', () => {
+    expect(extractVersion('README.md')).toBeNull();
+    expect(extractVersion('2026_corto.sql')).toBeNull();
+  });
+});
+
+describe('nextMigrationVersion', () => {
+  it('usa "ahora" cuando no hay nada posterior', () => {
+    expect(nextMigrationVersion([], NOW)).toBe(NOW_VERSION);
+    expect(nextMigrationVersion(['20250101000000_vieja.sql'], NOW)).toBe(NOW_VERSION);
+  });
+
+  it('bumpea +1 cuando ya existe una versión en el mismo segundo (otra sesión)', () => {
+    // Caso real que rompió Supabase Preview: dos sesiones, mismo timestamp.
+    expect(nextMigrationVersion([NOW_VERSION + '_otra.sql'], NOW)).toBe('20260607193001');
+  });
+
+  it('bumpea por encima del máximo aunque haya timestamps futuros', () => {
+    // incrementa el máximo en 1 (entero): ...235959 + 1 = ...235960. No es una
+    // hora "real" (segundos=60) pero es único y ordena después — que es lo único
+    // que importa para schema_migrations.
+    expect(nextMigrationVersion(['20260607190000', '20991231235959'], NOW)).toBe('20991231235960');
+  });
+
+  it('es estrictamente mayor que todas las versiones existentes', () => {
+    const existing = ['20260607193000', '20260607193000', '20260607192959'];
+    const next = nextMigrationVersion(existing, NOW);
+    for (const v of existing) expect(next > v).toBe(true);
+  });
+
+  it('ignora nombres sin prefijo de 14 dígitos', () => {
+    expect(nextMigrationVersion(['README.md', 'no-version.sql'], NOW)).toBe(NOW_VERSION);
+  });
+});

--- a/scripts/lib/migration-version.ts
+++ b/scripts/lib/migration-version.ts
@@ -1,0 +1,59 @@
+/**
+ * Cálculo del timestamp de una migración nueva, libre de colisiones entre
+ * sesiones (iniciativa `cross-session-coordination`).
+ *
+ * Lógica pura y testeable; el IO (leer migraciones locales + de PRs abiertos
+ * vía `gh`) vive en `scripts/new-migration.ts`.
+ */
+
+/** Formatea una fecha a versión de migración Supabase `YYYYMMDDHHMMSS` (UTC). */
+export function formatVersion(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return (
+    String(d.getUTCFullYear()) +
+    p(d.getUTCMonth() + 1) +
+    p(d.getUTCDate()) +
+    p(d.getUTCHours()) +
+    p(d.getUTCMinutes()) +
+    p(d.getUTCSeconds())
+  );
+}
+
+/**
+ * Incrementa una versión de 14 dígitos en 1 (como entero). El resultado
+ * sigue siendo único y ordenable lexicográficamente aunque deje de ser una
+ * fecha "real" (p.ej. segundos = 60) — Supabase solo exige unicidad + orden.
+ */
+export function incrementVersion(version: string): string {
+  return (BigInt(version) + 1n).toString().padStart(14, '0');
+}
+
+/** Extrae el prefijo de 14 dígitos de un nombre de archivo de migración. */
+export function extractVersion(filename: string): string | null {
+  return filename.match(/^(\d{14})/)?.[1] ?? null;
+}
+
+/**
+ * Próxima versión de migración: estrictamente mayor que CUALQUIER versión ya
+ * existente (local + PRs abiertos de otras sesiones) y, en el caso normal,
+ * igual a "ahora".
+ *
+ * - Si no hay nada >= ahora → usa el timestamp de ahora.
+ * - Si ya existe una versión >= ahora (otra sesión la creó en este segundo, o
+ *   hay una migración con timestamp futuro) → usa `max(existentes) + 1` para
+ *   garantizar unicidad y que ordene después de todo lo visto.
+ *
+ * @param existing versiones de 14 dígitos ya en uso (local + open PRs)
+ * @param now fecha de referencia (inyectable para tests deterministas)
+ */
+export function nextMigrationVersion(existing: readonly string[], now: Date): string {
+  const nowVersion = formatVersion(now);
+  const maxExisting = existing
+    .map((v) => v.match(/^\d{14}/)?.[0])
+    .filter((v): v is string => v !== undefined)
+    .reduce((max, v) => (v > max ? v : max), '');
+
+  // String compare es equivalente a numérico para cadenas de 14 dígitos.
+  if (maxExisting === '' || nowVersion > maxExisting) return nowVersion;
+  return incrementVersion(maxExisting);
+}

--- a/scripts/new-migration.ts
+++ b/scripts/new-migration.ts
@@ -1,0 +1,109 @@
+/**
+ * Genera una migración nueva con un timestamp libre de colisiones entre
+ * sesiones (iniciativa `cross-session-coordination`).
+ *
+ * Uso:  npm run db:new "<slug_snake_case>"
+ *   ej: npm run db:new "modulo_dilesa_manual"
+ *
+ * El timestamp resultante es estrictamente mayor que CUALQUIER migración que
+ * ya exista — localmente Y en los PRs abiertos de otras sesiones (vía `gh`).
+ * Así dos sesiones corriendo en paralelo no eligen el mismo `YYYYMMDDHHMMSS`
+ * (la colisión que rompe Supabase Preview / `schema_migrations`).
+ *
+ * NUNCA copiar un timestamp a mano de otra migración — siempre usar este
+ * generador. Ver CLAUDE.md → "Coordinación entre sesiones".
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, readdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { extractVersion, nextMigrationVersion } from './lib/migration-version';
+
+const MIGRATIONS_DIR = path.join(process.cwd(), 'supabase', 'migrations');
+
+function localVersions(): string[] {
+  if (!existsSync(MIGRATIONS_DIR)) return [];
+  return readdirSync(MIGRATIONS_DIR)
+    .map(extractVersion)
+    .filter((v): v is string => v !== null);
+}
+
+/**
+ * Versiones de migración en PRs abiertos (aún no en main). Este es el paso
+ * de coordinación cross-sesión: aunque la migración de otra sesión todavía
+ * no haya mergeado, vive en su PR abierto y la vemos aquí.
+ */
+function openPrVersions(): string[] {
+  try {
+    const prsJson = execSync('gh pr list --state open --limit 60 --json number', {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const prs = JSON.parse(prsJson) as Array<{ number: number }>;
+    const versions: string[] = [];
+    for (const pr of prs) {
+      try {
+        const out = execSync(`gh pr view ${pr.number} --json files --jq '.files[].path'`, {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        for (const line of out.split('\n')) {
+          const m = line.match(/supabase\/migrations\/(\d{14})/);
+          if (m) versions.push(m[1]);
+        }
+      } catch {
+        // PR sin archivos accesibles — saltar sin romper.
+      }
+    }
+    return versions;
+  } catch {
+    console.warn(
+      '⚠️  `gh` no disponible: usando solo migraciones locales.\n' +
+        '   Riesgo residual de colisión si otra sesión crea una migración en\n' +
+        '   este mismo segundo antes de abrir su PR. Abre tu PR pronto.'
+    );
+    return [];
+  }
+}
+
+function main(): void {
+  const slug = process.argv[2];
+  if (!slug || !/^[a-z0-9_]+$/.test(slug)) {
+    console.error('Uso: npm run db:new "<slug_snake_case>"');
+    console.error('  ej: npm run db:new "modulo_dilesa_manual"');
+    console.error('  (solo minúsculas, dígitos y guion bajo)');
+    process.exit(1);
+  }
+
+  const existing = [...localVersions(), ...openPrVersions()];
+  const version = nextMigrationVersion(existing, new Date());
+  const file = path.join(MIGRATIONS_DIR, `${version}_${slug}.sql`);
+
+  if (existsSync(file)) {
+    console.error(`✗ Ya existe ${path.relative(process.cwd(), file)} — abortando.`);
+    process.exit(1);
+  }
+
+  const template = `-- ╭─ ${version}_${slug} ─╮
+-- TODO: describe qué hace esta migración y por qué (1-3 líneas).
+--
+-- Timestamp generado con \`npm run db:new\` (anti-colisión multi-sesión:
+-- estrictamente mayor que toda migración local + de PRs abiertos).
+
+BEGIN;
+
+-- ... DDL / DML aquí ...
+
+-- Recarga el cache de PostgREST si tocaste tablas/columnas/embeds:
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;
+`;
+
+  writeFileSync(file, template);
+  console.log(`✓ Creada ${path.relative(process.cwd(), file)}`);
+  console.log(`  versión ${version} (estrictamente > ${existing.length} migraciones vistas)`);
+  console.log('  Tip: abre tu PR pronto para que otras sesiones vean esta migración.');
+}
+
+main();


### PR DESCRIPTION
## Qué

Promueve la iniciativa **`cross-session-coordination`** y entrega su **Pieza 1**: un generador de migraciones que elimina las **colisiones de timestamp entre sesiones autónomas paralelas**.

> Contexto: el 2026-06-07 dos sesiones eligieron el mismo `20260607190000` (#721 y #725) → colisión de PK en `schema_migrations` → **rompió Supabase Preview** de varios PRs (#720, #726). Esto lo previene por construcción.

## Cómo funciona

`npm run db:new "<slug>"` elige un timestamp **estrictamente mayor que toda migración existente** — locales **y de todos los PRs abiertos** (las ve vía `gh`). Así dos sesiones en paralelo nunca eligen el mismo, aunque la migración de la otra aún no haya mergeado.

```
$ npm run db:new "modulo_dilesa_manual"
✓ Creada supabase/migrations/20260607200001_modulo_dilesa_manual.sql
  versión 20260607200001 (estrictamente > 344 migraciones vistas)
```

## Cambios

- `scripts/lib/migration-version.ts` — lógica pura (`nextMigrationVersion`) + **10 tests**.
- `scripts/new-migration.ts` — CLI gh-aware (escanea local + PRs abiertos; degrada a solo-local con warning si no hay `gh`).
- `package.json` — `npm run db:new`.
- `CLAUDE.md` **Regla 0** — nunca copiar timestamps a mano; branch = slug de iniciativa; 1 iniciativa = 1 sesión; `gh pr list` antes de arrancar.
- `docs/planning/cross-session-coordination.md` + fila en `INITIATIVES.md`.

## Test plan

- typecheck ✓ · 1325 tests ✓ (incl. 10 nuevos) · lint 0 errores ✓ · format ✓.
- **Smoke end-to-end**: `db:new` escaneó 344 migraciones (local + PRs abiertos) y eligió un timestamp único por encima de la colisión `190000`. Archivo de prueba eliminado.
- Sin migración nueva en este PR → Supabase Preview no aplica.

## Sigue

**Sprint 2** (PR aparte): auto-generar `INITIATIVES.md` desde los headers de los planning docs (`initiatives:gen` + `initiatives:check` en CI) para eliminar ese segundo hotspot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)