### PR TITLE
fix(notificaciones): from de dilesa_estimacion homologado a noreply@bsop.io

### DIFF
--- a/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
+++ b/app/api/dilesa/estimaciones/[id]/pdf/route.tsx
@@ -297,7 +297,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   const def = await getDefinitionBySlug(sb, 'dilesa_estimacion');
 
   // Defaults hardcoded como fallback fail-open.
-  let fromAddress = 'DILESA Facturas <facturas@bsop.io>';
+  let fromAddress = 'DILESA Facturas <noreply@bsop.io>';
   let replyTo: string | null = 'facturas@dilesa.mx';
   let toList = [to];
   let ccList: string[] = [];


### PR DESCRIPTION
Seguimiento de #845. El correo de estimaciones al contratista salía con from `facturas@bsop.io` — todos los demás envíos del sistema usan `noreply@bsop.io` (con display name por envío). Pedido de Beto al revisar /settings/notificaciones.

- La fila `dilesa_estimacion` en `core.notification_definitions` **ya se actualizó en prod** (UPDATE con OK verbal; `from_name` "DILESA Facturas" se conserva, queda `DILESA Facturas <noreply@bsop.io>`).
- Este PR alinea el **fallback fail-open** del handler (1 línea).
- El reply-to `facturas@dilesa.mx` no cambia.

Checks: typecheck · test:coverage (1626 ✓) · lint · format:check · initiatives:check · schema:check (sin drift) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)