### PR TITLE
ci: bump a runtime node24-compatible antes del deadline del 16-jun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/db-types.yml
+++ b/.github/workflows/db-types.yml
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
@@ -95,7 +95,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: chore/supabase-types-autogen
           base: main

--- a/.github/workflows/dilesa-coda-sync.yml
+++ b/.github/workflows/dilesa-coda-sync.yml
@@ -65,12 +65,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install postgresql-client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client


### PR DESCRIPTION
## Qué

Bump de los 4 GitHub workflows para sobrevivir el cambio forzado de GitHub:
- `actions/checkout@v4 → @v5`
- `actions/setup-node@v4 → @v5` (y `node-version: 20 → 22`, LTS activo)
- `peter-evans/create-pull-request@v6 → @v7` (db-types)

## Por qué / urgencia

GitHub **fuerza Node.js 24 en los runners el 2026-06-16** (en días) y remueve Node 20 el 2026-09-16. El warning ya aparece en los logs de CI actuales. Las actions @v4 corren sobre el runtime viejo.

## Alcance / riesgo

Solo `.github/workflows/*.yml`. Cero código de app. `node-version: 22` solo afecta los scripts de CI (typecheck/test/lint), no el build de Vercel.

`engines.node` + `.nvmrc` se **difieren** a un PR aparte: tocan la versión de Node del build de Vercel y conviene confirmar la actual antes de cambiarla.

Hallazgo **C3** de la revisión general 2026-06-12 (Sprint 0 — perímetro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)