### PR TITLE
fix(dilesa-ventas): Cuadratura toma Valor Facturado/Nota de Crédito del CFDI cuando ya hay factura

### DIFF
--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -1176,6 +1176,12 @@ function DetailInner() {
             cuadratura={cuadratura}
             valorEscrituracion={venta.valor_escrituracion}
             chequeCapturado={venta.monto_cheque_notaria != null}
+            valorFacturadoCfdi={venta.valor_facturado}
+            montoNotaCreditoCfdi={venta.monto_nota_credito}
+            // Señal de factura real = el CFDI subido en F13, no el snapshot de
+            // Coda que algunas ventas tienen en valor_facturado (= escrituración).
+            hayFacturaCfdi={(adjuntosPorRolMap.get('factura_xml')?.length ?? 0) > 0}
+            hayNotaCreditoCfdi={(adjuntosPorRolMap.get('nota_credito_xml')?.length ?? 0) > 0}
           />
         </div>
       ) : null}
@@ -1742,7 +1748,11 @@ function DetailInner() {
                               </td>
                               <td className="py-1.5 pl-2 text-right">
                                 <div className="inline-flex items-center gap-1">
-                                  {!tieneReciboCaja ? (
+                                  {/* Un abono de institución (disposición del
+                                      crédito) no lleva recibo de caja facturable:
+                                      sumarlo duplicaría el Valor Facturado en la
+                                      cuadratura (bug operativo 2026-06-12). */}
+                                  {!tieneReciboCaja && a.fuente !== 'institucion' ? (
                                     <button
                                       type="button"
                                       onClick={() => {

--- a/components/dilesa/cuadratura-panel.tsx
+++ b/components/dilesa/cuadratura-panel.tsx
@@ -30,12 +30,31 @@ export type CuadraturaPanelProps = {
   valorEscrituracion: number | null;
   /** Si el cheque a notaría ya se capturó (Fase 11) vs el calculado. */
   chequeCapturado: boolean;
+  /**
+   * Valor Facturado persistido desde el CFDI (Fase 13,
+   * `dilesa.ventas.valor_facturado`). Autoritativo cuando ya hay factura; la
+   * fórmula del motor (`cuadratura.valorFacturado`) queda como "sugerido".
+   */
+  valorFacturadoCfdi: number | null;
+  /** Monto de la Nota de Crédito persistido desde el CFDI (Fase 13). */
+  montoNotaCreditoCfdi: number | null;
+  /**
+   * Ya existe el CFDI de factura (adjunto rol='factura_xml'), no solo un
+   * snapshot de Coda en `valor_facturado` (= escrituración, sin factura real).
+   */
+  hayFacturaCfdi: boolean;
+  /** Ya existe el CFDI de nota de crédito (adjunto rol='nota_credito_xml'). */
+  hayNotaCreditoCfdi: boolean;
 };
 
 export function CuadraturaPanel({
   cuadratura: c,
   valorEscrituracion,
   chequeCapturado,
+  valorFacturadoCfdi,
+  montoNotaCreditoCfdi,
+  hayFacturaCfdi,
+  hayNotaCreditoCfdi,
 }: CuadraturaPanelProps) {
   return (
     <div className="space-y-5">
@@ -81,8 +100,16 @@ export function CuadraturaPanel({
         />
         <Fila label="Depósitos recibidos (todos)" value={money(c.depositosRecibidos)} />
         <Fila label="Valor real venta Dilesa" value={money(c.valorRealVentaDilesa)} strong />
-        <Fila label="Valor facturado" value={money(c.valorFacturado)} />
-        <Fila label="Monto nota de crédito" value={money(c.montoNotaCredito)} />
+        <Fila
+          label={`Valor facturado ${hayFacturaCfdi ? '(CFDI)' : '(sugerido)'}`}
+          value={money(hayFacturaCfdi ? valorFacturadoCfdi : c.valorFacturado)}
+          hint={hayFacturaCfdi ? `Sugerido: ${money(c.valorFacturado)}` : undefined}
+        />
+        <Fila
+          label={`Monto nota de crédito ${hayNotaCreditoCfdi ? '(CFDI)' : '(sugerido)'}`}
+          value={money(hayNotaCreditoCfdi ? montoNotaCreditoCfdi : c.montoNotaCredito)}
+          hint={hayNotaCreditoCfdi ? `Sugerido: ${money(c.montoNotaCredito)}` : undefined}
+        />
         <Fila label="Descuento real" value={money(c.descuentoReal)} />
       </Bloque>
 
@@ -93,9 +120,10 @@ export function CuadraturaPanel({
       </Bloque>
 
       <p className="text-[11px] leading-relaxed text-[var(--text)]/45">
-        Valores derivados según las fórmulas de Coda. Algunos quedan aproximados hasta capturar
-        (Sprint 2) el apoyo de Infonavit por tipo de crédito, los buckets de descuento otorgado y el
-        recibo de caja por depósito (define el Valor Facturado).
+        El Valor Facturado y la Nota de Crédito vienen del CFDI capturado en la Fase 13 cuando ya
+        hay factura; antes de facturar, la fórmula de Coda los estima como «sugerido». El resto de
+        los derivados sigue las fórmulas de Coda y queda aproximado hasta capturar el apoyo de
+        Infonavit por tipo de crédito y los buckets de descuento otorgado.
       </p>
     </div>
   );

--- a/docs/planning/dilesa-ventas-expediente.md
+++ b/docs/planning/dilesa-ventas-expediente.md
@@ -7,7 +7,7 @@
 **Próximo hito:** — (cerrada: cutover Coda de ventas completado 2026-06-11 — paridad certificada, daily apagado, equipo de ventas con usuarios/perfiles activos. Coda queda read-only de consulta)
 **Dueño:** Beto
 **Creada:** 2026-06-09
-**Última actualización:** 2026-06-11 (hotfix post-cutover #3: 178 lotes sin prototipo de LDLE reclasificados a lote_urbanizado — el inventario ya solo ofrece casas reales)
+**Última actualización:** 2026-06-13 (post-cierre: la pestaña Cuadratura toma Valor Facturado / Nota de Crédito del CFDI cuando ya hay factura — fórmula = sugerido pre-factura — + blindaje de `fuente` contra doble conteo)
 
 ## Problema
 
@@ -350,6 +350,28 @@ expediente, copiloto), no reescritura.
   solo él (una Coda no brinca el hold). Mismo PR: la búsqueda de la lista
   de Ventas ahora matchea identificador de unidad además de comprador
   (antes era imposible ubicar una venta partiendo de la unidad).
+- **2026-06-13 (post-cierre — Cuadratura toma el CFDI):** La pestaña
+  Cuadratura mostraba SIEMPRE el Valor Facturado y la Nota de Crédito
+  estimados por la fórmula del motor (`lib/dilesa/cuadratura.ts`), nunca los
+  valores reales del CFDI capturado en Fase 13 (`dilesa.ventas.valor_facturado`
+  / `monto_nota_credito`, persistidos del total del XML). Tres fixes en un PR
+  (lógica/backend, auto-merge): **(1)** el panel
+  (`components/dilesa/cuadratura-panel.tsx`) ahora recibe los valores
+  persistidos y los muestra como autoritativos cuando ya existe el CFDI —
+  señal = presencia del adjunto `rol='factura_xml'` (factura) /
+  `rol='nota_credito_xml'` (NC), NO `valor_facturado != null` a secas (algunas
+  ventas traen un snapshot de Coda = escrituración sin factura real, p.ej.
+  Ahumada/Spencer en Detonada). Pre-factura, la fórmula queda como hint
+  «Sugerido: $X», mismo patrón que la fila «Cheque a notaría». **(2)** El
+  estimado de respaldo dejó de duplicar: `depositosConRecibo` ahora filtra
+  `tieneRecibo && directoCliente` — la disposición del crédito
+  (fuente='institucion') nunca factura aunque traiga un recibo importado de
+  Coda (caso Ahumada: escrituración 940k mostraba 1,880,000). Test de
+  regresión agregado; el del ejemplo de Coda sigue verde. **(3)** Guard-rail
+  UI: el botón «Subir recibo» (sube adjunto `rol='recibo_caja'`, lo que dispara
+  el doble conteo) ya no aparece en abonos `fuente='institucion'`. (FIX 4 del
+  scope — pre-select de fuente + aviso inline en el drawer de abono — ya venía
+  resuelto en #875.)
 
 - **2026-06-09:** Ir por rediseño completo (workspace "Expediente de
   Operación"), reusando los datos y formularios de las 13 fases ya
@@ -417,3 +439,20 @@ expediente, copiloto), no reescritura.
   no se tocan (en preventa manda la fase de obra). Vive en el flujo nativo
   (asignar/desasignar/expirar) y en el sync de rescate
   `import_dilesa_ventas.ts`.
+- **2026-06-13 (Cuadratura — el CFDI manda, la fórmula respalda — Beto):** Con
+  factura emitida, el Valor Facturado y la Nota de Crédito de la Cuadratura son
+  los del CFDI capturado en Fase 13 (persistidos en `dilesa.ventas`); la
+  fórmula reverse-engineered de Coda baja a «sugerido» y solo aplica antes de
+  facturar. La señal de "ya hay factura" es la presencia del adjunto del XML
+  (`factura_xml` / `nota_credito_xml`), no el valor persistido a secas (puede
+  ser un snapshot de Coda = valor de escrituración sin factura real).
+- **2026-06-13 (la `fuente` del abono NO es solo etiqueta — durable):** Corrige
+  la afirmación histórica de que en Coda el crédito de institución "nunca
+  llevaba recibo": SÍ lo llevaba (34 importados con `coda_url`), pero la
+  FÓRMULA de Coda del Valor Facturado filtraba por **tipo de depósito**
+  (Directo Cliente), no por la presencia del PDF. Por eso una disposición de
+  crédito etiquetada con recibo no debe facturar. El motor (`directoCliente`),
+  el guard-rail UI (sin «Subir recibo» en institución) y el pre-select del
+  drawer (#875) son blindajes durables: los datos vivos ya se corrigieron en
+  prod (5 abonos re-etiquetados + 35 adjuntos `recibo_caja` reclasificados a
+  `comprobante_deposito` sobre 20 ventas el 2026-06-12).

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -36,6 +36,24 @@ describe('calcularCuadratura', () => {
     expect(c.comisionVendedor).toBe(8990); // 899,000 × 1.0% (no Loma Verde)
   });
 
+  // Regresión (caso Ahumada, 2026-06-13): la disposición del crédito de
+  // institución traía un recibo de caja importado de Coda. La fórmula NO debe
+  // facturarlo — solo los depósitos del cliente con recibo suman al Valor
+  // Facturado. Antes del fix, escrituración 940,000 mostraba 1,880,000.
+  it('el respaldo no factura la disposición del crédito (recibo importado de Coda)', () => {
+    const c = calcularCuadratura({
+      valorEscrituracion: 940000,
+      montoCreditoTitular: 940000,
+      montoCreditoCotitular: 0,
+      montoCreditoDirecto: 0,
+      montoChequeNotaria: null,
+      gastosEscrituracion: null,
+      depositos: [{ monto: 940000, directoCliente: false, tieneRecibo: true }],
+    });
+    // El recibo es de institución (directoCliente=false) → no factura.
+    expect(c.valorFacturado).toBe(940000); // 940,000 escrituración + 0
+  });
+
   it('marca cubierta cuando el disponible cubre la escrituración', () => {
     const c = calcularCuadratura({
       valorEscrituracion: 500000,

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -17,7 +17,12 @@
  *                                Monto Disponible − Valor Escrituración
  *                                + Descuento Otorgado Total).
  *   Valor Real Venta Dilesa   = Depósitos Recibidos − Cheque Notaría + Pagaré.
- *   Valor Facturado           = Valor Escrituración + Σ depósitos(con recibo).
+ *   Valor Facturado           = Valor Escrituración + Σ depósitos del cliente
+ *                               (con recibo). NOTA: este es el ESTIMADO de
+ *                               respaldo; cuando ya hay CFDI de factura, la
+ *                               pestaña Cuadratura toma el valor persistido del
+ *                               XML (`dilesa.ventas.valor_facturado`) y deja
+ *                               esta fórmula como "sugerido".
  *   Monto Nota de Crédito     = Valor Facturado − Valor Real Venta Dilesa.
  *   Descuento Real            = Valor Escrituración − Valor Real Venta Dilesa.
  *   Comisión Vendedor         = Escrituración × (1.5% Loma Verde / 1.0% resto).
@@ -35,7 +40,12 @@ export type DepositoCuadratura = {
   monto: number | null;
   /** Tipo "Deposito Directo Cliente" (cuenta para Monto Disponible). */
   directoCliente?: boolean;
-  /** Tiene PDF Recibo de Caja (cuenta para Valor Facturado). */
+  /**
+   * Tiene PDF Recibo de Caja. Suma al Valor Facturado SOLO si además es
+   * `directoCliente`: la disposición del crédito (fuente='institucion') nunca
+   * factura, aunque traiga un recibo de caja importado de Coda. La fórmula de
+   * Coda filtraba por tipo de depósito, no por la sola presencia del PDF.
+   */
   tieneRecibo?: boolean;
 };
 
@@ -109,7 +119,7 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     .filter((d) => d.directoCliente)
     .reduce((s, d) => s + n(d.monto), 0);
   const depositosConRecibo = i.depositos
-    .filter((d) => d.tieneRecibo)
+    .filter((d) => d.tieneRecibo && d.directoCliente)
     .reduce((s, d) => s + n(d.monto), 0);
 
   const montoDisponible = depositosDirectoCliente + creditoInstitucion + montoCreditoDirecto;


### PR DESCRIPTION
## Qué

La pestaña **Cuadratura** del Expediente de Operación mostraba SIEMPRE el Valor Facturado y la Nota de Crédito **estimados por la fórmula del motor**, nunca los valores reales del CFDI capturado en Fase 13 (`dilesa.ventas.valor_facturado` / `monto_nota_credito`, persistidos del total del XML). Aún después de subir la factura real, la Cuadratura seguía divergiendo del CFDI (caso Ahumada: escrituración 940k mostraba 1,880,000).

## Cambios

1. **Panel toma el CFDI** (`components/dilesa/cuadratura-panel.tsx` + `page.tsx`): recibe los valores persistidos y los muestra como autoritativos cuando ya existe el CFDI. La **señal de "ya hay factura" es la presencia del adjunto** `rol='factura_xml'` / `rol='nota_credito_xml'`, NO `valor_facturado != null` a secas (algunas ventas traen un snapshot de Coda = escrituración sin factura real). Pre-factura, la fórmula baja a hint «Sugerido: $X» — mismo patrón que la fila «Cheque a notaría».
2. **El estimado de respaldo deja de duplicar** (`lib/dilesa/cuadratura.ts`): `depositosConRecibo` ahora filtra `tieneRecibo && directoCliente`. La disposición del crédito (`fuente='institucion'`) nunca factura aunque traiga un recibo de caja importado de Coda. Test de regresión agregado; el del ejemplo de Coda sigue verde.
3. **Guard-rail UI** (`page.tsx`): el botón «Subir recibo» (sube adjunto `rol='recibo_caja'`, lo que dispara el doble conteo) ya no aparece en abonos `fuente='institucion'`.

> FIX 4 del scope (pre-select de fuente + aviso inline en el drawer de abono) ya venía resuelto en #875. Los datos vivos ya se corrigieron en prod el 2026-06-12 (5 abonos re-etiquetados + 35 adjuntos reclasificados sobre 20 ventas) — estos cambios son blindaje durable.

## Verificación

Los 6 checks de CI verdes localmente sobre todo el repo: typecheck, test:coverage (137 archivos / 1789 tests), lint (0 errores), format:check, initiatives:check, schema:check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)