### PR TITLE
feat(dilesa-ventas-captura-colaborativa): estado 'terminada' separa pipeline vivo de operaciones concluidas

### DIFF
--- a/app/api/cron/dilesa-encuestas/route.ts
+++ b/app/api/cron/dilesa-encuestas/route.ts
@@ -87,8 +87,10 @@ export async function GET(req: Request) {
         .eq('id', enc.venta_id)
         .is('deleted_at', null)
         .maybeSingle();
-      if (!venta || venta.estado !== 'activa') {
+      if (!venta || (venta.estado !== 'activa' && venta.estado !== 'terminada')) {
         // Venta desasignada/borrada después de la entrega: ciclo muerto.
+        // 'terminada' sí encuesta: el ciclo post-entrega (6/12 meses) sigue
+        // vivo mucho después del cierre administrativo de la fase 17.
         await admin
           .schema('dilesa')
           .from('venta_encuestas')

--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -290,7 +290,9 @@ async function regresarAFaseInner(
     .eq('id', ventaId)
     .maybeSingle();
   if (!v) return { ok: false, error: 'Venta no encontrada' };
-  if (v.estado !== 'activa') {
+  // 'terminada' también puede regresarse (deshacer un cierre erróneo de la
+  // fase 17): al bajar fase_posicion, el trigger de DB la regresa a 'activa'.
+  if (v.estado !== 'activa' && v.estado !== 'terminada') {
     return { ok: false, error: `La venta está en estado "${v.estado}" — no se puede regresar.` };
   }
   if (faseDestino >= (v.fase_posicion ?? 0)) {
@@ -439,6 +441,13 @@ async function desasignarVentaInner(ventaId: string, motivo: string): Promise<Ac
   if (!v) return { ok: false, error: 'Venta no encontrada' };
   if (v.estado === 'desasignada') {
     return { ok: false, error: 'La venta ya está desasignada.' };
+  }
+  if (v.estado === 'terminada') {
+    return {
+      ok: false,
+      error:
+        'La venta está terminada (fase 17) — no se puede desasignar. Si el cierre fue un error, primero hay que regresarla a una fase anterior.',
+    };
   }
 
   // Resolver identificador de unidad + proyecto para incluir en la nota

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -37,6 +37,7 @@ import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Badge } from '@/components/ui/badge';
 import type { BadgeTone } from '@/components/ui/badge';
+import { VENTA_ESTADO_CONFIG } from '@/lib/status-tokens';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getAdjuntoProxyUrl } from '@/lib/adjuntos';
 import { buildAdjuntoPath } from '@/lib/storage/path';
@@ -236,15 +237,6 @@ type Adjunto = {
   nombre: string;
   url: string;
   tipo_mime: string | null;
-};
-
-const ESTADO_TONE: Record<string, BadgeTone> = {
-  activa: 'info',
-  desasignada: 'neutral',
-};
-const ESTADO_LABEL: Record<string, string> = {
-  activa: 'Activa',
-  desasignada: 'Desasignada',
 };
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -1092,8 +1084,14 @@ function DetailInner() {
               {venta.fase_actual}
             </Badge>
           ) : null}
-          <Badge tone={ESTADO_TONE[venta.estado] ?? 'neutral'}>
-            {ESTADO_LABEL[venta.estado] ?? venta.estado}
+          <Badge
+            tone={
+              VENTA_ESTADO_CONFIG[venta.estado as keyof typeof VENTA_ESTADO_CONFIG]?.tone ??
+              'neutral'
+            }
+          >
+            {VENTA_ESTADO_CONFIG[venta.estado as keyof typeof VENTA_ESTADO_CONFIG]?.label ??
+              venta.estado}
           </Badge>
           {venta.tipo_credito ? <Badge tone="neutral">{venta.tipo_credito}</Badge> : null}
         </div>
@@ -2304,7 +2302,11 @@ function MovimientosAdministrativos({
       </div>
     );
   }
-  if (estado !== 'activa') return null;
+  // 'terminada' conserva "Regresar a fase…" como única acción: deshace un
+  // cierre erróneo de la fase 17 (el trigger de DB regresa el estado a
+  // 'activa' al bajar la fase). Desasignar una terminada no procede — para
+  // tocarla hay que regresarla a pipeline primero.
+  if (estado !== 'activa' && estado !== 'terminada') return null;
   const pos = fasePosicion ?? 0;
 
   /**
@@ -2327,9 +2329,11 @@ function MovimientosAdministrativos({
           Regresar a fase…
         </Button>
       ) : null}
-      <Button variant="outline" size="sm" onClick={() => setOpenDesasignar(true)}>
-        Desasignar venta…
-      </Button>
+      {estado === 'activa' ? (
+        <Button variant="outline" size="sm" onClick={() => setOpenDesasignar(true)}>
+          Desasignar venta…
+        </Button>
+      ) : null}
 
       <RegresarFaseDialog
         ventaId={ventaId}

--- a/app/dilesa/ventas/clientes/[id]/page.tsx
+++ b/app/dilesa/ventas/clientes/[id]/page.tsx
@@ -23,6 +23,7 @@ import { ArrowLeft } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Badge } from '@/components/ui/badge';
+import { VENTA_ESTADO_CONFIG } from '@/lib/status-tokens';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
@@ -264,8 +265,14 @@ function ClienteDetailBody() {
                           {v.fase_actual}
                         </Badge>
                       ) : null}
-                      <Badge tone={v.estado === 'activa' ? 'info' : 'neutral'}>
-                        {v.estado === 'activa' ? 'Activa' : v.estado}
+                      <Badge
+                        tone={
+                          VENTA_ESTADO_CONFIG[v.estado as keyof typeof VENTA_ESTADO_CONFIG]?.tone ??
+                          'neutral'
+                        }
+                      >
+                        {VENTA_ESTADO_CONFIG[v.estado as keyof typeof VENTA_ESTADO_CONFIG]?.label ??
+                          v.estado}
                       </Badge>
                       <span className="tabular-nums text-sm font-medium text-[var(--text)]">
                         {moneyFmt.format(monto)}

--- a/app/dilesa/ventas/vendedores/[id]/page.tsx
+++ b/app/dilesa/ventas/vendedores/[id]/page.tsx
@@ -29,6 +29,7 @@ import { ArrowLeft } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Badge } from '@/components/ui/badge';
+import { VENTA_ESTADO_CONFIG } from '@/lib/status-tokens';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
@@ -226,8 +227,14 @@ function VendedorDetailBody() {
                           {v.fase_actual}
                         </Badge>
                       ) : null}
-                      <Badge tone={v.estado === 'activa' ? 'info' : 'neutral'}>
-                        {v.estado === 'activa' ? 'Activa' : v.estado}
+                      <Badge
+                        tone={
+                          VENTA_ESTADO_CONFIG[v.estado as keyof typeof VENTA_ESTADO_CONFIG]?.tone ??
+                          'neutral'
+                        }
+                      >
+                        {VENTA_ESTADO_CONFIG[v.estado as keyof typeof VENTA_ESTADO_CONFIG]?.label ??
+                          v.estado}
                       </Badge>
                       <span className="tabular-nums text-sm font-medium text-[var(--text)]">
                         {moneyFmt.format(monto)}

--- a/components/dilesa/ventas-module.tsx
+++ b/components/dilesa/ventas-module.tsx
@@ -16,7 +16,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { useScopeVendedorDilesa } from '@/lib/dilesa/use-scope-vendedor';
 import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
 import { Badge } from '@/components/ui/badge';
-import type { BadgeTone } from '@/components/ui/badge';
+import { VENTA_ESTADO_CONFIG, VENTA_ESTADOS } from '@/lib/status-tokens';
 import { Input } from '@/components/ui/input';
 import {
   DateRangeFilter,
@@ -55,15 +55,6 @@ export type VentaListaRow = VentaRow & {
   precio: number | null;
 };
 
-const ESTADO_TONE: Record<string, BadgeTone> = {
-  activa: 'info',
-  desasignada: 'neutral',
-};
-const ESTADO_LABEL: Record<string, string> = {
-  activa: 'Activa',
-  desasignada: 'Desasignada',
-};
-
 /**
  * KPIs reactivos a filtros — ADR-034 (Module-level KPI strips).
  * Deriva 100% client-side desde el array que alimenta la tabla (KPI2);
@@ -71,9 +62,10 @@ const ESTADO_LABEL: Record<string, string> = {
  * render (KPI3). Cap 5 (KPI1).
  *
  * Ajustes vs curaduría Sprint 0 (planning doc § "KPIs aprobados — Ventas"):
- * - KPI3 "% cerradas" → "% Escrituradas": el modelo solo tiene estado
- *   `activa | desasignada`; "cerrada" en el negocio inmobiliario significa
- *   escriturada → `numero_escritura IS NOT NULL` es la señal canónica.
+ * - KPI3 "% cerradas" → "% Escrituradas": "cerrada" en el negocio
+ *   inmobiliario significa escriturada → `numero_escritura IS NOT NULL` es
+ *   la señal canónica. (Con el filtro default en 'activa' el KPI lee la
+ *   madurez del pipeline vivo: cuántas vivas ya pasaron escritura.)
  * - KPI4 "Días promedio en fase" → "Avance promedio": `fase_posicion` no
  *   trae fecha de entrada a la fase, pero el promedio de la posición en el
  *   pipeline de 17 fases es proxy directo del avance global.
@@ -152,7 +144,12 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [proyectoFiltro, setProyectoFiltro] = useState('');
-  const [estadoFiltro, setEstadoFiltro] = useState('');
+  // Default 'activa' = pipeline vivo: el uso diario es ver lo que se está
+  // moviendo; el histórico (terminadas/desasignadas) queda a un cambio de
+  // dropdown ("Todos los estados").
+  const [estadoFiltro, setEstadoFiltro] = useState('activa');
+  const [vendedorFiltro, setVendedorFiltro] = useState('');
+  const [creditoFiltro, setCreditoFiltro] = useState('');
   const [rangoEscritura, setRangoEscritura] = useState<DateRange>(EMPTY_DATE_RANGE);
 
   // `faseFiltro` se deriva del query param (single source of truth: el URL).
@@ -352,17 +349,42 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
       ),
     [ventas]
   );
+  const vendedoresPresentes = useMemo(
+    () =>
+      [...new Set(ventas.map((v) => v.vendedor).filter((x): x is string => !!x))].sort((a, b) =>
+        a.localeCompare(b, 'es')
+      ),
+    [ventas]
+  );
+  const creditosPresentes = useMemo(
+    () =>
+      [...new Set(ventas.map((v) => v.tipo_credito).filter((x): x is string => !!x))].sort((a, b) =>
+        a.localeCompare(b, 'es')
+      ),
+    [ventas]
+  );
 
   const filtrados = useMemo(() => {
     return ventas.filter((v) => {
       if (proyectoFiltro && v.proyectoNombre !== proyectoFiltro) return false;
       if (faseFiltro && v.fase_actual !== faseFiltro) return false;
       if (estadoFiltro && v.estado !== estadoFiltro) return false;
+      if (vendedorFiltro && v.vendedor !== vendedorFiltro) return false;
+      if (creditoFiltro && v.tipo_credito !== creditoFiltro) return false;
       if (!isInDateRange(v.fecha_escritura, rangoEscritura)) return false;
       if (!matchVentaSearch(v, search)) return false;
       return true;
     });
-  }, [ventas, search, proyectoFiltro, faseFiltro, estadoFiltro, rangoEscritura]);
+  }, [
+    ventas,
+    search,
+    proyectoFiltro,
+    faseFiltro,
+    estadoFiltro,
+    vendedorFiltro,
+    creditoFiltro,
+    rangoEscritura,
+  ]);
 
   const kpis = useMemo(() => deriveKpis(filtrados), [filtrados]);
 
@@ -410,8 +432,12 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
       label: 'Estado',
       type: 'custom',
       render: (v) => (
-        <Badge tone={ESTADO_TONE[v.estado] ?? 'neutral'}>
-          {ESTADO_LABEL[v.estado] ?? v.estado}
+        <Badge
+          tone={
+            VENTA_ESTADO_CONFIG[v.estado as keyof typeof VENTA_ESTADO_CONFIG]?.tone ?? 'neutral'
+          }
+        >
+          {VENTA_ESTADO_CONFIG[v.estado as keyof typeof VENTA_ESTADO_CONFIG]?.label ?? v.estado}
         </Badge>
       ),
     },
@@ -477,9 +503,36 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
           onChange={(e) => setEstadoFiltro(e.target.value)}
           className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
         >
-          <option value="">Activa + Desasignada</option>
-          <option value="activa">Activa</option>
-          <option value="desasignada">Desasignada</option>
+          <option value="">Todos los estados</option>
+          {VENTA_ESTADOS.map((e) => (
+            <option key={e} value={e}>
+              {VENTA_ESTADO_CONFIG[e].label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={vendedorFiltro}
+          onChange={(e) => setVendedorFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los vendedores</option>
+          {vendedoresPresentes.map((v) => (
+            <option key={v} value={v}>
+              {v}
+            </option>
+          ))}
+        </select>
+        <select
+          value={creditoFiltro}
+          onChange={(e) => setCreditoFiltro(e.target.value)}
+          className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+        >
+          <option value="">Todos los créditos</option>
+          {creditosPresentes.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
         </select>
         <DateRangeFilter
           label="Escritura"

--- a/docs/planning/dilesa-ventas-captura-colaborativa.md
+++ b/docs/planning/dilesa-ventas-captura-colaborativa.md
@@ -132,6 +132,21 @@ Dirección, registrado. Cero trabajo perdido, cero captura a ciegas.
 
 ## Decisiones registradas
 
+- **2026-06-12 — Estado 'terminada': ciclo de vida ≠ avance de pipeline
+  (sprint estados-venta).** `estado` responde solo "¿viva, cerró bien o
+  cerró mal?" (activa / terminada / desasignada / expirada); el avance vive
+  en `fase_actual`/`fase_posicion`. No se replican fases como estados. La
+  sincronía es un trigger de DB (`trg_ventas_sync_estado_terminada`: fase
+  17 ⇒ terminada, bajar fase ⇒ activa) para que marcarFase, regresarAFase y
+  data-fixes futuros mantengan la invariante sin acordarse. Backfill solo
+  `fase_posicion=17` (~1,093); las ~45 activas sin fase NO se especulan
+  (consistente con el data-fix de 20260612025311) — quedan como pendiente
+  de clasificación operativa. La tubería del correo al consejo y el cron de
+  encuestas tratan 'terminada' como viva (la fila "Operación Terminada"
+  conserva el acumulado; encuestas 6/12m sobreviven el cierre). Cobranza NO
+  bloquea terminadas: con crédito directo se entrega la casa y se sigue
+  cobrando años. Default del filtro en la lista: 'activa' (pipeline vivo).
+
 - **2026-06-12 — Presentación PLD por operación, en dos pasos (S4c).** El
   esquema histórico era revisión manual de Michelle + envío masivo mensual
   (un acuse por lote). Nuevo flujo: la revisión IA sustituye el control
@@ -199,6 +214,17 @@ Dirección, registrado. Cero trabajo perdido, cero captura a ciegas.
   cada cierre (S3).
 
 ## Bitácora
+
+- **2026-06-12** — Sprint estados-venta entregado (PR #874): estado
+  'terminada' separa pipeline vivo de operaciones concluidas. Migración
+  `20260612215625` (constraint 4 estados + trigger de sincronía
+  fase↔estado + backfill ~1,093 activas en fase 17), `VENTA_ESTADO_CONFIG`
+  canónico en status-tokens (de-duplica 4 mapas inline), filtros nuevos en
+  la lista (estado default 'activa', vendedor, tipo de crédito),
+  regresarAFase acepta terminadas / desasignar las rechaza, tubería del
+  consejo y cron de encuestas tratan terminada como viva. KPIs del tab
+  Fases quedan midiendo solo pipeline vivo. Origen: rebote de Beto sobre
+  estados/filtrado de la tabla de ventas.
 
 - **2026-06-12** — Sprint 4c entregado (PR en revisión): flujo PLD en dos
   pasos en F13 — veredictos separados informe/acuse (separarChecks, sin

--- a/lib/dilesa/kpis/fases.test.ts
+++ b/lib/dilesa/kpis/fases.test.ts
@@ -26,8 +26,13 @@ describe('deriveFasesKpis (DILESA Fases — ADR-034)', () => {
     ]);
   });
 
-  it('activas cuenta solo estado="activa"', () => {
-    const rows = [v({ estado: 'activa' }), v({ estado: 'activa' }), v({ estado: 'desasignada' })];
+  it('activas cuenta solo estado="activa" — terminadas y desasignadas quedan fuera del pipeline vivo', () => {
+    const rows = [
+      v({ estado: 'activa' }),
+      v({ estado: 'activa' }),
+      v({ estado: 'desasignada' }),
+      v({ estado: 'terminada', fase_actual: 'Operación Terminada', fase_posicion: 17 }),
+    ];
     expect(deriveFasesKpis(rows, { now: NOW })[0]?.value).toBe(2);
   });
 

--- a/lib/dilesa/kpis/fases.ts
+++ b/lib/dilesa/kpis/fases.ts
@@ -19,6 +19,11 @@
  *    Las viejas que necesitan intervención.
  * 5. Avance promedio — `mean(fase_posicion) / max(fase_posicion)` —
  *    consistente con el mismo KPI en el tab Ventas.
+ *
+ * Estos KPIs miden el PIPELINE VIVO: solo estado='activa'. Las 'terminada'
+ * (fase 17 alcanzada — sprint estados-venta) son cierre histórico y quedan
+ * fuera a propósito; antes de ese sprint el histórico Coda contaminaba
+ * "Estancadas" y "Días en pipeline" con ventas concluidas hace años.
  */
 
 import type { ModuleKpi } from '@/components/module-page';

--- a/lib/dilesa/resumen-consejo-email.test.ts
+++ b/lib/dilesa/resumen-consejo-email.test.ts
@@ -185,6 +185,25 @@ describe('armarTuberia', () => {
     expect(rows.find((r) => r.fase === 'Sin fase asignada')).toBeUndefined();
   });
 
+  it('incluye terminadas — la fila "Operación Terminada" conserva el acumulado histórico', () => {
+    const rows = armarTuberia(CAT, [
+      { estado: 'terminada', fase_actual: 'Operación Terminada', valor_escrituracion: 2000 },
+      { estado: 'terminada', fase_actual: 'Operación Terminada', valor_escrituracion: 1000 },
+      { estado: 'expirada', fase_actual: 'Solicitud de Asignación', valor_escrituracion: 500 },
+    ]);
+    expect(rows.find((r) => r.fase === 'Operación Terminada')).toEqual({
+      fase: 'Operación Terminada',
+      clientes: 2,
+      valor: 3000,
+    });
+    // expirada es venta caída: no cuenta en ninguna fila.
+    expect(rows.find((r) => r.fase === 'Solicitud de Asignación')).toEqual({
+      fase: 'Solicitud de Asignación',
+      clientes: 0,
+      valor: 0,
+    });
+  });
+
   it('junta en "Sin fase asignada" las activas con fase NULL o fuera de catálogo', () => {
     const rows = armarTuberia(CAT, [
       { estado: 'activa', fase_actual: null, valor_escrituracion: null },

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -63,12 +63,15 @@ export type VentaTuberiaInput = {
 };
 
 /**
- * Tubería del correo: ventas ACTIVAS agrupadas por fase, en el orden del
- * catálogo, + una fila final "Sin fase asignada" si hay activas con fase NULL
- * o con una grafía que no existe en el catálogo — así la tubería nunca pierde
- * clientes en silencio (2026-06-11: 4 ventas "Solicitud de Dictaminacion" sin
- * tilde + 50 sin fase eran invisibles en el correo). Las desasignadas no
- * cuentan aunque conserven fase: son ventas caídas.
+ * Tubería del correo: ventas VIVAS (activas + terminadas) agrupadas por fase,
+ * en el orden del catálogo, + una fila final "Sin fase asignada" si hay vivas
+ * con fase NULL o con una grafía que no existe en el catálogo — así la tubería
+ * nunca pierde clientes en silencio (2026-06-11: 4 ventas "Solicitud de
+ * Dictaminacion" sin tilde + 50 sin fase eran invisibles en el correo). Las
+ * 'terminada' cuentan porque la fila "Operación Terminada" es la estación
+ * final de la tubería (sin ellas el acumulado histórico desaparecería del
+ * correo). Las desasignadas/expiradas no cuentan aunque conserven fase: son
+ * ventas caídas.
  */
 export function armarTuberia(
   fasesCat: { nombre: string; posicion: number }[],
@@ -79,7 +82,7 @@ export function armarTuberia(
   const porFase = new Map<string, { clientes: number; valor: number }>();
   const sinFase = { clientes: 0, valor: 0 };
   for (const v of ventas) {
-    if (v.estado !== 'activa') continue;
+    if (v.estado !== 'activa' && v.estado !== 'terminada') continue;
     const valor = Number(v.valor_escrituracion ?? 0);
     if (v.fase_actual && conocidas.has(v.fase_actual)) {
       const acc = porFase.get(v.fase_actual) ?? { clientes: 0, valor: 0 };

--- a/lib/status-tokens.ts
+++ b/lib/status-tokens.ts
@@ -14,6 +14,29 @@
 
 import type { BadgeTone } from '@/components/ui/badge';
 
+/**
+ * Estados de `dilesa.ventas.estado` (constraint `ventas_estado_check`).
+ * `estado` = ciclo de vida del registro; el avance vive en `fase_actual`/
+ * `fase_posicion` (pipeline de 17 fases). 'terminada' la setea el trigger
+ * `trg_ventas_sync_estado_terminada` cuando la venta alcanza la fase 17.
+ */
+export type VentaEstado = 'activa' | 'terminada' | 'desasignada' | 'expirada';
+
+export const VENTA_ESTADO_CONFIG: Record<VentaEstado, { label: string; tone: BadgeTone }> = {
+  activa: { label: 'Activa', tone: 'info' },
+  terminada: { label: 'Terminada', tone: 'success' },
+  desasignada: { label: 'Desasignada', tone: 'neutral' },
+  expirada: { label: 'Expirada', tone: 'warning' },
+};
+
+/** Orden canónico para dropdowns de filtro. */
+export const VENTA_ESTADOS: readonly VentaEstado[] = [
+  'activa',
+  'terminada',
+  'desasignada',
+  'expirada',
+];
+
 export type JuntaEstado = 'programada' | 'en_curso' | 'completada' | 'cancelada';
 
 export const JUNTA_ESTADO_CONFIG: Record<JuntaEstado, { label: string; tone: BadgeTone }> = {

--- a/supabase/migrations/20260612215625_dilesa_ventas_estado_terminada.sql
+++ b/supabase/migrations/20260612215625_dilesa_ventas_estado_terminada.sql
@@ -1,0 +1,68 @@
+-- ╭─ 20260612215625_dilesa_ventas_estado_terminada ─╮
+-- Estado 'terminada' en dilesa.ventas (sprint estados-venta, iniciativa
+-- dilesa-ventas-captura-colaborativa).
+--
+-- Problema: "Operación Terminada" es la fase 17 del pipeline pero llegar ahí
+-- no cambiaba el `estado` — la venta quedaba 'activa' para siempre. En prod
+-- 1,238 de 1,239 activas ya tienen escritura (histórico Coda cerrado), así
+-- que "activa" no distinguía pipeline vivo de operación concluida y
+-- contaminaba KPIs (Estancadas >180d, Días en pipeline) y filtros.
+--
+-- Modelo: `estado` = ciclo de vida del registro; `fase` = avance en pipeline.
+--   activa      → viva en pipeline (fases 1-16)
+--   terminada   → alcanzó fase 17 (terminal feliz)            ← NUEVO
+--   desasignada → caída (terminal, ya existía)
+--   expirada    → hold vencido (terminal, ya existía)
+--
+-- La sincronía fase↔estado vive en un trigger (no en capa app) para que
+-- marcarFase, regresarAFase y cualquier data-fix futuro mantengan la
+-- invariante sin acordarse de ella.
+
+BEGIN;
+
+-- ── 1. Constraint: agregar 'terminada' al vocabulario ───────────────────────
+ALTER TABLE dilesa.ventas DROP CONSTRAINT IF EXISTS ventas_estado_check;
+ALTER TABLE dilesa.ventas ADD CONSTRAINT ventas_estado_check
+  CHECK (estado IN ('activa', 'terminada', 'desasignada', 'expirada'));
+
+-- ── 2. Trigger de sincronía fase_posicion ↔ estado ──────────────────────────
+-- Solo transmuta activa↔terminada; jamás toca estados terminales tristes
+-- (desasignada/expirada): una venta caída que conserve fase 17 en su caché
+-- no debe "revivir" como terminada.
+CREATE OR REPLACE FUNCTION dilesa.fn_ventas_sync_estado_terminada()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.estado = 'activa' AND NEW.fase_posicion = 17 THEN
+    NEW.estado := 'terminada';
+  ELSIF NEW.estado = 'terminada' AND (NEW.fase_posicion IS NULL OR NEW.fase_posicion < 17) THEN
+    NEW.estado := 'activa';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ventas_sync_estado_terminada ON dilesa.ventas;
+CREATE TRIGGER trg_ventas_sync_estado_terminada
+  BEFORE INSERT OR UPDATE ON dilesa.ventas
+  FOR EACH ROW
+  EXECUTE FUNCTION dilesa.fn_ventas_sync_estado_terminada();
+
+-- ── 3. Backfill: activas que ya alcanzaron la fase 17 → terminada ───────────
+-- Criterio conservador, consistente con el data-fix de 20260612025311: solo
+-- fase_posicion = 17. Las ~45 activas sin fase NO se tocan — no hay evidencia
+-- de conclusión (el data-fix de ayer ya cerró las que tenían unidad
+-- entregada); quedan como pendiente de clasificación operativa.
+-- En prod al 2026-06-12: 1,093 filas.
+UPDATE dilesa.ventas
+SET estado = 'terminada'
+WHERE deleted_at IS NULL
+  AND estado = 'activa'
+  AND fase_posicion = 17;
+
+-- ── 4. Recargar PostgREST ────────────────────────────────────────────────────
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Problema

"Operación Terminada" es la fase 17 del pipeline de ventas pero alcanzarla no cambiaba el `estado` — la venta quedaba `activa` para siempre. En prod **1,238 de 1,239 activas ya tienen escritura** (histórico Coda cerrado): "Activa" no distinguía pipeline vivo de operación concluida, contaminando los KPIs del tab Fases (Estancadas >180d, Días en pipeline) y volviendo inútil el filtro de estado.

## Modelo

`estado` = ciclo de vida del registro; `fase` = avance en pipeline (no se duplican fases como estados):

| Estado | Significado |
|---|---|
| `activa` | viva en pipeline (fases 1–16) |
| `terminada` ← **nuevo** | alcanzó fase 17 (terminal feliz) |
| `desasignada` | caída (ya existía) |
| `expirada` | hold vencido (ya existía) |

## Cambios

**Migración `20260612215625`** — constraint `ventas_estado_check` con 4 valores + **trigger** `trg_ventas_sync_estado_terminada` (fase 17 ⇒ `terminada`; bajar fase ⇒ `activa`; nunca toca desasignada/expirada) + backfill de activas en fase 17 (**~1,093 filas** en prod). Las ~45 sin fase NO se tocan (sin evidencia de conclusión, consistente con el data-fix de 20260612025311).

**Código:**
- `VENTA_ESTADO_CONFIG` canónico en `lib/status-tokens.ts` — de-duplica 4 mapas inline (lista, detalle, cliente, vendedor).
- Lista de ventas: filtro de estado con los 4 valores, **default 'activa'** (pipeline vivo); filtros nuevos de **vendedor** y **tipo de crédito**.
- `armarTuberia` (correo al consejo): `terminada` cuenta como viva — la fila "Operación Terminada" conserva el acumulado histórico (cero cambio visible en el correo).
- Cron de encuestas: `terminada` sigue encuestable (ciclo 6/12 meses vive más que el cierre administrativo).
- `regresarAFase` acepta terminadas (deshacer cierre erróneo; el trigger regresa el estado); `desasignarVenta` las rechaza con error explicativo.
- Cobranza intacta a propósito: una terminada con crédito directo sigue cobrándose.
- KPIs del tab Fases quedan limpios: miden solo `estado='activa'`.

## Verificación

- 6 checks CI locales verdes (typecheck, test:coverage 1748 pass, lint, format, initiatives, schema).
- Tests nuevos: terminadas cuentan en tubería del consejo / no cuentan en KPIs de fases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)