### PR TITLE
feat(dilesa-ventas): número de crédito + institución (F6/F8) y gastos de escrituración (F8)

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
@@ -47,6 +47,8 @@ type VentaCtx = {
   tipo_credito: string | null;
   monto_credito_titular: number | null;
   monto_credito_cotitular: number | null;
+  credito_titular_ref: string | null;
+  credito_cotitular_ref: string | null;
 };
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -86,6 +88,9 @@ function CapturarFase6Body() {
   // Editables — defaults de los actuales de la venta (acarreo Fase 1).
   const [montoTitular, setMontoTitular] = useState<string>('');
   const [montoCotitular, setMontoCotitular] = useState<string>('');
+  // Número de crédito + institución (lo trae la constancia del banco).
+  const [creditoTitularRef, setCreditoTitularRef] = useState<string>('');
+  const [creditoCotitularRef, setCreditoCotitularRef] = useState<string>('');
   const [fechaInscripcion, setFechaInscripcion] = useState<string>(
     new Date().toISOString().slice(0, 10)
   );
@@ -109,7 +114,7 @@ function CapturarFase6Body() {
         .schema('dilesa')
         .from('ventas')
         .select(
-          'id, persona_id, unidad_id, tipo_credito, monto_credito_titular, monto_credito_cotitular'
+          'id, persona_id, unidad_id, tipo_credito, monto_credito_titular, monto_credito_cotitular, credito_titular_ref, credito_cotitular_ref'
         )
         .eq('id', ventaId)
         .is('deleted_at', null)
@@ -133,6 +138,8 @@ function CapturarFase6Body() {
       if (v.monto_credito_cotitular != null) {
         setMontoCotitular(String(v.monto_credito_cotitular));
       }
+      if (v.credito_titular_ref) setCreditoTitularRef(v.credito_titular_ref);
+      if (v.credito_cotitular_ref) setCreditoCotitularRef(v.credito_cotitular_ref);
 
       const [pRes, uRes, fRes] = await Promise.all([
         sb
@@ -258,6 +265,8 @@ function CapturarFase6Body() {
         camposVenta: {
           monto_credito_titular: montoTitNum,
           monto_credito_cotitular: montoCoNum,
+          credito_titular_ref: creditoTitularRef.trim() || null,
+          credito_cotitular_ref: creditoCotitularRef.trim() || null,
         },
         notas:
           fechaInscripcion !== new Date().toISOString().slice(0, 10)
@@ -288,6 +297,8 @@ function CapturarFase6Body() {
       fechaInscripcion,
       montoTitNum,
       montoCoNum,
+      creditoTitularRef,
+      creditoCotitularRef,
       requiereTitular,
       requiereCotitular,
       sinCredito,
@@ -417,6 +428,24 @@ function CapturarFase6Body() {
                   disabled={sinCredito}
                 />
                 <Hint>{money(montoCoNum)} — 0 si no hay co-titular</Hint>
+              </Field>
+              <Field label="Número de Crédito Titular e Institución">
+                <Input
+                  value={creditoTitularRef}
+                  onChange={(e) => setCreditoTitularRef(e.target.value)}
+                  placeholder="Ej. Infonavit 1234567890"
+                  disabled={sinCredito}
+                />
+                <Hint>Número del crédito + institución (lo trae la constancia del banco)</Hint>
+              </Field>
+              <Field label="Número de Crédito Co-Titular e Institución">
+                <Input
+                  value={creditoCotitularRef}
+                  onChange={(e) => setCreditoCotitularRef(e.target.value)}
+                  placeholder="Si no hay co-titular, déjalo en blanco"
+                  disabled={sinCredito}
+                />
+                <Hint>Solo si hay co-acreditado</Hint>
               </Field>
               <Field label="Fecha de inscripción *">
                 <Input

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -39,7 +39,18 @@ type VentaCtx = {
   persona_id: string;
   unidad_id: string | null;
   notario_id: string | null;
+  credito_titular_ref: string | null;
+  credito_cotitular_ref: string | null;
+  gastos_escrituracion: number | null;
 };
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const money = (n: number | null | undefined): string =>
+  n == null ? '—' : moneyFmt.format(Number(n));
 
 export default function CapturarFase8Page() {
   return (
@@ -65,6 +76,10 @@ function CapturarFase8Body() {
 
   const [fechaDictamen, setFechaDictamen] = useState<string>(new Date().toISOString().slice(0, 10));
   const [archivo, setArchivo] = useState<File | null>(null);
+  // Confirmar/editar (acarrean de Fase 6) + capturar gastos de escrituración.
+  const [creditoTitularRef, setCreditoTitularRef] = useState<string>('');
+  const [creditoCotitularRef, setCreditoCotitularRef] = useState<string>('');
+  const [gastosEscrituracion, setGastosEscrituracion] = useState<string>('');
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -81,7 +96,9 @@ function CapturarFase8Body() {
       const { data: vRow, error: vErr } = await sb
         .schema('dilesa')
         .from('ventas')
-        .select('id, persona_id, unidad_id, notario_id')
+        .select(
+          'id, persona_id, unidad_id, notario_id, credito_titular_ref, credito_cotitular_ref, gastos_escrituracion'
+        )
         .eq('id', ventaId)
         .is('deleted_at', null)
         .maybeSingle();
@@ -98,6 +115,9 @@ function CapturarFase8Body() {
       }
       const v = vRow as unknown as VentaCtx;
       setVenta(v);
+      if (v.credito_titular_ref) setCreditoTitularRef(v.credito_titular_ref);
+      if (v.credito_cotitular_ref) setCreditoCotitularRef(v.credito_cotitular_ref);
+      if (v.gastos_escrituracion != null) setGastosEscrituracion(String(v.gastos_escrituracion));
 
       const [pRes, uRes, fRes, notRes] = await Promise.all([
         sb
@@ -192,6 +212,7 @@ function CapturarFase8Body() {
       const { data: userRes } = await sb.auth.getUser();
       const userId = userRes?.user?.id ?? null;
 
+      const gastosNum = gastosEscrituracion.trim() ? Number(gastosEscrituracion) : null;
       const result = await marcarFase(sb, {
         ventaId: venta.id,
         faseNombre: 'Dictaminada',
@@ -199,6 +220,9 @@ function CapturarFase8Body() {
         docs: [{ rol: 'carta_instruccion_notarial', archivo }],
         camposVenta: {
           fecha_dictaminada: fechaDictamen,
+          credito_titular_ref: creditoTitularRef.trim() || null,
+          credito_cotitular_ref: creditoCotitularRef.trim() || null,
+          gastos_escrituracion: gastosNum,
         },
         notas: null,
         registradoPor: userId,
@@ -220,7 +244,55 @@ function CapturarFase8Body() {
       });
       router.push(`/dilesa/ventas/${venta.id}`);
     },
-    [archivo, fechaDictamen, router, sb, toast, venta]
+    [
+      archivo,
+      fechaDictamen,
+      creditoTitularRef,
+      creditoCotitularRef,
+      gastosEscrituracion,
+      router,
+      sb,
+      toast,
+      venta,
+    ]
+  );
+
+  // Caso magic link: el notario ya cerró F8 subiendo la carta, pero los
+  // datos administrativos (número de crédito + gastos de escrituración)
+  // los captura Gerencia Ventas. Este path hace UPDATE directo de la venta
+  // SIN insertar otra fila en venta_fases (la fase ya está cerrada).
+  const onActualizarDatos = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!venta) return;
+      setSubmitting(true);
+      const gastosNum = gastosEscrituracion.trim() ? Number(gastosEscrituracion) : null;
+      const { error: upErr } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .update({
+          credito_titular_ref: creditoTitularRef.trim() || null,
+          credito_cotitular_ref: creditoCotitularRef.trim() || null,
+          gastos_escrituracion: gastosNum,
+        })
+        .eq('id', venta.id);
+      setSubmitting(false);
+      if (upErr) {
+        toast.add({
+          title: 'Error al actualizar datos',
+          description: getSupabaseErrorMessage(upErr, 'No se pudieron guardar los datos.'),
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({
+        title: 'Datos actualizados',
+        description: 'Números de crédito y gastos de escrituración guardados.',
+        type: 'success',
+      });
+      router.push(`/dilesa/ventas/${venta.id}`);
+    },
+    [creditoTitularRef, creditoCotitularRef, gastosEscrituracion, router, sb, toast, venta]
   );
 
   if (loading) {
@@ -262,11 +334,63 @@ function CapturarFase8Body() {
       />
 
       {yaCerrada ? (
-        <Banner
-          tone="success"
-          title="Fase 8 ya está cerrada"
-          body="Esta venta ya pasó por Dictaminada. La siguiente fase es Validación Patronal."
-        />
+        <>
+          <Banner
+            tone="success"
+            title="Fase 8 ya está cerrada"
+            body="La Carta de Instrucción ya está capturada. Aquí puedes confirmar/actualizar los números de crédito y los gastos de escrituración (útil si el notario cerró la fase desde el enlace del correo)."
+          />
+          <form onSubmit={onActualizarDatos} className="mt-4 space-y-6">
+            <Section title="Datos del crédito y escrituración">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Field label="Número de Crédito Titular e Institución">
+                  <Input
+                    value={creditoTitularRef}
+                    onChange={(e) => setCreditoTitularRef(e.target.value)}
+                    placeholder="Ej. Infonavit 1234567890"
+                  />
+                </Field>
+                <Field label="Número de Crédito Co-Titular e Institución">
+                  <Input
+                    value={creditoCotitularRef}
+                    onChange={(e) => setCreditoCotitularRef(e.target.value)}
+                    placeholder="Si no hay co-titular, déjalo en blanco"
+                  />
+                </Field>
+                <Field label="Gastos de Escrituración">
+                  <Input
+                    type="number"
+                    step="1"
+                    min="0"
+                    value={gastosEscrituracion}
+                    onChange={(e) => setGastosEscrituracion(e.target.value)}
+                    placeholder="0"
+                  />
+                  <Hint>{money(Number(gastosEscrituracion) || 0)}</Hint>
+                </Field>
+              </div>
+            </Section>
+            <div className="flex items-center justify-end gap-3">
+              <Link
+                href={`/dilesa/ventas/${venta.id}`}
+                className="text-sm text-muted-foreground hover:text-[var(--text)]"
+              >
+                Volver al detalle
+              </Link>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" /> Guardando…
+                  </>
+                ) : (
+                  <>
+                    <Save className="mr-2 size-4" /> Actualizar datos
+                  </>
+                )}
+              </Button>
+            </div>
+          </form>
+        </>
       ) : !fase7Cerrada ? (
         <Banner
           tone="warning"
@@ -310,6 +434,39 @@ function CapturarFase8Body() {
                   value={fechaDictamen}
                   onChange={(e) => setFechaDictamen(e.target.value)}
                   required
+                />
+              </Field>
+              <Field label="Gastos de Escrituración">
+                <Input
+                  type="number"
+                  step="1"
+                  min="0"
+                  value={gastosEscrituracion}
+                  onChange={(e) => setGastosEscrituracion(e.target.value)}
+                  placeholder="0"
+                />
+                <Hint>{money(Number(gastosEscrituracion) || 0)} — los calcula el notario</Hint>
+              </Field>
+            </div>
+          </Section>
+
+          <Section title="Confirmar datos del crédito">
+            <p className="mb-3 text-xs text-[var(--text)]/50">
+              Acarreados de Inscrita (Fase 6). Confirma o corrige si el banco cambió algo.
+            </p>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field label="Número de Crédito Titular e Institución">
+                <Input
+                  value={creditoTitularRef}
+                  onChange={(e) => setCreditoTitularRef(e.target.value)}
+                  placeholder="Ej. Infonavit 1234567890"
+                />
+              </Field>
+              <Field label="Número de Crédito Co-Titular e Institución">
+                <Input
+                  value={creditoCotitularRef}
+                  onChange={(e) => setCreditoCotitularRef(e.target.value)}
+                  placeholder="Si no hay co-titular, déjalo en blanco"
                 />
               </Field>
             </div>
@@ -360,6 +517,10 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
       {children}
     </label>
   );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return <p className="text-[11px] text-[var(--text)]/50">{children}</p>;
 }
 
 function FileSlot({

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -41,6 +41,8 @@ type VentaCtx = {
   notario_id: string | null;
   credito_titular_ref: string | null;
   credito_cotitular_ref: string | null;
+  monto_credito_titular: number | null;
+  monto_credito_cotitular: number | null;
   gastos_escrituracion: number | null;
 };
 
@@ -77,6 +79,8 @@ function CapturarFase8Body() {
   const [fechaDictamen, setFechaDictamen] = useState<string>(new Date().toISOString().slice(0, 10));
   const [archivo, setArchivo] = useState<File | null>(null);
   // Confirmar/editar (acarrean de Fase 6) + capturar gastos de escrituración.
+  const [montoTitular, setMontoTitular] = useState<string>('');
+  const [montoCotitular, setMontoCotitular] = useState<string>('');
   const [creditoTitularRef, setCreditoTitularRef] = useState<string>('');
   const [creditoCotitularRef, setCreditoCotitularRef] = useState<string>('');
   const [gastosEscrituracion, setGastosEscrituracion] = useState<string>('');
@@ -97,7 +101,7 @@ function CapturarFase8Body() {
         .schema('dilesa')
         .from('ventas')
         .select(
-          'id, persona_id, unidad_id, notario_id, credito_titular_ref, credito_cotitular_ref, gastos_escrituracion'
+          'id, persona_id, unidad_id, notario_id, credito_titular_ref, credito_cotitular_ref, monto_credito_titular, monto_credito_cotitular, gastos_escrituracion'
         )
         .eq('id', ventaId)
         .is('deleted_at', null)
@@ -115,6 +119,8 @@ function CapturarFase8Body() {
       }
       const v = vRow as unknown as VentaCtx;
       setVenta(v);
+      if (v.monto_credito_titular != null) setMontoTitular(String(v.monto_credito_titular));
+      if (v.monto_credito_cotitular != null) setMontoCotitular(String(v.monto_credito_cotitular));
       if (v.credito_titular_ref) setCreditoTitularRef(v.credito_titular_ref);
       if (v.credito_cotitular_ref) setCreditoCotitularRef(v.credito_cotitular_ref);
       if (v.gastos_escrituracion != null) setGastosEscrituracion(String(v.gastos_escrituracion));
@@ -220,6 +226,8 @@ function CapturarFase8Body() {
         docs: [{ rol: 'carta_instruccion_notarial', archivo }],
         camposVenta: {
           fecha_dictaminada: fechaDictamen,
+          monto_credito_titular: montoTitular.trim() ? Number(montoTitular) : null,
+          monto_credito_cotitular: montoCotitular.trim() ? Number(montoCotitular) : null,
           credito_titular_ref: creditoTitularRef.trim() || null,
           credito_cotitular_ref: creditoCotitularRef.trim() || null,
           gastos_escrituracion: gastosNum,
@@ -247,6 +255,8 @@ function CapturarFase8Body() {
     [
       archivo,
       fechaDictamen,
+      montoTitular,
+      montoCotitular,
       creditoTitularRef,
       creditoCotitularRef,
       gastosEscrituracion,
@@ -271,6 +281,8 @@ function CapturarFase8Body() {
         .schema('dilesa')
         .from('ventas')
         .update({
+          monto_credito_titular: montoTitular.trim() ? Number(montoTitular) : null,
+          monto_credito_cotitular: montoCotitular.trim() ? Number(montoCotitular) : null,
           credito_titular_ref: creditoTitularRef.trim() || null,
           credito_cotitular_ref: creditoCotitularRef.trim() || null,
           gastos_escrituracion: gastosNum,
@@ -292,7 +304,17 @@ function CapturarFase8Body() {
       });
       router.push(`/dilesa/ventas/${venta.id}`);
     },
-    [creditoTitularRef, creditoCotitularRef, gastosEscrituracion, router, sb, toast, venta]
+    [
+      montoTitular,
+      montoCotitular,
+      creditoTitularRef,
+      creditoCotitularRef,
+      gastosEscrituracion,
+      router,
+      sb,
+      toast,
+      venta,
+    ]
   );
 
   if (loading) {
@@ -343,6 +365,28 @@ function CapturarFase8Body() {
           <form onSubmit={onActualizarDatos} className="mt-4 space-y-6">
             <Section title="Datos del crédito y escrituración">
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Field label="Monto Crédito Titular">
+                  <Input
+                    type="number"
+                    step="1"
+                    min="0"
+                    value={montoTitular}
+                    onChange={(e) => setMontoTitular(e.target.value)}
+                    placeholder="0"
+                  />
+                  <Hint>{money(Number(montoTitular) || 0)}</Hint>
+                </Field>
+                <Field label="Monto Crédito Co-Titular">
+                  <Input
+                    type="number"
+                    step="1"
+                    min="0"
+                    value={montoCotitular}
+                    onChange={(e) => setMontoCotitular(e.target.value)}
+                    placeholder="0"
+                  />
+                  <Hint>{money(Number(montoCotitular) || 0)}</Hint>
+                </Field>
                 <Field label="Número de Crédito Titular e Institución">
                   <Input
                     value={creditoTitularRef}
@@ -455,6 +499,28 @@ function CapturarFase8Body() {
               Acarreados de Inscrita (Fase 6). Confirma o corrige si el banco cambió algo.
             </p>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field label="Monto Crédito Titular">
+                <Input
+                  type="number"
+                  step="1"
+                  min="0"
+                  value={montoTitular}
+                  onChange={(e) => setMontoTitular(e.target.value)}
+                  placeholder="0"
+                />
+                <Hint>{money(Number(montoTitular) || 0)}</Hint>
+              </Field>
+              <Field label="Monto Crédito Co-Titular">
+                <Input
+                  type="number"
+                  step="1"
+                  min="0"
+                  value={montoCotitular}
+                  onChange={(e) => setMontoCotitular(e.target.value)}
+                  placeholder="0"
+                />
+                <Hint>{money(Number(montoCotitular) || 0)}</Hint>
+              </Field>
               <Field label="Número de Crédito Titular e Institución">
                 <Input
                   value={creditoTitularRef}


### PR DESCRIPTION
## Campos faltantes del flujo de inscripción/dictaminación

Beto detectó 3 campos de Coda que faltaban capturar. Las 3 columnas **ya existían** en `dilesa.ventas` — solo faltaba el formulario. **Sin migración.**

| Campo de Coda | Columna | Dónde se captura |
|---|---|---|
| Número del Crédito Titular e Institución | `credito_titular_ref` | F6 (captura) + F8 (confirma) |
| Número de crédito Co-Titular e Institución | `credito_cotitular_ref` | F6 (captura) + F8 (confirma) |
| Gastos Escrituración | `gastos_escrituracion` | F8 (Dictaminada) |

## Cambios

### Fase 6 (Inscrita)
2 campos de texto nuevos junto a los montos del crédito (la constancia del banco trae estos datos). Deshabilitados si es "Recursos propios".

### Fase 8 (Dictaminada)
- Confirmación editable de los 2 números de crédito (acarrean de F6).
- Gastos de Escrituración (monto) — los calcula el notario, los captura Gerencia.

### Caso magic link (lo que pediste: "Gerencia edita después")
Si el notario cierra F8 subiendo la Carta desde el enlace del correo, la fase queda cerrada sin los datos administrativos. Para ese caso, la page de F8 — **cuando ya está cerrada** — muestra un form **"Actualizar datos"** que hace UPDATE directo de la venta (sin re-cerrar la fase) para capturar números de crédito + gastos. Así Gerencia los completa después sin necesidad de reabrir la fase.

El detalle de venta ya mostraba estos 3 campos — se poblan automáticamente.

## UI — sin auto-merge

Dejo sin auto-merge para preview:
1. Avanza a Fase 6 (Inscrita) → captura número de crédito titular + institución → guarda.
2. Avanza a Fase 8 (Dictaminada) manual → verifica que los números acarrean de F6 (editables) + captura gastos de escrituración → guarda.
3. Caso magic link: deja que el notario suba la carta por el enlace (cierra F8) → entra a la page de F8 → debe mostrar "Actualizar datos" con los 3 campos → captura gastos → guarda.
4. Verifica en el detalle que aparezcan "Ref. crédito titular/co-titular" y "Gastos escrituración".

🤖 Generated with [Claude Code](https://claude.com/claude-code)