### PR TITLE
feat(cxp): comprobante de pago + filtro Pendientes + facturas por pago + TeToca consistente

### DIFF
--- a/components/cxp/cxp-pagos-module.test.ts
+++ b/components/cxp/cxp-pagos-module.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { filtrarPagosPorEstado } from './cxp-pagos-module';
+
+type EstadoPago = 'programado' | 'aprobado' | 'pagado' | 'rechazado' | 'cancelado';
+
+const PAGOS: { id: string; estado: EstadoPago }[] = [
+  { id: 'prog', estado: 'programado' },
+  { id: 'aprob', estado: 'aprobado' },
+  { id: 'pag', estado: 'pagado' },
+  { id: 'canc', estado: 'cancelado' },
+  { id: 'rech', estado: 'rechazado' },
+];
+
+describe('filtrarPagosPorEstado (CxP · Pagos)', () => {
+  it("'pendientes' (default de la vista) incluye programados Y aprobados — un pago aprobado no se pierde", () => {
+    expect(filtrarPagosPorEstado(PAGOS, 'pendientes').map((p) => p.id)).toEqual(['prog', 'aprob']);
+  });
+
+  it('cadena vacía = todos los estados', () => {
+    expect(filtrarPagosPorEstado(PAGOS, '')).toHaveLength(PAGOS.length);
+  });
+
+  it('un estado concreto filtra exacto', () => {
+    expect(filtrarPagosPorEstado(PAGOS, 'pagado').map((p) => p.id)).toEqual(['pag']);
+    expect(filtrarPagosPorEstado(PAGOS, 'cancelado').map((p) => p.id)).toEqual(['canc']);
+  });
+});

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -12,12 +12,18 @@
  *     rol "Dirección"; si el caller no lo es, se muestra el error del RPC
  *     con un toast claro. El botón NO se esconde por rol en cliente —
  *     defensa: manda el RPC.
- *   - Marcar pagado (aprobado → pagado): dialog con fecha + referencia,
- *     `cxp_pago_marcar_pagado`. **Confirmación fuerte** (egreso real).
+ *   - Marcar pagado (aprobado → pagado): dialog con fecha + referencia +
+ *     comprobante (imagen/PDF de la transferencia, `<FileAttachments>`
+ *     sobre `erp.adjuntos`), `cxp_pago_marcar_pagado`. **Confirmación
+ *     fuerte** (egreso real).
  *   - Cancelar (si no pagado): `cxp_pago_cancelar` con motivo.
  *
+ * Filtro default `'pendientes'` = programados + aprobados: lo vivo que aún
+ * no se ejecuta nunca sale de la vista hasta estar pagado.
+ *
  * El drawer de detalle muestra las facturas aplicadas
- * (`cxp_pago_aplicaciones` → `facturas`), montos, y quién aprobó/pagó.
+ * (`cxp_pago_aplicaciones` → `facturas`), montos, quién aprobó/pagó y los
+ * comprobantes adjuntos.
  *
  * No inventa lógica financiera: solo cablea las RPCs con buenas
  * confirmaciones. Parametrizado por `empresaId` (UUID). RDB y DILESA lo
@@ -49,6 +55,7 @@ import { useActionFeedback } from '@/hooks/use-action-feedback';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { formatCurrency } from '@/lib/format';
+import { FileAttachments } from '@/components/file-attachments';
 import type { EmpresaSlug } from '@/lib/empresa-branding';
 import { HiloGastoSection } from '@/components/gasto/hilo-gasto-stepper';
 import { useFocusDrilldown } from '@/hooks/use-focus-drilldown';
@@ -81,6 +88,8 @@ type Pago = {
   aprobado_at: string | null;
   pagado_at: string | null;
   notas: string | null;
+  /** Cuántas facturas cubre el pago (Programación agrupa por proveedor). */
+  facturas_count: number;
 };
 
 type FacturaAplicada = {
@@ -134,13 +143,33 @@ const METODO_LABEL: Record<string, string> = {
   tarjeta: 'Tarjeta',
 };
 
+/** Rol canónico del adjunto (ADR-022 FA4) para `erp.adjuntos.rol`. */
+const COMPROBANTE_ROLES = [{ id: 'comprobante', label: 'Comprobante de pago' }];
+
 const ESTADO_OPTIONS = [
+  { value: 'pendientes', label: 'Pendientes (programados + aprobados)' },
   { value: 'programado', label: 'Programado' },
   { value: 'aprobado', label: 'Aprobado' },
   { value: 'pagado', label: 'Pagado' },
   { value: 'cancelado', label: 'Cancelado' },
   { value: 'rechazado', label: 'Rechazado' },
 ];
+
+/**
+ * Filtro de la lista. `'pendientes'` (default) = todo lo vivo que aún no se
+ * ejecuta — programados Y aprobados — para que un pago aprobado no desaparezca
+ * de la vista hasta estar pagado. `''` = todos los estados.
+ */
+export function filtrarPagosPorEstado<T extends { estado: EstadoPago }>(
+  pagos: T[],
+  estado: string
+): T[] {
+  if (!estado) return pagos;
+  if (estado === 'pendientes') {
+    return pagos.filter((p) => p.estado === 'programado' || p.estado === 'aprobado');
+  }
+  return pagos.filter((p) => p.estado === estado);
+}
 
 // ── Módulo ─────────────────────────────────────────────────────────────────────
 
@@ -149,7 +178,7 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
   const [pagos, setPagos] = useState<Pago[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [estado, setEstado] = useState('programado');
+  const [estado, setEstado] = useState('pendientes');
 
   const [selected, setSelected] = useState<Pago | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -184,10 +213,25 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
         .order('created_at', { ascending: false });
       if (qErr) throw qErr;
 
-      type Raw = Omit<Pago, 'proveedor_nombre' | 'cuenta_nombre' | 'monto_total'> & {
+      type Raw = Omit<
+        Pago,
+        'proveedor_nombre' | 'cuenta_nombre' | 'monto_total' | 'facturas_count'
+      > & {
         monto_total: number | null;
       };
       const rows = (data ?? []) as Raw[];
+
+      // Cuántas facturas cubre cada pago — un pago por proveedor puede agrupar
+      // varias (la duda "¿dónde quedó mi factura?" se responde aquí).
+      const { data: apls } = await sb
+        .schema('erp')
+        .from('cxp_pago_aplicaciones')
+        .select('pago_id')
+        .eq('empresa_id', empresaId);
+      const facturasPorPago = new Map<string, number>();
+      for (const a of (apls ?? []) as { pago_id: string }[]) {
+        facturasPorPago.set(a.pago_id, (facturasPorPago.get(a.pago_id) ?? 0) + 1);
+      }
 
       // Nombres de proveedor (erp.personas) y de cuenta bancaria. Chunk a 150.
       const proveedorIds = [
@@ -234,6 +278,7 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
           cuenta_nombre: r.cuenta_bancaria_id
             ? (cuentaPorId.get(r.cuenta_bancaria_id) ?? null)
             : null,
+          facturas_count: facturasPorPago.get(r.id) ?? 0,
         }))
       );
     } catch (e) {
@@ -247,10 +292,7 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
     void fetchPagos();
   }, [fetchPagos]);
 
-  const filtered = useMemo(
-    () => (estado ? pagos.filter((p) => p.estado === estado) : pagos),
-    [pagos, estado]
-  );
+  const filtered = useMemo(() => filtrarPagosPorEstado(pagos, estado), [pagos, estado]);
 
   const openDetail = useCallback((p: Pago) => {
     setSelected(p);
@@ -363,11 +405,12 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
                           <div className="truncate font-medium">
                             {p.proveedor_nombre ?? '(sin proveedor)'}
                           </div>
-                          {p.referencia ? (
-                            <div className="font-mono text-xs text-muted-foreground">
-                              {p.referencia}
-                            </div>
-                          ) : null}
+                          <div className="text-xs text-muted-foreground">
+                            {p.facturas_count} factura{p.facturas_count !== 1 ? 's' : ''}
+                            {p.referencia ? (
+                              <span className="font-mono"> · {p.referencia}</span>
+                            ) : null}
+                          </div>
                         </td>
                         <td className="py-2 pr-2">
                           <Badge variant={b.variant} className={b.className}>
@@ -439,6 +482,7 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
 
       <PagoDrawer
         pago={selected}
+        empresaId={empresaId}
         empresa={empresa}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
@@ -496,6 +540,8 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
         <MarcarPagadoDialog
           key={pagarPago.id}
           pago={pagarPago}
+          empresaId={empresaId}
+          empresa={empresa}
           onClose={() => setPagarPago(null)}
           onDone={() => {
             setPagarPago(null);
@@ -511,6 +557,7 @@ export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
 
 function PagoDrawer({
   pago,
+  empresaId,
   empresa,
   open,
   onClose,
@@ -519,6 +566,7 @@ function PagoDrawer({
   onCancelar,
 }: {
   pago: Pago | null;
+  empresaId: string;
   empresa: EmpresaSlug;
   open: boolean;
   onClose: () => void;
@@ -713,6 +761,24 @@ function PagoDrawer({
                 </ul>
               )}
             </section>
+
+            <Separator />
+
+            {/* Comprobante (imagen/PDF de la transferencia o cheque) */}
+            <section className="space-y-2 text-sm">
+              <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Comprobante
+              </div>
+              <FileAttachments
+                empresaId={empresaId}
+                empresaSlug={empresa}
+                entidad="cxp_pagos"
+                entidadId={pago.id}
+                roles={COMPROBANTE_ROLES}
+                variant="flat"
+                readOnly={pago.estado === 'cancelado' || pago.estado === 'rechazado'}
+              />
+            </section>
           </div>
         )}
       </DetailDrawerContent>
@@ -733,11 +799,15 @@ function Field({ label, value, mono = false }: { label: string; value: string; m
 
 function MarcarPagadoDialog({
   pago,
+  empresaId,
+  empresa,
   onClose,
   onDone,
 }: {
   /** Siempre presente: el padre monta este dialog on-demand con key. */
   pago: Pago;
+  empresaId: string;
+  empresa: EmpresaSlug;
   onClose: () => void;
   onDone: () => void;
 }) {
@@ -805,6 +875,19 @@ function MarcarPagadoDialog({
               value={referencia}
               onChange={(e) => setReferencia(e.target.value)}
               placeholder="Ej. SPEI 0123456789"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <span className="text-xs text-muted-foreground">
+              Comprobante (imagen o PDF de la transferencia)
+            </span>
+            <FileAttachments
+              empresaId={empresaId}
+              empresaSlug={empresa}
+              entidad="cxp_pagos"
+              entidadId={pago.id}
+              roles={COMPROBANTE_ROLES}
+              variant="flat"
             />
           </div>
         </div>

--- a/components/gasto/te-toca-strip.tsx
+++ b/components/gasto/te-toca-strip.tsx
@@ -20,6 +20,10 @@ import { useEffect, useState } from 'react';
 import { ListChecks } from 'lucide-react';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { usePermissions, useEffectiveUser } from '@/components/providers';
+import {
+  pendientesDeProgramar,
+  type AplicacionViva,
+} from '@/components/cxp/cxp-programacion-module';
 
 type Chip = {
   key: string;
@@ -93,15 +97,33 @@ export function TeTocaStrip({ empresaId, empresa }: { empresaId: string; empresa
                   .is('deleted_at', null)
               )
             : 0,
-          count(
-            erp
-              .from('facturas')
-              .select('id', { count: 'exact', head: true })
-              .eq('empresa_id', empresaId)
-              .eq('flujo', 'egreso')
-              .in('estado_cxp', ['por_pagar', 'parcial'])
-              .gt('saldo', 0)
-          ),
+          // Por programar = mismo criterio que la pantalla de Programación:
+          // saldo abierto MENOS lo comprometido en pagos vivos sin ejecutar
+          // (un count plano contaría facturas ya 100% programadas).
+          (async () => {
+            const [factsRes, aplsRes] = await Promise.all([
+              erp
+                .from('facturas')
+                .select('id, saldo')
+                .eq('empresa_id', empresaId)
+                .eq('flujo', 'egreso')
+                .in('estado_cxp', ['por_pagar', 'parcial'])
+                .gt('saldo', 0),
+              erp
+                .from('cxp_pago_aplicaciones')
+                .select(
+                  'factura_id, monto_aplicado, pago:cxp_pagos!pago_id!inner(estado, deleted_at)'
+                )
+                .eq('empresa_id', empresaId)
+                .in('pago.estado', ['programado', 'aprobado'])
+                .is('pago.deleted_at', null),
+            ]);
+            if (factsRes.error || aplsRes.error) return 0;
+            const facts = ((factsRes.data ?? []) as { id: string; saldo: number | null }[]).map(
+              (f) => ({ id: f.id, saldo: Number(f.saldo ?? 0) })
+            );
+            return pendientesDeProgramar(facts, (aplsRes.data ?? []) as AplicacionViva[]).length;
+          })(),
           count(
             erp
               .from('cxp_pagos')

--- a/lib/storage/path.ts
+++ b/lib/storage/path.ts
@@ -37,6 +37,7 @@ export type AdjuntoEntidad =
   | 'ventas'
   | 'venta_pagos'
   | 'cxc_pagos'
+  | 'cxp_pagos'
   | 'facturas'
   | 'proyecto_tareas'
   | 'proyecto_tarea_pasos'


### PR DESCRIPTION
## Contexto

Feedback de Beto tras el fix de Programación ([#844](https://github.com/beto-sudo/BSOP/pull/844)): un pago "desaparecía", no había dónde subir el comprobante de la transferencia, y el filtro default de Pagos escondía los aprobados.

## Cambios

1. **Filtro default «Pendientes (programados + aprobados)»** — el default anterior (`programado`) escondía los pagos aprobados-no-pagados; parecían perdidos y son justo los que están listos para pagarse. Limpia el filtro para ver todos. Helper `filtrarPagosPorEstado` + tests.

2. **Comprobante de pago** — slot de adjuntos (imagen/PDF) en el dialog **Marcar pagado** y en el drawer del pago, vía `<FileAttachments>` canónico (ADR-022) sobre `erp.adjuntos` con rol `comprobante`. Entidad nueva `cxp_pagos` (espejo de `cxc_pagos`). **Sin migración**: RLS de adjuntos/storage gatean por empresa/bucket, no por entidad (verificado en prod).

3. **"N facturas" bajo el proveedor en la lista** — Programación agrupa por proveedor (1 pago puede cubrir varias facturas); el caso real "se me desapareció una factura" era el pago de \$306k que agrupa 2 facturas ($220k + $86k).

4. **Chip TeToca "facturas por programar"** ahora resta lo comprometido en pagos vivos (`pendientesDeProgramar`, mismo criterio que la pantalla) — seguía diciendo "3 facturas por programar" con las 3 ya 100% programadas.

## Verificación

- typecheck + 1626 tests + lint + format + initiatives + schema (sin drift) verdes en local; typecheck/tests re-corridos tras rebase sobre main con #845/#846.
- Políticas RLS de `erp.adjuntos` y `storage.objects` verificadas en prod: sin lista blanca de entidades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)