### PR TITLE
feat(dilesa): PDFs imprimibles de solicitudes + contacto = Gerente de Ventas

### DIFF
--- a/app/api/dilesa/ventas/[id]/notify-solicitud-avaluo/route.ts
+++ b/app/api/dilesa/ventas/[id]/notify-solicitud-avaluo/route.ts
@@ -24,6 +24,7 @@ import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { sendAvaluoSolicitudEmail, type AvaluoSolicitudContext } from '@/lib/dilesa/avaluo-emails';
 import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
 import { signAvaluoToken } from '@/lib/dilesa/avaluo-token';
+import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -175,6 +176,14 @@ export async function POST(_req: NextRequest, ctx: { params: Promise<{ id: strin
 
   const branding = await loadEmpresaBranding(admin, venta.empresa_id);
 
+  // Contacto para el valuador = Gerente de Ventas de la empresa (Edgar en
+  // DILESA), NO el asesor que capturó la venta. Decisión Beto: el valuador
+  // coordina con la gerencia comercial. Fallback al asesor si no hay
+  // gerente activo (defensa para no dejar el email sin contacto).
+  const gerente = await loadGerenteVentas(admin, venta.empresa_id);
+  const contactoNombre = gerente?.nombre ?? vendedorNombre;
+  const contactoEmail = gerente?.email ?? (usuario?.email as string | null) ?? null;
+
   // Genera el magic link para que el valuador suba el dictamen sin login.
   // Hardcodeamos `https://bsop.io` como en lib/dilesa/email-branding.ts: los
   // emails se envían desde prod siempre, usar `NEXT_PUBLIC_SITE_URL` haría
@@ -215,11 +224,12 @@ export async function POST(_req: NextRequest, ctx: { params: Promise<{ id: strin
     m2Construccion: unidad?.m2_construccion != null ? Number(unidad.m2_construccion) : null,
     esquina: unidad?.es_esquina ?? null,
     tieneFrenteVerde: unidad?.tiene_frente_verde ?? null,
-    vendedorNombre,
-    vendedorEmail: (usuario?.email as string | null) ?? null,
-    // `core.usuarios` no tiene columna teléfono — si lo necesitamos en
-    // el futuro habrá que agregarlo al perfil o leer de erp.personas.
-    vendedorTelefono: null,
+    // El campo "vendedor*" del contexto se etiqueta como "Gerencia de
+    // Ventas" en el email — usamos al Gerente de Ventas (Edgar), no al
+    // asesor que capturó la venta.
+    vendedorNombre: contactoNombre,
+    vendedorEmail: contactoEmail,
+    vendedorTelefono: gerente?.telefono ?? null,
   };
 
   const res = await sendAvaluoSolicitudEmail(emailCtx);

--- a/app/api/dilesa/ventas/[id]/notify-solicitud-dictamen/route.ts
+++ b/app/api/dilesa/ventas/[id]/notify-solicitud-dictamen/route.ts
@@ -23,6 +23,7 @@ import {
 } from '@/lib/dilesa/dictamen-emails';
 import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
 import { signDictamenToken } from '@/lib/dilesa/dictamen-token';
+import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -169,6 +170,12 @@ export async function POST(_req: NextRequest, ctx: { params: Promise<{ id: strin
 
   const branding = await loadEmpresaBranding(admin, venta.empresa_id);
 
+  // Contacto para el notario = Gerente de Ventas (Edgar en DILESA), NO el
+  // asesor que capturó la venta. Mismo criterio que el email de avalúo.
+  const gerente = await loadGerenteVentas(admin, venta.empresa_id);
+  const contactoNombre = gerente?.nombre ?? vendedorNombre;
+  const contactoEmail = gerente?.email ?? (usuario?.email as string | null) ?? null;
+
   // Genera el magic link para que el notario suba la Carta de Instrucción.
   let uploadUrl = '';
   try {
@@ -209,8 +216,10 @@ export async function POST(_req: NextRequest, ctx: { params: Promise<{ id: strin
       venta.monto_credito_titular != null ? Number(venta.monto_credito_titular) : null,
     montoCreditoCotitular:
       venta.monto_credito_cotitular != null ? Number(venta.monto_credito_cotitular) : null,
-    vendedorNombre,
-    vendedorEmail: (usuario?.email as string | null) ?? null,
+    // Etiquetado como "Gerencia de Ventas" en el email — usamos al
+    // Gerente de Ventas (Edgar), no al asesor que capturó la venta.
+    vendedorNombre: contactoNombre,
+    vendedorEmail: contactoEmail,
   };
 
   const res = await sendDictamenSolicitudEmail(emailCtx);

--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -24,11 +24,31 @@ import { SolicitudAsignacionPDF, type SolicitudData } from '@/lib/dilesa/pdf/sol
 import { AvisoPrivacidadPDF, type AvisoPrivacidadData } from '@/lib/dilesa/pdf/aviso-privacidad';
 import { FicuPDF, type FicuData } from '@/lib/dilesa/pdf/ficu';
 import { PromesaCompraventaPDF, type PromesaData } from '@/lib/dilesa/pdf/promesa-compraventa';
+import { SolicitudAvaluoPDF, type SolicitudAvaluoData } from '@/lib/dilesa/pdf/solicitud-avaluo';
+import {
+  SolicitudDictamenPDF,
+  type SolicitudDictamenData,
+} from '@/lib/dilesa/pdf/solicitud-dictamen';
 import { evaluarRiesgo } from '@/lib/dilesa/ficu/riesgo';
 import { formatMontoEnLetras } from '@/lib/format/numero-a-letras';
 
-const TIPOS = ['solicitud-asignacion', 'aviso-privacidad', 'ficu', 'promesa-compraventa'] as const;
+const TIPOS = [
+  'solicitud-asignacion',
+  'aviso-privacidad',
+  'ficu',
+  'promesa-compraventa',
+  'solicitud-avaluo',
+  'solicitud-dictamen',
+] as const;
 type TipoPdf = (typeof TIPOS)[number];
+
+const moneyFmtPdf = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const moneyPdf = (n: number | null | undefined): string | null =>
+  n == null || Number(n) <= 0 ? null : moneyFmtPdf.format(Number(n));
 
 const MESES_ES = [
   'Enero',
@@ -66,7 +86,7 @@ export async function GET(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, created_at, ine_numero, estado'
+      'id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, created_at, ine_numero, estado, valuador_id, notario_id'
     )
     .eq('id', id)
     .is('deleted_at', null)
@@ -108,6 +128,7 @@ export async function GET(
   // solo el first_name; si falta first_name, fallback a email; si nada,
   // al campo text legacy de la venta.
   let vendedorNombre = (venta.vendedor ?? '').toString();
+  let vendedorEmail: string | null = null;
   if (venta.vendedor_usuario_id) {
     const { data: u } = await sb
       .schema('core')
@@ -121,11 +142,22 @@ export async function GET(
     } else if (u?.email && !vendedorNombre) {
       vendedorNombre = u.email;
     }
+    vendedorEmail = (u?.email as string | null) ?? null;
   }
 
   // Unidad + proyecto + producto (todos en dilesa)
   let identificacionInventario = '';
   let pdfDataExtra: Partial<SolicitudData> = {};
+  // Datos del inmueble en scope superior para las solicitudes imprimibles
+  // (avalúo, dictamen) que los muestran tal cual sin desglose de precio.
+  let pdfFraccionamiento: string | null = null;
+  let pdfManzana: string | null = null;
+  let pdfLote: string | null = null;
+  let pdfPrototipo: string | null = null;
+  let pdfDomicilioOficial: string | null = null;
+  let pdfAreaTerreno: string | null = null;
+  let pdfAreaConstruida: string | null = null;
+  let pdfCaracteristicas: string | null = null;
   if (venta.unidad_id) {
     const { data: unidad } = await sb
       .schema('dilesa')
@@ -175,6 +207,21 @@ export async function GET(
         esquina: unidad.es_esquina ?? false,
         precioM2Excedente: Number(proyecto?.precio_m2_excedente ?? 0),
       };
+
+      // Datos para las solicitudes imprimibles (avalúo, dictamen).
+      pdfFraccionamiento = proyecto?.nombre ?? null;
+      pdfManzana = unidad.manzana ?? null;
+      pdfLote = unidad.numero_lote ?? null;
+      pdfPrototipo = protoSufijo || null;
+      pdfDomicilioOficial =
+        [unidad.calle, unidad.numero_oficial].filter(Boolean).join(' #') || null;
+      pdfAreaTerreno = unidad.area_m2 != null ? `${Number(unidad.area_m2).toFixed(2)} m²` : null;
+      pdfAreaConstruida =
+        unidad.m2_construccion != null ? `${Number(unidad.m2_construccion).toFixed(2)} m²` : null;
+      const carac: string[] = [];
+      if (unidad.es_esquina) carac.push('Esquina');
+      if (unidad.tiene_frente_verde) carac.push('Frente verde');
+      pdfCaracteristicas = carac.length > 0 ? carac.join(' · ') : null;
     }
   }
 
@@ -185,6 +232,83 @@ export async function GET(
     month: 'long',
     year: 'numeric',
   });
+
+  if (tipo === 'solicitud-avaluo') {
+    let valuadorNombre = '(casa valuadora)';
+    if (venta.valuador_id) {
+      const { data: val } = await sb
+        .schema('erp')
+        .from('personas')
+        .select('nombre, apellido_paterno, apellido_materno')
+        .eq('id', venta.valuador_id)
+        .maybeSingle();
+      valuadorNombre =
+        [val?.nombre, val?.apellido_paterno, val?.apellido_materno]
+          .filter(Boolean)
+          .join(' ')
+          .trim() || valuadorNombre;
+    }
+    const data: SolicitudAvaluoData = {
+      fechaTexto,
+      valuadorNombre,
+      fraccionamiento: pdfFraccionamiento,
+      manzana: pdfManzana,
+      lote: pdfLote,
+      prototipo: pdfPrototipo,
+      identificacionInventario,
+      domicilioOficial: pdfDomicilioOficial,
+      areaTerreno: pdfAreaTerreno,
+      areaConstruida: pdfAreaConstruida,
+      caracteristicas: pdfCaracteristicas,
+      clienteNombre,
+      clienteCurp: persona?.curp ?? null,
+      clienteTelefono: persona?.telefono ?? null,
+      vendedorNombre: vendedorNombre || null,
+      vendedorEmail,
+    };
+    const buf = await renderToBuffer(<SolicitudAvaluoPDF data={data} />);
+    return pdfResponse(buf, `solicitud-avaluo-${identificacionInventario || id}.pdf`);
+  }
+
+  if (tipo === 'solicitud-dictamen') {
+    let notarioNombre = '(notaría)';
+    if (venta.notario_id) {
+      const { data: not } = await sb
+        .schema('erp')
+        .from('personas')
+        .select('nombre, apellido_paterno, apellido_materno')
+        .eq('id', venta.notario_id)
+        .maybeSingle();
+      notarioNombre =
+        [not?.nombre, not?.apellido_paterno, not?.apellido_materno]
+          .filter(Boolean)
+          .join(' ')
+          .trim() || notarioNombre;
+    }
+    const data: SolicitudDictamenData = {
+      fechaTexto,
+      notarioNombre,
+      fraccionamiento: pdfFraccionamiento,
+      manzana: pdfManzana,
+      lote: pdfLote,
+      prototipo: pdfPrototipo,
+      identificacionInventario,
+      domicilioOficial: pdfDomicilioOficial,
+      areaTerreno: pdfAreaTerreno,
+      areaConstruida: pdfAreaConstruida,
+      clienteNombre,
+      clienteCurp: persona?.curp ?? null,
+      clienteTelefono: persona?.telefono ?? null,
+      tipoCredito: venta.tipo_credito ?? null,
+      precioVenta: moneyPdf(venta.precio_asignacion),
+      montoCreditoTitular: moneyPdf(venta.monto_credito_titular),
+      montoCreditoCotitular: moneyPdf(venta.monto_credito_cotitular),
+      vendedorNombre: vendedorNombre || null,
+      vendedorEmail,
+    };
+    const buf = await renderToBuffer(<SolicitudDictamenPDF data={data} />);
+    return pdfResponse(buf, `solicitud-dictamen-${identificacionInventario || id}.pdf`);
+  }
 
   if (tipo === 'aviso-privacidad') {
     const data: AvisoPrivacidadData = {

--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/lib/dilesa/pdf/solicitud-dictamen';
 import { evaluarRiesgo } from '@/lib/dilesa/ficu/riesgo';
 import { formatMontoEnLetras } from '@/lib/format/numero-a-letras';
+import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
 
 const TIPOS = [
   'solicitud-asignacion',
@@ -86,7 +87,7 @@ export async function GET(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, created_at, ine_numero, estado, valuador_id, notario_id'
+      'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, created_at, ine_numero, estado, valuador_id, notario_id'
     )
     .eq('id', id)
     .is('deleted_at', null)
@@ -233,6 +234,16 @@ export async function GET(
     year: 'numeric',
   });
 
+  // Para las solicitudes (avalúo/dictamen) el contacto es el Gerente de
+  // Ventas (Edgar en DILESA), no el asesor que capturó la venta. Mismo
+  // criterio que los emails. Solo se resuelve para esos 2 tipos.
+  const gerente =
+    tipo === 'solicitud-avaluo' || tipo === 'solicitud-dictamen'
+      ? await loadGerenteVentas(sb, venta.empresa_id)
+      : null;
+  const contactoNombre = gerente?.nombre ?? (vendedorNombre || null);
+  const contactoEmail = gerente?.email ?? vendedorEmail;
+
   if (tipo === 'solicitud-avaluo') {
     let valuadorNombre = '(casa valuadora)';
     if (venta.valuador_id) {
@@ -263,8 +274,8 @@ export async function GET(
       clienteNombre,
       clienteCurp: persona?.curp ?? null,
       clienteTelefono: persona?.telefono ?? null,
-      vendedorNombre: vendedorNombre || null,
-      vendedorEmail,
+      vendedorNombre: contactoNombre,
+      vendedorEmail: contactoEmail,
     };
     const buf = await renderToBuffer(<SolicitudAvaluoPDF data={data} />);
     return pdfResponse(buf, `solicitud-avaluo-${identificacionInventario || id}.pdf`);
@@ -303,8 +314,8 @@ export async function GET(
       precioVenta: moneyPdf(venta.precio_asignacion),
       montoCreditoTitular: moneyPdf(venta.monto_credito_titular),
       montoCreditoCotitular: moneyPdf(venta.monto_credito_cotitular),
-      vendedorNombre: vendedorNombre || null,
-      vendedorEmail,
+      vendedorNombre: contactoNombre,
+      vendedorEmail: contactoEmail,
     };
     const buf = await renderToBuffer(<SolicitudDictamenPDF data={data} />);
     return pdfResponse(buf, `solicitud-dictamen-${identificacionInventario || id}.pdf`);

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -97,6 +97,8 @@ type Venta = {
   vendedor: string | null;
   notario: string | null;
   casa_valuadora: string | null;
+  valuador_id: string | null;
+  notario_id: string | null;
   es_pep: boolean | null;
   ocupacion: string | null;
   ine_numero: string | null;
@@ -815,6 +817,16 @@ function DetailInner() {
           tipo="promesa-compraventa"
           label="Promesa de Compraventa"
         />
+        {venta.valuador_id ? (
+          <PdfDownloadLink ventaId={venta.id} tipo="solicitud-avaluo" label="Solicitud de Avalúo" />
+        ) : null}
+        {venta.notario_id ? (
+          <PdfDownloadLink
+            ventaId={venta.id}
+            tipo="solicitud-dictamen"
+            label="Solicitud de Dictaminación"
+          />
+        ) : null}
       </div>
 
       <MovimientosAdministrativos
@@ -1471,7 +1483,13 @@ function PdfDownloadLink({
   label,
 }: {
   ventaId: string;
-  tipo: 'solicitud-asignacion' | 'aviso-privacidad' | 'ficu' | 'promesa-compraventa';
+  tipo:
+    | 'solicitud-asignacion'
+    | 'aviso-privacidad'
+    | 'ficu'
+    | 'promesa-compraventa'
+    | 'solicitud-avaluo'
+    | 'solicitud-dictamen';
   label: string;
 }) {
   return (

--- a/lib/dilesa/gerente-ventas.ts
+++ b/lib/dilesa/gerente-ventas.ts
@@ -1,0 +1,98 @@
+/**
+ * Resuelve el Gerente de Ventas de una empresa para usarlo como contacto
+ * en las solicitudes a terceros (avalúo, dictamen).
+ *
+ * El Gerente de Ventas es un EMPLEADO (`erp.empleados` → `erp.personas`
+ * con puesto "Gerente de Ventas" en `erp.empleados_puestos`), NO un
+ * usuario de `core.usuarios`. Por eso no se puede resolver desde
+ * `dilesa.ventas.vendedor_usuario_id` (ese es el asesor que capturó la
+ * venta, que puede ser cualquiera del equipo de ventas).
+ *
+ * Decisión Beto (2026-06-08): el valuador/notario coordina SIEMPRE con
+ * el Gerente de Ventas (Edgar en DILESA), no con el asesor individual
+ * que metió la solicitud. Por eso los emails/PDFs de avalúo y dictamen
+ * muestran al gerente como "Gerencia de Ventas — contacto para
+ * coordinar".
+ *
+ * Si la empresa no tiene un gerente de ventas activo, retorna null y el
+ * caller decide el fallback (típicamente omitir la fila de contacto).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface GerenteVentas {
+  nombre: string;
+  email: string | null;
+  telefono: string | null;
+}
+
+/**
+ * Busca el empleado activo con puesto "Gerente de Ventas" en la empresa.
+ * Match case-insensitive por nombre del puesto para tolerar variantes
+ * ("Gerente de Ventas" / "Gerencia de Ventas"). Si hay varios, toma el
+ * primero (orden estable por nombre de la persona).
+ *
+ * Usa el admin client porque corre en endpoints server-side que componen
+ * emails/PDFs — solo lectura, sin exponer nada al cliente.
+ */
+export async function loadGerenteVentas(
+  admin: SupabaseClient,
+  empresaId: string
+): Promise<GerenteVentas | null> {
+  // 1. Puesto(s) de gerencia de ventas en la empresa.
+  /* eslint-disable @typescript-eslint/no-explicit-any -- supabase-js solo tipa public por default */
+  const { data: puestos } = await (admin.schema('erp') as any)
+    .from('puestos')
+    .select('id, nombre')
+    .eq('empresa_id', empresaId)
+    .or('nombre.ilike.%gerente de ventas%,nombre.ilike.%gerencia de ventas%');
+  const puestoIds = ((puestos ?? []) as Array<{ id: string }>).map((p) => p.id);
+  if (puestoIds.length === 0) return null;
+
+  // 2. Empleados activos con ese puesto.
+  const { data: ep } = await (admin.schema('erp') as any)
+    .from('empleados_puestos')
+    .select('empleado_id')
+    .in('puesto_id', puestoIds);
+  const empleadoIds = ((ep ?? []) as Array<{ empleado_id: string }>).map((r) => r.empleado_id);
+  if (empleadoIds.length === 0) return null;
+
+  const { data: empleados } = await (admin.schema('erp') as any)
+    .from('empleados')
+    .select('id, persona_id, activo')
+    .in('id', empleadoIds)
+    .eq('activo', true);
+  const personaIds = ((empleados ?? []) as Array<{ persona_id: string }>).map((e) => e.persona_id);
+  if (personaIds.length === 0) return null;
+
+  // 3. Datos de la persona.
+  const { data: personas } = await (admin.schema('erp') as any)
+    .from('personas')
+    .select('nombre, apellido_paterno, apellido_materno, email, telefono')
+    .in('id', personaIds)
+    .eq('empresa_id', empresaId)
+    .order('nombre', { ascending: true });
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  const persona = (personas ?? [])[0] as
+    | {
+        nombre: string | null;
+        apellido_paterno: string | null;
+        apellido_materno: string | null;
+        email: string | null;
+        telefono: string | null;
+      }
+    | undefined;
+  if (!persona) return null;
+
+  const nombre =
+    [persona.nombre, persona.apellido_paterno, persona.apellido_materno]
+      .filter(Boolean)
+      .join(' ')
+      .trim() || '(Gerente de Ventas)';
+
+  return {
+    nombre,
+    email: persona.email ?? null,
+    telefono: persona.telefono ?? null,
+  };
+}

--- a/lib/dilesa/pdf/seccion-datos.tsx
+++ b/lib/dilesa/pdf/seccion-datos.tsx
@@ -1,0 +1,72 @@
+/**
+ * Sección de datos reusable para PDFs DILESA — título + filas
+ * label/valor. Usada por las solicitudes imprimibles (avalúo, dictamen)
+ * que replican las secciones del email correspondiente en papel.
+ *
+ * Las filas con `value` null/'' se omiten para no ensuciar el PDF con
+ * campos vacíos (mismo criterio que `renderSeccionDatos` del email).
+ */
+import { Text, View } from '@react-pdf/renderer';
+import { StyleSheet } from '@react-pdf/renderer';
+import { colors } from './styles';
+
+export type FilaDato = { label: string; value: string | null | undefined };
+
+const s = StyleSheet.create({
+  sectionTitle: {
+    fontSize: 10,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.primary,
+    letterSpacing: 0.5,
+    marginTop: 10,
+    marginBottom: 4,
+    textTransform: 'uppercase',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 2,
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.borderSoft,
+  },
+  label: {
+    fontSize: 8.5,
+    color: colors.textMuted,
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
+    width: '45%',
+  },
+  value: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.text,
+    textAlign: 'right',
+    width: '55%',
+  },
+  paragraph: {
+    fontSize: 9.5,
+    lineHeight: 1.5,
+    marginBottom: 6,
+    textAlign: 'justify',
+  },
+});
+
+export function SeccionDatos({ titulo, filas }: { titulo: string; filas: FilaDato[] }) {
+  const visibles = filas.filter((f) => f.value != null && String(f.value).trim() !== '');
+  if (visibles.length === 0) return null;
+  return (
+    <View>
+      <Text style={s.sectionTitle}>{titulo}</Text>
+      {visibles.map((f) => (
+        <View style={s.row} key={f.label}>
+          <Text style={s.label}>{f.label}</Text>
+          <Text style={s.value}>{String(f.value)}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export function Parrafo({ children }: { children: string }) {
+  return <Text style={s.paragraph}>{children}</Text>;
+}

--- a/lib/dilesa/pdf/solicitud-avaluo.tsx
+++ b/lib/dilesa/pdf/solicitud-avaluo.tsx
@@ -1,0 +1,114 @@
+/**
+ * Template PDF: Solicitud de Avalúo (Sprint 7g).
+ *
+ * Versión imprimible del email de Fase 4 (`lib/dilesa/avaluo-emails.ts`).
+ * Para entregar la solicitud en papel cuando la casa valuadora no tiene
+ * email registrado, o cuando el operador quiere copia física.
+ *
+ * Mismo branding que los demás PDFs DILESA (banda olivo + footer).
+ */
+import { Document, Page, Text, View } from '@react-pdf/renderer';
+import { StyleSheet } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand } from './header-footer';
+import { SeccionDatos, Parrafo, type FilaDato } from './seccion-datos';
+
+export type SolicitudAvaluoData = {
+  fechaTexto: string;
+  valuadorNombre: string;
+  // Inmueble
+  fraccionamiento: string | null;
+  manzana: string | null;
+  lote: string | null;
+  prototipo: string | null;
+  identificacionInventario: string;
+  domicilioOficial: string | null;
+  areaTerreno: string | null; // "184.89 m²"
+  areaConstruida: string | null;
+  caracteristicas: string | null; // "Esquina · Frente verde"
+  // Comprador
+  clienteNombre: string;
+  clienteCurp: string | null;
+  clienteTelefono: string | null;
+  // Contacto ventas
+  vendedorNombre: string | null;
+  vendedorEmail: string | null;
+};
+
+const local = StyleSheet.create({
+  saludo: { fontSize: 10.5, marginTop: 4, marginBottom: 4 },
+  firmaWrap: { marginTop: 36, flexDirection: 'row', justifyContent: 'space-between' },
+  firmaCol: { width: '45%', alignItems: 'center' },
+  firmaLinea: {
+    borderTopWidth: 0.8,
+    borderTopColor: colors.text,
+    width: '100%',
+    marginBottom: 3,
+    paddingTop: 4,
+  },
+  firmaLabel: { fontSize: 8.5, color: colors.textMuted, textAlign: 'center' },
+});
+
+export function SolicitudAvaluoPDF({ data }: { data: SolicitudAvaluoData }) {
+  const filasInmueble: FilaDato[] = [
+    { label: 'Fraccionamiento', value: data.fraccionamiento },
+    { label: 'Manzana', value: data.manzana },
+    { label: 'Lote', value: data.lote },
+    { label: 'Prototipo', value: data.prototipo },
+    { label: 'Identificación inventario', value: data.identificacionInventario },
+    { label: 'Dirección', value: data.domicilioOficial },
+    { label: 'Área terreno', value: data.areaTerreno },
+    { label: 'Área construida', value: data.areaConstruida },
+    { label: 'Características', value: data.caracteristicas },
+  ];
+  const filasCliente: FilaDato[] = [
+    { label: 'Nombre', value: data.clienteNombre },
+    { label: 'CURP', value: data.clienteCurp },
+    { label: 'Teléfono', value: data.clienteTelefono },
+  ];
+  const filasVentas: FilaDato[] = [
+    { label: 'Gerencia de ventas', value: data.vendedorNombre },
+    { label: 'Correo', value: data.vendedorEmail },
+  ];
+
+  return (
+    <Document title={`Solicitud de Avalúo — ${data.identificacionInventario}`}>
+      <Page size="LETTER" style={styles.page}>
+        <HeaderBand title="SOLICITUD DE AVALÚO" fecha={data.fechaTexto} />
+
+        <Text style={local.saludo}>
+          Estimado(a) <Text style={{ fontFamily: 'Helvetica-Bold' }}>{data.valuadorNombre}</Text>,
+        </Text>
+        <Parrafo>
+          Por medio del presente solicitamos sus amables servicios para realizar el avalúo comercial
+          de la siguiente vivienda en proceso de venta. A continuación encontrará los datos del
+          inmueble y del comprador, así como los datos de contacto del responsable comercial para
+          coordinar la visita y la entrega del dictamen.
+        </Parrafo>
+
+        <SeccionDatos titulo="Datos del inmueble a valuar" filas={filasInmueble} />
+        <SeccionDatos titulo="Datos del comprador" filas={filasCliente} />
+        <SeccionDatos titulo="Contacto para coordinar la visita" filas={filasVentas} />
+
+        <Parrafo>
+          Una vez concluido el avalúo, le agradeceremos hacer llegar el dictamen al gerente de
+          ventas indicado para su captura en nuestro sistema. Quedamos atentos a cualquier solicitud
+          adicional de información.
+        </Parrafo>
+
+        <View style={local.firmaWrap}>
+          <View style={local.firmaCol}>
+            <View style={local.firmaLinea} />
+            <Text style={local.firmaLabel}>Solicita — DILESA</Text>
+          </View>
+          <View style={local.firmaCol}>
+            <View style={local.firmaLinea} />
+            <Text style={local.firmaLabel}>Recibe — Casa Valuadora</Text>
+          </View>
+        </View>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}

--- a/lib/dilesa/pdf/solicitud-dictamen.tsx
+++ b/lib/dilesa/pdf/solicitud-dictamen.tsx
@@ -1,0 +1,121 @@
+/**
+ * Template PDF: Solicitud de Dictaminación Notarial (Sprint 7g).
+ *
+ * Versión imprimible del email de Fase 7 (`lib/dilesa/dictamen-emails.ts`).
+ * Para entregar la solicitud en papel cuando la notaría no tiene email
+ * registrado, o cuando el operador quiere copia física.
+ */
+import { Document, Page, Text, View } from '@react-pdf/renderer';
+import { StyleSheet } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand } from './header-footer';
+import { SeccionDatos, Parrafo, type FilaDato } from './seccion-datos';
+
+export type SolicitudDictamenData = {
+  fechaTexto: string;
+  notarioNombre: string;
+  // Inmueble
+  fraccionamiento: string | null;
+  manzana: string | null;
+  lote: string | null;
+  prototipo: string | null;
+  identificacionInventario: string;
+  domicilioOficial: string | null;
+  areaTerreno: string | null;
+  areaConstruida: string | null;
+  // Comprador
+  clienteNombre: string;
+  clienteCurp: string | null;
+  clienteTelefono: string | null;
+  // Operación
+  tipoCredito: string | null;
+  precioVenta: string | null; // "$2,790,000"
+  montoCreditoTitular: string | null;
+  montoCreditoCotitular: string | null;
+  // Contacto ventas
+  vendedorNombre: string | null;
+  vendedorEmail: string | null;
+};
+
+const local = StyleSheet.create({
+  saludo: { fontSize: 10.5, marginTop: 4, marginBottom: 4 },
+  firmaWrap: { marginTop: 28, flexDirection: 'row', justifyContent: 'space-between' },
+  firmaCol: { width: '45%', alignItems: 'center' },
+  firmaLinea: {
+    borderTopWidth: 0.8,
+    borderTopColor: colors.text,
+    width: '100%',
+    marginBottom: 3,
+    paddingTop: 4,
+  },
+  firmaLabel: { fontSize: 8.5, color: colors.textMuted, textAlign: 'center' },
+});
+
+export function SolicitudDictamenPDF({ data }: { data: SolicitudDictamenData }) {
+  const filasInmueble: FilaDato[] = [
+    { label: 'Fraccionamiento', value: data.fraccionamiento },
+    { label: 'Manzana', value: data.manzana },
+    { label: 'Lote', value: data.lote },
+    { label: 'Prototipo', value: data.prototipo },
+    { label: 'Identificación inventario', value: data.identificacionInventario },
+    { label: 'Dirección', value: data.domicilioOficial },
+    { label: 'Área terreno', value: data.areaTerreno },
+    { label: 'Área construida', value: data.areaConstruida },
+  ];
+  const filasCliente: FilaDato[] = [
+    { label: 'Nombre', value: data.clienteNombre },
+    { label: 'CURP', value: data.clienteCurp },
+    { label: 'Teléfono', value: data.clienteTelefono },
+  ];
+  const filasOperacion: FilaDato[] = [
+    { label: 'Tipo de crédito', value: data.tipoCredito },
+    { label: 'Precio de venta', value: data.precioVenta },
+    { label: 'Crédito titular', value: data.montoCreditoTitular },
+    { label: 'Crédito co-titular', value: data.montoCreditoCotitular },
+  ];
+  const filasVentas: FilaDato[] = [
+    { label: 'Gerencia de ventas', value: data.vendedorNombre },
+    { label: 'Correo', value: data.vendedorEmail },
+  ];
+
+  return (
+    <Document title={`Solicitud de Dictaminación — ${data.identificacionInventario}`}>
+      <Page size="LETTER" style={styles.page}>
+        <HeaderBand title="SOLICITUD DE DICTAMINACIÓN" fecha={data.fechaTexto} />
+
+        <Text style={local.saludo}>
+          Estimado(a) <Text style={{ fontFamily: 'Helvetica-Bold' }}>{data.notarioNombre}</Text>,
+        </Text>
+        <Parrafo>
+          Por medio del presente solicitamos sus servicios para el dictamen jurídico y elaboración
+          de la Carta de Instrucción Notarial de la siguiente operación inmobiliaria. A continuación
+          encontrará los datos del inmueble, del comprador y de la operación.
+        </Parrafo>
+
+        <SeccionDatos titulo="Datos del inmueble a escriturar" filas={filasInmueble} />
+        <SeccionDatos titulo="Datos del comprador" filas={filasCliente} />
+        <SeccionDatos titulo="Datos de la operación" filas={filasOperacion} />
+        <SeccionDatos titulo="Contacto para coordinar la entrega" filas={filasVentas} />
+
+        <Parrafo>
+          Una vez concluido el dictamen, le agradeceremos hacer llegar la Carta de Instrucción al
+          gerente de ventas indicado para su captura en nuestro sistema. Quedamos atentos a
+          cualquier solicitud adicional de información.
+        </Parrafo>
+
+        <View style={local.firmaWrap}>
+          <View style={local.firmaCol}>
+            <View style={local.firmaLinea} />
+            <Text style={local.firmaLabel}>Solicita — DILESA</Text>
+          </View>
+          <View style={local.firmaCol}>
+            <View style={local.firmaLinea} />
+            <Text style={local.firmaLabel}>Recibe — Notaría</Text>
+          </View>
+        </View>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
## Sprint 7g — 2 cambios

### 1. PDFs imprimibles de las solicitudes (avalúo + dictamen)
Versión PDF imprimible de los emails de Fase 4 y Fase 7 — para entregar la solicitud en papel cuando el valuador/notario no tiene email, o cuando el operador quiere copia física.

- `lib/dilesa/pdf/seccion-datos.tsx` — componente reusable `SeccionDatos` + `Parrafo`.
- `lib/dilesa/pdf/solicitud-avaluo.tsx` + `solicitud-dictamen.tsx` — templates branded (olivo + header/footer + firmas).
- Endpoint `pdf/[tipo]` con 2 tipos nuevos.
- Botones en el detalle de venta condicionados a `valuador_id` / `notario_id`.

### 2. Fix: contacto = Gerente de Ventas (no el asesor)
Beto reportó que en los emails/PDFs aparecía **él** (el asesor que capturó la venta fantasma) como "Gerencia de Ventas". El contacto debe ser el **Gerente de Ventas real** de la empresa.

**Root cause:** el campo "Gerencia de Ventas" usaba `vendedor_usuario_id` (asesor que capturó). El Gerente de Ventas es un EMPLEADO (`erp.empleados` con puesto "Gerente de Ventas"), no un usuario con login — por eso no se resolvía.

**Fix:**
- Helper `lib/dilesa/gerente-ventas.ts` resuelve el empleado activo con puesto "Gerente de Ventas" de la empresa.
- Los 2 emails + los 2 PDFs usan al gerente como contacto (+ cc del email). Fallback al asesor si no hay gerente activo.
- Verificado: para DILESA → **EDGAR DANIEL PEÑA PALOMO · edgar.pp@dilesa.mx · 8787882628**.
- El "Asesor de ventas" del detalle y los demás PDFs NO cambian.

## UI — sin auto-merge

Dejo sin auto-merge para que valides en preview:
1. Venta con F4 cerrada → detalle muestra botón "Solicitud de Avalúo" → el PDF muestra a Edgar como Gerencia de Ventas (no a ti).
2. Igual para "Solicitud de Dictaminación" en F7.
3. Reenvía una solicitud de avalúo/dictamen y verifica que el email muestre a Edgar como contacto + esté en cc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)