### PR TITLE
chore(db-types): types regenerados tras migración 20260612173513

### DIFF
--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -5404,6 +5404,10 @@ export type Database = {
         Args: { p_construccion_id: string; p_costo: number }
         Returns: undefined
       }
+      fn_copiar_comprobante_detonacion: {
+        Args: { p_pago_id: string }
+        Returns: undefined
+      }
       fn_es_vendedor_restringido: { Args: never; Returns: boolean }
       fn_estimaciones_backfill_incremental: {
         Args: never


### PR DESCRIPTION
## Qué

`types/supabase.ts` regenerado contra prod tras aplicar la migración `20260612173513` (PR #863, ya en main y aplicada): agrega la firma de `dilesa.fn_copiar_comprobante_detonacion`. `SCHEMA_REF.md` no tuvo cambio real (solo timestamp, restaurado).

Migración verificada en prod post-aplicación: RPC sin filtro de fuente, unique `cxc_pagos_empresa_uuid_sat_uk` vivo, helper + 2 triggers habilitados.

## Verificación
- Typing puro auto-generado; CI valida typecheck/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)