### PR TITLE
feat(dilesa-ventas): Fase 17 + copiloto de cierre + scope del rol Vendedor

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/17-operacion-terminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/17-operacion-terminada/page.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+/**
+ * Captura Fase 17 — Operación Terminada (S4+S5 dilesa-ventas-expediente).
+ *
+ * El sello final del expediente. NO es una revisión manual: el copiloto
+ * re-evalúa aquí las 4 condiciones (fases 1-16, expediente documental
+ * completo descontando docs que la venta no amerita, cuadratura cubierta,
+ * conformidad registrada) y solo entonces habilita el cierre.
+ *
+ * Acceso: `dilesa.ventas.fase17_operacion_terminada` (pre-sembrado).
+ */
+
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircle2, Circle, Loader2, PartyPopper } from 'lucide-react';
+import { RequireAccess } from '@/components/require-access';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useToast } from '@/components/ui/toast';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
+import { marcarFase, FASES_PIPELINE } from '@/lib/dilesa/captura/marcar-fase';
+import { FASE_ROLES, ROL_LABEL, rolesOpcionales } from '@/lib/dilesa/captura/fase-roles';
+import { evaluarCierre, type CopilotoResultado } from '@/lib/dilesa/copiloto-cierre';
+import { calcularCuadratura } from '@/lib/dilesa/cuadratura';
+
+type VentaCtx = {
+  id: string;
+  empresa_id: string;
+  persona_id: string;
+  unidad_id: string | null;
+  tipo_credito: string | null;
+  valor_escrituracion: number | null;
+  precio_asignacion: number | null;
+  monto_credito_titular: number | null;
+  monto_credito_cotitular: number | null;
+  monto_credito_directo: number | null;
+  monto_cheque_notaria: number | null;
+  gastos_escrituracion: number | null;
+  monto_nota_credito: number | null;
+  descuento_precio: number | null;
+  descuento_equipamiento: number | null;
+  descuento_gastos_escrituracion: number | null;
+  descuento_nota_credito: number | null;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 2,
+});
+
+export default function CapturarFase17Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.fase17_operacion_terminada" write>
+      <CapturarFase17Body />
+    </RequireAccess>
+  );
+}
+
+function CapturarFase17Body() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const toast = useToast();
+  const sb = useMemo(() => createSupabaseBrowserClient(), []);
+  const ventaId = params.id;
+
+  const [venta, setVenta] = useState<VentaCtx | null>(null);
+  const [clienteNombre, setClienteNombre] = useState<string>('');
+  const [identificacionInv, setIdentificacionInv] = useState<string | null>(null);
+  const [resultado, setResultado] = useState<CopilotoResultado | null>(null);
+  const [yaCerrada, setYaCerrada] = useState<boolean>(false);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!ventaId) return;
+    let activo = true;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+
+      const { data: vRow, error: vErr } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .select(
+          'id, empresa_id, persona_id, unidad_id, tipo_credito, valor_escrituracion, precio_asignacion, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, monto_nota_credito, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito'
+        )
+        .eq('id', ventaId)
+        .is('deleted_at', null)
+        .maybeSingle();
+      if (!activo) return;
+      if (vErr || !vRow) {
+        setError(
+          vErr
+            ? getSupabaseErrorMessage(vErr, 'No se pudo cargar la venta.')
+            : 'Venta no encontrada.'
+        );
+        setLoading(false);
+        return;
+      }
+      const v = vRow as unknown as VentaCtx;
+      setVenta(v);
+
+      const [pRes, uRes, fRes, adjRes, abonosRes] = await Promise.all([
+        sb
+          .schema('erp')
+          .from('personas')
+          .select('nombre, apellido_paterno, apellido_materno')
+          .eq('id', v.persona_id)
+          .maybeSingle(),
+        v.unidad_id
+          ? sb
+              .schema('dilesa')
+              .from('unidades')
+              .select('identificador, producto_id')
+              .eq('id', v.unidad_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null }),
+        sb
+          .schema('dilesa')
+          .from('venta_fases')
+          .select('posicion')
+          .eq('venta_id', v.id)
+          .is('deleted_at', null),
+        sb
+          .schema('erp')
+          .from('adjuntos')
+          .select('rol')
+          .eq('entidad_tipo', 'venta')
+          .eq('entidad_id', v.id),
+        sb
+          .schema('erp')
+          .from('cxc_pagos')
+          .select('monto_total, fuente')
+          .eq('origen_tipo', 'venta_dilesa')
+          .eq('origen_id', v.id)
+          .is('deleted_at', null),
+      ]);
+      if (!activo) return;
+
+      if (pRes.data) {
+        setClienteNombre(
+          [pRes.data.nombre, pRes.data.apellido_paterno, pRes.data.apellido_materno]
+            .filter(Boolean)
+            .join(' ') || '(sin nombre)'
+        );
+      }
+      if (uRes.data) setIdentificacionInv(uRes.data.identificador as string);
+
+      const posicionesAlcanzadas = new Set(
+        ((fRes.data ?? []) as { posicion: number }[]).map((f) => f.posicion)
+      );
+      setYaCerrada(posicionesAlcanzadas.has(17));
+
+      // Apoyo Infonavit del catálogo (mismo criterio que el detalle).
+      let apoyo = 0;
+      if (v.tipo_credito) {
+        const { data: tc } = await sb
+          .schema('dilesa')
+          .from('tipos_credito')
+          .select('apoyo_infonavit_monto')
+          .eq('empresa_id', v.empresa_id)
+          .eq('nombre', v.tipo_credito)
+          .is('deleted_at', null)
+          .maybeSingle();
+        apoyo = Number(tc?.apoyo_infonavit_monto ?? 0);
+      }
+
+      const cuadratura = calcularCuadratura({
+        valorEscrituracion: v.valor_escrituracion,
+        montoCreditoTitular: v.monto_credito_titular,
+        montoCreditoCotitular: v.monto_credito_cotitular,
+        montoCreditoDirecto: v.monto_credito_directo,
+        montoChequeNotaria: v.monto_cheque_notaria,
+        gastosEscrituracion: v.gastos_escrituracion,
+        apoyoInfonavit: apoyo,
+        descuentoOtorgadoTotal:
+          Number(v.descuento_precio ?? 0) +
+          Number(v.descuento_equipamiento ?? 0) +
+          Number(v.descuento_gastos_escrituracion ?? 0) +
+          Number(v.descuento_nota_credito ?? 0),
+        precioAsignacion: v.precio_asignacion,
+        depositos: ((abonosRes.data ?? []) as { monto_total: number; fuente: string }[]).map(
+          (a) => ({ monto: a.monto_total, directoCliente: a.fuente === 'cliente' })
+        ),
+        proyectoNombre: null,
+      });
+
+      // Docs requeridos faltantes (descontando opcionales por la venta).
+      const cargados = new Set(((adjRes.data ?? []) as { rol: string }[]).map((a) => a.rol));
+      const opcionales = rolesOpcionales(v);
+      const docsFaltantes = FASES_PIPELINE.flatMap((f) =>
+        (FASE_ROLES[f.nombre] ?? [])
+          .filter((rol) => !cargados.has(rol) && !opcionales.has(rol))
+          .map((rol) => ({ fase: f.nombre, rol, label: ROL_LABEL[rol] ?? rol }))
+      );
+
+      const fases = FASES_PIPELINE.map((f) => ({
+        pos: f.posicion,
+        nombre: f.nombre,
+        alcanzada: posicionesAlcanzadas.has(f.posicion),
+      }));
+
+      setResultado(
+        evaluarCierre(
+          {
+            fases,
+            docsFaltantes,
+            saldoCliente: cuadratura.saldoCliente,
+            cubierta: v.valor_escrituracion == null ? null : cuadratura.cubierta,
+          },
+          (n) => moneyFmt.format(n)
+        )
+      );
+      setLoading(false);
+    })();
+
+    return () => {
+      activo = false;
+    };
+  }, [ventaId, sb]);
+
+  const cerrarOperacion = useCallback(async () => {
+    if (!venta || !resultado?.listo) return;
+    setSubmitting(true);
+    const { data: userRes } = await sb.auth.getUser();
+    const userId = userRes?.user?.id ?? null;
+
+    const result = await marcarFase(sb, {
+      ventaId: venta.id,
+      faseNombre: 'Operación Terminada',
+      faseposicion: 17,
+      docs: [],
+      camposVenta: {},
+      notas:
+        'Cierre verificado por el copiloto: pipeline completo, expediente documental, cuadratura cubierta y conformidad registrada.',
+      registradoPor: userId,
+    });
+    setSubmitting(false);
+    if (!result.ok) {
+      toast.add({
+        title: 'Error al cerrar la operación',
+        description: result.error ?? 'Error desconocido.',
+        type: 'error',
+      });
+      return;
+    }
+    toast.add({
+      title: 'Operación Terminada 🎉',
+      description: 'El expediente quedó sellado. Felicidades por otra entrega completa.',
+      type: 'success',
+    });
+    router.push(`/dilesa/ventas/${venta.id}`);
+  }, [resultado, router, sb, toast, venta]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (error || !venta) {
+    return (
+      <div className="container mx-auto max-w-3xl space-y-4 px-4 py-6">
+        <CapturarFaseHeader
+          ventaId={ventaId}
+          clienteNombre={null}
+          identificacionInventario={null}
+          faseposicion={17}
+          faseNombre="Operación Terminada"
+        />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {error ?? 'Venta no encontrada.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl space-y-6 px-4 py-6">
+      <CapturarFaseHeader
+        ventaId={venta.id}
+        clienteNombre={clienteNombre}
+        identificacionInventario={identificacionInv}
+        faseposicion={17}
+        faseNombre="Operación Terminada"
+        descripcion="El sello final: el copiloto verifica el expediente y habilita el cierre."
+      />
+
+      {yaCerrada ? (
+        <div className="rounded-lg border border-emerald-400/40 bg-emerald-50 p-5 dark:bg-emerald-950/25">
+          <div className="flex items-center gap-2">
+            <PartyPopper className="size-5 text-emerald-600 dark:text-emerald-400" />
+            <p className="text-sm font-semibold text-emerald-900 dark:text-emerald-100">
+              Esta operación ya está terminada.
+            </p>
+          </div>
+        </div>
+      ) : resultado ? (
+        <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+          <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+            Verificación de cierre ({resultado.items.length - resultado.pendientes}/
+            {resultado.items.length})
+          </h2>
+          <ul className="space-y-2">
+            {resultado.items.map((item) => (
+              <li key={item.label} className="flex items-start gap-2 text-sm">
+                {item.ok ? (
+                  <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                ) : (
+                  <Circle className="mt-0.5 size-4 shrink-0 text-[var(--text)]/30" />
+                )}
+                <div>
+                  <span
+                    className={item.ok ? 'text-[var(--text)]/70' : 'font-medium text-[var(--text)]'}
+                  >
+                    {item.label}
+                  </span>
+                  {item.detalle ? (
+                    <p className="text-xs text-[var(--text)]/55">{item.detalle}</p>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-5 flex items-center justify-end gap-3">
+            <Link
+              href={`/dilesa/ventas/${venta.id}`}
+              className="text-sm text-muted-foreground hover:text-[var(--text)]"
+            >
+              Volver al detalle
+            </Link>
+            <Button
+              type="button"
+              onClick={cerrarOperacion}
+              disabled={!resultado.listo || submitting}
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" /> Cerrando…
+                </>
+              ) : (
+                <>
+                  <PartyPopper className="mr-2 size-4" /> Marcar Operación Terminada
+                </>
+              )}
+            </Button>
+          </div>
+          {!resultado.listo ? (
+            <p className="mt-2 text-right text-[11px] text-[var(--text)]/50">
+              El botón se habilita cuando las {resultado.items.length} verificaciones estén en
+              verde.
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -53,6 +53,10 @@ import {
 } from '@/components/dilesa/cuadratura-ajustes';
 import { calcularCuadratura } from '@/lib/dilesa/cuadratura';
 import { camposCapturadosPorFase } from '@/lib/dilesa/captura/campos-capturados';
+import { FASE_ROLES, ROL_LABEL, rolesOpcionales } from '@/lib/dilesa/captura/fase-roles';
+import { evaluarCierre } from '@/lib/dilesa/copiloto-cierre';
+import { CopilotoCierre } from '@/components/dilesa/copiloto-cierre';
+import { useScopeVendedorDilesa } from '@/lib/dilesa/use-scope-vendedor';
 import { EstadoCuentaPrintable } from '@/components/dilesa/estado-cuenta-printable';
 import { ReciboCajaPrintable } from '@/components/dilesa/recibo-caja-printable';
 import { useTriggerPrint } from '@/components/print';
@@ -223,30 +227,6 @@ const ESTADO_LABEL: Record<string, string> = {
   desasignada: 'Desasignada',
 };
 
-const ROL_LABEL: Record<string, string> = {
-  factura: 'Factura',
-  aprobacion_credito: 'Aprobación de crédito',
-  constancia_credito_titular: 'Constancia de crédito (titular)',
-  constancia_credito_cotitular: 'Constancia de crédito (co-titular)',
-  aviso_pld: 'Aviso PLD',
-  avaluo_comercial: 'Avalúo comercial',
-  contrato_promesa: 'Contrato promesa de compraventa',
-  solicitud_asignacion: 'Solicitud de asignación',
-  recibos_caja: 'Recibos de caja',
-  expediente_digital: 'Expediente digital',
-  ficu: 'FICU',
-  aviso_privacidad: 'Aviso de privacidad',
-  carta_instruccion_notarial: 'Carta instrucción notarial',
-  checklist_entrega: 'Checklist de entrega',
-  checklist_pre_entrega: 'Checklist pre-entrega',
-  validacion_patronal: 'Validación patronal',
-  nota_credito: 'Nota de crédito',
-  pagare: 'Pagaré',
-  imagen_detonacion: 'Imagen de detonación',
-  recibo_caja: 'Recibo de caja',
-  comprobante_deposito: 'Comprobante de depósito',
-};
-
 const moneyFmt = new Intl.NumberFormat('es-MX', {
   style: 'currency',
   currency: 'MXN',
@@ -259,28 +239,6 @@ const moneyFmt = new Intl.NumberFormat('es-MX', {
  * concluirla. La UI muestra los cargados como chips clickeables y los
  * faltantes como chips outline gris.
  */
-const FASE_ROLES: Record<string, string[]> = {
-  'Solicitud de Asignación': ['solicitud_asignacion'],
-  Asignada: ['solicitud_asignacion', 'expediente_digital', 'ficu', 'aviso_privacidad'],
-  Formalizada: ['contrato_promesa'],
-  'Solicitud de Avalúo': [],
-  'Avalúo Cerrado': ['avaluo_comercial'],
-  // Beto: las Constancias de Crédito (titular + co-titular) van en Inscrita
-  // (el banco las entrega al inscribir el crédito). La Carta de instrucción
-  // notarial queda en Dictaminada (sale después con el dictamen jurídico).
-  Inscrita: ['constancia_credito_titular', 'constancia_credito_cotitular'],
-  'Solicitud de Dictaminación': ['aprobacion_credito'],
-  Dictaminada: ['carta_instruccion_notarial', 'condiciones_financieras'],
-  'Validación Patronal': ['validacion_patronal'],
-  'Firmas Programadas': [],
-  Escriturada: ['pagare'],
-  Detonada: ['imagen_detonacion'],
-  Facturada: ['factura', 'nota_credito', 'aviso_pld'],
-  'Preparada para Entrega': ['checklist_pre_entrega'],
-  Entregada: ['checklist_entrega'],
-  'Conformidad del Cliente': [],
-  'Operación Terminada': [],
-};
 
 /**
  * Slugs de captura disponibles — mapea posición de fase → slug de la
@@ -304,7 +262,7 @@ const CAPTURAR_SLUG_BY_POSICION: Record<number, string> = {
   14: '14-preparada-entrega',
   15: '15-entregada',
   16: '16-conformidad',
-  // 17 → próximo PR (cierre con copiloto, S4+S5 dilesa-ventas-expediente)
+  17: '17-operacion-terminada',
 };
 
 /**
@@ -384,6 +342,8 @@ function DetailInner() {
     'operacion'
   );
   const { permissions } = usePermissions();
+  // Scope del rol Vendedor: solo sus propias ventas (pedido de Beto).
+  const scopeVendedor = useScopeVendedorDilesa();
   const [cuadInputs, setCuadInputs] = useState<CuadraturaInputsStr>({
     descuentoPrecio: '',
     descuentoEquipamiento: '',
@@ -848,6 +808,32 @@ function DetailInner() {
     [venta, abonos, proyectoNombre, cuadInputs, apoyoInfonavit, comprobantesPorAbono]
   );
 
+  // Copiloto de cierre (S4): qué falta para Operación Terminada.
+  const copiloto = useMemo(() => {
+    const opcionales = venta
+      ? rolesOpcionales({
+          monto_credito_cotitular: venta.monto_credito_cotitular,
+          monto_credito_directo: venta.monto_credito_directo,
+          monto_nota_credito: venta.monto_nota_credito,
+          tipo_credito: venta.tipo_credito,
+        })
+      : new Set<string>();
+    const docsFaltantes = pipelineRows.flatMap((r) =>
+      r.faltantes
+        .filter((rol) => !opcionales.has(rol))
+        .map((rol) => ({ fase: r.nombre, rol, label: ROL_LABEL[rol] ?? rol }))
+    );
+    return evaluarCierre(
+      {
+        fases: pipelineRows.map((r) => ({ pos: r.pos, nombre: r.nombre, alcanzada: r.alcanzada })),
+        docsFaltantes,
+        saldoCliente: cuadratura.saldoCliente,
+        cubierta: venta?.valor_escrituracion == null ? null : cuadratura.cubierta,
+      },
+      (n) => moneyFmt.format(n)
+    );
+  }, [venta, pipelineRows, cuadratura]);
+
   if (loading) {
     return (
       <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
@@ -865,6 +851,23 @@ function DetailInner() {
         <BackLink />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
+        </div>
+      </div>
+    );
+  }
+
+  // Vendedor scoped: no puede abrir ventas de otros asesores.
+  if (
+    !scopeVendedor.loading &&
+    scopeVendedor.soloVendedor &&
+    venta.vendedor_usuario_id !== scopeVendedor.userId
+  ) {
+    return (
+      <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
+        <BackLink />
+        <div className="rounded-lg border border-amber-400/40 bg-amber-50 p-4 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+          Esta operación pertenece a otro asesor. Tu acceso está limitado a tus propios clientes y
+          ventas.
         </div>
       </div>
     );
@@ -1121,6 +1124,12 @@ function DetailInner() {
 
       {tab === 'operacion' ? (
         <div className="space-y-6">
+          <CopilotoCierre
+            resultado={copiloto}
+            ventaId={venta.id}
+            fase17Cerrada={pipelineRows.find((r) => r.pos === 17)?.alcanzada === true}
+            fecha17={pipelineRows.find((r) => r.pos === 17)?.fecha ?? null}
+          />
           <div className="flex flex-wrap gap-2">
             <PdfDownloadLink
               ventaId={venta.id}

--- a/app/dilesa/ventas/clientes/page.tsx
+++ b/app/dilesa/ventas/clientes/page.tsx
@@ -29,6 +29,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useScopeVendedorDilesa } from '@/lib/dilesa/use-scope-vendedor';
 import { RefreshCw, Search, Users } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
@@ -89,20 +90,29 @@ function VentasClientesBody() {
   const [search, setSearch] = useState('');
   const [proyectoFiltro, setProyectoFiltro] = useState('');
 
+  // Rol Vendedor: scoped a SUS clientes (los de sus propias ventas).
+  const scopeVendedor = useScopeVendedorDilesa();
+
   const cargar = useCallback(async () => {
+    if (scopeVendedor.loading) return;
     setLoading(true);
     setError(null);
     const sb = createSupabaseBrowserClient();
 
+    let ventasQuery = sb
+      .schema('dilesa')
+      .from('ventas')
+      .select(
+        'id, persona_id, unidad_id, estado, fase_actual, fase_posicion, precio_asignacion, valor_escrituracion, valor_comercial, created_at'
+      )
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .is('deleted_at', null);
+    if (scopeVendedor.soloVendedor && scopeVendedor.userId) {
+      ventasQuery = ventasQuery.eq('vendedor_usuario_id', scopeVendedor.userId);
+    }
+
     const [ventasRes, unidadesRes, prjRes, personasRes] = await Promise.all([
-      sb
-        .schema('dilesa')
-        .from('ventas')
-        .select(
-          'id, persona_id, unidad_id, estado, fase_actual, fase_posicion, precio_asignacion, valor_escrituracion, valor_comercial, created_at'
-        )
-        .eq('empresa_id', DILESA_EMPRESA_ID)
-        .is('deleted_at', null),
+      ventasQuery,
       sb
         .schema('dilesa')
         .from('unidades')
@@ -190,7 +200,7 @@ function VentasClientesBody() {
     rows.sort((a, b) => a.nombre.localeCompare(b.nombre));
     setClientes(rows);
     setLoading(false);
-  }, []);
+  }, [scopeVendedor]);
 
   useEffect(() => {
     void cargar();

--- a/components/dilesa/copiloto-cierre.tsx
+++ b/components/dilesa/copiloto-cierre.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+/**
+ * Copiloto de cierre (S4 dilesa-ventas-expediente) — tarjeta del Expediente
+ * de Operación que dice en lenguaje claro qué falta para terminar la
+ * operación, y habilita el cierre (F17) cuando todo está en orden.
+ *
+ * Presentational: el padre computa el `CopilotoResultado` con
+ * `evaluarCierre` (lib/dilesa/copiloto-cierre).
+ */
+
+import Link from 'next/link';
+import { CheckCircle2, ChevronRight, Circle, Flag, PartyPopper } from 'lucide-react';
+import type { CopilotoResultado } from '@/lib/dilesa/copiloto-cierre';
+
+export function CopilotoCierre({
+  resultado,
+  ventaId,
+  fase17Cerrada,
+  fecha17,
+}: {
+  resultado: CopilotoResultado;
+  ventaId: string;
+  /** Si la operación ya está terminada, el copiloto se vuelve el sello. */
+  fase17Cerrada: boolean;
+  fecha17: string | null;
+}) {
+  if (fase17Cerrada) {
+    return (
+      <section className="rounded-lg border border-emerald-400/40 bg-emerald-50 p-4 dark:bg-emerald-950/25">
+        <div className="flex items-center gap-2">
+          <PartyPopper className="size-5 text-emerald-600 dark:text-emerald-400" />
+          <h3 className="text-sm font-semibold text-emerald-900 dark:text-emerald-100">
+            Operación Terminada{fecha17 ? ` · ${fecha17}` : ''}
+          </h3>
+        </div>
+        <p className="mt-1 text-xs text-emerald-900/80 dark:text-emerald-100/80">
+          Expediente completo, cuadratura cubierta y conformidad del cliente registrada.
+        </p>
+      </section>
+    );
+  }
+
+  const completados = resultado.items.length - resultado.pendientes;
+
+  return (
+    <section
+      className={`rounded-lg border p-4 ${
+        resultado.listo
+          ? 'border-emerald-400/50 bg-emerald-50/60 dark:bg-emerald-950/20'
+          : 'border-[var(--border)] bg-[var(--card)]'
+      }`}
+    >
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h3 className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-[var(--text)]/60">
+          <Flag className="size-3.5" /> Copiloto de cierre
+        </h3>
+        <span className="text-[11px] font-medium tabular-nums text-[var(--text)]/55">
+          {completados}/{resultado.items.length}
+        </span>
+      </div>
+
+      <ul className="space-y-1.5">
+        {resultado.items.map((item) => (
+          <li key={item.label} className="flex items-start gap-2 text-sm">
+            {item.ok ? (
+              <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+            ) : (
+              <Circle className="mt-0.5 size-4 shrink-0 text-[var(--text)]/30" />
+            )}
+            <div className="min-w-0">
+              <span
+                className={item.ok ? 'text-[var(--text)]/70' : 'font-medium text-[var(--text)]'}
+              >
+                {item.label}
+              </span>
+              {item.detalle ? (
+                <p className="text-xs text-[var(--text)]/55">{item.detalle}</p>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {resultado.listo ? (
+        <Link
+          href={`/dilesa/ventas/${ventaId}/capturar/17-operacion-terminada`}
+          className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700"
+        >
+          Marcar Operación Terminada
+          <ChevronRight className="size-4" />
+        </Link>
+      ) : null}
+    </section>
+  );
+}

--- a/components/dilesa/ventas-module.tsx
+++ b/components/dilesa/ventas-module.tsx
@@ -13,6 +13,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { useScopeVendedorDilesa } from '@/lib/dilesa/use-scope-vendedor';
 import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
 import { Badge } from '@/components/ui/badge';
 import type { BadgeTone } from '@/components/ui/badge';
@@ -157,15 +158,21 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
   );
 
   // Fetch puro: regresa data o mensaje de error, NO toca state.
+  // Rol Vendedor: scoped a sus propias ventas (pedido de Beto).
+  const scopeVendedor = useScopeVendedorDilesa();
+
   const fetchVentas = useCallback(async (): Promise<{
     data?: VentaListaRow[];
     error?: string;
   }> => {
     const sb = createSupabaseBrowserClient();
+    // Mientras el scope del usuario resuelve, no mostramos nada (evita el
+    // flash de "todas las ventas" para un vendedor scoped).
+    if (scopeVendedor.loading) return { data: [] };
     // Sin embeds para evitar quirks de PostgREST cuando el nombre de la
     // tabla embebida existe en otros schemas (proyectos también en `erp`).
     // 4 queries: ventas + unidades + proyectos + personas (cross-schema).
-    const { data: rawVentas, error: vErr } = await sb
+    let ventasQuery = sb
       .schema('dilesa')
       .from('ventas')
       .select(
@@ -173,6 +180,10 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
       )
       .eq('empresa_id', empresaId)
       .is('deleted_at', null);
+    if (scopeVendedor.soloVendedor && scopeVendedor.userId) {
+      ventasQuery = ventasQuery.eq('vendedor_usuario_id', scopeVendedor.userId);
+    }
+    const { data: rawVentas, error: vErr } = await ventasQuery;
     if (vErr) {
       return { error: getSupabaseErrorMessage(vErr, 'No se pudieron cargar las ventas.') };
     }
@@ -282,7 +293,7 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
         };
       }),
     };
-  }, [empresaId]);
+  }, [empresaId, scopeVendedor]);
 
   // Botón refrescar: setState síncrono OK en event handler.
   const cargar = useCallback(async () => {

--- a/lib/dilesa/captura/fase-roles.ts
+++ b/lib/dilesa/captura/fase-roles.ts
@@ -1,0 +1,86 @@
+/**
+ * Catálogo documental del pipeline de ventas: qué adjuntos (roles) aporta
+ * cada fase, sus labels humanos, y cuáles son condicionales según los datos
+ * de la venta. Fuente única para el detalle (chips cargados/faltantes), el
+ * copiloto de cierre y la página de Operación Terminada (F17).
+ *
+ * Iniciativa dilesa-ventas-expediente (movido del detalle en S4).
+ */
+
+export const FASE_ROLES: Record<string, string[]> = {
+  'Solicitud de Asignación': ['solicitud_asignacion'],
+  Asignada: ['solicitud_asignacion', 'expediente_digital', 'ficu', 'aviso_privacidad'],
+  Formalizada: ['contrato_promesa'],
+  'Solicitud de Avalúo': [],
+  'Avalúo Cerrado': ['avaluo_comercial'],
+  // Beto: las Constancias de Crédito (titular + co-titular) van en Inscrita
+  // (el banco las entrega al inscribir el crédito). La Carta de instrucción
+  // notarial queda en Dictaminada (sale después con el dictamen jurídico).
+  Inscrita: ['constancia_credito_titular', 'constancia_credito_cotitular'],
+  'Solicitud de Dictaminación': ['aprobacion_credito'],
+  Dictaminada: ['carta_instruccion_notarial', 'condiciones_financieras'],
+  'Validación Patronal': ['validacion_patronal'],
+  'Firmas Programadas': [],
+  Escriturada: ['pagare'],
+  Detonada: ['imagen_detonacion'],
+  Facturada: ['factura', 'nota_credito', 'aviso_pld'],
+  'Preparada para Entrega': ['checklist_pre_entrega'],
+  Entregada: ['checklist_entrega'],
+  'Conformidad del Cliente': [],
+  'Operación Terminada': [],
+};
+
+export const ROL_LABEL: Record<string, string> = {
+  factura: 'Factura',
+  aprobacion_credito: 'Aprobación de crédito',
+  constancia_credito_titular: 'Constancia de crédito (titular)',
+  constancia_credito_cotitular: 'Constancia de crédito (co-titular)',
+  aviso_pld: 'Aviso PLD',
+  avaluo_comercial: 'Avalúo comercial',
+  contrato_promesa: 'Contrato promesa de compraventa',
+  solicitud_asignacion: 'Solicitud de asignación',
+  recibos_caja: 'Recibos de caja',
+  expediente_digital: 'Expediente digital',
+  ficu: 'FICU',
+  aviso_privacidad: 'Aviso de privacidad',
+  carta_instruccion_notarial: 'Carta instrucción notarial',
+  checklist_entrega: 'Checklist de entrega',
+  checklist_pre_entrega: 'Checklist pre-entrega',
+  validacion_patronal: 'Validación patronal',
+  nota_credito: 'Nota de crédito',
+  pagare: 'Pagaré',
+  imagen_detonacion: 'Imagen de detonación',
+  recibo_caja: 'Recibo de caja',
+};
+
+export type VentaFlagsDocs = {
+  monto_credito_cotitular: number | null;
+  monto_credito_directo: number | null;
+  monto_nota_credito: number | null;
+  tipo_credito: string | null;
+};
+
+/**
+ * Roles que NO se exigen para el cierre porque la venta no los amerita:
+ * - constancia co-titular: solo si hay crédito de co-titular.
+ * - pagaré: solo si hay crédito directo (CD).
+ * - nota de crédito: solo si el monto de nota de crédito es > 0.
+ * - condiciones financieras (Anexo B): formato INFONAVIT — en otros créditos
+ *   el notario no lo manda.
+ */
+export function rolesOpcionales(v: VentaFlagsDocs): Set<string> {
+  const opc = new Set<string>();
+  if (!v.monto_credito_cotitular || Number(v.monto_credito_cotitular) <= 0) {
+    opc.add('constancia_credito_cotitular');
+  }
+  if (!v.monto_credito_directo || Number(v.monto_credito_directo) <= 0) {
+    opc.add('pagare');
+  }
+  if (!v.monto_nota_credito || Number(v.monto_nota_credito) <= 0) {
+    opc.add('nota_credito');
+  }
+  if (!(v.tipo_credito ?? '').toLowerCase().includes('infonavit')) {
+    opc.add('condiciones_financieras');
+  }
+  return opc;
+}

--- a/lib/dilesa/copiloto-cierre.test.ts
+++ b/lib/dilesa/copiloto-cierre.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { evaluarCierre, type CopilotoInput } from './copiloto-cierre';
+import { rolesOpcionales } from './captura/fase-roles';
+
+const fasesCompletas = Array.from({ length: 17 }, (_, idx) => ({
+  pos: idx + 1,
+  nombre: `Fase ${idx + 1}`,
+  alcanzada: idx + 1 <= 16,
+}));
+
+const BASE: CopilotoInput = {
+  fases: fasesCompletas,
+  docsFaltantes: [],
+  saldoCliente: -276049.55,
+  cubierta: true,
+};
+
+describe('evaluarCierre', () => {
+  it('todo en orden → listo con 4 palomitas', () => {
+    const r = evaluarCierre(BASE);
+    expect(r.listo).toBe(true);
+    expect(r.pendientes).toBe(0);
+    expect(r.items.every((i) => i.ok)).toBe(true);
+  });
+
+  it('fases pendientes se listan con posición y nombre', () => {
+    const fases = BASE.fases.map((f) =>
+      f.pos === 9 || f.pos === 12 ? { ...f, alcanzada: false } : f
+    );
+    const r = evaluarCierre({ ...BASE, fases });
+    expect(r.listo).toBe(false);
+    expect(r.items[0]!.ok).toBe(false);
+    expect(r.items[0]!.detalle).toContain('9 · Fase 9');
+    expect(r.items[0]!.detalle).toContain('12 · Fase 12');
+  });
+
+  it('docs faltantes se enumeran por label', () => {
+    const r = evaluarCierre({
+      ...BASE,
+      docsFaltantes: [
+        { fase: 'Facturada', rol: 'factura', label: 'Factura' },
+        { fase: 'Escriturada', rol: 'pagare', label: 'Pagaré' },
+      ],
+    });
+    expect(r.items[1]!.ok).toBe(false);
+    expect(r.items[1]!.detalle).toContain('Faltan 2');
+    expect(r.items[1]!.detalle).toContain('Factura');
+  });
+
+  it('saldo pendiente muestra el monto; sin datos lo dice', () => {
+    const conSaldo = evaluarCierre({ ...BASE, cubierta: false, saldoCliente: 49000 });
+    expect(conSaldo.items[2]!.ok).toBe(false);
+    expect(conSaldo.items[2]!.detalle).toContain('49,000');
+
+    const sinDatos = evaluarCierre({ ...BASE, cubierta: null, saldoCliente: null });
+    expect(sinDatos.items[2]!.detalle).toContain('Sin datos');
+  });
+
+  it('fase 16 sin cerrar = conformidad pendiente', () => {
+    const fases = BASE.fases.map((f) => (f.pos === 16 ? { ...f, alcanzada: false } : f));
+    const r = evaluarCierre({ ...BASE, fases });
+    expect(r.items[3]!.ok).toBe(false);
+    expect(r.listo).toBe(false);
+  });
+});
+
+describe('rolesOpcionales (docs condicionales)', () => {
+  it('venta Infonavit simple sin CD ni nota: exime co-titular, pagaré y nota', () => {
+    const opc = rolesOpcionales({
+      monto_credito_cotitular: null,
+      monto_credito_directo: null,
+      monto_nota_credito: 0,
+      tipo_credito: 'Infonavit Tradicional',
+    });
+    expect(opc.has('constancia_credito_cotitular')).toBe(true);
+    expect(opc.has('pagare')).toBe(true);
+    expect(opc.has('nota_credito')).toBe(true);
+    expect(opc.has('condiciones_financieras')).toBe(false); // Infonavit SÍ lo exige
+  });
+
+  it('crédito bancario: exime el Anexo B', () => {
+    const opc = rolesOpcionales({
+      monto_credito_cotitular: 100000,
+      monto_credito_directo: 50000,
+      monto_nota_credito: 1000,
+      tipo_credito: 'Hipotecario',
+    });
+    expect(opc.has('condiciones_financieras')).toBe(true);
+    expect(opc.has('constancia_credito_cotitular')).toBe(false);
+    expect(opc.has('pagare')).toBe(false);
+    expect(opc.has('nota_credito')).toBe(false);
+  });
+});

--- a/lib/dilesa/copiloto-cierre.ts
+++ b/lib/dilesa/copiloto-cierre.ts
@@ -1,0 +1,103 @@
+/**
+ * Copiloto de cierre (S4 dilesa-ventas-expediente) — el motor puro que
+ * responde "¿qué falta para terminar la operación?" en lenguaje claro.
+ *
+ * 4 condiciones para Operación Terminada (F17):
+ *   1. Fases 1-16 cerradas.
+ *   2. Expediente documental completo (roles requeridos de FASE_ROLES,
+ *      descontando los opcionales que la venta no amerita — ver
+ *      `rolesOpcionales`).
+ *   3. Cuadratura cubierta (saldo del cliente ≤ 0 contra Valor de
+ *      Escrituración).
+ *   4. Conformidad del cliente registrada (la propia Fase 16 — la encuesta
+ *      respondida/capturada/sin-respuesta la cierra).
+ *
+ * La UI (componente CopilotoCierre + página F17) solo renderiza lo que este
+ * motor decide.
+ */
+
+export type CopilotoFase = {
+  pos: number;
+  nombre: string;
+  alcanzada: boolean;
+};
+
+export type CopilotoDocFaltante = {
+  fase: string;
+  rol: string;
+  label: string;
+};
+
+export type CopilotoInput = {
+  /** Las 17 fases en orden con su estado. */
+  fases: CopilotoFase[];
+  /** Docs requeridos que aún no están cargados (ya filtrados de opcionales). */
+  docsFaltantes: CopilotoDocFaltante[];
+  /** Saldo del cliente (Valor Escrituración − disponible). null = sin datos. */
+  saldoCliente: number | null;
+  /** Cuadratura cubierta (saldo ≤ 0). null = sin datos para evaluar. */
+  cubierta: boolean | null;
+};
+
+export type CopilotoItem = {
+  ok: boolean;
+  label: string;
+  detalle: string | null;
+};
+
+export type CopilotoResultado = {
+  items: CopilotoItem[];
+  listo: boolean;
+  pendientes: number;
+};
+
+export function evaluarCierre(
+  i: CopilotoInput,
+  fmtMoney?: (n: number) => string
+): CopilotoResultado {
+  const money = fmtMoney ?? ((n: number) => `$${n.toLocaleString('es-MX')}`);
+
+  const fasesPendientes = i.fases.filter((f) => f.pos <= 16 && !f.alcanzada);
+  const itemFases: CopilotoItem = {
+    ok: fasesPendientes.length === 0,
+    label: 'Pipeline completo (fases 1-16)',
+    detalle:
+      fasesPendientes.length === 0
+        ? null
+        : `Faltan: ${fasesPendientes.map((f) => `${f.pos} · ${f.nombre}`).join(', ')}`,
+  };
+
+  const itemDocs: CopilotoItem = {
+    ok: i.docsFaltantes.length === 0,
+    label: 'Expediente documental completo',
+    detalle:
+      i.docsFaltantes.length === 0
+        ? null
+        : `Faltan ${i.docsFaltantes.length}: ${i.docsFaltantes.map((d) => d.label).join(', ')}`,
+  };
+
+  const itemCuadratura: CopilotoItem = {
+    ok: i.cubierta === true,
+    label: 'Cuadratura cubierta',
+    detalle:
+      i.cubierta === true
+        ? null
+        : i.cubierta === null || i.saldoCliente == null
+          ? 'Sin datos suficientes (falta valor de escrituración o depósitos).'
+          : `Saldo del cliente: ${money(i.saldoCliente)}.`,
+  };
+
+  const fase16 = i.fases.find((f) => f.pos === 16);
+  const itemConformidad: CopilotoItem = {
+    ok: fase16?.alcanzada === true,
+    label: 'Conformidad del cliente registrada',
+    detalle:
+      fase16?.alcanzada === true
+        ? null
+        : 'La encuesta posventa no se ha respondido ni capturado (Fase 16).',
+  };
+
+  const items = [itemFases, itemDocs, itemCuadratura, itemConformidad];
+  const pendientes = items.filter((it) => !it.ok).length;
+  return { items, listo: pendientes === 0, pendientes };
+}

--- a/lib/dilesa/scope-vendedor.test.ts
+++ b/lib/dilesa/scope-vendedor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { esSoloVendedor } from './scope-vendedor';
+
+describe('esSoloVendedor', () => {
+  it('vendedor puro → scoped a sus ventas', () => {
+    expect(esSoloVendedor(['Vendedor'])).toBe(true);
+  });
+
+  it('vendedor que además es Gerencia/Dirección → ve todo', () => {
+    expect(esSoloVendedor(['Vendedor', 'Gerencia Ventas'])).toBe(false);
+    expect(esSoloVendedor(['Vendedor', 'Dirección'])).toBe(false);
+  });
+
+  it('roles amplios sin Vendedor → sin scope', () => {
+    expect(esSoloVendedor(['Dirección'])).toBe(false);
+    expect(esSoloVendedor(['Contabilidad'])).toBe(false);
+    expect(esSoloVendedor([])).toBe(false);
+  });
+
+  it('tolera acentos y mayúsculas distintas', () => {
+    expect(esSoloVendedor(['VENDEDOR'])).toBe(true);
+    expect(esSoloVendedor(['vendedor', 'direccion'])).toBe(false);
+    expect(esSoloVendedor(['Vendedor', 'Dirección'])).toBe(false);
+  });
+});

--- a/lib/dilesa/scope-vendedor.ts
+++ b/lib/dilesa/scope-vendedor.ts
@@ -1,0 +1,36 @@
+/**
+ * Scope de acceso del rol Vendedor en DILESA Ventas (pedido de Beto):
+ * un vendedor solo ve SUS clientes y SUS ventas.
+ *
+ * Implementación en capa app (consistente con el aislamiento de erp.* —
+ * la RLS de dilesa.* es por empresa, no por fila):
+ *   - Lista de ventas y clientes: filtro `vendedor_usuario_id = uid`.
+ *   - Detalle: guard que bloquea ventas ajenas.
+ *
+ * Regla: el scope aplica si el usuario tiene rol "Vendedor" en DILESA y NO
+ * tiene ninguno de los roles amplios (los que por su función ven todo).
+ * Admin global nunca queda bloqueado (política Beto 2026-06-10).
+ */
+
+/** Roles que ven todas las ventas de la empresa. */
+export const ROLES_AMPLIOS = [
+  'Dirección',
+  'Gerencia Ventas',
+  'Administración',
+  'Contabilidad',
+  'Obra',
+  'Comité',
+  'Accionista',
+  'Consejero',
+];
+
+const norm = (s: string): string => s.normalize('NFD').replace(/[̀-ͯ]/g, '').trim().toLowerCase();
+
+/** ¿El set de roles del usuario lo limita a ver solo sus propias ventas? */
+export function esSoloVendedor(roles: string[]): boolean {
+  const normalizados = roles.map(norm);
+  const esVendedor = normalizados.some((r) => r === 'vendedor');
+  if (!esVendedor) return false;
+  const amplios = new Set(ROLES_AMPLIOS.map(norm));
+  return !normalizados.some((r) => amplios.has(r));
+}

--- a/lib/dilesa/use-scope-vendedor.ts
+++ b/lib/dilesa/use-scope-vendedor.ts
@@ -1,0 +1,94 @@
+'use client';
+
+/**
+ * Hook: ¿el usuario actual está scoped a "solo sus ventas" en DILESA?
+ *
+ * Carga los roles del usuario en DILESA (core.usuarios_empresas → core.roles)
+ * y aplica `esSoloVendedor`. Admin global (core.usuarios.rol='admin') nunca
+ * queda scoped. Devuelve también el userId para armar los filtros
+ * (`vendedor_usuario_id = userId`).
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { esSoloVendedor } from './scope-vendedor';
+
+export type ScopeVendedor = {
+  loading: boolean;
+  /** true → filtrar lista/clientes y bloquear detalles ajenos. */
+  soloVendedor: boolean;
+  userId: string | null;
+};
+
+export function useScopeVendedorDilesa(): ScopeVendedor {
+  const sb = useMemo(() => createSupabaseBrowserClient(), []);
+  const [state, setState] = useState<ScopeVendedor>({
+    loading: true,
+    soloVendedor: false,
+    userId: null,
+  });
+
+  useEffect(() => {
+    let activo = true;
+    (async () => {
+      const {
+        data: { user },
+      } = await sb.auth.getUser();
+      if (!user) {
+        if (activo) setState({ loading: false, soloVendedor: false, userId: null });
+        return;
+      }
+
+      // Admin global → sin scope (política: admin nunca bloqueado).
+      const { data: coreUser } = await sb
+        .schema('core')
+        .from('usuarios')
+        .select('id, rol')
+        .eq('id', user.id)
+        .maybeSingle();
+      if (coreUser?.rol === 'admin') {
+        if (activo) setState({ loading: false, soloVendedor: false, userId: user.id });
+        return;
+      }
+
+      const { data: empresa } = await sb
+        .schema('core')
+        .from('empresas')
+        .select('id')
+        .eq('slug', 'dilesa')
+        .maybeSingle();
+      if (!empresa) {
+        if (activo) setState({ loading: false, soloVendedor: false, userId: user.id });
+        return;
+      }
+
+      const { data: ues } = await sb
+        .schema('core')
+        .from('usuarios_empresas')
+        .select('rol_id')
+        .eq('usuario_id', user.id)
+        .eq('empresa_id', empresa.id)
+        .eq('activo', true);
+      const rolIds = (ues ?? []).map((u) => u.rol_id).filter((x): x is string => !!x);
+
+      let roles: string[] = [];
+      if (rolIds.length > 0) {
+        const { data: rolesRows } = await sb
+          .schema('core')
+          .from('roles')
+          .select('nombre')
+          .in('id', rolIds);
+        roles = ((rolesRows ?? []) as { nombre: string }[]).map((r) => r.nombre);
+      }
+
+      if (activo) {
+        setState({ loading: false, soloVendedor: esSoloVendedor(roles), userId: user.id });
+      }
+    })();
+    return () => {
+      activo = false;
+    };
+  }, [sb]);
+
+  return state;
+}


### PR DESCRIPTION
Los 2 pendientes para cerrar la iniciativa `dilesa-ventas-expediente`:

## 1 · Copiloto de cierre (S4) + Fase 17

**Copiloto** en el tab Operación: checklist en lenguaje claro de las 4 condiciones para terminar la operación —

1. Pipeline completo (fases 1-16) — lista las pendientes
2. Expediente documental completo — lista los docs faltantes **descontando los que la venta no amerita** (constancia co-titular sin co-titular, pagaré sin crédito directo, nota de crédito en cero, Anexo B en créditos no-Infonavit)
3. Cuadratura cubierta — muestra el saldo si no
4. Conformidad del cliente registrada (F16)

Cuando todo está en verde aparece el CTA → **página F17** que re-verifica y habilita "Marcar Operación Terminada". Tras el cierre, el copiloto se convierte en el sello 🎉 con fecha. `FASE_ROLES`/`ROL_LABEL` movidos a lib (fuente única para detalle + F17).

## 2 · Scope del rol Vendedor (hallazgo de la verificación de Beto)

**No estaba implementado**: la RLS es por empresa y la lista no filtraba — cualquier usuario con el módulo veía todas las ventas. Hoy nadie tiene el rol Vendedor asignado (solo operan roles amplios), por eso no había mordido.

Ahora: usuario cuyo único rol DILESA es **Vendedor** → ve solo **sus ventas** (lista), **sus clientes** (tab Clientes) y no puede abrir detalles ajenos (guard con aviso). Roles amplios (Dirección, Gerencia Ventas, Administración, Contabilidad, Obra…) y admin ven todo. Capa app, mismo criterio que el aislamiento de `erp.*`.

## Tests

16 nuevos (motor del copiloto, docs condicionales, scope con acentos/combinaciones de roles). Sin migración.

## Validar en Preview

- ADALBERTO PRUEBA PRUEBA: el copiloto aparece arriba del pipeline con sus pendientes reales; ciérrale todo y mira el CTA habilitarse → F17 → sello.
- El scope se prueba en serio cuando asignes el rol Vendedor a un usuario de prueba (sin el rol, no cambia nada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)