### PR TITLE
fix(rdb): dropdown de unidad también en la receta inline del drawer de producto

### DIFF
--- a/app/rdb/productos/page.tsx
+++ b/app/rdb/productos/page.tsx
@@ -372,7 +372,7 @@ export default function ProductosPage() {
       }
       if (ins.data) {
         setInsumosDisponibles(
-          ins.data.map((i) => ({ id: i.id, nombre: i.nombre, unidad: i.unidad ?? 'pieza' }))
+          ins.data.map((i) => ({ id: i.id, nombre: i.nombre, unidad: i.unidad || UNIDAD_DEFAULT }))
         );
       }
       setRecetaLoading(false);
@@ -827,7 +827,18 @@ export default function ProductosPage() {
                             className="w-24 text-right"
                             aria-label={`Cantidad de ${row.insumo_nombre}`}
                           />
-                          <div className="w-16 text-xs text-muted-foreground">{row.unidad}</div>
+                          <Combobox
+                            value={row.unidad}
+                            onChange={(v) =>
+                              setRecetaRows((rows) =>
+                                rows.map((r, i) => (i === idx ? { ...r, unidad: v } : r))
+                              )
+                            }
+                            options={unidadOptions(row.unidad)}
+                            className="w-32"
+                            size="sm"
+                            aria-label={`Unidad de ${row.insumo_nombre}`}
+                          />
                           <Button
                             variant="ghost"
                             size="icon"


### PR DESCRIPTION
Reporte de Beto tras #822: al agregar un insumo en la receta desde el drawer **Configurar Producto**, la unidad seguía siendo texto estático — el dropdown solo quedó en el campo Unidad del producto y en el editor de la tab Recetas.

- La fila de receta inline ahora usa el mismo `Combobox` con el catálogo canónico de `lib/unidades.ts` (editable por línea, igual que `recetas-editor`).
- Fallback de unidad al cargar insumos disponibles cubre string vacío además de null (`||` en vez de `??`).

Verificación: 6 checks de CI en local ✓ (typecheck, coverage 1572 tests, lint, format, initiatives, schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)