### PR TITLE
fix(dilesa-ventas): FICU con campos KYC de ventas Coda + backfill a erp.personas

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -102,7 +102,7 @@ export async function GET(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, created_at, ine_numero, estado, valuador_id, notario_id'
+      'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, created_at, ine_numero, estado, valuador_id, notario_id, es_pep, ocupacion, forma_pago, uso_efectivo, conocimiento_dueno_beneficiario'
     )
     .eq('id', id)
     .is('deleted_at', null)
@@ -136,6 +136,17 @@ export async function GET(
     [persona?.nombre, persona?.apellido_paterno, persona?.apellido_materno]
       .filter(Boolean)
       .join(' ') || '(sin nombre)';
+
+  // KYC efectivo: el form de captura persiste estos campos en erp.personas,
+  // pero las ventas importadas de Coda los traen per-venta en dilesa.ventas
+  // y nunca poblaron la persona. Gana la fuente con dato (persona primero).
+  // PEP es OR de ambas fuentes: nunca degradar un true.
+  const kycOcupacion = persona?.ocupacion ?? venta.ocupacion ?? null;
+  const kycFormaPago = persona?.forma_pago_kyc ?? venta.forma_pago ?? null;
+  const kycUsoEfectivo = persona?.uso_efectivo_kyc ?? venta.uso_efectivo ?? null;
+  const kycConocimientoDB =
+    persona?.conocimiento_dueno_beneficiario ?? venta.conocimiento_dueno_beneficiario ?? null;
+  const kycEsPep = Boolean(persona?.es_pep || venta.es_pep);
 
   // Vendedor (asesor de ventas) — el form persiste `vendedor_usuario_id`
   // (FK a core.usuarios); el campo legacy `venta.vendedor` (text) puede
@@ -670,7 +681,7 @@ export async function GET(
         curp: persona?.curp ?? null,
         rfc: persona?.rfc ?? null,
         estadoCivil: null, // TODO sprint-7c: capturar estado civil en form
-        profesion: persona?.ocupacion ?? null,
+        profesion: kycOcupacion,
         domicilio: persona?.domicilio ?? null,
         ineNumero: venta.ine_numero ?? null,
       },
@@ -705,15 +716,12 @@ export async function GET(
   }
 
   if (tipo === 'ficu') {
-    // KYC fields viven en erp.personas (Sprint 7c-2). El form de Solicitud
-    // los persiste ahí, no en dilesa.ventas. Leer desde persona evita el
-    // bug de "FICU vacío" cuando los fields de la venta nunca se poblaron.
     const riesgo = evaluarRiesgo({
       tipoPersona: persona?.tipo_persona,
       nacionalidad: persona?.nacionalidad,
-      esPep: persona?.es_pep,
-      formaPago: persona?.forma_pago_kyc,
-      usoEfectivo: persona?.uso_efectivo_kyc,
+      esPep: kycEsPep,
+      formaPago: kycFormaPago,
+      usoEfectivo: kycUsoEfectivo,
     });
     const fechaNac = persona?.fecha_nacimiento
       ? new Date(`${persona.fecha_nacimiento}T12:00:00`).toLocaleDateString('es-MX', {
@@ -742,11 +750,11 @@ export async function GET(
       correo: persona?.email ?? '',
       personalidad: (persona?.tipo_persona ?? 'persona física').toUpperCase(),
       nacionalidad: (persona?.nacionalidad ?? '').toUpperCase(),
-      esPep: !!persona?.es_pep,
-      formaPago: (persona?.forma_pago_kyc ?? '').toUpperCase(),
-      usoEfectivo: (persona?.uso_efectivo_kyc ?? '').toUpperCase(),
-      ocupacion: (persona?.ocupacion ?? '').toUpperCase(),
-      conocimientoDuenoBeneficiario: persona?.conocimiento_dueno_beneficiario ?? '—',
+      esPep: kycEsPep,
+      formaPago: (kycFormaPago ?? '').toUpperCase(),
+      usoEfectivo: (kycUsoEfectivo ?? '').toUpperCase(),
+      ocupacion: (kycOcupacion ?? '').toUpperCase(),
+      conocimientoDuenoBeneficiario: kycConocimientoDB ?? '—',
       criteriosRiesgo: riesgo.criterios,
       scoreTotal: riesgo.scoreTotal,
       clasificacionRiesgo: riesgo.clasificacion,

--- a/supabase/migrations/20260611181150_backfill_kyc_personas_desde_ventas.sql
+++ b/supabase/migrations/20260611181150_backfill_kyc_personas_desde_ventas.sql
@@ -1,0 +1,66 @@
+-- ╭─ 20260611181150_backfill_kyc_personas_desde_ventas ─╮
+-- Backfill KYC: erp.personas ← dilesa.ventas (ventas importadas de Coda).
+--
+-- El import de Coda (import_dilesa_ventas.ts) guardó los campos KYC del
+-- FICU per-venta en dilesa.ventas (ocupacion, forma_pago, uso_efectivo,
+-- conocimiento_dueno_beneficiario, es_pep); el modelo actual (Sprint 7c-2)
+-- los lee de erp.personas, donde quedaron NULL para esas ~835 ventas y el
+-- FICU/promesa salían con los campos en blanco.
+--
+-- Política:
+--   * Solo rellena NULLs en la persona — nunca pisa un valor capturado.
+--   * Si la persona tiene varias ventas activas, gana el valor más
+--     reciente por campo (hoy no hay conflictos: 0 personas con valores
+--     distintos entre ventas).
+--   * es_pep es OR de todas las ventas activas: 45 ventas Coda traen
+--     PEP=true y la persona quedó en false por DEFAULT de columna;
+--     elevar false→true es lo conservador (LFPIORPI), nunca degradar.
+--
+-- Idempotente. En Supabase Preview (sin datos de prod) actualiza 0 filas.
+--
+-- Timestamp generado con `npm run db:new` (anti-colisión multi-sesión:
+-- estrictamente mayor que toda migración local + de PRs abiertos).
+
+BEGIN;
+
+UPDATE erp.personas p
+SET
+  ocupacion = COALESCE(p.ocupacion, vk.ocupacion),
+  forma_pago_kyc = COALESCE(p.forma_pago_kyc, vk.forma_pago),
+  uso_efectivo_kyc = COALESCE(p.uso_efectivo_kyc, vk.uso_efectivo),
+  conocimiento_dueno_beneficiario = COALESCE(
+    p.conocimiento_dueno_beneficiario,
+    vk.conocimiento_dueno_beneficiario
+  ),
+  es_pep = (COALESCE(p.es_pep, false) OR vk.alguna_pep),
+  updated_at = now()
+FROM (
+  SELECT
+    v.persona_id,
+    (ARRAY_AGG(v.ocupacion ORDER BY v.created_at DESC)
+       FILTER (WHERE v.ocupacion IS NOT NULL))[1] AS ocupacion,
+    (ARRAY_AGG(v.forma_pago ORDER BY v.created_at DESC)
+       FILTER (WHERE v.forma_pago IS NOT NULL))[1] AS forma_pago,
+    (ARRAY_AGG(v.uso_efectivo ORDER BY v.created_at DESC)
+       FILTER (WHERE v.uso_efectivo IS NOT NULL))[1] AS uso_efectivo,
+    (ARRAY_AGG(v.conocimiento_dueno_beneficiario ORDER BY v.created_at DESC)
+       FILTER (WHERE v.conocimiento_dueno_beneficiario IS NOT NULL))[1]
+      AS conocimiento_dueno_beneficiario,
+    BOOL_OR(COALESCE(v.es_pep, false)) AS alguna_pep
+  FROM dilesa.ventas v
+  WHERE v.deleted_at IS NULL
+  GROUP BY v.persona_id
+) vk
+WHERE vk.persona_id = p.id
+  AND (
+    (p.ocupacion IS NULL AND vk.ocupacion IS NOT NULL)
+    OR (p.forma_pago_kyc IS NULL AND vk.forma_pago IS NOT NULL)
+    OR (p.uso_efectivo_kyc IS NULL AND vk.uso_efectivo IS NOT NULL)
+    OR (
+      p.conocimiento_dueno_beneficiario IS NULL
+      AND vk.conocimiento_dueno_beneficiario IS NOT NULL
+    )
+    OR (vk.alguna_pep AND NOT COALESCE(p.es_pep, false))
+  );
+
+COMMIT;


### PR DESCRIPTION
## Problema

Reporte de operación: el FICU de un cliente (Cristian Nieto, venta importada de Coda) sale con **Forma de Pago, Uso de Efectivo y Ocupación en blanco**, aunque la pantalla de detalle de la venta sí los muestra.

**Causa raíz**: el import de Coda (`import_dilesa_ventas.ts`) guardó los campos KYC per-venta en `dilesa.ventas`; el PDF del FICU (Sprint 7c-2) los lee solo de `erp.personas`, donde quedaron NULL para **~835 de 1,439 ventas activas**. La pantalla lee la venta → por eso "en el sistema sí aparece".

**Efecto colateral**: el EBR aplicaba el default defensivo *Medio* en Forma de Pago (13.33% vs 6.67%) → clasificación de riesgo inflada en un documento LFPIORPI (el caso reportado marcaba 40.01% Medio cuando con el dato real es Bajo).

## Fix (2 piezas)

1. **Route PDF** (`app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx`): KYC efectivo = `persona.* ?? venta.*` — la fuente con dato gana; PEP es OR de ambas (nunca degradar un true). Aplica al FICU (datos + EBR) y a la promesa (profesión).
2. **Migración data-only** (`20260611181150`): backfill de NULLs en `erp.personas` desde la venta activa más reciente por campo. `es_pep` eleva false→true para las 45 ventas PEP de Coda (la persona quedó en false por DEFAULT de columna). Idempotente; en Preview (sin datos) actualiza 0 filas.

## Verificación

- Caso real verificado en prod: venta con `forma_pago='FINANCIAMIENTO HIPOTECARIO'` / persona con `forma_pago_kyc=NULL`.
- 0 personas con valores KYC conflictivos entre sus ventas (la política "más reciente gana" no tiene casos límite hoy).
- 6 checks de CI locales en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)