### PR TITLE
feat(dilesa-resumen-consejo): plantilla del correo al Consejo + 7 secciones (S1)

### DIFF
--- a/lib/dilesa/resumen-consejo-email.test.ts
+++ b/lib/dilesa/resumen-consejo-email.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fmtMoney,
+  fmtPct,
+  fmtInt,
+  fechaTituloCST,
+  renderResumenConsejoHtml,
+  type ResumenConsejoData,
+} from './resumen-consejo-email';
+
+const EMPTY: ResumenConsejoData = {
+  saldos: [],
+  avances: [],
+  margen: [],
+  inventario: [],
+  tuberia: [],
+  asignaciones: [],
+  contratistas: [],
+};
+
+describe('formato', () => {
+  it('fmtMoney formatea MXN con 2 decimales y devuelve — para null', () => {
+    expect(fmtMoney(829155.15)).toContain('829,155.15');
+    expect(fmtMoney(0)).toContain('0.00');
+    expect(fmtMoney(null)).toBe('—');
+    expect(fmtMoney(undefined)).toBe('—');
+  });
+
+  it('fmtPct usa 2 decimales y — para null', () => {
+    expect(fmtPct(60.4)).toBe('60.40%');
+    expect(fmtPct(null)).toBe('—');
+  });
+
+  it('fmtInt devuelve 0 para null', () => {
+    expect(fmtInt(5)).toBe('5');
+    expect(fmtInt(null)).toBe('0');
+    expect(fmtInt(0)).toBe('0');
+  });
+});
+
+describe('fechaTituloCST', () => {
+  it('aplica el offset CST (UTC-6) al título', () => {
+    // 2026-06-07T02:00:00Z → en CST (UTC-6) es 2026-06-06 20:00 → "6 de junio de 2026"
+    expect(fechaTituloCST(new Date('2026-06-07T02:00:00Z'))).toBe('6 de junio de 2026');
+    // 2026-06-07T18:00:00Z → CST 12:00 mismo día → "7 de junio de 2026"
+    expect(fechaTituloCST(new Date('2026-06-07T18:00:00Z'))).toBe('7 de junio de 2026');
+  });
+});
+
+describe('renderResumenConsejoHtml', () => {
+  it('renderiza el título y la fecha', () => {
+    const html = renderResumenConsejoHtml(EMPTY, { fechaTitulo: '7 de junio de 2026' });
+    expect(html).toContain('Resumen Diario Operación Dilesa');
+    expect(html).toContain('7 de junio de 2026');
+  });
+
+  it('omite el bloque de Saldos Bancos cuando no hay saldos', () => {
+    const html = renderResumenConsejoHtml(EMPTY, { fechaTitulo: 'x' });
+    expect(html).not.toContain('Resumen Saldos Bancos');
+  });
+
+  it('incluye el bloque de Saldos Bancos cuando hay saldos', () => {
+    const html = renderResumenConsejoHtml(
+      {
+        ...EMPTY,
+        saldos: [
+          { nombre: 'BBVA Bancomer', banco: 'BBVA', saldo: 404880.3, fecha_saldo: '2026-06-07' },
+        ],
+      },
+      { fechaTitulo: 'x' }
+    );
+    expect(html).toContain('Resumen Saldos Bancos');
+    expect(html).toContain('BBVA Bancomer');
+    expect(html).toContain('404,880.30');
+    expect(html).toContain('07/06/2026');
+  });
+
+  it('renderiza el margen con costo total y % formateados', () => {
+    const html = renderResumenConsejoHtml(
+      {
+        ...EMPTY,
+        margen: [
+          {
+            nombre: 'LDV-RMA',
+            valor_comercial: 2094000,
+            costo_total: 829155.15,
+            utilidad: 1264844.85,
+            margen_pct: 60.4,
+          },
+        ],
+      },
+      { fechaTitulo: 'x' }
+    );
+    expect(html).toContain('Análisis de Margen');
+    expect(html).toContain('LDV-RMA');
+    expect(html).toContain('829,155.15');
+    expect(html).toContain('60.40%');
+  });
+
+  it('renderiza la tubería con clientes y valor por fase', () => {
+    const html = renderResumenConsejoHtml(
+      {
+        ...EMPTY,
+        tuberia: [
+          { fase: 'Entregada', clientes: 1080, valor: 1052158615 },
+          { fase: 'Asignada', clientes: 2, valor: 2789500 },
+        ],
+      },
+      { fechaTitulo: 'x' }
+    );
+    expect(html).toContain('Tubería');
+    expect(html).toContain('Entregada');
+    expect(html).toContain('1,052,158,615.00');
+  });
+
+  it('muestra "Sin datos." en una sección vacía pero presente', () => {
+    const html = renderResumenConsejoHtml(EMPTY, { fechaTitulo: 'x' });
+    // Avances siempre se renderiza (no es opcional); sin filas muestra el placeholder
+    expect(html).toContain('Resumen Avances Proyectos');
+    expect(html).toContain('Sin datos.');
+  });
+});

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -1,0 +1,567 @@
+/**
+ * Resumen Diario Operación DILESA — correo al Consejo (cutover Coda → BSOP).
+ *
+ * Recrea el correo "Resumen Diario Operación Dilesa 🏘️" que Coda enviaba a
+ * `consejo@dilesa.mx`. Iniciativa `dilesa-resumen-consejo`.
+ *
+ * Diseño: las funciones de render son PURAS (reciben data, devuelven HTML) para
+ * testearlas sin DB. `fetchResumenConsejoData` arma la data desde las vistas.
+ * El bloque de Saldos Bancos (#1) es opcional — se enchufa cuando la iniciativa
+ * `tesoreria` tenga saldos capturados (vista `erp.v_cuenta_saldo_actual`).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// ── Tipos por sección ───────────────────────────────────────────────────────
+
+export type SaldoBancoRow = {
+  nombre: string;
+  banco: string | null;
+  saldo: number | null;
+  fecha_saldo: string | null;
+};
+
+export type AvanceRow = {
+  proyecto: string;
+  avance_urb_pct: number | null;
+  avance_const_pct: number | null;
+  avance_vts_pct: number | null;
+  lotes_residenciales: number;
+  casas_terminadas: number;
+  casas_en_construccion: number;
+  parque_disponible: number;
+  ticket_promedio: number | null;
+};
+
+export type MargenRow = {
+  nombre: string;
+  valor_comercial: number | null;
+  costo_total: number | null;
+  utilidad: number | null;
+  margen_pct: number | null;
+};
+
+export type InventarioRow = {
+  nombre: string;
+  inventario_construccion: number;
+  inventario_terminado: number;
+  en_inventario: number;
+  inventario_asignado: number;
+  inventario_disponible: number;
+};
+
+export type TuberiaRow = {
+  fase: string;
+  clientes: number;
+  valor: number;
+};
+
+export type AsignacionRow = {
+  nombre: string;
+  asignaciones_mes: number;
+  monto_asignaciones: number;
+  escrituras_mes: number;
+  monto_escrituras: number;
+};
+
+export type ContratistaRow = {
+  contratista: string;
+  estimaciones: number;
+  monto_bruto: number;
+  retencion: number;
+  monto_neto: number;
+};
+
+export type ResumenConsejoData = {
+  saldos: SaldoBancoRow[]; // vacío hasta que tesoreria capture saldos
+  avances: AvanceRow[];
+  margen: MargenRow[];
+  inventario: InventarioRow[];
+  tuberia: TuberiaRow[];
+  asignaciones: AsignacionRow[];
+  contratistas: ContratistaRow[];
+};
+
+// ── Formato ─────────────────────────────────────────────────────────────────
+
+export function fmtMoney(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return n.toLocaleString('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export function fmtPct(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return `${Number(n).toFixed(2)}%`;
+}
+
+export function fmtInt(n: number | null | undefined): string {
+  if (n == null) return '0';
+  return String(n);
+}
+
+function fmtShortDate(d: string | null | undefined): string {
+  if (!d) return '—';
+  // d es ISO date (YYYY-MM-DD) — formatear sin TZ shift
+  const [y, m, day] = d.slice(0, 10).split('-');
+  if (!y || !m || !day) return d;
+  return `${day}/${m}/${y}`;
+}
+
+// ── Render (puro) ────────────────────────────────────────────────────────────
+
+const TH =
+  'padding:8px 10px;text-align:left;font-size:12px;color:#475569;font-weight:600;border-bottom:2px solid #e2e8f0;white-space:nowrap;';
+const TD = 'padding:8px 10px;border-bottom:1px solid #e2e8f0;font-size:12px;color:#1e293b;';
+const TD_NUM = `${TD}text-align:right;white-space:nowrap;`;
+
+type Col = { label: string; align?: 'left' | 'right' };
+
+/** Tabla genérica con encabezado de sección. `rows` ya vienen formateadas. */
+export function renderSection(title: string, cols: Col[], rows: string[][]): string {
+  if (rows.length === 0) {
+    return `
+    <div style="padding:16px 32px 4px;">
+      <h2 style="margin:0 0 4px;font-size:15px;font-weight:700;color:#1a1a2e;">${title}</h2>
+      <p style="margin:0;font-size:12px;color:#94a3b8;">Sin datos.</p>
+    </div>`;
+  }
+  const headCells = cols
+    .map(
+      (c) => `<th style="${c.align === 'right' ? TH + 'text-align:right;' : TH}">${c.label}</th>`
+    )
+    .join('');
+  const bodyRows = rows
+    .map(
+      (r) =>
+        `<tr>${r
+          .map((cell, i) => `<td style="${cols[i]?.align === 'right' ? TD_NUM : TD}">${cell}</td>`)
+          .join('')}</tr>`
+    )
+    .join('');
+  return `
+    <div style="padding:16px 32px 4px;">
+      <h2 style="margin:0 0 8px;font-size:15px;font-weight:700;color:#1a1a2e;">${title}</h2>
+      <table style="width:100%;border-collapse:collapse;">
+        <tr style="background:#f1f5f9;">${headCells}</tr>
+        ${bodyRows}
+      </table>
+    </div>`;
+}
+
+function renderSaldos(rows: SaldoBancoRow[]): string {
+  return renderSection(
+    'Resumen Saldos Bancos',
+    [
+      { label: 'Banco' },
+      { label: 'Saldo', align: 'right' },
+      { label: 'Última actualización', align: 'right' },
+    ],
+    rows.map((r) => [r.nombre, fmtMoney(r.saldo), fmtShortDate(r.fecha_saldo)])
+  );
+}
+
+function renderAvances(rows: AvanceRow[]): string {
+  return renderSection(
+    'Resumen Avances Proyectos',
+    [
+      { label: 'Proyecto' },
+      { label: 'Urb. %', align: 'right' },
+      { label: 'Const. %', align: 'right' },
+      { label: 'Vts. %', align: 'right' },
+      { label: 'Lotes', align: 'right' },
+      { label: 'Terminadas', align: 'right' },
+      { label: 'En constr.', align: 'right' },
+      { label: 'Parque disp.', align: 'right' },
+      { label: 'Ticket prom.', align: 'right' },
+    ],
+    rows.map((r) => [
+      r.proyecto,
+      fmtPct(r.avance_urb_pct),
+      fmtPct(r.avance_const_pct),
+      fmtPct(r.avance_vts_pct),
+      fmtInt(r.lotes_residenciales),
+      fmtInt(r.casas_terminadas),
+      fmtInt(r.casas_en_construccion),
+      fmtInt(r.parque_disponible),
+      fmtMoney(r.ticket_promedio),
+    ])
+  );
+}
+
+function renderMargen(rows: MargenRow[]): string {
+  return renderSection(
+    'Análisis de Margen',
+    [
+      { label: 'Prototipo' },
+      { label: 'Valor comercial', align: 'right' },
+      { label: 'Costo total', align: 'right' },
+      { label: 'Utilidad', align: 'right' },
+      { label: 'Margen', align: 'right' },
+    ],
+    rows.map((r) => [
+      r.nombre,
+      fmtMoney(r.valor_comercial),
+      fmtMoney(r.costo_total),
+      fmtMoney(r.utilidad),
+      fmtPct(r.margen_pct),
+    ])
+  );
+}
+
+function renderInventario(rows: InventarioRow[]): string {
+  return renderSection(
+    'Inventario por Prototipo',
+    [
+      { label: 'Prototipo' },
+      { label: 'En constr.', align: 'right' },
+      { label: 'Terminado', align: 'right' },
+      { label: 'En inventario', align: 'right' },
+      { label: 'Asignado', align: 'right' },
+      { label: 'Disponible', align: 'right' },
+    ],
+    rows.map((r) => [
+      r.nombre,
+      fmtInt(r.inventario_construccion),
+      fmtInt(r.inventario_terminado),
+      fmtInt(r.en_inventario),
+      fmtInt(r.inventario_asignado),
+      fmtInt(r.inventario_disponible),
+    ])
+  );
+}
+
+function renderTuberia(rows: TuberiaRow[]): string {
+  return renderSection(
+    'Tubería',
+    [
+      { label: 'Fase' },
+      { label: 'Clientes', align: 'right' },
+      { label: 'Valor de escrituración', align: 'right' },
+    ],
+    rows.map((r) => [r.fase, fmtInt(r.clientes), fmtMoney(r.valor)])
+  );
+}
+
+function renderAsignaciones(rows: AsignacionRow[]): string {
+  return renderSection(
+    'Resumen de Asignaciones y Ventas (del mes)',
+    [
+      { label: 'Prototipo' },
+      { label: 'Asignaciones', align: 'right' },
+      { label: 'Monto', align: 'right' },
+      { label: 'Escrituras', align: 'right' },
+      { label: 'Monto', align: 'right' },
+    ],
+    rows.map((r) => [
+      r.nombre,
+      fmtInt(r.asignaciones_mes),
+      fmtMoney(r.monto_asignaciones),
+      fmtInt(r.escrituras_mes),
+      fmtMoney(r.monto_escrituras),
+    ])
+  );
+}
+
+function renderContratistas(rows: ContratistaRow[]): string {
+  return renderSection(
+    'Resumen Operación Contratistas',
+    [
+      { label: 'Contratista' },
+      { label: 'Estimaciones', align: 'right' },
+      { label: 'Monto bruto', align: 'right' },
+      { label: 'Retención', align: 'right' },
+      { label: 'Monto neto', align: 'right' },
+    ],
+    rows.map((r) => [
+      r.contratista,
+      fmtInt(r.estimaciones),
+      fmtMoney(r.monto_bruto),
+      fmtMoney(r.retencion),
+      fmtMoney(r.monto_neto),
+    ])
+  );
+}
+
+/** Ensambla el correo completo. El bloque de saldos solo aparece si hay data. */
+export function renderResumenConsejoHtml(
+  data: ResumenConsejoData,
+  opts: { headerImageUrl?: string | null; fechaTitulo: string }
+): string {
+  const sections = [
+    data.saldos.length ? renderSaldos(data.saldos) : '',
+    renderAvances(data.avances),
+    renderMargen(data.margen),
+    renderInventario(data.inventario),
+    renderTuberia(data.tuberia),
+    renderAsignaciones(data.asignaciones),
+    renderContratistas(data.contratistas),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const header = opts.headerImageUrl
+    ? `<div style="background:#1a1a2e;"><img src="${opts.headerImageUrl}" alt="DILESA" style="display:block;width:100%;height:auto;" /></div>`
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="es"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#ffffff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <div style="width:100%;background:#ffffff;">
+    ${header}
+    <div style="background:#1a1a2e;padding:18px 32px 22px;">
+      <h1 style="margin:0;font-size:19px;font-weight:700;color:#ffffff;">Resumen Diario Operación Dilesa 🏘️</h1>
+      <p style="margin:6px 0 0;font-size:13px;color:#cbd5e1;">${opts.fechaTitulo}</p>
+    </div>
+    ${sections}
+    <div style="padding:20px 32px 28px;">
+      <p style="margin:0;font-size:11px;color:#94a3b8;">Generado por BSOP — sistema operativo DILESA.</p>
+    </div>
+  </div>
+</body></html>`;
+}
+
+// ── Fetch ────────────────────────────────────────────────────────────────────
+
+const MONTH_NAMES = [
+  'enero',
+  'febrero',
+  'marzo',
+  'abril',
+  'mayo',
+  'junio',
+  'julio',
+  'agosto',
+  'septiembre',
+  'octubre',
+  'noviembre',
+  'diciembre',
+];
+
+/** Fecha-título en español (ej. "7 de junio de 2026"), TZ America/Matamoros. */
+export function fechaTituloCST(now: Date): string {
+  // America/Matamoros = UTC-6 (CST) / UTC-5 (CDT). Aproximación CST fija para el
+  // título; el guard de domingo del cron usa el TZ real.
+  const cst = new Date(now.getTime() - 6 * 3600 * 1000);
+  return `${cst.getUTCDate()} de ${MONTH_NAMES[cst.getUTCMonth()]} de ${cst.getUTCFullYear()}`;
+}
+
+/**
+ * Arma la data del correo desde las vistas DILESA. `supabase` debe ser un cliente
+ * con acceso de lectura a los schemas `dilesa` y `erp` (service-role en el cron).
+ * `empresaId` = DILESA. `now` para el corte del mes (asignaciones/escrituras).
+ */
+export async function fetchResumenConsejoData(
+  supabase: SupabaseClient,
+  empresaId: string,
+  now: Date
+): Promise<ResumenConsejoData> {
+  const dilesa = supabase.schema('dilesa');
+  const erp = supabase.schema('erp');
+  const inicioMes = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+    .toISOString()
+    .slice(0, 10);
+
+  const [
+    proyectosRes,
+    avancesRes,
+    margenRes,
+    inventarioRes,
+    productosRes,
+    ventasRes,
+    fasesCatRes,
+    fasesMesRes,
+    estimRes,
+    saldosRes,
+  ] = await Promise.all([
+    dilesa.from('proyectos').select('id,nombre').eq('empresa_id', empresaId).is('deleted_at', null),
+    dilesa.from('v_proyecto_avances').select('*').eq('empresa_id', empresaId),
+    dilesa.from('v_margen_prototipo').select('*').eq('empresa_id', empresaId),
+    dilesa.from('v_inventario_prototipo').select('*').eq('empresa_id', empresaId),
+    dilesa.from('productos').select('id,nombre').eq('empresa_id', empresaId).is('deleted_at', null),
+    dilesa
+      .from('ventas')
+      .select('fase_actual,fase_posicion,valor_escrituracion')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null),
+    dilesa
+      .from('venta_fase_catalogo')
+      .select('nombre,posicion')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null),
+    dilesa
+      .from('venta_fases')
+      .select('venta_id,fase,fecha')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .gte('fecha', inicioMes)
+      .in('fase', ['Asignada', 'Escriturada']),
+    erp.from('v_estimaciones_resumen').select('*').eq('empresa_id', empresaId),
+    erp.from('v_cuenta_saldo_actual').select('*').eq('empresa_id', empresaId),
+  ]);
+
+  const proyNombre = new Map<string, string>(
+    (proyectosRes.data ?? []).map((p: { id: string; nombre: string }) => [p.id, p.nombre])
+  );
+  const protoNombre = new Map<string, string>(
+    (productosRes.data ?? []).map((p: { id: string; nombre: string }) => [p.id, p.nombre])
+  );
+
+  // Avances: solo desarrollos con unidades (lotes_total > 0), ordenados por nombre
+  const avances: AvanceRow[] = (avancesRes.data ?? [])
+    .filter((a: Record<string, unknown>) => Number(a.lotes_total) > 0)
+    .map((a: Record<string, unknown>) => ({
+      proyecto: proyNombre.get(a.proyecto_id as string) ?? '—',
+      avance_urb_pct: a.avance_urb_pct as number | null,
+      avance_const_pct: a.avance_const_pct as number | null,
+      avance_vts_pct: a.avance_vts_pct as number | null,
+      lotes_residenciales: Number(a.lotes_residenciales ?? 0),
+      casas_terminadas: Number(a.casas_terminadas ?? 0),
+      casas_en_construccion: Number(a.casas_en_construccion ?? 0),
+      parque_disponible: Number(a.parque_disponible ?? 0),
+      ticket_promedio: a.ticket_promedio as number | null,
+    }))
+    .sort((x, y) => x.proyecto.localeCompare(y.proyecto));
+
+  const margen: MargenRow[] = (margenRes.data ?? [])
+    .map((m: Record<string, unknown>) => ({
+      nombre: m.nombre as string,
+      valor_comercial: m.valor_comercial as number | null,
+      costo_total: m.costo_total as number | null,
+      utilidad: m.utilidad as number | null,
+      margen_pct: m.margen_pct as number | null,
+    }))
+    .sort((x, y) => x.nombre.localeCompare(y.nombre));
+
+  const inventario: InventarioRow[] = (inventarioRes.data ?? [])
+    .map((i: Record<string, unknown>) => ({
+      nombre: protoNombre.get(i.prototipo_id as string) ?? '—',
+      inventario_construccion: Number(i.inventario_construccion ?? 0),
+      inventario_terminado: Number(i.inventario_terminado ?? 0),
+      en_inventario: Number(i.en_inventario ?? 0),
+      inventario_asignado: Number(i.inventario_asignado ?? 0),
+      inventario_disponible: Number(i.inventario_disponible ?? 0),
+    }))
+    .filter((i) => i.en_inventario > 0)
+    .sort((x, y) => x.nombre.localeCompare(y.nombre));
+
+  // Tubería: count + sum(valor_escrituracion) por fase, en el orden del catálogo
+  const fasesCat = (fasesCatRes.data ?? []).sort(
+    (a: { posicion: number }, b: { posicion: number }) => a.posicion - b.posicion
+  );
+  const porFase = new Map<string, { clientes: number; valor: number }>();
+  for (const v of ventasRes.data ?? []) {
+    const fase = (v as { fase_actual: string | null }).fase_actual;
+    if (!fase) continue;
+    const acc = porFase.get(fase) ?? { clientes: 0, valor: 0 };
+    acc.clientes += 1;
+    acc.valor += Number((v as { valor_escrituracion: number | null }).valor_escrituracion ?? 0);
+    porFase.set(fase, acc);
+  }
+  const tuberia: TuberiaRow[] = fasesCat.map((f: { nombre: string }) => ({
+    fase: f.nombre,
+    clientes: porFase.get(f.nombre)?.clientes ?? 0,
+    valor: porFase.get(f.nombre)?.valor ?? 0,
+  }));
+
+  // Asignaciones/escrituras del mes: por venta_fases del mes, agrupadas por prototipo.
+  // Requiere resolver venta → unidad → producto. Se hace con un fetch puntual de las
+  // ventas involucradas (rara vez son muchas en un mes).
+  const ventaIds = [
+    ...new Set((fasesMesRes.data ?? []).map((f: { venta_id: string }) => f.venta_id)),
+  ];
+  const asignaciones: AsignacionRow[] = [];
+  if (ventaIds.length) {
+    const ventasMes = await dilesa
+      .from('ventas')
+      .select('id,unidad_id,precio_asignacion,valor_escrituracion')
+      .in('id', ventaIds);
+    const unidadIds = [
+      ...new Set(
+        (ventasMes.data ?? []).map((v: { unidad_id: string | null }) => v.unidad_id).filter(Boolean)
+      ),
+    ] as string[];
+    const unidades = unidadIds.length
+      ? await dilesa.from('unidades').select('id,producto_id').in('id', unidadIds)
+      : { data: [] };
+    const unidadProto = new Map<string, string>(
+      (unidades.data ?? []).map((u: { id: string; producto_id: string | null }) => [
+        u.id,
+        u.producto_id ?? '',
+      ])
+    );
+    const ventaInfo = new Map(
+      (ventasMes.data ?? []).map((v: Record<string, unknown>) => [v.id as string, v])
+    );
+    const acc = new Map<string, AsignacionRow>();
+    for (const f of fasesMesRes.data ?? []) {
+      const ff = f as { venta_id: string; fase: string };
+      const v = ventaInfo.get(ff.venta_id) as Record<string, unknown> | undefined;
+      if (!v) continue;
+      const proto = protoNombre.get(unidadProto.get(v.unidad_id as string) ?? '') ?? '—';
+      const row = acc.get(proto) ?? {
+        nombre: proto,
+        asignaciones_mes: 0,
+        monto_asignaciones: 0,
+        escrituras_mes: 0,
+        monto_escrituras: 0,
+      };
+      if (ff.fase === 'Asignada') {
+        row.asignaciones_mes += 1;
+        row.monto_asignaciones += Number(v.precio_asignacion ?? 0);
+      } else if (ff.fase === 'Escriturada') {
+        row.escrituras_mes += 1;
+        row.monto_escrituras += Number(v.valor_escrituracion ?? 0);
+      }
+      acc.set(proto, row);
+    }
+    asignaciones.push(...[...acc.values()].sort((x, y) => x.nombre.localeCompare(y.nombre)));
+  }
+
+  // Contratistas: v_estimaciones_resumen agregado por contratista + nombre
+  const estimByContratista = new Map<string, ContratistaRow>();
+  const contratistaIds = [
+    ...new Set((estimRes.data ?? []).map((e: { contratista_id: string }) => e.contratista_id)),
+  ];
+  const personas = contratistaIds.length
+    ? await erp
+        .from('personas')
+        .select('id,nombre')
+        .in('id', contratistaIds as string[])
+    : { data: [] };
+  const personaNombre = new Map<string, string>(
+    (personas.data ?? []).map((p: { id: string; nombre: string | null }) => [p.id, p.nombre ?? '—'])
+  );
+  for (const e of estimRes.data ?? []) {
+    const ee = e as Record<string, unknown>;
+    const nombre = personaNombre.get(ee.contratista_id as string) ?? '—';
+    const row = estimByContratista.get(nombre) ?? {
+      contratista: nombre,
+      estimaciones: 0,
+      monto_bruto: 0,
+      retencion: 0,
+      monto_neto: 0,
+    };
+    row.estimaciones += Number(ee.estimaciones_count ?? 0);
+    row.monto_bruto += Number(ee.monto_bruto_total ?? 0);
+    row.retencion += Number(ee.retencion_total ?? 0);
+    row.monto_neto += Number(ee.monto_neto_total ?? 0);
+    estimByContratista.set(nombre, row);
+  }
+  const contratistas = [...estimByContratista.values()].sort((x, y) =>
+    x.contratista.localeCompare(y.contratista)
+  );
+
+  const saldos: SaldoBancoRow[] = (saldosRes.data ?? []).map((s: Record<string, unknown>) => ({
+    nombre: s.nombre as string,
+    banco: s.banco as string | null,
+    saldo: s.saldo as number | null,
+    fecha_saldo: s.fecha_saldo as string | null,
+  }));
+
+  return { saldos, avances, margen, inventario, tuberia, asignaciones, contratistas };
+}


### PR DESCRIPTION
## Correo al Consejo · Sprint 1 (plantilla)

`lib/dilesa/resumen-consejo-email.ts` — el render del correo "Resumen Diario Operación Dilesa 🏘️".

- **Render puro y testeable** (10 tests): funciones de formato (MXN/%/int), `renderSection` genérica, y `renderResumenConsejoHtml` que ensambla las 7 secciones (Saldos Bancos opcional · Avances · Margen · Inventario · Tubería · Asignaciones/Ventas del mes · Contratistas).
- **`fetchResumenConsejoData`** arma la data desde las vistas `dilesa`/`erp` (avances, margen, inventario, tubería por fase, asignaciones del mes vía `venta_fases`, contratistas). 
- El bloque de **Saldos Bancos** lee `erp.v_cuenta_saldo_actual` y solo aparece cuando hay saldos capturados (iniciativa `tesoreria`).

Próximo: Sprint 2 — ruta cron `/api/cron/dilesa-resumen-consejo` + envío vía Resend a `consejo@dilesa.mx` + log en `core.notification_log`.

## Checks
typecheck ✅ · lint ✅ · test 1335 ✅ · format ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)