### PR TITLE
feat(dilesa-estimaciones): contrato de cada vivienda en la estimación de pago

### DIFF
--- a/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
+++ b/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
@@ -89,7 +89,7 @@ async function buildPdfData(
   const construccionIds = [...new Set(tareas.map((t) => t.construccion_id as string))];
   const terminadaIds = [...new Set(tareas.map((t) => t.tarea_terminada_id as string))];
 
-  const [cRes, ttRes, taCatRes] = await Promise.all([
+  const [cRes, ttRes, taCatRes, clRes] = await Promise.all([
     construccionIds.length
       ? sb
           .schema('dilesa')
@@ -105,6 +105,14 @@ async function buildPdfData(
           .in('id', terminadaIds)
       : Promise.resolve({ data: [], error: null }),
     sb.schema('dilesa').from('tareas_construccion').select('id, nombre'),
+    construccionIds.length
+      ? sb
+          .schema('dilesa')
+          .from('contrato_lotes')
+          .select('construccion_id, contrato_id')
+          .in('construccion_id', construccionIds)
+          .is('deleted_at', null)
+      : Promise.resolve({ data: [], error: null }),
   ]);
 
   const cMap = new Map<string, { codigo: string; unidad_id: string }>();
@@ -143,12 +151,41 @@ async function buildPdfData(
   const tareaCatMap = new Map<string, string>();
   for (const t of taCatRes.data ?? []) tareaCatMap.set(t.id as string, t.nombre as string);
 
+  // Contrato(s) de cada construcción — solo los del contratista de la
+  // estimación, vigentes. El contratista los usa como referencia en su
+  // factura. Hoy cada (construcción, contratista) tiene exactamente 1
+  // contrato; si hubiera obra extra con 2º contrato se listan separados
+  // por coma.
+  const contratoIds = [...new Set((clRes.data ?? []).map((cl) => cl.contrato_id as string))];
+  const { data: ccRows } = contratoIds.length
+    ? await sb
+        .schema('dilesa')
+        .from('contratos_construccion')
+        .select('id, codigo')
+        .in('id', contratoIds)
+        .eq('contratista_id', estim.contratista_id as string)
+        .is('deleted_at', null)
+        .is('cancelada_at', null)
+    : { data: [] };
+  const ccCodigoMap = new Map<string, string>();
+  for (const cc of ccRows ?? []) ccCodigoMap.set(cc.id as string, cc.codigo as string);
+  const contratosPorConstruccion = new Map<string, Set<string>>();
+  for (const cl of clRes.data ?? []) {
+    const codigo = ccCodigoMap.get(cl.contrato_id as string);
+    if (!codigo) continue;
+    const cid = cl.construccion_id as string;
+    const set = contratosPorConstruccion.get(cid) ?? new Set<string>();
+    set.add(codigo);
+    contratosPorConstruccion.set(cid, set);
+  }
+
   // Agrupar por obra.
   const grupos = new Map<
     string,
     {
       unidad: string;
       construccionCodigo: string;
+      contrato: string | null;
       tareas: EstimacionPdfData['obras'][number]['tareas'];
       subtotal: number;
     }
@@ -167,6 +204,7 @@ async function buildPdfData(
     const grupo = grupos.get(cid) ?? {
       unidad: uMap.get(c.unidad_id) ?? '(sin unidad)',
       construccionCodigo: c.codigo,
+      contrato: [...(contratosPorConstruccion.get(cid) ?? [])].join(', ') || null,
       tareas: [],
       subtotal: 0,
     };

--- a/app/dilesa/construccion/estimaciones/[id]/page.tsx
+++ b/app/dilesa/construccion/estimaciones/[id]/page.tsx
@@ -175,6 +175,8 @@ function DetailInner() {
   const [estTareas, setEstTareas] = useState<EstimTarea[]>([]);
   const [construcciones, setConstrucciones] = useState<Map<string, Construccion>>(new Map());
   const [unidadIds, setUnidadIds] = useState<Map<string, string>>(new Map());
+  // construccion_id → código(s) de contrato del contratista (referencia de factura)
+  const [contratosObra, setContratosObra] = useState<Map<string, string>>(new Map());
   const [terminadas, setTerminadas] = useState<Map<string, TareaTerminada>>(new Map());
   const [plantillas, setPlantillas] = useState<Map<string, Plantilla>>(new Map());
   const [tareasCat, setTareasCat] = useState<Map<string, Tarea>>(new Map());
@@ -447,7 +449,7 @@ function DetailInner() {
         return;
       }
 
-      const [cRes, ttRes, taRes] = await Promise.all([
+      const [cRes, ttRes, taRes, clRes] = await Promise.all([
         sb
           .schema('dilesa')
           .from('construccion')
@@ -459,6 +461,12 @@ function DetailInner() {
           .select('id, plantilla_tarea_id, fecha_terminada')
           .in('id', tareaTerminadaIds),
         sb.schema('dilesa').from('tareas_construccion').select('id, nombre'),
+        sb
+          .schema('dilesa')
+          .from('contrato_lotes')
+          .select('construccion_id, contrato_id')
+          .in('construccion_id', construccionIds)
+          .is('deleted_at', null),
       ]);
       if (!activo) return;
 
@@ -481,6 +489,34 @@ function DetailInner() {
       const tMap = new Map<string, Tarea>();
       for (const t of taRes.data ?? []) tMap.set(t.id as string, { id: t.id, nombre: t.nombre });
       setTareasCat(tMap);
+
+      // Contrato(s) de cada construcción — solo los del contratista de la
+      // estimación, vigentes. Es la referencia que el contratista pone en
+      // su factura (mismo dato que imprime el PDF).
+      const contratoIds = [...new Set((clRes.data ?? []).map((cl) => cl.contrato_id as string))];
+      if (contratoIds.length > 0) {
+        const { data: ccRows } = await sb
+          .schema('dilesa')
+          .from('contratos_construccion')
+          .select('id, codigo')
+          .in('id', contratoIds)
+          .eq('contratista_id', estimRow.contratista_id)
+          .is('deleted_at', null)
+          .is('cancelada_at', null);
+        if (!activo) return;
+        const ccCodigo = new Map<string, string>();
+        for (const cc of ccRows ?? []) ccCodigo.set(cc.id as string, cc.codigo as string);
+        const porObra = new Map<string, Set<string>>();
+        for (const cl of clRes.data ?? []) {
+          const codigo = ccCodigo.get(cl.contrato_id as string);
+          if (!codigo) continue;
+          const cid = cl.construccion_id as string;
+          const set = porObra.get(cid) ?? new Set<string>();
+          set.add(codigo);
+          porObra.set(cid, set);
+        }
+        setContratosObra(new Map([...porObra.entries()].map(([k, v]) => [k, [...v].join(', ')])));
+      }
 
       // Plantillas → tareas (mapping plantilla_id → tarea_id)
       if (plantillaIds.size > 0) {
@@ -544,12 +580,13 @@ function DetailInner() {
           construccion_id,
           construccion_codigo: c?.codigo ?? '—',
           unidad_identificador: identificador,
+          contrato_codigo: contratosObra.get(construccion_id) ?? null,
           items: items.sort((a, b) => a.nombre.localeCompare(b.nombre)),
           subtotal,
         };
       })
       .sort((a, b) => a.unidad_identificador.localeCompare(b.unidad_identificador));
-  }, [estTareas, terminadas, plantillas, tareasCat, construcciones, unidadIds]);
+  }, [estTareas, terminadas, plantillas, tareasCat, construcciones, unidadIds, contratosObra]);
 
   if (loading) {
     return (
@@ -1090,6 +1127,7 @@ function ObraBlock({
     construccion_id: string;
     construccion_codigo: string;
     unidad_identificador: string;
+    contrato_codigo: string | null;
     items: Array<{ nombre: string; fecha: string | null; monto: number }>;
     subtotal: number;
   };
@@ -1112,6 +1150,11 @@ function ObraBlock({
           {grupo.unidad_identificador}
         </Link>
         <span className="text-xs text-[var(--text)]/50">{grupo.construccion_codigo}</span>
+        {grupo.contrato_codigo ? (
+          <span className="rounded bg-[var(--bg)]/60 px-1.5 py-0.5 text-[11px] text-[var(--text)]/60">
+            {grupo.contrato_codigo}
+          </span>
+        ) : null}
         <span className="ml-auto text-xs tabular-nums text-[var(--text)]/60">
           {grupo.items.length} tarea{grupo.items.length === 1 ? '' : 's'}
         </span>

--- a/lib/dilesa/pdf/estimacion.tsx
+++ b/lib/dilesa/pdf/estimacion.tsx
@@ -27,6 +27,8 @@ export type EstimacionPdfData = {
   obras: Array<{
     unidad: string;
     construccionCodigo: string;
+    /** Código(s) del contrato de obra al que pertenece la vivienda — referencia para la factura. */
+    contrato: string | null;
     tareas: Array<{ nombre: string; fechaTerminada: string; monto: number }>;
     subtotal: number;
   }>;
@@ -47,6 +49,9 @@ export function EstimacionPDF({ data }: { data: EstimacionPdfData }) {
   const contratistaDisplay = data.contratista.abreviacion
     ? `${data.contratista.abreviacion} · ${data.contratista.nombre}`
     : data.contratista.nombre;
+  const contratosUnicos = [
+    ...new Set(data.obras.flatMap((o) => (o.contrato ? o.contrato.split(', ') : []))),
+  ];
 
   return (
     <Document title={`Estimación ${data.codigo}`}>
@@ -77,6 +82,12 @@ export function EstimacionPDF({ data }: { data: EstimacionPdfData }) {
               <Text style={obraHeaderCodigo}>{obra.construccionCodigo}</Text>
               <Text style={obraHeaderSubtotal}>{m(obra.subtotal)}</Text>
             </View>
+            {obra.contrato ? (
+              <View style={obraContratoRow}>
+                <Text style={obraContratoLabel}>Contrato</Text>
+                <Text style={obraContratoValue}>{obra.contrato}</Text>
+              </View>
+            ) : null}
             {/* Filas de tareas */}
             <View style={tablaHeader}>
               <Text style={[tablaCellNombre, tablaHeaderText]}>Tarea</Text>
@@ -121,6 +132,13 @@ export function EstimacionPDF({ data }: { data: EstimacionPdfData }) {
             recibida la factura por correo a facturas@dilesa.mx, se programará el pago para la fecha
             indicada arriba.
           </Text>
+          {contratosUnicos.length ? (
+            <Text style={solicitudTexto}>
+              Favor de referenciar en la factura{' '}
+              {contratosUnicos.length === 1 ? 'el contrato' : 'los contratos'}:{' '}
+              <Text style={solicitudContrato}>{contratosUnicos.join(', ')}</Text>
+            </Text>
+          ) : null}
         </View>
 
         <FooterBand />
@@ -184,6 +202,22 @@ const obraHeaderSubtotal = {
   textAlign: 'right' as const,
   color: '#111',
 };
+// Segunda línea del bloque gris del header: contrato de la vivienda
+// (referencia que el contratista copia a su factura).
+const obraContratoRow = {
+  flexDirection: 'row' as const,
+  backgroundColor: '#f0f0f0',
+  paddingHorizontal: 4,
+  paddingBottom: 4,
+  alignItems: 'center' as const,
+};
+const obraContratoLabel = {
+  fontSize: 7,
+  color: '#666',
+  textTransform: 'uppercase' as const,
+  marginRight: 6,
+};
+const obraContratoValue = { fontSize: 8.5, fontWeight: 'bold' as const, color: '#333' };
 
 const tablaHeader = {
   flexDirection: 'row' as const,
@@ -257,3 +291,4 @@ const solicitudReceptor = {
   color: '#111',
   marginVertical: 2,
 };
+const solicitudContrato = { fontWeight: 'bold' as const, color: '#111' };


### PR DESCRIPTION
## Qué hace

El contratista necesita poner el contrato de obra como **referencia en su factura**. La estimación de pago semanal (destajos de vivienda) ahora resuelve y muestra a qué contrato pertenece cada vivienda.

- **PDF** ([lib/dilesa/pdf/estimacion.tsx](../blob/claude/sweet-engelbart-6e3bad/lib/dilesa/pdf/estimacion.tsx)): línea `CONTRATO <código>` bajo el header gris de cada obra, y el bloque **SOLICITUD DE FACTURA** pide explícitamente referenciar el/los contrato(s) únicos de la estimación.
- **Detalle web** (`/dilesa/construccion/estimaciones/[id]`): chip con el código del contrato en cada obra del desglose — mismo dato que imprime el PDF.

## Cómo se resuelve el contrato

`dilesa.contrato_lotes` (por `construccion_id`, no borrados) → `dilesa.contratos_construccion` filtrado al **contratista de la estimación** y vigentes (sin `deleted_at`/`cancelada_at`). Validado contra prod: los 713 pares (construcción, contratista) existentes tienen exactamente 1 contrato; si hubiera obra extra con 2º contrato, se listan separados por coma. Sin contrato ligado → la línea se omite.

## Verificación

- Render local del PDF con la data de `EST-2026-W24-MAYA-8920-001` (muestra adjunta en el chat a Beto) ✔
- 6 checks de CI locales: typecheck, test:coverage (1462 ✔), lint, format:check, initiatives:check, schema:check (sin drift) ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)