### PR TITLE
feat(dilesa-ventas): Fase 15 — Entregada + análisis IA de docs del notario en F8

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -32,6 +32,10 @@ import {
 import { PolizaGarantiaPDF, type PolizaGarantiaData } from '@/lib/dilesa/pdf/poliza-garantia';
 import { ChecklistEntregaPDF, type ChecklistEntregaData } from '@/lib/dilesa/pdf/checklist-entrega';
 import {
+  ChecklistEntregaClientePDF,
+  type ChecklistEntregaClienteData,
+} from '@/lib/dilesa/pdf/checklist-entrega-cliente';
+import {
   PagareCreditoDirectoPDF,
   type PagareCreditoDirectoData,
 } from '@/lib/dilesa/pdf/pagare-credito-directo';
@@ -49,6 +53,7 @@ const TIPOS = [
   'poliza-garantia',
   'pagare-credito-directo',
   'checklist-entrega',
+  'checklist-entrega-cliente',
 ] as const;
 type TipoPdf = (typeof TIPOS)[number];
 
@@ -348,6 +353,25 @@ export async function GET(
     };
     const buf = await renderToBuffer(<ChecklistEntregaPDF data={data} />);
     return pdfResponse(buf, `checklist-pre-entrega-${identificacionInventario || id}.pdf`);
+  }
+
+  if (tipo === 'checklist-entrega-cliente') {
+    // Checklist de Entrega de Vivienda (Fase 15): lo firman el cliente y
+    // Atención a Clientes en la entrega física; el escaneado se sube en la
+    // captura de la fase.
+    const data: ChecklistEntregaClienteData = {
+      fechaTexto,
+      fraccionamiento: pdfFraccionamiento,
+      manzana: pdfManzana,
+      lote: pdfLote,
+      domicilioOficial: pdfDomicilioOficial,
+      prototipo: pdfPrototipo ?? (pdfDataExtra.prototipo || null),
+      identificacionInventario,
+      clienteNombre,
+      watermark: watermarkText,
+    };
+    const buf = await renderToBuffer(<ChecklistEntregaClientePDF data={data} />);
+    return pdfResponse(buf, `checklist-entrega-${identificacionInventario || id}.pdf`);
   }
 
   if (tipo === 'poliza-garantia') {

--- a/app/dilesa/ventas/[id]/capturar/15-entregada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/15-entregada/page.tsx
@@ -1,0 +1,444 @@
+'use client';
+
+/**
+ * Captura Fase 15 — Entregada (dilesa-ventas-expediente S5).
+ *
+ * La entrega física de la vivienda al cliente: se imprime el Checklist para
+ * Entrega de Vivienda (PDF prellenado), se recorre la casa con el cliente
+ * palomeando SÍ/NO, firman el CLIENTE y Atención a Clientes, se escanea y se
+ * sube el PDF firmado. Subirlo cierra la fase.
+ *
+ * Gate: Fase 14 (Preparada para Entrega) debe estar cerrada.
+ *
+ * Captura:
+ *   - Doc requerido: rol `checklist_entrega` (checklist firmado por cliente).
+ *     Coincide con `FASE_ROLES['Entregada']` en el detalle.
+ *   - Notas opcionales → `venta_fases.notas`.
+ *
+ * Acceso: `dilesa.ventas.fase15_entregada` (escritura: Vendedor + Dirección;
+ * lectura: Gerencia Ventas — pre-sembrado en core.modulos).
+ */
+
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircle2, Loader2, Printer, Save, Upload, XCircle } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
+import { marcarFase } from '@/lib/dilesa/captura/marcar-fase';
+
+type VentaCtx = {
+  id: string;
+  persona_id: string;
+  unidad_id: string | null;
+};
+
+export default function CapturarFase15Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.fase15_entregada" write>
+      <CapturarFase15Body />
+    </RequireAccess>
+  );
+}
+
+function CapturarFase15Body() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const toast = useToast();
+  const sb = useMemo(() => createSupabaseBrowserClient(), []);
+  const ventaId = params.id;
+
+  const [venta, setVenta] = useState<VentaCtx | null>(null);
+  const [clienteNombre, setClienteNombre] = useState<string>('');
+  const [identificacionInv, setIdentificacionInv] = useState<string | null>(null);
+  const [fase14Cerrada, setFase14Cerrada] = useState<boolean | null>(null);
+  const [yaCerrada, setYaCerrada] = useState<boolean>(false);
+
+  const [archivo, setArchivo] = useState<File | null>(null);
+  const [notas, setNotas] = useState<string>('');
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // ── Cargar contexto ──────────────────────────────────────────────
+  useEffect(() => {
+    if (!ventaId) return;
+    let activo = true;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+
+      const { data: vRow, error: vErr } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .select('id, persona_id, unidad_id')
+        .eq('id', ventaId)
+        .is('deleted_at', null)
+        .maybeSingle();
+      if (!activo) return;
+      if (vErr) {
+        setError(getSupabaseErrorMessage(vErr, 'No se pudo cargar la venta.'));
+        setLoading(false);
+        return;
+      }
+      if (!vRow) {
+        setError('Venta no encontrada.');
+        setLoading(false);
+        return;
+      }
+      const v = vRow as unknown as VentaCtx;
+      setVenta(v);
+
+      const [pRes, uRes, fRes] = await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno')
+          .eq('id', v.persona_id)
+          .maybeSingle(),
+        v.unidad_id
+          ? sb
+              .schema('dilesa')
+              .from('unidades')
+              .select('identificador, producto_id')
+              .eq('id', v.unidad_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null, error: null }),
+        sb
+          .schema('dilesa')
+          .from('venta_fases')
+          .select('posicion')
+          .eq('venta_id', v.id)
+          .is('deleted_at', null),
+      ]);
+      if (!activo) return;
+
+      if (pRes.data) {
+        setClienteNombre(
+          [pRes.data.nombre, pRes.data.apellido_paterno, pRes.data.apellido_materno]
+            .filter(Boolean)
+            .join(' ') || '(sin nombre)'
+        );
+      }
+      if (uRes.data) {
+        const prodSufijo = uRes.data.producto_id
+          ? (
+              await sb
+                .schema('dilesa')
+                .from('productos')
+                .select('nombre')
+                .eq('id', uRes.data.producto_id)
+                .maybeSingle()
+            ).data?.nombre
+              ?.split('-')
+              .pop()
+          : '';
+        setIdentificacionInv(
+          prodSufijo ? `${uRes.data.identificador}-${prodSufijo}` : uRes.data.identificador
+        );
+      }
+      const posiciones = (fRes.data ?? []).map((f) => f.posicion as number);
+      setFase14Cerrada(posiciones.includes(14));
+      setYaCerrada(posiciones.includes(15));
+
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [ventaId, sb]);
+
+  // ── Submit ───────────────────────────────────────────────────────
+  const onSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!venta) return;
+      if (!archivo) {
+        toast.add({
+          title: 'Falta el checklist firmado por el cliente',
+          description:
+            'Imprime el checklist de entrega, recorre la vivienda con el cliente, recaba firmas y sube el escaneado.',
+          type: 'error',
+        });
+        return;
+      }
+
+      setSubmitting(true);
+      const { data: userRes } = await sb.auth.getUser();
+      const userId = userRes?.user?.id ?? null;
+
+      const result = await marcarFase(sb, {
+        ventaId: venta.id,
+        faseNombre: 'Entregada',
+        faseposicion: 15,
+        docs: [{ rol: 'checklist_entrega', archivo }],
+        camposVenta: {},
+        notas: notas.trim() || null,
+        registradoPor: userId,
+      });
+
+      setSubmitting(false);
+      if (!result.ok) {
+        toast.add({
+          title: 'Error al cerrar Fase 15',
+          description: result.error ?? 'Error desconocido.',
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({
+        title: 'Fase 15 cerrada',
+        description: 'Vivienda entregada al cliente. El checklist firmado quedó en el expediente.',
+        type: 'success',
+      });
+      router.push(`/dilesa/ventas/${venta.id}`);
+    },
+    [archivo, notas, router, sb, toast, venta]
+  );
+
+  // ── Render ───────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !venta) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-4 px-4 py-6">
+        <CapturarFaseHeader
+          ventaId={ventaId}
+          clienteNombre={null}
+          identificacionInventario={null}
+          faseposicion={15}
+          faseNombre="Entregada"
+        />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Venta no encontrada.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+      <CapturarFaseHeader
+        ventaId={venta.id}
+        clienteNombre={clienteNombre}
+        identificacionInventario={identificacionInv}
+        faseposicion={15}
+        faseNombre="Entregada"
+        descripcion="Entrega física al cliente: checklist impreso, recorrido, firmas y escaneado."
+      />
+
+      {yaCerrada ? (
+        <Banner
+          tone="success"
+          title="Fase 15 ya está cerrada"
+          body="Esta vivienda ya fue entregada al cliente. La siguiente fase es Comisión Pagada."
+        />
+      ) : !fase14Cerrada ? (
+        <Banner
+          tone="warning"
+          title="Falta cerrar Fase 14 (Preparada para Entrega)"
+          body={
+            <>
+              Antes de entregar al cliente, Calidad y Entrega debe dejar la vivienda preparada
+              (checklist pre-entrega). Vuelve al detalle y captura la Fase 14 primero.
+            </>
+          }
+          extra={
+            <Link
+              href={`/dilesa/ventas/${venta.id}`}
+              className="mt-3 inline-block text-sm font-medium text-[var(--accent)] underline"
+            >
+              Volver al detalle
+            </Link>
+          }
+        />
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-6">
+          <Section title="1 · Imprimir el checklist de entrega">
+            <div className="flex flex-wrap items-center gap-3">
+              <a
+                href={`/api/dilesa/ventas/${venta.id}/pdf/checklist-entrega-cliente`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm font-medium text-[var(--text)]/85 hover:bg-[var(--bg)]/40"
+              >
+                <Printer className="h-4 w-4" />
+                Checklist de Entrega (PDF prellenado)
+              </a>
+              <Hint>
+                Sale con los datos de la vivienda y del cliente. Se recorre la casa con el cliente
+                palomeando SÍ/NO; firman el cliente y Atención a Clientes.
+              </Hint>
+            </div>
+          </Section>
+
+          <Section title="2 · Subir el checklist firmado por el cliente">
+            <FileSlot
+              label="Checklist de Entrega firmado (escaneado) *"
+              archivo={archivo}
+              onChange={setArchivo}
+            />
+            <Hint>Subirlo cierra la fase y lo archiva en el expediente de la operación.</Hint>
+          </Section>
+
+          <Section title="Notas (opcional)">
+            <textarea
+              value={notas}
+              onChange={(e) => setNotas(e.target.value)}
+              rows={3}
+              placeholder="Acuerdos de entrega, pendientes menores, etc."
+              className="w-full rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-2 text-sm text-[var(--text)] placeholder:text-[var(--text)]/35 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/40"
+            />
+          </Section>
+
+          <div className="flex items-center justify-end gap-3">
+            <Link
+              href={`/dilesa/ventas/${venta.id}`}
+              className="text-sm text-muted-foreground hover:text-[var(--text)]"
+            >
+              Cancelar
+            </Link>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" /> Guardando…
+                </>
+              ) : (
+                <>
+                  <Save className="mr-2 size-4" /> Guardar fase
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return <p className="mt-2 text-[11px] text-[var(--text)]/50">{children}</p>;
+}
+
+/** Mismo slot estandarizado de las fases 2/3/5/9/14 (check + botón + drag-drop). */
+function FileSlot({
+  label,
+  archivo,
+  onChange,
+}: {
+  label: string;
+  archivo: File | null;
+  onChange: (f: File | null) => void;
+}) {
+  const [dragOver, setDragOver] = useState(false);
+  const completo = !!archivo;
+  return (
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+        if (!dragOver) setDragOver(true);
+      }}
+      onDragLeave={(e) => {
+        if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+        setDragOver(false);
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragOver(false);
+        const f = e.dataTransfer.files?.[0];
+        if (!f) return;
+        if (
+          !(
+            f.type === 'application/pdf' ||
+            f.type.startsWith('image/') ||
+            f.name.toLowerCase().endsWith('.pdf')
+          )
+        ) {
+          return;
+        }
+        onChange(f);
+      }}
+      className={`flex items-center justify-between gap-3 rounded-lg border bg-[var(--card)] px-4 py-3 transition-colors ${
+        dragOver
+          ? 'border-[var(--accent)] bg-[var(--accent)]/5 ring-2 ring-[var(--accent)]/40'
+          : 'border-[var(--border)]'
+      }`}
+    >
+      <div className="flex flex-1 items-center gap-2 text-sm">
+        {completo ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+        ) : (
+          <XCircle className="h-4 w-4 shrink-0 text-[var(--text)]/35" />
+        )}
+        <span className="font-medium">{label}</span>
+        {archivo ? (
+          <span className="ml-1 truncate text-xs text-[var(--text)]/60">
+            {archivo.name} · {(archivo.size / 1024).toFixed(0)} KB
+          </span>
+        ) : null}
+      </div>
+      <label className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-xs font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40 hover:text-[var(--text)]">
+        <Upload className="h-3.5 w-3.5" />
+        {archivo ? 'Cambiar' : 'Subir PDF'}
+        <input
+          type="file"
+          accept="application/pdf,image/*"
+          className="hidden"
+          onChange={(e) => onChange(e.target.files?.[0] ?? null)}
+        />
+      </label>
+    </div>
+  );
+}
+
+function Banner({
+  tone,
+  title,
+  body,
+  extra,
+}: {
+  tone: 'success' | 'warning';
+  title: string;
+  body: React.ReactNode;
+  extra?: React.ReactNode;
+}) {
+  const styles =
+    tone === 'success'
+      ? 'border-emerald-400/40 bg-emerald-50 text-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-100'
+      : 'border-amber-400/40 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-100';
+  return (
+    <div className={`rounded-lg border p-4 ${styles}`}>
+      <p className="text-sm font-medium">{title}</p>
+      <div className="mt-1 text-sm">{body}</div>
+      {extra}
+    </div>
+  );
+}

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -289,7 +289,8 @@ const CAPTURAR_SLUG_BY_POSICION: Record<number, string> = {
   12: '12-detonada',
   13: '13-facturada',
   14: '14-preparada-entrega',
-  // 15–17 → próximos PRs (S5 dilesa-ventas-expediente)
+  15: '15-entregada',
+  // 16–17 → próximos PRs (S5 dilesa-ventas-expediente)
 };
 
 /**
@@ -1155,6 +1156,13 @@ function DetailInner() {
                 label="Checklist Pre-Entrega"
               />
             ) : null}
+            {(venta.fase_posicion ?? 0) >= 14 ? (
+              <PdfDownloadLink
+                ventaId={venta.id}
+                tipo="checklist-entrega-cliente"
+                label="Checklist de Entrega (cliente)"
+              />
+            ) : null}
           </div>
 
           <MovimientosAdministrativos
@@ -1846,7 +1854,8 @@ function PdfDownloadLink({
     | 'solicitud-dictamen'
     | 'poliza-garantia'
     | 'pagare-credito-directo'
-    | 'checklist-entrega';
+    | 'checklist-entrega'
+    | 'checklist-entrega-cliente';
   label: string;
 }) {
   return (

--- a/lib/dilesa/pdf/checklist-entrega-cliente.tsx
+++ b/lib/dilesa/pdf/checklist-entrega-cliente.tsx
@@ -1,0 +1,201 @@
+/**
+ * Template PDF: Checklist para Entrega de Vivienda al cliente (Fase 15 —
+ * Entregada, iniciativa dilesa-ventas-expediente S5).
+ *
+ * Réplica del formato físico de DILESA ("Check List para Entrega de
+ * Vivienda"): mismas 7 secciones y 22 puntos íntegros con casillas SÍ / NO +
+ * observación por punto. Mejoras: fraccionamiento dinámico (el original lo
+ * traía impreso fijo), datos de la vivienda y del cliente prellenados, fecha
+ * de entrega, y numeración corregida (el original repetía el "6").
+ *
+ * Lo firman el CLIENTE y Atención a Clientes en la entrega física; el
+ * escaneado firmado se sube en la captura de la Fase 15 (rol
+ * `checklist_entrega`).
+ */
+import { Document, Page, Text, View } from '@react-pdf/renderer';
+import { StyleSheet } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand, Watermark } from './header-footer';
+import { SeccionDatos, type FilaDato } from './seccion-datos';
+
+export type ChecklistEntregaClienteData = {
+  fechaTexto: string;
+  // Vivienda
+  fraccionamiento: string | null;
+  manzana: string | null;
+  lote: string | null;
+  domicilioOficial: string | null;
+  prototipo: string | null;
+  identificacionInventario: string;
+  // Cliente
+  clienteNombre: string;
+  // Estado (watermark si desasignada/expirada)
+  watermark?: string | null;
+};
+
+const SECCIONES: Array<{ titulo: string; items: string[] }> = [
+  {
+    titulo: '1. CONCEPTOS HIDRÁULICOS',
+    items: [
+      'Inodoro y lavabo',
+      'Tinaco con tapa',
+      'Registro (1) y (2)',
+      'Murete de servicio de agua',
+    ],
+  },
+  {
+    titulo: '2. INSTALACIÓN ELÉCTRICA',
+    items: ['Murete de servicio de luz, guía y zapatas', 'Centro de carga con pastillas'],
+  },
+  {
+    titulo: '3. HERRERÍA Y VENTANERÍA',
+    items: ['Marcos de puertas', 'Ventanas', 'Vidrios quebrados'],
+  },
+  {
+    titulo: '4. CARPINTERÍA Y CERRAJERÍA',
+    items: ['Puertas de interior', 'Puerta de exterior', 'Chapas interiores y exteriores'],
+  },
+  {
+    titulo: '5. AZULEJOS',
+    items: ['Loseta en fachada', 'Pisos', 'Azulejo de baño', 'Piso antiderrapante en baño'],
+  },
+  {
+    titulo: '6. PINTURA',
+    items: ['Interior', 'Exterior'],
+  },
+  {
+    titulo: '7. DIVERSOS',
+    items: ['Impermeabilización', 'Bardas', 'Guía murete de luz', 'Terminales de baquelita'],
+  },
+];
+
+const local = StyleSheet.create({
+  secHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.primary,
+    paddingVertical: 2.5,
+    paddingHorizontal: 6,
+    marginTop: 8,
+    marginBottom: 2,
+  },
+  secTitle: { fontSize: 8.5, color: '#ffffff', fontFamily: 'Helvetica-Bold' },
+  colHeadRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    paddingBottom: 1.5,
+    borderBottomWidth: 0.6,
+    borderBottomColor: colors.border,
+    marginBottom: 1,
+  },
+  colHeadBox: { width: 20, fontSize: 6.5, color: colors.textMuted, textAlign: 'center' },
+  colHeadItem: { width: '38%', fontSize: 6.5, color: colors.textMuted, paddingLeft: 4 },
+  colHeadObs: { flex: 1, fontSize: 6.5, color: colors.textMuted, paddingLeft: 4 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 17,
+    borderBottomWidth: 0.4,
+    borderBottomColor: colors.border,
+  },
+  boxCell: { width: 20, alignItems: 'center', justifyContent: 'center' },
+  box: {
+    width: 10,
+    height: 10,
+    borderWidth: 0.9,
+    borderColor: colors.text,
+    borderRadius: 1,
+  },
+  itemCell: { width: '38%', fontSize: 8, paddingLeft: 4, paddingRight: 4, paddingVertical: 2 },
+  obsCell: {
+    flex: 1,
+    borderLeftWidth: 0.4,
+    borderLeftColor: colors.border,
+    alignSelf: 'stretch',
+  },
+  firmaWrap: { marginTop: 44, flexDirection: 'row', justifyContent: 'space-between' },
+  firmaCol: { width: '45%', alignItems: 'center' },
+  firmaLinea: {
+    borderTopWidth: 0.8,
+    borderTopColor: colors.text,
+    width: '100%',
+    marginBottom: 3,
+    paddingTop: 4,
+  },
+  firmaLabel: { fontSize: 8.5, color: colors.textMuted, textAlign: 'center' },
+  leyenda: { fontSize: 7.5, color: colors.textMuted, marginTop: 8 },
+});
+
+function SeccionChecklist({ titulo, items }: { titulo: string; items: string[] }) {
+  return (
+    <View>
+      <View style={local.secHeader} wrap={false}>
+        <Text style={local.secTitle}>{titulo}</Text>
+      </View>
+      <View style={local.colHeadRow} wrap={false}>
+        <Text style={local.colHeadBox}>SÍ</Text>
+        <Text style={local.colHeadBox}>NO</Text>
+        <Text style={local.colHeadItem}>CONCEPTO</Text>
+        <Text style={local.colHeadObs}>OBSERVACIONES</Text>
+      </View>
+      {items.map((item) => (
+        <View key={item} style={local.row} wrap={false}>
+          <View style={local.boxCell}>
+            <View style={local.box} />
+          </View>
+          <View style={local.boxCell}>
+            <View style={local.box} />
+          </View>
+          <Text style={local.itemCell}>{item}</Text>
+          <View style={local.obsCell} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export function ChecklistEntregaClientePDF({ data }: { data: ChecklistEntregaClienteData }) {
+  const filasVivienda: FilaDato[] = [
+    { label: 'Fraccionamiento', value: data.fraccionamiento },
+    { label: 'Manzana / Lote', value: [data.manzana, data.lote].filter(Boolean).join(' / ') },
+    { label: 'Dirección / No. oficial', value: data.domicilioOficial },
+    { label: 'Prototipo', value: data.prototipo },
+    { label: 'Identificación inventario', value: data.identificacionInventario },
+    { label: 'Nombre del cliente', value: data.clienteNombre },
+    { label: 'Fecha de entrega', value: '____________________' },
+  ];
+
+  return (
+    <Document title={`Checklist Entrega de Vivienda — ${data.identificacionInventario}`}>
+      <Page size="LETTER" style={styles.page}>
+        {data.watermark ? <Watermark text={data.watermark} /> : null}
+        <HeaderBand title="CHECKLIST PARA ENTREGA DE VIVIENDA" fecha={data.fechaTexto} />
+
+        <SeccionDatos titulo="Datos de la entrega" filas={filasVivienda} />
+
+        {SECCIONES.map((s) => (
+          <SeccionChecklist key={s.titulo} titulo={s.titulo} items={s.items} />
+        ))}
+
+        <View style={local.firmaWrap} wrap={false}>
+          <View style={local.firmaCol}>
+            <View style={local.firmaLinea} />
+            <Text style={local.firmaLabel}>Firma de Cliente</Text>
+          </View>
+          <View style={local.firmaCol}>
+            <View style={local.firmaLinea} />
+            <Text style={local.firmaLabel}>Firma de Atención a Clientes</Text>
+          </View>
+        </View>
+
+        <Text style={local.leyenda}>
+          El cliente recibe la vivienda de conformidad una vez revisados los conceptos anteriores.
+          El checklist firmado se digitaliza y se archiva en el expediente de la operación (Fase 15
+          — Entregada).
+        </Text>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}


### PR DESCRIPTION
Dos entregables del módulo de ventas, en el mismo Preview:

## 1 · Fase 15 — Entregada (checklist de entrega al cliente)

- **Checklist para Entrega de Vivienda** imprimible y prellenado: 7 secciones / 22 conceptos íntegros, casillas SÍ/NO + observaciones, firmas **Cliente / Atención a Clientes**, fraccionamiento dinámico y numeración corregida.
- Flujo igual a F14: imprimir → recorrido con el cliente → firmas → subir escaneado (rol `checklist_entrega`) cierra la fase. Gate: F14 cerrada.
- Sin migración (`fase15_entregada` pre-sembrado: escritura Vendedor + Dirección).

## 2 · Análisis IA automático en F8 — Dictaminada (pedido de Beto)

Al **seleccionar** la Carta de Instrucción o las Condiciones Financieras (Anexo B) — sin botón — el PDF se analiza con Claude y se **precargan** los campos: Valor de Escrituración (nuevo en F8), Monto Crédito Titular, Referencia (institución + número) y Gastos de Escrituración (titulación + impuestos y derechos). Nada se persiste hasta Guardar.

**Verificaciones cruzadas** (chips ✓/✗, panel rojo si algo no coincide): NSS y nombre vs cliente, domicilio vs Mz/Lote de la unidad, **CLABE de depósito vs cuentas de DILESA** (anti-fraude) y vendedor vs razón social.

- Slot nuevo "Condiciones Financieras" (opcional) en la captura **y** en el path post-magic-link.
- Créditos no-Infonavit: extrae lo que el doc traiga; lo ausente se captura manual — no bloquea.
- **Validado contra los 2 PDFs reales del notario** (exp. Arizpe Luna): extracción 100% exacta (precio \$909,000, crédito \$835,566.99, gastos \$12,569.42 + \$30,000, NSS, CLABE, domicilio).

## Validar en Preview

- F15 con ADALBERTO PRUEBA PRUEBA (tras cerrar F14).
- F8 con una venta en fase 7+: subir los PDFs del correo del notario y ver la precarga + chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)