### PR TITLE
feat(tesoreria): UI de captura de Saldos Bancos (Sprint 3)

### DIFF
--- a/app/dilesa/saldos-bancos/actions.test.ts
+++ b/app/dilesa/saldos-bancos/actions.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests para `app/dilesa/saldos-bancos/actions.ts` (iniciativa `tesoreria`,
+ * Sprint 3). Cubre la capa TS de `capturarSaldo`:
+ *   - Bloqueo en preview.
+ *   - Validaciones (cuenta, fecha, saldo numérico).
+ *   - Resolución del usuario autenticado → `capturado_por`.
+ *   - Payload del INSERT a `erp.cuenta_saldos` (empresa fija DILESA, notas
+ *     normalizadas a null).
+ *   - Propagación de errores de Supabase.
+ */
+
+// ── State del test ─────────────────────────────────────────────────────────
+
+let preventInPreview = false;
+let user: { id: string } | null = { id: 'user-1' };
+let insertError: { message: string } | null = null;
+let lastInsertPayload: Record<string, unknown> | null = null;
+let lastInsertTable: string | null = null;
+let lastSchema: string | null = null;
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/preview-guard', () => ({
+  assertNotInPreview: async () => {
+    if (preventInPreview) throw new Error('Mutation bloqueada en preview');
+  },
+}));
+
+vi.mock('@/lib/empresa-constants', () => ({
+  DILESA_EMPRESA_ID: 'dilesa-empresa-id',
+}));
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- test doubles */
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async (): Promise<any> => ({
+    auth: {
+      getUser: async () => ({ data: { user } }),
+    },
+    schema(schemaName: string) {
+      lastSchema = schemaName;
+      return {
+        from(tableName: string) {
+          return {
+            insert(payload: Record<string, unknown>) {
+              lastInsertTable = tableName;
+              lastInsertPayload = payload;
+              return Promise.resolve({ error: insertError });
+            },
+          };
+        },
+      };
+    },
+  }),
+}));
+
+import { capturarSaldo } from './actions';
+
+beforeEach(() => {
+  preventInPreview = false;
+  user = { id: 'user-1' };
+  insertError = null;
+  lastInsertPayload = null;
+  lastInsertTable = null;
+  lastSchema = null;
+});
+
+const validInput = {
+  cuentaId: 'cuenta-1',
+  fecha: '2026-06-07',
+  saldo: '12345.67',
+  notas: 'Corte del día',
+};
+
+describe('capturarSaldo', () => {
+  it('bloquea cuando hay preview activo', async () => {
+    preventInPreview = true;
+    await expect(capturarSaldo(validInput)).rejects.toThrow('Mutation bloqueada en preview');
+  });
+
+  it('inserta en erp.cuenta_saldos con empresa DILESA y capturado_por del usuario', async () => {
+    const res = await capturarSaldo(validInput);
+    expect(res.ok).toBe(true);
+    expect(lastSchema).toBe('erp');
+    expect(lastInsertTable).toBe('cuenta_saldos');
+    expect(lastInsertPayload).toMatchObject({
+      empresa_id: 'dilesa-empresa-id',
+      cuenta_id: 'cuenta-1',
+      fecha: '2026-06-07',
+      saldo: 12345.67,
+      capturado_por: 'user-1',
+      notas: 'Corte del día',
+    });
+    // saldo debe ir como number, no como string.
+    expect(typeof (lastInsertPayload as Record<string, unknown>).saldo).toBe('number');
+  });
+
+  it('normaliza notas vacías a null', async () => {
+    const res = await capturarSaldo({ ...validInput, notas: '   ' });
+    expect(res.ok).toBe(true);
+    expect((lastInsertPayload as Record<string, unknown>).notas).toBeNull();
+  });
+
+  it('rechaza cuenta faltante', async () => {
+    const res = await capturarSaldo({ ...validInput, cuentaId: '  ' });
+    expect(res).toEqual({ ok: false, error: 'Falta la cuenta a capturar.' });
+    expect(lastInsertPayload).toBeNull();
+  });
+
+  it('rechaza fecha faltante', async () => {
+    const res = await capturarSaldo({ ...validInput, fecha: '' });
+    expect(res).toEqual({ ok: false, error: 'Indica la fecha del saldo.' });
+  });
+
+  it('rechaza saldo no numérico', async () => {
+    const res = await capturarSaldo({ ...validInput, saldo: 'abc' });
+    expect(res).toEqual({ ok: false, error: 'El saldo debe ser un número válido.' });
+    expect(lastInsertPayload).toBeNull();
+  });
+
+  it('rechaza cuando no hay usuario autenticado', async () => {
+    user = null;
+    const res = await capturarSaldo(validInput);
+    expect(res).toEqual({ ok: false, error: 'No autenticado. Vuelve a iniciar sesión.' });
+  });
+
+  it('propaga el error de Supabase con mensaje amigable', async () => {
+    insertError = { message: 'duplicate key' };
+    const res = await capturarSaldo(validInput);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain('duplicate key');
+  });
+});

--- a/app/dilesa/saldos-bancos/actions.ts
+++ b/app/dilesa/saldos-bancos/actions.ts
@@ -1,0 +1,77 @@
+'use server';
+
+// Next.js requires `'use server'` modules to export only async functions —
+// los tipos compartidos con el cliente viven en ./types.ts.
+
+import { revalidatePath } from 'next/cache';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { assertNotInPreview } from '@/lib/auth/preview-guard';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import type { ActionResult, CapturarSaldoInput } from './types';
+
+/**
+ * Registra un snapshot de saldo de una cuenta bancaria DILESA.
+ *
+ * Apila un row en `erp.cuenta_saldos` (no edita el anterior — audit trail,
+ * ver iniciativa `tesoreria`). La vista `erp.v_cuenta_saldo_actual` deriva
+ * automáticamente el último saldo por cuenta (DISTINCT ON), que es lo que
+ * consume el correo diario al Consejo (`dilesa-resumen-consejo`, bloque #1).
+ *
+ * - `assertNotInPreview()` bloquea la mutación cuando un admin está en modo
+ *   "Viendo como" (contrato read-only de `viendo-como-readonly`).
+ * - `capturado_por` se resuelve del usuario autenticado (no se confía en el
+ *   cliente). `empresa_id` se fija a DILESA (golden D1).
+ * - El saldo llega como string desde el form para no perder precisión; se
+ *   convierte a number aquí tras validar que sea finito.
+ */
+export async function capturarSaldo(input: CapturarSaldoInput): Promise<ActionResult> {
+  await assertNotInPreview();
+
+  const cuentaId = input.cuentaId?.trim();
+  if (!cuentaId) {
+    return { ok: false, error: 'Falta la cuenta a capturar.' };
+  }
+
+  const fecha = input.fecha?.trim();
+  if (!fecha) {
+    return { ok: false, error: 'Indica la fecha del saldo.' };
+  }
+
+  const saldo = Number(input.saldo);
+  if (!Number.isFinite(saldo)) {
+    return { ok: false, error: 'El saldo debe ser un número válido.' };
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { ok: false, error: 'No autenticado. Vuelve a iniciar sesión.' };
+  }
+
+  const notas = input.notas?.trim();
+
+  const { error } = await supabase
+    .schema('erp')
+    .from('cuenta_saldos')
+    .insert({
+      empresa_id: DILESA_EMPRESA_ID,
+      cuenta_id: cuentaId,
+      fecha,
+      // numeric en Postgres acepta number; el valor ya pasó por el form con
+      // step=0.01, así que mantiene 2 decimales sin float drift relevante.
+      saldo,
+      capturado_por: user.id,
+      notas: notas && notas.length > 0 ? notas : null,
+    });
+
+  if (error) {
+    return { ok: false, error: getSupabaseErrorMessage(error, 'No se pudo registrar el saldo.') };
+  }
+
+  revalidatePath('/dilesa/saldos-bancos');
+  return { ok: true };
+}

--- a/app/dilesa/saldos-bancos/page.tsx
+++ b/app/dilesa/saldos-bancos/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { SaldosBancosModule } from '@/components/dilesa/saldos-bancos-module';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Saldos Bancos (DILESA)
+ * @responsive desktop-only
+ *
+ * Captura manual de saldos bancarios DILESA con historial (iniciativa
+ * `tesoreria`, Sprint 3). Una fila por cuenta activa con su último saldo,
+ * fecha y antigüedad; captura por cuenta apila un snapshot en
+ * `erp.cuenta_saldos`. Fuente de verdad del bloque #1 ("Saldos Bancos") del
+ * correo diario al Consejo (`dilesa-resumen-consejo`).
+ *
+ * Gate: `dilesa.saldos-bancos` (RBAC liberado en Sprint 2). El módulo no usa
+ * `useSearchParams`, así que no requiere Suspense boundary (Next.js 16).
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.saldos-bancos">
+      <DesktopOnlyNotice module="Saldos Bancos" />
+      <div className="hidden sm:block">
+        <SaldosBancosModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/app/dilesa/saldos-bancos/types.ts
+++ b/app/dilesa/saldos-bancos/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Tipos compartidos entre la server action (`actions.ts`) y el cliente
+ * (`components/dilesa/saldos-bancos-module.tsx`). Viven en un `.ts` plano
+ * (no en el módulo `'use server'`, que solo puede exportar funciones async;
+ * tampoco en el client component, para no arrastrar su árbol al server —
+ * ver memoria `feedback_use_client_constants_import`).
+ */
+
+export type ActionResult<T = void> =
+  | (T extends void ? { ok: true } : { ok: true; data: T })
+  | { ok: false; error: string };
+
+export type CapturarSaldoInput = {
+  cuentaId: string;
+  /** YYYY-MM-DD. */
+  fecha: string;
+  /** Llega como string desde el form para preservar precisión del numeric. */
+  saldo: string;
+  notas?: string;
+};

--- a/components/dilesa/saldo-capture-drawer.tsx
+++ b/components/dilesa/saldo-capture-drawer.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+/**
+ * SaldoCaptureDrawer — captura de un snapshot de saldo de una cuenta bancaria
+ * DILESA + historial de los snapshots previos de esa cuenta.
+ *
+ * Iniciativa `tesoreria` (Sprint 3). Llama la server action `capturarSaldo`,
+ * que apila un row en `erp.cuenta_saldos` (audit trail — no edita el anterior).
+ * Al abrir, lista los snapshots históricos de la cuenta desde
+ * `erp.cuenta_saldos` ordenados por fecha desc.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { z } from 'zod';
+
+import { DetailDrawer, DetailDrawerContent, DetailDrawerSection } from '@/components/detail-page';
+import { Form, FormActions, FormField, FormRow, useZodForm } from '@/components/forms';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/components/ui/toast';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { formatCurrency, formatDate, formatDateTime } from '@/lib/format';
+import { capturarSaldo } from '@/app/dilesa/saldos-bancos/actions';
+import type { CuentaSaldoRow } from '@/components/dilesa/saldos-bancos-utils';
+
+const SaldoSchema = z.object({
+  fecha: z.string().min(1, 'Indica la fecha del saldo'),
+  saldo: z
+    .string()
+    .min(1, 'Indica el saldo')
+    .refine((v) => Number.isFinite(Number(v)), 'El saldo debe ser un número válido'),
+  notas: z.string().default(''),
+});
+
+type SaldoValues = z.infer<typeof SaldoSchema>;
+
+/** Fecha de hoy en `YYYY-MM-DD` (default del campo fecha). */
+function hoyISO(): string {
+  return new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Matamoros' }).format(new Date());
+}
+
+type HistorialRow = {
+  id: string;
+  fecha: string;
+  saldo: number;
+  notas: string | null;
+  created_at: string;
+  capturado_por: string | null;
+};
+
+export type SaldoCaptureDrawerProps = {
+  cuenta: CuentaSaldoRow | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Llamado tras capturar con éxito — la tabla re-fetchea. */
+  onDone: () => void;
+};
+
+export function SaldoCaptureDrawer({
+  cuenta,
+  open,
+  onOpenChange,
+  onDone,
+}: SaldoCaptureDrawerProps) {
+  const toast = useToast();
+  const [historial, setHistorial] = useState<HistorialRow[]>([]);
+  const [historialLoading, setHistorialLoading] = useState(false);
+
+  const form = useZodForm({
+    schema: SaldoSchema,
+    defaultValues: { fecha: hoyISO(), saldo: '', notas: '' },
+  });
+
+  const cargarHistorial = useCallback(
+    async (cuentaId: string) => {
+      setHistorialLoading(true);
+      const sb = createSupabaseBrowserClient();
+      const { data, error } = await sb
+        .schema('erp')
+        .from('cuenta_saldos')
+        .select('id, fecha, saldo, notas, created_at, capturado_por')
+        .eq('cuenta_id', cuentaId)
+        .order('fecha', { ascending: false })
+        .order('created_at', { ascending: false })
+        .limit(50);
+
+      if (error) {
+        toast.add({
+          title: 'No se pudo cargar el historial',
+          description: getSupabaseErrorMessage(error, 'Reintenta abrir la cuenta.'),
+          type: 'error',
+        });
+        setHistorial([]);
+      } else {
+        setHistorial(data ?? []);
+      }
+      setHistorialLoading(false);
+    },
+    [toast]
+  );
+
+  // Reset del form + carga del historial cada vez que se abre una cuenta.
+  useEffect(() => {
+    if (open && cuenta) {
+      form.reset({ fecha: hoyISO(), saldo: '', notas: '' });
+      void cargarHistorial(cuenta.cuentaId);
+    } else if (!open) {
+      setHistorial([]);
+    }
+    // form es estable; cuenta?.cuentaId gobierna la recarga.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, cuenta?.cuentaId]);
+
+  const handleSubmit = async (values: SaldoValues) => {
+    if (!cuenta) return;
+    const result = await capturarSaldo({
+      cuentaId: cuenta.cuentaId,
+      fecha: values.fecha,
+      saldo: values.saldo,
+      notas: values.notas || undefined,
+    });
+
+    if (!result.ok) {
+      toast.add({
+        title: 'No se pudo registrar el saldo',
+        description: result.error,
+        type: 'error',
+      });
+      return;
+    }
+
+    toast.add({ title: 'Saldo registrado', type: 'success' });
+    onOpenChange(false);
+    onDone();
+  };
+
+  return (
+    <DetailDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      size="md"
+      title={cuenta ? `Capturar saldo · ${cuenta.nombre}` : 'Capturar saldo'}
+      description={cuenta ? `${cuenta.banco ?? cuenta.nombre} · ${cuenta.moneda}` : undefined}
+    >
+      <DetailDrawerContent>
+        <Form form={form} onSubmit={handleSubmit} className="space-y-5">
+          <FormRow cols={2}>
+            <FormField name="fecha" label="Fecha del saldo" required>
+              {(field) => (
+                <Input
+                  {...field}
+                  id={field.id}
+                  type="date"
+                  aria-invalid={field.invalid || undefined}
+                  aria-describedby={field.describedBy}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+                />
+              )}
+            </FormField>
+
+            <FormField name="saldo" label={`Saldo${cuenta ? ` (${cuenta.moneda})` : ''}`} required>
+              {(field) => (
+                <Input
+                  {...field}
+                  id={field.id}
+                  type="number"
+                  inputMode="decimal"
+                  step="0.01"
+                  placeholder="0.00"
+                  aria-invalid={field.invalid || undefined}
+                  aria-describedby={field.describedBy}
+                  className="rounded-xl border-[var(--border)] bg-[var(--panel)] text-right tabular-nums text-[var(--text)]"
+                />
+              )}
+            </FormField>
+          </FormRow>
+
+          <FormField name="notas" label="Notas">
+            {(field) => (
+              <Textarea
+                {...field}
+                id={field.id}
+                rows={2}
+                placeholder="Opcional — referencia, corte, etc."
+                aria-invalid={field.invalid || undefined}
+                aria-describedby={field.describedBy}
+                className="resize-none rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
+            )}
+          </FormField>
+
+          <FormActions
+            cancelLabel="Cancelar"
+            submitLabel="Registrar saldo"
+            submittingLabel="Registrando..."
+            submitIcon={<Plus className="h-4 w-4" />}
+            onCancel={() => onOpenChange(false)}
+            stretch
+          />
+        </Form>
+
+        <DetailDrawerSection title="Historial" description="Snapshots previos de esta cuenta">
+          {historialLoading ? (
+            <p className="text-sm text-[var(--text)]/50">Cargando historial…</p>
+          ) : historial.length === 0 ? (
+            <p className="text-sm text-[var(--text)]/50">
+              Aún no hay saldos capturados para esta cuenta.
+            </p>
+          ) : (
+            <ul className="divide-y divide-[var(--border)]">
+              {historial.map((h) => (
+                <li key={h.id} className="flex items-start justify-between gap-3 py-2.5">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-[var(--text)]">
+                        {formatDate(h.fecha)}
+                      </span>
+                      {h.notas ? (
+                        <span className="truncate text-xs text-[var(--text)]/60">{h.notas}</span>
+                      ) : null}
+                    </div>
+                    <div className="text-xs text-[var(--text)]/50">
+                      Capturado {formatDateTime(h.created_at)}
+                    </div>
+                  </div>
+                  <Badge tone="neutral" className="shrink-0 tabular-nums">
+                    {formatCurrency(h.saldo, { currency: cuenta?.moneda ?? 'MXN' })}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          )}
+        </DetailDrawerSection>
+      </DetailDrawerContent>
+    </DetailDrawer>
+  );
+}

--- a/components/dilesa/saldos-bancos-module.tsx
+++ b/components/dilesa/saldos-bancos-module.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+/**
+ * SaldosBancosModule — captura manual de saldos bancarios DILESA con historial.
+ *
+ * Iniciativa `tesoreria` (Sprint 3). Reemplaza la captura de saldos que hoy
+ * vive en Coda y alimenta el bloque #1 ("Saldos Bancos") del correo diario al
+ * Consejo (`dilesa-resumen-consejo`).
+ *
+ * Una fila por cuenta bancaria activa de DILESA. El último saldo se lee de la
+ * vista `erp.v_cuenta_saldo_actual` (DISTINCT ON por cuenta); las cuentas que
+ * todavía no tienen ningún snapshot se incluyen igual leyendo
+ * `erp.cuentas_bancarias` y haciendo merge (saldo = null). Cada captura apila
+ * un snapshot nuevo en `erp.cuenta_saldos` vía la server action `capturarSaldo`
+ * (audit trail — no se edita el anterior).
+ *
+ * Multi-moneda: BBVA Dólares es USD; el resto MXN. Como `moneda_id` viene null
+ * en las cuentas DILESA (la migración Sprint 1 solo cargó nombre/banco), la
+ * moneda se infiere del nombre de la cuenta (ver `monedaDeCuenta`). No se suma
+ * entre monedas distintas — cada cuenta muestra su saldo individual y los
+ * totales del KPI van por moneda.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Landmark, Plus, RefreshCw, Wallet } from 'lucide-react';
+
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { formatCurrency, formatDate } from '@/lib/format';
+import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
+import { Badge } from '@/components/ui/badge';
+import type { BadgeTone } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { SaldoCaptureDrawer } from '@/components/dilesa/saldo-capture-drawer';
+import {
+  type CuentaSaldoRow,
+  computeAntiguedadDias,
+  monedaDeCuenta,
+} from '@/components/dilesa/saldos-bancos-utils';
+
+// ─── Antigüedad → tono del badge ─────────────────────────────────────────────
+//
+// Un saldo stale (como Finamex en Coda, sin actualizar desde noviembre) debe
+// saltar a la vista. Verde ≤ 3 días, ámbar 4–14, rojo > 14, gris si nunca se
+// capturó.
+function antiguedadTone(dias: number | null): BadgeTone {
+  if (dias == null) return 'neutral';
+  if (dias <= 3) return 'success';
+  if (dias <= 14) return 'warning';
+  return 'danger';
+}
+
+function antiguedadLabel(dias: number | null): string {
+  if (dias == null) return 'Sin captura';
+  if (dias === 0) return 'Hoy';
+  if (dias === 1) return 'Ayer';
+  return `${dias} días`;
+}
+
+export function SaldosBancosModule({ empresaId = DILESA_EMPRESA_ID }: { empresaId?: string }) {
+  const [rows, setRows] = useState<CuentaSaldoRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | string | null>(null);
+  const [capturaCuenta, setCapturaCuenta] = useState<CuentaSaldoRow | null>(null);
+
+  const cargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const sb = createSupabaseBrowserClient();
+
+    // Cuentas activas (base) + último saldo por cuenta (vista). Dos queries
+    // separados, merge en JS: la vista solo trae cuentas con al menos un
+    // snapshot, así que la base garantiza que aparezcan también las vacías.
+    const [cuentasRes, saldosRes] = await Promise.all([
+      sb
+        .schema('erp')
+        .from('cuentas_bancarias')
+        .select('id, nombre, banco, moneda_id')
+        .eq('empresa_id', empresaId)
+        .eq('activo', true)
+        .order('nombre', { ascending: true }),
+      sb
+        .schema('erp')
+        .from('v_cuenta_saldo_actual')
+        .select('cuenta_id, saldo, fecha_saldo, capturado_at')
+        .eq('empresa_id', empresaId),
+    ]);
+
+    if (cuentasRes.error) {
+      setError(getSupabaseErrorMessage(cuentasRes.error, 'No se pudieron cargar las cuentas.'));
+      setRows([]);
+      setLoading(false);
+      return;
+    }
+    if (saldosRes.error) {
+      setError(getSupabaseErrorMessage(saldosRes.error, 'No se pudieron cargar los saldos.'));
+      setRows([]);
+      setLoading(false);
+      return;
+    }
+
+    const saldoPorCuenta = new Map((saldosRes.data ?? []).map((s) => [s.cuenta_id, s] as const));
+
+    const merged: CuentaSaldoRow[] = (cuentasRes.data ?? []).map((c) => {
+      const s = c.id ? saldoPorCuenta.get(c.id) : undefined;
+      return {
+        cuentaId: c.id,
+        nombre: c.nombre,
+        banco: c.banco,
+        moneda: monedaDeCuenta(c.nombre, c.banco),
+        saldo: s?.saldo ?? null,
+        fechaSaldo: s?.fecha_saldo ?? null,
+        capturadoAt: s?.capturado_at ?? null,
+      };
+    });
+
+    setRows(merged);
+    setLoading(false);
+  }, [empresaId]);
+
+  useEffect(() => {
+    let activo = true;
+    void (async () => {
+      await cargar();
+      if (!activo) return;
+    })();
+    return () => {
+      activo = false;
+    };
+  }, [cargar]);
+
+  // ─── KPIs: total por moneda + cuentas con saldo stale ──────────────────────
+  const kpis = useMemo<ModuleKpi[]>(() => {
+    const totalMXN = rows
+      .filter((r) => r.moneda === 'MXN' && r.saldo != null)
+      .reduce((acc, r) => acc + (r.saldo ?? 0), 0);
+    const totalUSD = rows
+      .filter((r) => r.moneda === 'USD' && r.saldo != null)
+      .reduce((acc, r) => acc + (r.saldo ?? 0), 0);
+    const sinCaptura = rows.filter((r) => r.saldo == null).length;
+    const stale = rows.filter((r) => {
+      const dias = computeAntiguedadDias(r.fechaSaldo);
+      return dias != null && dias > 14;
+    }).length;
+
+    return [
+      {
+        key: 'total-mxn',
+        label: 'Total MXN',
+        value: formatCurrency(totalMXN, { currency: 'MXN' }),
+      },
+      {
+        key: 'total-usd',
+        label: 'Total USD',
+        value: formatCurrency(totalUSD, { currency: 'USD' }),
+      },
+      {
+        key: 'sin-captura',
+        label: 'Sin captura',
+        value: sinCaptura,
+        valueClassName: sinCaptura > 0 ? 'text-amber-500' : undefined,
+      },
+      {
+        key: 'stale',
+        label: 'Saldo viejo (>14d)',
+        value: stale,
+        valueClassName: stale > 0 ? 'text-red-500' : undefined,
+      },
+    ];
+  }, [rows]);
+
+  const columns: Column<CuentaSaldoRow>[] = [
+    {
+      key: 'nombre',
+      label: 'Cuenta',
+      type: 'text',
+      sticky: true,
+      width: 'min-w-[220px]',
+      render: (r) => (
+        <div className="min-w-0">
+          <div className="font-medium text-[var(--text)]">{r.nombre}</div>
+          {r.banco && r.banco !== r.nombre ? (
+            <div className="text-xs text-[var(--text)]/60">{r.banco}</div>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: 'moneda',
+      label: 'Moneda',
+      type: 'custom',
+      sortable: false,
+      render: (r) => <Badge tone={r.moneda === 'USD' ? 'info' : 'neutral'}>{r.moneda}</Badge>,
+    },
+    {
+      key: 'saldo',
+      label: 'Último saldo',
+      type: 'currency',
+      align: 'right',
+      accessor: (r) => r.saldo ?? Number.NEGATIVE_INFINITY,
+      render: (r) =>
+        r.saldo != null ? (
+          formatCurrency(r.saldo, { currency: r.moneda })
+        ) : (
+          <span className="text-[var(--text)]/40">—</span>
+        ),
+    },
+    {
+      key: 'fechaSaldo',
+      label: 'Fecha del saldo',
+      type: 'text',
+      align: 'right',
+      accessor: (r) => r.fechaSaldo ?? '',
+      render: (r) => (r.fechaSaldo ? formatDate(r.fechaSaldo) : '—'),
+    },
+    {
+      key: 'antiguedad',
+      label: 'Antigüedad',
+      type: 'custom',
+      align: 'right',
+      sortable: false,
+      render: (r) => {
+        const dias = computeAntiguedadDias(r.fechaSaldo);
+        return <Badge tone={antiguedadTone(dias)}>{antiguedadLabel(dias)}</Badge>;
+      },
+    },
+    {
+      key: 'capturar',
+      label: '',
+      type: 'custom',
+      sortable: false,
+      align: 'right',
+      render: (r) => (
+        <DataTable.InteractiveCell>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setCapturaCuenta(r)}
+            className="gap-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Capturar saldo
+          </Button>
+        </DataTable.InteractiveCell>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--accent)]/10 text-[var(--accent)]">
+          <Landmark className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--text)]">
+            Saldos Bancos
+          </h1>
+          <p className="text-sm text-[var(--text)]/60">
+            Saldo actual de cada cuenta bancaria de DILESA. Captura un snapshot fechado por cuenta;
+            el historial alimenta el correo diario al Consejo.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void cargar()}
+          className="ml-auto flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refrescar
+        </button>
+      </header>
+
+      <ModuleKpiStrip stats={kpis} cols={4} />
+
+      <DataTable
+        data={rows}
+        columns={columns}
+        rowKey="cuentaId"
+        loading={loading}
+        error={error}
+        onRetry={() => void cargar()}
+        onRowClick={(r) => setCapturaCuenta(r)}
+        initialSort={{ key: 'nombre', dir: 'asc' }}
+        emptyTitle="Sin cuentas bancarias"
+        emptyDescription="No hay cuentas bancarias activas para DILESA."
+        emptyIcon={<Wallet className="h-6 w-6" />}
+        maxHeight="calc(100vh - 320px)"
+      />
+
+      <SaldoCaptureDrawer
+        cuenta={capturaCuenta}
+        open={capturaCuenta != null}
+        onOpenChange={(o) => {
+          if (!o) setCapturaCuenta(null);
+        }}
+        onDone={() => void cargar()}
+      />
+    </div>
+  );
+}

--- a/components/dilesa/saldos-bancos-utils.test.ts
+++ b/components/dilesa/saldos-bancos-utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+
+import { monedaDeCuenta, computeAntiguedadDias } from './saldos-bancos-utils';
+
+describe('monedaDeCuenta', () => {
+  it('detecta USD para la cuenta de dólares (con acento)', () => {
+    expect(monedaDeCuenta('BBVA Bancomer Dólares', 'BBVA Bancomer')).toBe('USD');
+  });
+
+  it('detecta USD sin acento y case-insensitive', () => {
+    expect(monedaDeCuenta('cuenta dolares')).toBe('USD');
+    expect(monedaDeCuenta('USD Operativa')).toBe('USD');
+  });
+
+  it('default MXN para las cuentas en pesos', () => {
+    expect(monedaDeCuenta('BBVA Bancomer', 'BBVA Bancomer')).toBe('MXN');
+    expect(monedaDeCuenta('Casa de Bolsa Finamex', 'Finamex')).toBe('MXN');
+    expect(monedaDeCuenta('Monex Grupo Financiero', 'Monex')).toBe('MXN');
+  });
+
+  it('maneja null/undefined sin romper', () => {
+    expect(monedaDeCuenta(null)).toBe('MXN');
+    expect(monedaDeCuenta(null, null)).toBe('MXN');
+  });
+
+  it('no confunde substrings que contienen "usd" embebido', () => {
+    // "usd" como palabra suelta → USD; pero no debe disparar por azar en
+    // nombres MXN comunes.
+    expect(monedaDeCuenta('Inversión a plazo')).toBe('MXN');
+  });
+});
+
+describe('computeAntiguedadDias', () => {
+  // Fijamos "ahora" para tests determinísticos. 2026-06-07 12:00 UTC cae el
+  // mismo día calendar en Matamoros (UTC-5).
+  const now = new Date('2026-06-07T12:00:00Z');
+
+  it('null cuando no hay fecha', () => {
+    expect(computeAntiguedadDias(null, now)).toBeNull();
+    expect(computeAntiguedadDias(undefined, now)).toBeNull();
+    expect(computeAntiguedadDias('', now)).toBeNull();
+  });
+
+  it('0 cuando el saldo es de hoy', () => {
+    expect(computeAntiguedadDias('2026-06-07', now)).toBe(0);
+  });
+
+  it('cuenta días civiles hacia atrás', () => {
+    expect(computeAntiguedadDias('2026-06-06', now)).toBe(1);
+    expect(computeAntiguedadDias('2026-05-24', now)).toBe(14);
+    expect(computeAntiguedadDias('2026-05-23', now)).toBe(15);
+  });
+
+  it('acepta timestamps ISO completos (toma el componente date)', () => {
+    expect(computeAntiguedadDias('2026-06-06T23:59:59Z', now)).toBe(1);
+  });
+
+  it('clampa fechas futuras a 0', () => {
+    expect(computeAntiguedadDias('2026-06-10', now)).toBe(0);
+  });
+
+  it('devuelve null para fechas malformadas', () => {
+    expect(computeAntiguedadDias('not-a-date', now)).toBeNull();
+    expect(computeAntiguedadDias('2026-13', now)).toBeNull();
+  });
+});

--- a/components/dilesa/saldos-bancos-utils.ts
+++ b/components/dilesa/saldos-bancos-utils.ts
@@ -1,0 +1,75 @@
+/**
+ * Helpers puros del módulo Saldos Bancos (iniciativa `tesoreria`).
+ *
+ * Separados del componente para poder testearlos sin montar React y para que
+ * tanto el módulo como sus tests los compartan.
+ */
+
+export type Moneda = 'MXN' | 'USD';
+
+export type CuentaSaldoRow = {
+  cuentaId: string;
+  nombre: string;
+  banco: string | null;
+  moneda: Moneda;
+  /** Último saldo conocido (de `v_cuenta_saldo_actual`); null si nunca se capturó. */
+  saldo: number | null;
+  /** Fecha del último snapshot (date-only `YYYY-MM-DD`); null si no hay. */
+  fechaSaldo: string | null;
+  /** Timestamp del último snapshot; null si no hay. */
+  capturadoAt: string | null;
+};
+
+/**
+ * Infiere la moneda de una cuenta desde su nombre/banco.
+ *
+ * Las cuentas DILESA se cargaron en Sprint 1 sin `moneda_id` (viene null), así
+ * que la única señal disponible es el nombre: "BBVA Bancomer Dólares" → USD.
+ * Detección accent/case-insensitive de "dolar"/"dólar"/"usd". Default MXN.
+ *
+ * Cuando `conciliacion-bancaria` o una captura futura pueble `moneda_id` real,
+ * este heurístico se reemplaza por el lookup del catálogo de monedas.
+ */
+export function monedaDeCuenta(nombre: string | null, banco?: string | null): Moneda {
+  const haystack = `${nombre ?? ''} ${banco ?? ''}`
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // quita acentos: "Dólares" → "Dolares"
+    .toLowerCase();
+  if (haystack.includes('dolar') || /\busd\b/.test(haystack)) {
+    return 'USD';
+  }
+  return 'MXN';
+}
+
+/**
+ * Días civiles transcurridos desde la fecha del saldo hasta hoy (TZ
+ * America/Matamoros, donde operan las empresas de Beto). Hace visible un saldo
+ * stale (como Finamex en Coda, sin actualizar desde noviembre).
+ *
+ * - null si no hay fecha (cuenta sin captura).
+ * - 0 si el saldo es de hoy.
+ * - Negativos se clampean a 0 (una fecha futura no es "antigüedad").
+ *
+ * Trabaja sobre el componente date-only para no shiftear por TZ: compara la
+ * fecha calendar del saldo contra "hoy" en Matamoros.
+ */
+export function computeAntiguedadDias(
+  fechaSaldo: string | null | undefined,
+  now: Date = new Date()
+): number | null {
+  if (!fechaSaldo) return null;
+  const isoDay = fechaSaldo.slice(0, 10);
+  const parts = isoDay.split('-').map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) return null;
+  const [y, m, d] = parts as [number, number, number];
+
+  // "Hoy" en hora de Matamoros, como componente calendar (sv-SE → YYYY-MM-DD).
+  const hoyStr = new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Matamoros' }).format(now);
+  const [hy, hm, hd] = hoyStr.split('-').map(Number) as [number, number, number];
+
+  // Compara en UTC para evitar shifts de DST entre las dos fechas calendar.
+  const saldoUTC = Date.UTC(y, m - 1, d);
+  const hoyUTC = Date.UTC(hy, hm - 1, hd);
+  const dias = Math.floor((hoyUTC - saldoUTC) / 86_400_000);
+  return Math.max(0, dias);
+}


### PR DESCRIPTION
## Tesorería · Sprint 3 — UI de captura de Saldos Bancos

Resuelve "Bancos no aparece en el correo": le da a Beto **dónde capturar** los saldos.

Página `/dilesa/saldos-bancos` (sección Tesorería, desktop-only, `RequireAccess`):
- Una fila por cuenta DILESA: último saldo, fecha, **antigüedad** (badge verde ≤3d / ámbar / rojo >14d — hace visible un saldo viejo) y botón Capturar.
- **Captura** por drawer (form ADR-016): saldo, fecha, notas → apila un snapshot en `erp.cuenta_saldos` (append-only, audit trail). **Historial** por cuenta en el drawer.
- Server action `capturarSaldo`: `assertNotInPreview` + auth (`capturado_por`) + empresa DILESA.
- Multi-moneda: moneda inferida del nombre (la carga inicial dejó `moneda_id` NULL); totales MXN/USD separados.

El correo al Consejo lee `erp.v_cuenta_saldo_actual` → el **bloque de Bancos aparece en cuanto captures el primer saldo**.

19 tests nuevos. **Sin auto-merge — revísalo en el preview antes de mergear.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)