### PR TITLE
fix(dilesa-ventas): guard-rails de fuente en abonos — evita doble conteo en cuadratura

### DIFF
--- a/components/dilesa/abono-capture-drawer.tsx
+++ b/components/dilesa/abono-capture-drawer.tsx
@@ -6,8 +6,13 @@
  *
  * Llama `erp.cxc_pago_registrar`, que inserta el abono y lo auto-aplica
  * FIFO a los cargos abiertos de la venta (ver iniciativa `cxc`, ADR-037).
- * La fuente (cliente/institución) es etiqueta para cobranza/reportería,
- * no filtra el cálculo.
+ * La fuente (cliente/institución) NO filtra esa aplicación FIFO, pero SÍ
+ * pesa en la cuadratura (lib/dilesa/cuadratura.ts): los abonos
+ * fuente='cliente' suman al Monto Disponible como depósito directo, y el
+ * crédito de institución ya entra por los campos de crédito de la venta —
+ * capturar la disposición del crédito como 'cliente' la cuenta doble (bug
+ * operativo 2026-06-12). Por eso la fuente se pre-selecciona según el
+ * siguiente cargo abierto y hay aviso inline si la etiqueta no cuadra.
  *
  * Recibo de caja XML (2026-06-12, decisión de Beto): el CFDI que emite
  * CONTPAQi por cada pago se sube aquí y es la FUENTE de los datos — fecha,
@@ -22,7 +27,7 @@
  * (trigger sobre `comprobante_adjunto_id`, migración 20260612173513).
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, CheckCircle2, Pencil, Plus } from 'lucide-react';
 import { z } from 'zod';
 
@@ -43,6 +48,11 @@ import {
   type ReciboPagoParsed,
   type VerificacionRecibo,
 } from '@/lib/dilesa/cxc/cfdi-recibo';
+import {
+  abonoCubreMayormenteInstitucion,
+  sugerirFuenteAbono,
+  type CargoAbiertoFuente,
+} from '@/lib/dilesa/cxc/fuente-abono';
 import { CfdiParseError } from '@/lib/cxp/cfdi-parser';
 import type { Json } from '@/types/supabase';
 
@@ -119,6 +129,9 @@ export function AbonoCaptureDrawer({
   // si viene `undefined` (p.ej. Cobranza · Pagos), se resuelve aquí desde
   // erp.personas — sin él, la verificación del recibo caería al nombre.
   const [rfcResuelto, setRfcResuelto] = useState<string | null>(null);
+  // Cargos abiertos de la venta en el orden FIFO del RPC — sugieren la fuente
+  // del abono y alimentan el aviso de etiqueta vs lo que va a cubrir.
+  const [cargosAbiertos, setCargosAbiertos] = useState<CargoAbiertoFuente[] | null>(null);
   const form = useZodForm({ schema: AbonoSchema, defaultValues: defaults });
 
   // RFC de la empresa (emisor esperado del recibo) — 1 fetch por apertura.
@@ -160,8 +173,51 @@ export function AbonoCaptureDrawer({
 
   const rfcCliente = clienteRfc !== undefined ? clienteRfc : rfcResuelto;
 
+  // Cargos abiertos en cada apertura (los saldos cambian con cada abono;
+  // `reset()` limpia al cerrar). Si lo siguiente por cubrir espera pago de
+  // institución, el abono casi seguro es la disposición del crédito →
+  // pre-selecciona la fuente.
+  useEffect(() => {
+    if (!open) return;
+    let activo = true;
+    (async () => {
+      const sb = createSupabaseBrowserClient();
+      const { data } = await sb
+        .schema('erp')
+        .from('cxc_cargos')
+        .select('saldo, fuente_esperada')
+        .eq('origen_tipo', 'venta_dilesa')
+        .eq('origen_id', ventaId)
+        .neq('estado', 'cancelado')
+        .gt('saldo', 0)
+        .is('deleted_at', null)
+        .order('fecha_vencimiento', { ascending: true, nullsFirst: false })
+        .order('numero', { ascending: true });
+      if (!activo) return;
+      const cargos = ((data ?? []) as { saldo: number; fuente_esperada: string }[]).map((c) => ({
+        saldo: Number(c.saldo),
+        fuente_esperada: c.fuente_esperada,
+      }));
+      setCargosAbiertos(cargos);
+      if (!form.formState.dirtyFields.fuente && sugerirFuenteAbono(cargos) === 'institucion') {
+        form.setValue('fuente', 'institucion');
+      }
+    })();
+    return () => {
+      activo = false;
+    };
+  }, [open, ventaId, form]);
+
+  const fuenteSel = form.watch('fuente');
+  const montoStr = form.watch('monto');
+  const avisoFuenteCliente = useMemo(() => {
+    if (fuenteSel !== 'cliente' || !cargosAbiertos?.length) return false;
+    return abonoCubreMayormenteInstitucion(cargosAbiertos, Number(montoStr));
+  }, [fuenteSel, montoStr, cargosAbiertos]);
+
   const reset = () => {
     form.reset(defaults);
+    setCargosAbiertos(null);
     setComprobante(null);
     setRecibo(null);
     setReciboXml(null);
@@ -510,6 +566,18 @@ export function AbonoCaptureDrawer({
               )}
             </FormField>
           </FormRow>
+
+          {avisoFuenteCliente ? (
+            <div className="-mt-3 flex items-start gap-2 rounded-lg border border-amber-400/50 bg-amber-50 p-3 text-xs text-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>
+                Este monto cubriría sobre todo el cargo que espera pago de{' '}
+                <strong>institución</strong> (la disposición del crédito). Si lo pagó
+                Infonavit/Fovissste/banco, cambia la fuente a «Institución» — etiquetado como
+                «Cliente» se cuenta doble en la cuadratura (depósito + crédito).
+              </p>
+            </div>
+          ) : null}
 
           <FormField name="referencia" label="Referencia">
             {(field) => (

--- a/components/dilesa/cuadratura-panel.tsx
+++ b/components/dilesa/cuadratura-panel.tsx
@@ -13,6 +13,8 @@
  * caja por depósito).
  */
 
+import { AlertTriangle } from 'lucide-react';
+
 import type { Cuadratura } from '@/lib/dilesa/cuadratura';
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -37,6 +39,19 @@ export function CuadraturaPanel({
 }: CuadraturaPanelProps) {
   return (
     <div className="space-y-5">
+      {c.posibleDobleConteo ? (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-400/50 bg-amber-50 p-3 text-xs text-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <p>
+            <strong>Posible doble conteo:</strong> los depósitos fuente «Cliente» (
+            {money(c.depositosDirectoCliente)}) más el crédito de institución (
+            {money(c.creditoInstitucion)}) exceden el valor de escrituración. Revisa si la
+            disposición del crédito se capturó como abono con fuente «Cliente» — ese dinero estaría
+            contando dos veces en el disponible.
+          </p>
+        </div>
+      ) : null}
+
       {/* Cobertura */}
       <Bloque titulo="Cobertura de la operación">
         <Fila label="Valor de escrituración" value={money(valorEscrituracion)} />

--- a/docs/planning/cxc.md
+++ b/docs/planning/cxc.md
@@ -7,7 +7,7 @@
 **Próximo hito:** Contabilidad registra los 2 abonos de la venta Ahumada (con XML y comprobante c/u — ya con FIFO sin fuente, saldan ambos cargos y los comprobantes caen al expediente). Luego: limpieza de ~$2.0M en saldos a favor históricos (185 ventas — requiere regla + OK de Beto), Sprint 4 (recordatorios de vencimiento) + Sprint 5 (retiro del módulo Coda "Depositos Clientes")
 **Dueño:** Beto
 **Creada:** 2026-06-01
-**Última actualización:** 2026-06-12 (migración `20260612173513` APLICADA a prod y verificada: FIFO sin fuente restaurado, unique uuid_sat, triggers de comprobantes; PRs #863 + #865 mergeados)
+**Última actualización:** 2026-06-12 (guard-rails de fuente en captura de abono: pre-selección por cargo FIFO + aviso inline + flag de doble conteo en Cuadratura — caso Maribel/Infonavit)
 
 ## Problema
 
@@ -329,6 +329,30 @@ reubicados cuya fase "Entregada" venía heredada del lote en Coda.
   queda `proposed` hasta que CxC+CxP emitan movimientos.
 
 ## Bitácora
+
+### 2026-06-12 — Guard-rails de fuente en captura de abono (doble conteo en cuadratura)
+
+Bug operativo detectado en prod: Maribel capturó las disposiciones de
+crédito Infonavit de 4 ventas con `fuente='cliente'` (el default del
+form). La cuadratura suma depósitos fuente-cliente **y** el crédito de
+institución de la venta, así que la disposición mal etiquetada cuenta
+dos veces → Disponible inflado (ej. $1,798,000 sobre escrituración de
+$899,000) y saldo negativo. Solo código/UI — la corrección de los 4
+abonos mal etiquetados es aparte, con aprobación de Beto. Entregado:
+
+- **Comentario falso corregido** en `abono-capture-drawer.tsx`: decía
+  que la fuente "no filtra el cálculo" — cierto para el FIFO, falso
+  para la cuadratura (`fuente='cliente'` ⇒ depósito directo en el
+  Monto Disponible).
+- **Prevención en captura**: el drawer trae los cargos abiertos de la
+  venta (mismo orden FIFO del RPC) al abrir; si lo siguiente por cubrir
+  espera institución, pre-selecciona `fuente='institucion'` (sin pisar
+  al usuario si ya tocó el campo). Aviso inline ámbar si deja
+  `cliente` y el monto cubriría mayormente cargos de institución.
+  Helpers puros en `lib/dilesa/cxc/fuente-abono.ts` (con tests).
+- **Flag `posibleDobleConteo`** en el motor (`lib/dilesa/cuadratura.ts`):
+  depósitos-cliente + crédito institución > escrituración + gastos
+  netos por >5% ⇒ alerta ámbar en la pestaña Cuadratura.
 
 ### 2026-06-12 — Migración `20260612173513` APLICADA a prod y verificada
 

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -82,4 +82,72 @@ describe('calcularCuadratura', () => {
     // min(25,000, 50,000) = 25,000
     expect(c.chequeNotariaCalculado).toBe(25000);
   });
+
+  describe('posibleDobleConteo', () => {
+    // Caso real 2026-06-12: la disposición del crédito Infonavit se capturó
+    // como abono fuente='cliente', así que el mismo dinero entra dos veces
+    // (depósito directo + crédito de la venta) y el disponible se infla.
+    it('detecta la disposición etiquetada como depósito del cliente', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 899000,
+        montoCreditoTitular: 636328.45,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: null,
+        gastosEscrituracion: null,
+        depositos: [
+          { monto: 261049.55, directoCliente: true },
+          // Disposición mal etiquetada: debió ser fuente='institucion'.
+          { monto: 636328.45, directoCliente: true },
+        ],
+      });
+      // disponible = 897,378 depósitos + 636,328.45 crédito = 1,533,706.45
+      expect(c.montoDisponible).toBe(1533706.45);
+      expect(c.posibleDobleConteo).toBe(true);
+    });
+
+    it('no marca la operación bien etiquetada (ejemplo de Coda)', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 899000,
+        montoCreditoTitular: 636328.45,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: null,
+        gastosEscrituracion: null,
+        depositos: [
+          { monto: 261049.55, directoCliente: true },
+          { monto: 636328.45, directoCliente: false },
+        ],
+      });
+      expect(c.posibleDobleConteo).toBe(false);
+    });
+
+    it('tolera el excedente legítimo de gastos de escrituración', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 800000,
+        montoCreditoTitular: 750000,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: null,
+        gastosEscrituracion: 30000,
+        // depósitos cliente = 80,000 (50,000 enganche + 30,000 para gastos)
+        depositos: [{ monto: 80000, directoCliente: true }],
+      });
+      // 80,000 + 750,000 − 800,000 − 30,000 = 0 ≤ 5% de 800,000
+      expect(c.posibleDobleConteo).toBe(false);
+    });
+
+    it('no marca ventas sin crédito de institución (contado / crédito directo)', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 500000,
+        montoCreditoTitular: 0,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: null,
+        gastosEscrituracion: null,
+        depositos: [{ monto: 600000, directoCliente: true }],
+      });
+      expect(c.posibleDobleConteo).toBe(false);
+    });
+  });
 });

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -78,7 +78,21 @@ export type Cuadratura = {
   descuentoReal: number;
   comisionVendedor: number;
   comisionGerencia: number;
+  /**
+   * Señal de doble conteo: depósitos fuente-cliente + crédito institución
+   * exceden el valor de escrituración (+ gastos netos legítimos) por más del
+   * umbral. Típico cuando la disposición del crédito se capturó como abono
+   * fuente='cliente' — el mismo dinero entra dos veces al disponible.
+   */
+  posibleDobleConteo: boolean;
 };
+
+/**
+ * Umbral del flag de doble conteo: 5% del valor de escrituración. El cliente
+ * legítimamente deposita de más (gastos de escrituración, ya descontados) por
+ * montos chicos; una disposición duplicada es el monto del crédito completo.
+ */
+const UMBRAL_DOBLE_CONTEO = 0.05;
 
 /** ¿El proyecto cae en la tasa alta de comisión (Loma Verde / Loma Verde 2)? */
 function esLomaVerde(proyecto: string | null | undefined): boolean {
@@ -106,6 +120,13 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   const gastosNetos = n(i.gastosEscrituracion) - n(i.apoyoInfonavit);
   const excedenteDisponible = montoDisponible - valorEscrituracion + descuentoOtorgadoTotal;
   const chequeNotariaCalculado = round2(Math.min(gastosNetos, excedenteDisponible));
+
+  // El crédito directo (pagaré) queda fuera: sus pagos sí son del cliente.
+  const posibleDobleConteo =
+    valorEscrituracion > 0 &&
+    creditoInstitucion > 0 &&
+    depositosDirectoCliente + creditoInstitucion - valorEscrituracion - Math.max(gastosNetos, 0) >
+      valorEscrituracion * UMBRAL_DOBLE_CONTEO;
 
   // El formulado de Coda usa el cheque CAPTURADO; si aún no se captura,
   // caemos al calculado para no dejar los derivados en blanco.
@@ -141,5 +162,6 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     descuentoReal,
     comisionVendedor,
     comisionGerencia,
+    posibleDobleConteo,
   };
 }

--- a/lib/dilesa/cxc/fuente-abono.test.ts
+++ b/lib/dilesa/cxc/fuente-abono.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  abonoCubreMayormenteInstitucion,
+  repartirAbonoFifo,
+  sugerirFuenteAbono,
+  type CargoAbiertoFuente,
+} from './fuente-abono';
+
+// Venta típica: enganche/mensualidades del cliente ya liquidadas (saldo 0) y
+// la disposición del crédito Infonavit como siguiente cargo abierto.
+const cargosDisposicionPendiente: CargoAbiertoFuente[] = [
+  { saldo: 0, fuente_esperada: 'cliente' },
+  { saldo: 636328.45, fuente_esperada: 'institucion' },
+  { saldo: 15000, fuente_esperada: 'cliente' },
+];
+
+describe('sugerirFuenteAbono', () => {
+  it('sugiere institución cuando el primer cargo abierto la espera', () => {
+    expect(sugerirFuenteAbono(cargosDisposicionPendiente)).toBe('institucion');
+  });
+
+  it('sugiere cliente cuando el primer cargo abierto es del cliente', () => {
+    expect(
+      sugerirFuenteAbono([
+        { saldo: 50000, fuente_esperada: 'cliente' },
+        { saldo: 600000, fuente_esperada: 'institucion' },
+      ])
+    ).toBe('cliente');
+  });
+
+  it('cae a cliente sin cargos abiertos (saldo a favor)', () => {
+    expect(sugerirFuenteAbono([])).toBe('cliente');
+    expect(sugerirFuenteAbono([{ saldo: 0, fuente_esperada: 'institucion' }])).toBe('cliente');
+  });
+});
+
+describe('repartirAbonoFifo', () => {
+  it('aplica en orden FIFO sin filtrar por fuente (espejo del RPC)', () => {
+    const r = repartirAbonoFifo(cargosDisposicionPendiente, 640000);
+    expect(r.institucion).toBe(636328.45);
+    expect(r.cliente).toBeCloseTo(3671.55, 2);
+    expect(r.sinAplicar).toBe(0);
+  });
+
+  it('deja el excedente como sin aplicar (saldo a favor)', () => {
+    const r = repartirAbonoFifo([{ saldo: 10000, fuente_esperada: 'cliente' }], 12500);
+    expect(r.cliente).toBe(10000);
+    expect(r.institucion).toBe(0);
+    expect(r.sinAplicar).toBe(2500);
+  });
+
+  it('con monto no positivo no aplica nada', () => {
+    expect(repartirAbonoFifo(cargosDisposicionPendiente, 0)).toEqual({
+      cliente: 0,
+      institucion: 0,
+      sinAplicar: 0,
+    });
+  });
+});
+
+describe('abonoCubreMayormenteInstitucion', () => {
+  it('detecta la disposición capturada como cliente (caso 2026-06-12)', () => {
+    expect(abonoCubreMayormenteInstitucion(cargosDisposicionPendiente, 636328.45)).toBe(true);
+  });
+
+  it('no avisa cuando el abono cubre sobre todo cargos del cliente', () => {
+    const cargos: CargoAbiertoFuente[] = [
+      { saldo: 50000, fuente_esperada: 'cliente' },
+      { saldo: 600000, fuente_esperada: 'institucion' },
+    ];
+    expect(abonoCubreMayormenteInstitucion(cargos, 30000)).toBe(false);
+  });
+
+  it('no avisa sin monto o sin cargos abiertos', () => {
+    expect(abonoCubreMayormenteInstitucion(cargosDisposicionPendiente, 0)).toBe(false);
+    expect(abonoCubreMayormenteInstitucion([], 100000)).toBe(false);
+  });
+});

--- a/lib/dilesa/cxc/fuente-abono.ts
+++ b/lib/dilesa/cxc/fuente-abono.ts
@@ -1,0 +1,62 @@
+/**
+ * Fuente de un abono CxC vs lo que va a cubrir.
+ *
+ * `erp.cxc_pago_registrar` aplica el abono FIFO a TODOS los cargos abiertos
+ * (la fuente NO filtra esa aplicación), pero la etiqueta `fuente` SÍ pesa en
+ * la cuadratura (lib/dilesa/cuadratura.ts): los abonos fuente='cliente' suman
+ * al Monto Disponible como "depósito directo cliente", mientras el crédito de
+ * institución ya entra por los campos de crédito de la venta. Etiquetar la
+ * disposición del crédito como 'cliente' duplica ese dinero en el disponible
+ * (bug operativo detectado 2026-06-12).
+ *
+ * Estos helpers asumen los cargos ya en el orden FIFO del RPC
+ * (`fecha_vencimiento ASC NULLS LAST, numero ASC`) para sugerir la etiqueta
+ * correcta al capturar y avisar cuando no cuadra con lo que va a cubrir.
+ */
+
+export type CargoAbiertoFuente = {
+  /** Saldo pendiente del cargo (> 0 = abierto). */
+  saldo: number;
+  fuente_esperada: string;
+};
+
+export type RepartoFifo = {
+  /** Monto que aplicaría a cargos con fuente_esperada='cliente'. */
+  cliente: number;
+  /** Monto que aplicaría a cargos con fuente_esperada='institucion'. */
+  institucion: number;
+  /** Excedente que no aplica a ningún cargo (queda como saldo a favor). */
+  sinAplicar: number;
+};
+
+/** Fuente sugerida para un abono nuevo: la que espera el primer cargo abierto. */
+export function sugerirFuenteAbono(cargos: CargoAbiertoFuente[]): 'cliente' | 'institucion' {
+  const primero = cargos.find((c) => c.saldo > 0);
+  return primero?.fuente_esperada === 'institucion' ? 'institucion' : 'cliente';
+}
+
+/** Simula la aplicación FIFO del RPC y reparte el monto por fuente esperada. */
+export function repartirAbonoFifo(cargos: CargoAbiertoFuente[], monto: number): RepartoFifo {
+  const reparto: RepartoFifo = { cliente: 0, institucion: 0, sinAplicar: 0 };
+  let restante = monto > 0 ? monto : 0;
+  for (const c of cargos) {
+    if (restante <= 0) break;
+    const aplica = Math.min(restante, Math.max(c.saldo, 0));
+    if (aplica <= 0) continue;
+    if (c.fuente_esperada === 'institucion') reparto.institucion += aplica;
+    else reparto.cliente += aplica;
+    restante -= aplica;
+  }
+  reparto.sinAplicar = restante;
+  return reparto;
+}
+
+/** ¿El abono aplicaría mayormente a cargos que esperan pago de institución? */
+export function abonoCubreMayormenteInstitucion(
+  cargos: CargoAbiertoFuente[],
+  monto: number
+): boolean {
+  if (!(monto > 0)) return false;
+  const r = repartirAbonoFifo(cargos, monto);
+  return r.institucion > r.cliente;
+}


### PR DESCRIPTION
## Problema

Bug operativo detectado en prod 2026-06-12: las disposiciones de crédito Infonavit de 4 ventas se capturaron con `fuente='cliente'` (el default del form de abono). La cuadratura calcula el Monto Disponible como **depósitos fuente-cliente + crédito de institución (campo de la venta) + crédito directo**, así que la disposición mal etiquetada cuenta dos veces: el header muestra Disponible inflado (ej. \$1,798,000 sobre escrituración de \$899,000) y saldo negativo.

**Solo código/UI** — los 4 abonos mal etiquetados se corrigen aparte con aprobación de Beto.

## Cambios

1. **Comentario falso corregido** en `components/dilesa/abono-capture-drawer.tsx`: decía que la fuente "es etiqueta para cobranza/reportería, no filtra el cálculo". Cierto para la aplicación FIFO del RPC, falso para la cuadratura: `lib/dilesa/cuadratura.ts` usa `fuente==='cliente'` como "depósito directo cliente" del Monto Disponible.
2. **Prevención en captura** (ambos call sites del drawer: detalle de venta y Cobranza · Pagos):
   - Al abrir, el drawer trae los cargos abiertos de la venta en el mismo orden FIFO del RPC (`fecha_vencimiento ASC NULLS LAST, numero ASC`). Si el siguiente cargo por cubrir espera `fuente_esperada='institucion'`, pre-selecciona `fuente='institucion'` (sin pisar al usuario si ya tocó el campo).
   - Aviso inline ámbar si el usuario deja `fuente='cliente'` y el monto cubriría mayormente cargos de institución (simulación FIFO).
   - Helpers puros en `lib/dilesa/cxc/fuente-abono.ts` con tests (9).
3. **Indicador en la pestaña Cuadratura**: flag `posibleDobleConteo` en el motor — depósitos fuente-cliente + crédito institución exceden escrituración + gastos netos por >5% del valor (el crédito directo/pagaré queda fuera: sus pagos sí son del cliente). Alerta ámbar en `CuadraturaPanel` con los montos. Tests del motor (4 nuevos, incluye el caso real).

## Verificación

- 6 checks de CI locales verdes (typecheck, test:coverage 1781 passed, lint 0 errors, format:check, initiatives:check, schema:check sin drift).
- Bitácora actualizada en `docs/planning/cxc.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)