### PR TITLE
feat(dilesa-presupuesto-baseline): S3 — adjuntos en partida + timeline del presupuesto

### DIFF
--- a/components/dilesa/costeo-concepto-form.tsx
+++ b/components/dilesa/costeo-concepto-form.tsx
@@ -26,11 +26,12 @@
  */
 
 import { useState } from 'react';
-import { Loader2, Plus, Save, Trash2 } from 'lucide-react';
+import { FileText, Loader2, Plus, Save, Trash2 } from 'lucide-react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { FileAttachments } from '@/components/file-attachments/file-attachments';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { proyectoOptionLabel, type ProyectoOption } from '@/lib/dilesa/proyectos-selector';
@@ -360,6 +361,29 @@ export function CosteoConceptoForm({
             ? 'La clasificación agrupa y ordena la partida por el catálogo de conceptos. El % de ejecución se calcula como gasto real ÷ presupuesto actualizado (o previo si no hay actualizado). Montos con IVA incluido.'
             : 'La clasificación agrupa la partida por el catálogo de conceptos. El gasto (comprometido, ejercido, pagado) llega solo desde las órdenes, recepciones y facturas ligadas a la partida. Monto con IVA incluido.'}
       </p>
+      {isEdit && editRow ? (
+        <div className="mt-3 rounded border border-dashed border-[var(--border)] bg-[var(--bg)] p-1">
+          <FileAttachments
+            empresaId={empresaId}
+            empresaSlug="dilesa"
+            entidad="presupuesto_partidas"
+            entidadId={editRow.id}
+            roles={[
+              {
+                id: 'soporte',
+                label: 'Documentos de la partida',
+                icon: <FileText className="h-3 w-3" />,
+              },
+            ]}
+            defaultUploadRole="soporte"
+            variant="flat"
+          />
+          <p className="px-1 text-[10px] text-[var(--text)]/50">
+            El soporte del estimado (cotizaciones, notas) vive con la partida; también se ve en su
+            historial.
+          </p>
+        </div>
+      ) : null}
       <div className="mt-3 flex items-center justify-between gap-2">
         <div>
           {isEdit && onDelete ? (

--- a/components/dilesa/costeo-module.tsx
+++ b/components/dilesa/costeo-module.tsx
@@ -60,6 +60,7 @@ import { CosteoConceptoForm } from '@/components/dilesa/costeo-concepto-form';
 import {
   BaselineBanner,
   CambiosPendientesPanel,
+  PresupuestoTimeline,
   SolicitarCambioCard,
 } from '@/components/dilesa/presupuesto-cambios';
 import { PresupuestoHistorialDrawer } from '@/components/dilesa/presupuesto-historial-drawer';
@@ -507,7 +508,7 @@ export function CosteoModule({
       (sb.schema('erp') as any)
         .from('presupuesto_cambios')
         .select(
-          'id, proyecto_id, partida_id, tipo, monto_delta, motivo_categoria, motivo, estado, solicitado_por, solicitado_at, resuelto_por, resuelto_at, motivo_rechazo, monto_aprobado_antes, monto_aprobado_despues'
+          'id, proyecto_id, partida_id, tipo, monto_delta, motivo_categoria, motivo, estado, solicitado_por, solicitado_at, resuelto_por, resuelto_at, motivo_rechazo, cancelada_por, cancelada_at, monto_aprobado_antes, monto_aprobado_despues'
         )
         .eq('empresa_id', empresaId)
         .order('solicitado_at', { ascending: true }),
@@ -1000,6 +1001,14 @@ export function CosteoModule({
           puedeAutorizar={puedeAutorizarDireccion}
           puedeEscribir={puedeEscribir}
           onResolved={() => void cargar()}
+        />
+      ) : null}
+
+      {proyectoSeleccionado ? (
+        <PresupuestoTimeline
+          baseline={baselineActual}
+          ordenes={ordenesProyecto}
+          partidaLabelById={partidaLabelById}
         />
       ) : null}
 

--- a/components/dilesa/presupuesto-cambios.tsx
+++ b/components/dilesa/presupuesto-cambios.tsx
@@ -21,6 +21,7 @@ import { useMemo, useState } from 'react';
 import {
   CheckCircle2,
   FileText,
+  History,
   Loader2,
   Lock,
   ShieldCheck,
@@ -37,12 +38,15 @@ import { formatCurrency } from '@/lib/format';
 import {
   CATEGORIA_LABELS,
   CATEGORIAS,
+  buildTimelinePresupuesto,
   deltaFirmado,
   type BaselineInfo,
   type OrdenCambio,
   type OrdenCambioCategoria,
   type OrdenCambioTipo,
+  type TimelineEventoTipo,
 } from '@/lib/presupuesto/ordenes-cambio';
+import { useUsuarioNombres } from '@/components/dilesa/presupuesto-historial-drawer';
 import {
   autorizarBaseline,
   cancelarCambio,
@@ -536,6 +540,99 @@ export function CambiosPendientesPanel({
         description="La orden queda cancelada sin afectar el presupuesto."
         confirmLabel="Retirar"
       />
+    </div>
+  );
+}
+
+// ─── Timeline del presupuesto (actividad del gobierno) ───────────────────────
+
+const TIMELINE_LABEL: Record<TimelineEventoTipo, string> = {
+  baseline: 'Presupuesto inicial autorizado',
+  orden_solicitada: 'Cambio solicitado',
+  orden_autorizada: 'Cambio autorizado',
+  orden_rechazada: 'Cambio rechazado',
+  orden_cancelada: 'Solicitud retirada',
+};
+
+const TIMELINE_ICON: Record<TimelineEventoTipo, React.ReactNode> = {
+  baseline: <ShieldCheck className="h-3.5 w-3.5 text-emerald-500" />,
+  orden_solicitada: <TriangleAlert className="h-3.5 w-3.5 text-amber-500" />,
+  orden_autorizada: <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />,
+  orden_rechazada: <XCircle className="h-3.5 w-3.5 text-red-500" />,
+  orden_cancelada: <XCircle className="h-3.5 w-3.5 text-[var(--text)]/40" />,
+};
+
+/**
+ * Cronología del gobierno presupuestal del proyecto: el baseline + cada
+ * orden (solicitada → autorizada/rechazada/retirada), con quién y cuándo.
+ * Colapsada por default; datos ya cargados por el CosteoModule (cero
+ * queries extra salvo la resolución de nombres).
+ */
+export function PresupuestoTimeline({
+  baseline,
+  ordenes,
+  partidaLabelById,
+}: {
+  baseline: BaselineInfo | null;
+  ordenes: readonly OrdenCambio[];
+  partidaLabelById: ReadonlyMap<string, string>;
+}) {
+  const [abierto, setAbierto] = useState(false);
+  const eventos = useMemo(() => buildTimelinePresupuesto(baseline, ordenes), [baseline, ordenes]);
+  const nombres = useUsuarioNombres(eventos.map((e) => e.actorId));
+
+  if (eventos.length === 0) return null;
+  const quien = (id: string | null) => (id ? (nombres.get(id) ?? '—') : '—');
+
+  return (
+    <div className="rounded-md border border-[var(--border)] bg-[var(--card)]">
+      <button
+        type="button"
+        onClick={() => setAbierto((v) => !v)}
+        className="flex w-full items-center gap-2 px-4 py-2.5 text-left"
+      >
+        <History className="h-4 w-4 text-[var(--text)]/50" />
+        <span className="text-sm font-medium text-[var(--text)]">
+          Actividad del presupuesto ({eventos.length})
+        </span>
+        <span className="ml-auto text-xs text-[var(--text)]/50">
+          {abierto ? 'Ocultar' : 'Mostrar'}
+        </span>
+      </button>
+      {abierto ? (
+        <ul className="divide-y divide-[var(--border)]/40 border-t border-[var(--border)]">
+          {eventos.map((e) => (
+            <li key={e.key} className="flex flex-wrap items-center gap-2 px-4 py-2 text-sm">
+              {TIMELINE_ICON[e.tipo]}
+              <span className="font-medium text-[var(--text)]">{TIMELINE_LABEL[e.tipo]}</span>
+              {e.partidaId ? (
+                <span className="text-[var(--text)]/70">
+                  {partidaLabelById.get(e.partidaId) ?? 'Partida'}
+                </span>
+              ) : null}
+              {e.delta != null ? (
+                <span
+                  className={`tabular-nums ${e.delta < 0 ? 'text-amber-600' : 'text-[var(--text)]/80'}`}
+                >
+                  {e.delta > 0 ? '+' : ''}
+                  {formatCurrency(e.delta)}
+                </span>
+              ) : null}
+              {e.monto != null ? (
+                <span className="tabular-nums text-[var(--text)]/80">
+                  {formatCurrency(e.monto)}
+                </span>
+              ) : null}
+              {e.detalle ? (
+                <span className="text-xs text-[var(--text)]/50">— {e.detalle}</span>
+              ) : null}
+              <span className="ml-auto text-xs text-[var(--text)]/50">
+                {fmtFecha(e.fecha)} · {quien(e.actorId)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </div>
   );
 }

--- a/components/dilesa/presupuesto-historial-drawer.tsx
+++ b/components/dilesa/presupuesto-historial-drawer.tsx
@@ -39,9 +39,9 @@ const fmtFechaHora = (iso: string) =>
 /**
  * Resuelve nombres de usuario para el audit trail. Falla silencioso a Map
  * vacío (la UI muestra solo fechas) — el historial no depende de poder leer
- * `core.usuarios`.
+ * `core.usuarios`. Compartido con `<PresupuestoTimeline>`.
  */
-function useUsuarioNombres(ids: readonly (string | null)[]) {
+export function useUsuarioNombres(ids: readonly (string | null)[]) {
   const [nombres, setNombres] = useState<Map<string, string>>(new Map());
   const key = [...new Set(ids.filter(Boolean) as string[])].sort().join(',');
 
@@ -133,6 +133,26 @@ export function PresupuestoHistorialDrawer({
                 {formatCurrency(partida.vigente)}
               </div>
             </div>
+          </div>
+
+          {/* Documentos de la partida (soporte del estimado — formación) */}
+          <div className="rounded border border-dashed border-[var(--border)] bg-[var(--bg)] p-1">
+            <FileAttachments
+              empresaId={empresaId}
+              empresaSlug="dilesa"
+              entidad="presupuesto_partidas"
+              entidadId={partida.id}
+              roles={[
+                {
+                  id: 'soporte',
+                  label: 'Documentos de la partida',
+                  icon: <FileText className="h-3 w-3" />,
+                },
+              ]}
+              defaultUploadRole="soporte"
+              variant="flat"
+              readOnly
+            />
           </div>
 
           {/* Punto de partida: baseline */}

--- a/docs/planning/dilesa-presupuesto-baseline.md
+++ b/docs/planning/dilesa-presupuesto-baseline.md
@@ -184,6 +184,17 @@ Que el presupuesto de un proyecto DILESA tenga ciclo de vida gobernado:
 
 ## Bitácora
 
+- **2026-06-10 — S3 resto (adjuntos en partida + timeline) a PR.**
+  `<FileAttachments entidad="presupuesto_partidas">` en el form de
+  edición (rol "Documentos de la partida" — el soporte del estimado vive
+  con la partida) y visible read-only en el drawer de historial.
+  `<PresupuestoTimeline>` (colapsable) en el tab Gasto: cronología del
+  gobierno — baseline + cada orden (solicitada → autorizada/rechazada/
+  retirada) con quién/cuándo, derivada de `buildTimelinePresupuesto`
+  (helper puro + 3 tests; `OrdenCambio` ganó cancelada_por/at). Cero
+  queries extra (reusa los datos del módulo). Falta solo el baseline
+  retroactivo de Delicias/Ampliación (acto de Beto) para cerrar.
+
 - **2026-06-10 — Sprint 2 (UI de baseline y órdenes de cambio) a PR.**
   Tab Gasto: `<BaselineBanner>` (autorizar presupuesto inicial con notas,
   gate Dirección, aviso de preliminares; post-baseline muestra

--- a/lib/presupuesto/ordenes-cambio.test.ts
+++ b/lib/presupuesto/ordenes-cambio.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
+  buildTimelinePresupuesto,
   cambiosNetosPorPartida,
   deltaFirmado,
   mapOrdenCambio,
   ordenesPendientes,
+  type BaselineInfo,
   type OrdenCambio,
 } from './ordenes-cambio';
 
@@ -22,6 +24,8 @@ function orden(partial: Partial<OrdenCambio>): OrdenCambio {
     resueltoPor: null,
     resueltoAt: null,
     motivoRechazo: null,
+    canceladaPor: null,
+    canceladaAt: null,
     montoAntes: null,
     montoDespues: null,
     ...partial,
@@ -63,6 +67,67 @@ describe('ordenesPendientes', () => {
       orden({ id: 'c', estado: 'rechazada' }),
     ]);
     expect(pend.map((o) => o.id)).toEqual(['a']);
+  });
+});
+
+describe('buildTimelinePresupuesto', () => {
+  const baseline: BaselineInfo = {
+    id: 'b1',
+    proyectoId: 'p1',
+    total: 1000,
+    partidasCount: 3,
+    notas: 'junta del 15',
+    autorizadoPor: 'u-dir',
+    autorizadoAt: '2026-06-01T10:00:00Z',
+  };
+
+  it('baseline + solicitud + resolución, cronológico DESC', () => {
+    const eventos = buildTimelinePresupuesto(baseline, [
+      orden({
+        id: 'a',
+        estado: 'autorizada',
+        solicitadoAt: '2026-06-02T10:00:00Z',
+        resueltoAt: '2026-06-03T10:00:00Z',
+        resueltoPor: 'u-dir',
+      }),
+    ]);
+    expect(eventos.map((e) => e.tipo)).toEqual([
+      'orden_autorizada',
+      'orden_solicitada',
+      'baseline',
+    ]);
+    expect(eventos[2]).toMatchObject({ monto: 1000, detalle: 'junta del 15', actorId: 'u-dir' });
+    expect(eventos[0]?.delta).toBe(100);
+  });
+
+  it('rechazada usa motivo de rechazo; cancelada usa cancelada_at', () => {
+    const eventos = buildTimelinePresupuesto(null, [
+      orden({
+        id: 'r',
+        estado: 'rechazada',
+        tipo: 'deductiva',
+        solicitadoAt: '2026-06-02T10:00:00Z',
+        resueltoAt: '2026-06-02T12:00:00Z',
+        motivoRechazo: 'sin soporte',
+      }),
+      orden({
+        id: 'c',
+        estado: 'cancelada',
+        solicitadoAt: '2026-06-01T10:00:00Z',
+        canceladaAt: '2026-06-01T11:00:00Z',
+        canceladaPor: 'u-op',
+      }),
+    ]);
+    const rechazo = eventos.find((e) => e.tipo === 'orden_rechazada');
+    expect(rechazo).toMatchObject({ detalle: 'sin soporte', delta: -100 });
+    const cancel = eventos.find((e) => e.tipo === 'orden_cancelada');
+    expect(cancel).toMatchObject({ actorId: 'u-op', fecha: '2026-06-01T11:00:00Z' });
+    // Solicitada pendiente (sin resolver) no genera evento terminal.
+    expect(eventos).toHaveLength(4);
+  });
+
+  it('sin baseline ni órdenes → vacío', () => {
+    expect(buildTimelinePresupuesto(null, [])).toEqual([]);
   });
 });
 

--- a/lib/presupuesto/ordenes-cambio.ts
+++ b/lib/presupuesto/ordenes-cambio.ts
@@ -33,6 +33,8 @@ export type OrdenCambio = {
   resueltoPor: string | null;
   resueltoAt: string | null;
   motivoRechazo: string | null;
+  canceladaPor: string | null;
+  canceladaAt: string | null;
   montoAntes: number | null;
   montoDespues: number | null;
 };
@@ -110,6 +112,8 @@ export function mapOrdenCambio(r: {
   resuelto_por: string | null;
   resuelto_at: string | null;
   motivo_rechazo: string | null;
+  cancelada_por?: string | null;
+  cancelada_at?: string | null;
   monto_aprobado_antes: number | string | null;
   monto_aprobado_despues: number | string | null;
 }): OrdenCambio {
@@ -127,7 +131,97 @@ export function mapOrdenCambio(r: {
     resueltoPor: r.resuelto_por ?? null,
     resueltoAt: r.resuelto_at ?? null,
     motivoRechazo: r.motivo_rechazo ?? null,
+    canceladaPor: r.cancelada_por ?? null,
+    canceladaAt: r.cancelada_at ?? null,
     montoAntes: r.monto_aprobado_antes != null ? Number(r.monto_aprobado_antes) : null,
     montoDespues: r.monto_aprobado_despues != null ? Number(r.monto_aprobado_despues) : null,
   };
+}
+
+// ─── Timeline del gobierno presupuestal ──────────────────────────────────────
+
+export type TimelineEventoTipo =
+  | 'baseline'
+  | 'orden_solicitada'
+  | 'orden_autorizada'
+  | 'orden_rechazada'
+  | 'orden_cancelada';
+
+export type TimelineEvento = {
+  /** Único por evento (ordenId + sufijo, o baselineId). */
+  key: string;
+  fecha: string;
+  tipo: TimelineEventoTipo;
+  partidaId: string | null;
+  /** Delta con signo (solo eventos de orden). */
+  delta: number | null;
+  actorId: string | null;
+  /** Motivo de la orden / notas del baseline / motivo de rechazo. */
+  detalle: string | null;
+  /** Total congelado (solo baseline). */
+  monto: number | null;
+};
+
+/**
+ * Aplana baseline + órdenes en eventos cronológicos (DESC — lo más nuevo
+ * arriba). Cada orden produce su evento de solicitud y, si fue resuelta o
+ * retirada, el evento terminal correspondiente.
+ */
+export function buildTimelinePresupuesto(
+  baseline: BaselineInfo | null,
+  ordenes: readonly OrdenCambio[]
+): TimelineEvento[] {
+  const out: TimelineEvento[] = [];
+
+  if (baseline) {
+    out.push({
+      key: `baseline-${baseline.id}`,
+      fecha: baseline.autorizadoAt,
+      tipo: 'baseline',
+      partidaId: null,
+      delta: null,
+      actorId: baseline.autorizadoPor,
+      detalle: baseline.notas,
+      monto: baseline.total,
+    });
+  }
+
+  for (const o of ordenes) {
+    out.push({
+      key: `${o.id}-solicitada`,
+      fecha: o.solicitadoAt,
+      tipo: 'orden_solicitada',
+      partidaId: o.partidaId,
+      delta: deltaFirmado(o),
+      actorId: o.solicitadoPor,
+      detalle: o.motivo,
+      monto: null,
+    });
+    if ((o.estado === 'autorizada' || o.estado === 'rechazada') && o.resueltoAt) {
+      out.push({
+        key: `${o.id}-${o.estado}`,
+        fecha: o.resueltoAt,
+        tipo: o.estado === 'autorizada' ? 'orden_autorizada' : 'orden_rechazada',
+        partidaId: o.partidaId,
+        delta: deltaFirmado(o),
+        actorId: o.resueltoPor,
+        detalle: o.estado === 'rechazada' ? o.motivoRechazo : o.motivo,
+        monto: null,
+      });
+    }
+    if (o.estado === 'cancelada' && o.canceladaAt) {
+      out.push({
+        key: `${o.id}-cancelada`,
+        fecha: o.canceladaAt,
+        tipo: 'orden_cancelada',
+        partidaId: o.partidaId,
+        delta: deltaFirmado(o),
+        actorId: o.canceladaPor,
+        detalle: o.motivo,
+        monto: null,
+      });
+    }
+  }
+
+  return out.sort((a, b) => b.fecha.localeCompare(a.fecha));
 }

--- a/lib/storage/path.ts
+++ b/lib/storage/path.ts
@@ -43,7 +43,8 @@ export type AdjuntoEntidad =
   | 'proyecto_planos'
   | 'cotizaciones'
   | 'frentes'
-  | 'presupuesto_cambios';
+  | 'presupuesto_cambios'
+  | 'presupuesto_partidas';
 
 export type BuildAdjuntoPathOpts = {
   empresa: EmpresaSlug;


### PR DESCRIPTION
## S3 (cierre) de `dilesa-presupuesto-baseline`

Las dos piezas finales del expediente:

- **Documentos de la partida**: `<FileAttachments>` en el form de edición — el soporte del estimado (cotizaciones, notas) vive con la partida desde la formación, y se consulta read-only en su drawer de historial.
- **Actividad del presupuesto** (`<PresupuestoTimeline>`, colapsable en el tab Gasto): la cronología completa del gobierno — baseline autorizado + cada orden (solicitada → autorizada/rechazada/retirada) con quién, cuándo y el delta. Derivada en cliente de datos ya cargados (cero queries extra); helper puro `buildTimelinePresupuesto` con tests.

Sin migraciones. Con esto el código de la iniciativa queda completo — falta solo el **baseline retroactivo** de los proyectos en vuelo (acto de Beto en el tab Gasto) para cerrarla.

⚠️ UI visible — sin auto-merge: ver el Vercel Preview (tab Gasto → "Actividad del presupuesto" al final, y el bloque de documentos al editar una partida).

🤖 Generated with [Claude Code](https://claude.com/claude-code)