### PR TITLE
feat(notificaciones): grupos de email DILESA — facturas@ canónico + catálogo completo

### DIFF
--- a/app/api/cron/dilesa-resumen-consejo/route.ts
+++ b/app/api/cron/dilesa-resumen-consejo/route.ts
@@ -12,8 +12,10 @@
  *   - Envío a las 20:00 hora de Matamoros, de lunes a sábado.
  *   - **Domingo NO se envía** (guard sobre el día, TZ real).
  *   - Destino: RESUMEN_CONSEJO_TEST_TO si está definida (modo prueba, subject con
- *     [PRUEBA]); en su defecto, consejo@dilesa.mx (producción). Sin candado extra
- *     — igual que el cron de tareas, siempre envía (TEST_TO es la única palanca).
+ *     [PRUEBA]); en su defecto, los destinatarios del catálogo
+ *     `core.notification_definitions` slug `dilesa_resumen_consejo` (ahí vive
+ *     consejo@dilesa.mx como `always`, editable runtime + kill switch `activo`).
+ *     FAIL-OPEN: sin definición usa los fallbacks hardcodeados.
  *   - El bloque de Saldos Bancos solo aparece cuando hay saldos capturados
  *     (iniciativa tesoreria → erp.v_cuenta_saldo_actual).
  *
@@ -30,12 +32,22 @@ import {
   relojMatamoros,
   HORA_ENVIO_LOCAL,
 } from '@/lib/dilesa/resumen-consejo-email';
+import {
+  getDefinitionBySlug,
+  renderSubject,
+  splitRecipientsExtra,
+  writeNotificationLog,
+} from '@/lib/notifications';
 
 export const maxDuration = 120;
 
 const DILESA_EMPRESA_ID = 'f5942ed4-7a6b-4c39-af18-67b9fbf7f479';
-const CONSEJO_EMAIL = 'consejo@dilesa.mx';
-const FROM = 'Desarrollo Inmobiliario los Encinos <noreply@bsop.io>';
+const RESUMEN_SLUG = 'dilesa_resumen_consejo';
+
+/** Fallbacks si el catálogo no responde (FAIL-OPEN, patrón escrituración). */
+const CONSEJO_EMAIL_FALLBACK = 'consejo@dilesa.mx';
+const FROM_FALLBACK = 'Desarrollo Inmobiliario los Encinos <noreply@bsop.io>';
+const SUBJECT_FALLBACK = 'Resumen Diario Operación Dilesa 🏘️ {fecha}';
 
 export async function GET(req: NextRequest) {
   const cronSecret = process.env.CRON_SECRET?.trim();
@@ -75,6 +87,21 @@ export async function GET(req: NextRequest) {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
+  // Catálogo de notificaciones (fail-open: sin definición usa fallbacks).
+  const def = await getDefinitionBySlug(supabase, RESUMEN_SLUG, DILESA_EMPRESA_ID);
+  if (def && !def.activo) {
+    await writeNotificationLog(supabase, {
+      definitionId: def.id,
+      empresaId: DILESA_EMPRESA_ID,
+      status: 'skipped',
+      recipients: { to: [] },
+      subject: `${RESUMEN_SLUG} — kill switch`,
+    });
+    const skip = { status: 'skipped', reason: 'kill_switch' };
+    console.log('[dilesa-resumen-consejo]', JSON.stringify(skip));
+    return NextResponse.json(skip);
+  }
+
   // Branding (header del correo) desde core.empresas.
   const { data: empresa } = await supabase
     .schema('core')
@@ -91,17 +118,45 @@ export async function GET(req: NextRequest) {
   });
 
   // Destino: RESUMEN_CONSEJO_TEST_TO definida → modo prueba (subject [PRUEBA], NO
-  // toca al Consejo); en su defecto, el Consejo real. Sin candado extra — igual
-  // que el cron de tareas, el correo siempre se envía.
+  // toca al Consejo, sin cc/bcc); en su defecto, los destinatarios del catálogo
+  // (o el fallback). Sin candado extra — el correo siempre se envía.
   const testTo = process.env.RESUMEN_CONSEJO_TEST_TO?.trim();
-  const recipients = testTo ? [testTo] : [CONSEJO_EMAIL];
-  const subject = `Resumen Diario Operación Dilesa 🏘️ ${fechaTitulo}${testTo ? ' [PRUEBA]' : ''}`;
+  const extras = def
+    ? splitRecipientsExtra(def.recipients_extra)
+    : { to: [CONSEJO_EMAIL_FALLBACK], cc: [], bcc: [] };
+  // Una definición sin `always` dejaría el correo sin destino — fallback.
+  const baseTo = extras.to.length > 0 ? extras.to : [CONSEJO_EMAIL_FALLBACK];
+  const recipients = testTo ? [testTo] : baseTo;
+  const cc = testTo ? [] : extras.cc;
+  const bcc = testTo ? [] : extras.bcc;
+
+  const fromAddress = def
+    ? def.from_name
+      ? `${def.from_name} <${def.from_email}>`
+      : def.from_email
+    : FROM_FALLBACK;
+  const subjectBase = renderSubject(def?.subject_template ?? SUBJECT_FALLBACK, {
+    fecha: fechaTitulo,
+  });
+  const subject = `${subjectBase}${testTo ? ' [PRUEBA]' : ''}`;
 
   const res = await sendResumenEmail(resendKey, {
     html,
     subject,
-    from: FROM,
+    from: fromAddress,
     recipients,
+    cc,
+    bcc,
+  });
+
+  await writeNotificationLog(supabase, {
+    definitionId: def?.id ?? null,
+    empresaId: DILESA_EMPRESA_ID,
+    status: res.ok ? 'sent' : 'failed',
+    recipients: { to: recipients, cc, bcc },
+    subject,
+    resendId: res.id ?? null,
+    errorMessage: res.ok ? null : String(res.error ?? 'unknown'),
   });
 
   const summary = {

--- a/app/api/dilesa/cotizaciones/[id]/solicitud/route.tsx
+++ b/app/api/dilesa/cotizaciones/[id]/solicitud/route.tsx
@@ -16,7 +16,7 @@ import {
   SolicitudCotizacionPDF,
   type SolicitudCotizacionData,
 } from '@/lib/dilesa/pdf/solicitud-cotizacion';
-import { getDefinitionBySlug, writeNotificationLog } from '@/lib/notifications';
+import { getDefinitionBySlug, renderSubject, writeNotificationLog } from '@/lib/notifications';
 
 const MESES_ES = [
   'Enero',
@@ -216,7 +216,12 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
   const buf = await renderToBuffer(<SolicitudCotizacionPDF data={data} />);
   const base64 = buf.toString('base64');
-  const subject = `Solicitud de cotización ${data.folio} — DILESA`;
+  const subject = renderSubject(
+    def?.subject_template ?? 'Solicitud de cotización {folio} — DILESA',
+    {
+      folio: data.folio,
+    }
+  );
 
   const html = `
 <div style="font-family: -apple-system, sans-serif; color: #222; max-width: 600px;">

--- a/app/dilesa/construccion/estimaciones/[id]/page.tsx
+++ b/app/dilesa/construccion/estimaciones/[id]/page.tsx
@@ -882,7 +882,7 @@ function EmailModal({
           </ModalField>
           <p className="text-[11px] text-[var(--text)]/55">
             Se envía con el PDF de la estimación adjunto + texto pidiendo que emita la factura por
-            el monto neto y la envíe a pagos@dilesa.mx. Puedes re-enviar las veces que necesites.
+            el monto neto y la envíe a facturas@dilesa.mx. Puedes re-enviar las veces que necesites.
           </p>
         </div>
 

--- a/docs/planning/dilesa-estimaciones.md
+++ b/docs/planning/dilesa-estimaciones.md
@@ -195,8 +195,8 @@ Sub-slugs:
 - API route `/api/dilesa/estimaciones/[id]/pdf` → returns PDF stream
 - Botón "Aprobar y enviar al contratista" en detalle estado=borrador →
   cambia estado a `aprobada` + envía email Resend con PDF adjunto +
-  template de email "favor de prepare factura por $X y enviar a
-  pagos@dilesa.mx".
+  template de email "favor de preparar factura por $X y enviar a
+  facturas@dilesa.mx".
 - Botón "Registrar factura recibida" en estado=aprobada → captura URL/folio.
 - Botón "Marcar como pagada" en estado=facturada → captura referencia
   bancaria + fecha + transiciona a `pagada` → dispara el lock en cascada.
@@ -268,6 +268,10 @@ Sub-slugs:
 - **2026-05-25** — Sprint 6 mergeado (PR #530): cutover del sync —
   5 scripts construcción + estimaciones incrementales al cron daily,
   email con columnas Antes/Después/Δ y columna Coda con flag de paridad.
+- **2026-06-11** — Fix post-cierre: el modal de envío decía "envíe la
+  factura a pagos@dilesa.mx" — ese grupo no existe en Workspace; el
+  canónico (decisión Beto) es `facturas@dilesa.mx`, que ya usaban el PDF
+  y el reply-to. Texto de UI y specs de este doc alineados.
 - **2026-05-25** — Iniciativa cerrada. Próximo: cutover operativo
   (sábado 31-may pausar Coda, lunes 2-jun staff usa BSOP).
 
@@ -283,7 +287,9 @@ Sub-slugs:
 - **R3**: Estimaciones con tareas de obras de varios proyectos —
   validar que el desglose por obra (con su proyecto) sea legible.
 - **R4**: Email Resend — pendiente confirmar template de remitente
-  (¿pagos@dilesa.mx?) y dominio verificado.
+  (¿pagos@dilesa.mx?) y dominio verificado. _Resuelto 2026-06-11: el
+  buzón para facturas de contratistas es `facturas@dilesa.mx` (grupo
+  Workspace existente); `pagos@dilesa.mx` nunca existió._
 
 ## Métricas de éxito
 

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -594,7 +594,14 @@ export async function fetchResumenConsejoData(
  */
 export async function sendResumenEmail(
   resendKey: string,
-  payload: { html: string; subject: string; from: string; recipients: string[] }
+  payload: {
+    html: string;
+    subject: string;
+    from: string;
+    recipients: string[];
+    cc?: string[];
+    bcc?: string[];
+  }
 ): Promise<{ ok: boolean; id?: string; error?: unknown }> {
   const res = await fetch('https://api.resend.com/emails', {
     method: 'POST',
@@ -605,6 +612,8 @@ export async function sendResumenEmail(
     body: JSON.stringify({
       from: payload.from,
       to: payload.recipients,
+      cc: payload.cc && payload.cc.length > 0 ? payload.cc : undefined,
+      bcc: payload.bcc && payload.bcc.length > 0 ? payload.bcc : undefined,
       subject: payload.subject,
       html: payload.html,
     }),

--- a/supabase/migrations/20260611232950_notif_catalogo_cotizacion_resumen_consejo.sql
+++ b/supabase/migrations/20260611232950_notif_catalogo_cotizacion_resumen_consejo.sql
@@ -1,0 +1,73 @@
+-- ╭─ 20260611232950_notif_catalogo_cotizacion_resumen_consejo ─╮
+-- Completa el catálogo `core.notification_definitions` con 2 envíos que ya
+-- corren en prod pero con destinatarios hardcodeados (auditoría de grupos
+-- de email DILESA, 2026-06-11):
+--
+--   1. `dilesa_cotizacion` — el handler de RFQ
+--      (`app/api/dilesa/cotizaciones/[id]/solicitud`) consulta este slug
+--      desde el Sprint 2 de notificaciones-catalogo, pero la fila nunca se
+--      sembró → siempre caía al fallback hardcode. Con la fila, from /
+--      reply-to (compras@dilesa.mx) / subject quedan editables runtime.
+--   2. `dilesa_resumen_consejo` — el cron diario al Consejo mandaba a
+--      `consejo@dilesa.mx` hardcodeado; este PR refactoriza el handler para
+--      leer el catálogo (destinatario como recipient extra `always`, mismo
+--      patrón que escrituras@ en `dilesa_escrituracion`) + kill switch.
+--
+-- Data-only (sin DDL → sin NOTIFY pgrst). Robusta a Preview branches: sin
+-- FK a datos de prod; idempotente vía WHERE NOT EXISTS — el UNIQUE
+-- (slug, empresa_id) no protege duplicados cuando empresa_id es NULL.
+
+BEGIN;
+
+INSERT INTO core.notification_definitions
+  (slug, empresa_id, nombre, descripcion, trigger_type, trigger_config,
+   from_email, from_name, reply_to, recipients_extra, subject_template, activo)
+SELECT
+  'dilesa_cotizacion',
+  NULL,
+  'Solicitud de cotización (RFQ) a proveedor',
+  'Email al proveedor con el PDF de la solicitud de cotización adjunto '
+  '(listado de conceptos a cotizar, fecha límite). Las respuestas llegan al '
+  'grupo compras@dilesa.mx vía reply-to. Disparo manual desde el detalle de '
+  'la cotización en /dilesa/compras.',
+  'manual',
+  '{"ui_location": "/dilesa/compras (detalle de cotización)", "button_label": "Enviar solicitud"}'::jsonb,
+  'noreply@bsop.io',
+  'DILESA Compras',
+  'compras@dilesa.mx',
+  '[]'::jsonb,
+  'Solicitud de cotización {folio} — DILESA',
+  true
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM core.notification_definitions
+  WHERE slug = 'dilesa_cotizacion' AND empresa_id IS NULL
+);
+
+INSERT INTO core.notification_definitions
+  (slug, empresa_id, nombre, descripcion, trigger_type, trigger_config,
+   from_email, from_name, reply_to, recipients_extra, subject_template, activo)
+SELECT
+  'dilesa_resumen_consejo',
+  NULL,
+  'Resumen Diario Operación DILESA al Consejo',
+  'Correo diario (lunes a sábado, 20:00 hora de Matamoros) al grupo '
+  'consejo@dilesa.mx con los 7 bloques de operación: saldos bancos, avances '
+  'de obra, margen, inventario, tubería de ventas, asignaciones y '
+  'contratistas. El destinatario vive como recipient extra `always`; '
+  'RESUMEN_CONSEJO_TEST_TO (env) lo overridea en modo prueba.',
+  'cron',
+  '{"schedule": "0 1,2 * * *", "guard": "solo la corrida que cae a las 20:00 de Matamoros; domingo no se envía"}'::jsonb,
+  'noreply@bsop.io',
+  'Desarrollo Inmobiliario los Encinos',
+  NULL,
+  '[{"email": "consejo@dilesa.mx", "type": "always"}]'::jsonb,
+  'Resumen Diario Operación Dilesa 🏘️ {fecha}',
+  true
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM core.notification_definitions
+  WHERE slug = 'dilesa_resumen_consejo' AND empresa_id IS NULL
+);
+
+COMMIT;


### PR DESCRIPTION
## Contexto

Auditoría de los grupos de email de Workspace dilesa.mx (los envíos del sistema van a grupos, nunca a empleados directos). Tres hallazgos, tres fixes:

## 1. `pagos@dilesa.mx` no existe — el canónico es `facturas@dilesa.mx`

El modal de envío de estimaciones decía al contratista *"envíe la factura a pagos@dilesa.mx"* — ese grupo **no existe** en Workspace (los correos rebotaban). Decisión de Beto: `facturas@` es el que los proveedores ya conocen. El PDF y el reply-to ya lo usaban; se alinea el texto de UI y los specs del planning doc (+ bitácora).

## 2. Fila `dilesa_cotizacion` sembrada en el catálogo

El handler de RFQ consulta `getDefinitionBySlug('dilesa_cotizacion')` desde el Sprint 2 de notificaciones-catalogo, pero la fila nunca se sembró → siempre caía al fallback hardcode (invisible en /settings/notificaciones). Con la fila, from / reply-to (`compras@dilesa.mx`) / subject quedan editables runtime. El subject ahora renderiza `subject_template` (`{folio}`).

## 3. Cron resumen-consejo conectado al catálogo

`consejo@dilesa.mx` estaba hardcodeado en el route. Ahora lee el slug `dilesa_resumen_consejo`: destinatario como recipient extra `always` (mismo patrón que `escrituras@` en `dilesa_escrituracion`), kill switch `activo`, from/subject del catálogo y traza en `notification_log`. FAIL-OPEN: sin definición usa los fallbacks hardcodeados (comportamiento idéntico al actual). `sendResumenEmail` acepta `cc`/`bcc`. `RESUMEN_CONSEJO_TEST_TO` sigue siendo la palanca de prueba.

## Migración

`20260611232950_notif_catalogo_cotizacion_resumen_consejo.sql` — **data-only** (2 INSERTs, sin DDL). Idempotente vía `WHERE NOT EXISTS` (el UNIQUE `(slug, empresa_id)` no protege con `empresa_id NULL`), sin FK a datos de prod → Preview-safe. No afecta SCHEMA_REF ni types.

## Checks

- [x] typecheck · test:coverage (1623 ✓) · lint · format:check · initiatives:check · schema:check (sin drift; solo timestamp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)