### PR TITLE
fix(dilesa-ventas): la Nota de Crédito de la cuadratura se deriva del Valor Facturado real

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/13-facturada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/13-facturada/page.tsx
@@ -906,7 +906,7 @@ function CapturarFase13Body() {
                   {cfdiFactura
                     ? `CFDI ${[cfdiFactura.serie, cfdiFactura.folio].filter(Boolean).join('-') || 's/folio'}${
                         cuadratura
-                          ? ` · Cuadratura sugiere ${money(cuadratura.valorFacturado)}`
+                          ? ` · Cuadratura sugiere ${money(cuadratura.valorFacturadoSugerido)}`
                           : ''
                       }`
                     : 'Se llena solo al subir el XML de la factura.'}
@@ -918,7 +918,7 @@ function CapturarFase13Body() {
                   {cfdiNotaCredito
                     ? `CFDI ${[cfdiNotaCredito.serie, cfdiNotaCredito.folio].filter(Boolean).join('-') || 's/folio'}${
                         cuadratura
-                          ? ` · Cuadratura sugiere ${money(cuadratura.montoNotaCredito)}`
+                          ? ` · Cuadratura sugiere ${money(cuadratura.montoNotaCreditoSugerido)}`
                           : ''
                       }`
                     : 'Se llena solo al subir el XML de la nota de crédito (si aplica).'}

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -821,6 +821,13 @@ function DetailInner() {
       ),
     [adjuntosPorRolMap]
   );
+  // Señal de factura real: el CFDI subido en F13, no el snapshot de Coda que
+  // algunas ventas tienen en valor_facturado (= valor de escrituración). Con
+  // factura, el motor toma el valor_facturado real y deriva de él la NC.
+  const hayFacturaCfdi = useMemo(
+    () => (adjuntosPorRolMap.get('factura_xml')?.length ?? 0) > 0,
+    [adjuntosPorRolMap]
+  );
 
   // Pipeline combinado: una fila por cada una de las 17 fases, con su
   // fecha (si alcanzada), docs cargados (clickeables) y docs faltantes
@@ -900,6 +907,10 @@ function DetailInner() {
           (Number(cuadInputs.descuentoGastosEscr) || 0) +
           (Number(cuadInputs.descuentoNotaCredito) || 0),
         precioAsignacion: venta?.precio_asignacion ?? null,
+        // Solo cuando ya hay CFDI de factura: su total es el Valor Facturado
+        // autoritativo y la NC se deriva de él (NC = facturado real − valor
+        // real). Sin factura, el motor cae al estimado de la fórmula.
+        valorFacturadoReal: hayFacturaCfdi ? (venta?.valor_facturado ?? null) : null,
         depositos: abonos.map((a) => ({
           monto: a.monto_total,
           directoCliente: a.fuente === 'cliente',
@@ -911,7 +922,15 @@ function DetailInner() {
         })),
         proyectoNombre,
       }),
-    [venta, abonos, proyectoNombre, cuadInputs, apoyoInfonavit, comprobantesPorAbono]
+    [
+      venta,
+      abonos,
+      proyectoNombre,
+      cuadInputs,
+      apoyoInfonavit,
+      comprobantesPorAbono,
+      hayFacturaCfdi,
+    ]
   );
 
   // Copiloto de cierre (S4): qué falta para Operación Terminada.
@@ -1176,12 +1195,7 @@ function DetailInner() {
             cuadratura={cuadratura}
             valorEscrituracion={venta.valor_escrituracion}
             chequeCapturado={venta.monto_cheque_notaria != null}
-            valorFacturadoCfdi={venta.valor_facturado}
-            montoNotaCreditoCfdi={venta.monto_nota_credito}
-            // Señal de factura real = el CFDI subido en F13, no el snapshot de
-            // Coda que algunas ventas tienen en valor_facturado (= escrituración).
-            hayFacturaCfdi={(adjuntosPorRolMap.get('factura_xml')?.length ?? 0) > 0}
-            hayNotaCreditoCfdi={(adjuntosPorRolMap.get('nota_credito_xml')?.length ?? 0) > 0}
+            hayFacturaCfdi={hayFacturaCfdi}
           />
         </div>
       ) : null}

--- a/components/dilesa/cuadratura-panel.tsx
+++ b/components/dilesa/cuadratura-panel.tsx
@@ -31,30 +31,19 @@ export type CuadraturaPanelProps = {
   /** Si el cheque a notaría ya se capturó (Fase 11) vs el calculado. */
   chequeCapturado: boolean;
   /**
-   * Valor Facturado persistido desde el CFDI (Fase 13,
-   * `dilesa.ventas.valor_facturado`). Autoritativo cuando ya hay factura; la
-   * fórmula del motor (`cuadratura.valorFacturado`) queda como "sugerido".
-   */
-  valorFacturadoCfdi: number | null;
-  /** Monto de la Nota de Crédito persistido desde el CFDI (Fase 13). */
-  montoNotaCreditoCfdi: number | null;
-  /**
    * Ya existe el CFDI de factura (adjunto rol='factura_xml'), no solo un
    * snapshot de Coda en `valor_facturado` (= escrituración, sin factura real).
+   * Con factura, el motor ya trae `valorFacturado` del CFDI real y la NC
+   * derivada de él; aquí solo define la etiqueta «CFDI/requerida» vs «sugerido».
    */
   hayFacturaCfdi: boolean;
-  /** Ya existe el CFDI de nota de crédito (adjunto rol='nota_credito_xml'). */
-  hayNotaCreditoCfdi: boolean;
 };
 
 export function CuadraturaPanel({
   cuadratura: c,
   valorEscrituracion,
   chequeCapturado,
-  valorFacturadoCfdi,
-  montoNotaCreditoCfdi,
   hayFacturaCfdi,
-  hayNotaCreditoCfdi,
 }: CuadraturaPanelProps) {
   return (
     <div className="space-y-5">
@@ -102,13 +91,13 @@ export function CuadraturaPanel({
         <Fila label="Valor real venta Dilesa" value={money(c.valorRealVentaDilesa)} strong />
         <Fila
           label={`Valor facturado ${hayFacturaCfdi ? '(CFDI)' : '(sugerido)'}`}
-          value={money(hayFacturaCfdi ? valorFacturadoCfdi : c.valorFacturado)}
-          hint={hayFacturaCfdi ? `Sugerido: ${money(c.valorFacturado)}` : undefined}
+          value={money(c.valorFacturado)}
+          hint={hayFacturaCfdi ? `Sugerido: ${money(c.valorFacturadoSugerido)}` : undefined}
         />
         <Fila
-          label={`Monto nota de crédito ${hayNotaCreditoCfdi ? '(CFDI)' : '(sugerido)'}`}
-          value={money(hayNotaCreditoCfdi ? montoNotaCreditoCfdi : c.montoNotaCredito)}
-          hint={hayNotaCreditoCfdi ? `Sugerido: ${money(c.montoNotaCredito)}` : undefined}
+          label={`Monto nota de crédito ${hayFacturaCfdi ? '(requerida)' : '(sugerido)'}`}
+          value={money(c.montoNotaCredito)}
+          hint={hayFacturaCfdi ? `Sugerido: ${money(c.montoNotaCreditoSugerido)}` : undefined}
         />
         <Fila label="Descuento real" value={money(c.descuentoReal)} />
       </Bloque>
@@ -120,10 +109,11 @@ export function CuadraturaPanel({
       </Bloque>
 
       <p className="text-[11px] leading-relaxed text-[var(--text)]/45">
-        El Valor Facturado y la Nota de Crédito vienen del CFDI capturado en la Fase 13 cuando ya
-        hay factura; antes de facturar, la fórmula de Coda los estima como «sugerido». El resto de
-        los derivados sigue las fórmulas de Coda y queda aproximado hasta capturar el apoyo de
-        Infonavit por tipo de crédito y los buckets de descuento otorgado.
+        Con factura emitida, el Valor Facturado es el del CFDI y la Nota de Crédito se deriva como
+        Valor Facturado − Valor real venta Dilesa; antes de facturar, la fórmula de Coda los estima
+        como «sugerido». El resto de los derivados sigue las fórmulas de Coda y queda aproximado
+        hasta capturar el apoyo de Infonavit por tipo de crédito y los buckets de descuento
+        otorgado.
       </p>
     </div>
   );

--- a/docs/planning/dilesa-ventas-expediente.md
+++ b/docs/planning/dilesa-ventas-expediente.md
@@ -7,7 +7,7 @@
 **Próximo hito:** — (cerrada: cutover Coda de ventas completado 2026-06-11 — paridad certificada, daily apagado, equipo de ventas con usuarios/perfiles activos. Coda queda read-only de consulta)
 **Dueño:** Beto
 **Creada:** 2026-06-09
-**Última actualización:** 2026-06-13 (post-cierre: la pestaña Cuadratura toma Valor Facturado / Nota de Crédito del CFDI cuando ya hay factura — fórmula = sugerido pre-factura — + blindaje de `fuente` contra doble conteo)
+**Última actualización:** 2026-06-13 (post-cierre: Valor Facturado del CFDI + NC derivada de «facturado real − valor real venta DILESA» en la Cuadratura y el control fiscal de F13; + blindaje de `fuente` contra doble conteo)
 
 ## Problema
 
@@ -372,6 +372,21 @@ expediente, copiloto), no reescritura.
   el doble conteo) ya no aparece en abonos `fuente='institucion'`. (FIX 4 del
   scope — pre-select de fuente + aviso inline en el drawer de abono — ya venía
   resuelto en #875.)
+- **2026-06-13 (post-cierre — NC derivada del facturado real):** Beto, revisando
+  #880, señaló que el Monto Nota de Crédito debe ser **Valor Facturado real −
+  Valor Real Venta DILESA**, no el total del CFDI de la NC (lo que #880 mostraba
+  cuando había `nota_credito_xml`), ni la resta con el facturado **estimado** (lo
+  que hacía el motor). Corrección: `calcularCuadratura` recibe `valorFacturadoReal`
+  y, cuando hay factura, usa el facturado real como `valorFacturado` y deriva de
+  él `montoNotaCredito`; expone `valorFacturadoSugerido`/`montoNotaCreditoSugerido`
+  (el estimado de la fórmula) para los hints. Wired en los 3 call-sites del motor:
+  panel (`page.tsx`), mini-cuadratura del header (`use-venta-resumen.ts`) y el
+  server-side de F13 (`cuadratura-server.ts`) — los tres ahora detectan el adjunto
+  `factura_xml` y pasan `valor_facturado` solo si existe. El control fiscal de F13
+  (`checksFacturacion` / cierre) exige y cuadra la NC contra el facturado real. La
+  fila «Monto nota de crédito» muestra la resta derivada («requerida» con factura,
+  «sugerido» antes); el total del CFDI de NC se sigue usando solo para validar.
+  Tests del motor agregados (efectivo vs sugerido). PR de lógica, auto-merge.
 
 - **2026-06-09:** Ir por rediseño completo (workspace "Expediente de
   Operación"), reusando los datos y formularios de las 13 fases ya
@@ -440,12 +455,22 @@ expediente, copiloto), no reescritura.
   (asignar/desasignar/expirar) y en el sync de rescate
   `import_dilesa_ventas.ts`.
 - **2026-06-13 (Cuadratura — el CFDI manda, la fórmula respalda — Beto):** Con
-  factura emitida, el Valor Facturado y la Nota de Crédito de la Cuadratura son
-  los del CFDI capturado en Fase 13 (persistidos en `dilesa.ventas`); la
-  fórmula reverse-engineered de Coda baja a «sugerido» y solo aplica antes de
-  facturar. La señal de "ya hay factura" es la presencia del adjunto del XML
-  (`factura_xml` / `nota_credito_xml`), no el valor persistido a secas (puede
-  ser un snapshot de Coda = valor de escrituración sin factura real).
+  factura emitida, el **Valor Facturado** de la Cuadratura es el del CFDI
+  capturado en Fase 13 (`dilesa.ventas.valor_facturado`); la fórmula
+  reverse-engineered de Coda baja a «sugerido» y solo aplica antes de facturar.
+  La señal de "ya hay factura" es la presencia del adjunto `factura_xml`, no el
+  valor persistido a secas (puede ser un snapshot de Coda = valor de
+  escrituración sin factura real).
+- **2026-06-13 (la Nota de Crédito es un DERIVADO, no el total del CFDI de NC —
+  Beto):** Beto, revisando, precisó la semántica: la NC se obtiene de **Valor
+  Facturado (real del CFDI) − Valor Real Venta DILESA**, no se lee del total del
+  XML de la NC. El motor (`cuadratura.ts`) recibe `valorFacturadoReal` y deriva
+  la NC de él; el total del CFDI de la NC se usa solo para **validar** (Fase 13
+  ya marca si el XML de NC no cuadra con esa resta, tolerancia 1 peso). Aplica a
+  los 3 call-sites del motor (panel, mini-cuadratura del header y el server-side
+  de F13), así el control fiscal que exige la NC ahora cuadra contra el
+  facturado real, no contra el estimado. Corrige un hueco introducido en #880,
+  donde la fila de NC mostraba el total del CFDI de NC en vez de la resta.
 - **2026-06-13 (la `fuente` del abono NO es solo etiqueta — durable):** Corrige
   la afirmación histórica de que en Coda el crédito de institución "nunca
   llevaba recibo": SÍ lo llevaba (34 importados con `coda_url`), pero la

--- a/lib/dilesa/cuadratura-server.ts
+++ b/lib/dilesa/cuadratura-server.ts
@@ -22,6 +22,7 @@ type VentaCuadraturaRow = {
   unidad_id: string | null;
   precio_asignacion: number | null;
   valor_escrituracion: number | null;
+  valor_facturado: number | null;
   monto_credito_titular: number | null;
   monto_credito_cotitular: number | null;
   monto_credito_directo: number | null;
@@ -45,7 +46,7 @@ export async function cargarCuadraturaVenta(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'empresa_id, tipo_credito, unidad_id, precio_asignacion, valor_escrituracion, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito'
+      'empresa_id, tipo_credito, unidad_id, precio_asignacion, valor_escrituracion, valor_facturado, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito'
     )
     .eq('id', ventaId)
     .is('deleted_at', null)
@@ -103,6 +104,19 @@ export async function cargarCuadraturaVenta(
     );
   }
 
+  // ¿Ya hay CFDI de factura? Solo entonces `valor_facturado` es autoritativo
+  // (un snapshot de Coda = valor de escrituración no es una factura real). Con
+  // factura, la NC se deriva del facturado real — control fiscal de Fase 13.
+  const { data: facturaAdj } = await sb
+    .schema('erp')
+    .from('adjuntos')
+    .select('id')
+    .eq('entidad_tipo', 'venta')
+    .eq('entidad_id', ventaId)
+    .eq('rol', 'factura_xml')
+    .limit(1);
+  const hayFactura = ((facturaAdj ?? []) as { id: string }[]).length > 0;
+
   let proyectoNombre: string | null = null;
   const proyectoId = (unidadRes.data as { proyecto_id: string | null } | null)?.proyecto_id ?? null;
   if (proyectoId) {
@@ -131,6 +145,7 @@ export async function cargarCuadraturaVenta(
       (Number(venta.descuento_gastos_escrituracion) || 0) +
       (Number(venta.descuento_nota_credito) || 0),
     precioAsignacion: venta.precio_asignacion,
+    valorFacturadoReal: hayFactura ? venta.valor_facturado : null,
     depositos: abonos.map((a) => ({
       monto: a.monto_total,
       directoCliente: a.fuente === 'cliente',

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -36,6 +36,50 @@ describe('calcularCuadratura', () => {
     expect(c.comisionVendedor).toBe(8990); // 899,000 × 1.0% (no Loma Verde)
   });
 
+  // Con factura emitida (decisión Beto 2026-06-13): el Valor Facturado es el
+  // del CFDI real y la NC se deriva de él (facturado real − valor real), no del
+  // estimado de la fórmula. El estimado queda expuesto como *Sugerido.
+  it('toma el Valor Facturado del CFDI cuando se pasa y deriva la NC de él', () => {
+    const c = calcularCuadratura({
+      valorEscrituracion: 899000,
+      montoCreditoTitular: 636328.45,
+      montoCreditoCotitular: 0,
+      montoCreditoDirecto: 0,
+      montoChequeNotaria: 13378,
+      gastosEscrituracion: null,
+      valorFacturadoReal: 1150000, // total del CFDI de factura (≠ estimado)
+      depositos: [
+        { monto: 261049.55, directoCliente: true, tieneRecibo: true },
+        { monto: 636328.45, directoCliente: false, tieneRecibo: false },
+      ],
+      proyectoNombre: 'Lomas del Sol',
+    });
+    expect(c.valorFacturado).toBe(1150000); // del CFDI, no el estimado
+    expect(c.valorFacturadoSugerido).toBe(1160049.55); // estimado de la fórmula
+    expect(c.valorRealVentaDilesa).toBe(884000); // 897,378 − 13,378
+    expect(c.montoNotaCredito).toBe(266000); // 1,150,000 − 884,000 (facturado REAL)
+    expect(c.montoNotaCreditoSugerido).toBe(276049.55); // 1,160,049.55 − 884,000
+  });
+
+  // Sin `valorFacturadoReal`, el efectivo == el sugerido (estimado de la fórmula).
+  it('el efectivo iguala al sugerido cuando aún no hay factura', () => {
+    const c = calcularCuadratura({
+      valorEscrituracion: 899000,
+      montoCreditoTitular: 636328.45,
+      montoCreditoCotitular: 0,
+      montoCreditoDirecto: 0,
+      montoChequeNotaria: 13378,
+      gastosEscrituracion: null,
+      depositos: [
+        { monto: 261049.55, directoCliente: true, tieneRecibo: true },
+        { monto: 636328.45, directoCliente: false, tieneRecibo: false },
+      ],
+    });
+    expect(c.valorFacturado).toBe(c.valorFacturadoSugerido);
+    expect(c.montoNotaCredito).toBe(c.montoNotaCreditoSugerido);
+    expect(c.valorFacturado).toBe(1160049.55);
+  });
+
   // Regresión (caso Ahumada, 2026-06-13): la disposición del crédito de
   // institución traía un recibo de caja importado de Coda. La fórmula NO debe
   // facturarlo — solo los depósitos del cliente con recibo suman al Valor

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -17,13 +17,15 @@
  *                                Monto Disponible − Valor Escrituración
  *                                + Descuento Otorgado Total).
  *   Valor Real Venta Dilesa   = Depósitos Recibidos − Cheque Notaría + Pagaré.
- *   Valor Facturado           = Valor Escrituración + Σ depósitos del cliente
- *                               (con recibo). NOTA: este es el ESTIMADO de
- *                               respaldo; cuando ya hay CFDI de factura, la
- *                               pestaña Cuadratura toma el valor persistido del
- *                               XML (`dilesa.ventas.valor_facturado`) y deja
- *                               esta fórmula como "sugerido".
+ *   Valor Facturado           = el del CFDI de factura cuando ya hay factura
+ *                               (`valorFacturadoReal`); si no, el ESTIMADO de
+ *                               respaldo = Valor Escrituración + Σ depósitos
+ *                               del cliente (con recibo). El estimado se
+ *                               expone como `valorFacturadoSugerido`.
  *   Monto Nota de Crédito     = Valor Facturado − Valor Real Venta Dilesa.
+ *                               Es un DERIVADO, no el total del CFDI de NC: con
+ *                               factura real usa el facturado real; la Fase 13
+ *                               valida aparte que el CFDI de NC coincida.
  *   Descuento Real            = Valor Escrituración − Valor Real Venta Dilesa.
  *   Comisión Vendedor         = Escrituración × (1.5% Loma Verde / 1.0% resto).
  *   Comisión Gerencia         = Escrituración × 0.5%.
@@ -64,6 +66,16 @@ export type CuadraturaInput = {
   descuentoOtorgadoTotal?: number | null;
   /** Para referencia (no entra al saldo). */
   precioAsignacion?: number | null;
+  /**
+   * Valor Facturado AUTORITATIVO del CFDI de factura (Fase 13,
+   * `dilesa.ventas.valor_facturado`). Cuando se pasa, el motor lo usa como
+   * `valorFacturado` y deriva de él el `montoNotaCredito` (NC = facturado real
+   * − valor real venta DILESA). null/undefined ⇒ aún no hay factura: el motor
+   * cae al estimado de la fórmula de Coda. Solo pasarlo cuando exista el
+   * adjunto `factura_xml` (un snapshot de Coda en `valor_facturado` = valor de
+   * escrituración NO es una factura real).
+   */
+  valorFacturadoReal?: number | null;
   depositos: DepositoCuadratura[];
   /** Nombre del proyecto, para la tasa de comisión del vendedor. */
   proyectoNombre?: string | null;
@@ -83,8 +95,14 @@ export type Cuadratura = {
   /** Cheque usado para los derivados: el capturado si existe, si no el calculado. */
   chequeNotariaUsado: number;
   valorRealVentaDilesa: number;
+  /** Valor Facturado efectivo: el del CFDI real si se pasó, si no el estimado. */
   valorFacturado: number;
+  /** Estimado de la fórmula de Coda (escrituración + Σ dep. cliente con recibo). */
+  valorFacturadoSugerido: number;
+  /** NC efectiva: `valorFacturado` (efectivo) − valor real venta DILESA. */
   montoNotaCredito: number;
+  /** NC estimada: `valorFacturadoSugerido` − valor real venta DILESA. */
+  montoNotaCreditoSugerido: number;
   descuentoReal: number;
   comisionVendedor: number;
   comisionGerencia: number;
@@ -147,8 +165,13 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   const valorRealVentaDilesa = round2(
     depositosRecibidos - chequeNotariaUsado + montoCreditoDirecto
   );
-  const valorFacturado = round2(valorEscrituracion + depositosConRecibo);
+  // Estimado de la fórmula (respaldo pre-factura). Cuando ya hay CFDI de
+  // factura, el valor REAL del XML manda y la NC se deriva de él.
+  const valorFacturadoSugerido = round2(valorEscrituracion + depositosConRecibo);
+  const valorFacturado =
+    i.valorFacturadoReal != null ? round2(n(i.valorFacturadoReal)) : valorFacturadoSugerido;
   const montoNotaCredito = round2(valorFacturado - valorRealVentaDilesa);
+  const montoNotaCreditoSugerido = round2(valorFacturadoSugerido - valorRealVentaDilesa);
   const descuentoReal = round2(valorEscrituracion - valorRealVentaDilesa);
 
   const comisionVendedor = round2(
@@ -168,7 +191,9 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     chequeNotariaUsado,
     valorRealVentaDilesa,
     valorFacturado,
+    valorFacturadoSugerido,
     montoNotaCredito,
+    montoNotaCreditoSugerido,
     descuentoReal,
     comisionVendedor,
     comisionGerencia,

--- a/lib/dilesa/use-venta-resumen.ts
+++ b/lib/dilesa/use-venta-resumen.ts
@@ -55,6 +55,7 @@ type VentaRow = {
   tipo_credito: string | null;
   precio_asignacion: number | null;
   valor_escrituracion: number | null;
+  valor_facturado: number | null;
   monto_credito_titular: number | null;
   monto_credito_cotitular: number | null;
   monto_credito_directo: number | null;
@@ -86,7 +87,7 @@ export function useVentaResumen(ventaId: string | null): VentaResumenState {
         .schema('dilesa')
         .from('ventas')
         .select(
-          'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, vendedor, notario, notario_id, fase_actual, fase_posicion, tipo_credito, precio_asignacion, valor_escrituracion, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito, fecha_firma_programada, ine_numero'
+          'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, vendedor, notario, notario_id, fase_actual, fase_posicion, tipo_credito, precio_asignacion, valor_escrituracion, valor_facturado, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito, fecha_firma_programada, ine_numero'
         )
         .eq('id', ventaId)
         .is('deleted_at', null)
@@ -191,6 +192,19 @@ export function useVentaResumen(ventaId: string | null): VentaResumenState {
         );
       }
 
+      // ¿Ya hay CFDI de factura? Solo entonces `valor_facturado` es el real (y
+      // la NC se deriva de él); si no, el motor cae al estimado de la fórmula.
+      const { data: facturaAdj } = await sb
+        .schema('erp')
+        .from('adjuntos')
+        .select('id')
+        .eq('entidad_tipo', 'venta')
+        .eq('entidad_id', venta.id)
+        .eq('rol', 'factura_xml')
+        .limit(1);
+      if (!activo) return;
+      const hayFactura = ((facturaAdj ?? []) as { id: string }[]).length > 0;
+
       const [prjRes, prodRes] = await Promise.all([
         unidad?.proyecto_id
           ? sb
@@ -240,6 +254,7 @@ export function useVentaResumen(ventaId: string | null): VentaResumenState {
           (Number(venta.descuento_gastos_escrituracion) || 0) +
           (Number(venta.descuento_nota_credito) || 0),
         precioAsignacion: venta.precio_asignacion,
+        valorFacturadoReal: hayFactura ? venta.valor_facturado : null,
         depositos: abonos.map((a) => ({
           monto: a.monto_total,
           directoCliente: a.fuente === 'cliente',


### PR DESCRIPTION
## Qué

Seguimiento de [#880](https://github.com/beto-sudo/BSOP/pull/880). Revisando, Beto precisó la semántica de la Nota de Crédito:

> **NC = Valor Facturado real (CFDI) − Valor Real Venta DILESA**

No es el total del CFDI de la NC (lo que #880 mostraba cuando había `nota_credito_xml`), ni la resta con el facturado **estimado** (lo que hacía el motor). La NC es un **derivado** del facturado real; el CFDI de la NC se usa solo para **validar** que coincida.

## Cambios

1. **Motor** (`lib/dilesa/cuadratura.ts`): recibe `valorFacturadoReal`; cuando hay factura lo usa como `valorFacturado` y deriva de él `montoNotaCredito`. Expone `valorFacturadoSugerido` / `montoNotaCreditoSugerido` (el estimado de Coda) para los hints. Sin factura, cae al estimado como respaldo.
2. **3 call-sites del motor** detectan el adjunto `factura_xml` y pasan `valor_facturado` solo si existe: panel ([page.tsx](app/dilesa/ventas/[id]/page.tsx)), mini-cuadratura del header ([use-venta-resumen.ts](lib/dilesa/use-venta-resumen.ts)) y el server-side de F13 ([cuadratura-server.ts](lib/dilesa/cuadratura-server.ts)).
3. **Control fiscal de F13**: como `cargarCuadraturaVenta` ahora deriva la NC del facturado real, `checksFacturacion` y el cierre exigen/cuadran la NC contra el real, no el estimado. El total del CFDI de NC se sigue usando solo para validar (tolerancia 1 peso).
4. **Panel**: la fila «Monto nota de crédito» muestra la resta derivada (etiqueta «requerida» con factura, «sugerido» antes); ya no el total del CFDI de NC. F13 «Cuadratura sugiere» usa el estimado puro.

## Verificación

6 checks de CI verdes localmente sobre todo el repo: typecheck, test:coverage (137 archivos / **1791** tests, +2 nuevos del motor), lint (0 errores), format:check, initiatives:check, schema:check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)