### PR TITLE
feat(dilesa-resumen-rediseno): snapshot diario de KPIs (Sprint 1)

### DIFF
--- a/app/api/cron/dilesa-resumen-consejo/route.ts
+++ b/app/api/cron/dilesa-resumen-consejo/route.ts
@@ -38,6 +38,11 @@ import {
   splitRecipientsExtra,
   writeNotificationLog,
 } from '@/lib/notifications';
+import {
+  computeKpisDelDia,
+  upsertKpiSnapshot,
+  fechaLocalMatamoros,
+} from '@/lib/dilesa/resumen-consejo-kpis';
 
 export const maxDuration = 120;
 
@@ -158,6 +163,21 @@ export async function GET(req: NextRequest) {
     resendId: res.id ?? null,
     errorMessage: res.ok ? null : String(res.error ?? 'unknown'),
   });
+
+  // Snapshot de cierre del día (base de los deltas del resumen ejecutivo, Sprint
+  // 1 del rediseño). No-fatal: un fallo aquí no debe bloquear el correo, que ya
+  // se envió. La fecha es la LOCAL de Matamoros, no la UTC del cron.
+  try {
+    const fechaLocal = fechaLocalMatamoros(now);
+    const kpis = await computeKpisDelDia(supabase, DILESA_EMPRESA_ID, fechaLocal);
+    const up = await upsertKpiSnapshot(supabase, DILESA_EMPRESA_ID, fechaLocal, kpis);
+    console.log(
+      '[dilesa-resumen-consejo] snapshot',
+      JSON.stringify({ fecha: fechaLocal, ok: up.ok })
+    );
+  } catch (e) {
+    console.error('[dilesa-resumen-consejo] snapshot error', e);
+  }
 
   const summary = {
     status: res.ok ? 'sent' : 'error',

--- a/lib/dilesa/resumen-consejo-kpis.test.ts
+++ b/lib/dilesa/resumen-consejo-kpis.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest';
+import {
+  armarKpis,
+  calcularDeltas,
+  fechaLocalMatamoros,
+  computeKpisDelDia,
+  upsertKpiSnapshot,
+  fetchSnapshotPrevio,
+  type KpisDelDia,
+  type KpisRaw,
+} from './resumen-consejo-kpis';
+
+const RAW_VACIO: KpisRaw = {
+  fasesHoy: [],
+  ventaMontos: [],
+  pagosHoy: [],
+  cargosAbiertos: [],
+  saldos: [],
+  casasEnObra: 0,
+  fechaLocal: '2026-06-13',
+};
+
+/**
+ * Mock mínimo del query-builder de supabase-js: cada método de filtro devuelve
+ * el mismo chain (thenable) que resuelve al resultado de su tabla. Soporta los
+ * chains que usan computeKpisDelDia / upsert / fetchSnapshotPrevio.
+ */
+function makeSupabase(results: Record<string, unknown> = {}) {
+  const calls: { upsert: { table: string; row: unknown; opts: unknown } | null } = { upsert: null };
+  const chainFor = (table: string) => {
+    const result = (results[table] as Record<string, unknown>) ?? { data: [] };
+    const chain: Record<string, unknown> = {};
+    for (const m of ['select', 'eq', 'is', 'in', 'lt', 'order', 'limit']) chain[m] = () => chain;
+    chain.maybeSingle = () => Promise.resolve(result);
+    chain.upsert = (row: unknown, opts: unknown) => {
+      calls.upsert = { table, row, opts };
+      return Promise.resolve({ error: (results.__upsertError as unknown) ?? null });
+    };
+    chain.then = (res: (v: unknown) => unknown, rej: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(res, rej);
+    return chain;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sb: any = { schema: () => ({ from: chainFor }), __calls: calls };
+  return sb;
+}
+
+describe('fechaLocalMatamoros — fecha local con DST real', () => {
+  it('verano (CDT, UTC-5): 01:00 UTC = 20:00 del día anterior', () => {
+    expect(fechaLocalMatamoros(new Date('2026-06-13T01:00:00Z'))).toBe('2026-06-12');
+  });
+  it('invierno (CST, UTC-6): 02:00 UTC = 20:00 del día anterior', () => {
+    expect(fechaLocalMatamoros(new Date('2026-01-13T02:00:00Z'))).toBe('2026-01-12');
+  });
+});
+
+describe('armarKpis — agregación pura', () => {
+  it('separa asignaciones de escrituras y suma sus montos por venta', () => {
+    const kpis = armarKpis({
+      ...RAW_VACIO,
+      fasesHoy: [
+        { venta_id: 'v1', fase: 'Asignada' },
+        { venta_id: 'v2', fase: 'Escriturada' },
+      ],
+      ventaMontos: [
+        { id: 'v1', precio_asignacion: 100, valor_escrituracion: null },
+        { id: 'v2', precio_asignacion: null, valor_escrituracion: 500 },
+      ],
+    });
+    expect(kpis.ventas_hoy_n).toBe(1);
+    expect(kpis.ventas_hoy_monto).toBe(100);
+    expect(kpis.escrituras_hoy_n).toBe(1);
+    expect(kpis.escrituras_hoy_monto).toBe(500);
+  });
+
+  it('suma cobranza del día y liquidez de todas las cuentas', () => {
+    const kpis = armarKpis({
+      ...RAW_VACIO,
+      pagosHoy: [{ monto_total: 30 }, { monto_total: 20 }, { monto_total: null }],
+      saldos: [{ saldo: 128 }, { saldo: 5 }, { saldo: null }],
+    });
+    expect(kpis.cobrado_hoy).toBe(50);
+    expect(kpis.liquidez_total).toBe(133);
+  });
+
+  it('CxC abierto = todos los cargos; vencido = solo los con fecha < hoy', () => {
+    const kpis = armarKpis({
+      ...RAW_VACIO,
+      fechaLocal: '2026-06-13',
+      cargosAbiertos: [
+        { saldo: 1000, fecha_vencimiento: '2026-06-01' }, // vencido
+        { saldo: 500, fecha_vencimiento: '2026-12-31' }, // al corriente
+        { saldo: 200, fecha_vencimiento: null }, // sin fecha → no vencido
+      ],
+    });
+    expect(kpis.cxc_abierto).toBe(1700);
+    expect(kpis.cxc_vencido).toBe(1000);
+  });
+
+  it('casas en obra pasa directo', () => {
+    expect(armarKpis({ ...RAW_VACIO, casasEnObra: 12 }).casas_en_obra).toBe(12);
+  });
+});
+
+describe('calcularDeltas', () => {
+  const HOY: KpisDelDia = {
+    ventas_hoy_n: 3,
+    ventas_hoy_monto: 5400,
+    escrituras_hoy_n: 2,
+    escrituras_hoy_monto: 3200,
+    cobrado_hoy: 1800,
+    liquidez_total: 137,
+    cxc_abierto: 133,
+    cxc_vencido: 47,
+    casas_en_obra: 12,
+  };
+
+  it('sin snapshot previo, todos los deltas son null', () => {
+    const d = calcularDeltas(HOY, null);
+    expect(d.liquidez_total).toBeNull();
+    expect(d.cxc_vencido).toBeNull();
+  });
+
+  it('con previo, el delta es la diferencia campo a campo', () => {
+    const previo: KpisDelDia = { ...HOY, liquidez_total: 140, cxc_vencido: 50, casas_en_obra: 11 };
+    const d = calcularDeltas(HOY, previo);
+    expect(d.liquidez_total).toBe(-3);
+    expect(d.cxc_vencido).toBe(-3);
+    expect(d.casas_en_obra).toBe(1);
+    expect(d.ventas_hoy_n).toBe(0);
+  });
+});
+
+describe('computeKpisDelDia — wiring de queries', () => {
+  it('arma los KPIs desde las filas de cada tabla', async () => {
+    const sb = makeSupabase({
+      venta_fases: {
+        data: [
+          { venta_id: 'v1', fase: 'Asignada' },
+          { venta_id: 'v2', fase: 'Escriturada' },
+        ],
+      },
+      ventas: {
+        data: [
+          { id: 'v1', precio_asignacion: 100, valor_escrituracion: null },
+          { id: 'v2', precio_asignacion: null, valor_escrituracion: 500 },
+        ],
+      },
+      cxc_pagos: { data: [{ monto_total: 30 }, { monto_total: 20 }] },
+      cxc_cargos: {
+        data: [
+          { saldo: 1000, fecha_vencimiento: '2026-06-01' },
+          { saldo: 500, fecha_vencimiento: '2026-12-31' },
+        ],
+      },
+      v_cuenta_saldo_actual: { data: [{ saldo: 128 }, { saldo: 5 }] },
+      construccion: { count: 12 },
+    });
+    const kpis = await computeKpisDelDia(sb, 'e1', '2026-06-13');
+    expect(kpis).toEqual({
+      ventas_hoy_n: 1,
+      ventas_hoy_monto: 100,
+      escrituras_hoy_n: 1,
+      escrituras_hoy_monto: 500,
+      cobrado_hoy: 50,
+      liquidez_total: 133,
+      cxc_abierto: 1500,
+      cxc_vencido: 1000,
+      casas_en_obra: 12,
+    });
+  });
+
+  it('sin fases del día no consulta ventas y los flujos quedan en 0', async () => {
+    const sb = makeSupabase({ construccion: { count: 0 } });
+    const kpis = await computeKpisDelDia(sb, 'e1', '2026-06-13');
+    expect(kpis.ventas_hoy_n).toBe(0);
+    expect(kpis.escrituras_hoy_n).toBe(0);
+  });
+});
+
+describe('upsertKpiSnapshot', () => {
+  it('upserta por empresa+fecha y devuelve ok', async () => {
+    const sb = makeSupabase();
+    const kpis = { ...RAW_VACIO } as unknown as KpisDelDia;
+    const res = await upsertKpiSnapshot(sb, 'e1', '2026-06-13', {
+      ...kpis,
+      ventas_hoy_n: 3,
+    } as KpisDelDia);
+    expect(res.ok).toBe(true);
+    expect(sb.__calls.upsert.table).toBe('kpi_snapshot');
+    expect(sb.__calls.upsert.row).toMatchObject({
+      empresa_id: 'e1',
+      fecha: '2026-06-13',
+      ventas_hoy_n: 3,
+    });
+    expect(sb.__calls.upsert.opts).toEqual({ onConflict: 'empresa_id,fecha' });
+  });
+
+  it('propaga error del upsert', async () => {
+    const sb = makeSupabase({ __upsertError: { message: 'boom' } });
+    const res = await upsertKpiSnapshot(sb, 'e1', '2026-06-13', {} as KpisDelDia);
+    expect(res.ok).toBe(false);
+    expect(res.error).toEqual({ message: 'boom' });
+  });
+});
+
+describe('fetchSnapshotPrevio', () => {
+  it('mapea la fila previa a KpisDelDia', async () => {
+    const sb = makeSupabase({
+      kpi_snapshot: {
+        data: {
+          ventas_hoy_n: 2,
+          ventas_hoy_monto: 200,
+          escrituras_hoy_n: 1,
+          escrituras_hoy_monto: 100,
+          cobrado_hoy: 50,
+          liquidez_total: 140,
+          cxc_abierto: 130,
+          cxc_vencido: 50,
+          casas_en_obra: 11,
+        },
+      },
+    });
+    const previo = await fetchSnapshotPrevio(sb, 'e1', '2026-06-13');
+    expect(previo?.liquidez_total).toBe(140);
+    expect(previo?.casas_en_obra).toBe(11);
+  });
+
+  it('devuelve null cuando no hay snapshot previo', async () => {
+    const sb = makeSupabase({ kpi_snapshot: { data: null } });
+    expect(await fetchSnapshotPrevio(sb, 'e1', '2026-06-13')).toBeNull();
+  });
+});

--- a/lib/dilesa/resumen-consejo-kpis.ts
+++ b/lib/dilesa/resumen-consejo-kpis.ts
@@ -1,0 +1,232 @@
+/**
+ * KPIs del cierre diario — correo al Consejo DILESA
+ * (iniciativa dilesa-resumen-consejo-rediseno, Sprint 1).
+ *
+ * El cron del correo, al enviar (~20:00 Matamoros), calcula los KPIs del día y
+ * los guarda en `dilesa.kpi_snapshot` (upsert por empresa+fecha). Eso habilita
+ * los DELTAS ▲▼ del resumen ejecutivo (Sprint 3): el correo de hoy compara su
+ * snapshot contra el más reciente previo.
+ *
+ * Diseño espejo de `resumen-consejo-email.ts`: la lógica de agregación vive en
+ * funciones PURAS (`armarKpis`, `calcularDeltas`) testeables sin DB; las async
+ * solo hacen fetch/upsert.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Métricas de un día (lo que se persiste por fila de snapshot). */
+export type KpisDelDia = {
+  ventas_hoy_n: number;
+  ventas_hoy_monto: number;
+  escrituras_hoy_n: number;
+  escrituras_hoy_monto: number;
+  cobrado_hoy: number;
+  liquidez_total: number;
+  cxc_abierto: number;
+  cxc_vencido: number;
+  casas_en_obra: number;
+};
+
+/** Filas crudas que alimentan `armarKpis` (ya fetcheadas). */
+export type KpisRaw = {
+  fasesHoy: { venta_id: string; fase: string }[];
+  ventaMontos: {
+    id: string;
+    precio_asignacion: number | null;
+    valor_escrituracion: number | null;
+  }[];
+  pagosHoy: { monto_total: number | null }[];
+  cargosAbiertos: { saldo: number | null; fecha_vencimiento: string | null }[];
+  saldos: { saldo: number | null }[];
+  casasEnObra: number;
+  /** Fecha local (YYYY-MM-DD) para decidir qué cargo CxC está vencido. */
+  fechaLocal: string;
+};
+
+const KPI_CAMPOS: (keyof KpisDelDia)[] = [
+  'ventas_hoy_n',
+  'ventas_hoy_monto',
+  'escrituras_hoy_n',
+  'escrituras_hoy_monto',
+  'cobrado_hoy',
+  'liquidez_total',
+  'cxc_abierto',
+  'cxc_vencido',
+  'casas_en_obra',
+];
+
+/**
+ * Fecha LOCAL de Matamoros (YYYY-MM-DD) para un instante dado, con DST real.
+ * El cron dispara en UTC ~01:00/02:00; a las 20:00 locales el día UTC ya rodó,
+ * así que la fecha del snapshot debe calcularse en el TZ real, no en UTC (si no,
+ * "hoy" se desfasa un día). `en-CA` formatea como YYYY-MM-DD.
+ */
+export function fechaLocalMatamoros(now: Date): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Matamoros',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+}
+
+/** Agrega las filas crudas en las métricas del día (pura). */
+export function armarKpis(raw: KpisRaw): KpisDelDia {
+  const montoPorVenta = new Map(raw.ventaMontos.map((v) => [v.id, v]));
+  let ventas_hoy_n = 0;
+  let ventas_hoy_monto = 0;
+  let escrituras_hoy_n = 0;
+  let escrituras_hoy_monto = 0;
+  for (const f of raw.fasesHoy) {
+    const v = montoPorVenta.get(f.venta_id);
+    if (f.fase === 'Asignada') {
+      ventas_hoy_n += 1;
+      ventas_hoy_monto += Number(v?.precio_asignacion ?? 0);
+    } else if (f.fase === 'Escriturada') {
+      escrituras_hoy_n += 1;
+      escrituras_hoy_monto += Number(v?.valor_escrituracion ?? 0);
+    }
+  }
+
+  const cobrado_hoy = raw.pagosHoy.reduce((s, p) => s + Number(p.monto_total ?? 0), 0);
+  const liquidez_total = raw.saldos.reduce((s, c) => s + Number(c.saldo ?? 0), 0);
+
+  let cxc_abierto = 0;
+  let cxc_vencido = 0;
+  for (const c of raw.cargosAbiertos) {
+    const saldo = Number(c.saldo ?? 0);
+    cxc_abierto += saldo;
+    // Comparación de strings YYYY-MM-DD = comparación cronológica.
+    if (c.fecha_vencimiento && c.fecha_vencimiento < raw.fechaLocal) cxc_vencido += saldo;
+  }
+
+  return {
+    ventas_hoy_n,
+    ventas_hoy_monto,
+    escrituras_hoy_n,
+    escrituras_hoy_monto,
+    cobrado_hoy,
+    liquidez_total,
+    cxc_abierto,
+    cxc_vencido,
+    casas_en_obra: raw.casasEnObra,
+  };
+}
+
+/**
+ * Delta de cada métrica vs el snapshot previo (pura). `null` cuando no hay
+ * previo (primer día) — el render muestra el valor sin flecha en ese caso.
+ */
+export function calcularDeltas(
+  hoy: KpisDelDia,
+  previo: KpisDelDia | null
+): Record<keyof KpisDelDia, number | null> {
+  const out = {} as Record<keyof KpisDelDia, number | null>;
+  for (const k of KPI_CAMPOS) {
+    out[k] = previo ? Number(hoy[k]) - Number(previo[k]) : null;
+  }
+  return out;
+}
+
+/**
+ * Calcula los KPIs del día contra las vistas/tablas DILESA+ERP. `fechaLocal` es
+ * la fecha de Matamoros (de `fechaLocalMatamoros`). Lee con el cliente del cron
+ * (service role).
+ */
+export async function computeKpisDelDia(
+  supabase: SupabaseClient,
+  empresaId: string,
+  fechaLocal: string
+): Promise<KpisDelDia> {
+  const dilesa = supabase.schema('dilesa');
+  const erp = supabase.schema('erp');
+
+  const [fasesRes, pagosRes, cargosRes, saldosRes, obraRes] = await Promise.all([
+    dilesa
+      .from('venta_fases')
+      .select('venta_id,fase')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .eq('fecha', fechaLocal)
+      .in('fase', ['Asignada', 'Escriturada']),
+    erp
+      .from('cxc_pagos')
+      .select('monto_total')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .eq('fecha', fechaLocal),
+    erp
+      .from('cxc_cargos')
+      .select('saldo,fecha_vencimiento')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .in('estado', ['pendiente', 'parcial']),
+    erp.from('v_cuenta_saldo_actual').select('saldo').eq('empresa_id', empresaId),
+    dilesa
+      .from('construccion')
+      .select('id', { count: 'exact', head: true })
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .eq('estado', 'en_progreso'),
+  ]);
+
+  const fasesHoy = (fasesRes.data ?? []) as { venta_id: string; fase: string }[];
+  const ventaIds = [...new Set(fasesHoy.map((f) => f.venta_id))];
+  const ventaMontos = ventaIds.length
+    ? ((
+        await dilesa
+          .from('ventas')
+          .select('id,precio_asignacion,valor_escrituracion')
+          .in('id', ventaIds)
+      ).data ?? [])
+    : [];
+
+  return armarKpis({
+    fasesHoy,
+    ventaMontos: ventaMontos as KpisRaw['ventaMontos'],
+    pagosHoy: (pagosRes.data ?? []) as KpisRaw['pagosHoy'],
+    cargosAbiertos: (cargosRes.data ?? []) as KpisRaw['cargosAbiertos'],
+    saldos: (saldosRes.data ?? []) as KpisRaw['saldos'],
+    casasEnObra: obraRes.count ?? 0,
+    fechaLocal,
+  });
+}
+
+/** Upsert idempotente del snapshot del día (por empresa+fecha). */
+export async function upsertKpiSnapshot(
+  supabase: SupabaseClient,
+  empresaId: string,
+  fecha: string,
+  kpis: KpisDelDia
+): Promise<{ ok: boolean; error?: unknown }> {
+  const { error } = await supabase
+    .schema('dilesa')
+    .from('kpi_snapshot')
+    .upsert(
+      { empresa_id: empresaId, fecha, ...kpis, updated_at: new Date().toISOString() },
+      { onConflict: 'empresa_id,fecha' }
+    );
+  return error ? { ok: false, error } : { ok: true };
+}
+
+/** Snapshot más reciente ANTERIOR a `fecha` (para los deltas). null si no hay. */
+export async function fetchSnapshotPrevio(
+  supabase: SupabaseClient,
+  empresaId: string,
+  fecha: string
+): Promise<KpisDelDia | null> {
+  const { data } = await supabase
+    .schema('dilesa')
+    .from('kpi_snapshot')
+    .select('*')
+    .eq('empresa_id', empresaId)
+    .lt('fecha', fecha)
+    .order('fecha', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!data) return null;
+  const row = data as Record<string, unknown>;
+  const out = {} as KpisDelDia;
+  for (const k of KPI_CAMPOS) out[k] = Number(row[k] ?? 0);
+  return out;
+}

--- a/supabase/migrations/20260613185527_dilesa_kpi_snapshot.sql
+++ b/supabase/migrations/20260613185527_dilesa_kpi_snapshot.sql
@@ -1,0 +1,57 @@
+-- ╭─ 20260613185527_dilesa_kpi_snapshot ─╮
+-- Cierre diario de KPIs del correo al Consejo DILESA
+-- (iniciativa dilesa-resumen-consejo-rediseno, Sprint 1).
+--
+-- Una fila por (empresa, día): los flujos del día (ventas/escrituras/cobranza)
+-- y los stocks de cierre (liquidez, CxC, casas en obra). El cron escribe la
+-- fila del día al enviar el correo (upsert idempotente por empresa+fecha).
+-- Es la base de los DELTAS ▲▼: el correo compara el snapshot de hoy contra el
+-- más reciente previo. Sin historial propio en los stocks (CxC, casas en obra)
+-- no habría delta — esta tabla lo provee. La fecha es la LOCAL de Matamoros
+-- al momento del envío (20:00), no la UTC del cron.
+--
+-- Timestamp generado con `npm run db:new` (anti-colisión multi-sesión:
+-- estrictamente mayor que toda migración local + de PRs abiertos).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS dilesa.kpi_snapshot (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES core.empresas (id),
+  -- Fecha LOCAL de Matamoros del cierre (no la UTC del cron).
+  fecha date NOT NULL,
+  -- Flujos del día.
+  ventas_hoy_n integer NOT NULL DEFAULT 0,
+  ventas_hoy_monto numeric NOT NULL DEFAULT 0,
+  escrituras_hoy_n integer NOT NULL DEFAULT 0,
+  escrituras_hoy_monto numeric NOT NULL DEFAULT 0,
+  cobrado_hoy numeric NOT NULL DEFAULT 0,
+  -- Stocks de cierre.
+  liquidez_total numeric NOT NULL DEFAULT 0,
+  cxc_abierto numeric NOT NULL DEFAULT 0,
+  cxc_vencido numeric NOT NULL DEFAULT 0,
+  casas_en_obra integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  -- Un snapshot por empresa por día (el cron hace upsert al reintentar).
+  CONSTRAINT kpi_snapshot_empresa_fecha_key UNIQUE (empresa_id, fecha)
+);
+
+COMMENT ON TABLE dilesa.kpi_snapshot IS
+  'Cierre diario de KPIs del correo al Consejo (dilesa-resumen-consejo-rediseno S1). Una fila por empresa+día; el cron la upserta al enviar. Base de los deltas ▲▼ del resumen ejecutivo. fecha = local de Matamoros, no UTC.';
+
+CREATE INDEX IF NOT EXISTS kpi_snapshot_empresa_fecha_idx
+  ON dilesa.kpi_snapshot (empresa_id, fecha DESC);
+
+-- RLS canónica (aislamiento por empresa, espejo de dilesa.venta_fase_revisiones).
+-- Escritura: solo service role (el cron) — sin políticas de INSERT/UPDATE para
+-- usuarios autenticados; el snapshot no se captura a mano.
+ALTER TABLE dilesa.kpi_snapshot ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS kpi_snapshot_select ON dilesa.kpi_snapshot;
+CREATE POLICY kpi_snapshot_select ON dilesa.kpi_snapshot
+  FOR SELECT USING (core.fn_has_empresa(empresa_id) OR core.fn_is_admin());
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Qué

**Sprint 1** del rediseño del correo al Consejo: la base invisible para los deltas ▲▼ del resumen ejecutivo.

- **Migración** `dilesa.kpi_snapshot` — una fila por empresa+día con los flujos del día (ventas/escrituras/cobranza) y los stocks de cierre (liquidez, CxC abierto/vencido, casas en obra). RLS empresa-scoped; escritura solo service role. **No aplicada a prod aún** (pendiente OK de Beto).
- **`lib/dilesa/resumen-consejo-kpis.ts`** — `armarKpis`/`calcularDeltas`/`fechaLocalMatamoros` (puras) + `computeKpisDelDia`/`upsertKpiSnapshot`/`fetchSnapshotPrevio` (DB). 14 tests.
- **Cron** — bloque no-fatal que computa + upserta el snapshot al enviar (un fallo nunca bloquea el correo). `fecha` = local de Matamoros con DST real, no la UTC del cron.

## Por qué una tabla

Los flujos del día se derivan directo de `venta_fases`/`cxc_pagos`, pero los **stocks** (liquidez, CxC, casas en obra) no tienen historial propio → sin un snapshot diario no hay "▲▼ vs ayer". Esta tabla lo provee.

## No cambia nada visible

El correo se ve idéntico; esto solo empieza a acumular el historial que Sprint 3 consumirá para la tarjeta ejecutiva.

## Checks locales

typecheck ✓ · 1805 tests ✓ (14 nuevos) · coverage 43.8/77.9/83.7 (sobre umbral) ✓ · lint ✓ · format ✓

Columnas/valores verificados contra prod (cxc_cargos.estado pendiente/parcial, construccion.estado=en_progreso, venta_fases.fase). Iniciativa `dilesa-resumen-consejo-rediseno`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)