### PR TITLE
docs(dilesa-resumen-consejo): cutover — cron activado al Consejo

### DIFF
--- a/docs/planning/dilesa-resumen-consejo.md
+++ b/docs/planning/dilesa-resumen-consejo.md
@@ -3,10 +3,10 @@
 **Slug:** `dilesa-resumen-consejo`
 **Empresas:** DILESA
 **Schemas afectados:** `dilesa` (vistas nuevas `v_margen_prototipo`, `v_inventario_prototipo`; lectura de `v_proyecto_avances`, `ventas`, `venta_fase_catalogo`, `v_estimaciones_resumen`, `unidades`, `productos`, `proyectos`), `erp` (`cuentas_bancarias` — captura manual de saldos), `core` (`notification_log` + registry)
-**Estado:** planned
+**Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-06-07
-**Última actualización:** 2026-06-07 (promovida a `planned`; mismo día se refinó: RUV/Seguro resuelto (Coda correcto, BSOP tiene el % ÷10 → fix en Sprint 0) y el bloque de bancos pasa a depender del módulo Saldos Bancos de la nueva iniciativa hermana `tesoreria` — el correo espera ese módulo para lanzar los 7 bloques. Paridad 1:1 primero + mejoras en Fase 2; envío a `consejo@dilesa.mx` ~20:00 CST L–S, domingo no.)
+**Última actualización:** 2026-06-07 (**CUTOVER** — Sprints 0-2 en prod: vistas margen/inventario + fix RUV/Seguro (#725), plantilla del correo (#733), cron+envío con fail-safe (#734), rediseño de Contratistas a obra-en-construcción con vista `v_contratista_obra` (#736), layout al original full-width (#738), y UI de captura de saldos `tesoreria` S3 (#739). Correo validado end-to-end con Beto: 7/7 secciones (incl. Bancos con saldos demo de Coda). `RESUMEN_CONSEJO_LIVE=1` activado en Vercel prod → el cron empieza a enviar a `consejo@dilesa.mx` (L–S 20:00 CST, domingo no); Coda apagado por Beto. Pendiente: Beto captura los saldos reales en la UI (los cargados son demo del 3-jun). Mejoras Fase 2 (CxC/CxP, resumen ejecutivo, alertas) en backlog. | promovida a `planned`; mismo día se refinó: RUV/Seguro resuelto (Coda correcto, BSOP tiene el % ÷10 → fix en Sprint 0) y el bloque de bancos pasa a depender del módulo Saldos Bancos de la nueva iniciativa hermana `tesoreria` — el correo espera ese módulo para lanzar los 7 bloques. Paridad 1:1 primero + mejoras en Fase 2; envío a `consejo@dilesa.mx` ~20:00 CST L–S, domingo no.)
 
 ## Problema
 


### PR DESCRIPTION
Cutover del correo al Consejo: `RESUMEN_CONSEJO_LIVE=1` activado en Vercel prod. El merge dispara el deploy que toma la env (el cron empezará a enviar a consejo@dilesa.mx, L–S 20:00 CST). Coda apagado por Beto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)