### PR TITLE
feat(dilesa-ventas): análisis IA de docs ya cargados (persistido) + datos capturados por fase

### DIFF
--- a/app/api/dilesa/ventas/[id]/analizar-notarial/route.ts
+++ b/app/api/dilesa/ventas/[id]/analizar-notarial/route.ts
@@ -2,25 +2,31 @@
  * POST /api/dilesa/ventas/[id]/analizar-notarial
  *
  * Análisis IA automático de los documentos del notario (Fase 8 — Dictaminada):
- * Carta de Instrucción Notarial y Condiciones Financieras (Anexo B). Se invoca
- * al seleccionar el archivo en la captura — extrae los montos/datos que le
- * interesan a DILESA y devuelve verificaciones cruzadas contra la venta
- * (lógica pura en `lib/dilesa/notarial-ai/verificar.ts`).
+ * Carta de Instrucción Notarial y Condiciones Financieras (Anexo B). Extrae
+ * los montos/datos que le interesan a DILESA y devuelve verificaciones
+ * cruzadas contra la venta (lógica pura en `lib/dilesa/notarial-ai/verificar.ts`).
  *
- * NO escribe nada: la página precarga el formulario con lo extraído y el
- * operador decide al guardar la fase.
+ * Dos modos:
+ *   1. multipart/form-data con `file` — archivo recién seleccionado en la
+ *      captura (aún no es adjunto). No persiste nada: la página precarga el
+ *      form y el operador decide al guardar.
+ *   2. JSON { adjunto_id } — documento YA cargado (típico: el notario lo
+ *      subió por su magic link). Se baja de Storage, se analiza UNA vez y el
+ *      resultado se PERSISTE en `erp.adjuntos.metadata.analisis_notarial`
+ *      para que la página lo muestre al instante en visitas futuras.
  *
- * Body: multipart/form-data con `file` (PDF, máx 10 MB).
- * Respuesta: { extraccion, verificaciones }.
+ * Respuesta (ambos modos): { extraccion, verificaciones }.
  */
 import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { extraerDocNotarial, type NotarialExtraccion } from '@/lib/dilesa/notarial-ai/extraer';
 import { verificarNotarial } from '@/lib/dilesa/notarial-ai/verificar';
 
 export const maxDuration = 60;
 
 const MAX_BYTES = 10 * 1024 * 1024;
+const ROLES_ANALIZABLES = ['carta_instruccion_notarial', 'condiciones_financieras'];
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -38,13 +44,48 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
     return NextResponse.json({ error: 'Venta no encontrada' }, { status: 404 });
   }
 
-  const form = await req.formData().catch(() => null);
-  const file = form?.get('file');
-  if (!(file instanceof File)) {
-    return NextResponse.json({ error: 'Falta el archivo (campo `file`)' }, { status: 400 });
-  }
-  if (file.size > MAX_BYTES) {
-    return NextResponse.json({ error: 'Archivo mayor a 10 MB' }, { status: 413 });
+  // ── Resolver los bytes del PDF según el modo ─────────────────────────
+  let pdfBytes: Uint8Array | null = null;
+  let adjuntoId: string | null = null;
+
+  const contentType = req.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    const body = (await req.json().catch(() => null)) as { adjunto_id?: string } | null;
+    adjuntoId = body?.adjunto_id ?? null;
+    if (!adjuntoId) {
+      return NextResponse.json({ error: 'Falta adjunto_id' }, { status: 400 });
+    }
+    const { data: adj } = await sb
+      .schema('erp')
+      .from('adjuntos')
+      .select('id, url, rol, entidad_tipo, entidad_id')
+      .eq('id', adjuntoId)
+      .maybeSingle();
+    if (
+      !adj ||
+      adj.entidad_tipo !== 'venta' ||
+      adj.entidad_id !== id ||
+      !ROLES_ANALIZABLES.includes(adj.rol as string)
+    ) {
+      return NextResponse.json({ error: 'Adjunto no válido para esta venta' }, { status: 404 });
+    }
+    const { data: blob, error: dlErr } = await sb.storage
+      .from('adjuntos')
+      .download(adj.url as string);
+    if (dlErr || !blob) {
+      return NextResponse.json({ error: 'No se pudo leer el documento' }, { status: 502 });
+    }
+    pdfBytes = new Uint8Array(await blob.arrayBuffer());
+  } else {
+    const form = await req.formData().catch(() => null);
+    const file = form?.get('file');
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'Falta el archivo (campo `file`)' }, { status: 400 });
+    }
+    if (file.size > MAX_BYTES) {
+      return NextResponse.json({ error: 'Archivo mayor a 10 MB' }, { status: 413 });
+    }
+    pdfBytes = new Uint8Array(await file.arrayBuffer());
   }
 
   const [{ data: persona }, { data: unidad }, { data: empresa }, { data: cuentas }] =
@@ -79,7 +120,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
   let extraccion: NotarialExtraccion;
   try {
-    extraccion = await extraerDocNotarial(new Uint8Array(await file.arrayBuffer()));
+    extraccion = await extraerDocNotarial(pdfBytes);
   } catch (e) {
     return NextResponse.json(
       { error: `No se pudo analizar el documento: ${e instanceof Error ? e.message : 'error'}` },
@@ -99,6 +140,35 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       .filter(Boolean),
     razonesEmpresa: [empresa?.razon_social, empresa?.nombre].filter(Boolean) as string[],
   });
+
+  // Modo adjunto: persistir el análisis en metadata para no re-analizar
+  // (el write usa admin — RLS de adjuntos no contempla UPDATE de usuarios).
+  if (adjuntoId) {
+    const admin = getSupabaseAdminClient();
+    if (admin) {
+      const { data: adjMeta } = await admin
+        .schema('erp')
+        .from('adjuntos')
+        .select('metadata')
+        .eq('id', adjuntoId)
+        .maybeSingle();
+      const metadataActual = (adjMeta?.metadata as Record<string, unknown> | null) ?? {};
+      await admin
+        .schema('erp')
+        .from('adjuntos')
+        .update({
+          metadata: {
+            ...metadataActual,
+            analisis_notarial: {
+              extraccion,
+              verificaciones,
+              analizado_en: new Date().toISOString(),
+            },
+          },
+        })
+        .eq('id', adjuntoId);
+    }
+  }
 
   return NextResponse.json({ extraccion, verificaciones });
 }

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -30,7 +30,7 @@
  */
 
 import { useParams, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { CheckCircle2, Loader2, MinusCircle, Save, Sparkles, Upload, XCircle } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
@@ -81,6 +81,13 @@ type Extraccion = {
   clabe_beneficiario: string;
   banco_beneficiario: string;
 };
+type AdjuntoNotarial = {
+  id: string;
+  rol: string;
+  metadata: {
+    analisis_notarial?: { extraccion: Extraccion; verificaciones: Verificaciones };
+  } | null;
+};
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
   style: 'currency',
@@ -123,14 +130,51 @@ function CapturarFase8Body() {
   const [gastosEscrituracion, setGastosEscrituracion] = useState<string>('');
   const [valorEscrituracion, setValorEscrituracion] = useState<string>('');
 
-  // Análisis IA automático al subir documentos.
+  // Análisis IA automático al subir documentos (o de los ya cargados).
   const [analizando, setAnalizando] = useState(false);
   const [verif, setVerif] = useState<Verificaciones | null>(null);
   const [extracciones, setExtracciones] = useState<Extraccion[]>([]);
+  const [adjuntosNotariales, setAdjuntosNotariales] = useState<AdjuntoNotarial[]>([]);
+  // Evita re-analizar los adjuntos existentes en cada re-render.
+  const adjuntosProcesadosRef = useRef(false);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  /**
+   * Aplica un resultado de análisis al estado: precarga campos + acumula
+   * verificaciones. `pisar=true` cuando el operador acaba de subir el archivo
+   * (lo extraído manda); `pisar=false` para análisis de adjuntos ya cargados
+   * al abrir la página (solo rellena campos vacíos — no pisa lo guardado).
+   */
+  const registrarAnalisis = useCallback(
+    (extraccion: Extraccion, verificaciones: Verificaciones, pisar: boolean) => {
+      const setSuave = (setter: (fn: (prev: string) => string) => void, valor: string) =>
+        setter((prev) => (pisar || !prev.trim() ? valor : prev));
+      if (extraccion.precio_compraventa > 0)
+        setSuave(setValorEscrituracion, String(extraccion.precio_compraventa));
+      if (extraccion.monto_credito > 0) setSuave(setMontoTitular, String(extraccion.monto_credito));
+      if (extraccion.numero_credito) {
+        const inst = extraccion.institucion_credito ? `${extraccion.institucion_credito} ` : '';
+        setSuave(setCreditoTitularRef, `${inst}${extraccion.numero_credito}`);
+      }
+      const gastos = extraccion.gastos_titulacion + extraccion.impuestos_derechos;
+      if (gastos > 0) setSuave(setGastosEscrituracion, String(gastos));
+
+      // Las verificaciones se acumulan entre documentos: un false o un true
+      // nuevo pisa un null previo, pero un null nunca borra un resultado.
+      setVerif((prev) => {
+        const next = { ...(prev ?? verificaciones) };
+        (Object.keys(verificaciones) as (keyof Verificaciones)[]).forEach((k) => {
+          if (verificaciones[k] !== null) next[k] = verificaciones[k];
+        });
+        return next;
+      });
+      setExtracciones((prev) => [...prev, extraccion]);
+    },
+    []
+  );
 
   /**
    * Analiza el PDF con Claude apenas se selecciona y PRECARGA los campos del
@@ -156,29 +200,7 @@ function CapturarFase8Body() {
           extraccion: Extraccion;
           verificaciones: Verificaciones;
         };
-
-        // Precarga: lo extraído manda (es el dato del documento oficial);
-        // el operador puede corregir antes de guardar.
-        if (extraccion.precio_compraventa > 0)
-          setValorEscrituracion(String(extraccion.precio_compraventa));
-        if (extraccion.monto_credito > 0) setMontoTitular(String(extraccion.monto_credito));
-        if (extraccion.numero_credito) {
-          const inst = extraccion.institucion_credito ? `${extraccion.institucion_credito} ` : '';
-          setCreditoTitularRef(`${inst}${extraccion.numero_credito}`);
-        }
-        const gastos = extraccion.gastos_titulacion + extraccion.impuestos_derechos;
-        if (gastos > 0) setGastosEscrituracion(String(gastos));
-
-        // Las verificaciones se acumulan entre documentos: un false o un true
-        // nuevo pisa un null previo, pero un null nunca borra un resultado.
-        setVerif((prev) => {
-          const next = { ...(prev ?? verificaciones) };
-          (Object.keys(verificaciones) as (keyof Verificaciones)[]).forEach((k) => {
-            if (verificaciones[k] !== null) next[k] = verificaciones[k];
-          });
-          return next;
-        });
-        setExtracciones((prev) => [...prev, extraccion]);
+        registrarAnalisis(extraccion, verificaciones, true);
         toast.add({
           title: 'Documento analizado',
           description: 'Campos precargados — revisa los datos antes de guardar.',
@@ -194,8 +216,56 @@ function CapturarFase8Body() {
         setAnalizando(false);
       }
     },
-    [toast, ventaId]
+    [registrarAnalisis, toast, ventaId]
   );
+
+  /**
+   * Análisis de los documentos YA cargados (típico: el notario los subió por
+   * su magic link). Los que ya tienen `metadata.analisis_notarial` se
+   * muestran al instante; los que no, se analizan una vez (el endpoint
+   * persiste el resultado). Precarga suave: solo campos vacíos.
+   */
+  useEffect(() => {
+    if (adjuntosProcesadosRef.current || adjuntosNotariales.length === 0) return;
+    adjuntosProcesadosRef.current = true;
+    let activo = true;
+
+    (async () => {
+      const pendientes: AdjuntoNotarial[] = [];
+      for (const adj of adjuntosNotariales) {
+        const previo = adj.metadata?.analisis_notarial;
+        if (previo) {
+          registrarAnalisis(previo.extraccion, previo.verificaciones, false);
+        } else {
+          pendientes.push(adj);
+        }
+      }
+      if (pendientes.length === 0) return;
+      setAnalizando(true);
+      try {
+        for (const adj of pendientes) {
+          const res = await fetch(`/api/dilesa/ventas/${ventaId}/analizar-notarial`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ adjunto_id: adj.id }),
+          });
+          if (!activo) return;
+          if (!res.ok) continue; // best-effort: el doc se puede analizar después
+          const { extraccion, verificaciones } = (await res.json()) as {
+            extraccion: Extraccion;
+            verificaciones: Verificaciones;
+          };
+          registrarAnalisis(extraccion, verificaciones, false);
+        }
+      } finally {
+        if (activo) setAnalizando(false);
+      }
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [adjuntosNotariales, registrarAnalisis, ventaId]);
 
   useEffect(() => {
     if (!ventaId) return;
@@ -302,6 +372,18 @@ function CapturarFase8Body() {
       const posiciones = (fRes.data ?? []).map((f) => f.posicion as number);
       setFase7Cerrada(posiciones.includes(7));
       setYaCerrada(posiciones.includes(8));
+
+      // Documentos del notario ya cargados (magic link o captura previa) —
+      // disparan el análisis IA automático (efecto aparte).
+      const { data: adjs } = await sb
+        .schema('erp')
+        .from('adjuntos')
+        .select('id, rol, metadata')
+        .eq('entidad_tipo', 'venta')
+        .eq('entidad_id', v.id)
+        .in('rol', ['carta_instruccion_notarial', 'condiciones_financieras']);
+      if (activo) setAdjuntosNotariales((adjs ?? []) as AdjuntoNotarial[]);
+
       setLoading(false);
     })();
 

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -52,6 +52,7 @@ import {
   type CuadraturaInputsStr,
 } from '@/components/dilesa/cuadratura-ajustes';
 import { calcularCuadratura } from '@/lib/dilesa/cuadratura';
+import { camposCapturadosPorFase } from '@/lib/dilesa/captura/campos-capturados';
 import { EstadoCuentaPrintable } from '@/components/dilesa/estado-cuenta-printable';
 import { ReciboCajaPrintable } from '@/components/dilesa/recibo-caja-printable';
 import { useTriggerPrint } from '@/components/print';
@@ -100,6 +101,7 @@ type Venta = {
   anticipo_comision: number | null;
   monto_avaluo: number | null;
   gastos_escrituracion: number | null;
+  numero_cheque_notaria: string | null;
   monto_cheque_notaria: number | null;
   apoyo_infonavit: number | null;
   descuento_precio: number | null;
@@ -110,6 +112,17 @@ type Venta = {
   monto_detonado: number | null;
   numero_escritura: string | null;
   fecha_escritura: string | null;
+  // Fechas/montos por fase (resumen "qué se capturó" del pipeline).
+  fecha_solicitud_avaluo: string | null;
+  fecha_avaluo_cerrado: string | null;
+  fecha_solicitud_dictamen: string | null;
+  fecha_dictaminada: string | null;
+  fecha_validacion_patronal: string | null;
+  fecha_firma_programada: string | null;
+  fecha_detonacion: string | null;
+  valor_facturado: number | null;
+  valor_real_venta_dilesa: number | null;
+  monto_nota_credito: number | null;
   vendedor: string | null;
   notario: string | null;
   casa_valuadora: string | null;
@@ -1277,78 +1290,112 @@ function DetailInner() {
                       </span>
                     </div>
                     <ol className="space-y-1 border-l-2 border-[var(--border)] pl-2">
-                      {filas.map((r) => (
-                        <li
-                          key={r.pos}
-                          className={
-                            'flex items-start gap-3 rounded-md px-2 py-1.5 ' +
-                            (r.alcanzada ? 'bg-[var(--bg)]/40' : 'opacity-60')
-                          }
-                        >
-                          {/* Status circle + posición */}
-                          <div className="flex w-8 shrink-0 items-center gap-1.5 pt-0.5">
-                            {r.alcanzada ? (
-                              <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
-                            ) : (
-                              <Circle className="h-3.5 w-3.5 text-[var(--text)]/30" />
-                            )}
-                            <span className="font-mono text-[10px] tabular-nums text-[var(--text)]/40">
-                              {r.pos}
-                            </span>
-                          </div>
-
-                          {/* Nombre + fecha */}
-                          <div className="min-w-[200px] shrink-0">
-                            <div className="text-sm font-medium text-[var(--text)]">{r.nombre}</div>
-                            <div className="text-[11px] text-[var(--text)]/50">
-                              {r.fecha ? fmtFecha(r.fecha) : '—'}
-                            </div>
-                          </div>
-
-                          {/* Docs cargados + faltantes */}
-                          <div className="flex flex-1 flex-wrap items-center gap-1">
-                            {r.cargados.map((a) => (
-                              <AdjuntoLink key={a.id} a={a} compact />
-                            ))}
-                            {r.faltantes.map((rol) => (
-                              <span
-                                key={rol}
-                                className="inline-flex items-center gap-1 rounded border border-dashed border-[var(--border)] px-1.5 py-0.5 text-[10px] text-[var(--text)]/40"
-                                title={`Falta cargar: ${ROL_LABEL[rol] ?? rol}`}
-                              >
-                                <FileText className="h-2.5 w-2.5" />
-                                {ROL_LABEL[rol] ?? rol}
-                              </span>
-                            ))}
-                            {r.cargados.length === 0 && r.faltantes.length === 0 ? (
-                              <span className="text-[10px] text-[var(--text)]/30">—</span>
-                            ) : null}
-                          </div>
-
-                          {/* Capturar fase — solo si la página está implementada y aplica */}
-                          {r.slugCaptura ? (
-                            <div className="shrink-0">
-                              {r.puedeCapturar ? (
-                                <Link
-                                  href={`/dilesa/ventas/${id}/capturar/${r.slugCaptura}`}
-                                  className="inline-flex items-center gap-1 rounded-md border border-[var(--accent)] bg-[var(--accent)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--accent)] hover:bg-[var(--accent)]/20"
-                                >
-                                  <Pencil className="h-2.5 w-2.5" />
-                                  Capturar fase
-                                </Link>
-                              ) : r.alcanzada ? null : (
-                                <span
-                                  className="inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-[var(--border)] px-2 py-0.5 text-[10px] text-[var(--text)]/30"
-                                  title={`Falta cerrar la fase ${r.pos - 1} primero.`}
-                                >
-                                  <Pencil className="h-2.5 w-2.5" />
-                                  Capturar
+                      {filas.map((r) => {
+                        const capturados =
+                          r.alcanzada && venta
+                            ? camposCapturadosPorFase(r.pos, venta, fmtMoney)
+                            : [];
+                        return (
+                          <li
+                            key={r.pos}
+                            className={
+                              'rounded-md px-2 py-1.5 ' +
+                              (r.alcanzada ? 'bg-[var(--bg)]/40' : 'opacity-60')
+                            }
+                          >
+                            <div className="flex items-start gap-3">
+                              {/* Status circle + posición */}
+                              <div className="flex w-8 shrink-0 items-center gap-1.5 pt-0.5">
+                                {r.alcanzada ? (
+                                  <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+                                ) : (
+                                  <Circle className="h-3.5 w-3.5 text-[var(--text)]/30" />
+                                )}
+                                <span className="font-mono text-[10px] tabular-nums text-[var(--text)]/40">
+                                  {r.pos}
                                 </span>
-                              )}
+                              </div>
+
+                              {/* Nombre + fecha */}
+                              <div className="min-w-[200px] shrink-0">
+                                <div className="text-sm font-medium text-[var(--text)]">
+                                  {r.nombre}
+                                </div>
+                                <div className="text-[11px] text-[var(--text)]/50">
+                                  {r.fecha ? fmtFecha(r.fecha) : '—'}
+                                </div>
+                              </div>
+
+                              {/* Docs cargados + faltantes */}
+                              <div className="flex flex-1 flex-wrap items-center gap-1">
+                                {r.cargados.map((a) => (
+                                  <AdjuntoLink key={a.id} a={a} compact />
+                                ))}
+                                {r.faltantes.map((rol) => (
+                                  <span
+                                    key={rol}
+                                    className="inline-flex items-center gap-1 rounded border border-dashed border-[var(--border)] px-1.5 py-0.5 text-[10px] text-[var(--text)]/40"
+                                    title={`Falta cargar: ${ROL_LABEL[rol] ?? rol}`}
+                                  >
+                                    <FileText className="h-2.5 w-2.5" />
+                                    {ROL_LABEL[rol] ?? rol}
+                                  </span>
+                                ))}
+                                {r.cargados.length === 0 && r.faltantes.length === 0 ? (
+                                  <span className="text-[10px] text-[var(--text)]/30">—</span>
+                                ) : null}
+                              </div>
+
+                              {/* Capturar fase — solo si la página está implementada y aplica */}
+                              {r.slugCaptura ? (
+                                <div className="shrink-0">
+                                  {r.puedeCapturar ? (
+                                    <Link
+                                      href={`/dilesa/ventas/${id}/capturar/${r.slugCaptura}`}
+                                      className="inline-flex items-center gap-1 rounded-md border border-[var(--accent)] bg-[var(--accent)]/10 px-2 py-0.5 text-[10px] font-medium text-[var(--accent)] hover:bg-[var(--accent)]/20"
+                                    >
+                                      <Pencil className="h-2.5 w-2.5" />
+                                      Capturar fase
+                                    </Link>
+                                  ) : r.alcanzada ? null : (
+                                    <span
+                                      className="inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-[var(--border)] px-2 py-0.5 text-[10px] text-[var(--text)]/30"
+                                      title={`Falta cerrar la fase ${r.pos - 1} primero.`}
+                                    >
+                                      <Pencil className="h-2.5 w-2.5" />
+                                      Capturar
+                                    </span>
+                                  )}
+                                </div>
+                              ) : null}
                             </div>
-                          ) : null}
-                        </li>
-                      ))}
+
+                            {/* Qué se capturó en esta fase (expandible) */}
+                            {capturados.length > 0 ? (
+                              <details className="ml-11 mt-0.5">
+                                <summary className="cursor-pointer select-none text-[10px] text-[var(--text)]/45 hover:text-[var(--text)]/70">
+                                  Datos capturados ({capturados.length})
+                                </summary>
+                                <dl className="mt-1 grid grid-cols-1 gap-x-6 gap-y-0.5 sm:grid-cols-2 lg:grid-cols-3">
+                                  {capturados.map(([label, value]) => (
+                                    <div
+                                      key={label}
+                                      className="flex items-baseline gap-2 text-[11px]"
+                                    >
+                                      <dt className="shrink-0 text-[var(--text)]/45">{label}:</dt>
+                                      <dd className="font-medium tabular-nums text-[var(--text)]/85">
+                                        {value.match(/^\d{4}-\d{2}-\d{2}$/)
+                                          ? fmtFecha(value)
+                                          : value}
+                                      </dd>
+                                    </div>
+                                  ))}
+                                </dl>
+                              </details>
+                            ) : null}
+                          </li>
+                        );
+                      })}
                     </ol>
                   </div>
                 );

--- a/lib/dilesa/captura/campos-capturados.test.ts
+++ b/lib/dilesa/captura/campos-capturados.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { camposCapturadosPorFase, type VentaCamposFase } from './campos-capturados';
+
+const money = (n: number | null): string | null => (n == null ? null : `$${n.toLocaleString()}`);
+
+const VENTA: VentaCamposFase = {
+  tipo_credito: 'Infonavit Tradicional',
+  precio_asignacion: 1250000,
+  enganche_requerido: 12500,
+  descuento_total: null,
+  fecha_solicitud_avaluo: '2026-05-02',
+  casa_valuadora: 'Valuadora del Norte',
+  monto_avaluo: 1210000,
+  fecha_avaluo_cerrado: '2026-05-08',
+  monto_credito_titular: 850000,
+  monto_credito_cotitular: null,
+  credito_titular_ref: 'INFONAVIT 0526096361',
+  credito_cotitular_ref: null,
+  fecha_solicitud_dictamen: '2026-05-15',
+  fecha_dictaminada: '2026-05-20',
+  valor_escrituracion: 899000,
+  gastos_escrituracion: 42569.42,
+  fecha_validacion_patronal: '2026-05-23',
+  fecha_firma_programada: '2026-05-28',
+  monto_credito_directo: null,
+  numero_escritura: '9876',
+  fecha_escritura: '2026-06-05',
+  numero_cheque_notaria: '1234',
+  monto_cheque_notaria: 5000,
+  fecha_detonacion: '2026-06-08',
+  monto_detonado: 850000,
+  valor_facturado: null,
+  valor_real_venta_dilesa: null,
+  monto_nota_credito: null,
+};
+
+describe('camposCapturadosPorFase', () => {
+  it('omite pares sin valor (co-titular null en F6)', () => {
+    const f6 = camposCapturadosPorFase(6, VENTA, money);
+    expect(f6.map(([l]) => l)).toEqual(['Crédito titular', 'Ref. titular']);
+  });
+
+  it('F8 incluye dictamen + escrituración + crédito', () => {
+    const f8 = camposCapturadosPorFase(8, VENTA, money);
+    expect(f8).toContainEqual(['Valor de escrituración', '$899,000']);
+    expect(f8).toContainEqual(['Gastos de escrituración', '$42,569.42']);
+    expect(f8).toContainEqual(['Fecha dictamen', '2026-05-20']);
+  });
+
+  it('F11 arma escritura + cheque a notaría', () => {
+    expect(camposCapturadosPorFase(11, VENTA, money)).toEqual([
+      ['Escritura #', '9876'],
+      ['Fecha escritura', '2026-06-05'],
+      ['Cheque notaría #', '1234'],
+      ['Monto cheque', '$5,000'],
+    ]);
+  });
+
+  it('F13 sin montos de factura aún → solo valor de escrituración', () => {
+    expect(camposCapturadosPorFase(13, VENTA, money)).toEqual([
+      ['Valor de escrituración', '$899,000'],
+    ]);
+  });
+
+  it('fases sin campos mapeados (2, 14-17) → vacío', () => {
+    for (const pos of [2, 14, 15, 16, 17]) {
+      expect(camposCapturadosPorFase(pos, VENTA, money)).toEqual([]);
+    }
+  });
+
+  it('cada fase mapeada produce pares con la venta completa', () => {
+    for (const pos of [1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]) {
+      expect(camposCapturadosPorFase(pos, VENTA, money).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/lib/dilesa/captura/campos-capturados.ts
+++ b/lib/dilesa/captura/campos-capturados.ts
@@ -1,0 +1,119 @@
+/**
+ * Resumen "qué se capturó" por fase del pipeline de ventas — pares
+ * label/valor que cada fase dejó en `dilesa.ventas`, para verlos en el
+ * expediente sin entrar a la página de captura (Beto, 2026-06-10: "falta
+ * poder ver lo que está capturado en cada fase").
+ *
+ * Pura: recibe el subset de campos de la venta y la posición; devuelve solo
+ * los pares con valor. Los montos llegan formateados por el formateador que
+ * inyecte el caller (la página usa su `fmtMoney`).
+ */
+
+export type VentaCamposFase = {
+  tipo_credito: string | null;
+  precio_asignacion: number | null;
+  enganche_requerido: number | null;
+  descuento_total: number | null;
+  fecha_solicitud_avaluo: string | null;
+  casa_valuadora: string | null;
+  monto_avaluo: number | null;
+  fecha_avaluo_cerrado: string | null;
+  monto_credito_titular: number | null;
+  monto_credito_cotitular: number | null;
+  credito_titular_ref: string | null;
+  credito_cotitular_ref: string | null;
+  fecha_solicitud_dictamen: string | null;
+  fecha_dictaminada: string | null;
+  valor_escrituracion: number | null;
+  gastos_escrituracion: number | null;
+  fecha_validacion_patronal: string | null;
+  fecha_firma_programada: string | null;
+  monto_credito_directo: number | null;
+  numero_escritura: string | null;
+  fecha_escritura: string | null;
+  numero_cheque_notaria: string | null;
+  monto_cheque_notaria: number | null;
+  fecha_detonacion: string | null;
+  monto_detonado: number | null;
+  valor_facturado: number | null;
+  valor_real_venta_dilesa: number | null;
+  monto_nota_credito: number | null;
+};
+
+export function camposCapturadosPorFase(
+  pos: number,
+  v: VentaCamposFase,
+  money: (n: number | null) => string | null
+): Array<[string, string]> {
+  const pares: Array<[string, string | null]> = (() => {
+    switch (pos) {
+      case 1:
+        return [
+          ['Tipo de crédito', v.tipo_credito],
+          ['Precio de asignación', money(v.precio_asignacion)],
+        ];
+      case 3:
+        return [
+          ['Precio de asignación', money(v.precio_asignacion)],
+          ['Enganche requerido', money(v.enganche_requerido)],
+          ['Descuento total', money(v.descuento_total)],
+        ];
+      case 4:
+        return [
+          ['Fecha solicitud', v.fecha_solicitud_avaluo],
+          ['Casa valuadora', v.casa_valuadora],
+        ];
+      case 5:
+        return [
+          ['Monto del avalúo', money(v.monto_avaluo)],
+          ['Fecha avalúo cerrado', v.fecha_avaluo_cerrado],
+        ];
+      case 6:
+        return [
+          ['Crédito titular', money(v.monto_credito_titular)],
+          ['Crédito co-titular', money(v.monto_credito_cotitular)],
+          ['Ref. titular', v.credito_titular_ref],
+          ['Ref. co-titular', v.credito_cotitular_ref],
+        ];
+      case 7:
+        return [['Fecha solicitud', v.fecha_solicitud_dictamen]];
+      case 8:
+        return [
+          ['Fecha dictamen', v.fecha_dictaminada],
+          ['Valor de escrituración', money(v.valor_escrituracion)],
+          ['Gastos de escrituración', money(v.gastos_escrituracion)],
+          ['Crédito titular', money(v.monto_credito_titular)],
+          ['Ref. titular', v.credito_titular_ref],
+        ];
+      case 9:
+        return [['Fecha validación', v.fecha_validacion_patronal]];
+      case 10:
+        return [
+          ['Fecha de firma', v.fecha_firma_programada],
+          ['Crédito directo (pagaré)', money(v.monto_credito_directo)],
+        ];
+      case 11:
+        return [
+          ['Escritura #', v.numero_escritura],
+          ['Fecha escritura', v.fecha_escritura],
+          ['Cheque notaría #', v.numero_cheque_notaria],
+          ['Monto cheque', money(v.monto_cheque_notaria)],
+        ];
+      case 12:
+        return [
+          ['Fecha detonación', v.fecha_detonacion],
+          ['Monto detonado', money(v.monto_detonado)],
+        ];
+      case 13:
+        return [
+          ['Valor de escrituración', money(v.valor_escrituracion)],
+          ['Valor facturado', money(v.valor_facturado)],
+          ['Valor real venta', money(v.valor_real_venta_dilesa)],
+          ['Nota de crédito', money(v.monto_nota_credito)],
+        ];
+      default:
+        return [];
+    }
+  })();
+  return pares.filter((p): p is [string, string] => p[1] != null && p[1] !== '');
+}


### PR DESCRIPTION
Feedback de Beto probando el magic link en prod (#796): los 2 archivos llegaron bien, pero **el análisis IA no se veía** — solo corría al seleccionar un archivo nuevo. Y del expediente: "falta poder ver lo que está capturado en cada fase".

## 1 · Análisis IA de documentos ya cargados, persistido

- La captura de **F8** detecta la carta y las condiciones **ya subidas** (magic link del notario) y las analiza automáticamente.
- El resultado se **persiste** en `erp.adjuntos.metadata.analisis_notarial` → se analiza **una vez por documento**; las visitas siguientes muestran el panel al instante.
- Precarga **suave**: rellena solo campos vacíos (no pisa lo ya guardado en la venta). Subir un archivo a mano sigue precargando completo.
- Endpoint: nuevo modo JSON `{adjunto_id}` — valida que el adjunto sea de la venta, baja de Storage con la sesión del usuario (RLS) y escribe metadata con admin.

## 2 · "Datos capturados" por fase en el pipeline

Cada fase cerrada muestra un expandible con los pares que dejó en la venta — ej. F11: Escritura #, fecha, cheque notaría # y monto; F8: dictamen, valor de escrituración, gastos, crédito. Mapa puro y testeado en `lib/dilesa/captura/campos-capturados.ts` (6 tests).

## Validar en Preview

- ADALBERTO PRUEBA PRUEBA (está en fase 7): cierra F8 vía magic link o sube los PDFs → al reabrir la captura de F8 el panel de análisis aparece solo.
- En el detalle, pipeline → "Datos capturados (N)" en cada fase cerrada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)