### PR TITLE
feat(dilesa-resumen-consejo): cron + envío del correo al Consejo (S2)

### DIFF
--- a/app/api/cron/dilesa-resumen-consejo/route.ts
+++ b/app/api/cron/dilesa-resumen-consejo/route.ts
@@ -1,0 +1,119 @@
+/**
+ * Resumen Diario Operación DILESA — cron del correo al Consejo.
+ *
+ * Schedule: `0 2 * * *` (02:00 UTC ≈ 20:00 CST). Ver vercel.json.
+ * Iniciativa dilesa-resumen-consejo.
+ *
+ * Reglas:
+ *   - Lunes a sábado. **Domingo NO se envía** (guard sobre el día en CST).
+ *   - Destino: RESUMEN_CONSEJO_TEST_TO si está definida (modo prueba, subject con
+ *     [PRUEBA]); en su defecto, consejo@dilesa.mx (producción).
+ *   - El bloque de Saldos Bancos solo aparece cuando hay saldos capturados
+ *     (iniciativa tesoreria → erp.v_cuenta_saldo_actual).
+ *
+ * Security: requiere `Authorization: Bearer ${CRON_SECRET}` (lo manda Vercel Cron).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import {
+  fetchResumenConsejoData,
+  renderResumenConsejoHtml,
+  fechaTituloCST,
+  sendResumenEmail,
+} from '@/lib/dilesa/resumen-consejo-email';
+
+export const maxDuration = 120;
+
+const DILESA_EMPRESA_ID = 'f5942ed4-7a6b-4c39-af18-67b9fbf7f479';
+const CONSEJO_EMAIL = 'consejo@dilesa.mx';
+const FROM = 'Desarrollo Inmobiliario los Encinos <noreply@bsop.io>';
+
+/** Día de la semana en CST (UTC-6 fijo, México sin DST). 0 = domingo. */
+function diaSemanaCst(now: Date): number {
+  const cst = new Date(now.getTime() - 6 * 60 * 60 * 1000);
+  return cst.getUTCDay();
+}
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET?.trim();
+  const authHeader = req.headers.get('authorization');
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = new Date();
+
+  // Guard de domingo — el resumen del domingo no se envía.
+  if (diaSemanaCst(now) === 0) {
+    return NextResponse.json({ status: 'skipped', reason: 'domingo' });
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!supabaseUrl || !serviceKey) {
+    return NextResponse.json({ error: 'Supabase env missing' }, { status: 500 });
+  }
+  if (!resendKey) {
+    return NextResponse.json({ error: 'RESEND_API_KEY missing' }, { status: 500 });
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  // Branding (header del correo) desde core.empresas.
+  const { data: empresa } = await supabase
+    .schema('core')
+    .from('empresas')
+    .select('header_email_url')
+    .eq('id', DILESA_EMPRESA_ID)
+    .single();
+
+  const data = await fetchResumenConsejoData(supabase, DILESA_EMPRESA_ID, now);
+  const fechaTitulo = fechaTituloCST(now);
+  const html = renderResumenConsejoHtml(data, {
+    headerImageUrl: empresa?.header_email_url ?? null,
+    fechaTitulo,
+  });
+
+  // Destino con FAIL-SAFE: hasta el cutover NO se manda al Consejo.
+  //   - RESUMEN_CONSEJO_TEST_TO definida → manda ahí, subject con [PRUEBA].
+  //   - RESUMEN_CONSEJO_LIVE='1' (y sin TEST_TO) → manda al Consejo real.
+  //   - ninguna de las dos → skip sin enviar. Evita un envío accidental al
+  //     Consejo cuando el cron entra a prod antes de que Beto valide el correo.
+  const testTo = process.env.RESUMEN_CONSEJO_TEST_TO?.trim();
+  const live = process.env.RESUMEN_CONSEJO_LIVE === '1';
+  if (!testTo && !live) {
+    return NextResponse.json({
+      status: 'skipped',
+      reason:
+        'sin destino: configura RESUMEN_CONSEJO_TEST_TO (prueba) o RESUMEN_CONSEJO_LIVE=1 (Consejo)',
+    });
+  }
+  const recipients = testTo ? [testTo] : [CONSEJO_EMAIL];
+  const subject = `Resumen Diario Operación Dilesa 🏘️ ${fechaTitulo}${testTo ? ' [PRUEBA]' : ''}`;
+
+  const res = await sendResumenEmail(resendKey, {
+    html,
+    subject,
+    from: FROM,
+    recipients,
+  });
+
+  return NextResponse.json({
+    status: res.ok ? 'sent' : 'error',
+    recipients,
+    secciones: {
+      saldos: data.saldos.length,
+      avances: data.avances.length,
+      margen: data.margen.length,
+      inventario: data.inventario.length,
+      tuberia: data.tuberia.length,
+      asignaciones: data.asignaciones.length,
+      contratistas: data.contratistas.length,
+    },
+    error: res.ok ? undefined : res.error,
+  });
+}

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -400,7 +400,7 @@ export async function fetchResumenConsejoData(
       .is('deleted_at', null)
       .gte('fecha', inicioMes)
       .in('fase', ['Asignada', 'Escriturada']),
-    erp.from('v_estimaciones_resumen').select('*').eq('empresa_id', empresaId),
+    dilesa.from('v_estimaciones_resumen').select('*').eq('empresa_id', empresaId),
     erp.from('v_cuenta_saldo_actual').select('*').eq('empresa_id', empresaId),
   ]);
 
@@ -564,4 +564,34 @@ export async function fetchResumenConsejoData(
   }));
 
   return { saldos, avances, margen, inventario, tuberia, asignaciones, contratistas };
+}
+
+// ── Envío ────────────────────────────────────────────────────────────────────
+
+/**
+ * Envío genérico vía Resend (sendMinutaEmail está acoplada a juntas). Sin estado
+ * de juntas/notification_log — el caller decide la trazabilidad.
+ */
+export async function sendResumenEmail(
+  resendKey: string,
+  payload: { html: string; subject: string; from: string; recipients: string[] }
+): Promise<{ ok: boolean; id?: string; error?: unknown }> {
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${resendKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: payload.from,
+      to: payload.recipients,
+      subject: payload.subject,
+      html: payload.html,
+    }),
+  });
+  if (!res.ok) {
+    return { ok: false, error: await res.text().catch(() => res.statusText) };
+  }
+  const data = (await res.json()) as { id?: string };
+  return { ok: true, id: data.id };
 }

--- a/scripts/send_resumen_consejo_test.ts
+++ b/scripts/send_resumen_consejo_test.ts
@@ -1,0 +1,72 @@
+/**
+ * Envía una prueba del "Resumen Diario Operación Dilesa" (correo al Consejo).
+ * Iniciativa dilesa-resumen-consejo. Destino: RESUMEN_CONSEJO_TEST_TO o el default
+ * de prueba. NO manda al Consejo real.
+ *
+ *   npx tsx --env-file=/Users/Beto/BSOP/.env.local scripts/send_resumen_consejo_test.ts
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import {
+  fetchResumenConsejoData,
+  renderResumenConsejoHtml,
+  fechaTituloCST,
+  sendResumenEmail,
+} from '../lib/dilesa/resumen-consejo-email';
+
+const DILESA_ID = 'f5942ed4-7a6b-4c39-af18-67b9fbf7f479';
+const HEADER =
+  'https://ybklderteyhuugzfmxbi.supabase.co/storage/v1/object/public/branding/dilesa/brand/header-email.png?v=1776736258319';
+const TEST_TO = process.env.RESUMEN_CONSEJO_TEST_TO || 'beto@anorte.com';
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!url || !key || !resendKey) {
+    throw new Error(
+      'Faltan env: NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY / RESEND_API_KEY'
+    );
+  }
+
+  const supabase = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const now = new Date();
+  const data = await fetchResumenConsejoData(supabase, DILESA_ID, now);
+  const fechaTitulo = fechaTituloCST(now);
+  const html = renderResumenConsejoHtml(data, { headerImageUrl: HEADER, fechaTitulo });
+
+  console.log('Conteo por sección:', {
+    saldos: data.saldos.length,
+    avances: data.avances.length,
+    margen: data.margen.length,
+    inventario: data.inventario.length,
+    tuberia: data.tuberia.length,
+    asignaciones: data.asignaciones.length,
+    contratistas: data.contratistas.length,
+  });
+
+  if (process.env.DRY) {
+    const fs = await import('node:fs');
+    const out = '/tmp/resumen-consejo-preview.html';
+    fs.writeFileSync(out, html);
+    console.log('DRY — HTML escrito en', out, '(', html.length, 'bytes )');
+    return;
+  }
+
+  const res = await sendResumenEmail(resendKey, {
+    html,
+    subject: `Resumen Diario Operación Dilesa 🏘️ ${fechaTitulo} [PRUEBA]`,
+    from: 'Desarrollo Inmobiliario los Encinos <noreply@bsop.io>',
+    recipients: [TEST_TO],
+  });
+
+  console.log('Resultado envío:', JSON.stringify(res));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,10 @@
     {
       "path": "/api/cron/dilesa-ventas-expirar",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/dilesa-resumen-consejo",
+      "schedule": "0 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Correo al Consejo · Sprint 2 (cron + envío)

- **`app/api/cron/dilesa-resumen-consejo`** — ruta cron (auth `Bearer CRON_SECRET`, guard de domingo en CST, `maxDuration`). **FAIL-SAFE de destino:** sin `RESUMEN_CONSEJO_TEST_TO` ni `RESUMEN_CONSEJO_LIVE=1` hace **skip sin enviar** — nunca manda al Consejo por accidente antes del cutover. Con `TEST_TO` → prueba (`[PRUEBA]` en subject); con `LIVE=1` → Consejo real.
- **`vercel.json`** — cron `0 2 * * *` (≈20:00 CST).
- **`sendResumenEmail`** — envío genérico vía Resend (`sendMinutaEmail` está acoplada a juntas).
- **Fix:** `v_estimaciones_resumen` vive en schema `dilesa`, no `erp` (contratistas salía 0 → ahora 23).
- **`scripts/send_resumen_consejo_test.ts`** — prueba manual (modo `DRY` escribe el HTML a archivo).

Validado en DRY contra prod: **6/7 secciones pobladas** (avances 8 · margen 11 · inventario 5 · tubería 17 · asignaciones 2 · contratistas 23; saldos espera a `tesoreria`). Preview ya compartido contigo.

## Checks
typecheck ✅ · lint ✅ · test ✅ · format ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)