### PR TITLE
feat(dilesa-ventas): Expediente de Operación S1 — motor de cuadratura + Zona A

### DIFF
--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -45,6 +45,8 @@ import { getAdjuntoProxyUrl } from '@/lib/adjuntos';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { useToast } from '@/components/ui/toast';
 import { AbonoCaptureDrawer } from '@/components/dilesa/abono-capture-drawer';
+import { OperacionResumen } from '@/components/dilesa/operacion-resumen';
+import { calcularCuadratura } from '@/lib/dilesa/cuadratura';
 import { EstadoCuentaPrintable } from '@/components/dilesa/estado-cuenta-printable';
 import { ReciboCajaPrintable } from '@/components/dilesa/recibo-caja-printable';
 import { useTriggerPrint } from '@/components/print';
@@ -93,6 +95,8 @@ type Venta = {
   anticipo_comision: number | null;
   monto_avaluo: number | null;
   gastos_escrituracion: number | null;
+  monto_cheque_notaria: number | null;
+  monto_detonado: number | null;
   numero_escritura: string | null;
   fecha_escritura: string | null;
   vendedor: string | null;
@@ -676,6 +680,28 @@ function DetailInner() {
     [abonos, aplicadoPorAbono]
   );
 
+  // Cuadratura de la operación (motor único — lib/dilesa/cuadratura.ts). Los
+  // depósitos vienen de CxC (abonos); fuente='cliente' aproxima "Directo
+  // Cliente". El detalle por depósito (recibo de caja) llega en Sprint 2.
+  const cuadratura = useMemo(
+    () =>
+      calcularCuadratura({
+        valorEscrituracion: venta?.valor_escrituracion ?? null,
+        montoCreditoTitular: venta?.monto_credito_titular ?? null,
+        montoCreditoCotitular: venta?.monto_credito_cotitular ?? null,
+        montoCreditoDirecto: venta?.monto_credito_directo ?? null,
+        montoChequeNotaria: venta?.monto_cheque_notaria ?? null,
+        gastosEscrituracion: venta?.gastos_escrituracion ?? null,
+        precioAsignacion: venta?.precio_asignacion ?? null,
+        depositos: abonos.map((a) => ({
+          monto: a.monto_total,
+          directoCliente: a.fuente === 'cliente',
+        })),
+        proyectoNombre,
+      }),
+    [venta, abonos, proyectoNombre]
+  );
+
   if (loading) {
     return (
       <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
@@ -809,6 +835,29 @@ function DetailInner() {
       {holdSnapshot && holdSnapshot.estado !== 'no_aplica' ? (
         <HoldBanner snapshot={holdSnapshot} />
       ) : null}
+
+      {/* Zona A — cabecera persistente del Expediente de Operación. */}
+      <OperacionResumen
+        cliente={{
+          nombre: clienteNombre || '(sin nombre)',
+          contacto: [persona?.telefono, persona?.email].filter(Boolean).join(' · ') || null,
+          curp: persona?.curp ?? null,
+        }}
+        vivienda={{
+          proyecto: proyectoNombre,
+          mzLote: null,
+          prototipo: prototipoNombre,
+          domicilio: null,
+          identificador: unidad?.identificador ?? null,
+        }}
+        precioAsignacion={venta.precio_asignacion}
+        valorEscrituracion={venta.valor_escrituracion}
+        vendedor={vendedorNombre ?? venta.vendedor}
+        faseActual={venta.fase_actual}
+        fasePosicion={venta.fase_posicion}
+        totalFases={FASES_ORDEN.length}
+        cuadratura={cuadratura}
+      />
 
       <div className="flex flex-wrap gap-2">
         <PdfDownloadLink

--- a/components/dilesa/operacion-resumen.tsx
+++ b/components/dilesa/operacion-resumen.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+/**
+ * Zona A del Expediente de Operación — cabecera persistente.
+ *
+ * Resumen siempre-a-la-vista de una venta: cliente, vivienda, datos
+ * comerciales, estado del pipeline y la **mini-cuadratura** (Valor de
+ * Escrituración vs Monto Disponible → Saldo, con semáforo).
+ *
+ * Presentacional: el padre calcula la `Cuadratura` (con
+ * `lib/dilesa/cuadratura.ts`) y arma los strings. Iniciativa
+ * `dilesa-ventas-expediente` (Sprint 1).
+ */
+
+import type { Cuadratura } from '@/lib/dilesa/cuadratura';
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const money = (n: number | null | undefined): string =>
+  n == null ? '—' : moneyFmt.format(Number(n));
+
+export type OperacionResumenProps = {
+  cliente: { nombre: string; contacto: string | null; curp: string | null };
+  vivienda: {
+    proyecto: string | null;
+    mzLote: string | null;
+    prototipo: string | null;
+    domicilio: string | null;
+    identificador: string | null;
+  };
+  precioAsignacion: number | null;
+  valorEscrituracion: number | null;
+  vendedor: string | null;
+  faseActual: string | null;
+  fasePosicion: number | null;
+  totalFases: number;
+  cuadratura: Cuadratura;
+};
+
+export function OperacionResumen({
+  cliente,
+  vivienda,
+  precioAsignacion,
+  valorEscrituracion,
+  vendedor,
+  faseActual,
+  fasePosicion,
+  totalFases,
+  cuadratura,
+}: OperacionResumenProps) {
+  const pct =
+    fasePosicion != null && totalFases > 0
+      ? Math.round((Math.min(fasePosicion, totalFases) / totalFases) * 100)
+      : 0;
+
+  return (
+    <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-5">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Bloque titulo="Cliente">
+          <p className="text-sm font-semibold text-[var(--text)]">{cliente.nombre}</p>
+          {cliente.contacto ? <Linea>{cliente.contacto}</Linea> : null}
+          {cliente.curp ? <Linea>CURP: {cliente.curp}</Linea> : null}
+        </Bloque>
+
+        <Bloque titulo="Vivienda">
+          <p className="text-sm font-semibold text-[var(--text)]">
+            {vivienda.identificador ?? '—'}
+          </p>
+          {vivienda.proyecto ? <Linea>{vivienda.proyecto}</Linea> : null}
+          {vivienda.mzLote || vivienda.prototipo ? (
+            <Linea>{[vivienda.mzLote, vivienda.prototipo].filter(Boolean).join(' · ')}</Linea>
+          ) : null}
+          {vivienda.domicilio ? <Linea>{vivienda.domicilio}</Linea> : null}
+        </Bloque>
+
+        <Bloque titulo="Comercial">
+          <p className="text-sm font-semibold text-[var(--text)]">
+            {money(precioAsignacion)}{' '}
+            <span className="text-[11px] font-normal text-[var(--text)]/50">precio asignación</span>
+          </p>
+          {vendedor ? <Linea>Asesor: {vendedor}</Linea> : null}
+          {faseActual ? (
+            <div className="mt-1.5">
+              <div className="flex items-center justify-between text-[11px] text-[var(--text)]/60">
+                <span className="font-medium text-[var(--text)]/80">{faseActual}</span>
+                <span>
+                  {fasePosicion ?? 0}/{totalFases}
+                </span>
+              </div>
+              <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-[var(--bg)]">
+                <div
+                  className="h-full rounded-full bg-[var(--accent)]"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          ) : null}
+        </Bloque>
+      </div>
+
+      {/* Mini-cuadratura */}
+      <div className="mt-4 border-t border-[var(--border)] pt-3">
+        <div className="flex flex-wrap items-stretch gap-x-6 gap-y-2 text-sm">
+          <Cifra label="Valor escrituración" value={money(valorEscrituracion)} />
+          <Cifra label="Crédito institución" value={money(cuadratura.creditoInstitucion)} />
+          <Cifra label="Crédito directo" value={money(cuadratura.montoCreditoDirecto)} />
+          <Cifra label="Depósitos directos" value={money(cuadratura.depositosDirectoCliente)} />
+          <Cifra label="Disponible" value={money(cuadratura.montoDisponible)} strong />
+          <div className="ml-auto">
+            <Cifra
+              label={cuadratura.cubierta ? 'Saldo' : 'Saldo pendiente'}
+              value={money(cuadratura.saldoCliente)}
+              strong
+              tone={cuadratura.cubierta ? 'ok' : 'warn'}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Bloque({ titulo, children }: { titulo: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="mb-1 text-[10px] font-medium uppercase tracking-wider text-[var(--text)]/45">
+        {titulo}
+      </p>
+      <div className="space-y-0.5">{children}</div>
+    </div>
+  );
+}
+
+function Linea({ children }: { children: React.ReactNode }) {
+  return <p className="text-xs text-[var(--text)]/65">{children}</p>;
+}
+
+function Cifra({
+  label,
+  value,
+  strong = false,
+  tone,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+  tone?: 'ok' | 'warn';
+}) {
+  const toneClass =
+    tone === 'ok'
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : tone === 'warn'
+        ? 'text-amber-600 dark:text-amber-400'
+        : 'text-[var(--text)]';
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] uppercase tracking-wide text-[var(--text)]/45">{label}</span>
+      <span className={`${strong ? 'text-base font-semibold' : 'font-medium'} ${toneClass}`}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { calcularCuadratura } from './cuadratura';
+
+describe('calcularCuadratura', () => {
+  // Ejemplo real de Beto (pantalla de Coda):
+  //   Valor de Escrituración = 899,000
+  //   Depósitos: 261,049.55 (Directo Cliente, con recibo de caja)
+  //              636,328.45 (Pago Infonavit, sin recibo) — su crédito = mismo monto
+  //   Valor Facturado = 1,160,049.55 · Valor Real Venta Dilesa = 884,000
+  //   Monto Nota de Crédito = 276,049.55
+  it('reproduce el ejemplo de Coda', () => {
+    const c = calcularCuadratura({
+      valorEscrituracion: 899000,
+      montoCreditoTitular: 636328.45, // crédito Infonavit (= el Pago Infonavit)
+      montoCreditoCotitular: 0,
+      montoCreditoDirecto: 0,
+      montoChequeNotaria: 13378, // 897,378 − 13,378 = 884,000
+      gastosEscrituracion: null,
+      precioAsignacion: 920000,
+      depositos: [
+        { monto: 261049.55, directoCliente: true, tieneRecibo: true },
+        { monto: 636328.45, directoCliente: false, tieneRecibo: false },
+      ],
+      proyectoNombre: 'Lomas del Sol',
+    });
+
+    expect(c.depositosRecibidos).toBe(897378);
+    expect(c.montoDisponible).toBe(897378); // 261,049.55 directo + 636,328.45 crédito
+    expect(c.saldoCliente).toBe(1622); // 899,000 − 897,378
+    expect(c.cubierta).toBe(false);
+    expect(c.valorFacturado).toBe(1160049.55); // 899,000 + 261,049.55 (con recibo)
+    expect(c.valorRealVentaDilesa).toBe(884000); // 897,378 − 13,378 + 0
+    expect(c.montoNotaCredito).toBe(276049.55); // 1,160,049.55 − 884,000
+    expect(c.descuentoReal).toBe(15000); // 899,000 − 884,000
+    expect(c.comisionGerencia).toBe(4495); // 899,000 × 0.5%
+    expect(c.comisionVendedor).toBe(8990); // 899,000 × 1.0% (no Loma Verde)
+  });
+
+  it('marca cubierta cuando el disponible cubre la escrituración', () => {
+    const c = calcularCuadratura({
+      valorEscrituracion: 500000,
+      montoCreditoTitular: 400000,
+      montoCreditoCotitular: 0,
+      montoCreditoDirecto: 50000,
+      montoChequeNotaria: null,
+      gastosEscrituracion: null,
+      depositos: [{ monto: 60000, directoCliente: true, tieneRecibo: true }],
+    });
+    // disponible = 60,000 + 400,000 + 50,000 = 510,000 ≥ 500,000
+    expect(c.montoDisponible).toBe(510000);
+    expect(c.saldoCliente).toBe(-10000);
+    expect(c.cubierta).toBe(true);
+  });
+
+  it('aplica 1.5% de comisión de vendedor en Loma Verde', () => {
+    const c = calcularCuadratura({
+      valorEscrituracion: 1000000,
+      montoCreditoTitular: null,
+      montoCreditoCotitular: null,
+      montoCreditoDirecto: null,
+      montoChequeNotaria: null,
+      gastosEscrituracion: null,
+      depositos: [],
+      proyectoNombre: 'Loma Verde 2',
+    });
+    expect(c.comisionVendedor).toBe(15000); // 1,000,000 × 1.5%
+  });
+
+  it('cheque a notaría = min(gastos − apoyo, disponible − escrituración + descuento)', () => {
+    const c = calcularCuadratura({
+      valorEscrituracion: 800000,
+      montoCreditoTitular: 850000,
+      montoCreditoCotitular: 0,
+      montoCreditoDirecto: 0,
+      montoChequeNotaria: null,
+      gastosEscrituracion: 30000,
+      apoyoInfonavit: 5000,
+      descuentoOtorgadoTotal: 0,
+      depositos: [],
+    });
+    // gastos − apoyo = 25,000 ; disponible − escrituración + desc = 850,000 − 800,000 = 50,000
+    // min(25,000, 50,000) = 25,000
+    expect(c.chequeNotariaCalculado).toBe(25000);
+  });
+});

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -1,0 +1,145 @@
+/**
+ * Motor de cuadratura de una venta DILESA.
+ *
+ * Replica el modelo financiero que vivía en Coda (tabla Clientes,
+ * grid-mMIXWCSfyr) como una función pura y testeable. Es la fuente única de
+ * verdad para la mini-cuadratura del Expediente de Operación, la pestaña
+ * Cuadratura y el copiloto de cierre (iniciativa `dilesa-ventas-expediente`).
+ *
+ * Fórmulas (de Coda):
+ *   Depósitos Recibidos       = Σ todos los depósitos del cliente.
+ *   Monto Disponible          = Σ depósitos(Directo Cliente) + crédito titular
+ *                               + crédito co-titular + pagaré autorizado (CD).
+ *   Saldo Cliente             = Valor de Escrituración − Monto Disponible.
+ *                               (≤ 0 ⇒ operación cubierta — saldo cero vs
+ *                                Valor de Escrituración, confirmado por Beto.)
+ *   Cheque Notaría (cálculo)  = min(Gastos Escrituración − Apoyo Infonavit,
+ *                                Monto Disponible − Valor Escrituración
+ *                                + Descuento Otorgado Total).
+ *   Valor Real Venta Dilesa   = Depósitos Recibidos − Cheque Notaría + Pagaré.
+ *   Valor Facturado           = Valor Escrituración + Σ depósitos(con recibo).
+ *   Monto Nota de Crédito     = Valor Facturado − Valor Real Venta Dilesa.
+ *   Descuento Real            = Valor Escrituración − Valor Real Venta Dilesa.
+ *   Comisión Vendedor         = Escrituración × (1.5% Loma Verde / 1.0% resto).
+ *   Comisión Gerencia         = Escrituración × 0.5%.
+ *
+ * GAPS de captura (aún no en BSOP; el motor los acepta opcionales y asume 0):
+ * apoyoInfonavit (por tipo de crédito), los 4 buckets de descuento, y el
+ * detalle por depósito (tipo Directo Cliente / con recibo de caja).
+ */
+
+const n = (v: number | null | undefined): number => (v == null ? 0 : Number(v));
+const round2 = (v: number): number => Math.round((v + Number.EPSILON) * 100) / 100;
+
+export type DepositoCuadratura = {
+  monto: number | null;
+  /** Tipo "Deposito Directo Cliente" (cuenta para Monto Disponible). */
+  directoCliente?: boolean;
+  /** Tiene PDF Recibo de Caja (cuenta para Valor Facturado). */
+  tieneRecibo?: boolean;
+};
+
+export type CuadraturaInput = {
+  valorEscrituracion: number | null;
+  montoCreditoTitular: number | null;
+  montoCreditoCotitular: number | null;
+  /** Pagaré autorizado del crédito directo (Fase 10). */
+  montoCreditoDirecto: number | null;
+  /** Cheque enviado a la notaría (capturado en Fase 11). */
+  montoChequeNotaria: number | null;
+  gastosEscrituracion: number | null;
+  /** GAP: apoyo del Infonavit a gastos de escrituración (por tipo de crédito). */
+  apoyoInfonavit?: number | null;
+  /** GAP: suma de los 4 buckets de descuento otorgado. */
+  descuentoOtorgadoTotal?: number | null;
+  /** Para referencia (no entra al saldo). */
+  precioAsignacion?: number | null;
+  depositos: DepositoCuadratura[];
+  /** Nombre del proyecto, para la tasa de comisión del vendedor. */
+  proyectoNombre?: string | null;
+};
+
+export type Cuadratura = {
+  depositosRecibidos: number;
+  depositosDirectoCliente: number;
+  creditoInstitucion: number;
+  montoCreditoDirecto: number;
+  montoDisponible: number;
+  saldoCliente: number;
+  /** true si el Monto Disponible cubre el Valor de Escrituración. */
+  cubierta: boolean;
+  /** Cheque a notaría sugerido por la fórmula (vs el capturado). */
+  chequeNotariaCalculado: number;
+  /** Cheque usado para los derivados: el capturado si existe, si no el calculado. */
+  chequeNotariaUsado: number;
+  valorRealVentaDilesa: number;
+  valorFacturado: number;
+  montoNotaCredito: number;
+  descuentoReal: number;
+  comisionVendedor: number;
+  comisionGerencia: number;
+};
+
+/** ¿El proyecto cae en la tasa alta de comisión (Loma Verde / Loma Verde 2)? */
+function esLomaVerde(proyecto: string | null | undefined): boolean {
+  return /loma\s*verde/i.test(proyecto ?? '');
+}
+
+export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
+  const valorEscrituracion = n(i.valorEscrituracion);
+  const creditoInstitucion = n(i.montoCreditoTitular) + n(i.montoCreditoCotitular);
+  const montoCreditoDirecto = n(i.montoCreditoDirecto);
+
+  const depositosRecibidos = i.depositos.reduce((s, d) => s + n(d.monto), 0);
+  const depositosDirectoCliente = i.depositos
+    .filter((d) => d.directoCliente)
+    .reduce((s, d) => s + n(d.monto), 0);
+  const depositosConRecibo = i.depositos
+    .filter((d) => d.tieneRecibo)
+    .reduce((s, d) => s + n(d.monto), 0);
+
+  const montoDisponible = depositosDirectoCliente + creditoInstitucion + montoCreditoDirecto;
+  const saldoCliente = round2(valorEscrituracion - montoDisponible);
+  const cubierta = saldoCliente <= 0.0049;
+
+  const descuentoOtorgadoTotal = n(i.descuentoOtorgadoTotal);
+  const gastosNetos = n(i.gastosEscrituracion) - n(i.apoyoInfonavit);
+  const excedenteDisponible = montoDisponible - valorEscrituracion + descuentoOtorgadoTotal;
+  const chequeNotariaCalculado = round2(Math.min(gastosNetos, excedenteDisponible));
+
+  // El formulado de Coda usa el cheque CAPTURADO; si aún no se captura,
+  // caemos al calculado para no dejar los derivados en blanco.
+  const chequeNotariaUsado = round2(
+    i.montoChequeNotaria != null ? n(i.montoChequeNotaria) : chequeNotariaCalculado
+  );
+
+  const valorRealVentaDilesa = round2(
+    depositosRecibidos - chequeNotariaUsado + montoCreditoDirecto
+  );
+  const valorFacturado = round2(valorEscrituracion + depositosConRecibo);
+  const montoNotaCredito = round2(valorFacturado - valorRealVentaDilesa);
+  const descuentoReal = round2(valorEscrituracion - valorRealVentaDilesa);
+
+  const comisionVendedor = round2(
+    valorEscrituracion * (esLomaVerde(i.proyectoNombre) ? 0.015 : 0.01)
+  );
+  const comisionGerencia = round2(valorEscrituracion * 0.005);
+
+  return {
+    depositosRecibidos: round2(depositosRecibidos),
+    depositosDirectoCliente: round2(depositosDirectoCliente),
+    creditoInstitucion: round2(creditoInstitucion),
+    montoCreditoDirecto: round2(montoCreditoDirecto),
+    montoDisponible: round2(montoDisponible),
+    saldoCliente,
+    cubierta,
+    chequeNotariaCalculado,
+    chequeNotariaUsado,
+    valorRealVentaDilesa,
+    valorFacturado,
+    montoNotaCredito,
+    descuentoReal,
+    comisionVendedor,
+    comisionGerencia,
+  };
+}


### PR DESCRIPTION
**Iniciativa `dilesa-ventas-expediente`, Sprint 1.** Primer paso del workspace
unificado de venta.

## Cambios
- **Motor de cuadratura** (`lib/dilesa/cuadratura.ts`): función pura que replica
  el modelo financiero de Coda (Monto Disponible, **Saldo vs Valor de
  Escrituración**, cheque notaría, valor real venta, valor facturado, nota de
  crédito, descuento real, comisiones). **Test reproduce el ejemplo real de
  Beto** (escrituración 899k → facturado 1,160,049.55, nota crédito 276,049.55).
- **Zona A — `<OperacionResumen>`**: cabecera persistente con cliente +
  vivienda + comercial + progreso del pipeline + **mini-cuadratura** (semáforo
  de saldo). Integrada arriba del detalle de venta (additivo).

## 👀 Para revisar
Abre cualquier venta en el Preview → arriba aparece la nueva cabecera con la
mini-cuadratura. Es el primer ladrillo del Expediente de Operación.

Sin `--auto` — revisión visual.

## Próximo (Sprint 2)
Pestaña Cuadratura completa + capturar los gaps: apoyo Infonavit por tipo de
crédito, 4 buckets de descuento, recibo de caja por depósito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)