### PR TITLE
fix(dilesa-ventas): sincronizar unidades.estado con ventas activas en el sync de rescate

### DIFF
--- a/docs/planning/dilesa-ventas-expediente.md
+++ b/docs/planning/dilesa-ventas-expediente.md
@@ -7,7 +7,7 @@
 **Próximo hito:** — (cerrada: cutover Coda de ventas completado 2026-06-11 — paridad certificada, daily apagado, equipo de ventas con usuarios/perfiles activos. Coda queda read-only de consulta)
 **Dueño:** Beto
 **Creada:** 2026-06-09
-**Última actualización:** 2026-06-11 (hotfix post-cutover: 61 ventas falsas-desasignadas reactivadas tras cruce Coda↔BSOP; regla de desasignación corregida en el import)
+**Última actualización:** 2026-06-11 (hotfix post-cutover #2: unidades.estado re-sincronizado con ventas activas — 17 unidades corregidas en prod, sync agregado al import de rescate)
 
 ## Problema
 
@@ -308,6 +308,19 @@ expediente, copiloto), no reescritura.
   "ADALBERTO SANTOS PRUEBA" — excluido, sigue desasignada. La regla quedó
   corregida también en `import_dilesa_ventas.ts` por si se usa el sync
   manual de rescate (#842).
+- **2026-06-11 (hotfix unidades.estado desincronizado):** Beto reportó que
+  M20-L34-LDLE aparecía en Inventario disponible estando vendida (venta de
+  Victor Manuel Luna, Escriturada). Causa: el import de inventario congeló
+  `unidades.estado` al snapshot del 2026-05-22 y el sync de ventas nunca lo
+  actualizaba — solo el flujo nativo de BSOP lo hace, y las ventas nacidas
+  en Coda no pasan por él. Backfill aplicado en prod con confirmación de
+  Beto: 16 unidades con venta activa que aparecían disponibles → `asignada`
+  (13) / `escriturada` (3, fase ≥11), y el caso espejo M2-L8-LDLE
+  (`asignada` con su única venta desasignada — cliente desperfilado) →
+  `terminada` (de vuelta al inventario). Verificación post-fix: 0
+  inconsistencias en ambas direcciones. `import_dilesa_ventas.ts` ahora
+  sincroniza `unidades.estado` al final de cada corrida (promueve por fase,
+  libera asignadas sin venta activa, nunca degrada escriturada/entregada).
 
 ## Decisiones registradas
 
@@ -369,3 +382,11 @@ expediente, copiloto), no reescritura.
   la reutilización de filas en Coda). Desasignada de verdad ⇔ ya sin
   `Inventario`. El `motivo_desasignacion` se conserva en ventas reactivadas
   como histórico de la reubicación.
+- **2026-06-11 (unidades.estado se deriva de las ventas activas):** Para el
+  ciclo comercial, `dilesa.unidades.estado` es derivado: venta activa fase
+  <11 → `asignada`, ≥11 → `escriturada`, ≥15 → `entregada`; sin venta activa
+  y `asignada` → se libera a `terminada`. Solo se promueve, nunca se degrada
+  (escriturada/entregada son hechos consumados); `planeada`/`lote_urbanizado`
+  no se tocan (en preventa manda la fase de obra). Vive en el flujo nativo
+  (asignar/desasignar/expirar) y en el sync de rescate
+  `import_dilesa_ventas.ts`.

--- a/scripts/import_dilesa_ventas.ts
+++ b/scripts/import_dilesa_ventas.ts
@@ -9,6 +9,10 @@
  *   - La transacción → dilesa.ventas (liga persona ↔ unidad).
  *   - El pipeline    → dilesa.venta_fases (una fila por fase alcanzada).
  *   - Los depósitos  → dilesa.venta_pagos (de la tabla Depositos Clientes).
+ *   - Al final sincroniza dilesa.unidades.estado con las ventas activas
+ *     (asignada/escriturada/entregada según fase; libera a 'terminada' las
+ *     asignadas sin venta activa) — sin esto el Inventario muestra como
+ *     disponibles unidades vendidas (bug M20-L34-LDLE, 2026-06-11).
  *
  * El expediente digital (PDFs) NO se importa aquí — es Fase 4.5.
  * Mapeo: docs/planning/dilesa-portafolio-mapeo-coda.md § 6.
@@ -516,10 +520,80 @@ async function main() {
     else okP += chunk.length;
   }
 
+  // ── unidades.estado: sincronizar con las ventas activas ─────────────────────
+  // El import de inventario congeló el estado de cada unidad al día del
+  // snapshot (2026-05-22); las asignaciones/desasignaciones posteriores en
+  // Coda no se reflejaban y el Inventario (filtra estado IN
+  // ('en_construccion','terminada')) ofrecía como disponibles unidades con
+  // venta activa encima — 16 casos detectados el 2026-06-11 (M20-L34-LDLE).
+  // Misma semántica que el flujo nativo (asignar → 'asignada', desasignar →
+  // 'terminada') + los hitos del mapEstado del import de inventario
+  // (fase ≥11 Escriturada → 'escriturada', ≥15 Entregada → 'entregada').
+  // Solo promueve — nunca degrada un estado de venta ya alcanzado — y no
+  // toca planeada/lote_urbanizado (preventa: la fase de obra sigue mandando).
+  const RANGO_ESTADO: Record<string, number> = { asignada: 1, escriturada: 2, entregada: 3 };
+  const estadoPorFase = (pos: number): string =>
+    pos >= 15 ? 'entregada' : pos >= 11 ? 'escriturada' : 'asignada';
+
+  // Fase máxima de las ventas activas por unidad — todas las ventas de la
+  // empresa (también las nativas BSOP), no solo las recién importadas.
+  const { data: ventasActivas, error: vaErr } = await sb
+    .schema('dilesa')
+    .from('ventas')
+    .select('unidad_id, fase_posicion')
+    .eq('empresa_id', empresaId)
+    .eq('estado', 'activa')
+    .is('deleted_at', null)
+    .not('unidad_id', 'is', null);
+  if (vaErr) throw new Error(`SELECT ventas activas: ${vaErr.message}`);
+  const faseMaxPorUnidad = new Map<string, number>();
+  for (const v of ventasActivas ?? []) {
+    const uid = v.unidad_id as string;
+    const pos = (v.fase_posicion as number | null) ?? 0;
+    faseMaxPorUnidad.set(uid, Math.max(faseMaxPorUnidad.get(uid) ?? 0, pos));
+  }
+
+  const { data: unidadesEstado, error: ueErr } = await sb
+    .schema('dilesa')
+    .from('unidades')
+    .select('id, identificador, estado')
+    .eq('empresa_id', empresaId)
+    .is('deleted_at', null);
+  if (ueErr) throw new Error(`SELECT unidades para sync: ${ueErr.message}`);
+
+  let okU = 0;
+  for (const u of unidadesEstado ?? []) {
+    const actual = u.estado as string;
+    const faseMax = faseMaxPorUnidad.get(u.id as string);
+    let target: string | null = null;
+    if (faseMax !== undefined) {
+      const objetivo = estadoPorFase(faseMax);
+      const promovible =
+        actual === 'en_construccion' ||
+        actual === 'terminada' ||
+        (RANGO_ESTADO[actual] ?? 99) < RANGO_ESTADO[objetivo];
+      if (promovible) target = objetivo;
+    } else if (actual === 'asignada') {
+      // Sin venta activa: liberar de vuelta al inventario (mismo destino que
+      // la desasignación nativa). escriturada/entregada no se revierten —
+      // son hechos consumados que Dirección maneja manual si hiciera falta.
+      target = 'terminada';
+    }
+    if (!target || target === actual) continue;
+    const { error } = await sb
+      .schema('dilesa')
+      .from('unidades')
+      .update({ estado: target })
+      .eq('id', u.id);
+    if (error) console.error(`✗ unidad ${u.identificador} → ${target}: ${error.message}`);
+    else okU++;
+  }
+
   console.log(
     `\n✔ UPSERT ${okV}/${registros.length} ventas, fases: ${okF} nuevas + ${updF} fechas actualizadas ` +
       `(${fasesInserts.length} en Coda, merge manual), ` +
-      `${okP} pagos${pagosHuerfanos ? ` (${pagosHuerfanos} depósitos sin venta — omitidos)` : ''}.`
+      `${okP} pagos${pagosHuerfanos ? ` (${pagosHuerfanos} depósitos sin venta — omitidos)` : ''}, ` +
+      `${okU} unidades con estado sincronizado.`
   );
 }
 


### PR DESCRIPTION
## Problema

Beto reportó que **M20-L34-LDLE** aparecía en Inventario disponible estando asignada y vendida (venta activa en fase Escriturada, con plan CxC generado).

**Causa raíz:** el import de inventario (`import_dilesa_inventario.ts`) congeló `dilesa.unidades.estado` al snapshot del 22-may. Las asignaciones/desasignaciones que ocurrieron en Coda después nunca se reflejaron: el sync de ventas (`import_dilesa_ventas.ts`) vincula la venta a la unidad pero no tocaba su estado — solo el flujo nativo de BSOP lo hace, y las ventas nacidas en Coda no pasan por él. El Inventario filtra `estado IN ('en_construccion','terminada')`, así que esas unidades se ofrecían como disponibles.

## Backfill ya aplicado en prod (con confirmación de Beto)

- **16 unidades** con venta activa que aparecían disponibles → `asignada` (13) / `escriturada` (3, fase ≥11). Entre ellas M20-L34-LDLE.
- **M2-L8-LDLE** (caso espejo: `asignada` con su única venta desasignada) → liberada a `terminada`, vuelve al inventario.
- Verificación post-fix: **0 inconsistencias** en ambas direcciones.

## Cambio de código

`import_dilesa_ventas.ts` ahora sincroniza `unidades.estado` al final de cada corrida (aplica solo si se reusa el sync manual de rescate post-cutover):

- Venta activa fase <11 → `asignada`; ≥11 → `escriturada`; ≥15 → `entregada` (mismos hitos que el mapEstado del import de inventario).
- `asignada` sin venta activa → se libera a `terminada` (mismo destino que la desasignación nativa).
- Solo promueve, nunca degrada (`escriturada`/`entregada` son hechos consumados); `planeada`/`lote_urbanizado` no se tocan (en preventa manda la fase de obra).

Bitácora y decisión registradas en `docs/planning/dilesa-ventas-expediente.md`.

## Checks

Los 6 checks de CI corridos en local: typecheck ✓, test:coverage ✓ (1615 tests), lint ✓ (0 errores), format:check ✓, initiatives:check ✓, schema:check ✓ (sin drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)