### PR TITLE
feat(cxp): control por partida en el drawer del pago + fix capa pagado de v_partida_control

### DIFF
--- a/components/cxp/cxp-pagos-module.test.ts
+++ b/components/cxp/cxp-pagos-module.test.ts
@@ -25,3 +25,119 @@ describe('filtrarPagosPorEstado (CxP · Pagos)', () => {
     expect(filtrarPagosPorEstado(PAGOS, 'cancelado').map((p) => p.id)).toEqual(['canc']);
   });
 });
+
+// ── armarControlPorPartida ────────────────────────────────────────────────────
+
+import { armarControlPorPartida, type AbonoEjecutado } from './cxp-pagos-module';
+
+const PARTIDA_MURO = {
+  id: 'muro',
+  concepto_texto: 'Muro de contención',
+  presupuesto_aprobado: 1631152,
+};
+const CONTRATO_MURO = { partida_id: 'muro', codigo: '2026/1-DIE-MAYA-CAB#1', valor_total: 860000 };
+
+const abono = (over: Partial<AbonoEjecutado>): AbonoEjecutado => ({
+  pago_id: 'p-x',
+  partida_id: 'muro',
+  monto: 0,
+  fecha: null,
+  referencia: null,
+  ...over,
+});
+
+describe('armarControlPorPartida (CxP · drawer del pago)', () => {
+  it('caso real Morado: contrato en la partida, sin abonos previos', () => {
+    const cards = armarControlPorPartida({
+      pagoId: 'pago-195',
+      aplicacionesDelPago: [{ monto_aplicado: 195000, partida_id: 'muro' }],
+      partidas: [PARTIDA_MURO],
+      contratos: [CONTRATO_MURO],
+      abonosEjecutados: [],
+    });
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      concepto: 'Muro de contención',
+      contratado: 860000,
+      contratoCodigo: '2026/1-DIE-MAYA-CAB#1',
+      abonadoPrevio: 0,
+      estePago: 195000,
+      abonos: [],
+    });
+  });
+
+  it('un pago ya ejecutado excluye sus propias aplicaciones de "abonado previo"', () => {
+    const cards = armarControlPorPartida({
+      pagoId: 'pago-195',
+      aplicacionesDelPago: [{ monto_aplicado: 195000, partida_id: 'muro' }],
+      partidas: [PARTIDA_MURO],
+      contratos: [CONTRATO_MURO],
+      abonosEjecutados: [
+        abono({ pago_id: 'pago-195', monto: 195000, fecha: '2026-06-12' }),
+        abono({ pago_id: 'pago-306', monto: 306000, fecha: '2026-06-11', referencia: 'SPEI 1' }),
+      ],
+    });
+    expect(cards[0].abonadoPrevio).toBe(306000);
+    expect(cards[0].estePago).toBe(195000);
+    expect(cards[0].abonos.map((a) => a.pago_id)).toEqual(['pago-306']);
+  });
+
+  it('sin contrato usa presupuesto como referencia (contratado null)', () => {
+    const cards = armarControlPorPartida({
+      pagoId: 'p',
+      aplicacionesDelPago: [{ monto_aplicado: 100, partida_id: 'muro' }],
+      partidas: [PARTIDA_MURO],
+      contratos: [],
+      abonosEjecutados: [],
+    });
+    expect(cards[0].contratado).toBeNull();
+    expect(cards[0].presupuesto).toBe(1631152);
+  });
+
+  it('suma varias facturas del pago a la misma partida y agrupa abonos por pago (desc por fecha)', () => {
+    const cards = armarControlPorPartida({
+      pagoId: 'p-nuevo',
+      aplicacionesDelPago: [
+        { monto_aplicado: 220000, partida_id: 'muro' },
+        { monto_aplicado: 86000, partida_id: 'muro' },
+        { monto_aplicado: 999, partida_id: null },
+      ],
+      partidas: [PARTIDA_MURO],
+      contratos: [CONTRATO_MURO],
+      abonosEjecutados: [
+        abono({ pago_id: 'p-a', monto: 50000, fecha: '2026-05-01' }),
+        abono({ pago_id: 'p-b', monto: 25000, fecha: '2026-06-01' }),
+        abono({ pago_id: 'p-b', monto: 25000, fecha: '2026-06-01' }),
+      ],
+    });
+    expect(cards[0].estePago).toBe(306000);
+    expect(cards[0].abonadoPrevio).toBe(100000);
+    expect(cards[0].abonos.map((a) => [a.pago_id, a.monto])).toEqual([
+      ['p-b', 50000],
+      ['p-a', 50000],
+    ]);
+  });
+
+  it('dos contratos en la partida: suma valores y no muestra código único', () => {
+    const cards = armarControlPorPartida({
+      pagoId: 'p',
+      aplicacionesDelPago: [{ monto_aplicado: 1, partida_id: 'muro' }],
+      partidas: [PARTIDA_MURO],
+      contratos: [CONTRATO_MURO, { partida_id: 'muro', codigo: 'OTRO', valor_total: 140000 }],
+      abonosEjecutados: [],
+    });
+    expect(cards[0].contratado).toBe(1000000);
+    expect(cards[0].contratoCodigo).toBeNull();
+  });
+
+  it('partida sin aplicación de este pago no genera card', () => {
+    const cards = armarControlPorPartida({
+      pagoId: 'p',
+      aplicacionesDelPago: [{ monto_aplicado: 1, partida_id: 'muro' }],
+      partidas: [PARTIDA_MURO, { id: 'otra', concepto_texto: 'Otra', presupuesto_aprobado: null }],
+      contratos: [],
+      abonosEjecutados: [],
+    });
+    expect(cards.map((c) => c.partida_id)).toEqual(['muro']);
+  });
+});

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -22,8 +22,12 @@
  * no se ejecuta nunca sale de la vista hasta estar pagado.
  *
  * El drawer de detalle muestra las facturas aplicadas
- * (`cxp_pago_aplicaciones` → `facturas`), montos, quién aprobó/pagó y los
- * comprobantes adjuntos.
+ * (`cxp_pago_aplicaciones` → `facturas`), montos, quién aprobó/pagó, los
+ * comprobantes adjuntos y el **control por partida**: por cada partida
+ * presupuestal de las facturas, qué hay contratado contra ella
+ * (`dilesa.contratos_construccion.valor_total`, fallback presupuesto
+ * aprobado), los abonos EJECUTADOS previos, lo que aplica este pago y cómo
+ * quedará (`armarControlPorPartida`).
  *
  * No inventa lógica financiera: solo cablea las RPCs con buenas
  * confirmaciones. Parametrizado por `empresaId` (UUID). RDB y DILESA lo
@@ -100,7 +104,104 @@ type FacturaAplicada = {
   emisor_nombre: string | null;
   total: number | null;
   saldo: number | null;
+  partida_id: string | null;
 };
+
+// ── Control por partida (estado de cuenta al momento de pagar) ───────────────
+
+export type AbonoEjecutado = {
+  pago_id: string;
+  partida_id: string;
+  monto: number;
+  fecha: string | null;
+  referencia: string | null;
+};
+
+export type PartidaControlCard = {
+  partida_id: string;
+  concepto: string;
+  /** Σ valor_total de contratos vivos ligados a la partida. null = sin contrato. */
+  contratado: number | null;
+  /** Código del contrato si la partida tiene exactamente uno. */
+  contratoCodigo: string | null;
+  presupuesto: number | null;
+  /** Abonado ejecutado a la partida ANTES de este pago. */
+  abonadoPrevio: number;
+  /** Lo que este pago aplica a la partida. */
+  estePago: number;
+  /** Abonos ejecutados previos (agrupados por pago), más reciente primero. */
+  abonos: { pago_id: string; fecha: string | null; referencia: string | null; monto: number }[];
+};
+
+/**
+ * Arma el estado de cuenta por partida de un pago: qué hay contratado contra
+ * la partida, cuánto se le ha abonado (solo pagos EJECUTADOS — los
+ * programados/aprobados son compromiso, no abono), cuánto aplica este pago y
+ * cómo quedará. Si el pago ya está pagado, sus propias aplicaciones se
+ * excluyen de "abonadoPrevio" para no contarlo doble contra "estePago".
+ */
+export function armarControlPorPartida(opts: {
+  pagoId: string;
+  aplicacionesDelPago: { monto_aplicado: number; partida_id: string | null }[];
+  partidas: { id: string; concepto_texto: string | null; presupuesto_aprobado: number | null }[];
+  contratos: { partida_id: string | null; codigo: string; valor_total: number | null }[];
+  abonosEjecutados: AbonoEjecutado[];
+}): PartidaControlCard[] {
+  const { pagoId, aplicacionesDelPago, partidas, contratos, abonosEjecutados } = opts;
+
+  const estePagoPorPartida = new Map<string, number>();
+  for (const a of aplicacionesDelPago) {
+    if (!a.partida_id) continue;
+    estePagoPorPartida.set(
+      a.partida_id,
+      (estePagoPorPartida.get(a.partida_id) ?? 0) + Number(a.monto_aplicado ?? 0)
+    );
+  }
+
+  const cards: PartidaControlCard[] = [];
+  for (const p of partidas) {
+    const estePago = estePagoPorPartida.get(p.id);
+    if (estePago == null) continue;
+
+    const contratosPartida = contratos.filter((c) => c.partida_id === p.id);
+    const contratado =
+      contratosPartida.length > 0
+        ? contratosPartida.reduce((acc, c) => acc + Number(c.valor_total ?? 0), 0)
+        : null;
+
+    // Abonos previos: ejecutados, agrupados por pago, sin este pago.
+    const porPago = new Map<
+      string,
+      { pago_id: string; fecha: string | null; referencia: string | null; monto: number }
+    >();
+    for (const ab of abonosEjecutados) {
+      if (ab.partida_id !== p.id || ab.pago_id === pagoId) continue;
+      const g = porPago.get(ab.pago_id) ?? {
+        pago_id: ab.pago_id,
+        fecha: ab.fecha,
+        referencia: ab.referencia,
+        monto: 0,
+      };
+      g.monto += Number(ab.monto ?? 0);
+      porPago.set(ab.pago_id, g);
+    }
+    const abonos = [...porPago.values()].sort((a, b) =>
+      (b.fecha ?? '').localeCompare(a.fecha ?? '')
+    );
+
+    cards.push({
+      partida_id: p.id,
+      concepto: p.concepto_texto ?? '(partida)',
+      contratado,
+      contratoCodigo: contratosPartida.length === 1 ? contratosPartida[0].codigo : null,
+      presupuesto: p.presupuesto_aprobado != null ? Number(p.presupuesto_aprobado) : null,
+      abonadoPrevio: abonos.reduce((acc, a) => acc + a.monto, 0),
+      estePago,
+      abonos,
+    });
+  }
+  return cards.sort((a, b) => a.concepto.localeCompare(b.concepto));
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -575,6 +676,7 @@ function PagoDrawer({
   onCancelar: (pago: Pago) => void;
 }) {
   const [aplicaciones, setAplicaciones] = useState<FacturaAplicada[]>([]);
+  const [controlPartidas, setControlPartidas] = useState<PartidaControlCard[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -583,12 +685,13 @@ function PagoDrawer({
     (async () => {
       setLoading(true);
       setAplicaciones([]);
+      setControlPartidas([]);
       const sb = createSupabaseBrowserClient();
       const { data } = await sb
         .schema('erp')
         .from('cxp_pago_aplicaciones')
         .select(
-          'id, monto_aplicado, factura_id, factura:facturas!factura_id(uuid_sat, emisor_nombre, total, saldo)'
+          'id, monto_aplicado, factura_id, factura:facturas!factura_id(uuid_sat, emisor_nombre, total, saldo, partida_id)'
         )
         .eq('pago_id', pago.id);
       if (!activo) return;
@@ -602,20 +705,87 @@ function PagoDrawer({
           emisor_nombre: string | null;
           total: number | null;
           saldo: number | null;
+          partida_id: string | null;
         } | null;
       };
       const rows = (data ?? []) as unknown as Raw[];
-      setAplicaciones(
-        rows.map((r) => ({
-          id: r.id,
-          monto_aplicado: Number(r.monto_aplicado),
-          factura_id: r.factura_id,
-          uuid_sat: r.factura?.uuid_sat ?? null,
-          emisor_nombre: r.factura?.emisor_nombre ?? null,
-          total: r.factura?.total ?? null,
-          saldo: r.factura?.saldo ?? null,
-        }))
-      );
+      const apls: FacturaAplicada[] = rows.map((r) => ({
+        id: r.id,
+        monto_aplicado: Number(r.monto_aplicado),
+        factura_id: r.factura_id,
+        uuid_sat: r.factura?.uuid_sat ?? null,
+        emisor_nombre: r.factura?.emisor_nombre ?? null,
+        total: r.factura?.total ?? null,
+        saldo: r.factura?.saldo ?? null,
+        partida_id: r.factura?.partida_id ?? null,
+      }));
+      setAplicaciones(apls);
+
+      // Estado de cuenta por partida: contratado / abonado / este pago.
+      // Tolerante a fallas parciales — la sección se omite, el drawer vive.
+      const partidaIds = [
+        ...new Set(apls.map((a) => a.partida_id).filter((x): x is string => !!x)),
+      ];
+      if (partidaIds.length > 0) {
+        const [partidasRes, contratosRes, abonosRes] = await Promise.all([
+          sb
+            .schema('erp')
+            .from('presupuesto_partidas')
+            .select('id, concepto_texto, presupuesto_aprobado')
+            .in('id', partidaIds),
+          sb
+            .schema('dilesa')
+            .from('contratos_construccion')
+            .select('partida_id, codigo, valor_total')
+            .in('partida_id', partidaIds)
+            .is('deleted_at', null)
+            .is('cancelada_at', null),
+          sb
+            .schema('erp')
+            .from('cxp_pago_aplicaciones')
+            .select(
+              'monto_aplicado, pago_id, factura:facturas!factura_id!inner(partida_id), pago:cxp_pagos!pago_id!inner(estado, deleted_at, fecha_pago, referencia)'
+            )
+            .in('factura.partida_id', partidaIds)
+            .eq('pago.estado', 'pagado')
+            .is('pago.deleted_at', null),
+        ]);
+        if (!activo) return;
+
+        type AbonoRaw = {
+          monto_aplicado: number;
+          pago_id: string;
+          factura: { partida_id: string | null } | null;
+          pago: { fecha_pago: string | null; referencia: string | null } | null;
+        };
+        const abonos: AbonoEjecutado[] = ((abonosRes.data ?? []) as unknown as AbonoRaw[])
+          .filter((a) => !!a.factura?.partida_id)
+          .map((a) => ({
+            pago_id: a.pago_id,
+            partida_id: a.factura!.partida_id as string,
+            monto: Number(a.monto_aplicado ?? 0),
+            fecha: a.pago?.fecha_pago ?? null,
+            referencia: a.pago?.referencia ?? null,
+          }));
+
+        setControlPartidas(
+          armarControlPorPartida({
+            pagoId: pago.id,
+            aplicacionesDelPago: apls,
+            partidas: (partidasRes.data ?? []) as {
+              id: string;
+              concepto_texto: string | null;
+              presupuesto_aprobado: number | null;
+            }[],
+            contratos: (contratosRes.data ?? []) as {
+              partida_id: string | null;
+              codigo: string;
+              valor_total: number | null;
+            }[],
+            abonosEjecutados: abonos,
+          })
+        );
+      }
       setLoading(false);
     })();
     return () => {
@@ -761,6 +931,98 @@ function PagoDrawer({
                 </ul>
               )}
             </section>
+
+            {controlPartidas.length > 0 && (
+              <>
+                <Separator />
+
+                {/* Estado de cuenta por partida: contratado / abonado / este pago */}
+                <section className="space-y-2 text-sm">
+                  <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    Control por partida
+                  </div>
+                  <div className="space-y-2">
+                    {controlPartidas.map((c) => {
+                      const referencia = c.contratado ?? c.presupuesto;
+                      const despues = c.abonadoPrevio + c.estePago;
+                      const porAbonar = referencia != null ? referencia - despues : null;
+                      const pct =
+                        referencia != null && referencia > 0
+                          ? Math.round((despues / referencia) * 100)
+                          : null;
+                      const yaPagado = pago.estado === 'pagado';
+                      return (
+                        <div key={c.partida_id} className="rounded-lg border bg-muted/30 px-3 py-2">
+                          <div className="flex items-baseline justify-between gap-2">
+                            <span className="font-medium">{c.concepto}</span>
+                            <span className="whitespace-nowrap text-xs text-muted-foreground">
+                              {c.contratado != null
+                                ? `${c.contratoCodigo ? `Contrato ${c.contratoCodigo} · ` : ''}contratado ${formatCurrency(c.contratado)}`
+                                : c.presupuesto != null
+                                  ? `presupuesto ${formatCurrency(c.presupuesto)}`
+                                  : 'sin contrato ni presupuesto'}
+                            </span>
+                          </div>
+                          <dl className="mt-1.5 space-y-0.5 text-xs">
+                            <div className="flex justify-between">
+                              <dt className="text-muted-foreground">Abonado previo</dt>
+                              <dd className="tabular-nums">{formatCurrency(c.abonadoPrevio)}</dd>
+                            </div>
+                            <div className="flex justify-between">
+                              <dt className="text-muted-foreground">Este pago</dt>
+                              <dd className="tabular-nums font-medium">
+                                + {formatCurrency(c.estePago)}
+                              </dd>
+                            </div>
+                            <div className="flex justify-between border-t pt-0.5 font-medium">
+                              <dt>
+                                {yaPagado ? 'Abonado (incluye este pago)' : 'Quedará abonado'}
+                              </dt>
+                              <dd className="tabular-nums">
+                                {formatCurrency(despues)}
+                                {pct != null ? ` (${pct}%)` : ''}
+                              </dd>
+                            </div>
+                            {porAbonar != null && (
+                              <div className="flex justify-between">
+                                <dt className="text-muted-foreground">
+                                  {c.contratado != null
+                                    ? 'Por abonar del contrato'
+                                    : 'Por abonar del presupuesto'}
+                                </dt>
+                                <dd className="tabular-nums">{formatCurrency(porAbonar)}</dd>
+                              </div>
+                            )}
+                          </dl>
+                          <div className="mt-1.5 border-t pt-1.5">
+                            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                              Abonos anteriores
+                            </div>
+                            {c.abonos.length === 0 ? (
+                              <p className="text-xs text-muted-foreground">Sin abonos previos.</p>
+                            ) : (
+                              <ul className="mt-0.5 space-y-0.5 text-xs">
+                                {c.abonos.map((a) => (
+                                  <li key={a.pago_id} className="flex justify-between gap-2">
+                                    <span className="truncate text-muted-foreground">
+                                      {formatDate(a.fecha)}
+                                      {a.referencia ? (
+                                        <span className="font-mono"> · {a.referencia}</span>
+                                      ) : null}
+                                    </span>
+                                    <span className="tabular-nums">{formatCurrency(a.monto)}</span>
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              </>
+            )}
 
             <Separator />
 

--- a/supabase/migrations/20260612001114_fix_v_partida_control_pagado_ejecutado.sql
+++ b/supabase/migrations/20260612001114_fix_v_partida_control_pagado_ejecutado.sql
@@ -1,0 +1,65 @@
+-- ╭──────────────────────────────────────────────────────────────────╮
+-- │  20260612001114_fix_v_partida_control_pagado_ejecutado            │
+-- │                                                                    │
+-- │  La capa "pagado" de erp.v_partida_control sumaba TODAS las        │
+-- │  aplicaciones de pago sin verificar el estado del pago — el mismo  │
+-- │  bug conceptual que el hotfix 20260611003056 corrigió en el        │
+-- │  trigger de saldo de facturas. Un pago programado/aprobado es      │
+-- │  compromiso, no dinero pagado.                                     │
+-- │                                                                    │
+-- │  Caso real (partida "Muro de contención", DILESA): pagado=$501k    │
+-- │  con $0 ejecutado (2 pagos vivos en programado/aprobado).          │
+-- │                                                                    │
+-- │  Cambio único: la lateral `pg` ahora exige p.estado='pagado' y     │
+-- │  p.deleted_at IS NULL. El resto de la vista queda idéntico         │
+-- │  (ADR-040: comprometido = OCs activas + contratos vivos;           │
+-- │  ejercido = recibido + gasto directo + estimaciones autorizadas).  │
+-- ╰──────────────────────────────────────────────────────────────────╯
+
+BEGIN;
+
+CREATE OR REPLACE VIEW erp.v_partida_control AS
+SELECT pp.id AS partida_id,
+    pp.empresa_id,
+    pp.proyecto_id,
+    pp.concepto_id,
+    pp.concepto_texto,
+    pp.etapa,
+    pp.estado,
+    pp.presupuesto_aprobado,
+    COALESCE(comp.comprometido, 0::numeric) + COALESCE(con.comprometido_contratos, 0::numeric) AS comprometido,
+    COALESCE(ej.ejercido, 0::numeric) AS ejercido,
+    COALESCE(pg.pagado, 0::numeric) AS pagado,
+    pp.gasto_real_total AS gasto_real_manual,
+    COALESCE(pp.presupuesto_aprobado, 0::numeric) - (COALESCE(comp.comprometido, 0::numeric) + COALESCE(con.comprometido_contratos, 0::numeric)) AS disponible
+   FROM erp.presupuesto_partidas pp
+     LEFT JOIN LATERAL ( SELECT sum(ocd.cantidad * COALESCE(ocd.precio_real, ocd.precio_unitario, 0::numeric)) AS comprometido
+           FROM erp.ordenes_compra_detalle ocd
+             JOIN erp.ordenes_compra oc ON oc.id = ocd.orden_compra_id
+          WHERE ocd.partida_id = pp.id AND (oc.estado = ANY (ARRAY['enviada'::text, 'parcial'::text, 'cerrada'::text]))) comp ON true
+     LEFT JOIN LATERAL ( SELECT sum(c.valor_total) AS comprometido_contratos
+           FROM dilesa.contratos_construccion c
+          WHERE c.partida_id = pp.id AND c.empresa_id = pp.empresa_id AND c.deleted_at IS NULL) con ON true
+     LEFT JOIN LATERAL ( SELECT COALESCE(( SELECT sum(ocd.cantidad_recibida * COALESCE(ocd.precio_real, ocd.precio_unitario, 0::numeric)) AS sum
+                   FROM erp.ordenes_compra_detalle ocd
+                  WHERE ocd.partida_id = pp.id), 0::numeric) + COALESCE(( SELECT sum(f.total) AS sum
+                   FROM erp.facturas f
+                  WHERE f.partida_id = pp.id AND f.orden_compra_id IS NULL AND f.obra_estimacion_id IS NULL AND f.contrato_id IS NULL AND f.flujo = 'egreso'::text AND f.cancelada_at IS NULL AND f.estado_cxp <> 'cancelada'::text), 0::numeric) + COALESCE(( SELECT sum(e.monto_total) AS sum
+                   FROM dilesa.obra_estimaciones e
+                     JOIN dilesa.contratos_construccion c ON c.id = e.contrato_id
+                  WHERE c.partida_id = pp.id AND c.empresa_id = pp.empresa_id AND c.deleted_at IS NULL AND e.deleted_at IS NULL AND (e.estado = ANY (ARRAY['autorizada'::text, 'pagada'::text]))), 0::numeric) AS ejercido) ej ON true
+     LEFT JOIN LATERAL ( SELECT sum(app.monto_aplicado) AS pagado
+           FROM erp.cxp_pago_aplicaciones app
+             JOIN erp.cxp_pagos p ON p.id = app.pago_id
+             JOIN erp.facturas f ON f.id = app.factura_id
+          WHERE f.partida_id = pp.id
+            AND p.estado = 'pagado'::text
+            AND p.deleted_at IS NULL) pg ON true
+  WHERE pp.deleted_at IS NULL;
+
+COMMENT ON VIEW erp.v_partida_control IS
+  'Control presupuestal 3 capas por partida: comprometido (OC activas + contratos vivos) / ejercido (recibido + gasto directo + estimaciones autorizadas) / pagado (solo aplicaciones de pagos EJECUTADOS, estado=pagado vivos — fix 2026-06-12) + disponible. gasto_real_manual es la captura histórica de obra. ADR-040.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Pedido (Michelle/Beto, 2026-06-11)

Al revisar un pago en CxP, ver el estado de cuenta de las partidas que afectan sus facturas: **total contratado, cada abono previo, y cómo quedará cuando se pague este pago**.

## Cambios

### 1. Sección "Control por partida" en el drawer del pago

Por cada partida presupuestal de las facturas aplicadas:

- **Contratado**: Σ `contratos_construccion` vivos ligados a la partida (con código si es único); fallback al presupuesto aprobado si no hay contrato.
- **Abonado previo**: solo pagos **ejecutados** (`estado='pagado'`, vivos) — programado/aprobado es compromiso, no abono.
- **Este pago** y **Quedará abonado** (con % del contrato) + **Por abonar**.
- **Abonos anteriores**: lista fecha · referencia · monto, agrupados por pago, más reciente primero.

Caso real verificado en prod: partida "Muro de contención" — contrato `2026/1-DIE-MAYA-CAB#1` de A.S. Morado por \$860k, presupuesto \$1.63M, 3 facturas (\$501k) sin abonos ejecutados aún. Helper puro `armarControlPorPartida` + 6 tests.

### 2. Fix: capa "pagado" de `erp.v_partida_control` (migración, **pendiente de aplicar**)

La vista sumaba aplicaciones de pago **sin verificar el estado del pago** — mismo bug conceptual que el hotfix `20260611003056` corrigió en el trigger de facturas. Hoy reporta `pagado=$501k` en esa partida con \$0 ejecutado, inflando "Pagado" en el tab Gasto de Proyectos. El fix exige `p.estado='pagado' AND p.deleted_at IS NULL`.

⚠️ **La migración NO está aplicada a prod** — es `CREATE OR REPLACE VIEW` (solo lectura, sin cambio de columnas, SCHEMA_REF intacto). La UI nueva no depende de ella (calcula client-side con el filtro correcto). Aplicar tras OK de Beto.

## Verificación

- 6/6 checks CI locales verdes (typecheck, 1632 tests, lint, format, initiatives, schema sin drift).
- RLS verificada: `presupuesto_partidas` y `contratos_construccion` legibles por usuarios con la empresa asignada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)