### PR TITLE
feat(dilesa-ventas): Fase 14 — Preparada para Entrega (checklist imprimible + captura)

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -30,6 +30,7 @@ import {
   type SolicitudDictamenData,
 } from '@/lib/dilesa/pdf/solicitud-dictamen';
 import { PolizaGarantiaPDF, type PolizaGarantiaData } from '@/lib/dilesa/pdf/poliza-garantia';
+import { ChecklistEntregaPDF, type ChecklistEntregaData } from '@/lib/dilesa/pdf/checklist-entrega';
 import {
   PagareCreditoDirectoPDF,
   type PagareCreditoDirectoData,
@@ -47,6 +48,7 @@ const TIPOS = [
   'solicitud-dictamen',
   'poliza-garantia',
   'pagare-credito-directo',
+  'checklist-entrega',
 ] as const;
 type TipoPdf = (typeof TIPOS)[number];
 
@@ -326,6 +328,26 @@ export async function GET(
     };
     const buf = await renderToBuffer(<SolicitudDictamenPDF data={data} />);
     return pdfResponse(buf, `solicitud-dictamen-${identificacionInventario || id}.pdf`);
+  }
+
+  if (tipo === 'checklist-entrega') {
+    // Checklist Pre-Entrega (Fase 14): imprimible para que Calidad y Entrega
+    // recorra la vivienda, palomee en papel y firme. El escaneado firmado se
+    // sube en la captura de la fase. Disponible desde cualquier momento (el
+    // gate de la fase vive en el pipeline, no aquí).
+    const data: ChecklistEntregaData = {
+      fechaTexto,
+      fraccionamiento: pdfFraccionamiento,
+      manzana: pdfManzana,
+      lote: pdfLote,
+      domicilioOficial: pdfDomicilioOficial,
+      prototipo: pdfPrototipo ?? (pdfDataExtra.prototipo || null),
+      identificacionInventario,
+      clienteNombre,
+      watermark: watermarkText,
+    };
+    const buf = await renderToBuffer(<ChecklistEntregaPDF data={data} />);
+    return pdfResponse(buf, `checklist-pre-entrega-${identificacionInventario || id}.pdf`);
   }
 
   if (tipo === 'poliza-garantia') {

--- a/app/dilesa/ventas/[id]/capturar/14-preparada-entrega/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/14-preparada-entrega/page.tsx
@@ -1,0 +1,445 @@
+'use client';
+
+/**
+ * Captura Fase 14 — Preparada para Entrega (dilesa-ventas-expediente S5).
+ *
+ * El equipo de Calidad y Entrega revisa la vivienda con el Checklist
+ * Pre-Entrega: lo imprime desde aquí (PDF prellenado con vivienda + cliente),
+ * recorre la casa palomeando en papel, firma, escanea y sube el PDF firmado.
+ * Subirlo cierra la fase.
+ *
+ * Gate especial (Beto, 2026-06-10): la preparación puede hacerse desde que se
+ * registra la escritura (Fase 11) — NO espera Detonada (12) ni Facturada (13).
+ *
+ * Captura:
+ *   - Doc requerido: rol `checklist_pre_entrega` (checklist firmado).
+ *     Coincide con `FASE_ROLES['Preparada para Entrega']` en el detalle.
+ *   - Notas opcionales → `venta_fases.notas`.
+ *
+ * Acceso: `dilesa.ventas.fase14_preparada_entrega` (escritura: Obra +
+ * Dirección; lectura: Gerencia Ventas — pre-sembrado en core.modulos).
+ */
+
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircle2, Loader2, Printer, Save, Upload, XCircle } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
+import { marcarFase } from '@/lib/dilesa/captura/marcar-fase';
+
+type VentaCtx = {
+  id: string;
+  persona_id: string;
+  unidad_id: string | null;
+};
+
+export default function CapturarFase14Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.fase14_preparada_entrega" write>
+      <CapturarFase14Body />
+    </RequireAccess>
+  );
+}
+
+function CapturarFase14Body() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const toast = useToast();
+  const sb = useMemo(() => createSupabaseBrowserClient(), []);
+  const ventaId = params.id;
+
+  const [venta, setVenta] = useState<VentaCtx | null>(null);
+  const [clienteNombre, setClienteNombre] = useState<string>('');
+  const [identificacionInv, setIdentificacionInv] = useState<string | null>(null);
+  const [fase11Cerrada, setFase11Cerrada] = useState<boolean | null>(null);
+  const [yaCerrada, setYaCerrada] = useState<boolean>(false);
+
+  const [archivo, setArchivo] = useState<File | null>(null);
+  const [notas, setNotas] = useState<string>('');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // ── Cargar contexto ──────────────────────────────────────────────
+  useEffect(() => {
+    if (!ventaId) return;
+    let activo = true;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+
+      const { data: vRow, error: vErr } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .select('id, persona_id, unidad_id')
+        .eq('id', ventaId)
+        .is('deleted_at', null)
+        .maybeSingle();
+      if (!activo) return;
+      if (vErr) {
+        setError(getSupabaseErrorMessage(vErr, 'No se pudo cargar la venta.'));
+        setLoading(false);
+        return;
+      }
+      if (!vRow) {
+        setError('Venta no encontrada.');
+        setLoading(false);
+        return;
+      }
+      const v = vRow as unknown as VentaCtx;
+      setVenta(v);
+
+      const [pRes, uRes, fRes] = await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno')
+          .eq('id', v.persona_id)
+          .maybeSingle(),
+        v.unidad_id
+          ? sb
+              .schema('dilesa')
+              .from('unidades')
+              .select('identificador, producto_id')
+              .eq('id', v.unidad_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+        sb
+          .schema('dilesa')
+          .from('venta_fases')
+          .select('posicion')
+          .eq('venta_id', v.id)
+          .is('deleted_at', null),
+      ]);
+      if (!activo) return;
+
+      if (pRes.data) {
+        setClienteNombre(
+          [pRes.data.nombre, pRes.data.apellido_paterno, pRes.data.apellido_materno]
+            .filter(Boolean)
+            .join(' ') || '(sin nombre)'
+        );
+      }
+      if (uRes.data) {
+        const prodSufijo = uRes.data.producto_id
+          ? (
+              await sb
+                .schema('dilesa')
+                .from('productos')
+                .select('nombre')
+                .eq('id', uRes.data.producto_id)
+                .maybeSingle()
+            ).data?.nombre
+              ?.split('-')
+              .pop()
+          : '';
+        setIdentificacionInv(
+          prodSufijo ? `${uRes.data.identificador}-${prodSufijo}` : uRes.data.identificador
+        );
+      }
+      const posiciones = (fRes.data ?? []).map((f) => f.posicion as number);
+      setFase11Cerrada(posiciones.includes(11));
+      setYaCerrada(posiciones.includes(14));
+
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [ventaId, sb]);
+
+  // ── Submit ───────────────────────────────────────────────────────
+  const onSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!venta) return;
+      if (!archivo) {
+        toast.add({
+          title: 'Falta el checklist firmado',
+          description:
+            'Imprime el checklist, realiza la revisión de la vivienda, fírmalo y sube el escaneado.',
+          type: 'error',
+        });
+        return;
+      }
+
+      setSubmitting(true);
+      const { data: userRes } = await sb.auth.getUser();
+      const userId = userRes?.user?.id ?? null;
+
+      const result = await marcarFase(sb, {
+        ventaId: venta.id,
+        faseNombre: 'Preparada para Entrega',
+        faseposicion: 14,
+        docs: [{ rol: 'checklist_pre_entrega', archivo }],
+        camposVenta: {},
+        notas: notas.trim() || null,
+        registradoPor: userId,
+      });
+
+      setSubmitting(false);
+      if (!result.ok) {
+        toast.add({
+          title: 'Error al cerrar Fase 14',
+          description: result.error ?? 'Error desconocido.',
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({
+        title: 'Fase 14 cerrada',
+        description: 'Vivienda preparada para entrega. El checklist quedó en el expediente.',
+        type: 'success',
+      });
+      router.push(`/dilesa/ventas/${venta.id}`);
+    },
+    [archivo, notas, router, sb, toast, venta]
+  );
+
+  // ── Render ───────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !venta) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-4 px-4 py-6">
+        <CapturarFaseHeader
+          ventaId={ventaId}
+          clienteNombre={null}
+          identificacionInventario={null}
+          faseposicion={14}
+          faseNombre="Preparada para Entrega"
+        />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Venta no encontrada.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+      <CapturarFaseHeader
+        ventaId={venta.id}
+        clienteNombre={clienteNombre}
+        identificacionInventario={identificacionInv}
+        faseposicion={14}
+        faseNombre="Preparada para Entrega"
+        descripcion="Calidad y Entrega revisa la vivienda con el checklist impreso y sube el escaneado firmado."
+      />
+
+      {yaCerrada ? (
+        <Banner
+          tone="success"
+          title="Fase 14 ya está cerrada"
+          body="Esta vivienda ya quedó preparada para entrega. La siguiente fase es Entregada."
+        />
+      ) : !fase11Cerrada ? (
+        <Banner
+          tone="warning"
+          title="Falta cerrar Fase 11 (Escriturada)"
+          body={
+            <>
+              La preparación de entrega puede hacerse desde que se registra la escritura — sin
+              esperar Detonada ni Facturada. Vuelve al detalle y captura la Fase 11 primero.
+            </>
+          }
+          extra={
+            <Link
+              href={`/dilesa/ventas/${venta.id}`}
+              className="mt-3 inline-block text-sm font-medium text-[var(--accent)] underline"
+            >
+              Volver al detalle
+            </Link>
+          }
+        />
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-6">
+          <Section title="1 · Imprimir el checklist">
+            <div className="flex flex-wrap items-center gap-3">
+              <a
+                href={`/api/dilesa/ventas/${venta.id}/pdf/checklist-entrega`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-medium text-[var(--text)]/85 hover:bg-[var(--bg)]/40"
+              >
+                <Printer className="h-4 w-4" />
+                Checklist Pre-Entrega (PDF prellenado)
+              </a>
+              <Hint>
+                Sale con los datos de la vivienda y del cliente. Se palomea y firma en papel durante
+                el recorrido.
+              </Hint>
+            </div>
+          </Section>
+
+          <Section title="2 · Subir el checklist firmado">
+            <FileSlot
+              label="Checklist Pre-Entrega firmado (escaneado) *"
+              archivo={archivo}
+              onChange={setArchivo}
+            />
+            <Hint>Subirlo cierra la fase y lo archiva en el expediente de la operación.</Hint>
+          </Section>
+
+          <Section title="Notas (opcional)">
+            <textarea
+              value={notas}
+              onChange={(e) => setNotas(e.target.value)}
+              rows={3}
+              placeholder="Daños menores pendientes, acuerdos con obra, etc."
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--text)]/35 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
+            />
+          </Section>
+
+          <div className="flex items-center justify-end gap-3">
+            <Link
+              href={`/dilesa/ventas/${venta.id}`}
+              className="text-sm text-muted-foreground hover:text-[var(--text)]"
+            >
+              Cancelar
+            </Link>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" /> Guardando…
+                </>
+              ) : (
+                <>
+                  <Save className="mr-2 size-4" /> Guardar fase
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return <p className="mt-2 text-[11px] text-[var(--text)]/50">{children}</p>;
+}
+
+/** Mismo slot estandarizado de las fases 2/3/5/9 (check + botón + drag-drop). */
+function FileSlot({
+  label,
+  archivo,
+  onChange,
+}: {
+  label: string;
+  archivo: File | null;
+  onChange: (f: File | null) => void;
+}) {
+  const [dragOver, setDragOver] = useState(false);
+  const completo = !!archivo;
+  return (
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+        if (!dragOver) setDragOver(true);
+      }}
+      onDragLeave={(e) => {
+        if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+        setDragOver(false);
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragOver(false);
+        const f = e.dataTransfer.files?.[0];
+        if (!f) return;
+        if (
+          !(
+            f.type === 'application/pdf' ||
+            f.type.startsWith('image/') ||
+            f.name.toLowerCase().endsWith('.pdf')
+          )
+        ) {
+          return;
+        }
+        onChange(f);
+      }}
+      className={`flex items-center justify-between gap-3 rounded-lg border bg-[var(--card)] px-4 py-3 transition-colors ${
+        dragOver
+          ? 'border-[var(--accent)] bg-[var(--accent)]/5 ring-2 ring-[var(--accent)]/40'
+          : 'border-[var(--border)]'
+      }`}
+    >
+      <div className="flex flex-1 items-center gap-2 text-sm">
+        {completo ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+        ) : (
+          <XCircle className="h-4 w-4 shrink-0 text-[var(--text)]/35" />
+        )}
+        <span className="font-medium">{label}</span>
+        {archivo ? (
+          <span className="ml-1 truncate text-xs text-[var(--text)]/60">
+            {archivo.name} · {(archivo.size / 1024).toFixed(0)} KB
+          </span>
+        ) : null}
+      </div>
+      <label className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-xs font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40 hover:text-[var(--text)]">
+        <Upload className="h-3.5 w-3.5" />
+        {archivo ? 'Cambiar' : 'Subir PDF'}
+        <input
+          type="file"
+          accept="application/pdf,image/*"
+          className="hidden"
+          onChange={(e) => onChange(e.target.files?.[0] ?? null)}
+        />
+      </label>
+    </div>
+  );
+}
+
+function Banner({
+  tone,
+  title,
+  body,
+  extra,
+}: {
+  tone: 'success' | 'warning';
+  title: string;
+  body: React.ReactNode;
+  extra?: React.ReactNode;
+}) {
+  const styles =
+    tone === 'success'
+      ? 'border-emerald-400/40 bg-emerald-50 text-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-100'
+      : 'border-amber-400/40 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-100';
+  return (
+    <div className={`rounded-lg border p-4 ${styles}`}>
+      <p className="text-sm font-medium">{title}</p>
+      <div className="mt-1 text-sm">{body}</div>
+      {extra}
+    </div>
+  );
+}

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -288,7 +288,17 @@ const CAPTURAR_SLUG_BY_POSICION: Record<number, string> = {
   11: '11-escriturada',
   12: '12-detonada',
   13: '13-facturada',
-  // 14–17 → próximos PRs del Sprint 7c
+  14: '14-preparada-entrega',
+  // 15–17 → próximos PRs (S5 dilesa-ventas-expediente)
+};
+
+/**
+ * Gate de apertura por fase cuando NO es la inmediata anterior. Beto
+ * (2026-06-10): la preparación de entrega (14) arranca desde que se registra
+ * la escritura (11) — no espera Detonada (12) ni Facturada (13).
+ */
+const GATE_PREVIA_OVERRIDE: Record<number, number> = {
+  14: 11,
 };
 
 /** Las 17 fases canónicas en orden — para mostrar incluso las no alcanzadas. */
@@ -747,7 +757,8 @@ function DetailInner() {
       const rolesCargados = new Set(cargados.map((a) => a.rol));
       const faltantes = roles.filter((r) => !rolesCargados.has(r));
       const slugCaptura = CAPTURAR_SLUG_BY_POSICION[pos];
-      const previaCerrada = pos === 1 || posicionesAlcanzadas.has(pos - 1);
+      const previaCerrada =
+        pos === 1 || posicionesAlcanzadas.has(GATE_PREVIA_OVERRIDE[pos] ?? pos - 1);
       const alcanzada = !!f?.fecha;
       // Si la venta ya está desasignada, el pipeline queda como histórico
       // — el operador no puede avanzar fases. La unidad está liberada.
@@ -1135,6 +1146,13 @@ function DetailInner() {
                 ventaId={venta.id}
                 tipo="pagare-credito-directo"
                 label="Pagaré (crédito directo)"
+              />
+            ) : null}
+            {(venta.fase_posicion ?? 0) >= 11 ? (
+              <PdfDownloadLink
+                ventaId={venta.id}
+                tipo="checklist-entrega"
+                label="Checklist Pre-Entrega"
               />
             ) : null}
           </div>
@@ -1827,7 +1845,8 @@ function PdfDownloadLink({
     | 'solicitud-avaluo'
     | 'solicitud-dictamen'
     | 'poliza-garantia'
-    | 'pagare-credito-directo';
+    | 'pagare-credito-directo'
+    | 'checklist-entrega';
   label: string;
 }) {
   return (

--- a/lib/dilesa/pdf/checklist-entrega.tsx
+++ b/lib/dilesa/pdf/checklist-entrega.tsx
@@ -1,0 +1,266 @@
+/**
+ * Template PDF: Checklist Pre-Entrega de Vivienda (Fase 14 — Preparada
+ * para Entrega, iniciativa dilesa-ventas-expediente S5).
+ *
+ * Réplica mejorada del formato físico de DILESA ("CHECK LIST PRE - ENTREGA
+ * VIVIENDA", 3 páginas Excel): mismas 5 secciones y los 43 puntos íntegros,
+ * pero compactado a una fila por punto con casillas OK / NO + línea de
+ * observación, datos de la vivienda y del cliente prellenados, y bloque de
+ * firmas (el original no traía casillas ni firmas).
+ *
+ * Flujo: el equipo de Calidad y Entrega lo imprime desde BSOP, recorre la
+ * vivienda palomeando en papel, firma, escanea y sube el PDF firmado en la
+ * captura de la Fase 14 (rol `checklist_pre_entrega`).
+ */
+import { Document, Page, Text, View } from '@react-pdf/renderer';
+import { StyleSheet } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand, Watermark } from './header-footer';
+import { SeccionDatos, type FilaDato } from './seccion-datos';
+
+export type ChecklistEntregaData = {
+  fechaTexto: string;
+  // Vivienda
+  fraccionamiento: string | null;
+  manzana: string | null;
+  lote: string | null;
+  domicilioOficial: string | null;
+  prototipo: string | null;
+  identificacionInventario: string;
+  // Cliente
+  clienteNombre: string;
+  // Estado (watermark si desasignada/expirada)
+  watermark?: string | null;
+};
+
+const SECCIONES: Array<{ titulo: string; nota?: string; items: string[] }> = [
+  {
+    titulo: 'EXTERIOR',
+    items: [
+      'Banqueta, zinc y accesos libres sin daño',
+      'Acometida eléctrica con pruebas y número oficial',
+      'Toma de agua domiciliaria con pruebas',
+      'Muros sin daño',
+      'Pintura exterior uniforme',
+      'Sellado exterior en ventanas',
+      'Cristales de ventanas limpios',
+      'Impermeabilización sin marcas ni humedad y/o insulación',
+      'Limpieza exterior',
+    ],
+  },
+  {
+    titulo: 'INTERIOR — PLANTA BAJA',
+    items: [
+      'Funcionamiento de puertas y chapas',
+      'Acabado de interiores y yeso en muros',
+      'Acabado de interiores y yeso en cielos',
+      'Pintura en marcos',
+      'Colocación de zoclos y boquilla',
+      'Pisos cerámicos y boquilla',
+      'Centro de carga y breakers',
+      'Rosetas, contactos y apagadores',
+      'Equipamiento sanitario con accesorios y pruebas',
+      'Lavabos, llaves y accesorios (pruebas)',
+      'Regadera, coladera y accesorios (pruebas)',
+      'Limpieza interior',
+    ],
+  },
+  {
+    titulo: 'INTERIOR — PLANTA ALTA',
+    nota: 'N/A si la vivienda es de una sola planta',
+    items: [
+      'Funcionamiento de puertas y chapas',
+      'Acabado de interiores y yeso en muros',
+      'Acabado de interiores y yeso en cielos',
+      'Pintura en marcos',
+      'Colocación de zoclos y boquilla',
+      'Pisos cerámicos y boquilla',
+      'Centro de carga y breakers',
+      'Rosetas, contactos y apagadores',
+      'Revisión de lavadora con pruebas',
+      'Equipamiento sanitario con accesorios y pruebas',
+      'Lavabos, llaves y accesorios (pruebas)',
+      'Regadera, coladera y accesorios (pruebas)',
+      'Limpieza interior',
+    ],
+  },
+  {
+    titulo: 'PLANTA AZOTEA',
+    items: [
+      'Pretiles, diamantes y base de tinaco',
+      'Tinaco, accesorios y pruebas',
+      'Insulación y/o impermeabilización en azotea con acabado',
+      'Flashing, filetes y pintura',
+    ],
+  },
+  {
+    titulo: 'PATIO DE SERVICIO O EXTERIOR',
+    items: [
+      'Lavadero con tomas',
+      'Preparación de boiler con pruebas',
+      'Tubería de gas con pruebas',
+      'Rosetas exteriores y pruebas eléctricas',
+      'Pruebas hidrosanitarias a red municipal',
+    ],
+  },
+];
+
+const local = StyleSheet.create({
+  secHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.primary,
+    paddingVertical: 2.5,
+    paddingHorizontal: 6,
+    marginTop: 8,
+    marginBottom: 2,
+  },
+  secTitle: { fontSize: 8.5, color: '#ffffff', fontFamily: 'Helvetica-Bold' },
+  secNota: { fontSize: 7, color: '#ffffff', marginLeft: 6, opacity: 0.85 },
+  colHeadRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    paddingBottom: 1.5,
+    borderBottomWidth: 0.6,
+    borderBottomColor: colors.border,
+    marginBottom: 1,
+  },
+  colHeadBox: { width: 20, fontSize: 6.5, color: colors.textMuted, textAlign: 'center' },
+  colHeadItem: { width: '38%', fontSize: 6.5, color: colors.textMuted, paddingLeft: 4 },
+  colHeadObs: { flex: 1, fontSize: 6.5, color: colors.textMuted, paddingLeft: 4 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 17,
+    borderBottomWidth: 0.4,
+    borderBottomColor: colors.border,
+  },
+  boxCell: { width: 20, alignItems: 'center', justifyContent: 'center' },
+  box: {
+    width: 10,
+    height: 10,
+    borderWidth: 0.9,
+    borderColor: colors.text,
+    borderRadius: 1,
+  },
+  itemCell: { width: '38%', fontSize: 8, paddingLeft: 4, paddingRight: 4, paddingVertical: 2 },
+  obsCell: {
+    flex: 1,
+    borderLeftWidth: 0.4,
+    borderLeftColor: colors.border,
+    alignSelf: 'stretch',
+  },
+  obsLineasWrap: { marginTop: 4 },
+  obsLinea: {
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.textMuted,
+    height: 16,
+  },
+  firmaWrap: { marginTop: 30, flexDirection: 'row', justifyContent: 'space-between' },
+  firmaCol: { width: '45%', alignItems: 'center' },
+  firmaLinea: {
+    borderTopWidth: 0.8,
+    borderTopColor: colors.text,
+    width: '100%',
+    marginBottom: 3,
+    paddingTop: 4,
+  },
+  firmaLabel: { fontSize: 8.5, color: colors.textMuted, textAlign: 'center' },
+  leyenda: { fontSize: 7.5, color: colors.textMuted, marginTop: 6 },
+});
+
+function SeccionChecklist({
+  titulo,
+  nota,
+  items,
+}: {
+  titulo: string;
+  nota?: string;
+  items: string[];
+}) {
+  return (
+    <View>
+      <View style={local.secHeader} wrap={false}>
+        <Text style={local.secTitle}>{titulo}</Text>
+        {nota ? <Text style={local.secNota}>({nota})</Text> : null}
+      </View>
+      <View style={local.colHeadRow} wrap={false}>
+        <Text style={local.colHeadBox}>OK</Text>
+        <Text style={local.colHeadBox}>NO</Text>
+        <Text style={local.colHeadItem}>PUNTO A REVISAR</Text>
+        <Text style={local.colHeadObs}>OBSERVACIÓN O UBICACIÓN DE DAÑOS</Text>
+      </View>
+      {items.map((item) => (
+        <View key={item} style={local.row} wrap={false}>
+          <View style={local.boxCell}>
+            <View style={local.box} />
+          </View>
+          <View style={local.boxCell}>
+            <View style={local.box} />
+          </View>
+          <Text style={local.itemCell}>{item}</Text>
+          <View style={local.obsCell} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export function ChecklistEntregaPDF({ data }: { data: ChecklistEntregaData }) {
+  const filasVivienda: FilaDato[] = [
+    { label: 'Fraccionamiento', value: data.fraccionamiento },
+    { label: 'Manzana / Lote', value: [data.manzana, data.lote].filter(Boolean).join(' / ') },
+    { label: 'Domicilio oficial', value: data.domicilioOficial },
+    { label: 'Prototipo', value: data.prototipo },
+    { label: 'Identificación inventario', value: data.identificacionInventario },
+    { label: 'Cliente', value: data.clienteNombre },
+    { label: 'Entidad', value: 'Piedras Negras, Coah.' },
+    { label: 'Fecha de revisión', value: '____________________' },
+  ];
+
+  return (
+    <Document title={`Checklist Pre-Entrega — ${data.identificacionInventario}`}>
+      <Page size="LETTER" style={styles.page}>
+        {data.watermark ? <Watermark text={data.watermark} /> : null}
+        <HeaderBand title="CHECKLIST PRE-ENTREGA DE VIVIENDA" fecha={data.fechaTexto} />
+
+        <SeccionDatos titulo="Datos de la vivienda" filas={filasVivienda} />
+
+        {SECCIONES.map((s) => (
+          <SeccionChecklist key={s.titulo} titulo={s.titulo} nota={s.nota} items={s.items} />
+        ))}
+
+        <View wrap={false}>
+          <View style={local.secHeader}>
+            <Text style={local.secTitle}>OBSERVACIONES NO CONTEMPLADAS EN EL CHECKLIST</Text>
+          </View>
+          <View style={local.obsLineasWrap}>
+            <View style={local.obsLinea} />
+            <View style={local.obsLinea} />
+            <View style={local.obsLinea} />
+            <View style={local.obsLinea} />
+          </View>
+        </View>
+
+        <View style={local.firmaWrap} wrap={false}>
+          <View style={local.firmaCol}>
+            <View style={local.firmaLinea} />
+            <Text style={local.firmaLabel}>Realizó — Calidad y Entrega</Text>
+          </View>
+          <View style={local.firmaCol}>
+            <View style={local.firmaLinea} />
+            <Text style={local.firmaLabel}>Vo.Bo. — Gerencia</Text>
+          </View>
+        </View>
+
+        <Text style={local.leyenda}>
+          La vivienda queda preparada para entrega una vez verificados todos los puntos. El
+          checklist firmado se digitaliza y se archiva en el expediente de la operación (Fase 14 —
+          Preparada para Entrega).
+        </Text>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
## Qué

**Fase 14 — Preparada para Entrega**, con el Checklist Pre-Entrega imprimible desde BSOP.

## Flujo (como lo pidió Beto)

1. Calidad y Entrega abre la captura de F14 y descarga el **checklist prellenado** (vivienda + cliente).
2. Recorre la vivienda palomeando **en papel**, firma.
3. Escanea y sube el PDF firmado → **cierra la fase** y queda en el expediente (rol `checklist_pre_entrega`).

## El checklist (rediseño del formato físico)

- Mismas **5 secciones y 43 puntos íntegros** (Exterior 9 · Planta Baja 12 · Planta Alta 13 · Azotea 4 · Patio 5) + observaciones libres.
- Mejoras: casillas **OK / NO** + línea de observación por punto (el original solo tenía cajas de texto), datos prellenados (fraccionamiento, Mz/Lote, domicilio, prototipo, **cliente**), nota "N/A si es de una planta", y **bloque de firmas** (Realizó — Calidad y Entrega / Vo.Bo. — Gerencia).
- 2 páginas carta, branding DILESA, watermark si la venta se desasigna. Verificado con render local.

## Gate especial

La preparación puede hacerse **desde que se registra la escritura (F11)** — sin esperar Detonada ni Facturada (`GATE_PREVIA_OVERRIDE`). `marcarFase` ya protege que cerrar la 12/13 después no regrese la posición.

## Sin migración

`dilesa.ventas.fase14_preparada_entrega` ya estaba pre-sembrado en `core.modulos` — escritura: **Obra** (equipo de calidad/entrega) + Dirección; lectura: Gerencia Ventas.

## Validar en Preview

- Venta escriturada → chip "Checklist Pre-Entrega" en Operación + botón Capturar en la fase 14 del pipeline.
- Descargar el PDF y revisar acomodo/contenido.
- Venta sin escriturar → banner "Falta cerrar Fase 11".

🤖 Generated with [Claude Code](https://claude.com/claude-code)