### PR TITLE
fix(accesos): hubs visibles con permisos parciales + matriz jerárquica de Accesos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,15 +231,21 @@ la regla anterior:
 
 - **`NAV_ITEMS`**: solo entry del padre. **`ROUTE_TO_MODULE`**: entry por cada
   sub-page (la URL default `/<modulo>` → sub-slug del primer tab).
-  **`EXPECTED_DB_MODULE_SLUGS`**: padre + cada sub-slug. **Migración**: INSERT de
-  cada sub-slug (heredando `seccion`/`empresa_id` del padre) + backfill clonando
-  permisos del padre. Plantilla: `…20260509162620_modulos_subscope_permissions.sql`.
+  **`HUB_PARENT_BY_ROUTE`** (`lib/permissions.ts`): entry URL-landing → slug del
+  padre — la visibilidad en sidebar/paneles la decide `canSeeNavRoute` (padre O
+  cualquier sub-slug accesible), no el sub-slug del primer tab (SS8; test de
+  sync la valida). **`EXPECTED_DB_MODULE_SLUGS`**: padre + cada sub-slug.
+  **Migración**: INSERT de cada sub-slug (heredando `seccion`/`empresa_id` del
+  padre) + backfill clonando permisos del padre. Plantilla:
+  `…20260509162620_modulos_subscope_permissions.sql`.
 - **Código**: TABS del layout con campo `module: '<sub-slug>'` (`<RoutedModuleTabs>`
-  filtra sin permiso); cada sub-page con `<RequireAccess modulo="<sub-slug>">`;
+  filtra sin permiso) + `<HubAccessRedirect tabs={TABS}/>` en el mismo layout
+  (si el landing no es accesible, aterriza en el primer tab que sí — SS8); cada
+  sub-page con `<RequireAccess modulo="<sub-slug>">`;
   si usa `useSearchParams`/`useUrlFilters`, separar el cuerpo a `<XBody/>`
   wrappeado por `<RequireAccess>` (evita el error Next.js 16
   `missing-suspense-with-csr-bailout`). Plantillas: `app/rdb/productos/recetas/page.tsx`,
-  `app/rdb/inventario/page.tsx`. Reglas SS1-SS7 en ADR-030.
+  `app/rdb/inventario/page.tsx`. Reglas SS1-SS8 en ADR-030.
 
 ---
 

--- a/app/dilesa/cobranza/layout.tsx
+++ b/app/dilesa/cobranza/layout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { RoutedModuleTabs } from '@/components/module-page';
+import { HubAccessRedirect, RoutedModuleTabs } from '@/components/module-page';
 
 /**
  * Layout del hub Cobranza (DILESA · CxC). Patrón routed tabs (ADR-005) +
@@ -28,6 +28,7 @@ const TABS = [
 export default function CobranzaLayout({ children }: { children: ReactNode }) {
   return (
     <>
+      <HubAccessRedirect tabs={TABS} />
       <div className="px-4 pt-4 sm:px-6 sm:pt-6">
         <RoutedModuleTabs tabs={TABS} />
       </div>

--- a/app/dilesa/compras/layout.tsx
+++ b/app/dilesa/compras/layout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { RoutedModuleTabs } from '@/components/module-page';
+import { HubAccessRedirect, RoutedModuleTabs } from '@/components/module-page';
 import { TeTocaStrip } from '@/components/gasto/te-toca-strip';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
@@ -55,6 +55,7 @@ export default function ComprasLayout({ children }: { children: ReactNode }) {
     <>
       <div className="space-y-3 px-4 pt-4 sm:px-6 sm:pt-6">
         <TeTocaStrip empresaId={DILESA_EMPRESA_ID} empresa="dilesa" />
+        <HubAccessRedirect tabs={TABS} />
         <RoutedModuleTabs tabs={TABS} />
       </div>
       {children}

--- a/app/dilesa/construccion/layout.tsx
+++ b/app/dilesa/construccion/layout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { RoutedModuleTabs } from '@/components/module-page';
+import { HubAccessRedirect, RoutedModuleTabs } from '@/components/module-page';
 
 /**
  * Layout compartido del hub Construcción (DILESA).
@@ -64,6 +64,7 @@ const TABS = [
 export default function ConstruccionLayout({ children }: { children: ReactNode }) {
   return (
     <>
+      <HubAccessRedirect tabs={TABS} />
       <div className="px-4 pt-4 sm:px-6 sm:pt-6">
         <RoutedModuleTabs tabs={TABS} />
       </div>

--- a/app/dilesa/cxp/layout.tsx
+++ b/app/dilesa/cxp/layout.tsx
@@ -1,5 +1,10 @@
 import { type ReactNode } from 'react';
-import { ModulePage, ModuleHeader, RoutedModuleTabs } from '@/components/module-page';
+import {
+  HubAccessRedirect,
+  ModulePage,
+  ModuleHeader,
+  RoutedModuleTabs,
+} from '@/components/module-page';
 import { TeTocaStrip } from '@/components/gasto/te-toca-strip';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
@@ -56,6 +61,7 @@ export default function CxpLayout({ children }: { children: ReactNode }) {
       <div className="px-4 pt-3 sm:px-6">
         <TeTocaStrip empresaId={DILESA_EMPRESA_ID} empresa="dilesa" />
       </div>
+      <HubAccessRedirect tabs={TABS} />
       <RoutedModuleTabs tabs={TABS} />
       {children}
     </ModulePage>

--- a/app/dilesa/page.tsx
+++ b/app/dilesa/page.tsx
@@ -23,7 +23,7 @@ import {
 } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { usePermissions } from '@/components/providers';
-import { canAccessModulo, ROUTE_TO_MODULE } from '@/lib/permissions';
+import { canSeeNavRoute } from '@/lib/permissions';
 import { NAV_ITEMS } from '@/components/app-shell/nav-config';
 
 type ModulePresentation = { icon: LucideIcon; color: string };
@@ -81,12 +81,7 @@ export default function DilesaPage() {
     return DILESA_SECTIONS.map((section) => ({
       title: section.label,
       items: section.children
-        .filter((child) => {
-          if (showAll) return true;
-          const moduloSlug = ROUTE_TO_MODULE[child.href];
-          if (!moduloSlug) return true;
-          return canAccessModulo(permissions, moduloSlug);
-        })
+        .filter((child) => showAll || canSeeNavRoute(permissions, child.href))
         .map((child) => ({
           label: child.label,
           href: child.href,

--- a/app/dilesa/proyectos/layout.tsx
+++ b/app/dilesa/proyectos/layout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { RoutedModuleTabs } from '@/components/module-page';
+import { HubAccessRedirect, RoutedModuleTabs } from '@/components/module-page';
 
 /**
  * Layout compartido del módulo Proyectos (DILESA).
@@ -41,6 +41,7 @@ const TABS = [
 export default function ProyectosLayout({ children }: { children: ReactNode }) {
   return (
     <>
+      <HubAccessRedirect tabs={TABS} />
       <div className="px-4 pt-4 sm:px-6 sm:pt-6">
         <RoutedModuleTabs tabs={TABS} />
       </div>

--- a/app/dilesa/ventas/layout.tsx
+++ b/app/dilesa/ventas/layout.tsx
@@ -2,7 +2,7 @@
 
 import { type ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
-import { RoutedModuleTabs } from '@/components/module-page';
+import { HubAccessRedirect, RoutedModuleTabs } from '@/components/module-page';
 
 /**
  * Layout compartido del hub Ventas (DILESA).
@@ -98,6 +98,7 @@ export default function VentasLayout({ children }: { children: ReactNode }) {
 
   return (
     <>
+      <HubAccessRedirect tabs={TABS} />
       {showTabs ? (
         <div className="px-4 pt-4 sm:px-6 sm:pt-6">
           <RoutedModuleTabs tabs={TABS} />

--- a/app/rdb/cxp/layout.tsx
+++ b/app/rdb/cxp/layout.tsx
@@ -1,5 +1,10 @@
 import { type ReactNode } from 'react';
-import { ModulePage, ModuleHeader, RoutedModuleTabs } from '@/components/module-page';
+import {
+  HubAccessRedirect,
+  ModulePage,
+  ModuleHeader,
+  RoutedModuleTabs,
+} from '@/components/module-page';
 
 /**
  * Layout del módulo Cuentas por Pagar (RDB · CxP). Patrón routed tabs
@@ -51,6 +56,7 @@ export default function CxpLayout({ children }: { children: ReactNode }) {
   return (
     <ModulePage>
       <ModuleHeader title="Cuentas por Pagar" subtitle="Facturas de egreso, saldos y proveedores" />
+      <HubAccessRedirect tabs={TABS} />
       <RoutedModuleTabs tabs={TABS} />
       {children}
     </ModulePage>

--- a/app/rdb/inventario/layout.tsx
+++ b/app/rdb/inventario/layout.tsx
@@ -1,5 +1,10 @@
 import { type ReactNode } from 'react';
-import { ModulePage, ModuleHeader, RoutedModuleTabs } from '@/components/module-page';
+import {
+  HubAccessRedirect,
+  ModulePage,
+  ModuleHeader,
+  RoutedModuleTabs,
+} from '@/components/module-page';
 
 /**
  * Layout compartido del módulo Inventario (RDB).
@@ -38,6 +43,7 @@ export default function InventarioLayout({ children }: { children: ReactNode }) 
   return (
     <ModulePage>
       <ModuleHeader title="Inventario" subtitle="Control de stock y movimientos" />
+      <HubAccessRedirect tabs={TABS} />
       <RoutedModuleTabs tabs={TABS} />
       {children}
     </ModulePage>

--- a/app/rdb/page.tsx
+++ b/app/rdb/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react';
 import { RequireAccess } from '@/components/require-access';
 import { usePermissions } from '@/components/providers';
-import { canAccessModulo, ROUTE_TO_MODULE } from '@/lib/permissions';
+import { canSeeNavRoute } from '@/lib/permissions';
 import Link from 'next/link';
 import {
   ClipboardList,
@@ -176,19 +176,15 @@ export default function RdbPage() {
 
   // Filter cards by the effective user's permissions. When admin is in
   // "Viendo como" preview, this hides modules the impersonated user cannot
-  // access — same logic the sidebar uses (canAccessModulo). Modules without
-  // a route mapping are shown by default.
+  // access — same hub-aware logic the sidebar uses (canSeeNavRoute). Modules
+  // without a route mapping are shown by default.
   const visibleGroups = useMemo(() => {
     if (permissions.loading) return moduleGroups;
     if (permissions.isAdmin) return moduleGroups;
     return moduleGroups
       .map((group) => ({
         ...group,
-        items: group.items.filter((item) => {
-          const moduloSlug = ROUTE_TO_MODULE[item.href];
-          if (!moduloSlug) return true;
-          return canAccessModulo(permissions, moduloSlug);
-        }),
+        items: group.items.filter((item) => canSeeNavRoute(permissions, item.href)),
       }))
       .filter((group) => group.items.length > 0);
   }, [permissions]);

--- a/app/rdb/productos/layout.tsx
+++ b/app/rdb/productos/layout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { RoutedModuleTabs } from '@/components/module-page';
+import { HubAccessRedirect, RoutedModuleTabs } from '@/components/module-page';
 
 /**
  * Layout compartido del módulo Productos (RDB).
@@ -35,6 +35,7 @@ const TABS = [
 export default function ProductosLayout({ children }: { children: ReactNode }) {
   return (
     <>
+      <HubAccessRedirect tabs={TABS} />
       <div className="px-4 pt-4 sm:px-6 sm:pt-6">
         <RoutedModuleTabs tabs={TABS} />
       </div>

--- a/app/settings/acceso/acceso-client.tsx
+++ b/app/settings/acceso/acceso-client.tsx
@@ -61,6 +61,7 @@ import type {
   UsuarioCore,
   UsuarioEmpresa,
 } from './actions';
+import { nestModulosByHub, shortChildName } from './modulos-tree';
 import {
   createEmpresa,
   updateEmpresa,
@@ -282,6 +283,19 @@ export function AccesoClient({
 
   function getPermisoRol(rolId: string, moduloId: string): PermisoRol | undefined {
     return permisosRol.find((p) => p.rol_id === rolId && p.modulo_id === moduloId);
+  }
+
+  /**
+   * Acciones de grupo de un hub (fila padre): "Todo" da lectura+escritura al
+   * padre y todos sus sub-módulos; "Nada" los apaga. Secuencial a propósito —
+   * son pocos upserts y `run` ya da un solo toast/transition para el lote.
+   */
+  function setGrupoPermisos(rolId: string, mods: Modulo[], on: boolean) {
+    run(async () => {
+      for (const m of mods) {
+        await upsertPermisoRol(rolId, m.id, on, on);
+      }
+    });
   }
 
   function getUserEmpresas(userId: string): UsuarioEmpresa[] {
@@ -560,7 +574,9 @@ export function AccesoClient({
                       {selectedRol.nombre}
                     </p>
                     <p className="mt-0.5 text-xs dark:text-white/40 text-[var(--text-subtle)]">
-                      Permisos por módulo — haz clic para cambiar
+                      Permisos por módulo — haz clic para cambiar. Un hub aparece en el menú si él o
+                      cualquiera de sus sub-módulos tiene Lectura; cada sub-módulo gobierna su
+                      pestaña.
                     </p>
                   </div>
                   <Table>
@@ -598,53 +614,119 @@ export function AccesoClient({
                                 {grupo.label}
                               </TableCell>
                             </TableRow>
-                            {grupo.modulos.map((mod) => {
-                              const perm = getPermisoRol(selectedRol.id, mod.id);
+                            {nestModulosByHub(grupo.modulos).map(({ modulo: padre, hijos }) => {
+                              const renderRow = (mod: Modulo, dentroDe?: Modulo) => {
+                                const perm = getPermisoRol(selectedRol.id, mod.id);
+                                const esHub = !dentroDe && hijos.length > 0;
+                                return (
+                                  <TableRow
+                                    key={mod.id}
+                                    className="border-[var(--border)] dark:hover:bg-white/3 hover:bg-black/2"
+                                  >
+                                    <TableCell className="text-sm dark:text-white/80 text-[var(--text)]/80">
+                                      {dentroDe ? (
+                                        <span className="flex items-center gap-2 pl-6">
+                                          <span
+                                            aria-hidden
+                                            className="text-xs dark:text-white/25 text-[var(--text)]/25"
+                                          >
+                                            └
+                                          </span>
+                                          {shortChildName(mod, dentroDe)}
+                                        </span>
+                                      ) : esHub ? (
+                                        <span className="flex items-center justify-between gap-3">
+                                          <span className="flex items-center gap-2">
+                                            {mod.nombre}
+                                            <span
+                                              title="Hub con pestañas: aparece en el menú si este módulo o cualquier sub-módulo tiene Lectura. Cada sub-módulo gobierna su pestaña."
+                                              className="rounded-full border border-[var(--border)] px-1.5 py-0.5 text-[10px] uppercase tracking-wide dark:text-white/45 text-[var(--text-subtle)]"
+                                            >
+                                              Hub
+                                            </span>
+                                          </span>
+                                          <span className="flex shrink-0 items-center gap-1.5 text-[11px]">
+                                            <button
+                                              type="button"
+                                              disabled={isPending}
+                                              onClick={() =>
+                                                setGrupoPermisos(
+                                                  selectedRol.id,
+                                                  [mod, ...hijos],
+                                                  true
+                                                )
+                                              }
+                                              className="text-[var(--accent)] hover:underline disabled:opacity-50"
+                                            >
+                                              Todo
+                                            </button>
+                                            <span className="dark:text-white/20 text-[var(--text)]/20">
+                                              ·
+                                            </span>
+                                            <button
+                                              type="button"
+                                              disabled={isPending}
+                                              onClick={() =>
+                                                setGrupoPermisos(
+                                                  selectedRol.id,
+                                                  [mod, ...hijos],
+                                                  false
+                                                )
+                                              }
+                                              className="text-[var(--accent)] hover:underline disabled:opacity-50"
+                                            >
+                                              Nada
+                                            </button>
+                                          </span>
+                                        </span>
+                                      ) : (
+                                        mod.nombre
+                                      )}
+                                    </TableCell>
+                                    <TableCell className="text-center">
+                                      <input
+                                        type="checkbox"
+                                        disabled={isPending}
+                                        checked={perm?.acceso_lectura ?? false}
+                                        onChange={(e) => {
+                                          run(() =>
+                                            upsertPermisoRol(
+                                              selectedRol.id,
+                                              mod.id,
+                                              e.target.checked,
+                                              perm?.acceso_escritura ?? false
+                                            )
+                                          );
+                                        }}
+                                        className="h-4 w-4 cursor-pointer rounded accent-[var(--accent)]"
+                                      />
+                                    </TableCell>
+                                    <TableCell className="text-center">
+                                      <input
+                                        type="checkbox"
+                                        disabled={isPending}
+                                        checked={perm?.acceso_escritura ?? false}
+                                        onChange={(e) => {
+                                          run(() =>
+                                            upsertPermisoRol(
+                                              selectedRol.id,
+                                              mod.id,
+                                              perm?.acceso_lectura ?? false,
+                                              e.target.checked
+                                            )
+                                          );
+                                        }}
+                                        className="h-4 w-4 cursor-pointer rounded accent-[var(--accent)]"
+                                      />
+                                    </TableCell>
+                                  </TableRow>
+                                );
+                              };
                               return (
-                                <TableRow
-                                  key={mod.id}
-                                  className="border-[var(--border)] dark:hover:bg-white/3 hover:bg-black/2"
-                                >
-                                  <TableCell className="text-sm dark:text-white/80 text-[var(--text)]/80">
-                                    {mod.nombre}
-                                  </TableCell>
-                                  <TableCell className="text-center">
-                                    <input
-                                      type="checkbox"
-                                      disabled={isPending}
-                                      checked={perm?.acceso_lectura ?? false}
-                                      onChange={(e) => {
-                                        run(() =>
-                                          upsertPermisoRol(
-                                            selectedRol.id,
-                                            mod.id,
-                                            e.target.checked,
-                                            perm?.acceso_escritura ?? false
-                                          )
-                                        );
-                                      }}
-                                      className="h-4 w-4 cursor-pointer rounded accent-[var(--accent)]"
-                                    />
-                                  </TableCell>
-                                  <TableCell className="text-center">
-                                    <input
-                                      type="checkbox"
-                                      disabled={isPending}
-                                      checked={perm?.acceso_escritura ?? false}
-                                      onChange={(e) => {
-                                        run(() =>
-                                          upsertPermisoRol(
-                                            selectedRol.id,
-                                            mod.id,
-                                            perm?.acceso_lectura ?? false,
-                                            e.target.checked
-                                          )
-                                        );
-                                      }}
-                                      className="h-4 w-4 cursor-pointer rounded accent-[var(--accent)]"
-                                    />
-                                  </TableCell>
-                                </TableRow>
+                                <Fragment key={padre.id}>
+                                  {renderRow(padre)}
+                                  {hijos.map((hijo) => renderRow(hijo, padre))}
+                                </Fragment>
                               );
                             })}
                           </Fragment>

--- a/app/settings/acceso/modulos-tree.test.ts
+++ b/app/settings/acceso/modulos-tree.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+
+import { nestModulosByHub, shortChildName } from './modulos-tree';
+import type { Modulo } from './actions';
+
+/**
+ * Helpers puros de la matriz jerárquica de Roles y Permisos
+ * (settings/acceso). La regla crítica: solo anidar bajo un padre que EXISTE
+ * como módulo — los slugs planos de 3 segmentos (`dilesa.admin.tasks`) no
+ * tienen jerarquía RBAC y deben quedar top-level.
+ */
+
+let counter = 0;
+function mod(slug: string, nombre: string): Modulo {
+  counter += 1;
+  return { id: `m-${counter}`, slug, nombre, empresa_id: 'e-1', seccion: 'operaciones' };
+}
+
+describe('nestModulosByHub', () => {
+  it('nests sub-slugs under their hub parent preserving order', () => {
+    const compras = mod('dilesa.compras', 'Compras');
+    const ordenes = mod('dilesa.compras.ordenes', 'Compras · Órdenes');
+    const requisiciones = mod('dilesa.compras.requisiciones', 'Compras · Requisiciones');
+    const proveedores = mod('dilesa.proveedores', 'Proveedores');
+
+    const nodes = nestModulosByHub([compras, ordenes, requisiciones, proveedores]);
+
+    expect(nodes.map((n) => n.modulo.slug)).toEqual(['dilesa.compras', 'dilesa.proveedores']);
+    expect(nodes[0].hijos.map((h) => h.slug)).toEqual([
+      'dilesa.compras.ordenes',
+      'dilesa.compras.requisiciones',
+    ]);
+    expect(nodes[1].hijos).toEqual([]);
+  });
+
+  it('keeps 3-segment flat slugs top-level when no parent module exists', () => {
+    // `dilesa.admin` no es un módulo — tasks/juntas son hermanos planos, no tabs.
+    const tasks = mod('dilesa.admin.tasks', 'Tareas');
+    const juntas = mod('dilesa.admin.juntas', 'Juntas');
+
+    const nodes = nestModulosByHub([tasks, juntas]);
+
+    expect(nodes.map((n) => n.modulo.slug)).toEqual(['dilesa.admin.tasks', 'dilesa.admin.juntas']);
+    expect(nodes.every((n) => n.hijos.length === 0)).toBe(true);
+  });
+
+  it('does not treat shared string prefixes without a dot as hierarchy', () => {
+    const compras = mod('dilesa.compras', 'Compras');
+    const comprasx = mod('dilesa.comprasx', 'Comprasx');
+
+    const nodes = nestModulosByHub([compras, comprasx]);
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].hijos).toEqual([]);
+  });
+
+  it('never drops modules: top-levels plus nested children cover the input', () => {
+    const input = [
+      mod('dilesa.compras', 'Compras'),
+      mod('dilesa.compras.ordenes', 'Compras · Órdenes'),
+      mod('dilesa.admin.tasks', 'Tareas'),
+      mod('dilesa.manual', 'Manual'),
+    ];
+    const nodes = nestModulosByHub(input);
+    const total = nodes.length + nodes.reduce((sum, n) => sum + n.hijos.length, 0);
+    expect(total).toBe(input.length);
+  });
+});
+
+describe('shortChildName', () => {
+  it('strips the "Padre · " prefix when the DB name follows the convention', () => {
+    const padre = mod('dilesa.compras', 'Compras');
+    const hijo = mod('dilesa.compras.ordenes', 'Compras · Órdenes');
+    expect(shortChildName(hijo, padre)).toBe('Órdenes');
+  });
+
+  it('returns the full name when the convention does not match', () => {
+    const padre = mod('dilesa.ventas', 'Ventas');
+    const hijo = mod('dilesa.ventas.lista', 'Listado de ventas');
+    expect(shortChildName(hijo, padre)).toBe('Listado de ventas');
+  });
+});

--- a/app/settings/acceso/modulos-tree.ts
+++ b/app/settings/acceso/modulos-tree.ts
@@ -1,0 +1,52 @@
+import type { Modulo } from './actions';
+
+/**
+ * Helpers puros de la matriz de permisos (Accesos · Roles y Permisos).
+ *
+ * Viven en un `.ts` plano (sin `'use client'` ni server actions) para que
+ * los tests los importen sin arrastrar el árbol del client component — el
+ * `import type` de arriba se borra en compilación.
+ */
+
+/** Módulo con sus sub-slugs anidados (hub de routed tabs, ADR-030). */
+export interface ModuloNode {
+  modulo: Modulo;
+  hijos: Modulo[];
+}
+
+/**
+ * Anida sub-slugs (`<padre>.<tab>`, ADR-030) bajo su módulo padre cuando el
+ * padre existe en la misma lista. Un slug solo se considera "hijo" si algún
+ * prefijo suyo es un módulo real — así los slugs planos de 3 segmentos
+ * (`dilesa.admin.tasks`, cuyo prefijo `dilesa.admin` no es módulo) quedan
+ * top-level y la matriz no inventa jerarquías que no existen en RBAC.
+ */
+export function nestModulosByHub(modulos: Modulo[]): ModuloNode[] {
+  const slugs = new Set(modulos.map((m) => m.slug));
+  const tieneAncestro = (slug: string): boolean => {
+    let idx = slug.lastIndexOf('.');
+    while (idx > 0) {
+      const prefijo = slug.slice(0, idx);
+      if (slugs.has(prefijo)) return true;
+      idx = prefijo.lastIndexOf('.');
+    }
+    return false;
+  };
+  return modulos
+    .filter((m) => !tieneAncestro(m.slug))
+    .map((padre) => ({
+      modulo: padre,
+      hijos: modulos.filter((m) => m.slug.startsWith(`${padre.slug}.`)),
+    }));
+}
+
+/**
+ * Nombre corto de un sub-módulo dentro de su hub: los nombres en DB siguen
+ * la convención "Padre · Hijo" ("Compras · Órdenes") — indentado bajo su
+ * padre, repetir el prefijo es ruido. Si el nombre no sigue la convención,
+ * se muestra completo.
+ */
+export function shortChildName(hijo: Modulo, padre: Modulo): string {
+  const prefijo = `${padre.nombre} · `;
+  return hijo.nombre.startsWith(prefijo) ? hijo.nombre.slice(prefijo.length) : hijo.nombre;
+}

--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -80,9 +80,11 @@ export const NAV_ITEMS: NavItem[] = [
         label: 'Compras',
         children: [
           { label: 'Proveedores', href: '/dilesa/proveedores' },
-          // Hub P2P con tabs (Órdenes / Requisiciones / Recepciones) — ADR-030.
-          // Sidebar muestra solo el padre; la URL default cae al tab Órdenes.
-          { label: 'Órdenes de compra', href: '/dilesa/compras' },
+          // Hub P2P con tabs (Requisiciones / Cotizaciones / Órdenes /
+          // Recepciones) — ADR-030. Sidebar muestra solo el padre; la URL
+          // default cae al tab Órdenes. El label es el hub completo, no el
+          // primer tab: un rol puede tener solo parte del ciclo.
+          { label: 'Compras', href: '/dilesa/compras' },
         ],
       },
       {

--- a/components/app-shell/sidebar.tsx
+++ b/components/app-shell/sidebar.tsx
@@ -16,7 +16,12 @@ import {
 } from 'lucide-react';
 import { useLocale } from '@/lib/i18n';
 import { usePermissions } from '@/components/providers';
-import { canAccessEmpresa, canAccessModulo, ROUTE_TO_MODULE } from '@/lib/permissions';
+import {
+  canAccessEmpresa,
+  canAccessModulo,
+  canSeeNavRoute,
+  ROUTE_TO_MODULE,
+} from '@/lib/permissions';
 import {
   NAV_ITEMS,
   NAV_TO_EMPRESA,
@@ -89,12 +94,10 @@ export function Sidebar({
     if (permissions.isAdmin) {
       byPermissions = NAV_ITEMS;
     } else {
-      const filterChild = (child: NavChild) => {
-        const moduloSlug = ROUTE_TO_MODULE[child.href];
-        // If no modulo mapping, show if empresa is accessible.
-        if (!moduloSlug) return true;
-        return canAccessModulo(permissions, moduloSlug);
-      };
+      // Visibilidad por módulo con conciencia de hubs (ADR-030): la entrada
+      // de un hub se muestra si el usuario alcanza el padre umbrella o
+      // cualquiera de sus sub-slugs, no solo el del primer tab.
+      const filterChild = (child: NavChild) => canSeeNavRoute(permissions, child.href);
 
       byPermissions = NAV_ITEMS.reduce<NavItem[]>((acc, item) => {
         // Overview is always visible to authenticated users.

--- a/components/module-page/hub-access-redirect.tsx
+++ b/components/module-page/hub-access-redirect.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+
+import { usePermissions } from '@/components/providers';
+import { canAccessModulo } from '@/lib/permissions';
+import type { RoutedModuleTab } from './routed-module-tabs';
+
+/**
+ * Compañero de `<RoutedModuleTabs>` para hubs con sub-slugs (ADR-030).
+ *
+ * Si el usuario está parado en la URL de un tab cuyo sub-slug NO le es
+ * accesible (típico: el landing default del hub gobernado por el primer tab,
+ * p. ej. `/dilesa/compras` → `dilesa.compras.ordenes`), lo redirige al primer
+ * tab que SÍ puede leer. Así un rol con permisos parciales del hub aterriza
+ * en contenido útil en vez de en `<AccessDenied>` con tabs arriba.
+ *
+ * No renderiza nada y no toca rutas profundas que no matchean ningún tab
+ * (p. ej. wizards como `/dilesa/ventas/nueva` — su gate vive en la page).
+ * Sin ningún tab accesible es no-op: el `<RequireAccess>` de la sub-page
+ * muestra el denied normal (SS5). Montar en el `layout.tsx` del hub con los
+ * mismos `TABS` que `<RoutedModuleTabs>`.
+ */
+export function HubAccessRedirect({ tabs }: { tabs: ReadonlyArray<RoutedModuleTab> }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { permissions } = usePermissions();
+
+  useEffect(() => {
+    if (permissions.loading || permissions.isAdmin) return;
+    const current = tabs.find((tab) =>
+      tab.exact
+        ? pathname === tab.href
+        : pathname === tab.href || pathname.startsWith(`${tab.href}/`)
+    );
+    if (!current?.module || canAccessModulo(permissions, current.module)) return;
+    const target = tabs.find((tab) => tab.module && canAccessModulo(permissions, tab.module));
+    if (target && target.href !== pathname) router.replace(target.href);
+  }, [pathname, permissions, router, tabs]);
+
+  return null;
+}

--- a/components/module-page/index.ts
+++ b/components/module-page/index.ts
@@ -6,6 +6,7 @@ export { ModuleTabs } from './module-tabs';
 export type { ModuleTab, ModuleTabsProps } from './module-tabs';
 export { RoutedModuleTabs } from './routed-module-tabs';
 export type { RoutedModuleTab, RoutedModuleTabsProps } from './routed-module-tabs';
+export { HubAccessRedirect } from './hub-access-redirect';
 export { ModuleKpiStrip } from './module-kpi-strip';
 export type { ModuleKpi, ModuleKpiStripProps } from './module-kpi-strip';
 export { ModuleFilters } from './module-filters';

--- a/docs/adr/030_submodule_permissions.md
+++ b/docs/adr/030_submodule_permissions.md
@@ -20,7 +20,7 @@ Use case real: usuarios que necesitan ver/configurar solo algunas tabs específi
 - **Padre** (`rdb.inventario`) actúa como **umbrella** — gobierna visibilidad del módulo en sidebar.
 - **Sub-slug** (`rdb.inventario.stock`) gobierna **acceso real al contenido** específico de cada sub-página.
 
-## Reglas SS1-SS7
+## Reglas SS1-SS8
 
 ### SS1 · Sub-slug por tab
 
@@ -43,12 +43,9 @@ Cada URL de sub-página mapea a su sub-slug en `lib/permissions.ts`:
 '/rdb/inventario/levantamientos':  'rdb.inventario.levantamientos',
 ```
 
-**La URL default del módulo (`/<modulo>`) apunta al sub-slug del primer tab.** No al padre. Eso porque:
+**La URL default del módulo (`/<modulo>`) apunta al sub-slug del primer tab.** No al padre. El gate de contenido del landing es el del primer tab, y el manual in-app deriva su doc de este mapa (`resolveHelpSlug`).
 
-- El sidebar usa la URL default del módulo para determinar visibilidad.
-- Si el rol tiene cualquier tab del módulo, hay alguna URL en `ROUTE_TO_MODULE` que mapea a un sub-slug accesible — el módulo aparece en sidebar via esa URL.
-- Si solo tiene el primer tab, la URL default funciona naturalmente.
-- Si solo tiene tabs internas (no la primera), la URL default da AccessDenied pero el sidebar muestra alguna otra URL accesible.
+> ⚠️ **Corrección 2026-06-10 (ver SS8).** La justificación original asumía que "si el rol tiene cualquier tab, el módulo aparece en sidebar vía alguna URL accesible" — falso: el sidebar solo lista la URL **default** de cada hub, así que un rol con tabs internas pero sin el primer tab perdía la puerta de entrada a todo el hub (caso real: Gerente de Proyectos con Requisiciones/Cotizaciones/Recepciones pero sin Órdenes no veía Compras). La visibilidad del sidebar ya NO se decide con este mapa sino con `canSeeNavRoute` (SS8).
 
 ### SS3 · Backfill defensivo al introducir sub-slugs
 
@@ -118,6 +115,17 @@ Plantilla canónica: [`app/rdb/productos/recetas/page.tsx`](../../app/rdb/produc
 
 Cada sub-slug debe agregarse a la lista canónica en [`lib/permissions.test.ts`](../../lib/permissions.test.ts) en el mismo PR que extiende `ROUTE_TO_MODULE`. El test `'every slug in ROUTE_TO_MODULE has an expected DB row'` falla si olvidas — recordatorio explícito de que la migración SQL debe acompañar.
 
+### SS8 · Visibilidad de hub: padre O cualquier sub-slug + aterrizaje accesible
+
+_(Agregada 2026-06-10 — fix del caso "rol con permisos parciales no ve el hub".)_
+
+Dos piezas en el mismo PR al liberar un hub:
+
+1. **`HUB_PARENT_BY_ROUTE`** ([lib/permissions.ts](../../lib/permissions.ts)): entrada `'/<empresa>/<hub>': '<empresa>.<hub>'` (URL landing → slug padre umbrella). El sidebar y los paneles de empresa deciden visibilidad con `canSeeNavRoute(perms, href)`: la entrada del hub se muestra si el usuario lee el sub-slug mapeado, el padre umbrella **o cualquier sub-slug** del hub (`canAccessModuloOrChild`). Un test de sync en `permissions.test.ts` valida que cada entrada sea coherente con `ROUTE_TO_MODULE` y exista en DB.
+2. **`<HubAccessRedirect tabs={TABS} />`** en el `layout.tsx` del hub (junto a `<RoutedModuleTabs>`, mismos TABS): si el usuario está parado en la URL de un tab cuyo sub-slug no puede leer (típico: el landing default), lo redirige al primer tab que sí puede. Sin ningún tab accesible es no-op y el `<RequireAccess>` de la sub-page muestra su AccessDenied (SS5 intacto).
+
+Los gates de contenido NO cambian: `ROUTE_TO_MODULE` y `<RequireAccess>` por sub-page siguen igual — SS8 solo gobierna puerta de entrada (visibilidad) y aterrizaje.
+
 ## Consecuencias
 
 ### Positivas
@@ -135,10 +143,10 @@ Cada sub-slug debe agregarse a la lista canónica en [`lib/permissions.test.ts`]
 
 ### Estados inconsistentes posibles
 
-- **Padre sin hijos (admin quita todos los sub-slugs pero deja padre):** módulo aparece en sidebar (vía URL default), pero al entrar todas las tabs están ocultas y la URL default da AccessDenied. La UI Settings/Roles podría warning-ear esta config (follow-up no urgente).
-- **Hijos sin padre (admin quita padre pero deja sub-slug):** sidebar oculta el módulo (porque la URL default → sub-slug del primer tab inaccesible), pero entrando por URL directa el sub-slug accesible funciona. Estado raro pero coherente: usuarios con bookmark a `/rdb/inventario/movimientos` siguen viéndolo.
+- **Padre sin hijos (admin quita todos los sub-slugs pero deja padre):** módulo aparece en sidebar, pero al entrar todas las tabs están ocultas y la URL default da AccessDenied. La matriz de Settings/Roles agrupa los sub-slugs bajo su hub (con acciones "Todo/Nada") para hacer esta config visible de un vistazo.
+- **Hijos sin padre (admin quita padre pero deja sub-slug):** desde SS8 el hub sigue visible en sidebar (`canSeeNavRoute` considera cualquier sub-slug) y `<HubAccessRedirect>` aterriza en el tab accesible. El padre queda como slug del hub para backfills y agrupación, ya no como única llave de visibilidad.
 
-Ambos estados son creables solo manualmente por admin desde Settings/Roles. La UI debería warning-ear pero por ahora no bloquea — la semántica es coherente.
+Ambos estados son creables solo manualmente por admin desde Settings/Roles; con SS8 ninguno deja al usuario sin puerta de entrada a contenido que sí tiene permitido.
 
 ## Alternativas consideradas
 

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect, vi } from 'vitest';
 
 import {
   ADMIN_ONLY_ROUTES,
+  HUB_PARENT_BY_ROUTE,
   ROUTE_TO_EMPRESA,
   ROUTE_TO_MODULE,
   canAccessEmpresa,
   canAccessModulo,
+  canAccessModuloOrChild,
+  canSeeNavRoute,
   fetchPermissionsForUserId,
   fetchUserPermissions,
   isAdminOnly,
@@ -110,6 +113,89 @@ describe('canAccessModulo', () => {
     });
     expect(canAccessModulo(perms, 'rdb.ventas', 'read')).toBe(false);
     expect(canAccessModulo(perms, 'rdb.ventas', 'write')).toBe(false);
+  });
+});
+
+describe('canAccessModuloOrChild', () => {
+  it('returns true with direct access to the umbrella slug', () => {
+    const perms = makePerms({
+      modulos: new Map([['dilesa.compras', { read: true, write: false }]]),
+    });
+    expect(canAccessModuloOrChild(perms, 'dilesa.compras')).toBe(true);
+  });
+
+  it('returns true when only a sub-slug is readable', () => {
+    const perms = makePerms({
+      modulos: new Map([['dilesa.compras.requisiciones', { read: true, write: true }]]),
+    });
+    expect(canAccessModuloOrChild(perms, 'dilesa.compras')).toBe(true);
+  });
+
+  it('ignores sub-slugs whose flags are false (deny exception)', () => {
+    const perms = makePerms({
+      modulos: new Map([['dilesa.compras.requisiciones', { read: false, write: false }]]),
+    });
+    expect(canAccessModuloOrChild(perms, 'dilesa.compras')).toBe(false);
+  });
+
+  it('does not match sibling modules that merely share a string prefix', () => {
+    const perms = makePerms({
+      // `dilesa.comprasx` no es hijo de `dilesa.compras` — el prefix incluye el punto.
+      modulos: new Map([['dilesa.comprasx', { read: true, write: true }]]),
+    });
+    expect(canAccessModuloOrChild(perms, 'dilesa.compras')).toBe(false);
+  });
+
+  it('checks the write flag in write mode', () => {
+    const perms = makePerms({
+      modulos: new Map([['dilesa.compras.requisiciones', { read: true, write: false }]]),
+    });
+    expect(canAccessModuloOrChild(perms, 'dilesa.compras', 'write')).toBe(false);
+  });
+});
+
+describe('canSeeNavRoute', () => {
+  it('shows routes without a module mapping (empresa-gated)', () => {
+    expect(canSeeNavRoute(makePerms(), '/dilesa/sin-mapeo')).toBe(true);
+  });
+
+  it('shows a flat module entry only with direct access', () => {
+    const conAcceso = makePerms({
+      modulos: new Map([['dilesa.proveedores', { read: true, write: false }]]),
+    });
+    expect(canSeeNavRoute(conAcceso, '/dilesa/proveedores')).toBe(true);
+    expect(canSeeNavRoute(makePerms(), '/dilesa/proveedores')).toBe(false);
+  });
+
+  it('shows a hub entry when only the umbrella parent is readable', () => {
+    const perms = makePerms({
+      modulos: new Map([['dilesa.compras', { read: true, write: true }]]),
+    });
+    expect(canSeeNavRoute(perms, '/dilesa/compras')).toBe(true);
+  });
+
+  it('shows a hub entry with partial sub-slug access (caso Nahum)', () => {
+    // Rol con Requisiciones/Cotizaciones/Recepciones pero SIN el sub-slug del
+    // primer tab (`dilesa.compras.ordenes`, al que mapea la URL default): el
+    // hub debe seguir visible — antes de `canSeeNavRoute` el sidebar lo
+    // ocultaba por completo.
+    const perms = makePerms({
+      modulos: new Map([
+        ['dilesa.compras', { read: true, write: true }],
+        ['dilesa.compras.requisiciones', { read: true, write: true }],
+        ['dilesa.compras.cotizaciones', { read: true, write: true }],
+        ['dilesa.compras.recepciones', { read: true, write: true }],
+      ]),
+    });
+    expect(canAccessModulo(perms, ROUTE_TO_MODULE['/dilesa/compras'])).toBe(false);
+    expect(canSeeNavRoute(perms, '/dilesa/compras')).toBe(true);
+  });
+
+  it('hides a hub entry when nothing in the hub is readable', () => {
+    const perms = makePerms({
+      modulos: new Map([['dilesa.ventas.lista', { read: true, write: false }]]),
+    });
+    expect(canSeeNavRoute(perms, '/dilesa/compras')).toBe(false);
   });
 });
 
@@ -353,6 +439,23 @@ describe('ROUTE_TO_MODULE ↔ core.modulos sync', () => {
     // (a) agregarlo a EXPECTED_DB_MODULE_SLUGS arriba y (b) crear una
     // migración SQL con INSERT en `core.modulos` + backfill de permisos.
     // Ver BSOP/CLAUDE.md → "Reglas DB" → "Liberación de módulo nuevo".
+  });
+
+  it('every hub landing in HUB_PARENT_BY_ROUTE is consistent', () => {
+    for (const [href, parentSlug] of Object.entries(HUB_PARENT_BY_ROUTE)) {
+      // La URL del hub existe en ROUTE_TO_MODULE (es una entrada real de nav).
+      expect(ROUTE_TO_MODULE[href], `${href} falta en ROUTE_TO_MODULE`).toBeTruthy();
+      // El slug mapeado es un sub-slug del padre umbrella declarado.
+      expect(
+        ROUTE_TO_MODULE[href].startsWith(`${parentSlug}.`),
+        `${href}: ${ROUTE_TO_MODULE[href]} no es sub-slug de ${parentSlug}`
+      ).toBe(true);
+      // El padre existe como módulo en DB (mismo contrato que el test de arriba).
+      expect(
+        EXPECTED_DB_MODULE_SLUGS.has(parentSlug),
+        `${parentSlug} falta en EXPECTED_DB_MODULE_SLUGS / core.modulos`
+      ).toBe(true);
+    }
   });
 
   // Nota: no validamos uniqueness de slugs en `ROUTE_TO_MODULE`.

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -158,6 +158,27 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   '/settings/notificaciones': 'settings.notificaciones',
 };
 
+/**
+ * Landing de hub (URL default con routed tabs, ADR-030) → slug del módulo
+ * padre umbrella. La visibilidad del hub en sidebar/paneles NO la decide el
+ * sub-slug del primer tab (a eso mapea `ROUTE_TO_MODULE`, y así debe seguir:
+ * el manual deriva sus docs de ahí) sino el padre **o cualquier sub-slug**:
+ * un rol con acceso a Requisiciones pero no a Órdenes debe ver el hub Compras.
+ * Consumido por `canSeeNavRoute`. Al liberar un hub nuevo, agregar su entrada
+ * aquí (el test de sync en `permissions.test.ts` lo valida).
+ */
+export const HUB_PARENT_BY_ROUTE: Record<string, string> = {
+  '/dilesa/proyectos': 'dilesa.proyectos',
+  '/dilesa/ventas': 'dilesa.ventas',
+  '/dilesa/cobranza': 'dilesa.cobranza',
+  '/dilesa/cxp': 'dilesa.cxp',
+  '/dilesa/construccion': 'dilesa.construccion',
+  '/dilesa/compras': 'dilesa.compras',
+  '/rdb/cxp': 'rdb.cxp',
+  '/rdb/productos': 'rdb.productos',
+  '/rdb/inventario': 'rdb.inventario',
+};
+
 /** Maps a nav section href to its empresa slug */
 export const ROUTE_TO_EMPRESA: Record<string, string> = {
   '/rdb': 'rdb',
@@ -394,6 +415,44 @@ export function canAccessModulo(
   const access = perms.modulos.get(moduloSlug);
   if (!access) return false;
   return mode === 'read' ? access.read : access.write;
+}
+
+/**
+ * Acceso al módulo o a cualquiera de sus sub-slugs (`<slug>.<tab>`). Solo
+ * tiene sentido para slugs de hub umbrella (ADR-030) — para un módulo plano
+ * el prefix no matchea nada y equivale a `canAccessModulo`.
+ */
+export function canAccessModuloOrChild(
+  perms: UserPermissions,
+  moduloSlug: string,
+  mode: 'read' | 'write' = 'read'
+): boolean {
+  if (canAccessModulo(perms, moduloSlug, mode)) return true;
+  const prefix = `${moduloSlug}.`;
+  for (const [slug, access] of perms.modulos) {
+    if (slug.startsWith(prefix) && (mode === 'read' ? access.read : access.write)) return true;
+  }
+  return false;
+}
+
+/**
+ * ¿Esta entrada de navegación (sidebar / panel de empresa) es visible?
+ *
+ * - Ruta sin módulo mapeado → visible (gobierna el gate de empresa).
+ * - Ruta con módulo → visible con acceso de lectura al módulo mapeado.
+ * - Landing de hub (ADR-030) → visible también con acceso al padre umbrella
+ *   o a CUALQUIER sub-slug del hub. Sin esto, un rol con permisos parciales
+ *   (p. ej. Requisiciones sin Órdenes) pierde la puerta de entrada a todo el
+ *   hub aunque sus tabs le funcionen — el contenido sigue gateado por
+ *   `<RequireAccess>` en cada sub-page (SS5).
+ */
+export function canSeeNavRoute(perms: UserPermissions, href: string): boolean {
+  const moduloSlug = ROUTE_TO_MODULE[href];
+  if (!moduloSlug) return true;
+  if (canAccessModulo(perms, moduloSlug)) return true;
+  const hubParent = HUB_PARENT_BY_ROUTE[href];
+  if (!hubParent) return false;
+  return canAccessModuloOrChild(perms, hubParent);
 }
 
 export function isAdminOnly(pathname: string): boolean {


### PR DESCRIPTION
## Problema (caso Nahum)

Nahum Solís (rol **Gerente de Proyectos**, DILESA) tiene permisos de `dilesa.compras` (padre) + `requisiciones`/`cotizaciones`/`recepciones`, pero **no** `dilesa.compras.ordenes`. El sidebar decidía la visibilidad del hub Compras con el sub-slug del **primer tab** (`ROUTE_TO_MODULE['/dilesa/compras'] → dilesa.compras.ordenes`) → el módulo desaparecía por completo aunque 4 de 5 permisos estaban dados. La premisa documentada en ADR-030 SS2 ("si tiene cualquier tab, el módulo aparece vía otra URL") era falsa: el sidebar solo lista la URL default de cada hub. Aplicaba a los 9 hubs (Compras/Ventas/Construcción/CxC/CxP/Proyectos DILESA + CxP/Productos/Inventario RDB).

## Fix sistémico (ADR-030 SS8)

- **`HUB_PARENT_BY_ROUTE` + `canSeeNavRoute`/`canAccessModuloOrChild`** en `lib/permissions.ts`: un hub es visible si el usuario lee el padre umbrella **o cualquier sub-slug**. `ROUTE_TO_MODULE` queda intacto — gates de contenido (`<RequireAccess>`) y el manual in-app (`resolveHelpSlug`) no cambian. Test de sync valida coherencia con `ROUTE_TO_MODULE` y `EXPECTED_DB_MODULE_SLUGS`.
- **Sidebar + paneles landing** DILESA/RDB adoptan `canSeeNavRoute`.
- **`<HubAccessRedirect>`** en los 9 layouts de hub: parado en un tab sin permiso (típico: el landing default), redirige al primer tab accesible. Sin ningún tab accesible es no-op (AccessDenied normal, SS5 intacto).
- **Label sidebar**: "Órdenes de compra" → "Compras" (la entrada es el hub P2P completo, no solo órdenes).

## Accesos · Roles y Permisos (el "último toque")

- **Matriz jerárquica**: sub-slugs anidados bajo su hub (└ + nombre corto "Órdenes" en vez de "Compras · Órdenes"), badge **Hub** con tooltip del modelo de visibilidad.
- **Acciones de grupo** "Todo / Nada" en la fila del hub (lectura+escritura del padre y todos los sub-módulos en un click).
- Hint del modelo en el header de la matriz. Helpers puros en `modulos-tree.ts` (anida solo bajo padre que existe como módulo — `dilesa.admin.tasks` y similares quedan planos) con tests.

## Docs

ADR-030: SS2 corregido + SS8 nuevo + estados inconsistentes actualizados. CLAUDE.md: regla de liberación de hub incluye `HUB_PARENT_BY_ROUTE` y `<HubAccessRedirect>`.

## Verificación

- typecheck ✓ · 1545 tests ✓ (coverage ✓) · lint 0 errores ✓ · format ✓ · initiatives ✓ · schema:check sin drift ✓
- Caso Nahum cubierto por test explícito en `lib/permissions.test.ts`.
- **Pendiente validación visual en Preview** (login real funciona en previews): "Ver como usuario" → Nahum → debe ver Compras en sidebar y aterrizar en Requisiciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)