### PR TITLE
fix(tesoreria): exponer la sección Tesorería en la gestión de accesos

### DIFF
--- a/app/settings/acceso/acceso-client.tsx
+++ b/app/settings/acceso/acceso-client.tsx
@@ -156,6 +156,7 @@ function modulosAsignablesParaRol(
 const SECCION_ORDER: readonly ModuloSeccion[] = [
   'operativa',
   'administracion',
+  'tesoreria',
   'rh',
   'compras',
   'inventario',
@@ -166,6 +167,7 @@ const SECCION_ORDER: readonly ModuloSeccion[] = [
 const SECCION_LABELS: Record<ModuloSeccion, string> = {
   operativa: 'Operativa',
   administracion: 'Administración',
+  tesoreria: 'Tesorería',
   rh: 'Recursos Humanos',
   compras: 'Compras',
   inventario: 'Inventario',

--- a/app/settings/acceso/actions.ts
+++ b/app/settings/acceso/actions.ts
@@ -32,6 +32,7 @@ export type ModuloSeccion =
   | 'compras'
   | 'inventario'
   | 'operaciones'
+  | 'tesoreria'
   | 'sistema';
 
 export type Modulo = {


### PR DESCRIPTION
Bug de Sprint 2: al mover CxC/CxP a la sección `tesoreria` nueva, desaparecieron de `/settings/acceso` (la UI tiene un espejo manual de secciones ADR-014). Agrego `tesoreria` al tipo `ModuloSeccion` + `SECCION_ORDER` + `SECCION_LABELS`. Los permisos en DB estaban OK (clonados de CxP); solo no se gestionaban desde la UI.

typecheck ✅ · lint ✅ · test ✅ · format ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)