### PR TITLE
feat(dilesa): cortar construcción del sync diario Coda→BSOP (cutover de obra)

### DIFF
--- a/.github/workflows/dilesa-coda-sync.yml
+++ b/.github/workflows/dilesa-coda-sync.yml
@@ -1,8 +1,13 @@
 name: DILESA Coda Sync
 
-# Refresh nocturno del schema dilesa desde Coda. Corre los 5 imports en
-# serie (terrenos → proyectos → inventario → ventas → expediente) y
-# manda email con resumen vía Resend (siempre — éxito o fallo).
+# Refresh nocturno del schema dilesa desde Coda. Desde el 2026-06-09 el
+# daily corre SOLO ventas + expediente: construcción se cortó del sync
+# (cutover de obra a BSOP — los supervisores ya no palomean en Coda).
+# Manda email con resumen vía Resend (siempre — éxito o fallo).
+#
+# Corridas manuales: input `construccion` re-incluye los 6 scripts de
+# construcción (rezagos puntuales); input `full` corre todo (portafolio +
+# construcción + ventas + expediente).
 #
 # Idempotente: las ventas creadas nativas en BSOP (sin coda_row_id) se
 # preservan. Los adjuntos de expediente solo se descargan/suben si son
@@ -25,8 +30,12 @@ name: DILESA Coda Sync
 on:
   workflow_dispatch:
     inputs:
+      construccion:
+        description: 'Incluir los 6 scripts de construcción (cortados del daily el 2026-06-09) — para rezagos puntuales'
+        type: boolean
+        default: false
       full:
-        description: 'Refresh completo (incluye terrenos/proyectos/inventario) — por default solo ventas + expediente'
+        description: 'Refresh completo (portafolio + construcción + ventas + expediente)'
         type: boolean
         default: false
   schedule:
@@ -51,6 +60,7 @@ jobs:
       NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
       SYNC_FROM_EMAIL: ${{ secrets.SYNC_FROM_EMAIL }}
       FULL: ${{ inputs.full && '1' || '' }}
+      CONSTRUCCION: ${{ inputs.construccion && '1' || '' }}
 
     steps:
       - name: Checkout

--- a/scripts/run-dilesa-sync.ts
+++ b/scripts/run-dilesa-sync.ts
@@ -77,20 +77,26 @@ type CodaCounts = Partial<Record<keyof typeof CODA_TABLES, number>>;
  * Sync orquestador — 3 modos según volumen y costo:
  *
  * DAILY (default, todos los días):
- *   - Ventas, Expediente, y los 5 scripts de Construcción + Estimaciones
- *     incrementales. Todos usan UPSERT por coda_row_id (idempotentes).
- *   - Sprint 6 (cutover): se promovieron a daily porque del 2026-05-26
- *     al sábado 2026-05-31 el equipo sigue capturando en Coda — sin esto,
- *     las nuevas tareas/contratos/contratistas no llegarían a BSOP.
- *   - Orden importa por FK: contratistas → catálogos → contratos →
- *     construcción → tareas_terminadas → estimaciones (backfill incr).
+ *   - Solo Ventas + Expediente. Construcción se cortó del daily el
+ *     2026-06-09 (cutover de obra a BSOP): los supervisores ya no tienen
+ *     acceso a palomear tareas en Coda, así que seguir sincronizando solo
+ *     re-traería captura vieja o colisionaría con la captura nativa.
+ *     Ventas/Expediente siguen hasta su propio cutoff.
+ *
+ * CONSTRUCCION (CONSTRUCCION=1, manual):
+ *   - Los 6 scripts de construcción + ventas/expediente. Para traer un
+ *     rezago puntual de Coda post-cutover. Orden importa por FK:
+ *     contratistas → catálogos → contratos → construcción →
+ *     tareas_terminadas → estimaciones (backfill incr). Todos idempotentes
+ *     por coda_row_id.
  *
  * FULL (FULL=1, manual):
- *   - DAILY + terrenos + proyectos + inventario. Los 3 últimos cambian
- *     mensual y sus scripts antes truenaban (resuelto en F2 con UPSERT
- *     puro, ver iniciativa dilesa-portafolio).
+ *   - Todo: terrenos + proyectos + inventario + construcción + ventas +
+ *     expediente. Los 3 de portafolio cambian mensual y sus scripts antes
+ *     truenaban (resuelto en F2 con UPSERT puro, ver dilesa-portafolio).
  */
 const FULL = process.env.FULL === '1';
+const CONSTRUCCION = process.env.CONSTRUCCION === '1';
 
 const CONSTRUCCION_SCRIPTS: Array<{ name: string; path: string }> = [
   { name: 'Contratistas', path: 'scripts/import_dilesa_contratistas.ts' },
@@ -102,7 +108,6 @@ const CONSTRUCCION_SCRIPTS: Array<{ name: string; path: string }> = [
 ];
 
 const DAILY_SCRIPTS: Array<{ name: string; path: string }> = [
-  ...CONSTRUCCION_SCRIPTS,
   { name: 'Ventas', path: 'scripts/import_dilesa_ventas.ts' },
   { name: 'Expediente', path: 'scripts/import_dilesa_expediente.ts' },
 ];
@@ -110,9 +115,14 @@ const FULL_SCRIPTS: Array<{ name: string; path: string }> = [
   { name: 'Terrenos', path: 'scripts/import_dilesa_terrenos.ts' },
   { name: 'Proyectos', path: 'scripts/import_dilesa_proyectos.ts' },
   { name: 'Inventario', path: 'scripts/import_dilesa_inventario.ts' },
+  ...CONSTRUCCION_SCRIPTS,
   ...DAILY_SCRIPTS,
 ];
-const SCRIPTS = FULL ? FULL_SCRIPTS : DAILY_SCRIPTS;
+const SCRIPTS = FULL
+  ? FULL_SCRIPTS
+  : CONSTRUCCION
+    ? [...CONSTRUCCION_SCRIPTS, ...DAILY_SCRIPTS]
+    : DAILY_SCRIPTS;
 
 type StepResult = {
   name: string;


### PR DESCRIPTION
## Qué

El sync nocturno (GitHub Action `dilesa-coda-sync`, 09:00 UTC) queda **solo con Ventas + Expediente**. Los 6 scripts de construcción salen del daily.

## Por qué

Cutover de obra a BSOP: Beto cortó el acceso de los supervisores a palomear tareas en Coda (~2026-06-03). Seguir sincronizando construcción solo re-traería captura vieja o colisionaría con la captura nativa de BSOP.

## Verificación pre-corte (2026-06-09)

- **Diff Coda↔BSOP de tareas terminadas: 13,942/13,943 en BSOP.** La única faltante es de feb-2021, sin lote asignado, pagada en 2021 — skip permanente por lookup, irrelevante.
- **Últimos palomeos en Coda: 2026-06-03** (66 tareas el 06-02, 44 el 06-03). Cero actividad posterior al corte de accesos — nada queda pendiente de traer.

## Escotillas

- `workflow_dispatch` con input **construccion** → re-incluye los 6 scripts (rezagos puntuales).
- Input **full** → todo (portafolio + construcción + ventas + expediente).
- El email de reporte mantiene los conteos pre/post de construcción (visibilidad de drift; delta esperado = 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)