### PR TITLE
fix(dilesa-ventas): liga 'Ver / corregir' a las fases cerradas del pipeline

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/13-facturada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/13-facturada/page.tsx
@@ -675,7 +675,7 @@ function CapturarFase13Body() {
         <Banner
           tone="success"
           title="Fase 13 ya está cerrada"
-          body="Esta venta ya está facturada. Puedes reemplazar un documento si hubo una corrección — queda versionado."
+          body="Esta venta ya está facturada. Los documentos quedan congelados; si hubo un error, solo Dirección puede reemplazarlos (queda versionado y la revisión debe re-correrse)."
         />
       ) : bloqueadaPorFase12 ? (
         <Banner
@@ -713,8 +713,11 @@ function CapturarFase13Body() {
               {DOCS_FASE13.map((d) => {
                 // Paso 1 en verde → el PLD se congela (solo Dirección
                 // reemplaza); el acuse se habilita hasta entonces.
-                const bloqueo =
-                  d.rol === 'aviso_pld' && !docs?.factura_xml
+                const bloqueo = yaCerrada
+                  ? soyDireccion
+                    ? null
+                    : 'La fase está cerrada — solo Dirección puede reemplazar documentos.'
+                  : d.rol === 'aviso_pld' && !docs?.factura_xml
                     ? 'Se habilita al cargar el XML de la factura (y la nota de crédito, si aplica).'
                     : d.rol === 'aviso_pld' && pasosPld.informeVerde && !soyDireccion
                       ? 'El PLD quedó congelado para presentación — solo Dirección puede reemplazarlo.'

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -1515,7 +1515,16 @@ function DetailInner() {
                                       <Pencil className="h-2.5 w-2.5" />
                                       Capturar fase
                                     </Link>
-                                  ) : r.alcanzada ? null : (
+                                  ) : r.alcanzada ? (
+                                    <Link
+                                      href={`/dilesa/ventas/${id}/capturar/${r.slugCaptura}`}
+                                      className="inline-flex items-center gap-1 rounded-md border border-[var(--border)] px-2 py-0.5 text-[10px] font-medium text-[var(--text)]/60 hover:bg-[var(--bg)]/40 hover:text-[var(--text)]"
+                                      title="Ver la fase cerrada; algunas permiten corregir datos o reemplazar documentos."
+                                    >
+                                      <Pencil className="h-2.5 w-2.5" />
+                                      Ver / corregir
+                                    </Link>
+                                  ) : (
                                     <span
                                       className="inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-[var(--border)] px-2 py-0.5 text-[10px] text-[var(--text)]/30"
                                       title={`Falta cerrar la fase ${r.pos - 1} primero.`}


### PR DESCRIPTION
El expediente solo mostraba **"Capturar fase"** en fases pendientes; las páginas de fases **cerradas** — que desde hoy permiten corregir datos (F11: instrumento/fecha, #872), reemplazar documentos versionados (S1–S4b) y correr la revisión PLD (F13) — no tenían liga y solo se alcanzaban por URL directa. Hallazgo de Beto buscando dónde corregir el número de escritura.

Ahora cada fase alcanzada con página implementada muestra **"Ver / corregir"**.

- Typecheck/format verdes; sin migraciones. UI → sin auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)