### PR TITLE
fix(dilesa): saldo de cuadratura considera descuento + cheque a notaría

### DIFF
--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -67,7 +67,7 @@ import {
   type ColaItem,
   type HoldSnapshot,
 } from '@/lib/dilesa/hold-cola';
-import { usePermissions } from '@/components/providers';
+import { usePermissions, useEffectiveUser } from '@/components/providers';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -354,6 +354,7 @@ function DetailInner() {
     'operacion'
   );
   const { permissions } = usePermissions();
+  const { data: effectiveUser } = useEffectiveUser();
   // Scope del rol Vendedor: solo sus propias ventas (pedido de Beto).
   const scopeVendedor = useScopeVendedorDilesa();
   const [cuadInputs, setCuadInputs] = useState<CuadraturaInputsStr>({
@@ -906,6 +907,9 @@ function DetailInner() {
           (Number(cuadInputs.descuentoEquipamiento) || 0) +
           (Number(cuadInputs.descuentoGastosEscr) || 0) +
           (Number(cuadInputs.descuentoNotaCredito) || 0),
+        // Tope confiable SOLO desde la promoción de la solicitud; el máximo
+        // legacy de Coda no es de fiar (159/315 ventas lo exceden por mal dato).
+        descuentoMaximoAutorizado: promo ? promo.monto : null,
         precioAsignacion: venta?.precio_asignacion ?? null,
         // Solo cuando ya hay CFDI de factura: su total es el Valor Facturado
         // autoritativo y la NC se deriva de él (NC = facturado real − valor
@@ -928,6 +932,7 @@ function DetailInner() {
       proyectoNombre,
       cuadInputs,
       apoyoInfonavit,
+      promo,
       comprobantesPorAbono,
       hayFacturaCfdi,
     ]
@@ -1187,8 +1192,10 @@ function DetailInner() {
                   : null
             }
             canWrite={
-              permissions.isAdmin ||
-              permissions.modulos.get('dilesa.ventas.fase13_facturada')?.write === true
+              // Buckets de descuento: solo Dirección (regla Beto 2026-06-15) —
+              // admin global O rol Dirección en la empresa de la venta.
+              !!effectiveUser?.isAdmin ||
+              (effectiveUser?.direccionEmpresaIds ?? []).includes(venta.empresa_id)
             }
           />
           <CuadraturaPanel

--- a/components/dilesa/cuadratura-panel.tsx
+++ b/components/dilesa/cuadratura-panel.tsx
@@ -71,12 +71,25 @@ export function CuadraturaPanel({
         <Fila label="Crédito directo (pagaré)" value={money(c.montoCreditoDirecto)} />
         <Fila label="Depósitos directos del cliente" value={money(c.depositosDirectoCliente)} />
         <Fila label="Monto disponible para operación" value={money(c.montoDisponible)} strong />
+        {c.descuentoOtorgado > 0 || c.chequePagado > 0 ? (
+          <>
+            <Fila label="(+) Descuento otorgado" value={money(c.descuentoOtorgado)} />
+            {c.chequePagado > 0 ? (
+              <Fila label="(−) Cheque a notaría girado" value={money(c.chequePagado)} />
+            ) : null}
+          </>
+        ) : null}
         <div className="my-1 border-t border-[var(--border)]" />
         <Fila
           label={c.cubierta ? 'Saldo (cubierta)' : 'Saldo pendiente'}
           value={money(c.saldoCliente)}
           strong
           tone={c.cubierta ? 'ok' : 'warn'}
+          hint={
+            c.descuentoOtorgado > 0 || c.chequePagado > 0
+              ? `Cobranza cruda: ${money(c.saldoCobranza)}`
+              : undefined
+          }
         />
       </Bloque>
 

--- a/components/dilesa/cuadratura-panel.tsx
+++ b/components/dilesa/cuadratura-panel.tsx
@@ -73,7 +73,15 @@ export function CuadraturaPanel({
         <Fila label="Monto disponible para operación" value={money(c.montoDisponible)} strong />
         {c.descuentoOtorgado > 0 || c.chequePagado > 0 ? (
           <>
-            <Fila label="(+) Descuento otorgado" value={money(c.descuentoOtorgado)} />
+            <Fila
+              label="(+) Descuento aplicado"
+              value={money(c.descuentoAplicado)}
+              hint={
+                c.descuentoAplicado < c.descuentoOtorgado
+                  ? `Otorgado ${money(c.descuentoOtorgado)} · topado al autorizado`
+                  : undefined
+              }
+            />
             {c.chequePagado > 0 ? (
               <Fila label="(−) Cheque a notaría girado" value={money(c.chequePagado)} />
             ) : null}

--- a/docs/planning/dilesa-ventas-expediente.md
+++ b/docs/planning/dilesa-ventas-expediente.md
@@ -164,10 +164,14 @@ expediente, copiloto), no reescritura.
   por redondeo de captura. Verificado vs prod (1,186 ventas): 248 pasan de
   «pendiente»→«cubierta» correctamente; ~17 cerradas surfacean como anomalía
   real (cheque a notaría girado sin descuento documentado / por encima del
-  autorizado). Revisión adversarial: H1 (el descuento es campo editable y ahora
-  carga el gate de cierre F17) queda como decisión de gobernanza de Beto — tope
-  por máximo autorizado descartado por ahora (159/315 ventas ya exceden su
-  máximo legacy). PR (TBD).
+  autorizado). Revisión adversarial encontró H1 (el descuento es campo editable
+  y ahora carga el gate de cierre F17). **Decisión Beto:** (a) el descuento que
+  entra al saldo se topa a lo autorizado desde el inicio — implementado SOLO
+  contra el tope confiable (monto de la promoción de la solicitud); el máximo
+  legacy de Coda NO topa (159/315 ventas lo exceden por mal dato, no por
+  sobre-descuento real); (b) los 4 buckets de descuento solo editables por
+  **Dirección** (admin global O rol Dirección en la empresa), antes era
+  admin/escritura-F13. PR #890.
 - **2026-06-09:** Promovida. Beto eligió el rediseño completo (opción B) sobre
   el parche incremental, tras notar que la captura por fase pierde el contexto
   de la operación.

--- a/docs/planning/dilesa-ventas-expediente.md
+++ b/docs/planning/dilesa-ventas-expediente.md
@@ -7,7 +7,7 @@
 **Próximo hito:** — (cerrada: cutover Coda de ventas completado 2026-06-11 — paridad certificada, daily apagado, equipo de ventas con usuarios/perfiles activos. Coda queda read-only de consulta)
 **Dueño:** Beto
 **Creada:** 2026-06-09
-**Última actualización:** 2026-06-13 (post-cierre: Valor Facturado del CFDI + NC derivada de «facturado real − valor real venta DILESA» en la Cuadratura y el control fiscal de F13; + blindaje de `fuente` contra doble conteo)
+**Última actualización:** 2026-06-15 (follow-up: Saldo efectivo — el descuento autorizado y el cheque a notaría girado entran al saldo de la cuadratura; antes el saldo era ciego al descuento y un descuento perdonado se veía como deuda)
 
 ## Problema
 
@@ -153,6 +153,21 @@ expediente, copiloto), no reescritura.
 
 ## Bitácora
 
+- **2026-06-15 (follow-up financiero):** **Saldo efectivo** — el saldo de la
+  cuadratura ahora considera el descuento autorizado y el cheque a notaría
+  girado, no solo efectivo+crédito. Antes el saldo era ciego al descuento, así
+  que un descuento perdonado (ej. caso JOSUE DANIEL CRUZ VALVERDE: $1,622 que
+  eran descuento, no deuda) se mostraba como pendiente y los 4 buckets de
+  descuento eran inertes (solo movían el cheque _sugerido_). Nueva fórmula:
+  `Saldo efectivo = Cobranza cruda − Descuento Otorgado + Cheque girado`
+  (= `Cheque girado − Excedente Disponible`), `cubierta` con tolerancia de $5
+  por redondeo de captura. Verificado vs prod (1,186 ventas): 248 pasan de
+  «pendiente»→«cubierta» correctamente; ~17 cerradas surfacean como anomalía
+  real (cheque a notaría girado sin descuento documentado / por encima del
+  autorizado). Revisión adversarial: H1 (el descuento es campo editable y ahora
+  carga el gate de cierre F17) queda como decisión de gobernanza de Beto — tope
+  por máximo autorizado descartado por ahora (159/315 ventas ya exceden su
+  máximo legacy). PR (TBD).
 - **2026-06-09:** Promovida. Beto eligió el rediseño completo (opción B) sobre
   el parche incremental, tras notar que la captura por fase pierde el contexto
   de la operación.

--- a/lib/dilesa/copiloto-cierre.ts
+++ b/lib/dilesa/copiloto-cierre.ts
@@ -7,8 +7,9 @@
  *   2. Expediente documental completo (roles requeridos de FASE_ROLES,
  *      descontando los opcionales que la venta no amerita — ver
  *      `rolesOpcionales`).
- *   3. Cuadratura cubierta (saldo del cliente ≤ 0 contra Valor de
- *      Escrituración).
+ *   3. Cuadratura cubierta (saldo EFECTIVO del cliente ≤ tolerancia: el
+ *      descuento autorizado + el disponible cubren la escrituración, neto del
+ *      cheque a notaría girado).
  *   4. Conformidad del cliente registrada (la propia Fase 16 — la encuesta
  *      respondida/capturada/sin-respuesta la cierra).
  *
@@ -33,9 +34,10 @@ export type CopilotoInput = {
   fases: CopilotoFase[];
   /** Docs requeridos que aún no están cargados (ya filtrados de opcionales). */
   docsFaltantes: CopilotoDocFaltante[];
-  /** Saldo del cliente (Valor Escrituración − disponible). null = sin datos. */
+  /** Saldo EFECTIVO del cliente (cobranza − descuento + cheque girado). null =
+   *  sin datos. */
   saldoCliente: number | null;
-  /** Cuadratura cubierta (saldo ≤ 0). null = sin datos para evaluar. */
+  /** Cuadratura cubierta (saldo efectivo ≤ tolerancia). null = sin datos. */
   cubierta: boolean | null;
 };
 

--- a/lib/dilesa/cuadratura-server.ts
+++ b/lib/dilesa/cuadratura-server.ts
@@ -32,6 +32,7 @@ type VentaCuadraturaRow = {
   descuento_equipamiento: number | null;
   descuento_gastos_escrituracion: number | null;
   descuento_nota_credito: number | null;
+  promocion_id: string | null;
 };
 
 /**
@@ -46,7 +47,7 @@ export async function cargarCuadraturaVenta(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'empresa_id, tipo_credito, unidad_id, precio_asignacion, valor_escrituracion, valor_facturado, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito'
+      'empresa_id, tipo_credito, unidad_id, precio_asignacion, valor_escrituracion, valor_facturado, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito, promocion_id'
     )
     .eq('id', ventaId)
     .is('deleted_at', null)
@@ -54,7 +55,7 @@ export async function cargarCuadraturaVenta(
   if (!vRow) return null;
   const venta = vRow as unknown as VentaCuadraturaRow;
 
-  const [abonosRes, tcRes, unidadRes] = await Promise.all([
+  const [abonosRes, tcRes, unidadRes, promoRes] = await Promise.all([
     sb
       .schema('erp')
       .from('cxc_pagos')
@@ -78,6 +79,15 @@ export async function cargarCuadraturaVenta(
           .from('unidades')
           .select('proyecto_id')
           .eq('id', venta.unidad_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    // Promoción de la solicitud → tope CONFIABLE de descuento autorizado.
+    venta.promocion_id
+      ? sb
+          .schema('dilesa')
+          .from('promociones')
+          .select('monto')
+          .eq('id', venta.promocion_id)
           .maybeSingle()
       : Promise.resolve({ data: null }),
   ]);
@@ -144,6 +154,8 @@ export async function cargarCuadraturaVenta(
       (Number(venta.descuento_equipamiento) || 0) +
       (Number(venta.descuento_gastos_escrituracion) || 0) +
       (Number(venta.descuento_nota_credito) || 0),
+    // Tope confiable solo desde la promo (el máximo legacy no es de fiar).
+    descuentoMaximoAutorizado: (promoRes.data as { monto: number | null } | null)?.monto ?? null,
     precioAsignacion: venta.precio_asignacion,
     valorFacturadoReal: hayFactura ? venta.valor_facturado : null,
     depositos: abonos.map((a) => ({

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -279,6 +279,45 @@ describe('calcularCuadratura', () => {
       expect(c.cubierta).toBe(false);
     });
 
+    // Tope a lo autorizado (regla Beto 2026-06-15): si se otorga más que el
+    // máximo confiable (promo), solo el autorizado entra al saldo; el exceso
+    // queda como pendiente a revisar, no reduce el saldo.
+    it('topa el descuento aplicado al máximo autorizado confiable', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 899000,
+        montoCreditoTitular: 636328,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: 13378,
+        gastosEscrituracion: 43378,
+        apoyoInfonavit: 30000,
+        descuentoOtorgadoTotal: 30000, // se otorgó de más
+        descuentoMaximoAutorizado: 15000, // pero solo 15,000 autorizados
+        depositos: [{ monto: 261049.55, directoCliente: true, tieneRecibo: true }],
+      });
+      expect(c.descuentoOtorgado).toBe(30000);
+      expect(c.descuentoAplicado).toBe(15000); // topado
+      expect(c.saldoCliente).toBe(0.45); // 1,622.45 − 15,000 + 13,378 (no 30,000)
+      expect(c.cubierta).toBe(true);
+    });
+
+    // Sin tope confiable (legacy), el descuento aplicado == el otorgado.
+    it('aplica el descuento completo cuando no hay tope confiable (legacy)', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 899000,
+        montoCreditoTitular: 636328,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: 13378,
+        gastosEscrituracion: 43378,
+        descuentoOtorgadoTotal: 15000,
+        // descuentoMaximoAutorizado ausente ⇒ sin tope
+        depositos: [{ monto: 261049.55, directoCliente: true, tieneRecibo: true }],
+      });
+      expect(c.descuentoAplicado).toBe(15000);
+      expect(c.saldoCliente).toBe(0.45);
+    });
+
     // La tolerancia absorbe el residual de centavos de captura (≤ 5 pesos).
     it('marca cubierta un residual de pocos pesos por redondeo de captura', () => {
       const c = calcularCuadratura({

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -26,7 +26,11 @@ describe('calcularCuadratura', () => {
 
     expect(c.depositosRecibidos).toBe(897378);
     expect(c.montoDisponible).toBe(897378); // 261,049.55 directo + 636,328.45 crédito
-    expect(c.saldoCliente).toBe(1622); // 899,000 − 897,378
+    expect(c.saldoCobranza).toBe(1622); // 899,000 − 897,378 (cobranza cruda)
+    // Sin descuento registrado pero con un cheque de 13,378 girado: el saldo
+    // efectivo EXPONE el descuento no documentado (1,622 sin cobrar + 13,378 de
+    // cheque = 15,000). No cubierta hasta capturar el descuento en los buckets.
+    expect(c.saldoCliente).toBe(15000); // 1,622 − 0 + 13,378
     expect(c.cubierta).toBe(false);
     expect(c.valorFacturado).toBe(1160049.55); // 899,000 + 261,049.55 (con recibo)
     expect(c.valorRealVentaDilesa).toBe(884000); // 897,378 − 13,378 + 0
@@ -210,6 +214,85 @@ describe('calcularCuadratura', () => {
         depositos: [{ monto: 600000, directoCliente: true }],
       });
       expect(c.posibleDobleConteo).toBe(false);
+    });
+  });
+
+  // Saldo efectivo (decisión Beto 2026-06-15): el descuento autorizado y el
+  // cheque a notaría girado entran al saldo. Antes el saldo era ciego al
+  // descuento y un descuento perdonado se veía como deuda.
+  describe('saldo efectivo (descuento + cheque)', () => {
+    // Caso real Beto (JOSUE DANIEL CRUZ VALVERDE): descuento de 15,000 otorgado,
+    // 13,378 girados como cheque a notaría, 1,622 perdonados ⇒ operación saldada.
+    it('cuadra a ~0 cuando el descuento cubre el faltante (caso Beto)', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 899000,
+        montoCreditoTitular: 636328, // campo de crédito (prod = 636,328.00)
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: 13378,
+        gastosEscrituracion: 43378,
+        apoyoInfonavit: 30000,
+        descuentoOtorgadoTotal: 15000,
+        depositos: [{ monto: 261049.55, directoCliente: true, tieneRecibo: true }],
+      });
+      expect(c.montoDisponible).toBe(897377.55); // 261,049.55 + 636,328
+      expect(c.saldoCobranza).toBe(1622.45); // cobranza cruda
+      expect(c.descuentoOtorgado).toBe(15000);
+      expect(c.chequePagado).toBe(13378);
+      expect(c.saldoCliente).toBe(0.45); // 1,622.45 − 15,000 + 13,378 (residual de campo)
+      expect(c.cubierta).toBe(true); // ≤ tolerancia
+    });
+
+    // Un cheque a notaría girado por encima del (excedente + descuento) deja un
+    // saldo positivo real: descuento no documentado o cheque excedido a revisar.
+    it('marca pendiente cuando el cheque excede el descuento autorizado', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 890000,
+        montoCreditoTitular: 900719, // disponible cubre la cobranza (saldo cobranza −10,719)
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: 25720, // cheque grande SIN descuento registrado
+        gastosEscrituracion: 55720,
+        descuentoOtorgadoTotal: 0,
+        depositos: [],
+      });
+      expect(c.saldoCobranza).toBe(-10719); // cobranza cubierta
+      expect(c.saldoCliente).toBe(15001); // −10,719 − 0 + 25,720 → faltante real
+      expect(c.cubierta).toBe(false);
+    });
+
+    // Sin descuento ni cheque, el saldo efectivo == la cobranza cruda.
+    it('iguala la cobranza cruda cuando no hay descuento ni cheque', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 800000,
+        montoCreditoTitular: 700000,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: null,
+        gastosEscrituracion: null,
+        depositos: [{ monto: 50000, directoCliente: true }],
+      });
+      expect(c.saldoCobranza).toBe(50000);
+      expect(c.chequePagado).toBe(0);
+      expect(c.saldoCliente).toBe(50000);
+      expect(c.saldoCliente).toBe(c.saldoCobranza);
+      expect(c.cubierta).toBe(false);
+    });
+
+    // La tolerancia absorbe el residual de centavos de captura (≤ 5 pesos).
+    it('marca cubierta un residual de pocos pesos por redondeo de captura', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 890000,
+        montoCreditoTitular: 890522, // saldo cobranza = −522
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: 15524,
+        gastosEscrituracion: 45524,
+        descuentoOtorgadoTotal: 15000,
+        depositos: [],
+      });
+      expect(c.saldoCliente).toBe(2); // −522 − 15,000 + 15,524
+      expect(c.cubierta).toBe(true); // ≤ tolerancia
     });
   });
 });

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -77,6 +77,15 @@ export type CuadraturaInput = {
   apoyoInfonavit?: number | null;
   /** GAP: suma de los 4 buckets de descuento otorgado. */
   descuentoOtorgadoTotal?: number | null;
+  /**
+   * Tope CONFIABLE de descuento autorizado (regla Beto 2026-06-15: el descuento
+   * que entra al saldo está topado a lo autorizado desde el inicio). Pasar SOLO
+   * cuando la autorización es de fiar — el monto de la promoción de la Solicitud
+   * de Asignación. null/undefined ⇒ sin tope (ventas legacy de Coda cuyo
+   * `descuento_maximo_autorizado` no es confiable: 159/315 lo exceden por mal
+   * dato; ahí no se topa para no inventar pendientes falsos).
+   */
+  descuentoMaximoAutorizado?: number | null;
   /** Para referencia (no entra al saldo). */
   precioAsignacion?: number | null;
   /**
@@ -107,6 +116,9 @@ export type Cuadratura = {
   saldoCliente: number;
   /** Suma de los 4 buckets de descuento otorgado (eco del input, para la UI). */
   descuentoOtorgado: number;
+  /** Descuento efectivamente aplicado al saldo: `descuentoOtorgado` topado al
+   *  máximo autorizado confiable (= otorgado cuando no hay tope). */
+  descuentoAplicado: number;
   /** Cheque a notaría CAPTURADO (0 si aún no se gira). Distinto del calculado. */
   chequePagado: number;
   /** true si el descuento autorizado + el disponible cubren la escrituración
@@ -175,18 +187,26 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   const saldoCobranza = round2(valorEscrituracion - montoDisponible);
 
   const descuentoOtorgadoTotal = n(i.descuentoOtorgadoTotal);
+  // Tope a lo autorizado desde el inicio: el saldo solo acredita el descuento
+  // hasta el máximo CONFIABLE (promo de la solicitud). Sin tope confiable
+  // (legacy) se aplica el otorgado completo. El exceso sobre el tope NO reduce
+  // el saldo (queda como pendiente a revisar).
+  const descuentoAplicado =
+    i.descuentoMaximoAutorizado != null
+      ? Math.min(descuentoOtorgadoTotal, Math.max(0, n(i.descuentoMaximoAutorizado)))
+      : descuentoOtorgadoTotal;
   const gastosNetos = n(i.gastosEscrituracion) - n(i.apoyoInfonavit);
-  const excedenteDisponible = montoDisponible - valorEscrituracion + descuentoOtorgadoTotal;
+  const excedenteDisponible = montoDisponible - valorEscrituracion + descuentoAplicado;
   const chequeNotariaCalculado = round2(Math.min(gastosNetos, excedenteDisponible));
 
   // Cheque a notaría GIRADO (capturado en Fase 11; 0 si aún no se gira). El
   // saldo efectivo usa este, no el calculado: mide un giro real contra el
   // descuento, no una sugerencia.
   const chequePagado = round2(n(i.montoChequeNotaria));
-  // Saldo efectivo: el descuento autorizado cubre el faltante de cobranza y el
+  // Saldo efectivo: el descuento aplicado cubre el faltante de cobranza y el
   // cheque girado se fondea de ese descuento (o del excedente). Equivale a
   // `chequePagado − excedenteDisponible`.
-  const saldoCliente = round2(saldoCobranza - descuentoOtorgadoTotal + chequePagado);
+  const saldoCliente = round2(saldoCobranza - descuentoAplicado + chequePagado);
   const cubierta = saldoCliente <= TOLERANCIA_SALDO;
 
   // El crédito directo (pagaré) queda fuera: sus pagos sí son del cliente.
@@ -228,6 +248,7 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     saldoCobranza,
     saldoCliente,
     descuentoOtorgado: round2(descuentoOtorgadoTotal),
+    descuentoAplicado: round2(descuentoAplicado),
     chequePagado,
     cubierta,
     chequeNotariaCalculado,

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -10,9 +10,22 @@
  *   Depósitos Recibidos       = Σ todos los depósitos del cliente.
  *   Monto Disponible          = Σ depósitos(Directo Cliente) + crédito titular
  *                               + crédito co-titular + pagaré autorizado (CD).
- *   Saldo Cliente             = Valor de Escrituración − Monto Disponible.
- *                               (≤ 0 ⇒ operación cubierta — saldo cero vs
- *                                Valor de Escrituración, confirmado por Beto.)
+ *   Saldo Cobranza            = Valor de Escrituración − Monto Disponible
+ *                               (cobertura cruda: solo efectivo + crédito).
+ *   Saldo Cliente (efectivo)  = Saldo Cobranza − Descuento Otorgado
+ *                               + Cheque Notaría girado.
+ *                               El descuento AUTORIZADO cubre el faltante de
+ *                               cobranza; el cheque a notaría es un giro que se
+ *                               fondea de ese mismo descuento (o del excedente
+ *                               de cobranza). Equivale a: Cheque girado −
+ *                               (Disponible − Escrituración + Descuento) =
+ *                               Cheque girado − Excedente Disponible.
+ *                               ≤ TOLERANCIA_SALDO ⇒ operación cubierta.
+ *                               (Decisión Beto 2026-06-15: el descuento y el
+ *                               cheque entran al saldo; antes el saldo era ciego
+ *                               al descuento y un descuento perdonado se veía
+ *                               como deuda. El cheque usa el CAPTURADO, no el
+ *                               calculado: mide un giro real, no uno sugerido.)
  *   Cheque Notaría (cálculo)  = min(Gastos Escrituración − Apoyo Infonavit,
  *                                Monto Disponible − Valor Escrituración
  *                                + Descuento Otorgado Total).
@@ -87,8 +100,17 @@ export type Cuadratura = {
   creditoInstitucion: number;
   montoCreditoDirecto: number;
   montoDisponible: number;
+  /** Saldo de cobranza cruda: Valor Escrituración − Monto Disponible (ciego al
+   *  descuento). Se conserva para auditoría — cuánto faltó de puro efectivo. */
+  saldoCobranza: number;
+  /** Saldo efectivo: cobranza − descuento otorgado + cheque a notaría girado. */
   saldoCliente: number;
-  /** true si el Monto Disponible cubre el Valor de Escrituración. */
+  /** Suma de los 4 buckets de descuento otorgado (eco del input, para la UI). */
+  descuentoOtorgado: number;
+  /** Cheque a notaría CAPTURADO (0 si aún no se gira). Distinto del calculado. */
+  chequePagado: number;
+  /** true si el descuento autorizado + el disponible cubren la escrituración
+   *  (saldo efectivo ≤ TOLERANCIA_SALDO). */
   cubierta: boolean;
   /** Cheque a notaría sugerido por la fórmula (vs el capturado). */
   chequeNotariaCalculado: number;
@@ -122,6 +144,15 @@ export type Cuadratura = {
  */
 const UMBRAL_DOBLE_CONTEO = 0.05;
 
+/**
+ * Tolerancia (pesos) del saldo efectivo para marcar "cubierta". Absorbe el
+ * redondeo de captura: el cheque a notaría se captura en pesos enteros mientras
+ * gastos y crédito traen centavos, así que una operación perfectamente saldada
+ * puede dar un residual de unos pocos pesos. Arriba de esto es un faltante real
+ * (o un cheque girado por encima del descuento autorizado) que hay que revisar.
+ */
+const TOLERANCIA_SALDO = 5;
+
 /** ¿El proyecto cae en la tasa alta de comisión (Loma Verde / Loma Verde 2)? */
 function esLomaVerde(proyecto: string | null | undefined): boolean {
   return /loma\s*verde/i.test(proyecto ?? '');
@@ -141,13 +172,22 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     .reduce((s, d) => s + n(d.monto), 0);
 
   const montoDisponible = depositosDirectoCliente + creditoInstitucion + montoCreditoDirecto;
-  const saldoCliente = round2(valorEscrituracion - montoDisponible);
-  const cubierta = saldoCliente <= 0.0049;
+  const saldoCobranza = round2(valorEscrituracion - montoDisponible);
 
   const descuentoOtorgadoTotal = n(i.descuentoOtorgadoTotal);
   const gastosNetos = n(i.gastosEscrituracion) - n(i.apoyoInfonavit);
   const excedenteDisponible = montoDisponible - valorEscrituracion + descuentoOtorgadoTotal;
   const chequeNotariaCalculado = round2(Math.min(gastosNetos, excedenteDisponible));
+
+  // Cheque a notaría GIRADO (capturado en Fase 11; 0 si aún no se gira). El
+  // saldo efectivo usa este, no el calculado: mide un giro real contra el
+  // descuento, no una sugerencia.
+  const chequePagado = round2(n(i.montoChequeNotaria));
+  // Saldo efectivo: el descuento autorizado cubre el faltante de cobranza y el
+  // cheque girado se fondea de ese descuento (o del excedente). Equivale a
+  // `chequePagado − excedenteDisponible`.
+  const saldoCliente = round2(saldoCobranza - descuentoOtorgadoTotal + chequePagado);
+  const cubierta = saldoCliente <= TOLERANCIA_SALDO;
 
   // El crédito directo (pagaré) queda fuera: sus pagos sí son del cliente.
   const posibleDobleConteo =
@@ -185,7 +225,10 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     creditoInstitucion: round2(creditoInstitucion),
     montoCreditoDirecto: round2(montoCreditoDirecto),
     montoDisponible: round2(montoDisponible),
+    saldoCobranza,
     saldoCliente,
+    descuentoOtorgado: round2(descuentoOtorgadoTotal),
+    chequePagado,
     cubierta,
     chequeNotariaCalculado,
     chequeNotariaUsado,

--- a/lib/dilesa/use-venta-resumen.ts
+++ b/lib/dilesa/use-venta-resumen.ts
@@ -65,6 +65,7 @@ type VentaRow = {
   descuento_equipamiento: number | null;
   descuento_gastos_escrituracion: number | null;
   descuento_nota_credito: number | null;
+  promocion_id: string | null;
   fecha_firma_programada: string | null;
   /** INE capturado en el KYC de la venta (fallback si la persona no lo trae). */
   ine_numero: string | null;
@@ -87,7 +88,7 @@ export function useVentaResumen(ventaId: string | null): VentaResumenState {
         .schema('dilesa')
         .from('ventas')
         .select(
-          'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, vendedor, notario, notario_id, fase_actual, fase_posicion, tipo_credito, precio_asignacion, valor_escrituracion, valor_facturado, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito, fecha_firma_programada, ine_numero'
+          'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, vendedor, notario, notario_id, fase_actual, fase_posicion, tipo_credito, precio_asignacion, valor_escrituracion, valor_facturado, monto_credito_titular, monto_credito_cotitular, monto_credito_directo, monto_cheque_notaria, gastos_escrituracion, descuento_precio, descuento_equipamiento, descuento_gastos_escrituracion, descuento_nota_credito, promocion_id, fecha_firma_programada, ine_numero'
         )
         .eq('id', ventaId)
         .is('deleted_at', null)
@@ -111,7 +112,7 @@ export function useVentaResumen(ventaId: string | null): VentaResumenState {
         return;
       }
 
-      const [pRes, uRes, abonosRes, tcRes, vendRes, notRes] = await Promise.all([
+      const [pRes, uRes, abonosRes, tcRes, vendRes, notRes, promoRes] = await Promise.all([
         sb
           .schema('erp')
           .from('personas')
@@ -157,6 +158,15 @@ export function useVentaResumen(ventaId: string | null): VentaResumenState {
           : Promise.resolve({ data: null, error: null }),
         // Notaría desde el catálogo de proveedores (categoria='notaria').
         venta.notario_id ? getNotaria(sb, venta.notario_id) : Promise.resolve(null),
+        // Promoción de la solicitud → tope CONFIABLE de descuento autorizado.
+        venta.promocion_id
+          ? sb
+              .schema('dilesa')
+              .from('promociones')
+              .select('monto')
+              .eq('id', venta.promocion_id)
+              .maybeSingle()
+          : Promise.resolve({ data: null }),
       ]);
       if (!activo) return;
 
@@ -253,6 +263,9 @@ export function useVentaResumen(ventaId: string | null): VentaResumenState {
           (Number(venta.descuento_equipamiento) || 0) +
           (Number(venta.descuento_gastos_escrituracion) || 0) +
           (Number(venta.descuento_nota_credito) || 0),
+        // Tope confiable solo desde la promo (el máximo legacy no es de fiar).
+        descuentoMaximoAutorizado:
+          (promoRes.data as { monto: number | null } | null)?.monto ?? null,
         precioAsignacion: venta.precio_asignacion,
         valorFacturadoReal: hayFactura ? venta.valor_facturado : null,
         depositos: abonos.map((a) => ({


### PR DESCRIPTION
## Problema

El saldo de la cuadratura DILESA era **ciego al descuento autorizado**: `saldoCliente = Valor Escrituración − Monto Disponible` (solo efectivo + crédito). Dos consecuencias:

1. Un descuento ya otorgado pero "perdonado" (la parte no cobrada) se mostraba como **saldo pendiente**, como si el cliente debiera dinero.
2. Los 4 buckets de descuento eran **inertes** — solo movían el cheque a notaría *sugerido* (ignorado si el cheque ya está capturado), así que editarlos no movía nada visible.

**Caso de referencia** — JOSUE DANIEL CRUZ VALVERDE: saldo "pendiente" de $1,622 que en realidad era descuento ($13,378 girados a notaría + $1,622 perdonados = $15,000 autorizados). Operación saldada; el panel decía lo contrario.

## Cambio

```
descuentoAplicado = min(Descuento Otorgado, Máximo Autorizado confiable)
Saldo efectivo    = Cobranza cruda − descuentoAplicado + Cheque a notaría girado
                  ( = Cheque girado − Excedente Disponible )
cubierta = saldo efectivo ≤ TOLERANCIA_SALDO ($5, absorbe redondeo de captura)
```

- El **descuento autorizado** cubre el faltante de cobranza; el **cheque a notaría** es un giro que se fondea de ese descuento (o del excedente).
- Usa el cheque **capturado** (0 si aún no se gira), no el calculado: mide un giro real.
- Se conserva `saldoCobranza` (cobranza cruda) + se exponen `descuentoOtorgado`/`descuentoAplicado`/`chequePagado`. El panel muestra la aritmética.

## Controles (pedido de Beto)

1. **Tope a lo autorizado desde el inicio:** el descuento que entra al saldo se topa al máximo. El tope se aplica SOLO contra el monto de la **promoción de la solicitud** (dato confiable). El **máximo legacy de Coda NO topa** — 159/315 ventas con descuento lo exceden por avg $143k (mal dato/semántica, no sobre-descuento real); topar ahí inventaría pendientes falsos. El exceso sobre el tope no reduce el saldo.
2. **Buckets de descuento editables solo por Dirección** (admin global O rol Dirección en la empresa), antes era admin/escritura-F13.

## Verificación (prod, 1,186 ventas)

- **248** ventas pasan de «pendiente»→«cubierta» correctamente (incluye el caso Beto → saldo ≈ $0).
- **~17** ventas cerradas surfacean como **anomalía real**: cheque a notaría girado sin descuento documentado o por encima del autorizado (antes ocultas).
- Tests con números exactos de prod: caso Beto, cheque-excede-descuento, tope al autorizado, sin-tope-legacy, tolerancia. `cuadratura.ts` 100% cobertura.

## Archivos

- `lib/dilesa/cuadratura.ts` — saldo efectivo + tope + campos nuevos + tolerancia.
- `lib/dilesa/cuadratura.test.ts` — 6 casos nuevos.
- `components/dilesa/cuadratura-panel.tsx` — aritmética visible.
- `app/dilesa/ventas/[id]/page.tsx` — tope (promo) + buckets solo Dirección.
- `lib/dilesa/use-venta-resumen.ts`, `lib/dilesa/cuadratura-server.ts` — cablean el tope.
- `lib/dilesa/copiloto-cierre.ts` — comentarios (gate F17 usa saldo efectivo).

Sin migración de datos. UI financiera visible → **no auto-merge**, para revisión de Beto + Vercel preview.

## Seguimiento (no en este PR)
- Reconciliar el `descuento_maximo_autorizado` legacy (159 ventas) para que el tope pueda aplicar también ahí.
- Punch-list de las ~17 ventas con cheque a notaría sin descuento documentado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)