### PR TITLE
feat(ui): el detalle expone el set completo de acciones (ADR-044)

### DIFF
--- a/app/rdb/inventario/page.tsx
+++ b/app/rdb/inventario/page.tsx
@@ -167,6 +167,8 @@ function InventarioStockBody() {
   const [selectedItem, setSelectedItem] = useState<StockItem | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  // Producto pre-seleccionado al abrir el registro desde el drawer de detalle.
+  const [movimientoProductoId, setMovimientoProductoId] = useState<string | undefined>(undefined);
 
   const fetchStock = useCallback(async () => {
     setLoadingStock(true);
@@ -443,13 +445,22 @@ function InventarioStockBody() {
           item={selectedItem}
           open={drawerOpen}
           onClose={() => setDrawerOpen(false)}
+          onRegistrarMovimiento={(item) => {
+            setDrawerOpen(false);
+            setMovimientoProductoId(item.id);
+            setDialogOpen(true);
+          }}
         />
 
         <RegistrarMovimientoDialog
           open={dialogOpen}
-          onClose={() => setDialogOpen(false)}
+          onClose={() => {
+            setDialogOpen(false);
+            setMovimientoProductoId(undefined);
+          }}
           productos={items}
           onSuccess={handleSuccess}
+          defaultProductoId={movimientoProductoId}
         />
       </div>
     </>

--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -510,6 +510,8 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
         throw e; // mantiene abierto el diálogo de motivo
       }
       toast.add({ title: 'Cotización cancelada', description: c.codigo, type: 'success' });
+      // Si la cancelada era la captura abierta, ciérrala (quedaría editable en falso).
+      setCapturaId((cur) => (cur === c.id ? null : cur));
       void cargar();
     },
     [toast, cargar]
@@ -852,6 +854,7 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
             void cargar();
           }}
           onRefresh={() => void cargar()}
+          onCancelarCotizacion={() => setCancelarCot(enCaptura)}
         />
       ) : null}
 
@@ -898,6 +901,7 @@ function CapturaPrecios({
   onClose,
   onSaved,
   onRefresh,
+  onCancelarCotizacion,
 }: {
   cotizacion: CotizacionRow;
   empresaId: string;
@@ -907,6 +911,8 @@ function CapturaPrecios({
   onClose: () => void;
   onSaved: () => void;
   onRefresh: () => void;
+  /** Cancela la RFQ desde el detalle — misma acción que la X de la fila (ADR-044). */
+  onCancelarCotizacion: () => void;
 }) {
   const toast = useToast();
   const [saving, setSaving] = useState(false);
@@ -1485,14 +1491,26 @@ function CapturaPrecios({
         </div>
       ) : null}
 
-      <div className="mt-4 flex items-center justify-end gap-2">
-        <Button variant="outline" onClick={onClose} disabled={saving}>
-          Cerrar
-        </Button>
-        <Button onClick={guardar} disabled={saving || !puedeEscribir}>
-          {saving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
-          Guardar precios
-        </Button>
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        {puedeEscribir && (cotizacion.estado === 'abierta' || cotizacion.estado === 'comparada') ? (
+          <Button
+            variant="ghost"
+            onClick={onCancelarCotizacion}
+            disabled={saving}
+            className="text-[var(--text)]/60 hover:text-red-600"
+          >
+            <X className="size-4" /> Cancelar cotización
+          </Button>
+        ) : null}
+        <div className="ml-auto flex items-center gap-2">
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cerrar
+          </Button>
+          <Button onClick={guardar} disabled={saving || !puedeEscribir}>
+            {saving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Guardar precios
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/components/compras/ordenes-compra-module.tsx
+++ b/components/compras/ordenes-compra-module.tsx
@@ -26,6 +26,7 @@ import {
   DetailDrawerSection,
 } from '@/components/detail-page/detail-drawer';
 import { HiloGastoStepper } from '@/components/gasto/hilo-gasto-stepper';
+import { CancelarConMotivoDialog } from '@/components/shared/cancelar-con-motivo-dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge, type BadgeTone } from '@/components/ui/badge';
@@ -130,6 +131,7 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
 
   const [detalle, setDetalle] = useState<OcRow | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [cancelarOcRow, setCancelarOcRow] = useState<OcRow | null>(null);
 
   // Drill-down (?focus=<oc_id>) desde el hilo del gasto de otros módulos.
   useFocusDrilldown(
@@ -348,6 +350,13 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
     });
   }, [rows, q, proyectoFiltro]);
 
+  // El drawer lee la fila viva: tras una acción (enviar / cerrar) el refetch
+  // actualiza `rows` y el detalle abierto refleja el estado nuevo.
+  const detalleActual = useMemo(
+    () => (detalle ? (rows.find((r) => r.id === detalle.id) ?? detalle) : null),
+    [rows, detalle]
+  );
+
   const kpisData = useMemo(() => deriveOcKpis(filtrados), [filtrados]);
   const kpis: ModuleKpi[] = [
     { key: 'total', label: 'Órdenes', value: kpisData.total === 0 ? '—' : String(kpisData.total) },
@@ -546,7 +555,7 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
   );
 
   const cancelar = useCallback(
-    async (oc: OcRow, motivo: string) => {
+    async (oc: OcRow, motivo: string): Promise<boolean> => {
       const sb = createSupabaseBrowserClient();
       const ahora = new Date().toISOString();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -565,10 +574,11 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
           description: getSupabaseErrorMessage(e, 'No se pudo cancelar.'),
           type: 'error',
         });
-        return;
+        return false;
       }
       toast.add({ title: 'Orden cancelada', description: oc.codigo, type: 'success' });
       void cargar();
+      return true;
     },
     [toast, cargar]
   );
@@ -636,7 +646,9 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
                 onDelete={
                   r.estado === 'borrador' || r.estado === 'enviada'
                     ? {
-                        onConfirm: (motivo) => cancelar(r, motivo ?? ''),
+                        onConfirm: async (motivo) => {
+                          await cancelar(r, motivo ?? '');
+                        },
                         label: 'Cancelar OC',
                         confirmTitle: `¿Cancelar ${r.codigo}?`,
                         confirmDescription:
@@ -904,7 +916,33 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
         maxHeight="calc(100vh - 320px)"
       />
 
-      <OcDetalleDrawer oc={detalle} open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+      <OcDetalleDrawer
+        oc={detalleActual}
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        puedeEscribir={puedeEscribir}
+        onEditar={(r) => {
+          setDrawerOpen(false);
+          abrirEdicionOc(r);
+        }}
+        onMarcarEnviada={(r) => void cambiarEstado(r, 'enviada', 'Orden enviada')}
+        onCerrarOrden={(r) => void cerrar(r)}
+        onCancelar={(r) => setCancelarOcRow(r)}
+      />
+
+      {cancelarOcRow ? (
+        <CancelarConMotivoDialog
+          key={cancelarOcRow.id}
+          title={`¿Cancelar ${cancelarOcRow.codigo}?`}
+          description="La orden quedará cancelada y dejará de comprometer presupuesto."
+          confirmLabel="Cancelar OC"
+          onClose={() => setCancelarOcRow(null)}
+          onConfirm={async (motivo) => {
+            const ok = await cancelar(cancelarOcRow, motivo);
+            if (ok) setDrawerOpen(false);
+          }}
+        />
+      ) : null}
     </div>
   );
 }
@@ -914,16 +952,33 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
  * antes la OC solo existía como fila con acciones — el detalle (líneas) y el
  * hilo del gasto (incluida la bidireccionalidad OC → facturas/pagos, que
  * aporta el stepper con sus refs) no eran visibles desde ningún lado.
+ *
+ * El footer expone el set completo de acciones del documento (ADR-044): las
+ * mismas del menú ⋯ de la fila, con los mismos gates de permiso y estado.
  */
 function OcDetalleDrawer({
   oc,
   open,
   onClose,
+  puedeEscribir,
+  onEditar,
+  onMarcarEnviada,
+  onCerrarOrden,
+  onCancelar,
 }: {
   oc: OcRow | null;
   open: boolean;
   onClose: () => void;
+  puedeEscribir: boolean;
+  onEditar: (oc: OcRow) => void;
+  onMarcarEnviada: (oc: OcRow) => void;
+  onCerrarOrden: (oc: OcRow) => void;
+  onCancelar: (oc: OcRow) => void;
 }) {
+  const conAcciones =
+    !!oc &&
+    puedeEscribir &&
+    (oc.estado === 'borrador' || oc.estado === 'enviada' || oc.estado === 'parcial');
   return (
     <DetailDrawer
       open={open}
@@ -934,6 +989,36 @@ function OcDetalleDrawer({
         oc ? [oc.proveedorNombre, oc.proyectoNombre].filter(Boolean).join(' · ') : undefined
       }
       meta={oc ? <Badge tone={ESTADO_TONE[oc.estado]}>{ESTADO_LABEL[oc.estado]}</Badge> : null}
+      footer={
+        conAcciones ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {oc.estado === 'borrador' ? (
+              <>
+                <Button variant="outline" onClick={() => onEditar(oc)}>
+                  <Pencil className="size-4" /> Editar borrador
+                </Button>
+                <Button onClick={() => onMarcarEnviada(oc)}>
+                  <Send className="size-4" /> Marcar enviada
+                </Button>
+              </>
+            ) : null}
+            {oc.estado === 'enviada' || oc.estado === 'parcial' ? (
+              <Button variant="outline" onClick={() => onCerrarOrden(oc)}>
+                <X className="size-4" /> Cerrar orden
+              </Button>
+            ) : null}
+            {oc.estado === 'borrador' || oc.estado === 'enviada' ? (
+              <Button
+                variant="ghost"
+                className="ml-auto text-[var(--text)]/60 hover:text-red-600"
+                onClick={() => onCancelar(oc)}
+              >
+                <Trash2 className="size-4" /> Cancelar OC
+              </Button>
+            ) : null}
+          </div>
+        ) : null
+      }
     >
       <DetailDrawerContent>
         {!oc ? null : (

--- a/components/compras/requisiciones-module.tsx
+++ b/components/compras/requisiciones-module.tsx
@@ -61,6 +61,7 @@ import {
   DetailDrawerContent,
   DetailDrawerSection,
 } from '@/components/detail-page/detail-drawer';
+import { CancelarConMotivoDialog } from '@/components/shared/cancelar-con-motivo-dialog';
 import { HiloGastoStepper } from '@/components/gasto/hilo-gasto-stepper';
 import { useFocusDrilldown } from '@/hooks/use-focus-drilldown';
 
@@ -137,6 +138,7 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
 
   const [detalle, setDetalle] = useState<ReqRow | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [cancelarReq, setCancelarReq] = useState<ReqRow | null>(null);
 
   // Drill-down (?focus=<req_id>) desde el hilo del gasto de otros módulos.
   useFocusDrilldown(
@@ -371,6 +373,13 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
     },
   ];
 
+  // El drawer lee la fila viva: tras una acción (autorizar / generar OC) el
+  // refetch actualiza `rows` y el detalle abierto refleja el estado nuevo.
+  const detalleActual = useMemo(
+    () => (detalle ? (rows.find((r) => r.id === detalle.id) ?? detalle) : null),
+    [rows, detalle]
+  );
+
   const modoLibre = proyectoFiltro === LIBRE;
   const proyectoActivo =
     proyectoFiltro && proyectoFiltro !== SIN && proyectoFiltro !== LIBRE ? proyectoFiltro : '';
@@ -489,7 +498,7 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
   );
 
   const cancelar = useCallback(
-    async (req: ReqRow, motivo: string) => {
+    async (req: ReqRow, motivo: string): Promise<boolean> => {
       const sb = createSupabaseBrowserClient();
       const ahora = new Date().toISOString();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -503,10 +512,11 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
           description: getSupabaseErrorMessage(e, 'No se pudo cancelar.'),
           type: 'error',
         });
-        return;
+        return false;
       }
       toast.add({ title: 'Requisición cancelada', description: req.codigo, type: 'success' });
       void cargar();
+      return true;
     },
     [toast, cargar]
   );
@@ -702,7 +712,9 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
                   onDelete={
                     estado !== 'con_oc'
                       ? {
-                          onConfirm: (motivo) => cancelar(r, motivo ?? ''),
+                          onConfirm: async (motivo) => {
+                            await cancelar(r, motivo ?? '');
+                          },
                           label: 'Cancelar requisición',
                           confirmTitle: `¿Cancelar ${r.codigo}?`,
                           confirmDescription: 'La requisición quedará cancelada (borrado suave).',
@@ -979,7 +991,31 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
         maxHeight="calc(100vh - 320px)"
       />
 
-      <ReqDetalleDrawer req={detalle} open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+      <ReqDetalleDrawer
+        req={detalleActual}
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        puedeEscribir={puedeEscribir}
+        accionBusy={accionId !== null}
+        onAutorizar={(r) => void autorizar(r)}
+        onGenerarOc={(r) => void generarOC(r)}
+        onPedirRfq={(r) => void pedirCotizaciones(r)}
+        onCancelar={(r) => setCancelarReq(r)}
+      />
+
+      {cancelarReq ? (
+        <CancelarConMotivoDialog
+          key={cancelarReq.id}
+          title={`¿Cancelar ${cancelarReq.codigo}?`}
+          description="La requisición quedará cancelada (borrado suave)."
+          confirmLabel="Cancelar requisición"
+          onClose={() => setCancelarReq(null)}
+          onConfirm={async (motivo) => {
+            const ok = await cancelar(cancelarReq, motivo);
+            if (ok) setDrawerOpen(false);
+          }}
+        />
+      ) : null}
     </div>
   );
 }
@@ -988,17 +1024,33 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
  * Drawer de detalle de la requisición (Sprint 1 de `dilesa-flujo-gasto`):
  * antes la requisición solo era una fila con acciones; aquí se ven sus líneas
  * y el hilo del gasto (qué RFQ/OC/factura/pago derivaron de ella).
+ *
+ * El footer expone el set completo de acciones del documento (ADR-044): las
+ * mismas del menú ⋯ de la fila, con los mismos gates de permiso y estado.
  */
 function ReqDetalleDrawer({
   req,
   open,
   onClose,
+  puedeEscribir,
+  accionBusy,
+  onAutorizar,
+  onGenerarOc,
+  onPedirRfq,
+  onCancelar,
 }: {
   req: ReqRow | null;
   open: boolean;
   onClose: () => void;
+  puedeEscribir: boolean;
+  accionBusy: boolean;
+  onAutorizar: (req: ReqRow) => void;
+  onGenerarOc: (req: ReqRow) => void;
+  onPedirRfq: (req: ReqRow) => void;
+  onCancelar: (req: ReqRow) => void;
 }) {
   const estado = req ? deriveReqEstado(req) : null;
+  const conAcciones = !!req && puedeEscribir && estado !== 'con_oc';
   return (
     <DetailDrawer
       open={open}
@@ -1007,6 +1059,35 @@ function ReqDetalleDrawer({
       title={req?.codigo ?? 'Requisición'}
       description={req?.solicitanteNombre || undefined}
       meta={req && estado ? <Badge tone={ESTADO_TONE[estado]}>{ESTADO_LABEL[estado]}</Badge> : null}
+      footer={
+        conAcciones ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {estado === 'pendiente' ? (
+              <Button variant="outline" onClick={() => onAutorizar(req)} disabled={accionBusy}>
+                <ClipboardList className="size-4" /> Marcar autorizada
+              </Button>
+            ) : null}
+            {puedeGenerarOc(req) ? (
+              <>
+                <Button onClick={() => onGenerarOc(req)} disabled={accionBusy}>
+                  <ShoppingCart className="size-4" /> Generar orden de compra
+                </Button>
+                <Button variant="outline" onClick={() => onPedirRfq(req)} disabled={accionBusy}>
+                  <FileSearch className="size-4" /> Pedir cotizaciones (RFQ)
+                </Button>
+              </>
+            ) : null}
+            <Button
+              variant="ghost"
+              className="ml-auto text-[var(--text)]/60 hover:text-red-600"
+              onClick={() => onCancelar(req)}
+              disabled={accionBusy}
+            >
+              <Trash2 className="size-4" /> Cancelar
+            </Button>
+          </div>
+        ) : null
+      }
     >
       <DetailDrawerContent>
         {!req ? null : (

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -442,6 +442,18 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
         empresa={empresa}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
+        onAprobar={(p) => {
+          setDrawerOpen(false);
+          setAprobarPago(p);
+        }}
+        onMarcarPagado={(p) => {
+          setDrawerOpen(false);
+          setPagarPago(p);
+        }}
+        onCancelar={(p) => {
+          setDrawerOpen(false);
+          setCancelarPago(p);
+        }}
       />
 
       {/* Aprobar — confirmación (el RPC valida Dirección). */}
@@ -502,11 +514,17 @@ function PagoDrawer({
   empresa,
   open,
   onClose,
+  onAprobar,
+  onMarcarPagado,
+  onCancelar,
 }: {
   pago: Pago | null;
   empresa: EmpresaSlug;
   open: boolean;
   onClose: () => void;
+  onAprobar: (pago: Pago) => void;
+  onMarcarPagado: (pago: Pago) => void;
+  onCancelar: (pago: Pago) => void;
 }) {
   const [aplicaciones, setAplicaciones] = useState<FacturaAplicada[]>([]);
   const [loading, setLoading] = useState(false);
@@ -559,6 +577,16 @@ function PagoDrawer({
 
   const b = pago ? estadoBadge(pago.estado) : null;
 
+  // Set completo de acciones del documento en el footer (ADR-044) — los mismos
+  // gates por estado que los botones de la fila; el RPC valida el rol al final.
+  const puedeCancelar =
+    !!pago &&
+    pago.estado !== 'pagado' &&
+    pago.estado !== 'cancelado' &&
+    pago.estado !== 'rechazado';
+  const conAcciones =
+    !!pago && (pago.estado === 'programado' || pago.estado === 'aprobado' || puedeCancelar);
+
   return (
     <DetailDrawer
       open={open}
@@ -571,6 +599,34 @@ function PagoDrawer({
           <Badge variant={b.variant} className={b.className}>
             {b.label}
           </Badge>
+        ) : null
+      }
+      footer={
+        conAcciones ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {pago.estado === 'programado' ? (
+              <Button variant="outline" className="gap-1.5" onClick={() => onAprobar(pago)}>
+                <CheckCircle2 className="h-4 w-4" />
+                Aprobar
+              </Button>
+            ) : null}
+            {pago.estado === 'aprobado' ? (
+              <Button className="gap-1.5" onClick={() => onMarcarPagado(pago)}>
+                <Wallet className="h-4 w-4" />
+                Marcar pagado
+              </Button>
+            ) : null}
+            {puedeCancelar ? (
+              <Button
+                variant="ghost"
+                className="ml-auto gap-1.5 text-muted-foreground hover:text-destructive"
+                onClick={() => onCancelar(pago)}
+              >
+                <XCircle className="h-4 w-4" />
+                Cancelar
+              </Button>
+            ) : null}
+          </div>
         ) : null
       }
     >

--- a/components/inventario/registrar-movimiento-dialog.tsx
+++ b/components/inventario/registrar-movimiento-dialog.tsx
@@ -31,6 +31,8 @@ export interface RegistrarMovimientoDialogProps {
   onClose: () => void;
   productos: StockItem[];
   onSuccess: () => void;
+  /** Pre-selecciona el producto (ej. al abrir desde el drawer de detalle). */
+  defaultProductoId?: string;
 }
 
 export function RegistrarMovimientoDialog({
@@ -38,6 +40,7 @@ export function RegistrarMovimientoDialog({
   onClose,
   productos,
   onSuccess,
+  defaultProductoId,
 }: RegistrarMovimientoDialogProps) {
   const [productoId, setProductoId] = useState('');
   const [productoPopoverOpen, setProductoPopoverOpen] = useState(false);
@@ -49,13 +52,13 @@ export function RegistrarMovimientoDialog({
 
   useEffect(() => {
     if (open) {
-      setProductoId('');
+      setProductoId(defaultProductoId ?? '');
       setTipo('ajuste_positivo');
       setCantidad('');
       setNotas('');
       setFormError(null);
     }
-  }, [open]);
+  }, [open, defaultProductoId]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/components/inventario/stock-detail-drawer.tsx
+++ b/components/inventario/stock-detail-drawer.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Plus } from 'lucide-react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import {
   DetailDrawer,
@@ -32,9 +32,16 @@ export interface StockDetailDrawerProps {
   item: StockItem | null;
   open: boolean;
   onClose: () => void;
+  /** Abre el registro de movimiento con este producto pre-seleccionado (ADR-044). */
+  onRegistrarMovimiento?: (item: StockItem) => void;
 }
 
-export function StockDetailDrawer({ item, open, onClose }: StockDetailDrawerProps) {
+export function StockDetailDrawer({
+  item,
+  open,
+  onClose,
+  onRegistrarMovimiento,
+}: StockDetailDrawerProps) {
   const [kardex, setKardex] = useState<MovimientoRow[]>([]);
   const [loading, setLoading] = useState(false);
   const triggerPrint = useTriggerPrint();
@@ -75,9 +82,17 @@ export function StockDetailDrawer({ item, open, onClose }: StockDetailDrawerProp
       title={item.nombre}
       description={`${item.categoria ?? 'Sin categoría'} · ${item.unidad ?? 'pieza'}`}
       actions={
-        <Button variant="outline" size="sm" onClick={triggerPrint}>
-          Imprimir
-        </Button>
+        <>
+          {onRegistrarMovimiento ? (
+            <Button size="sm" className="gap-1.5" onClick={() => onRegistrarMovimiento(item)}>
+              <Plus className="h-3.5 w-3.5" />
+              Registrar movimiento
+            </Button>
+          ) : null}
+          <Button variant="outline" size="sm" onClick={triggerPrint}>
+            Imprimir
+          </Button>
+        </>
       }
     >
       {/* Membrete solo para impresión */}

--- a/components/rh/departamentos-module.tsx
+++ b/components/rh/departamentos-module.tsx
@@ -28,7 +28,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Plus, RefreshCw, Loader2, Network } from 'lucide-react';
+import { Plus, RefreshCw, Loader2, Network, Power, Trash2 } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import {
@@ -54,6 +54,7 @@ import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field-label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { RowActions } from '@/components/shared/row-actions';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 import { useToast } from '@/components/ui/toast';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -237,6 +238,8 @@ export function DepartamentosModule({
     };
   }, [fetchEmpresaIds, fetchAll]);
 
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
   const openCreate = () => {
     setEditingId(null);
     setForm(EMPTY_FORM);
@@ -307,7 +310,7 @@ export function DepartamentosModule({
     await fetchAll(empresaIds);
   };
 
-  const handleSoftDelete = async (dept: Departamento) => {
+  const handleSoftDelete = async (dept: Departamento): Promise<boolean> => {
     const { error: err } = await supabase
       .schema('erp')
       .from('departamentos')
@@ -315,10 +318,11 @@ export function DepartamentosModule({
       .eq('id', dept.id);
     if (err) {
       toast.add({ title: 'No se pudo eliminar', description: err.message, type: 'error' });
-      return;
+      return false;
     }
     toast.add({ title: `Departamento "${dept.nombre}" eliminado`, type: 'success' });
     await fetchAll(empresaIds);
+    return true;
   };
 
   const parentOptions = departamentos.filter((d) => d.id !== editingId && d.activo);
@@ -377,6 +381,30 @@ export function DepartamentosModule({
       </Button>
     </>
   );
+
+  // En edición, el detalle expone también las acciones de entidad del menú ⋯
+  // de la fila (ADR-044): activar/desactivar y eliminar.
+  const editing = editingId ? (departamentos.find((d) => d.id === editingId) ?? null) : null;
+  const EntityActions = editing ? (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => void handleToggleActivo(editing)}
+        className="gap-1.5 rounded-xl border-[var(--border)] text-[var(--text)]"
+      >
+        <Power className="h-4 w-4" />
+        {editing.activo ? 'Desactivar' : 'Activar'}
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => setConfirmDelete(true)}
+        className="gap-1.5 rounded-xl border-[var(--border)] text-red-500 hover:text-red-600"
+      >
+        <Trash2 className="h-4 w-4" />
+        Eliminar
+      </Button>
+    </>
+  ) : null;
 
   return (
     <div className="space-y-6">
@@ -504,7 +532,9 @@ export function DepartamentosModule({
                       onEdit={{ onClick: () => openEdit(d) }}
                       onToggle={{ activo: d.activo, onClick: () => handleToggleActivo(d) }}
                       onDelete={{
-                        onConfirm: () => handleSoftDelete(d),
+                        onConfirm: async () => {
+                          await handleSoftDelete(d);
+                        },
                         confirmTitle: `¿Eliminar "${d.nombre}"?`,
                         confirmDescription:
                           'Esta acción marcará el departamento como eliminado. ' +
@@ -530,7 +560,12 @@ export function DepartamentosModule({
           onOpenChange={setShowDialog}
           size="sm"
           title={editingId ? 'Editar departamento' : 'Nuevo departamento'}
-          footer={<div className="flex flex-wrap items-center gap-2">{FormActions}</div>}
+          footer={
+            <div className="flex w-full flex-wrap items-center gap-2">
+              {EntityActions}
+              <div className="ml-auto flex items-center gap-2">{FormActions}</div>
+            </div>
+          }
         >
           <DetailDrawerContent>{FormBody}</DetailDrawerContent>
         </DetailDrawer>
@@ -541,10 +576,30 @@ export function DepartamentosModule({
               <DialogTitle>{editingId ? 'Editar departamento' : 'Nuevo departamento'}</DialogTitle>
             </DialogHeader>
             {FormBody}
-            <DialogFooter className="gap-2">{FormActions}</DialogFooter>
+            <DialogFooter className="gap-2">
+              {EntityActions}
+              {FormActions}
+            </DialogFooter>
           </DialogContent>
         </Dialog>
       )}
+
+      {/* Eliminar desde el detalle — mismo confirm que el menú ⋯ de la fila. */}
+      {editing ? (
+        <ConfirmDialog
+          open={confirmDelete}
+          onOpenChange={setConfirmDelete}
+          onConfirm={async () => {
+            const ok = await handleSoftDelete(editing);
+            if (ok) setShowDialog(false);
+          }}
+          title={`¿Eliminar "${editing.nombre}"?`}
+          description={
+            'Esta acción marcará el departamento como eliminado. ' +
+            'Los empleados asignados conservarán su historial y podrá restaurarse desde auditoría.'
+          }
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/rh/puestos-module.tsx
+++ b/components/rh/puestos-module.tsx
@@ -27,7 +27,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Plus, RefreshCw, Loader2, Briefcase } from 'lucide-react';
+import { Plus, RefreshCw, Loader2, Briefcase, Power, Trash2 } from 'lucide-react';
 
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import {
@@ -55,6 +55,7 @@ import { FieldLabel } from '@/components/ui/field-label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 import { RowActions } from '@/components/shared/row-actions';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 import { useToast } from '@/components/ui/toast';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -269,6 +270,8 @@ export function PuestosModule({
     };
   }, [fetchEmpresaIds, fetchAll]);
 
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
   const openCreate = () => {
     setEditingId(null);
     setForm(EMPTY_FORM);
@@ -353,7 +356,7 @@ export function PuestosModule({
     await fetchAll(empresaIds);
   };
 
-  const handleSoftDelete = async (p: Puesto) => {
+  const handleSoftDelete = async (p: Puesto): Promise<boolean> => {
     const { error: err } = await supabase
       .schema('erp')
       .from('puestos')
@@ -361,10 +364,11 @@ export function PuestosModule({
       .eq('id', p.id);
     if (err) {
       toast.add({ title: 'No se pudo eliminar', description: err.message, type: 'error' });
-      return;
+      return false;
     }
     toast.add({ title: `Puesto "${p.nombre}" eliminado`, type: 'success' });
     await fetchAll(empresaIds);
+    return true;
   };
 
   const visible = puestos.filter(
@@ -488,6 +492,30 @@ export function PuestosModule({
       </Button>
     </>
   );
+
+  // En edición, el detalle expone también las acciones de entidad del menú ⋯
+  // de la fila (ADR-044): activar/desactivar y eliminar.
+  const editing = editingId ? (puestos.find((p) => p.id === editingId) ?? null) : null;
+  const EntityActions = editing ? (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => void handleToggleActivo(editing)}
+        className="gap-1.5 rounded-xl border-[var(--border)] text-[var(--text)]"
+      >
+        <Power className="h-4 w-4" />
+        {editing.activo ? 'Desactivar' : 'Activar'}
+      </Button>
+      <Button
+        variant="outline"
+        onClick={() => setConfirmDelete(true)}
+        className="gap-1.5 rounded-xl border-[var(--border)] text-red-500 hover:text-red-600"
+      >
+        <Trash2 className="h-4 w-4" />
+        Eliminar
+      </Button>
+    </>
+  ) : null;
 
   return (
     <div className="space-y-6">
@@ -647,7 +675,9 @@ export function PuestosModule({
                       onEdit={{ onClick: () => openEdit(p) }}
                       onToggle={{ activo: p.activo, onClick: () => handleToggleActivo(p) }}
                       onDelete={{
-                        onConfirm: () => handleSoftDelete(p),
+                        onConfirm: async () => {
+                          await handleSoftDelete(p);
+                        },
                         confirmTitle: `¿Eliminar "${p.nombre}"?`,
                         confirmDescription:
                           'Esta acción marcará el puesto como eliminado. ' +
@@ -673,7 +703,12 @@ export function PuestosModule({
           onOpenChange={setShowDialog}
           size="md"
           title={editingId ? 'Editar puesto' : 'Nuevo puesto'}
-          footer={<div className="flex flex-wrap items-center gap-2">{FormActions}</div>}
+          footer={
+            <div className="flex w-full flex-wrap items-center gap-2">
+              {EntityActions}
+              <div className="ml-auto flex items-center gap-2">{FormActions}</div>
+            </div>
+          }
         >
           <DetailDrawerContent>{FormBody}</DetailDrawerContent>
         </DetailDrawer>
@@ -684,10 +719,30 @@ export function PuestosModule({
               <DialogTitle>{editingId ? 'Editar puesto' : 'Nuevo puesto'}</DialogTitle>
             </DialogHeader>
             {FormBody}
-            <DialogFooter className="gap-2">{FormActions}</DialogFooter>
+            <DialogFooter className="gap-2">
+              {EntityActions}
+              {FormActions}
+            </DialogFooter>
           </DialogContent>
         </Dialog>
       )}
+
+      {/* Eliminar desde el detalle — mismo confirm que el menú ⋯ de la fila. */}
+      {editing ? (
+        <ConfirmDialog
+          open={confirmDelete}
+          onOpenChange={setConfirmDelete}
+          onConfirm={async () => {
+            const ok = await handleSoftDelete(editing);
+            if (ok) setShowDialog(false);
+          }}
+          title={`¿Eliminar "${editing.nombre}"?`}
+          description={
+            'Esta acción marcará el puesto como eliminado. ' +
+            'Los empleados asignados conservarán su historial y podrá restaurarse desde auditoría.'
+          }
+        />
+      ) : null}
     </div>
   );
 }

--- a/content/manual/dilesa/compras/ordenes.md
+++ b/content/manual/dilesa/compras/ordenes.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Compras — Órdenes de compra'
 modulo: dilesa.compras.ordenes
-version: '1.0.0'
-actualizado: '2026-06-07'
+version: '1.1.0'
+actualizado: '2026-06-11'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -28,7 +28,9 @@ de lo que has amarrado).
 ## La tabla
 
 Cada renglón: **Folio**, **Proveedor**, **Estado**, **Líneas** (cuántas trae),
-**Total** y **Fecha**.
+**Total** y **Fecha**. **Haz clic en un renglón** para abrir el detalle: el hilo
+del gasto, las líneas y **los botones de acción** (editar borrador, marcar
+enviada, cerrar, cancelar).
 
 ## Cómo crear una orden (paso a paso)
 
@@ -36,8 +38,8 @@ Cada renglón: **Folio**, **Proveedor**, **Estado**, **Líneas** (cuántas trae)
 2. **Nueva orden** → eliges proveedor y agregas **líneas**: cada una con su
    **partida** del presupuesto, descripción, cantidad, unidad y precio.
 3. **Crear orden (borrador)** — queda en Borrador (todavía no compromete nada).
-4. Desde el menú del renglón, **Marcar enviada** → ahí sí compromete el monto
-   contra las partidas.
+4. Haz clic en la orden y, en el detalle, **Marcar enviada** → ahí sí compromete
+   el monto contra las partidas (la misma acción vive en el menú ⋯ del renglón).
 5. Cuando ya no falta nada por recibir, **Cerrar orden**. Si te equivocaste,
    **Cancelar** (con motivo) la anula y libera el presupuesto.
 

--- a/content/manual/dilesa/compras/requisiciones.md
+++ b/content/manual/dilesa/compras/requisiciones.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Compras — Requisiciones'
 modulo: dilesa.compras.requisiciones
-version: '1.0.0'
-actualizado: '2026-06-07'
+version: '1.1.0'
+actualizado: '2026-06-11'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -24,13 +24,16 @@ comprar**.
 ## La tabla
 
 Cada renglón: **Folio**, **Solicitante**, **Estado**, **Orden** (la OC ligada si
-ya se generó), **Líneas**, **Estimado** y **Fecha**.
+ya se generó), **Líneas**, **Estimado** y **Fecha**. **Haz clic en un renglón**
+para abrir el detalle: ahí ves el hilo del gasto, las líneas y **los botones de
+acción** (autorizar, generar orden, pedir cotizaciones, cancelar).
 
 ## Cómo funciona (paso a paso)
 
 1. **Nueva requisición** → eliges si es de **proyecto** (cada línea con su
    partida) o **gasto suelto** (solo descripción), y capturas las líneas.
-2. Desde el menú del renglón, **Marcar autorizada**.
+2. Haz clic en la requisición y, en el detalle, **Marcar autorizada** (la misma
+   acción vive en el menú ⋯ del renglón, como atajo).
 3. **Generar orden de compra** → crea la OC heredando las líneas y su partida (así
    la orden sí compromete el presupuesto). La OC nace en Borrador.
 

--- a/docs/adr/044_detalle_con_set_completo_de_acciones.md
+++ b/docs/adr/044_detalle_con_set_completo_de_acciones.md
@@ -1,0 +1,60 @@
+# ADR-044 — El detalle expone el set completo de acciones (DA1-DA4)
+
+- **Status**: Accepted
+- **Date**: 2026-06-11
+- **Authors**: Beto, Claude Code
+- **Companion to**: [ADR-018](./018_drawer_anatomy.md) / [ADR-026](./026_drawer_anatomy_polish.md) (anatomía del drawer), [ADR-009](./009_detail_page.md) (detail page), [ADR-008](./008_action_feedback.md) (confirmaciones)
+
+---
+
+## Contexto
+
+Auditoría UX del 2026-06-11 (reporte de Beto sobre Compras DILESA): en
+varios módulos, hacer clic en una fila abre un drawer de detalle que solo
+muestra información, mientras las acciones del documento (autorizar,
+generar OC, cancelar, aprobar pago, eliminar…) viven **únicamente** en el
+menú ⋯ de la fila (`<RowActions>`) o en botones inline de la celda. El
+usuario abre el detalle "para trabajar el documento" y se topa con que
+debe cerrarlo y cazar el menú en el extremo derecho de la fila.
+
+El barrido del repo encontró el anti-patrón en 6 superficies (requisiciones
+y OC de Compras DILESA, pagos CxP, departamentos/puestos RH, stock RDB,
+panel de captura de cotizaciones) y lo descartó en ~22 más que ya estaban
+bien (acciones en el header/footer del drawer o en página de detalle
+completa).
+
+## Decisión
+
+- **DA1 — Set completo en el detalle.** Toda superficie de detalle que
+  abre el clic en fila (drawer o página) expone **todas** las acciones
+  disponibles del documento, con los mismos gates de permiso y estado que
+  cualquier otra superficie. Si la fila ofrece una acción, el detalle
+  también.
+- **DA2 — Ubicación canónica.** En `<DetailDrawer>`: acciones de workflow
+  (autorizar, generar, aprobar, cerrar, cancelar) van en el `footer`
+  (sticky); utilidades (imprimir, editar, procesar) pueden ir en el
+  `actions` del header. En páginas de detalle: el header de la página.
+- **DA3 — Quick actions complementarias, nunca exclusivas.** Los
+  mini-botones de fila (completar tarea con un clic, aprobar pago inline)
+  y el menú ⋯ se quedan — son atajos válidos. Lo prohibido es que sean el
+  _único_ lugar donde vive una acción que el detalle no ofrece.
+- **DA4 — Misma confirmación, mismo audit trail.** Las acciones
+  destructivas o con motivo disparadas desde el detalle reusan el mismo
+  dialog compartido que la fila (`<ConfirmDialog>`,
+  `<CancelarConMotivoDialog>`); nada de caminos paralelos con menos
+  fricción.
+
+Patrón de referencia: `ReqDetalleDrawer` en
+`components/compras/requisiciones-module.tsx` (footer con Marcar
+autorizada / Generar OC / Pedir RFQ / Cancelar, sincronizado con la fila
+viva vía `detalleActual`).
+
+## Consecuencias
+
+- El clic en fila vuelve a ser el camino primario para operar un
+  documento; el menú ⋯ queda como atajo.
+- Los drawers de detalle que refrescan datos tras una acción deben leer
+  la **fila viva** (`rows.find(...)` memoizado) para que badges y botones
+  reflejen el estado nuevo sin cerrar/reabrir.
+- Revisiones de PR: un drawer/página de detalle nuevo con acciones solo
+  en `<RowActions>` es un smell que se rechaza citando este ADR.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -315,17 +315,18 @@ Ver [reglas SS1-SS7 en ADR-030](../adr/030_submodule_permissions.md).
 
 ### Layout y navegación
 
-| Tema                                | ADR                                                                                     | Patrón canónico                                                 |
-| ----------------------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| Sidebar y secciones                 | [ADR-014](../adr/014_sidebar_taxonomia.md)                                              | `NAV_ITEMS` agrupado por sección, filtrado por permisos         |
-| Sub-módulos como routed tabs        | [ADR-005](../adr/005_module_with_submodules_routed_tabs.md)                             | `app/<modulo>/{sub1,sub2}/page.tsx` con `layout.tsx` compartido |
-| Module page anatomy                 | [supabase/adr/004](../../supabase/adr/004_module_page_layout_convention.md)             | `<ModulePage>` slots o estructura libre con primitivos          |
-| Module states (empty/loading/error) | [ADR-006](../adr/006_module_states.md)                                                  | `<EmptyState>` / `<TableSkeleton>` / `<ErrorBanner>`            |
-| Filters URL-sync                    | [ADR-007](../adr/007_filters_url_sync.md)                                               | `useUrlFilters` + `<ActiveFiltersChip>`                         |
-| Detail page anatomy                 | [ADR-009](../adr/009_detail_page.md)                                                    | `<DetailPage>` + `<DetailHeader>` + `<DetailContent>` (D1-D5)   |
-| Detail drawer                       | [ADR-018](../adr/018_drawer_anatomy.md), [ADR-026](../adr/026_drawer_anatomy_polish.md) | `<DetailDrawer size="sm/md/lg/xl">` (DD1-DD11)                  |
-| Data tables                         | [ADR-010](../adr/010_data_table.md)                                                     | `<DataTable>` sobre @tanstack/react-table (DT1-DT8)             |
-| Module-level KPI strips             | [ADR-034](../adr/034_module_kpi_strips.md)                                              | `<ModuleKpiStrip>` deriva client-side del dataset (KPI1-KPI7)   |
+| Tema                                | ADR                                                                                     | Patrón canónico                                                         |
+| ----------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Sidebar y secciones                 | [ADR-014](../adr/014_sidebar_taxonomia.md)                                              | `NAV_ITEMS` agrupado por sección, filtrado por permisos                 |
+| Sub-módulos como routed tabs        | [ADR-005](../adr/005_module_with_submodules_routed_tabs.md)                             | `app/<modulo>/{sub1,sub2}/page.tsx` con `layout.tsx` compartido         |
+| Module page anatomy                 | [supabase/adr/004](../../supabase/adr/004_module_page_layout_convention.md)             | `<ModulePage>` slots o estructura libre con primitivos                  |
+| Module states (empty/loading/error) | [ADR-006](../adr/006_module_states.md)                                                  | `<EmptyState>` / `<TableSkeleton>` / `<ErrorBanner>`                    |
+| Filters URL-sync                    | [ADR-007](../adr/007_filters_url_sync.md)                                               | `useUrlFilters` + `<ActiveFiltersChip>`                                 |
+| Detail page anatomy                 | [ADR-009](../adr/009_detail_page.md)                                                    | `<DetailPage>` + `<DetailHeader>` + `<DetailContent>` (D1-D5)           |
+| Detail drawer                       | [ADR-018](../adr/018_drawer_anatomy.md), [ADR-026](../adr/026_drawer_anatomy_polish.md) | `<DetailDrawer size="sm/md/lg/xl">` (DD1-DD11)                          |
+| Acciones completas en el detalle    | [ADR-044](../adr/044_detalle_con_set_completo_de_acciones.md)                           | footer del drawer/página con todas las acciones del documento (DA1-DA4) |
+| Data tables                         | [ADR-010](../adr/010_data_table.md)                                                     | `<DataTable>` sobre @tanstack/react-table (DT1-DT8)                     |
+| Module-level KPI strips             | [ADR-034](../adr/034_module_kpi_strips.md)                                              | `<ModuleKpiStrip>` deriva client-side del dataset (KPI1-KPI7)           |
 
 ### Forms y captura
 


### PR DESCRIPTION
## Problema (reporte de Beto)

En Compras DILESA, el clic en una requisición abría un drawer **solo informativo**: para accionar había que cerrar e ir al menú ⋯ del extremo derecho de la fila. Barrido de todo el repo: **6 superficies** con el mismo anti-patrón, **~22 verificadas OK** (ya tenían acciones en el detalle o navegan a página completa).

## Regla nueva — ADR-044 (DA1-DA4)

El detalle que abre el clic en fila expone **todas** las acciones del documento (footer del drawer para workflow, header para utilidades), con los mismos gates de permiso/estado. Las quick actions de fila (mini-botones, menú ⋯) se quedan como atajos — complementarias, nunca exclusivas.

## Correcciones

| Superficie | Acciones que ahora viven también en el detalle |
|---|---|
| Compras DILESA · Requisiciones | Marcar autorizada · Generar OC · Pedir RFQ · Cancelar (con motivo) |
| Compras DILESA · Órdenes | Editar borrador · Marcar enviada · Cerrar orden · Cancelar OC |
| CxP · Pagos | Aprobar · Marcar pagado · Cancelar (mismos dialogs de confirmación) |
| RH · Departamentos y Puestos | Activar/Desactivar · Eliminar (en el form de edición) |
| RDB · Inventario Stock | Registrar movimiento con el producto pre-seleccionado |
| Compras DILESA · Cotizaciones | Cancelar cotización dentro del panel de captura (y cancela→cierra captura) |

Detalle técnico: los drawers de requisiciones/OC leen la **fila viva** (`detalleActual` memo) — tras autorizar/enviar, el badge y los botones del drawer abierto se actualizan solos.

## Docs
- `docs/adr/044_detalle_con_set_completo_de_acciones.md` + línea en ARCHITECTURE §5.
- Manual de usuario: `compras/requisiciones.md` y `compras/ordenes.md` ahora enseñan el flujo "clic en el renglón → detalle con botones".

## Checks
6/6 locales verdes (typecheck · test:coverage 1586 · lint · format · initiatives · schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)