### PR TITLE
docs: re-sincronizar protocolo de CI, bitácora de construcción y ARCHITECTURE §8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,15 +75,21 @@ una iniciativa, vive en su `## Decisiones registradas`.
 
 > Un PR no está "listo" hasta que CI pase verde. No reportar entregado antes.
 
-### Antes de `git push` — correr los 4 checks de CI
+### Antes de `git push` — correr los 6 checks de CI
 
-**Sobre todo el repo, no solo los archivos tocados**, en este orden:
+**Sobre todo el repo, no solo los archivos tocados**, en este orden (espejo de
+`.github/workflows/ci.yml`; si CI cambia, actualizar esta lista):
 
 ```bash
-npm run typecheck       # tsc --noEmit
-npm run test:run        # vitest run
-npm run lint            # eslint .
-npm run format:check    # prettier --check . (¡todo el repo!)
+npm run typecheck         # tsc --noEmit
+npm run test:coverage     # vitest + coverage thresholds — `test:run` NO basta:
+                          # puede pasar local y CI fallar por coverage
+npm run lint              # eslint .
+npm run format:check      # prettier --check . (¡todo el repo!)
+npm run initiatives:check # tabla Activas de INITIATIVES.md en sync con docs/planning/
+npm run schema:check      # SCHEMA_REF.md vs DB prod — requiere SUPABASE_DB_URL
+                          # (op read "op://Infrastructure/SUPABASE_DB_URL/credential");
+                          # si no tocaste DB puede saltarse: CI lo corre igual
 ```
 
 Si `format:check` reporta archivos que no toqué, **igual los formateo en este

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -465,10 +465,8 @@ Decisiones que no han sido tomadas o que son aspiracionales. No documentar prema
 - **Workflow DevKit (Vercel Workflows)** — para crons largos, orquestación multi-paso con retries. No usado aún; los crons hoy son simples Vercel Cron Jobs.
 - **Backups externos** — iniciativa `db-backup-strategy` en `proposed`. Hoy solo daily backup automático de Supabase Pro (7 días retención).
 - **BI externo (Metabase)** — iniciativa `analytics` en `blocked` esperando bootstrap del Cowork.
-- **Cuentas por Pagar (CxP)** — iniciativa `cxp` en `planned`. Schema delta + RPCs por arrancar.
 - **Ramp-up de schemas tenant** — `coagan` y `ansa` aún sin masa crítica de módulos UI; entran cuando esas empresas operen activamente.
 - **Realtime cross-tab/cross-page** — Supabase Realtime + Broadcast Channel. Ad-hoc por ahora; documentado como follow-up en varios planning docs.
-- **Auto-generación de `INITIATIVES.md`** — escalar a `npm run initiatives:gen` desde headers de planning docs si los conflicts de hotspot persisten (ver `CLAUDE.md` repo "CI / PRs").
 - **Conflicto de numeración ADR** — ADR-005-008 existen tanto en `docs/adr/` como en `supabase/adr/`. Cleanup pendiente (ver `docs/planning/architecture-master.md`).
 
 ---

--- a/docs/planning/dilesa-construccion.md
+++ b/docs/planning/dilesa-construccion.md
@@ -329,6 +329,10 @@ decisión legal de Beto.
 
 (append-only, escrito por Claude Code al ejecutar)
 
+- **2026-06-09 (post-cierre — cutover de obra)** — Construcción salió del sync
+  diario Coda→BSOP (#782: ajusta `dilesa-coda-sync.yml` + `run-dilesa-sync.ts`).
+  BSOP deja de leer obra desde Coda; la captura de avances de obra vive en BSOP
+  desde esta fecha. Registrado en revisión de docs del mismo día.
 - **2026-06-08 (cierre de la iniciativa)** — 5 sprints + Sprint 6 reabierto y cerrado en prod — PDF del contrato de obra generable + ANEXO 3 de precios unitarios derivado por % de costo (#608), sobre el backfill de obras (#594). Residuales no-código: que Beto valide el Anexo 3 derivado contra uno real en preview, y la decisión legal de cuál representante/escritura DILESA es la vigente. Sprint 7 (Anexos 1/2 + persistir PDF) queda como opcional no comprometido. Cerrada por instrucción de Beto tras auditoría de estado real (el header estaba stale respecto al trabajo ya en prod).
 
 ### 2026-05-25 — Sprint 3 (UI lectura)

--- a/docs/strategy/INITIATIVES.md
+++ b/docs/strategy/INITIATIVES.md
@@ -5,7 +5,7 @@
 > ADR-012 para el contexto histórico de la deprecación del split
 > Cowork/CC).
 >
-> **Última actualización:** 2026-06-08 — auditoría de estado real: cerradas 11 iniciativas ya terminadas, afinados 4 hitos pendientes y depurado este índice. El historial detallado de cada iniciativa vive en su `docs/planning/<slug>.md` (sección `## Bitácora`).
+> **Última actualización:** 2026-06-09 — revisión de docs: checks de CI re-sincronizados en `CLAUDE.md` (6 reales, no 4), bitácora post-cierre del cutover de obra en `dilesa-construccion` (#782) y retiro de 2 topics vencidos de `ARCHITECTURE.md` §8. (2026-06-08: auditoría de estado real — 11 iniciativas cerradas, índice depurado.) El historial detallado de cada iniciativa vive en su `docs/planning/<slug>.md` (sección `## Bitácora`).
 
 ## Convenciones
 


### PR DESCRIPTION
## Contexto

Salidas de la revisión de docs del 2026-06-09 (CLAUDE.md / INITIATIVES.md / INFRASTRUCTURE.md y satélites), pedida por Beto tras la depuración de ayer (#752/#756).

## Cambios

- **CLAUDE.md** — la sección "Antes de `git push`" decía **4 checks** (`typecheck`, `test:run`, `lint`, `format:check`); CI real corre **6** ([ci.yml](.github/workflows/ci.yml)). Ahora documenta: `test:coverage` (CI aplica coverage thresholds — `test:run` puede pasar local y CI fallar), `initiatives:check` y `schema:check` (con cómo leer `SUPABASE_DB_URL` de 1Password).
- **docs/planning/dilesa-construccion.md** — entrada de bitácora post-cierre: el cutover de obra (#782, construcción fuera del sync diario Coda→BSOP) no estaba registrado en el doc de referencia del módulo.
- **docs/architecture/ARCHITECTURE.md §8** — retirados 2 topics vencidos: CxP (ya `in_progress` con Sprints 1-4 en prod, dejó de ser "por arrancar") y auto-generación de INITIATIVES.md (ya construida en #744).
- **docs/strategy/INITIATIVES.md** — nota de cabecera al día.

## No incluido (y por qué)

El hito/bitácora stale de `dilesa-ventas-expediente` que detectó la revisión lo corrigió la propia sesión dueña en #783 mientras este PR se preparaba — el rebase tomó su versión, que es más completa.

## Verificación

Los 6 checks verdes en local sobre todo el repo: typecheck · test:coverage · lint · format:check · initiatives:check · schema:check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)