### PR TITLE
feat(dilesa-ventas): botones de PDF gateados por fase (Promesa F2+, Póliza F9+)

### DIFF
--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -1170,11 +1170,15 @@ function DetailInner() {
               label="Aviso de Privacidad"
             />
             <PdfDownloadLink ventaId={venta.id} tipo="ficu" label="FICU" />
-            <PdfDownloadLink
-              ventaId={venta.id}
-              tipo="promesa-compraventa"
-              label="Promesa de Compraventa"
-            />
+            {/* La promesa se imprime para firmarse en F3 — solo desde que la
+                unidad quedó asignada (F2 autorizada). */}
+            {(venta.fase_posicion ?? 0) >= 2 ? (
+              <PdfDownloadLink
+                ventaId={venta.id}
+                tipo="promesa-compraventa"
+                label="Promesa de Compraventa"
+              />
+            ) : null}
             {venta.valuador_id ? (
               <PdfDownloadLink
                 ventaId={venta.id}
@@ -1189,7 +1193,9 @@ function DetailInner() {
                 label="Solicitud de Dictaminación"
               />
             ) : null}
-            {venta.unidad_id ? (
+            {/* La póliza se entrega ya con el crédito validado — desde que la
+                Validación Patronal (F9) quedó cerrada. */}
+            {venta.unidad_id && (venta.fase_posicion ?? 0) >= 9 ? (
               <PdfDownloadLink
                 ventaId={venta.id}
                 tipo="poliza-garantia"

--- a/content/manual/dilesa/ventas/expediente.md
+++ b/content/manual/dilesa/ventas/expediente.md
@@ -85,6 +85,12 @@ queda registrada en la Bitácora. Avísale a tu gerente.
 Es un documento que esa fase espera y todavía no se sube. Al subirlo (en la
 pantalla de captura de la fase) el chip se vuelve clickeable.
 
+**No veo el botón para imprimir la Promesa de Compraventa (o la Póliza).**
+Los botones de impresión aparecen cuando la venta llega a la fase que les
+toca: la **Promesa de Compraventa** desde que la unidad queda **Asignada**
+(fase 2), la **Póliza de Garantía** desde la **Validación Patronal** (fase 9),
+y los checklists de entrega desde la Escritura (fase 11).
+
 ## Si algo no cuadra
 
 Si el saldo de la cuadratura no baja con un depósito que sí se hizo, revisa


### PR DESCRIPTION
## Qué hace

En el Expediente de Operación, dos botones de impresión aparecían desde el día uno de la venta; ahora respetan el proceso:

- **Promesa de Compraventa** — visible desde que la unidad queda **Asignada** (fase 2 autorizada). Es el contrato que se firma en F3; antes de la autorización no debe imprimirse.
- **Póliza de Garantía** — visible desde que cierra la **Validación Patronal** (fase 9).

Mismo patrón `fase_posicion >= N` que ya usan los checklists de entrega (F11/F14). Las pantallas de captura F3/F10 que también enlazan estos PDFs ya cumplen el gate por construcción (solo se alcanzan con la fase previa cerrada).

Extra: FAQ del manual del expediente explica cuándo aparece cada botón.

## Checks

6/6 verdes local (typecheck · 1,577 tests · lint · format · initiatives · schema sin drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)