### PR TITLE
fix(dilesa-ventas): el menú de tabs persiste al ver una venta

### DIFF
--- a/app/dilesa/ventas/layout.tsx
+++ b/app/dilesa/ventas/layout.tsx
@@ -1,7 +1,4 @@
-'use client';
-
 import { type ReactNode } from 'react';
-import { usePathname } from 'next/navigation';
 import { HubAccessRedirect, RoutedModuleTabs } from '@/components/module-page';
 
 /**
@@ -18,31 +15,17 @@ import { HubAccessRedirect, RoutedModuleTabs } from '@/components/module-page';
  *   /dilesa/ventas/clientes     → tab "Clientes".
  *   /dilesa/ventas/vendedores   → tab "Vendedores".
  *
+ * El strip de tabs vive aquí para que cualquier ruta del hub (incluyendo
+ * sub-detalles profundos como el detalle de venta `/dilesa/ventas/[id]`,
+ * los forms de captura `/[id]/capturar/*`, `/nueva`, `/clientes/[id]` o
+ * `/vendedores/[id]`) muestre la misma navegación, manteniendo el contexto
+ * del módulo. Mismo criterio que `construccion/layout.tsx`.
+ *
  * Cada `module` en el TABS array es un sub-slug que `<RoutedModuleTabs>`
  * filtra automáticamente — tabs sin permiso quedan ocultas. Los gates de
  * acceso viven en cada sub-page (ADR-030 SS5), no en el layout — así el
  * AccessDenied de cada page muestra el sub-slug específico faltante en
  * vez del padre.
- *
- * --- Por qué se ocultan las tabs en sub-rutas profundas ---
- *
- * El strip de tabs NO se renderiza en sub-páginas que tienen su propia
- * vista detallada (back-link incluido), porque agregar tabs ahí seria
- * confuso (el contexto visual ya cambió a "detalle de X"):
- *
- *   - /dilesa/ventas/[id]                       (detalle de venta)
- *   - /dilesa/ventas/nueva                       (form Fase 1)
- *   - /dilesa/ventas/[id]/capturar/*             (forms de captura por fase)
- *   - /dilesa/ventas/clientes/[id]               (detalle de cliente)
- *   - /dilesa/ventas/vendedores/[id]             (detalle de vendedor)
- *
- * Las tabs sí se muestran en las 5 URLs canónicas de cada tab + cualquier
- * otra sub-ruta directa de la tab (sin un siguiente segmento).
- *
- * Construcción/layout.tsx no hace este filtrado porque sus detalles
- * (`/dilesa/construccion/[id]`) son menos invasivos; aquí ya tenemos un
- * detalle de venta con header propio (back-link, badges, secciones) que
- * compite visualmente con un strip extra de tabs.
  */
 const TABS = [
   {
@@ -73,37 +56,13 @@ const TABS = [
   },
 ] as const;
 
-/**
- * Hrefs que sí muestran tabs (las 5 URLs canónicas de cada tab).
- */
-const TAB_HREFS: ReadonlySet<string> = new Set(TABS.map((t) => t.href));
-
-/**
- * Resuelve si la ruta actual debe mostrar el strip de tabs.
- * - Las 5 URLs canónicas: SI.
- * - Sub-paths inmediatos de Clientes/Vendedores que son listados
- *   (segmento extra que no es UUID) — improbable, pero seguro mostrarlos.
- * - Cualquier otro sub-path: NO (detalle de venta, forms, etc.).
- */
-function shouldShowTabs(pathname: string): boolean {
-  // Match exacto con cualquiera de las URLs canónicas.
-  if (TAB_HREFS.has(pathname)) return true;
-  // No mostrar en detalles ni forms — son sub-rutas con su propia vista.
-  return false;
-}
-
 export default function VentasLayout({ children }: { children: ReactNode }) {
-  const pathname = usePathname();
-  const showTabs = shouldShowTabs(pathname);
-
   return (
     <>
       <HubAccessRedirect tabs={TABS} />
-      {showTabs ? (
-        <div className="px-4 pt-4 sm:px-6 sm:pt-6">
-          <RoutedModuleTabs tabs={TABS} />
-        </div>
-      ) : null}
+      <div className="px-4 pt-4 sm:px-6 sm:pt-6">
+        <RoutedModuleTabs tabs={TABS} />
+      </div>
       {children}
     </>
   );


### PR DESCRIPTION
## Problema

En el módulo **Ventas** de DILESA, al seleccionar una venta y entrar a su detalle, el menú de tabs (Ventas · Inventario · Fases · Clientes · Vendedores) **desaparecía**, perdiendo la navegación del módulo. Lo mismo pasaba en captura por fase, venta nueva y detalle de cliente/vendedor.

## Causa

`app/dilesa/ventas/layout.tsx` tenía un gate `shouldShowTabs()` que ocultaba el strip de tabs en toda sub-ruta con vista propia (detalle, forms). Decisión vieja que ya no aplica.

## Fix

Se alinea con el patrón ya establecido en `construccion/layout.tsx`: el strip vive en el layout y se muestra en **toda** ruta del hub, manteniendo el contexto del módulo. Se elimina la maquinaria client-only (`usePathname`/`shouldShowTabs`) y el layout vuelve a ser server component, igual que Construcción.

El filtrado por permisos (sub-slugs ADR-030) y el resaltado del tab activo siguen iguales — en el detalle de venta ningún tab queda resaltado (mismo comportamiento que el detalle de Obras en Construcción).

## Verificación

- `typecheck` ✓ · `lint` ✓ (solo warnings preexistentes) · `format:check` ✓ · `initiatives:check` ✓ · `test:coverage` ✓ (137 archivos / 1791 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)