### PR TITLE
feat(dilesa-ventas): Sprint 2c — Valor Facturado exacto + puente CxC + bitácora/documentos

### DIFF
--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -163,7 +163,13 @@ type DesgloseCalculo = {
   isai_2pct: number;
   gastos_notariales_6pct: number;
 };
-type Fase = { id: string; fase: string; posicion: number | null; fecha: string | null };
+type Fase = {
+  id: string;
+  fase: string;
+  posicion: number | null;
+  fecha: string | null;
+  registrado_por: string | null;
+};
 type Cargo = {
   id: string;
   tipo_cargo: string;
@@ -378,6 +384,8 @@ function DetailInner() {
   const [adjuntos, setAdjuntos] = useState<Adjunto[]>([]);
   const [calculo, setCalculo] = useState<DesgloseCalculo | null>(null);
   const [vendedorNombre, setVendedorNombre] = useState<string | null>(null);
+  // Nombre por usuario que registró cada fase (bitácora: "quién cerró qué").
+  const [registradoresPorId, setRegistradoresPorId] = useState<Map<string, string>>(new Map());
   const [holdSnapshot, setHoldSnapshot] = useState<HoldSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -461,7 +469,7 @@ function DetailInner() {
         sb
           .schema('dilesa')
           .from('venta_fases')
-          .select('id, fase, posicion, fecha')
+          .select('id, fase, posicion, fecha, registrado_por')
           .eq('venta_id', ventaRow.id)
           .is('deleted_at', null)
           .order('posicion', { ascending: true }),
@@ -503,7 +511,33 @@ function DetailInner() {
       }
 
       setPersona((pRes.data as unknown as Persona) ?? null);
-      setFases((fRes.data ?? []) as Fase[]);
+      const fasesData = (fRes.data ?? []) as Fase[];
+      setFases(fasesData);
+
+      // Resolver nombres de quién registró cada fase (bitácora).
+      const registradorIds = [
+        ...new Set(fasesData.map((f) => f.registrado_por).filter((x): x is string => !!x)),
+      ];
+      if (registradorIds.length > 0) {
+        const { data: regUsers } = await sb
+          .schema('core')
+          .from('usuarios')
+          .select('id, first_name, last_name, email')
+          .in('id', registradorIds);
+        if (activo) {
+          const rm = new Map<string, string>();
+          for (const u of (regUsers ?? []) as {
+            id: string;
+            first_name: string | null;
+            last_name: string | null;
+            email: string | null;
+          }[]) {
+            const completo = [u.first_name, u.last_name].filter(Boolean).join(' ').trim();
+            rm.set(u.id, completo || u.email || '');
+          }
+          setRegistradoresPorId(rm);
+        }
+      }
       const cargosData = (cargosRes.data ?? []) as Cargo[];
       const abonosData = (abonosRes.data ?? []) as Abono[];
       setCargos(cargosData);
@@ -723,6 +757,7 @@ function DetailInner() {
         pos,
         nombre,
         fecha: f?.fecha ?? null,
+        registradoPor: f?.registrado_por ?? null,
         alcanzada,
         cargados,
         faltantes,
@@ -773,10 +808,15 @@ function DetailInner() {
         depositos: abonos.map((a) => ({
           monto: a.monto_total,
           directoCliente: a.fuente === 'cliente',
+          // Con recibo de caja emitido ⇒ suma al Valor Facturado (paridad
+          // Coda). El recibo vive como adjunto rol='recibo_caja' del abono.
+          tieneRecibo: (comprobantesPorAbono.get(a.id) ?? []).some(
+            (adj) => adj.rol === 'recibo_caja'
+          ),
         })),
         proyectoNombre,
       }),
-    [venta, abonos, proyectoNombre, cuadInputs, apoyoInfonavit]
+    [venta, abonos, proyectoNombre, cuadInputs, apoyoInfonavit, comprobantesPorAbono]
   );
 
   if (loading) {
@@ -987,12 +1027,34 @@ function DetailInner() {
           {pipelineRows.flatMap((r) => r.cargados).length === 0 ? (
             <p className="text-sm text-[var(--text)]/50">Sin documentos cargados aún.</p>
           ) : (
-            <div className="flex flex-wrap gap-2">
-              {pipelineRows
-                .flatMap((r) => r.cargados)
-                .map((a) => (
-                  <AdjuntoLink key={a.id} a={a} />
-                ))}
+            <div className="space-y-4">
+              {MACRO_ETAPAS.map((me) => {
+                const rowsConDocs = pipelineRows.filter(
+                  (r) => r.pos >= me.desde && r.pos <= me.hasta && r.cargados.length > 0
+                );
+                if (rowsConDocs.length === 0) return null;
+                const total = rowsConDocs.reduce((s, r) => s + r.cargados.length, 0);
+                return (
+                  <div key={me.nombre}>
+                    <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[var(--text)]/55">
+                      {me.nombre}{' '}
+                      <span className="font-normal text-[var(--text)]/40">· {total}</span>
+                    </h4>
+                    <div className="space-y-2">
+                      {rowsConDocs.map((r) => (
+                        <div key={r.pos} className="flex flex-wrap items-baseline gap-2">
+                          <span className="w-44 shrink-0 text-[11px] text-[var(--text)]/50">
+                            {r.pos}. {r.nombre}
+                          </span>
+                          {r.cargados.map((a) => (
+                            <AdjuntoLink key={a.id} a={a} />
+                          ))}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           )}
         </Section>
@@ -1006,19 +1068,23 @@ function DetailInner() {
             <ol className="space-y-1.5">
               {pipelineRows
                 .filter((r) => r.alcanzada)
-                .map((r) => (
-                  <li key={r.pos} className="flex items-center justify-between text-sm">
-                    <span className="text-[var(--text)]/80">
-                      <span className="mr-2 font-mono text-[11px] text-[var(--text)]/40">
-                        {r.pos}
+                .map((r) => {
+                  const quien = r.registradoPor ? registradoresPorId.get(r.registradoPor) : null;
+                  return (
+                    <li key={r.pos} className="flex items-center justify-between text-sm">
+                      <span className="text-[var(--text)]/80">
+                        <span className="mr-2 font-mono text-[11px] text-[var(--text)]/40">
+                          {r.pos}
+                        </span>
+                        {r.nombre}
                       </span>
-                      {r.nombre}
-                    </span>
-                    <span className="text-[11px] text-[var(--text)]/55">
-                      {r.fecha ? fmtFecha(r.fecha) : '—'}
-                    </span>
-                  </li>
-                ))}
+                      <span className="text-[11px] text-[var(--text)]/55">
+                        {quien ? <span className="mr-2 text-[var(--text)]/45">{quien}</span> : null}
+                        {r.fecha ? fmtFecha(r.fecha) : '—'}
+                      </span>
+                    </li>
+                  );
+                })}
             </ol>
           )}
         </Section>

--- a/scripts/import_dilesa_expediente.ts
+++ b/scripts/import_dilesa_expediente.ts
@@ -323,7 +323,7 @@ async function main() {
     entidad_tipo: string;
     entidad_id: string;
     rol: string;
-    metadata: { coda_source_url?: string } | null;
+    metadata: { coda_source_url?: string; recableado_de_venta_pago?: string } | null;
   };
   const PAGE = 1000;
   const existing: ExistingRow[] = [];
@@ -333,7 +333,11 @@ async function main() {
       .from('adjuntos')
       .select('entidad_tipo, entidad_id, rol, metadata')
       .eq('empresa_id', empresaId)
-      .in('entidad_tipo', ['venta', 'venta_pago'])
+      // 'cxc_pago' DEBE estar en el set: el recableo (migración 20260602180000
+      // + paso nocturno sync_dilesa_cxc_incremental) re-apunta los adjuntos de
+      // depósito venta_pago → cxc_pago. Sin verlos, el dedup re-descarga todo
+      // el set recableado (bug que generó 1,450 duplicados el 2026-06-03).
+      .in('entidad_tipo', ['venta', 'venta_pago', 'cxc_pago'])
       .range(from, from + PAGE - 1);
     if (error) throw new Error(`Error leyendo adjuntos existentes: ${error.message}`);
     const rows = (data ?? []) as ExistingRow[];
@@ -345,11 +349,21 @@ async function main() {
   for (const a of existing) {
     const src = a.metadata?.coda_source_url;
     if (!src) continue;
+    // Un adjunto recableado a cxc_pago dedupea con la key del venta_pago de
+    // origen (preservado en metadata) — es la misma key que generaría el
+    // target si se re-importara.
+    const ventaPagoOrigen =
+      a.entidad_tipo === 'cxc_pago' ? a.metadata?.recableado_de_venta_pago : null;
     const inScope =
       (a.entidad_tipo === 'venta' && ventaSet.has(a.entidad_id)) ||
-      (a.entidad_tipo === 'venta_pago' && pagoSet.has(a.entidad_id));
+      (a.entidad_tipo === 'venta_pago' && pagoSet.has(a.entidad_id)) ||
+      (!!ventaPagoOrigen && pagoSet.has(ventaPagoOrigen));
     if (!inScope) continue;
-    existingKey.add(`${a.entidad_tipo}|${a.entidad_id}|${a.rol}|${src}`);
+    if (ventaPagoOrigen) {
+      existingKey.add(`venta_pago|${ventaPagoOrigen}|${a.rol}|${src}`);
+    } else {
+      existingKey.add(`${a.entidad_tipo}|${a.entidad_id}|${a.rol}|${src}`);
+    }
   }
   console.log(`Adjuntos ya migrados en alcance: ${existingKey.size}`);
 

--- a/scripts/run-dilesa-sync.ts
+++ b/scripts/run-dilesa-sync.ts
@@ -110,6 +110,10 @@ const CONSTRUCCION_SCRIPTS: Array<{ name: string; path: string }> = [
 const DAILY_SCRIPTS: Array<{ name: string; path: string }> = [
   { name: 'Ventas', path: 'scripts/import_dilesa_ventas.ts' },
   { name: 'Expediente', path: 'scripts/import_dilesa_expediente.ts' },
+  // Puente venta_pagos → CxC (la UI de cuadratura/estado de cuenta lee
+  // erp.cxc_pagos). Va después de Expediente: recablea adjuntos recién
+  // importados. Muere con el daily al cutoff de ventas.
+  { name: 'CxC puente (incr)', path: 'scripts/sync_dilesa_cxc_incremental.ts' },
 ];
 const FULL_SCRIPTS: Array<{ name: string; path: string }> = [
   { name: 'Terrenos', path: 'scripts/import_dilesa_terrenos.ts' },

--- a/scripts/sync_dilesa_cxc_incremental.ts
+++ b/scripts/sync_dilesa_cxc_incremental.ts
@@ -1,0 +1,108 @@
+/**
+ * sync_dilesa_cxc_incremental.ts
+ *
+ * Iniciativa dilesa-ventas-expediente · Sprint 2c — puente nocturno
+ * venta_pagos → CxC (vigente hasta el cutoff de ventas).
+ *
+ * El sync diario importa los depósitos de Coda a `dilesa.venta_pagos`, pero la
+ * UI (cuadratura + estado de cuenta del Expediente de Operación) lee
+ * `erp.cxc_pagos`. El puente original fue one-shot (fn_backfill_cxc +
+ * recableo de adjuntos, migración 20260602180000) y quedó congelado — los
+ * depósitos nuevos no llegaban a CxC. Este paso lo vuelve incremental:
+ *
+ *   1. RPC `dilesa.fn_backfill_cxc()` — idempotente (skip por coda_row_id):
+ *      genera planes de cargos nuevos, espeja pagos nuevos, aplica FIFO.
+ *   2. Recablea adjuntos de depósito venta_pago → cxc_pago (mismo DML que la
+ *      migración 20260602180000) con guard anti-duplicado por
+ *      coda_source_url — defensa por si vuelven a existir copias dobles.
+ *   3. Setea `cxc_pagos.comprobante_adjunto_id` donde falte.
+ *
+ * Los pagos de ventas desasignadas o sin valor_escrituracion quedan fuera por
+ * diseño (fn_backfill_cxc los salta); se auto-puentean si la venta avanza.
+ *
+ * Post-cutoff de ventas el daily se apaga y este paso muere con él.
+ *
+ * Prerequisites (env): SUPABASE_DB_URL.
+ * Uso: npx tsx scripts/sync_dilesa_cxc_incremental.ts
+ */
+import { Client } from 'pg';
+
+const SUPABASE_DB_URL = process.env.SUPABASE_DB_URL ?? '';
+if (!SUPABASE_DB_URL) throw new Error('Falta SUPABASE_DB_URL');
+
+const RECABLE_SQL = `
+with map as (
+  select a.id          as adjunto_id,
+         a.entidad_id  as venta_pago_id,
+         cp.id         as cxc_pago_id
+  from erp.adjuntos a
+  join dilesa.venta_pagos vp on vp.id = a.entidad_id and vp.deleted_at is null
+  join erp.cxc_pagos cp on cp.coda_row_id = vp.coda_row_id and cp.deleted_at is null
+  where a.entidad_tipo = 'venta_pago'
+    and not exists (
+      select 1 from erp.adjuntos b
+      where b.entidad_tipo = 'cxc_pago'
+        and b.metadata->>'coda_source_url' = a.metadata->>'coda_source_url'
+    )
+)
+update erp.adjuntos a
+set entidad_tipo = 'cxc_pago',
+    entidad_id   = m.cxc_pago_id,
+    metadata     = coalesce(a.metadata, '{}'::jsonb)
+                   || jsonb_build_object(
+                        'recableado_de_venta_pago', m.venta_pago_id::text,
+                        'recableado_en', now()::text,
+                        'recableado_por', 'sync_dilesa_cxc_incremental'
+                      )
+from map m
+where a.id = m.adjunto_id
+`;
+
+const COMPROBANTE_SQL = `
+with pref as (
+  select distinct on (a.entidad_id)
+         a.entidad_id as cxc_pago_id,
+         a.id         as adjunto_id
+  from erp.adjuntos a
+  where a.entidad_tipo = 'cxc_pago'
+  order by a.entidad_id,
+           case a.rol
+             when 'comprobante_deposito' then 0
+             when 'comprobante'          then 1
+             when 'recibo_caja'          then 2
+             else 3
+           end,
+           a.created_at
+)
+update erp.cxc_pagos cp
+set comprobante_adjunto_id = pref.adjunto_id,
+    updated_at             = now()
+from pref
+where cp.id = pref.cxc_pago_id
+  and cp.comprobante_adjunto_id is null
+`;
+
+async function main() {
+  const pg = new Client({ connectionString: SUPABASE_DB_URL });
+  await pg.connect();
+  try {
+    const backfill = await pg.query('SELECT * FROM dilesa.fn_backfill_cxc()');
+    console.log('fn_backfill_cxc:');
+    for (const r of backfill.rows as { metrica: string; valor: string }[]) {
+      console.log(`  ${r.metrica}: ${r.valor}`);
+    }
+
+    const recable = await pg.query(RECABLE_SQL);
+    console.log(`adjuntos recableados venta_pago → cxc_pago: ${recable.rowCount}`);
+
+    const comprobantes = await pg.query(COMPROBANTE_SQL);
+    console.log(`comprobante_adjunto_id seteados: ${comprobantes.rowCount}`);
+  } finally {
+    await pg.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Bug raíz

Los depósitos viven en dos modelos a media migración: Coda → `dilesa.venta_pagos` (sync nocturno) pero la UI lee `erp.cxc_pagos`. El puente fue one-shot (2026-06-01) y quedó congelado. Tres síntomas:

1. **Valor Facturado corto**: el motor filtra depósitos `tieneRecibo` pero la página nunca pasaba el flag → Nota de Crédito mal.
2. **~137 depósitos invisibles** en cuadratura/estado de cuenta (sin espejo CxC).
3. **1,450 adjuntos duplicados**: el recableo del 2026-06-02 movió adjuntos a `cxc_pago`; el dedup del sync no los ve y re-descargó todo.

## Fix

- **Página**: `tieneRecibo` derivado de adjuntos `rol='recibo_caja'` del abono (860 ya migrados — sin captura nueva ni schema).
- **`sync_dilesa_cxc_incremental.ts`** (paso nocturno nuevo, después de Expediente): `fn_backfill_cxc()` idempotente + recableo de adjuntos con guard anti-dup + `comprobante_adjunto_id`. Muere con el daily al cutoff.
- **Dedup del expediente**: ve los recableados vía `metadata.recableado_de_venta_pago` → no re-descarga.

## UI (pulidos del plan)

- **Bitácora**: muestra quién registró cada fase.
- **Documentos**: agrupados por macro-etapa con conteo, una fila por fase.

## Ya ejecutado en prod (idempotente)

`fn_backfill_cxc()`: 29 pagos espejados + 46 aplicaciones FIFO + 507 planes. Residual correcto: 93 pagos de ventas desasignadas (histórico) + 12 de activas sin valor de escrituración (se auto-puentean al avanzar).

## Pendiente con OK de Beto (destructivo)

DELETE de los 1,450 adjuntos `venta_pago` duplicados (mismo path de Storage que su gemelo `cxc_pago` — solo filas DB, cero objetos) y recableo de alcance completo.

## Validar en Preview

Venta escriturada con depósitos: pestaña Cuadratura → Valor Facturado = Escrituración + depósitos con recibo; Nota de Crédito = Facturado − Valor Real. Bitácora con responsable; Documentos agrupados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)