### PR TITLE
fix(dilesa-ventas): FICU/expediente — INE, domicilio y asesor desde sus fuentes reales

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -41,6 +41,8 @@ import {
 } from '@/lib/dilesa/pdf/pagare-credito-directo';
 import { desglosarPagare } from '@/lib/dilesa/pagare-interes';
 import { evaluarRiesgo } from '@/lib/dilesa/ficu/riesgo';
+import { domicilioEstructurado, domicilioTexto, kycEfectivo } from '@/lib/dilesa/kyc-efectivo';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { formatMontoEnLetras } from '@/lib/format/numero-a-letras';
 import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
 import { getNotaria } from '@/lib/dilesa/notarios';
@@ -123,13 +125,15 @@ export async function GET(
         ? 'EXPIRADA'
         : null;
 
-  // Persona (cliente) cross-schema — FICU + Promesa necesitan todos los KYC
-  // fields que el form de Sprint 7c-2 persistió aquí (no en `dilesa.ventas`).
+  // Persona (cliente) cross-schema — FICU + Promesa necesitan los KYC del
+  // form (Sprint 7c-2), la INE y el domicilio estructurado. La resolución
+  // persona-vs-venta vive en lib/dilesa/kyc-efectivo (dos poblaciones:
+  // Coda per-venta, BSOP en persona).
   const { data: persona } = await sb
     .schema('erp')
     .from('personas')
     .select(
-      'nombre, apellido_paterno, apellido_materno, fecha_nacimiento, curp, rfc, email, telefono, nacionalidad, tipo_persona, domicilio, forma_pago_kyc, uso_efectivo_kyc, ocupacion, conocimiento_dueno_beneficiario, es_pep'
+      'nombre, apellido_paterno, apellido_materno, fecha_nacimiento, curp, rfc, email, telefono, nacionalidad, tipo_persona, domicilio, forma_pago_kyc, uso_efectivo_kyc, ocupacion, conocimiento_dueno_beneficiario, es_pep, numero_credencial_ine, domicilio_calle, domicilio_numero_exterior, domicilio_numero_interior, domicilio_colonia, domicilio_codigo_postal, domicilio_ciudad, domicilio_estado'
     )
     .eq('id', venta.persona_id)
     .maybeSingle();
@@ -138,27 +142,21 @@ export async function GET(
       .filter(Boolean)
       .join(' ') || '(sin nombre)';
 
-  // KYC efectivo: el form de captura persiste estos campos en erp.personas,
-  // pero las ventas importadas de Coda los traen per-venta en dilesa.ventas
-  // y nunca poblaron la persona. Gana la fuente con dato (persona primero).
-  // PEP es OR de ambas fuentes: nunca degradar un true.
-  const kycOcupacion = persona?.ocupacion ?? venta.ocupacion ?? null;
-  const kycFormaPago = persona?.forma_pago_kyc ?? venta.forma_pago ?? null;
-  const kycUsoEfectivo = persona?.uso_efectivo_kyc ?? venta.uso_efectivo ?? null;
-  const kycConocimientoDB =
-    persona?.conocimiento_dueno_beneficiario ?? venta.conocimiento_dueno_beneficiario ?? null;
-  const kycEsPep = Boolean(persona?.es_pep || venta.es_pep);
+  const kyc = kycEfectivo(persona, venta);
+  const domEstructurado = domicilioEstructurado(persona);
+  const domTexto = domicilioTexto(persona);
 
   // Vendedor (asesor de ventas) — el form persiste `vendedor_usuario_id`
-  // (FK a core.usuarios); el campo legacy `venta.vendedor` (text) puede
-  // estar vacío en ventas nuevas. Resolvemos el nombre completo via lookup.
-  // Concatena `first_name + ' ' + last_name`; si falta last_name, queda
-  // solo el first_name; si falta first_name, fallback a email; si nada,
-  // al campo text legacy de la venta.
+  // (FK a core.usuarios). El lookup va con el ADMIN client: la RLS de
+  // core.usuarios es self-only (usuarios_select_own), así que con el client
+  // de la sesión el nombre solo salía cuando imprimía el propio vendedor.
+  // Solo se extrae nombre/email para estamparlos en el documento; el acceso
+  // a la venta ya pasó por la RLS de dilesa.ventas arriba.
   let vendedorNombre = (venta.vendedor ?? '').toString();
   let vendedorEmail: string | null = null;
   if (venta.vendedor_usuario_id) {
-    const { data: u } = await sb
+    const lookupClient = getSupabaseAdminClient() ?? sb;
+    const { data: u } = await lookupClient
       .schema('core')
       .from('usuarios')
       .select('first_name, last_name, email')
@@ -547,7 +545,7 @@ export async function GET(
       beneficiario,
       beneficiarioDomicilio,
       deudorNombre: clienteNombre,
-      deudorDomicilio: (persona?.domicilio as string | null) ?? null,
+      deudorDomicilio: domTexto,
       deudorIdentificacion: persona?.curp || persona?.rfc || null,
       identificacionInventario,
       fraccionamiento: pdfFraccionamiento,
@@ -674,9 +672,9 @@ export async function GET(
         curp: persona?.curp ?? null,
         rfc: persona?.rfc ?? null,
         estadoCivil: null, // TODO sprint-7c: capturar estado civil en form
-        profesion: kycOcupacion,
-        domicilio: persona?.domicilio ?? null,
-        ineNumero: venta.ine_numero ?? null,
+        profesion: kyc.ocupacion,
+        domicilio: domTexto,
+        ineNumero: kyc.ineNumero,
       },
       coTitular: null, // TODO sprint-7c: agregar FK persona_cotitular_id
       inmueble: {
@@ -712,9 +710,9 @@ export async function GET(
     const riesgo = evaluarRiesgo({
       tipoPersona: persona?.tipo_persona,
       nacionalidad: persona?.nacionalidad,
-      esPep: kycEsPep,
-      formaPago: kycFormaPago,
-      usoEfectivo: kycUsoEfectivo,
+      esPep: kyc.esPep,
+      formaPago: kyc.formaPago,
+      usoEfectivo: kyc.usoEfectivo,
     });
     const fechaNac = persona?.fecha_nacimiento
       ? new Date(`${persona.fecha_nacimiento}T12:00:00`).toLocaleDateString('es-MX', {
@@ -734,20 +732,20 @@ export async function GET(
       rfc: (persona?.rfc ?? '').toUpperCase(),
       identificacion: {
         tipo: 'INE / Credencial para Votar',
-        numero: venta.ine_numero ?? '',
+        numero: kyc.ineNumero ?? '',
         autoridad: 'Instituto Nacional Electoral',
         vigencia: 'Vigente',
       },
-      domicilio: { integrado: persona?.domicilio ?? null },
+      domicilio: { ...domEstructurado, integrado: persona?.domicilio ?? null },
       telefono: persona?.telefono ?? '',
       correo: persona?.email ?? '',
       personalidad: (persona?.tipo_persona ?? 'persona física').toUpperCase(),
       nacionalidad: (persona?.nacionalidad ?? '').toUpperCase(),
-      esPep: kycEsPep,
-      formaPago: (kycFormaPago ?? '').toUpperCase(),
-      usoEfectivo: (kycUsoEfectivo ?? '').toUpperCase(),
-      ocupacion: (kycOcupacion ?? '').toUpperCase(),
-      conocimientoDuenoBeneficiario: kycConocimientoDB ?? '—',
+      esPep: kyc.esPep,
+      formaPago: (kyc.formaPago ?? '').toUpperCase(),
+      usoEfectivo: (kyc.usoEfectivo ?? '').toUpperCase(),
+      ocupacion: (kyc.ocupacion ?? '').toUpperCase(),
+      conocimientoDuenoBeneficiario: kyc.conocimientoDuenoBeneficiario ?? '—',
       criteriosRiesgo: riesgo.criterios,
       scoreTotal: riesgo.scoreTotal,
       clasificacionRiesgo: riesgo.clasificacion,

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -55,6 +55,7 @@ import { FASE_ROLES, ROL_LABEL, rolesOpcionales } from '@/lib/dilesa/captura/fas
 import { evaluarCierre } from '@/lib/dilesa/copiloto-cierre';
 import { CopilotoCierre } from '@/components/dilesa/copiloto-cierre';
 import { useScopeVendedorDilesa } from '@/lib/dilesa/use-scope-vendedor';
+import { domicilioTexto, kycEfectivo } from '@/lib/dilesa/kyc-efectivo';
 import { EstadoCuentaPrintable } from '@/components/dilesa/estado-cuenta-printable';
 import { ReciboCajaPrintable } from '@/components/dilesa/recibo-caja-printable';
 import { useTriggerPrint } from '@/components/print';
@@ -157,6 +158,21 @@ type Persona = {
   tipo_persona: string | null;
   estado_civil: string | null;
   domicilio: string | null;
+  // KYC + INE + domicilio estructurado (form Sprint 7c-2) — la resolución
+  // persona-vs-venta vive en lib/dilesa/kyc-efectivo.
+  ocupacion: string | null;
+  forma_pago_kyc: string | null;
+  uso_efectivo_kyc: string | null;
+  conocimiento_dueno_beneficiario: string | null;
+  es_pep: boolean | null;
+  numero_credencial_ine: string | null;
+  domicilio_calle: string | null;
+  domicilio_numero_exterior: string | null;
+  domicilio_numero_interior: string | null;
+  domicilio_colonia: string | null;
+  domicilio_codigo_postal: string | null;
+  domicilio_ciudad: string | null;
+  domicilio_estado: string | null;
 };
 
 type UnidadInfo = {
@@ -472,7 +488,7 @@ function DetailInner() {
           .schema('erp')
           .from('personas')
           .select(
-            'nombre, apellido_paterno, apellido_materno, email, telefono, curp, rfc, nss, fecha_nacimiento, nacionalidad, tipo_persona, estado_civil, domicilio'
+            'nombre, apellido_paterno, apellido_materno, email, telefono, curp, rfc, nss, fecha_nacimiento, nacionalidad, tipo_persona, estado_civil, domicilio, ocupacion, forma_pago_kyc, uso_efectivo_kyc, conocimiento_dueno_beneficiario, es_pep, numero_credencial_ine, domicilio_calle, domicilio_numero_exterior, domicilio_numero_interior, domicilio_colonia, domicilio_codigo_postal, domicilio_ciudad, domicilio_estado'
           )
           .eq('id', ventaRow.persona_id)
           .maybeSingle(),
@@ -998,21 +1014,25 @@ function DetailInner() {
           ['Nacionalidad', persona.nacionalidad],
           ['Estado civil', persona.estado_civil],
           ['Tipo persona', persona.tipo_persona],
-          ['Domicilio', persona.domicilio],
+          ['Domicilio', domicilioTexto(persona)],
         ] as [string, string | null][]
       )
         .filter((r): r is [string, string] => r[1] != null && r[1] !== '')
         .map(([label, value]) => ({ label, value }))
     : [];
 
+  // KYC efectivo: ventas Coda lo traen per-venta, capturas BSOP en la
+  // persona — sin la resolución, las nativas mostraban este bloque vacío.
+  const kycResuelto = kycEfectivo(persona, venta);
+  const pepConocido = persona?.es_pep != null || venta.es_pep != null;
   const kyc: { label: string; value: string }[] = (
     [
-      ['PEP', venta.es_pep == null ? null : venta.es_pep ? 'Sí' : 'No'],
-      ['Ocupación', venta.ocupacion],
-      ['INE', venta.ine_numero],
-      ['Forma de pago', venta.forma_pago],
-      ['Uso de efectivo', venta.uso_efectivo],
-      ['Dueño beneficiario', venta.conocimiento_dueno_beneficiario],
+      ['PEP', pepConocido ? (kycResuelto.esPep ? 'Sí' : 'No') : null],
+      ['Ocupación', kycResuelto.ocupacion],
+      ['INE', kycResuelto.ineNumero],
+      ['Forma de pago', kycResuelto.formaPago],
+      ['Uso de efectivo', kycResuelto.usoEfectivo],
+      ['Dueño beneficiario', kycResuelto.conocimientoDuenoBeneficiario],
     ] as [string, string | null][]
   )
     .filter((r): r is [string, string] => r[1] != null && r[1] !== '')

--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -537,10 +537,25 @@ function NuevaSolicitudForm() {
         personaId = ins.id as string;
       }
 
-      // 2) Usuario actual (para vendedor_usuario_id)
+      // 2) Usuario actual (para vendedor_usuario_id) + snapshot del nombre
+      //    en venta.vendedor (text). El snapshot evita el lookup a
+      //    core.usuarios al renderizar docs/pantalla: su RLS es self-only,
+      //    así que a cualquier usuario distinto del vendedor el nombre le
+      //    salía vacío (FICU/solicitud impresos por gerencia).
       const {
         data: { user },
       } = await sb.auth.getUser();
+      let vendedorSnapshot: string | null = null;
+      if (user?.id) {
+        const { data: yo } = await sb
+          .schema('core')
+          .from('usuarios')
+          .select('first_name, last_name, email')
+          .eq('id', user.id)
+          .maybeSingle();
+        vendedorSnapshot =
+          [yo?.first_name, yo?.last_name].filter(Boolean).join(' ').trim() || yo?.email || null;
+      }
 
       // 3) Crear venta
       const unidad = unidades.find((u) => u.id === unidadId);
@@ -553,6 +568,7 @@ function NuevaSolicitudForm() {
           persona_id: personaId,
           unidad_id: unidadId,
           vendedor_usuario_id: user?.id ?? null,
+          vendedor: vendedorSnapshot,
           estado: 'activa',
           fase_actual: 'Solicitud de Asignación',
           fase_posicion: 1,

--- a/lib/dilesa/kyc-efectivo.test.ts
+++ b/lib/dilesa/kyc-efectivo.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  domicilioEstructurado,
+  domicilioTexto,
+  kycEfectivo,
+  type KycPersonaFuente,
+  type KycVentaFuente,
+} from './kyc-efectivo';
+
+// Población 1: venta capturada en BSOP (form Sprint 7c-2) — todo en persona.
+const personaBsop: KycPersonaFuente = {
+  ocupacion: 'OPERADOR DE MAQUINARIA',
+  forma_pago_kyc: 'FINANCIAMIENTO HIPOTECARIO',
+  uso_efectivo_kyc: 'SIN USO DE EFECTIVO',
+  conocimiento_dueno_beneficiario: 'No',
+  es_pep: false,
+  numero_credencial_ine: '2149282219',
+  domicilio: null,
+  domicilio_calle: 'EULALIO GUTIERREZ',
+  domicilio_numero_exterior: '105',
+  domicilio_numero_interior: null,
+  domicilio_colonia: 'FRAC GOBERNADORES',
+  domicilio_codigo_postal: '26090',
+  domicilio_ciudad: 'PIEDRAS NEGRAS',
+  domicilio_estado: 'COAHUILA',
+};
+const ventaBsop: KycVentaFuente = {
+  ocupacion: null,
+  forma_pago: null,
+  uso_efectivo: null,
+  conocimiento_dueno_beneficiario: null,
+  es_pep: null,
+  ine_numero: null,
+};
+
+// Población 2: venta importada de Coda — KYC + INE per-venta, blob en persona.
+const personaCoda: KycPersonaFuente = {
+  ocupacion: null,
+  forma_pago_kyc: null,
+  uso_efectivo_kyc: null,
+  conocimiento_dueno_beneficiario: 'No',
+  es_pep: false,
+  numero_credencial_ine: null,
+  domicilio: 'PASEO DE LA REV 1006, REAL DEL NORTE, PIEDRAS NEGRAS, COAHUILA, CP 26070',
+};
+const ventaCoda: KycVentaFuente = {
+  ocupacion: 'COMERCIANTE',
+  forma_pago: 'RECURSOS PROPIOS',
+  uso_efectivo: 'HASTA 1604 UMAS',
+  conocimiento_dueno_beneficiario: 'No',
+  es_pep: false,
+  ine_numero: '2906427095',
+};
+
+describe('kycEfectivo', () => {
+  it('venta BSOP-nativa: resuelve todo desde persona (incl. INE)', () => {
+    const k = kycEfectivo(personaBsop, ventaBsop);
+    expect(k.ocupacion).toBe('OPERADOR DE MAQUINARIA');
+    expect(k.formaPago).toBe('FINANCIAMIENTO HIPOTECARIO');
+    expect(k.usoEfectivo).toBe('SIN USO DE EFECTIVO');
+    expect(k.ineNumero).toBe('2149282219');
+    expect(k.esPep).toBe(false);
+  });
+
+  it('venta Coda: resuelve KYC + INE desde la venta', () => {
+    const k = kycEfectivo(personaCoda, ventaCoda);
+    expect(k.ocupacion).toBe('COMERCIANTE');
+    expect(k.formaPago).toBe('RECURSOS PROPIOS');
+    expect(k.usoEfectivo).toBe('HASTA 1604 UMAS');
+    expect(k.ineNumero).toBe('2906427095');
+  });
+
+  it('la INE per-venta (Coda) gana sobre la de la persona', () => {
+    const k = kycEfectivo(
+      { ...personaBsop, numero_credencial_ine: '1111111111' },
+      { ...ventaBsop, ine_numero: '2222222222' }
+    );
+    expect(k.ineNumero).toBe('2222222222');
+  });
+
+  it('PEP es OR: true en cualquiera de las dos fuentes gana', () => {
+    expect(
+      kycEfectivo({ ...personaBsop, es_pep: false }, { ...ventaBsop, es_pep: true }).esPep
+    ).toBe(true);
+    expect(
+      kycEfectivo({ ...personaBsop, es_pep: true }, { ...ventaBsop, es_pep: false }).esPep
+    ).toBe(true);
+    expect(kycEfectivo(personaBsop, ventaBsop).esPep).toBe(false);
+  });
+
+  it('tolera persona/venta null', () => {
+    const k = kycEfectivo(null, null);
+    expect(k.ocupacion).toBeNull();
+    expect(k.ineNumero).toBeNull();
+    expect(k.esPep).toBe(false);
+  });
+});
+
+describe('domicilioEstructurado', () => {
+  it('mapea municipio←ciudad y entidadFederativa←estado', () => {
+    const d = domicilioEstructurado(personaBsop);
+    expect(d?.municipio).toBe('PIEDRAS NEGRAS');
+    expect(d?.entidadFederativa).toBe('COAHUILA');
+    expect(d?.calle).toBe('EULALIO GUTIERREZ');
+  });
+
+  it('null cuando no hay ningún campo estructurado (persona Coda)', () => {
+    expect(domicilioEstructurado(personaCoda)).toBeNull();
+    expect(domicilioEstructurado(null)).toBeNull();
+  });
+});
+
+describe('domicilioTexto', () => {
+  it('usa el blob histórico si existe', () => {
+    expect(domicilioTexto(personaCoda)).toBe(
+      'PASEO DE LA REV 1006, REAL DEL NORTE, PIEDRAS NEGRAS, COAHUILA, CP 26070'
+    );
+  });
+
+  it('compone desde estructurado cuando no hay blob', () => {
+    expect(domicilioTexto(personaBsop)).toBe(
+      'EULALIO GUTIERREZ 105, FRAC GOBERNADORES, PIEDRAS NEGRAS, COAHUILA, CP 26090'
+    );
+  });
+
+  it('incluye número interior cuando existe', () => {
+    expect(domicilioTexto({ ...personaBsop, domicilio_numero_interior: '4B' })).toBe(
+      'EULALIO GUTIERREZ 105 INT 4B, FRAC GOBERNADORES, PIEDRAS NEGRAS, COAHUILA, CP 26090'
+    );
+  });
+
+  it('null cuando no hay blob ni estructurado', () => {
+    expect(domicilioTexto(personaCoda && { ...personaCoda, domicilio: null })).toBeNull();
+    expect(domicilioTexto(null)).toBeNull();
+  });
+});

--- a/lib/dilesa/kyc-efectivo.ts
+++ b/lib/dilesa/kyc-efectivo.ts
@@ -1,0 +1,122 @@
+/**
+ * Resolución de fuentes para los datos KYC/identificación del cliente en
+ * el expediente DILESA (FICU, promesa, pagaré, pantalla de detalle).
+ *
+ * Hay DOS poblaciones de ventas con los datos en lugares distintos:
+ *
+ *   - Importadas de Coda: KYC + INE per-venta en `dilesa.ventas`
+ *     (ocupacion, forma_pago, uso_efectivo, conocimiento_dueno_beneficiario,
+ *     es_pep, ine_numero) y domicilio como blob en `erp.personas.domicilio`.
+ *   - Capturadas en BSOP (form Sprint 7c-2): todo en `erp.personas`
+ *     (ocupacion, forma_pago_kyc, uso_efectivo_kyc, es_pep,
+ *     numero_credencial_ine, domicilio_* estructurado).
+ *
+ * El backfill 20260611181150 copió los KYC Coda→persona, pero la INE y el
+ * domicilio siguen divididos. Regla: gana la fuente con dato; PEP es OR de
+ * ambas (nunca degradar un true); la INE per-venta (Coda) gana sobre la de
+ * la persona porque es la credencial específica del expediente.
+ */
+
+export type KycPersonaFuente = {
+  ocupacion?: string | null;
+  forma_pago_kyc?: string | null;
+  uso_efectivo_kyc?: string | null;
+  conocimiento_dueno_beneficiario?: string | null;
+  es_pep?: boolean | null;
+  numero_credencial_ine?: string | null;
+  domicilio?: string | null;
+  domicilio_calle?: string | null;
+  domicilio_numero_exterior?: string | null;
+  domicilio_numero_interior?: string | null;
+  domicilio_colonia?: string | null;
+  domicilio_codigo_postal?: string | null;
+  domicilio_ciudad?: string | null;
+  domicilio_estado?: string | null;
+};
+
+export type KycVentaFuente = {
+  ocupacion?: string | null;
+  forma_pago?: string | null;
+  uso_efectivo?: string | null;
+  conocimiento_dueno_beneficiario?: string | null;
+  es_pep?: boolean | null;
+  ine_numero?: string | null;
+};
+
+export type KycEfectivo = {
+  ocupacion: string | null;
+  formaPago: string | null;
+  usoEfectivo: string | null;
+  conocimientoDuenoBeneficiario: string | null;
+  esPep: boolean;
+  ineNumero: string | null;
+};
+
+export function kycEfectivo(
+  persona: KycPersonaFuente | null | undefined,
+  venta: KycVentaFuente | null | undefined
+): KycEfectivo {
+  return {
+    ocupacion: persona?.ocupacion ?? venta?.ocupacion ?? null,
+    formaPago: persona?.forma_pago_kyc ?? venta?.forma_pago ?? null,
+    usoEfectivo: persona?.uso_efectivo_kyc ?? venta?.uso_efectivo ?? null,
+    conocimientoDuenoBeneficiario:
+      persona?.conocimiento_dueno_beneficiario ?? venta?.conocimiento_dueno_beneficiario ?? null,
+    esPep: Boolean(persona?.es_pep || venta?.es_pep),
+    ineNumero: venta?.ine_numero ?? persona?.numero_credencial_ine ?? null,
+  };
+}
+
+export type DomicilioEstructurado = {
+  calle: string | null;
+  numeroExterior: string | null;
+  numeroInterior: string | null;
+  colonia: string | null;
+  municipio: string | null;
+  codigoPostal: string | null;
+  entidadFederativa: string | null;
+};
+
+/** Campos estructurados de la persona, o null si no hay ninguno. */
+export function domicilioEstructurado(
+  persona: KycPersonaFuente | null | undefined
+): DomicilioEstructurado | null {
+  if (!persona) return null;
+  const d: DomicilioEstructurado = {
+    calle: persona.domicilio_calle ?? null,
+    numeroExterior: persona.domicilio_numero_exterior ?? null,
+    numeroInterior: persona.domicilio_numero_interior ?? null,
+    colonia: persona.domicilio_colonia ?? null,
+    municipio: persona.domicilio_ciudad ?? null,
+    codigoPostal: persona.domicilio_codigo_postal ?? null,
+    entidadFederativa: persona.domicilio_estado ?? null,
+  };
+  const tieneAlgo = Object.values(d).some(Boolean);
+  return tieneAlgo ? d : null;
+}
+
+/**
+ * Domicilio como una línea de texto (para promesa, pagaré y pantalla):
+ * el blob histórico de Coda si existe; si no, compuesto desde los campos
+ * estructurados con el mismo formato del blob
+ * ("CALLE 123 INT 4, COLONIA, CIUDAD, ESTADO, CP 26070").
+ */
+export function domicilioTexto(persona: KycPersonaFuente | null | undefined): string | null {
+  if (persona?.domicilio) return persona.domicilio;
+  const d = domicilioEstructurado(persona);
+  if (!d) return null;
+  const calleNumero = [
+    [d.calle, d.numeroExterior].filter(Boolean).join(' '),
+    d.numeroInterior ? `INT ${d.numeroInterior}` : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const partes = [
+    calleNumero || null,
+    d.colonia,
+    d.municipio,
+    d.entidadFederativa,
+    d.codigoPostal ? `CP ${d.codigoPostal}` : null,
+  ].filter(Boolean);
+  return partes.length > 0 ? partes.join(', ') : null;
+}

--- a/supabase/migrations/20260611220739_backfill_venta_vendedor_snapshot.sql
+++ b/supabase/migrations/20260611220739_backfill_venta_vendedor_snapshot.sql
@@ -1,0 +1,34 @@
+-- ╭─ 20260611220739_backfill_venta_vendedor_snapshot ─╮
+-- Backfill: dilesa.ventas.vendedor (text) ← core.usuarios para ventas
+-- BSOP-nativas que solo guardaron vendedor_usuario_id. La RLS de
+-- core.usuarios es self-only (usuarios_select_own): el lookup del nombre
+-- al render solo funcionaba cuando imprimía/veía el propio vendedor, y a
+-- los demás (gerencia) el asesor les salía vacío en la solicitud de
+-- asignación y en la pantalla del expediente. El form de venta nueva ya
+-- persiste este snapshot al crear; esto cubre las ventas previas.
+--
+-- Idempotente (solo filas con vendedor NULL/''). En Supabase Preview
+-- (sin datos de prod) actualiza 0 filas.
+--
+-- Timestamp generado con `npm run db:new` (anti-colisión multi-sesión:
+-- estrictamente mayor que toda migración local + de PRs abiertos).
+
+BEGIN;
+
+UPDATE dilesa.ventas v
+SET
+  vendedor = COALESCE(
+    NULLIF(TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')), ''),
+    u.email
+  ),
+  updated_at = now()
+FROM core.usuarios u
+WHERE u.id = v.vendedor_usuario_id
+  AND v.deleted_at IS NULL
+  AND (v.vendedor IS NULL OR v.vendedor = '')
+  AND COALESCE(
+    NULLIF(TRIM(COALESCE(u.first_name, '') || ' ' || COALESCE(u.last_name, '')), ''),
+    u.email
+  ) IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Problema (reporte de ventas, 2026-06-11)

FICU de la venta de hoy (capturada por Rosalinda en BSOP): **no arrastra el número de INE** aunque sí se capturó, y **no sale el nombre del asesor**.

Auditoría completa de fuentes — tres causas distintas:

| Campo | Form escribe en | PDF/pantalla leía | Quién lo sufría |
|---|---|---|---|
| INE | `erp.personas.numero_credencial_ine` | `dilesa.ventas.ine_numero` (solo import Coda) | Ventas BSOP-nativas |
| Domicilio | `erp.personas.domicilio_*` (estructurado) | blob `erp.personas.domicilio` (solo Coda) | Ventas BSOP-nativas (FICU, promesa, pagaré, pantalla) |
| Asesor | `vendedor_usuario_id` → lookup `core.usuarios` | — | **Cualquiera que no sea el propio vendedor**: la RLS `usuarios_select_own` es self-only → 0 filas → caía al legacy `venta.vendedor` (NULL en nativas) |
| KYC en pantalla | `erp.personas.*_kyc` | `venta.*` | Bug espejo del FICU de ayer: el bloque KYC de la pantalla salía vacío para ventas nativas |

## Fix

- **`lib/dilesa/kyc-efectivo.ts`** (nuevo, con tests): resolución única persona↔venta — KYC efectivo, INE (per-venta Coda gana sobre persona), PEP = OR, domicilio estructurado + texto compuesto con blob fallback. La usan el route PDF y la pantalla.
- **Route PDF**: lookup del asesor con **admin client** (solo first/last/email para estamparlo; el acceso a la venta ya pasó por la RLS de `dilesa.ventas`). FICU recibe domicilio estructurado (el template ya lo soportaba, nunca se le pasaba).
- **Form venta nueva**: persiste `venta.vendedor` (text) como snapshot al crear — paridad con Coda, independencia de RLS para pantalla client-side.
- **Migración `20260611220739`** (data-only, idempotente, 0 filas en Preview): backfill del snapshot para las ventas BSOP-nativas previas.

## Verificación

- Caso real (venta 22d58a9b, Silverio E. Torres): `persona.numero_credencial_ine='2149282219'` / `venta.ine_numero=NULL` → con el fix la INE resuelve de persona. Domicilio estructurado presente, blob NULL → compone texto.
- 11 tests nuevos del helper; 1,597 tests verdes; typecheck/lint/format/initiatives OK.
- ⚠️ `schema:check` puede fallar por drift ajeno de #838 (DDL de conciliación bancaria ya aplicado a prod sin mergear) — no absorbido aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)