### PR TITLE
fix(dilesa-ventas): pagaré de crédito directo — desglose de interés ordinario

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -39,6 +39,7 @@ import {
   PagareCreditoDirectoPDF,
   type PagareCreditoDirectoData,
 } from '@/lib/dilesa/pdf/pagare-credito-directo';
+import { desglosarPagare } from '@/lib/dilesa/pagare-interes';
 import { evaluarRiesgo } from '@/lib/dilesa/ficu/riesgo';
 import { formatMontoEnLetras } from '@/lib/format/numero-a-letras';
 import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
@@ -499,16 +500,31 @@ export async function GET(
       [emp?.domicilio_municipio, emp?.domicilio_estado].filter(Boolean).join(', ') ||
       'Piedras Negras, Coahuila';
 
-    const parcialidades = (Array.isArray(cd.cd_plan_pagos) ? cd.cd_plan_pagos : []).map((p, i) => ({
-      num: Number(p?.num ?? i + 1),
-      fechaTexto: fmtFechaLarga(p?.fecha ?? null),
-      montoFmt: money2.format(Number(p?.monto ?? 0)),
-    }));
-
     const tiie = cd.cd_tiie28_pct != null ? Number(cd.cd_tiie28_pct) : null;
     const spread = cd.cd_spread_moratorio_pct != null ? Number(cd.cd_spread_moratorio_pct) : 4;
     const tasaMoratoria = tiie != null ? Math.round((tiie + spread) * 100) / 100 : null;
     const fechaSuscripcion = cd.cd_fecha_suscripcion ?? new Date().toISOString().slice(0, 10);
+
+    // Desglose de interés ordinario por parcialidad (mismo motor que la
+    // preview de la fase 10 — lib/dilesa/pagare-interes.ts).
+    const ordinarioPct =
+      cd.cd_interes_ordinario_pct != null ? Number(cd.cd_interes_ordinario_pct) : 0;
+    const desglose = desglosarPagare(
+      (Array.isArray(cd.cd_plan_pagos) ? cd.cd_plan_pagos : []).map((p) => ({
+        fecha: p?.fecha ?? '',
+        monto: Number(p?.monto ?? 0),
+      })),
+      ordinarioPct,
+      fechaSuscripcion
+    );
+    const parcialidades = desglose.parcialidades.map((p) => ({
+      num: p.num,
+      fechaTexto: fmtFechaLarga(p.fecha || null),
+      montoFmt: money2.format(p.capital),
+      ...(ordinarioPct > 0
+        ? { interesFmt: money2.format(p.interes), pagoFmt: money2.format(p.pago) }
+        : {}),
+    }));
 
     const data: PagareCreditoDirectoData = {
       folio: `PG-${identificacionInventario || id}`,
@@ -525,6 +541,13 @@ export async function GET(
       montoTotalFmt: money2.format(montoTotal),
       montoTotalLetra: formatMontoEnLetras(montoTotal),
       parcialidades,
+      totalCapitalFmt: money2.format(desglose.totalCapital),
+      ...(ordinarioPct > 0
+        ? {
+            totalInteresFmt: money2.format(desglose.totalInteres),
+            totalPagarFmt: money2.format(desglose.totalPagar),
+          }
+        : {}),
       interesOrdinarioPct:
         cd.cd_interes_ordinario_pct != null ? Number(cd.cd_interes_ordinario_pct) : null,
       tiie28Pct: tiie,

--- a/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
@@ -36,6 +36,7 @@ import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
 import { marcarFase } from '@/lib/dilesa/captura/marcar-fase';
+import { desglosarPagare } from '@/lib/dilesa/pagare-interes';
 
 type PlanPagoJson = { num?: number; fecha?: string; monto?: number };
 
@@ -287,6 +288,19 @@ function CapturarFase10Body() {
   );
   const montoCDNum = Number(montoCD) || 0;
   const planCuadra = Math.abs(sumaPlan - montoCDNum) < 0.01 && montoCDNum > 0;
+
+  // Desglose de interés ordinario (mismo motor que el PDF del pagaré).
+  const ordinarioPct = Number(ordinario) || 0;
+  const desglose = useMemo(() => {
+    if (ordinarioPct <= 0) return null;
+    const filas = planPagos.filter((r) => r.fecha && Number(r.monto) > 0);
+    if (filas.length === 0) return null;
+    return desglosarPagare(
+      filas.map((r) => ({ fecha: r.fecha, monto: Number(r.monto) })),
+      ordinarioPct,
+      fechaSuscripcion || null
+    );
+  }, [planPagos, ordinarioPct, fechaSuscripcion]);
 
   // Cualquier edición del crédito directo invalida el "guardado" (hay que
   // re-guardar antes de generar el pagaré con datos frescos).
@@ -713,9 +727,53 @@ function CapturarFase10Body() {
                       : 'text-amber-700 dark:text-amber-300'
                   }`}
                 >
-                  Suma del plan: {money(sumaPlan)} / {money(montoCDNum)}{' '}
-                  {planCuadra ? '✓ cuadra' : '— debe igualar el monto del crédito'}
+                  Suma del plan (capital): {money(sumaPlan)} / {money(montoCDNum)}{' '}
+                  {planCuadra
+                    ? '✓ cuadra'
+                    : '— debe igualar el monto del crédito; el interés ordinario se calcula aparte'}
                 </p>
+
+                {desglose ? (
+                  <div className="mt-3 overflow-hidden rounded-md border border-[var(--border)]">
+                    <div className="border-b border-[var(--border)] bg-[var(--bg)]/40 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--text)]/60">
+                      Desglose con interés ordinario ({ordinarioPct}% anual, saldos insolutos, año
+                      de 360 días) — así saldrá en el pagaré
+                    </div>
+                    <table className="w-full text-xs">
+                      <thead>
+                        <tr className="text-[var(--text)]/50">
+                          <th className="px-3 py-1 text-left font-medium">No.</th>
+                          <th className="px-3 py-1 text-left font-medium">Vencimiento</th>
+                          <th className="px-3 py-1 text-right font-medium">Capital</th>
+                          <th className="px-3 py-1 text-right font-medium">Interés</th>
+                          <th className="px-3 py-1 text-right font-medium">Pago total</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {desglose.parcialidades.map((p) => (
+                          <tr key={p.num} className="border-t border-[var(--border)]/60">
+                            <td className="px-3 py-1">{p.num}</td>
+                            <td className="px-3 py-1">
+                              {p.fecha}
+                              <span className="ml-1 text-[var(--text)]/40">({p.dias} días)</span>
+                            </td>
+                            <td className="px-3 py-1 text-right">{money(p.capital)}</td>
+                            <td className="px-3 py-1 text-right">{money(p.interes)}</td>
+                            <td className="px-3 py-1 text-right font-medium">{money(p.pago)}</td>
+                          </tr>
+                        ))}
+                        <tr className="border-t border-[var(--border)] bg-[var(--bg)]/40 font-semibold">
+                          <td className="px-3 py-1.5" colSpan={2}>
+                            Total
+                          </td>
+                          <td className="px-3 py-1.5 text-right">{money(desglose.totalCapital)}</td>
+                          <td className="px-3 py-1.5 text-right">{money(desglose.totalInteres)}</td>
+                          <td className="px-3 py-1.5 text-right">{money(desglose.totalPagar)}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                ) : null}
               </div>
 
               {/* Intereses */}

--- a/docs/planning/dilesa-ventas-expediente.md
+++ b/docs/planning/dilesa-ventas-expediente.md
@@ -7,7 +7,7 @@
 **Próximo hito:** Verificación final de Beto + S6 (cutover Coda de ventas: paridad final, apagar daily ventas/expediente, cortar accesos de captura) → cierre de la iniciativa
 **Dueño:** Beto
 **Creada:** 2026-06-09
-**Última actualización:** 2026-06-11 (pipeline 17/17 + flag problema ZCU exenta 6% Fovissste)
+**Última actualización:** 2026-06-11 (problema ZCU + desglose de intereses en pagaré de crédito directo)
 
 ## Problema
 
@@ -218,6 +218,13 @@ expediente, copiloto), no reescritura.
   `zcu_exento`; UI de captura y detalle lo señalan. Mapeo agregado al import
   FULL de inventario (#816). Quedan 5 ventas activas capturadas con el 6%
   adentro (4 Fovissste + 1 Infonavit/Fovissste) — Beto decide si se corrigen.
+- **2026-06-11 (pagaré con intereses):** Reporte de Beto en prueba de fase 10:
+  el interés ordinario del crédito directo se capturaba pero nunca se
+  calculaba (solo cláusula de texto) y el pagaré no desglosaba. Motor nuevo
+  `lib/dilesa/pagare-interes.ts` (interés simple sobre saldos insolutos, año
+  comercial 360, redondeo por fila) + tests; el PDF ahora desglosa Capital /
+  Interés / Pago total por parcialidad con fila TOTAL, y la fase 10 muestra
+  preview en vivo del mismo motor antes de generar.
 
 ## Decisiones registradas
 
@@ -248,3 +255,10 @@ expediente, copiloto), no reescritura.
   flag vive en la unidad, no en la venta; la fuente de marcado sigue siendo
   Coda Inventario (botón "Registra Problema ZCU") mientras el módulo viva
   ahí. Ventas ya capturadas no se recalculan automáticamente.
+- **2026-06-11:** El plan de pagos del pagaré captura SOLO capital (la suerte
+  principal — el "Bueno por" del título no cambia); el interés ordinario se
+  deriva en runtime con convención mercantil mexicana: interés simple sobre
+  saldos insolutos, año comercial de 360 días, periodo desde la suscripción /
+  vencimiento anterior. No se persiste el desglose (es determinista de
+  fechas + tasa); UI y PDF comparten el motor. Si el abogado pide otra base
+  (p. ej. 365), se cambia en un solo lugar.

--- a/lib/dilesa/pagare-interes.test.ts
+++ b/lib/dilesa/pagare-interes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { desglosarPagare } from './pagare-interes';
+
+describe('desglosarPagare', () => {
+  it('tasa 0 → interés 0, totales = capital', () => {
+    const d = desglosarPagare(
+      [
+        { fecha: '2026-07-01', monto: 50000 },
+        { fecha: '2026-08-01', monto: 50000 },
+      ],
+      0,
+      '2026-06-01'
+    );
+    expect(d.totalCapital).toBe(100000);
+    expect(d.totalInteres).toBe(0);
+    expect(d.totalPagar).toBe(100000);
+    expect(d.parcialidades.every((p) => p.interes === 0)).toBe(true);
+  });
+
+  it('una sola exhibición a 30 días con 12% anual: interés = monto × 12% × 30/360', () => {
+    const d = desglosarPagare([{ fecha: '2026-07-01', monto: 120000 }], 12, '2026-06-01');
+    // 120,000 × 0.12 × 30/360 = 1,200
+    expect(d.parcialidades[0].dias).toBe(30);
+    expect(d.parcialidades[0].saldoInsoluto).toBe(120000);
+    expect(d.parcialidades[0].interes).toBe(1200);
+    expect(d.parcialidades[0].pago).toBe(121200);
+    expect(d.totalPagar).toBe(121200);
+  });
+
+  it('interés sobre saldos insolutos: el saldo baja con cada abono a capital', () => {
+    const d = desglosarPagare(
+      [
+        { fecha: '2026-07-01', monto: 60000 },
+        { fecha: '2026-07-31', monto: 60000 },
+      ],
+      12,
+      '2026-06-01'
+    );
+    // P1: 120,000 × 0.12 × 30/360 = 1,200
+    expect(d.parcialidades[0].saldoInsoluto).toBe(120000);
+    expect(d.parcialidades[0].interes).toBe(1200);
+    // P2: saldo 60,000 × 0.12 × 30/360 = 600
+    expect(d.parcialidades[1].saldoInsoluto).toBe(60000);
+    expect(d.parcialidades[1].dias).toBe(30);
+    expect(d.parcialidades[1].interes).toBe(600);
+    expect(d.totalCapital).toBe(120000);
+    expect(d.totalInteres).toBe(1800);
+    expect(d.totalPagar).toBe(121800);
+  });
+
+  it('ordena cronológicamente aunque se capturen en desorden y renumera', () => {
+    const d = desglosarPagare(
+      [
+        { fecha: '2026-08-01', monto: 30000 },
+        { fecha: '2026-07-01', monto: 70000 },
+      ],
+      12,
+      '2026-06-01'
+    );
+    expect(d.parcialidades[0].fecha).toBe('2026-07-01');
+    expect(d.parcialidades[0].num).toBe(1);
+    expect(d.parcialidades[0].capital).toBe(70000);
+    expect(d.parcialidades[1].fecha).toBe('2026-08-01');
+    expect(d.parcialidades[1].num).toBe(2);
+  });
+
+  it('el total de interés suma las filas ya redondeadas (cuadra con la tabla)', () => {
+    // Montos que generan fracciones de centavo por fila.
+    const d = desglosarPagare(
+      [
+        { fecha: '2026-07-13', monto: 33333.33 },
+        { fecha: '2026-08-13', monto: 33333.33 },
+        { fecha: '2026-09-13', monto: 33333.34 },
+      ],
+      10.5,
+      '2026-06-01'
+    );
+    const sumaFilas = d.parcialidades.reduce((s, p) => s + p.interes, 0);
+    expect(d.totalInteres).toBe(Math.round(sumaFilas * 100) / 100);
+    expect(d.totalPagar).toBe(d.totalCapital + d.totalInteres);
+  });
+
+  it('fila con fecha anterior a la suscripción no genera interés (defensivo)', () => {
+    const d = desglosarPagare([{ fecha: '2026-05-01', monto: 10000 }], 12, '2026-06-01');
+    expect(d.parcialidades[0].dias).toBe(0);
+    expect(d.parcialidades[0].interes).toBe(0);
+  });
+
+  it('sin fecha de suscripción → interés 0 (no hay periodo base)', () => {
+    const d = desglosarPagare([{ fecha: '2026-07-01', monto: 10000 }], 12, null);
+    expect(d.totalInteres).toBe(0);
+  });
+});

--- a/lib/dilesa/pagare-interes.ts
+++ b/lib/dilesa/pagare-interes.ts
@@ -1,0 +1,113 @@
+/**
+ * Motor de intereses ordinarios del pagaré de crédito directo (Fase 10).
+ *
+ * El plan de pagos captura SOLO capital (la suma debe igualar el monto del
+ * crédito — esa es la suerte principal del pagaré). El interés ordinario,
+ * cuando la tasa es > 0, se calcula aquí y se desglosa por parcialidad:
+ *
+ *   interés_k = saldo_insoluto_k × (tasa_anual/100) × días_k / 360
+ *
+ * donde saldo_insoluto_k es el capital aún no pagado al inicio del periodo k
+ * y días_k son los días naturales entre el vencimiento anterior (o la fecha
+ * de suscripción para la primera parcialidad) y el vencimiento k. Año
+ * comercial de 360 días — convención mercantil mexicana.
+ *
+ * Mismo motor para la preview de la UI (fase 10) y el PDF del pagaré: si
+ * cambia la convención (p. ej. base 365), se cambia en UN lugar y ambos
+ * quedan alineados.
+ */
+
+export type ParcialidadCapital = {
+  /** Fecha de vencimiento ISO `YYYY-MM-DD`. */
+  fecha: string;
+  /** Abono a capital de la parcialidad. */
+  monto: number;
+};
+
+export type ParcialidadDesglosada = {
+  num: number;
+  fecha: string;
+  capital: number;
+  /** Días naturales del periodo que genera el interés. */
+  dias: number;
+  /** Saldo insoluto sobre el que se calculó el interés del periodo. */
+  saldoInsoluto: number;
+  interes: number;
+  /** capital + interés. */
+  pago: number;
+};
+
+export type DesglosePagare = {
+  parcialidades: ParcialidadDesglosada[];
+  totalCapital: number;
+  totalInteres: number;
+  /** totalCapital + totalInteres. */
+  totalPagar: number;
+};
+
+const MS_DIA = 86_400_000;
+
+/** Días naturales entre dos fechas ISO (UTC-safe, sin DST). */
+function diasEntre(desdeIso: string, hastaIso: string): number {
+  const [y1, m1, d1] = desdeIso.split('-').map(Number);
+  const [y2, m2, d2] = hastaIso.split('-').map(Number);
+  if (!y1 || !m1 || !d1 || !y2 || !m2 || !d2) return 0;
+  return Math.round((Date.UTC(y2, m2 - 1, d2) - Date.UTC(y1, m1 - 1, d1)) / MS_DIA);
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+/**
+ * Desglosa el plan de pagos de capital en parcialidades con interés ordinario.
+ *
+ * - Las parcialidades se procesan en orden cronológico (se ordenan por fecha
+ *   de forma estable) y se renumeran 1..n.
+ * - Tasa 0 (o sin fecha de suscripción) → interés 0 en todas las filas; el
+ *   desglose sigue siendo útil para totales.
+ * - Filas sin fecha o con fecha anterior al inicio del periodo no generan
+ *   interés (días = 0) — la validación del form impide capturarlas, esto es
+ *   solo defensivo.
+ * - El interés se redondea a centavos por parcialidad; los totales suman las
+ *   filas ya redondeadas, de modo que el total SIEMPRE cuadra con la tabla.
+ */
+export function desglosarPagare(
+  plan: ParcialidadCapital[],
+  tasaAnualPct: number,
+  fechaSuscripcion: string | null
+): DesglosePagare {
+  const ordenadas = plan
+    .map((p, i) => ({ ...p, _i: i }))
+    .sort((a, b) => (a.fecha < b.fecha ? -1 : a.fecha > b.fecha ? 1 : a._i - b._i));
+
+  const tasa = Number.isFinite(tasaAnualPct) && tasaAnualPct > 0 ? tasaAnualPct : 0;
+  const totalCapital = round2(ordenadas.reduce((s, p) => s + (Number(p.monto) || 0), 0));
+
+  let saldo = totalCapital;
+  let inicioPeriodo = fechaSuscripcion;
+  const parcialidades: ParcialidadDesglosada[] = ordenadas.map((p, idx) => {
+    const capital = round2(Number(p.monto) || 0);
+    const dias =
+      tasa > 0 && inicioPeriodo && p.fecha ? Math.max(0, diasEntre(inicioPeriodo, p.fecha)) : 0;
+    const saldoInsoluto = round2(saldo);
+    const interes = round2(saldoInsoluto * (tasa / 100) * (dias / 360));
+    saldo = round2(saldo - capital);
+    if (p.fecha) inicioPeriodo = p.fecha;
+    return {
+      num: idx + 1,
+      fecha: p.fecha,
+      capital,
+      dias,
+      saldoInsoluto,
+      interes,
+      pago: round2(capital + interes),
+    };
+  });
+
+  const totalInteres = round2(parcialidades.reduce((s, p) => s + p.interes, 0));
+  return {
+    parcialidades,
+    totalCapital,
+    totalInteres,
+    totalPagar: round2(totalCapital + totalInteres),
+  };
+}

--- a/lib/dilesa/pdf/pagare-credito-directo.tsx
+++ b/lib/dilesa/pdf/pagare-credito-directo.tsx
@@ -19,7 +19,12 @@ import { HeaderBand, FooterBand, Watermark } from './header-footer';
 export type PagareParcialidad = {
   num: number;
   fechaTexto: string;
+  /** Abono a capital. */
   montoFmt: string;
+  /** Interés ordinario del periodo — solo cuando la tasa es > 0. */
+  interesFmt?: string;
+  /** Capital + interés — solo cuando la tasa es > 0. */
+  pagoFmt?: string;
 };
 
 export type PagareCreditoDirectoData = {
@@ -41,6 +46,10 @@ export type PagareCreditoDirectoData = {
   montoTotalFmt: string;
   montoTotalLetra: string;
   parcialidades: PagareParcialidad[];
+  /** Totales del plan — interés/pago presentes solo con tasa ordinaria > 0. */
+  totalCapitalFmt: string;
+  totalInteresFmt?: string;
+  totalPagarFmt?: string;
   // Intereses
   interesOrdinarioPct: number | null;
   tiie28Pct: number | null;
@@ -95,6 +104,22 @@ const local = StyleSheet.create({
   tdNum: { width: '15%', padding: 3, fontSize: 8.5 },
   tdFecha: { width: '45%', padding: 3, fontSize: 8.5 },
   tdMonto: { width: '40%', padding: 3, fontSize: 8.5, textAlign: 'right' },
+  // Variante con interés desglosado (5 columnas).
+  thNumI: { width: '8%', padding: 3, fontSize: 8.5, fontFamily: 'Helvetica-Bold' },
+  thFechaI: { width: '32%', padding: 3, fontSize: 8.5, fontFamily: 'Helvetica-Bold' },
+  thImpI: {
+    width: '20%',
+    padding: 3,
+    fontSize: 8.5,
+    fontFamily: 'Helvetica-Bold',
+    textAlign: 'right',
+  },
+  tdNumI: { width: '8%', padding: 3, fontSize: 8.5 },
+  tdFechaI: { width: '32%', padding: 3, fontSize: 8.5 },
+  tdImpI: { width: '20%', padding: 3, fontSize: 8.5, textAlign: 'right' },
+  trTotal: { flexDirection: 'row', backgroundColor: colors.bgSoft },
+  tdTotalLabel: { padding: 3, fontSize: 8.5, fontFamily: 'Helvetica-Bold' },
+  tdTotalMonto: { padding: 3, fontSize: 8.5, fontFamily: 'Helvetica-Bold', textAlign: 'right' },
   clausula: { fontSize: 8.3, lineHeight: 1.35, marginBottom: 5, textAlign: 'justify' },
   firmaWrap: { marginTop: 30, flexDirection: 'row', justifyContent: 'space-between' },
   firmaCol: { width: '46%', alignItems: 'center' },
@@ -147,26 +172,66 @@ export function PagareCreditoDirectoPDF({ data }: { data: PagareCreditoDirectoDa
           {data.parcialidades.length === 1 ? 'exhibición' : 'parcialidades'}, en las fechas y por
           los importes siguientes, siendo el lugar de pago el domicilio del beneficiario:
         </Text>
-        <View style={local.table}>
-          <View style={local.trHead}>
-            <Text style={local.thNum}>No.</Text>
-            <Text style={local.thFecha}>Fecha de vencimiento</Text>
-            <Text style={local.thMonto}>Importe</Text>
-          </View>
-          {data.parcialidades.map((p) => (
-            <View style={local.tr} key={p.num}>
-              <Text style={local.tdNum}>{p.num}</Text>
-              <Text style={local.tdFecha}>{p.fechaTexto}</Text>
-              <Text style={local.tdMonto}>{p.montoFmt}</Text>
+        {tieneOrdinario ? (
+          <View style={local.table}>
+            <View style={local.trHead}>
+              <Text style={local.thNumI}>No.</Text>
+              <Text style={local.thFechaI}>Fecha de vencimiento</Text>
+              <Text style={local.thImpI}>Capital</Text>
+              <Text style={local.thImpI}>Interés ordinario</Text>
+              <Text style={local.thImpI}>Pago total</Text>
             </View>
-          ))}
-        </View>
+            {data.parcialidades.map((p) => (
+              <View style={local.tr} key={p.num}>
+                <Text style={local.tdNumI}>{p.num}</Text>
+                <Text style={local.tdFechaI}>{p.fechaTexto}</Text>
+                <Text style={local.tdImpI}>{p.montoFmt}</Text>
+                <Text style={local.tdImpI}>{p.interesFmt ?? '—'}</Text>
+                <Text style={local.tdImpI}>{p.pagoFmt ?? p.montoFmt}</Text>
+              </View>
+            ))}
+            <View style={local.trTotal}>
+              <Text style={[local.tdTotalLabel, { width: '40%' }]}>TOTAL</Text>
+              <Text style={[local.tdTotalMonto, { width: '20%' }]}>{data.totalCapitalFmt}</Text>
+              <Text style={[local.tdTotalMonto, { width: '20%' }]}>
+                {data.totalInteresFmt ?? '—'}
+              </Text>
+              <Text style={[local.tdTotalMonto, { width: '20%' }]}>
+                {data.totalPagarFmt ?? data.totalCapitalFmt}
+              </Text>
+            </View>
+          </View>
+        ) : (
+          <View style={local.table}>
+            <View style={local.trHead}>
+              <Text style={local.thNum}>No.</Text>
+              <Text style={local.thFecha}>Fecha de vencimiento</Text>
+              <Text style={local.thMonto}>Importe</Text>
+            </View>
+            {data.parcialidades.map((p) => (
+              <View style={local.tr} key={p.num}>
+                <Text style={local.tdNum}>{p.num}</Text>
+                <Text style={local.tdFecha}>{p.fechaTexto}</Text>
+                <Text style={local.tdMonto}>{p.montoFmt}</Text>
+              </View>
+            ))}
+            <View style={local.trTotal}>
+              <Text style={[local.tdTotalLabel, { width: '60%' }]}>TOTAL</Text>
+              <Text style={[local.tdTotalMonto, { width: '40%' }]}>{data.totalCapitalFmt}</Text>
+            </View>
+          </View>
+        )}
 
         {tieneOrdinario ? (
           <Text style={local.clausula}>
             <Text style={local.bold}>INTERÉS ORDINARIO. </Text>La suerte principal generará un
-            interés ordinario a razón del {data.interesOrdinarioPct}% anual, pagadero junto con cada
-            parcialidad.
+            interés ordinario a razón del {data.interesOrdinarioPct}% anual, calculado sobre saldos
+            insolutos sobre la base de un año comercial de 360 días, pagadero junto con cada
+            parcialidad conforme al desglose de la tabla anterior
+            {data.totalInteresFmt && data.totalPagarFmt
+              ? `; los intereses ordinarios del plan ascienden a ${data.totalInteresFmt}, para un total a pagar de ${data.totalPagarFmt}`
+              : ''}
+            .
           </Text>
         ) : null}
 


### PR DESCRIPTION
## Qué arregla

Reporte de Beto en una venta de prueba (fase 10): capturó **interés ordinario** en el crédito directo y el pagaré **no desglosaba los intereses** — la tasa solo aparecía como cláusula de texto, nunca se calculaba — y el total no cuadraba contra lo esperado.

## Cambios

- **`lib/dilesa/pagare-interes.ts`** (motor puro + 7 tests): interés simple sobre **saldos insolutos**, año comercial de **360 días** (convención mercantil MX), periodo desde la suscripción/vencimiento anterior. Interés redondeado a centavos por fila; los totales suman filas ya redondeadas → **el total siempre cuadra con la tabla**.
- **PDF del pagaré**: con tasa > 0 la tabla desglosa **Capital / Interés ordinario / Pago total** por parcialidad + fila **TOTAL**; la cláusula de interés ordinario explicita la convención y los totales. Sin tasa, la tabla queda como antes pero ahora con fila TOTAL. El "Bueno por" sigue siendo la suerte principal (capital) — correcto para el título de crédito.
- **Fase 10 (UI)**: preview en vivo del desglose con el **mismo motor** debajo del plan de pagos; el label del cuadre aclara que valida **capital** ("el interés ordinario se calcula aparte").

El plan sigue capturando solo capital — no cambia el modelo de datos ni `cd_plan_pagos`.

## Verificación

- 7 tests del motor (tasa 0, exhibición única, saldos insolutos, desorden cronológico, redondeos, fechas defensivas).
- Suite completa: 118 files / 1,566 tests verdes + typecheck + lint + format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)