### PR TITLE
feat(dilesa-ventas): análisis IA automático de docs del notario en F8 + condiciones financieras

### DIFF
--- a/app/api/dilesa/notario/dictamen/[token]/route.ts
+++ b/app/api/dilesa/notario/dictamen/[token]/route.ts
@@ -53,6 +53,9 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ token: str
   const fecha = (form.get('fecha') as string | null)?.trim() || null;
   const comentarios = (form.get('comentarios') as string | null)?.trim() || null;
   const archivo = form.get('archivo');
+  // Opcional: Condiciones Financieras Definitivas (Anexo B) — el notario las
+  // manda junto con la carta en créditos INFONAVIT.
+  const archivoCondiciones = form.get('archivo_condiciones');
 
   if (!fecha || !/^\d{4}-\d{2}-\d{2}$/.test(fecha)) {
     return NextResponse.json(
@@ -72,6 +75,15 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ token: str
   if (archivo.size > MAX_FILE_BYTES) {
     return NextResponse.json(
       { ok: false, error: `El archivo supera el límite de ${MAX_FILE_BYTES / 1024 / 1024}MB.` },
+      { status: 413 }
+    );
+  }
+  if (archivoCondiciones instanceof File && archivoCondiciones.size > MAX_FILE_BYTES) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `Las condiciones financieras superan el límite de ${MAX_FILE_BYTES / 1024 / 1024}MB.`,
+      },
       { status: 413 }
     );
   }
@@ -173,6 +185,51 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ token: str
       { ok: false, error: 'Archivo subido pero no se registró. Contacta a Gerencia.' },
       { status: 500 }
     );
+  }
+
+  // Condiciones Financieras (opcional) — mismo tratamiento, rol propio.
+  if (archivoCondiciones instanceof File && archivoCondiciones.size > 0) {
+    const cfFilename = sanitizeFilename(archivoCondiciones.name);
+    const cfPath = buildAdjuntoPath({
+      empresa: 'dilesa',
+      entidad: 'ventas',
+      entidadId: ventaId,
+      filename: cfFilename,
+    });
+    const { error: cfUpErr } = await admin.storage
+      .from('adjuntos')
+      .upload(cfPath, archivoCondiciones, {
+        contentType: archivoCondiciones.type || 'application/pdf',
+        upsert: false,
+      });
+    if (cfUpErr) {
+      console.warn('[notario-dictamen-upload] condiciones storage error:', cfUpErr.message);
+      return NextResponse.json(
+        { ok: false, error: 'No se pudieron subir las condiciones financieras. Intenta de nuevo.' },
+        { status: 500 }
+      );
+    }
+    const { error: cfAdjErr } = await admin
+      .schema('erp')
+      .from('adjuntos')
+      .insert({
+        empresa_id: DILESA_EMPRESA_ID,
+        entidad_tipo: 'venta',
+        entidad_id: ventaId,
+        rol: 'condiciones_financieras',
+        nombre: cfFilename,
+        url: cfPath,
+        tipo_mime: archivoCondiciones.type || 'application/pdf',
+        tamano_bytes: archivoCondiciones.size,
+        uploaded_by: null,
+      });
+    if (cfAdjErr) {
+      console.warn('[notario-dictamen-upload] condiciones insert error:', cfAdjErr.message);
+      return NextResponse.json(
+        { ok: false, error: 'Condiciones subidas pero no registradas. Contacta a Gerencia.' },
+        { status: 500 }
+      );
+    }
   }
 
   const { error: vUpErr } = await admin

--- a/app/api/dilesa/ventas/[id]/analizar-notarial/route.ts
+++ b/app/api/dilesa/ventas/[id]/analizar-notarial/route.ts
@@ -1,0 +1,173 @@
+/**
+ * POST /api/dilesa/ventas/[id]/analizar-notarial
+ *
+ * Análisis IA automático de los documentos del notario (Fase 8 — Dictaminada):
+ * Carta de Instrucción Notarial y Condiciones Financieras (Anexo B). Se invoca
+ * al seleccionar el archivo en la captura — extrae los montos/datos que le
+ * interesan a DILESA y devuelve verificaciones cruzadas contra la venta.
+ *
+ * NO escribe nada: la página precarga el formulario con lo extraído y el
+ * operador decide al guardar la fase.
+ *
+ * Body: multipart/form-data con `file` (PDF, máx 10 MB).
+ * Respuesta: { extraccion, verificaciones }.
+ *
+ * Verificaciones (true=coincide, false=NO coincide, null=sin datos para comparar):
+ *   - nss_coincide        vs erp.personas.nss del comprador
+ *   - nombre_coincide     vs nombre completo del comprador
+ *   - domicilio_coincide  vs manzana/lote de la unidad asignada
+ *   - clabe_es_dilesa     vs CLABEs de erp.cuentas_bancarias de DILESA (anti-fraude:
+ *                         el depósito de la detonación debe caer en cuenta propia)
+ *   - vendedor_es_dilesa  vs razón social de la empresa
+ */
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { extraerDocNotarial, type NotarialExtraccion } from '@/lib/dilesa/notarial-ai/extraer';
+
+export const maxDuration = 60;
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+const norm = (s: string): string =>
+  s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9 ]/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toUpperCase();
+
+const soloDigitos = (s: string): string => s.replace(/\D/g, '');
+
+export type VerificacionesNotarial = {
+  nss_coincide: boolean | null;
+  nombre_coincide: boolean | null;
+  domicilio_coincide: boolean | null;
+  clabe_es_dilesa: boolean | null;
+  vendedor_es_dilesa: boolean | null;
+};
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const sb = await createSupabaseServerClient();
+
+  // Venta + contexto (RLS filtra el acceso).
+  const { data: venta, error: vErr } = await sb
+    .schema('dilesa')
+    .from('ventas')
+    .select('id, empresa_id, persona_id, unidad_id')
+    .eq('id', id)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (vErr || !venta) {
+    return NextResponse.json({ error: 'Venta no encontrada' }, { status: 404 });
+  }
+
+  const form = await req.formData().catch(() => null);
+  const file = form?.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'Falta el archivo (campo `file`)' }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: 'Archivo mayor a 10 MB' }, { status: 413 });
+  }
+
+  const [{ data: persona }, { data: unidad }, { data: empresa }, { data: cuentas }] =
+    await Promise.all([
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('nombre, apellido_paterno, apellido_materno, nss')
+        .eq('id', venta.persona_id)
+        .maybeSingle(),
+      venta.unidad_id
+        ? sb
+            .schema('dilesa')
+            .from('unidades')
+            .select('manzana, numero_lote, calle, numero_oficial')
+            .eq('id', venta.unidad_id)
+            .maybeSingle()
+        : Promise.resolve({ data: null }),
+      sb
+        .schema('core')
+        .from('empresas')
+        .select('nombre, razon_social')
+        .eq('id', venta.empresa_id)
+        .maybeSingle(),
+      sb
+        .schema('erp')
+        .from('cuentas_bancarias')
+        .select('clabe')
+        .eq('empresa_id', venta.empresa_id)
+        .eq('activo', true),
+    ]);
+
+  let extraccion: NotarialExtraccion;
+  try {
+    extraccion = await extraerDocNotarial(new Uint8Array(await file.arrayBuffer()));
+  } catch (e) {
+    return NextResponse.json(
+      { error: `No se pudo analizar el documento: ${e instanceof Error ? e.message : 'error'}` },
+      { status: 502 }
+    );
+  }
+
+  // ── Verificaciones cruzadas ─────────────────────────────────────────
+  const nombreCliente = norm(
+    [persona?.nombre, persona?.apellido_paterno, persona?.apellido_materno]
+      .filter(Boolean)
+      .join(' ')
+  );
+  const nombreExtraido = norm(extraccion.nombre_titular);
+  // El orden varía (APELLIDOS NOMBRE vs NOMBRE APELLIDOS) → comparamos tokens.
+  const nombre_coincide =
+    nombreExtraido && nombreCliente
+      ? nombreCliente
+          .split(' ')
+          .filter((t) => t.length > 2)
+          .every((t) => nombreExtraido.includes(t))
+      : null;
+
+  const nssExtraido = soloDigitos(extraccion.nss);
+  const nssCliente = soloDigitos(persona?.nss ?? '');
+  const nss_coincide = nssExtraido && nssCliente ? nssExtraido === nssCliente : null;
+
+  const domicilioExtraido = norm(extraccion.domicilio_inmueble);
+  const mz = (unidad?.manzana ?? '').toString().replace(/^0+/, '');
+  const lt = (unidad?.numero_lote ?? '').toString().replace(/^0+/, '');
+  const domicilio_coincide =
+    domicilioExtraido && mz && lt
+      ? new RegExp(`\\bMZ\\.? ?0*${mz}\\b`).test(domicilioExtraido) &&
+        new RegExp(`\\bLT\\.? ?0*${lt}\\b`).test(domicilioExtraido)
+      : null;
+
+  const clabeExtraida = soloDigitos(extraccion.clabe_beneficiario);
+  const clabesDilesa = new Set(
+    ((cuentas ?? []) as { clabe: string | null }[])
+      .map((c) => soloDigitos(c.clabe ?? ''))
+      .filter((c) => c.length === 18)
+  );
+  const clabe_es_dilesa =
+    clabeExtraida.length === 18 && clabesDilesa.size > 0 ? clabesDilesa.has(clabeExtraida) : null;
+
+  const vendedorExtraido = norm(extraccion.vendedor);
+  const razones = [empresa?.razon_social, empresa?.nombre]
+    .filter(Boolean)
+    .map((r) => norm(r as string));
+  const vendedor_es_dilesa = vendedorExtraido
+    ? razones.some(
+        (r) =>
+          r.includes(vendedorExtraido.slice(0, 25)) || vendedorExtraido.includes(r.slice(0, 25))
+      )
+    : null;
+
+  const verificaciones: VerificacionesNotarial = {
+    nss_coincide,
+    nombre_coincide,
+    domicilio_coincide,
+    clabe_es_dilesa,
+    vendedor_es_dilesa,
+  };
+
+  return NextResponse.json({ extraccion, verificaciones });
+}

--- a/app/api/dilesa/ventas/[id]/analizar-notarial/route.ts
+++ b/app/api/dilesa/ventas/[id]/analizar-notarial/route.ts
@@ -4,48 +4,23 @@
  * Análisis IA automático de los documentos del notario (Fase 8 — Dictaminada):
  * Carta de Instrucción Notarial y Condiciones Financieras (Anexo B). Se invoca
  * al seleccionar el archivo en la captura — extrae los montos/datos que le
- * interesan a DILESA y devuelve verificaciones cruzadas contra la venta.
+ * interesan a DILESA y devuelve verificaciones cruzadas contra la venta
+ * (lógica pura en `lib/dilesa/notarial-ai/verificar.ts`).
  *
  * NO escribe nada: la página precarga el formulario con lo extraído y el
  * operador decide al guardar la fase.
  *
  * Body: multipart/form-data con `file` (PDF, máx 10 MB).
  * Respuesta: { extraccion, verificaciones }.
- *
- * Verificaciones (true=coincide, false=NO coincide, null=sin datos para comparar):
- *   - nss_coincide        vs erp.personas.nss del comprador
- *   - nombre_coincide     vs nombre completo del comprador
- *   - domicilio_coincide  vs manzana/lote de la unidad asignada
- *   - clabe_es_dilesa     vs CLABEs de erp.cuentas_bancarias de DILESA (anti-fraude:
- *                         el depósito de la detonación debe caer en cuenta propia)
- *   - vendedor_es_dilesa  vs razón social de la empresa
  */
 import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { extraerDocNotarial, type NotarialExtraccion } from '@/lib/dilesa/notarial-ai/extraer';
+import { verificarNotarial } from '@/lib/dilesa/notarial-ai/verificar';
 
 export const maxDuration = 60;
 
 const MAX_BYTES = 10 * 1024 * 1024;
-
-const norm = (s: string): string =>
-  s
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .replace(/[^a-z0-9 ]/gi, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .toUpperCase();
-
-const soloDigitos = (s: string): string => s.replace(/\D/g, '');
-
-export type VerificacionesNotarial = {
-  nss_coincide: boolean | null;
-  nombre_coincide: boolean | null;
-  domicilio_coincide: boolean | null;
-  clabe_es_dilesa: boolean | null;
-  vendedor_es_dilesa: boolean | null;
-};
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -84,7 +59,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         ? sb
             .schema('dilesa')
             .from('unidades')
-            .select('manzana, numero_lote, calle, numero_oficial')
+            .select('manzana, numero_lote')
             .eq('id', venta.unidad_id)
             .maybeSingle()
         : Promise.resolve({ data: null }),
@@ -112,62 +87,18 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     );
   }
 
-  // ── Verificaciones cruzadas ─────────────────────────────────────────
-  const nombreCliente = norm(
-    [persona?.nombre, persona?.apellido_paterno, persona?.apellido_materno]
+  const verificaciones = verificarNotarial(extraccion, {
+    clienteNombre: [persona?.nombre, persona?.apellido_paterno, persona?.apellido_materno]
       .filter(Boolean)
-      .join(' ')
-  );
-  const nombreExtraido = norm(extraccion.nombre_titular);
-  // El orden varía (APELLIDOS NOMBRE vs NOMBRE APELLIDOS) → comparamos tokens.
-  const nombre_coincide =
-    nombreExtraido && nombreCliente
-      ? nombreCliente
-          .split(' ')
-          .filter((t) => t.length > 2)
-          .every((t) => nombreExtraido.includes(t))
-      : null;
-
-  const nssExtraido = soloDigitos(extraccion.nss);
-  const nssCliente = soloDigitos(persona?.nss ?? '');
-  const nss_coincide = nssExtraido && nssCliente ? nssExtraido === nssCliente : null;
-
-  const domicilioExtraido = norm(extraccion.domicilio_inmueble);
-  const mz = (unidad?.manzana ?? '').toString().replace(/^0+/, '');
-  const lt = (unidad?.numero_lote ?? '').toString().replace(/^0+/, '');
-  const domicilio_coincide =
-    domicilioExtraido && mz && lt
-      ? new RegExp(`\\bMZ\\.? ?0*${mz}\\b`).test(domicilioExtraido) &&
-        new RegExp(`\\bLT\\.? ?0*${lt}\\b`).test(domicilioExtraido)
-      : null;
-
-  const clabeExtraida = soloDigitos(extraccion.clabe_beneficiario);
-  const clabesDilesa = new Set(
-    ((cuentas ?? []) as { clabe: string | null }[])
-      .map((c) => soloDigitos(c.clabe ?? ''))
-      .filter((c) => c.length === 18)
-  );
-  const clabe_es_dilesa =
-    clabeExtraida.length === 18 && clabesDilesa.size > 0 ? clabesDilesa.has(clabeExtraida) : null;
-
-  const vendedorExtraido = norm(extraccion.vendedor);
-  const razones = [empresa?.razon_social, empresa?.nombre]
-    .filter(Boolean)
-    .map((r) => norm(r as string));
-  const vendedor_es_dilesa = vendedorExtraido
-    ? razones.some(
-        (r) =>
-          r.includes(vendedorExtraido.slice(0, 25)) || vendedorExtraido.includes(r.slice(0, 25))
-      )
-    : null;
-
-  const verificaciones: VerificacionesNotarial = {
-    nss_coincide,
-    nombre_coincide,
-    domicilio_coincide,
-    clabe_es_dilesa,
-    vendedor_es_dilesa,
-  };
+      .join(' '),
+    clienteNss: (persona?.nss as string | null) ?? null,
+    unidadManzana: (unidad?.manzana as string | null) ?? null,
+    unidadLote: (unidad?.numero_lote as string | null) ?? null,
+    clabesEmpresa: ((cuentas ?? []) as { clabe: string | null }[])
+      .map((c) => c.clabe ?? '')
+      .filter(Boolean),
+    razonesEmpresa: [empresa?.razon_social, empresa?.nombre].filter(Boolean) as string[],
+  });
 
   return NextResponse.json({ extraccion, verificaciones });
 }

--- a/app/dilesa/notario/dictamen/[token]/form.tsx
+++ b/app/dilesa/notario/dictamen/[token]/form.tsx
@@ -9,7 +9,9 @@
  * Campos:
  *   - Fecha del dictamen * (default hoy)
  *   - Comentarios (opcional)
- *   - PDF * (drag-drop)
+ *   - Carta de Instrucción Notarial (PDF) * (drag-drop)
+ *   - Condiciones Financieras Definitivas Anexo B (PDF, opcional) — el
+ *     notario las manda junto con la carta en créditos INFONAVIT.
  */
 
 import { CheckCircle2, Loader2, Save, Upload, XCircle } from 'lucide-react';
@@ -23,10 +25,10 @@ export function DictamenUploadForm({ token }: Props) {
   const [fecha, setFecha] = useState(new Date().toISOString().slice(0, 10));
   const [comentarios, setComentarios] = useState('');
   const [archivo, setArchivo] = useState<File | null>(null);
+  const [archivoCondiciones, setArchivoCondiciones] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [exito, setExito] = useState(false);
-  const [dragOver, setDragOver] = useState(false);
 
   const onSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -41,6 +43,7 @@ export function DictamenUploadForm({ token }: Props) {
       fd.set('fecha', fecha);
       fd.set('comentarios', comentarios.trim());
       fd.set('archivo', archivo);
+      if (archivoCondiciones) fd.set('archivo_condiciones', archivoCondiciones);
       const res = await fetch(`/api/dilesa/notario/dictamen/${encodeURIComponent(token)}`, {
         method: 'POST',
         body: fd,
@@ -53,7 +56,7 @@ export function DictamenUploadForm({ token }: Props) {
       }
       setExito(true);
     },
-    [archivo, comentarios, fecha, token]
+    [archivo, archivoCondiciones, comentarios, fecha, token]
   );
 
   if (exito) {
@@ -64,7 +67,8 @@ export function DictamenUploadForm({ token }: Props) {
           <h2 className="text-base font-semibold text-emerald-900">Dictamen cargado</h2>
         </div>
         <p className="mt-2 text-sm text-emerald-900">
-          Gracias. DILESA ya recibió la Carta de Instrucción Notarial. Gerencia de Ventas verá la
+          Gracias. DILESA ya recibió la Carta de Instrucción Notarial
+          {archivoCondiciones ? ' y las Condiciones Financieras' : ''}. Gerencia de Ventas verá la
           captura en su sistema y te contactará si requiere algo más.
         </p>
       </section>
@@ -99,64 +103,11 @@ export function DictamenUploadForm({ token }: Props) {
         </Field>
 
         <Field label="Carta de Instrucción Notarial (PDF) *">
-          <div
-            onDragOver={(e) => {
-              e.preventDefault();
-              e.dataTransfer.dropEffect = 'copy';
-              if (!dragOver) setDragOver(true);
-            }}
-            onDragLeave={(e) => {
-              if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
-              setDragOver(false);
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              setDragOver(false);
-              const f = e.dataTransfer.files?.[0];
-              if (!f) return;
-              if (
-                !(
-                  f.type === 'application/pdf' ||
-                  f.type.startsWith('image/') ||
-                  f.name.toLowerCase().endsWith('.pdf')
-                )
-              ) {
-                return;
-              }
-              setArchivo(f);
-            }}
-            className={`flex items-center justify-between gap-3 rounded-lg border bg-white px-4 py-3 transition-colors ${
-              dragOver
-                ? 'border-[#7D812E] bg-[#7D812E]/5 ring-2 ring-[#7D812E]/30'
-                : 'border-[#7D812E]/30'
-            }`}
-          >
-            <div className="flex flex-1 items-center gap-2 text-sm">
-              {archivo ? (
-                <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
-              ) : (
-                <XCircle className="h-4 w-4 shrink-0 text-[#4F4C4D]/40" />
-              )}
-              <span className="font-medium">
-                {archivo ? archivo.name : 'Arrastra el PDF aquí o usa el botón'}
-              </span>
-              {archivo ? (
-                <span className="ml-1 truncate text-xs text-[#4F4C4D]">
-                  {(archivo.size / 1024).toFixed(0)} KB
-                </span>
-              ) : null}
-            </div>
-            <label className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-[#7D812E]/30 bg-white px-3 py-1.5 text-xs font-medium text-[#4F4C4D] hover:bg-[#FAF7EE]">
-              <Upload className="h-3.5 w-3.5" />
-              {archivo ? 'Cambiar' : 'Subir PDF'}
-              <input
-                type="file"
-                accept="application/pdf,image/*"
-                className="hidden"
-                onChange={(e) => setArchivo(e.target.files?.[0] ?? null)}
-              />
-            </label>
-          </div>
+          <FileDrop archivo={archivo} onChange={setArchivo} />
+        </Field>
+
+        <Field label="Condiciones Financieras Definitivas — Anexo B (PDF, opcional)">
+          <FileDrop archivo={archivoCondiciones} onChange={setArchivoCondiciones} />
         </Field>
 
         {error ? (
@@ -195,5 +146,76 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
       </span>
       {children}
     </label>
+  );
+}
+
+/** Dropzone PDF/imagen — mismo look del form del valuador. */
+function FileDrop({
+  archivo,
+  onChange,
+}: {
+  archivo: File | null;
+  onChange: (f: File | null) => void;
+}) {
+  const [dragOver, setDragOver] = useState(false);
+  return (
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+        if (!dragOver) setDragOver(true);
+      }}
+      onDragLeave={(e) => {
+        if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+        setDragOver(false);
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragOver(false);
+        const f = e.dataTransfer.files?.[0];
+        if (!f) return;
+        if (
+          !(
+            f.type === 'application/pdf' ||
+            f.type.startsWith('image/') ||
+            f.name.toLowerCase().endsWith('.pdf')
+          )
+        ) {
+          return;
+        }
+        onChange(f);
+      }}
+      className={`flex items-center justify-between gap-3 rounded-lg border bg-white px-4 py-3 transition-colors ${
+        dragOver
+          ? 'border-[#7D812E] bg-[#7D812E]/5 ring-2 ring-[#7D812E]/30'
+          : 'border-[#7D812E]/30'
+      }`}
+    >
+      <div className="flex flex-1 items-center gap-2 text-sm">
+        {archivo ? (
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+        ) : (
+          <XCircle className="h-4 w-4 shrink-0 text-[#4F4C4D]/40" />
+        )}
+        <span className="font-medium">
+          {archivo ? archivo.name : 'Arrastra el PDF aquí o usa el botón'}
+        </span>
+        {archivo ? (
+          <span className="ml-1 truncate text-xs text-[#4F4C4D]">
+            {(archivo.size / 1024).toFixed(0)} KB
+          </span>
+        ) : null}
+      </div>
+      <label className="inline-flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-[#7D812E]/30 bg-white px-3 py-1.5 text-xs font-medium text-[#4F4C4D] hover:bg-[#FAF7EE]">
+        <Upload className="h-3.5 w-3.5" />
+        {archivo ? 'Cambiar' : 'Subir PDF'}
+        <input
+          type="file"
+          accept="application/pdf,image/*"
+          className="hidden"
+          onChange={(e) => onChange(e.target.files?.[0] ?? null)}
+        />
+      </label>
+    </div>
   );
 }

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 8 — Dictaminada (Sprint 7f, fallback manual).
+ * Captura Fase 8 — Dictaminada (Sprint 7f, fallback manual + análisis IA).
  *
  * Cierra la fase de Dictaminación: Gerencia Ventas captura manualmente
  * la Carta de Instrucción Notarial cuando el notario no usa el magic
@@ -9,11 +9,20 @@
  *
  * El flujo principal es que el notario suba via magic link
  * (`/dilesa/notario/dictamen/<token>`), que cierra F8 automáticamente.
- * Esta page es el fallback.
+ * Esta page es el fallback — y el lugar donde Gerencia sube las
+ * Condiciones Financieras y captura los números.
  *
  * Captura:
  *   - PDF Carta de Instrucción Notarial (rol `carta_instruccion_notarial`)
- *   - Fecha del dictamen (default hoy)
+ *   - PDF Condiciones Financieras Anexo B (rol `condiciones_financieras`,
+ *     opcional — los créditos no-Infonavit pueden no traerlo)
+ *   - Fecha del dictamen (default hoy) + montos/referencias del crédito
+ *
+ * Análisis IA automático (Beto, 2026-06-10): al seleccionar cualquiera de
+ * los dos PDFs se analiza con Claude y se PRECARGAN los campos del form
+ * (valor de escrituración, monto crédito, referencia, gastos) + chips de
+ * verificación cruzada (NSS, nombre, domicilio vs unidad, CLABE de DILESA).
+ * Nada se escribe a la venta hasta "Guardar" — la precarga es editable.
  *
  * Enforcement: Fase 7 (Solicitud de Dictaminación) debe estar cerrada.
  *
@@ -23,7 +32,7 @@
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { CheckCircle2, Loader2, Save, Upload, XCircle } from 'lucide-react';
+import { CheckCircle2, Loader2, MinusCircle, Save, Sparkles, Upload, XCircle } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
@@ -33,6 +42,8 @@ import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
 import { marcarFase } from '@/lib/dilesa/captura/marcar-fase';
+import { buildAdjuntoPath } from '@/lib/storage/path';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
 type VentaCtx = {
   id: string;
@@ -44,6 +55,31 @@ type VentaCtx = {
   monto_credito_titular: number | null;
   monto_credito_cotitular: number | null;
   gastos_escrituracion: number | null;
+  valor_escrituracion: number | null;
+};
+
+type Verificaciones = {
+  nss_coincide: boolean | null;
+  nombre_coincide: boolean | null;
+  domicilio_coincide: boolean | null;
+  clabe_es_dilesa: boolean | null;
+  vendedor_es_dilesa: boolean | null;
+};
+type Extraccion = {
+  tipo_documento: string;
+  nombre_titular: string;
+  nss: string;
+  numero_credito: string;
+  institucion_credito: string;
+  precio_compraventa: number;
+  monto_credito: number;
+  gastos_titulacion: number;
+  impuestos_derechos: number;
+  costo_avaluo: number;
+  domicilio_inmueble: string;
+  vendedor: string;
+  clabe_beneficiario: string;
+  banco_beneficiario: string;
 };
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -78,16 +114,88 @@ function CapturarFase8Body() {
 
   const [fechaDictamen, setFechaDictamen] = useState<string>(new Date().toISOString().slice(0, 10));
   const [archivo, setArchivo] = useState<File | null>(null);
+  const [archivoCondiciones, setArchivoCondiciones] = useState<File | null>(null);
   // Confirmar/editar (acarrean de Fase 6) + capturar gastos de escrituración.
   const [montoTitular, setMontoTitular] = useState<string>('');
   const [montoCotitular, setMontoCotitular] = useState<string>('');
   const [creditoTitularRef, setCreditoTitularRef] = useState<string>('');
   const [creditoCotitularRef, setCreditoCotitularRef] = useState<string>('');
   const [gastosEscrituracion, setGastosEscrituracion] = useState<string>('');
+  const [valorEscrituracion, setValorEscrituracion] = useState<string>('');
+
+  // Análisis IA automático al subir documentos.
+  const [analizando, setAnalizando] = useState(false);
+  const [verif, setVerif] = useState<Verificaciones | null>(null);
+  const [extracciones, setExtracciones] = useState<Extraccion[]>([]);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  /**
+   * Analiza el PDF con Claude apenas se selecciona y PRECARGA los campos del
+   * form (el operador revisa/edita antes de guardar — nada se persiste aquí).
+   * Si la extracción falla o el doc no trae un dato, los campos quedan como
+   * están y se capturan a mano (créditos no-Infonavit, escaneos malos, etc.).
+   */
+  const analizarArchivo = useCallback(
+    async (f: File) => {
+      setAnalizando(true);
+      try {
+        const fd = new FormData();
+        fd.append('file', f);
+        const res = await fetch(`/api/dilesa/ventas/${ventaId}/analizar-notarial`, {
+          method: 'POST',
+          body: fd,
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(body?.error ?? `HTTP ${res.status}`);
+        }
+        const { extraccion, verificaciones } = (await res.json()) as {
+          extraccion: Extraccion;
+          verificaciones: Verificaciones;
+        };
+
+        // Precarga: lo extraído manda (es el dato del documento oficial);
+        // el operador puede corregir antes de guardar.
+        if (extraccion.precio_compraventa > 0)
+          setValorEscrituracion(String(extraccion.precio_compraventa));
+        if (extraccion.monto_credito > 0) setMontoTitular(String(extraccion.monto_credito));
+        if (extraccion.numero_credito) {
+          const inst = extraccion.institucion_credito ? `${extraccion.institucion_credito} ` : '';
+          setCreditoTitularRef(`${inst}${extraccion.numero_credito}`);
+        }
+        const gastos = extraccion.gastos_titulacion + extraccion.impuestos_derechos;
+        if (gastos > 0) setGastosEscrituracion(String(gastos));
+
+        // Las verificaciones se acumulan entre documentos: un false o un true
+        // nuevo pisa un null previo, pero un null nunca borra un resultado.
+        setVerif((prev) => {
+          const next = { ...(prev ?? verificaciones) };
+          (Object.keys(verificaciones) as (keyof Verificaciones)[]).forEach((k) => {
+            if (verificaciones[k] !== null) next[k] = verificaciones[k];
+          });
+          return next;
+        });
+        setExtracciones((prev) => [...prev, extraccion]);
+        toast.add({
+          title: 'Documento analizado',
+          description: 'Campos precargados — revisa los datos antes de guardar.',
+          type: 'success',
+        });
+      } catch (e) {
+        toast.add({
+          title: 'No se pudo analizar el documento',
+          description: `${e instanceof Error ? e.message : 'Error'}. Captura los datos manualmente.`,
+          type: 'error',
+        });
+      } finally {
+        setAnalizando(false);
+      }
+    },
+    [toast, ventaId]
+  );
 
   useEffect(() => {
     if (!ventaId) return;
@@ -101,7 +209,7 @@ function CapturarFase8Body() {
         .schema('dilesa')
         .from('ventas')
         .select(
-          'id, persona_id, unidad_id, notario_id, credito_titular_ref, credito_cotitular_ref, monto_credito_titular, monto_credito_cotitular, gastos_escrituracion'
+          'id, persona_id, unidad_id, notario_id, credito_titular_ref, credito_cotitular_ref, monto_credito_titular, monto_credito_cotitular, gastos_escrituracion, valor_escrituracion'
         )
         .eq('id', ventaId)
         .is('deleted_at', null)
@@ -124,6 +232,7 @@ function CapturarFase8Body() {
       if (v.credito_titular_ref) setCreditoTitularRef(v.credito_titular_ref);
       if (v.credito_cotitular_ref) setCreditoCotitularRef(v.credito_cotitular_ref);
       if (v.gastos_escrituracion != null) setGastosEscrituracion(String(v.gastos_escrituracion));
+      if (v.valor_escrituracion != null) setValorEscrituracion(String(v.valor_escrituracion));
 
       const [pRes, uRes, fRes, notRes] = await Promise.all([
         sb
@@ -219,11 +328,14 @@ function CapturarFase8Body() {
       const userId = userRes?.user?.id ?? null;
 
       const gastosNum = gastosEscrituracion.trim() ? Number(gastosEscrituracion) : null;
+      const docs = [{ rol: 'carta_instruccion_notarial', archivo }];
+      if (archivoCondiciones)
+        docs.push({ rol: 'condiciones_financieras', archivo: archivoCondiciones });
       const result = await marcarFase(sb, {
         ventaId: venta.id,
         faseNombre: 'Dictaminada',
         faseposicion: 8,
-        docs: [{ rol: 'carta_instruccion_notarial', archivo }],
+        docs,
         camposVenta: {
           fecha_dictaminada: fechaDictamen,
           monto_credito_titular: montoTitular.trim() ? Number(montoTitular) : null,
@@ -231,6 +343,7 @@ function CapturarFase8Body() {
           credito_titular_ref: creditoTitularRef.trim() || null,
           credito_cotitular_ref: creditoCotitularRef.trim() || null,
           gastos_escrituracion: gastosNum,
+          valor_escrituracion: valorEscrituracion.trim() ? Number(valorEscrituracion) : null,
         },
         notas: null,
         registradoPor: userId,
@@ -254,12 +367,14 @@ function CapturarFase8Body() {
     },
     [
       archivo,
+      archivoCondiciones,
       fechaDictamen,
       montoTitular,
       montoCotitular,
       creditoTitularRef,
       creditoCotitularRef,
       gastosEscrituracion,
+      valorEscrituracion,
       router,
       sb,
       toast,
@@ -270,12 +385,55 @@ function CapturarFase8Body() {
   // Caso magic link: el notario ya cerró F8 subiendo la carta, pero los
   // datos administrativos (número de crédito + gastos de escrituración)
   // los captura Gerencia Ventas. Este path hace UPDATE directo de la venta
-  // SIN insertar otra fila en venta_fases (la fase ya está cerrada).
+  // SIN insertar otra fila en venta_fases (la fase ya está cerrada). Si
+  // se subieron las Condiciones Financieras aquí, se archivan como adjunto.
   const onActualizarDatos = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
       if (!venta) return;
       setSubmitting(true);
+      const { data: userRes } = await sb.auth.getUser();
+      const userId = userRes?.user?.id ?? null;
+
+      if (archivoCondiciones) {
+        const path = buildAdjuntoPath({
+          empresa: 'dilesa',
+          entidad: 'ventas',
+          entidadId: venta.id,
+          filename: archivoCondiciones.name,
+        });
+        const { error: upStorageErr } = await sb.storage
+          .from('adjuntos')
+          .upload(path, archivoCondiciones, {
+            contentType: archivoCondiciones.type || 'application/octet-stream',
+            upsert: false,
+          });
+        if (!upStorageErr) {
+          await sb
+            .schema('erp')
+            .from('adjuntos')
+            .insert({
+              empresa_id: DILESA_EMPRESA_ID,
+              entidad_tipo: 'venta',
+              entidad_id: venta.id,
+              rol: 'condiciones_financieras',
+              nombre: archivoCondiciones.name,
+              url: path,
+              tipo_mime: archivoCondiciones.type || null,
+              tamano_bytes: archivoCondiciones.size,
+              uploaded_by: userId,
+            });
+        } else {
+          toast.add({
+            title: 'No se pudo subir el PDF de condiciones',
+            description: upStorageErr.message,
+            type: 'error',
+          });
+          setSubmitting(false);
+          return;
+        }
+      }
+
       const gastosNum = gastosEscrituracion.trim() ? Number(gastosEscrituracion) : null;
       const { error: upErr } = await sb
         .schema('dilesa')
@@ -286,6 +444,7 @@ function CapturarFase8Body() {
           credito_titular_ref: creditoTitularRef.trim() || null,
           credito_cotitular_ref: creditoCotitularRef.trim() || null,
           gastos_escrituracion: gastosNum,
+          valor_escrituracion: valorEscrituracion.trim() ? Number(valorEscrituracion) : null,
         })
         .eq('id', venta.id);
       setSubmitting(false);
@@ -299,17 +458,19 @@ function CapturarFase8Body() {
       }
       toast.add({
         title: 'Datos actualizados',
-        description: 'Números de crédito y gastos de escrituración guardados.',
+        description: 'Números de crédito y datos de escrituración guardados.',
         type: 'success',
       });
       router.push(`/dilesa/ventas/${venta.id}`);
     },
     [
+      archivoCondiciones,
       montoTitular,
       montoCotitular,
       creditoTitularRef,
       creditoCotitularRef,
       gastosEscrituracion,
+      valorEscrituracion,
       router,
       sb,
       toast,
@@ -363,8 +524,36 @@ function CapturarFase8Body() {
             body="La Carta de Instrucción ya está capturada. Aquí puedes confirmar/actualizar los números de crédito y los gastos de escrituración (útil si el notario cerró la fase desde el enlace del correo)."
           />
           <form onSubmit={onActualizarDatos} className="mt-4 space-y-6">
+            <Section title="Condiciones Financieras (Anexo B)">
+              <FileSlot
+                label="Condiciones Financieras Definitivas (opcional)"
+                archivo={archivoCondiciones}
+                onChange={(f) => {
+                  setArchivoCondiciones(f);
+                  if (f) void analizarArchivo(f);
+                }}
+              />
+              <Hint>
+                Al subirlo se analiza automáticamente y se precargan los datos del crédito — revisa
+                y guarda. Si el crédito no es Infonavit y no hay anexo, captura manual.
+              </Hint>
+            </Section>
+
+            <PanelAnalisis analizando={analizando} verif={verif} extracciones={extracciones} />
+
             <Section title="Datos del crédito y escrituración">
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Field label="Valor de Escrituración">
+                  <Input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={valorEscrituracion}
+                    onChange={(e) => setValorEscrituracion(e.target.value)}
+                    placeholder="0"
+                  />
+                  <Hint>{money(Number(valorEscrituracion) || 0)} — precio de compra-venta</Hint>
+                </Field>
                 <Field label="Monto Crédito Titular">
                   <Input
                     type="number"
@@ -462,13 +651,33 @@ function CapturarFase8Body() {
             </div>
           ) : null}
 
-          <Section title="Carta de Instrucción Notarial">
-            <FileSlot
-              label="Carta de Instrucción firmada por el notario *"
-              archivo={archivo}
-              onChange={setArchivo}
-            />
+          <Section title="Documentos del notario">
+            <div className="space-y-3">
+              <FileSlot
+                label="Carta de Instrucción firmada por el notario *"
+                archivo={archivo}
+                onChange={(f) => {
+                  setArchivo(f);
+                  if (f) void analizarArchivo(f);
+                }}
+              />
+              <FileSlot
+                label="Condiciones Financieras Definitivas — Anexo B (opcional)"
+                archivo={archivoCondiciones}
+                onChange={(f) => {
+                  setArchivoCondiciones(f);
+                  if (f) void analizarArchivo(f);
+                }}
+              />
+            </div>
+            <Hint>
+              Al seleccionar cada PDF se analiza automáticamente y se precargan los campos de abajo
+              — revisa antes de guardar. Créditos no-Infonavit: se extrae lo que el documento
+              traiga; lo demás se captura manual.
+            </Hint>
           </Section>
+
+          <PanelAnalisis analizando={analizando} verif={verif} extracciones={extracciones} />
 
           <Section title="Datos del dictamen">
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -479,6 +688,17 @@ function CapturarFase8Body() {
                   onChange={(e) => setFechaDictamen(e.target.value)}
                   required
                 />
+              </Field>
+              <Field label="Valor de Escrituración">
+                <Input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={valorEscrituracion}
+                  onChange={(e) => setValorEscrituracion(e.target.value)}
+                  placeholder="0"
+                />
+                <Hint>{money(Number(valorEscrituracion) || 0)} — precio de compra-venta</Hint>
               </Field>
               <Field label="Gastos de Escrituración">
                 <Input
@@ -570,6 +790,90 @@ function Section({ title, children }: { title: string; children: React.ReactNode
         {title}
       </h2>
       {children}
+    </section>
+  );
+}
+
+/**
+ * Resultado del análisis IA: chips de verificación cruzada contra la venta +
+ * resumen de lo extraído. Solo informativo — los valores editables viven en
+ * los campos del form (precargados).
+ */
+function PanelAnalisis({
+  analizando,
+  verif,
+  extracciones,
+}: {
+  analizando: boolean;
+  verif: Verificaciones | null;
+  extracciones: Extraccion[];
+}) {
+  if (analizando) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--card)] px-4 py-3 text-sm text-[var(--text)]/70">
+        <Loader2 className="size-4 animate-spin" /> Analizando documento…
+      </div>
+    );
+  }
+  if (!verif || extracciones.length === 0) return null;
+
+  const checks: Array<{ label: string; valor: boolean | null }> = [
+    { label: 'NSS coincide con el cliente', valor: verif.nss_coincide },
+    { label: 'Nombre coincide con el cliente', valor: verif.nombre_coincide },
+    { label: 'Domicilio coincide con la unidad', valor: verif.domicilio_coincide },
+    { label: 'CLABE de depósito es de DILESA', valor: verif.clabe_es_dilesa },
+    { label: 'Vendedor es DILESA', valor: verif.vendedor_es_dilesa },
+  ];
+  const ultima = extracciones[extracciones.length - 1];
+  const hayRojo = checks.some((c) => c.valor === false);
+
+  return (
+    <section
+      className={`rounded-lg border p-4 ${
+        hayRojo
+          ? 'border-red-400/50 bg-red-50 dark:bg-red-950/20'
+          : 'border-[var(--border)] bg-[var(--card)]'
+      }`}
+    >
+      <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-[var(--text)]/60">
+        <Sparkles className="size-3.5" /> Análisis del documento
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {checks.map((c) => (
+          <span
+            key={c.label}
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] ${
+              c.valor === true
+                ? 'border-emerald-400/50 bg-emerald-50 text-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-200'
+                : c.valor === false
+                  ? 'border-red-400/60 bg-red-100 font-medium text-red-800 dark:bg-red-950/40 dark:text-red-200'
+                  : 'border-[var(--border)] text-[var(--text)]/45'
+            }`}
+          >
+            {c.valor === true ? (
+              <CheckCircle2 className="size-3" />
+            ) : c.valor === false ? (
+              <XCircle className="size-3" />
+            ) : (
+              <MinusCircle className="size-3" />
+            )}
+            {c.label}
+          </span>
+        ))}
+      </div>
+      {hayRojo ? (
+        <p className="mt-2 text-xs font-medium text-red-700 dark:text-red-300">
+          ⚠ Hay datos del documento que NO coinciden con la venta — verifica antes de guardar.
+        </p>
+      ) : null}
+      {ultima ? (
+        <p className="mt-2 text-[11px] text-[var(--text)]/55">
+          Último documento: {ultima.tipo_documento.replace('_', ' ')}
+          {ultima.numero_credito ? ` · crédito ${ultima.numero_credito}` : ''}
+          {ultima.banco_beneficiario ? ` · depósito vía ${ultima.banco_beneficiario}` : ''}
+          {ultima.costo_avaluo > 0 ? ` · costo avalúo ${moneyFmt.format(ultima.costo_avaluo)}` : ''}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -257,7 +257,7 @@ const FASE_ROLES: Record<string, string[]> = {
   // notarial queda en Dictaminada (sale después con el dictamen jurídico).
   Inscrita: ['constancia_credito_titular', 'constancia_credito_cotitular'],
   'Solicitud de Dictaminación': ['aprobacion_credito'],
-  Dictaminada: ['carta_instruccion_notarial'],
+  Dictaminada: ['carta_instruccion_notarial', 'condiciones_financieras'],
   'Validación Patronal': ['validacion_patronal'],
   'Firmas Programadas': [],
   Escriturada: ['pagare'],

--- a/lib/dilesa/notarial-ai/extraer.ts
+++ b/lib/dilesa/notarial-ai/extraer.ts
@@ -1,0 +1,81 @@
+/**
+ * Extracción IA de documentos notariales del expediente de venta (Fase 8 —
+ * Dictaminada): Carta de Instrucción Notarial y Carta de Condiciones
+ * Financieras Definitivas (Anexo B).
+ *
+ * Diseñada para los formatos del Sistema de Titulación Notarial de INFONAVIT
+ * pero genérica a propósito: con cartas equivalentes de FOVISSSTE o de banca
+ * hipotecaria extrae lo que encuentre; lo ausente regresa como ""/0 y el
+ * operador lo captura a mano (la precarga nunca bloquea).
+ *
+ * Convención de ausentes (límite Anthropic de 16 union types en el schema):
+ * campos planos sin nullables — "" para strings y 0 para números. El
+ * consumidor trata ""/0 como "no extraído".
+ *
+ * Iniciativa dilesa-ventas-expediente.
+ */
+import { generateObject } from 'ai';
+import { z } from 'zod';
+import { anthropic, MODELO_CLAUDE } from '@/lib/documentos/extraction-core';
+
+export const NotarialExtraccionSchema = z.object({
+  tipo_documento: z.enum(['carta_instruccion', 'condiciones_financieras', 'otro']),
+  nombre_titular: z.string(),
+  nss: z.string(),
+  numero_credito: z.string(),
+  institucion_credito: z.string(),
+  precio_compraventa: z.number(),
+  monto_credito: z.number(),
+  gastos_titulacion: z.number(),
+  impuestos_derechos: z.number(),
+  costo_avaluo: z.number(),
+  domicilio_inmueble: z.string(),
+  vendedor: z.string(),
+  clabe_beneficiario: z.string(),
+  banco_beneficiario: z.string(),
+});
+export type NotarialExtraccion = z.infer<typeof NotarialExtraccionSchema>;
+
+const PROMPT =
+  `Eres un analista hipotecario mexicano. El PDF es un documento que un notario ` +
+  `envía a una desarrolladora de vivienda durante la titulación de un crédito ` +
+  `hipotecario — típicamente una "Carta de Instrucción Notarial" o una "Carta de ` +
+  `Condiciones Financieras Definitivas (Anexo B)" de INFONAVIT, aunque puede venir ` +
+  `de FOVISSSTE o de un banco. Extrae los campos solicitados.\n\n` +
+  `Guía de mapeo:\n` +
+  `- precio_compraventa: "Precio de compra-venta" (carta de instrucción). Es el valor ` +
+  `de escrituración de la vivienda.\n` +
+  `- monto_credito: "Monto del Crédito Otorgado" (condiciones financieras) o "Importe ` +
+  `garantizado con la hipoteca" (carta de instrucción) si el otorgado no aparece.\n` +
+  `- numero_credito: "Número de Crédito" del titular.\n` +
+  `- institucion_credito: la institución que otorga el crédito (INFONAVIT, FOVISSSTE, ` +
+  `nombre del banco). En mayúsculas.\n` +
+  `- gastos_titulacion: "Monto de Gastos de Titulación".\n` +
+  `- impuestos_derechos: "Monto de Impuestos y Derechos".\n` +
+  `- costo_avaluo: "Monto del costo del avalúo".\n` +
+  `- nss: Número de Seguridad Social del titular (solo dígitos).\n` +
+  `- domicilio_inmueble: domicilio completo del inmueble objeto del crédito/garantía.\n` +
+  `- vendedor: nombre/razón social del vendedor.\n` +
+  `- clabe_beneficiario: CLABE de la cuenta de depósito del beneficiario/vendedor ` +
+  `(18 dígitos, solo dígitos).\n` +
+  `- banco_beneficiario: banco de esa cuenta.\n\n` +
+  `Campos ausentes: usa "" para strings y 0 para números. NO inventes valores. ` +
+  `Los montos van como número sin símbolos ni comas (ej. 835566.99).`;
+
+export async function extraerDocNotarial(pdfBytes: Uint8Array): Promise<NotarialExtraccion> {
+  const { object } = await generateObject({
+    model: anthropic(MODELO_CLAUDE),
+    schema: NotarialExtraccionSchema,
+    maxRetries: 3,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: PROMPT },
+          { type: 'file', data: pdfBytes, mediaType: 'application/pdf' },
+        ],
+      },
+    ],
+  });
+  return object;
+}

--- a/lib/dilesa/notarial-ai/verificar.test.ts
+++ b/lib/dilesa/notarial-ai/verificar.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { norm, soloDigitos, verificarNotarial, type ContextoVenta } from './verificar';
+import type { NotarialExtraccion } from './extraer';
+
+// Basado en el documento real del expediente Arizpe Luna (carta de
+// instrucción INFONAVIT, 2026-05-07).
+const EXTRACCION: NotarialExtraccion = {
+  tipo_documento: 'carta_instruccion',
+  nombre_titular: 'ARIZPE LUNA LUIS GERARDO',
+  nss: '63169350517',
+  numero_credito: '0526096361',
+  institucion_credito: 'INFONAVIT',
+  precio_compraventa: 909000,
+  monto_credito: 835566.99,
+  gastos_titulacion: 0,
+  impuestos_derechos: 0,
+  costo_avaluo: 0,
+  domicilio_inmueble:
+    'PASEO DE LA GAVIOTA 147 SMZ 112 MZ 10 LT 34 EDIF CASA HABITACION NIV 03, FRACCIONAMIENTO LOMAS DE LOS ENCINOS, C.P: 26170, NAVA, COAHUILA',
+  vendedor: 'DESARROLLO INMOBILIARIO LOS ENCINOS S.A. DE C.V.',
+  clabe_beneficiario: '012068001415024927',
+  banco_beneficiario: 'BBVA BANCOMER',
+};
+
+const CTX: ContextoVenta = {
+  clienteNombre: 'Luis Gerardo Arizpe Luna', // orden NOMBRE APELLIDOS (BSOP)
+  clienteNss: '63169350517',
+  unidadManzana: '10',
+  unidadLote: '34',
+  clabesEmpresa: ['012068001415024927', '012345678901234567'],
+  razonesEmpresa: ['Desarrollo Inmobiliario Los Encinos S.A de C.V.', 'DILESA'],
+};
+
+describe('verificarNotarial', () => {
+  it('todo coincide con el expediente real (orden de nombre distinto)', () => {
+    const v = verificarNotarial(EXTRACCION, CTX);
+    expect(v).toEqual({
+      nss_coincide: true,
+      nombre_coincide: true,
+      domicilio_coincide: true,
+      clabe_es_dilesa: true,
+      vendedor_es_dilesa: true,
+    });
+  });
+
+  it('NSS distinto → false; sin NSS del cliente → null', () => {
+    expect(verificarNotarial(EXTRACCION, { ...CTX, clienteNss: '99999999999' }).nss_coincide).toBe(
+      false
+    );
+    expect(verificarNotarial(EXTRACCION, { ...CTX, clienteNss: null }).nss_coincide).toBe(null);
+    expect(verificarNotarial({ ...EXTRACCION, nss: '' }, CTX).nss_coincide).toBe(null);
+  });
+
+  it('manzana/lote: tolera ceros a la izquierda y detecta mismatch', () => {
+    // Unidad con cero a la izquierda ("010") sigue matcheando "MZ 10".
+    expect(verificarNotarial(EXTRACCION, { ...CTX, unidadManzana: '010' }).domicilio_coincide).toBe(
+      true
+    );
+    // Lote distinto → false (es otra vivienda).
+    expect(verificarNotarial(EXTRACCION, { ...CTX, unidadLote: '35' }).domicilio_coincide).toBe(
+      false
+    );
+    // Sin manzana en la unidad → null (no hay con qué comparar).
+    expect(verificarNotarial(EXTRACCION, { ...CTX, unidadManzana: null }).domicilio_coincide).toBe(
+      null
+    );
+  });
+
+  it('CLABE foránea → false (alerta anti-fraude); sin CLABE extraída → null', () => {
+    expect(
+      verificarNotarial({ ...EXTRACCION, clabe_beneficiario: '999999999999999999' }, CTX)
+        .clabe_es_dilesa
+    ).toBe(false);
+    expect(verificarNotarial({ ...EXTRACCION, clabe_beneficiario: '' }, CTX).clabe_es_dilesa).toBe(
+      null
+    );
+    expect(verificarNotarial(EXTRACCION, { ...CTX, clabesEmpresa: [] }).clabe_es_dilesa).toBe(null);
+  });
+
+  it('vendedor: tolera variantes de razón social ("S.A. DE C.V." vs "S.A DE C.V")', () => {
+    expect(verificarNotarial(EXTRACCION, CTX).vendedor_es_dilesa).toBe(true);
+    expect(
+      verificarNotarial({ ...EXTRACCION, vendedor: 'INMOBILIARIA PIRATA SA DE CV' }, CTX)
+        .vendedor_es_dilesa
+    ).toBe(false);
+  });
+
+  it('nombre con token faltante → false', () => {
+    expect(
+      verificarNotarial({ ...EXTRACCION, nombre_titular: 'ARIZPE LUNA JOSE' }, CTX).nombre_coincide
+    ).toBe(false);
+  });
+});
+
+describe('helpers', () => {
+  it('norm quita acentos, símbolos y normaliza espacios', () => {
+    expect(norm('  Desarrollo  Inmobiliário, S.A. de C.V. ')).toBe(
+      'DESARROLLO INMOBILIARIO S A DE C V'
+    );
+  });
+  it('soloDigitos', () => {
+    expect(soloDigitos('012-068 001415024927')).toBe('012068001415024927');
+  });
+});

--- a/lib/dilesa/notarial-ai/verificar.ts
+++ b/lib/dilesa/notarial-ai/verificar.ts
@@ -1,0 +1,93 @@
+/**
+ * Verificaciones cruzadas de la extracción notarial (Fase 8) contra los datos
+ * de la venta en BSOP. Lógica pura — el route (`analizar-notarial`) carga el
+ * contexto de DB y delega aquí.
+ *
+ * Convención: true = coincide, false = NO coincide (alerta roja en UI),
+ * null = sin datos suficientes para comparar.
+ */
+import type { NotarialExtraccion } from './extraer';
+
+export type VerificacionesNotarial = {
+  nss_coincide: boolean | null;
+  nombre_coincide: boolean | null;
+  domicilio_coincide: boolean | null;
+  clabe_es_dilesa: boolean | null;
+  vendedor_es_dilesa: boolean | null;
+};
+
+export type ContextoVenta = {
+  clienteNombre: string;
+  clienteNss: string | null;
+  unidadManzana: string | null;
+  unidadLote: string | null;
+  /** CLABEs (18 dígitos) de las cuentas bancarias activas de la empresa. */
+  clabesEmpresa: string[];
+  /** Razón social y/o nombre de la empresa. */
+  razonesEmpresa: string[];
+};
+
+export const norm = (s: string): string =>
+  s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9 ]/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toUpperCase();
+
+export const soloDigitos = (s: string): string => s.replace(/\D/g, '');
+
+export function verificarNotarial(
+  e: NotarialExtraccion,
+  ctx: ContextoVenta
+): VerificacionesNotarial {
+  // Nombre: el orden varía (APELLIDOS NOMBRE vs NOMBRE APELLIDOS) → todos los
+  // tokens significativos del cliente deben aparecer en el extraído.
+  const nombreCliente = norm(ctx.clienteNombre);
+  const nombreExtraido = norm(e.nombre_titular);
+  const nombre_coincide =
+    nombreExtraido && nombreCliente
+      ? nombreCliente
+          .split(' ')
+          .filter((t) => t.length > 2)
+          .every((t) => nombreExtraido.includes(t))
+      : null;
+
+  const nssExtraido = soloDigitos(e.nss);
+  const nssCliente = soloDigitos(ctx.clienteNss ?? '');
+  const nss_coincide = nssExtraido && nssCliente ? nssExtraido === nssCliente : null;
+
+  // Domicilio: los formatos INFONAVIT traen "MZ 10 LT 34" — comparamos manzana
+  // y lote de la unidad (tolerando ceros a la izquierda y puntos).
+  const domicilioExtraido = norm(e.domicilio_inmueble);
+  const mz = (ctx.unidadManzana ?? '').toString().replace(/^0+/, '');
+  const lt = (ctx.unidadLote ?? '').toString().replace(/^0+/, '');
+  const domicilio_coincide =
+    domicilioExtraido && mz && lt
+      ? new RegExp(`\\bMZ\\.? ?0*${mz}\\b`).test(domicilioExtraido) &&
+        new RegExp(`\\bLT\\.? ?0*${lt}\\b`).test(domicilioExtraido)
+      : null;
+
+  // CLABE: anti-fraude — el depósito de la detonación debe caer en una cuenta
+  // bancaria registrada de la empresa.
+  const clabeExtraida = soloDigitos(e.clabe_beneficiario);
+  const clabes = new Set(
+    ctx.clabesEmpresa.map((c) => soloDigitos(c)).filter((c) => c.length === 18)
+  );
+  const clabe_es_dilesa =
+    clabeExtraida.length === 18 && clabes.size > 0 ? clabes.has(clabeExtraida) : null;
+
+  // Vendedor: fuzzy contra razón social/nombre (los docs truncan o varían
+  // "S.A. DE C.V." vs "S.A DE C.V").
+  const vendedorExtraido = norm(e.vendedor);
+  const razones = ctx.razonesEmpresa.filter(Boolean).map((r) => norm(r));
+  const vendedor_es_dilesa = vendedorExtraido
+    ? razones.some(
+        (r) =>
+          r.includes(vendedorExtraido.slice(0, 25)) || vendedorExtraido.includes(r.slice(0, 25))
+      )
+    : null;
+
+  return { nss_coincide, nombre_coincide, domicilio_coincide, clabe_es_dilesa, vendedor_es_dilesa };
+}


### PR DESCRIPTION
> Continuación de #795 (la parte de análisis IA llegó a esa rama después del squash-merge — este PR la re-aterriza limpia sobre main).

## Qué

Al **seleccionar** la Carta de Instrucción Notarial o las Condiciones Financieras (Anexo B) en la captura de F8 — sin botón — el PDF se analiza con Claude y se **precargan** los campos del form: Valor de Escrituración (nuevo en F8, antes hasta F13), Monto Crédito Titular, Referencia (institución + número) y Gastos de Escrituración (titulación + impuestos y derechos). Nada se persiste hasta Guardar.

## Verificaciones cruzadas (chips ✓/✗, panel rojo si algo no coincide)

- NSS y nombre vs el cliente en BSOP
- Domicilio vs Mz/Lote de la unidad asignada
- **CLABE de depósito vs cuentas bancarias de DILESA** (anti-fraude: la detonación debe caer en cuenta propia)
- Vendedor vs razón social

## Alcance

- Slot nuevo **Condiciones Financieras** (rol `condiciones_financieras`, opcional) en la captura y en el path post-magic-link (sube adjunto suelto).
- Créditos no-Infonavit: extrae lo que el documento traiga; lo ausente queda en blanco y se captura manual — no bloquea.
- `lib/dilesa/notarial-ai/extraer.ts` reusa el stack de extracción existente (extraction-core / Claude).

## Validación

Probado contra los **2 PDFs reales del notario** (exp. Arizpe Luna): extracción 100% exacta en ambos — precio \$909,000, crédito \$835,566.99, número 0526096361, gastos \$12,569.42 + \$30,000 (cuadran con el apoyo Infonavit del catálogo), NSS, CLABE BBVA y domicilio.

## Validar en Preview

Venta en fase 7+ → Capturar F8 → subir los PDFs del correo del notario → ver precarga + chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)