### PR TITLE
fix(dilesa): el check PLD de Fase 13 descuenta el perdonado (no más falso saldo)

### DIFF
--- a/app/api/dilesa/ventas/[ventaId]/revision-pld/route.ts
+++ b/app/api/dilesa/ventas/[ventaId]/revision-pld/route.ts
@@ -302,7 +302,7 @@ export async function POST(_req: NextRequest, { params }: Params) {
     fecha_escritura: string | null;
   };
 
-  const [{ data: empresa }, { data: persona }, { data: unidad }, notaria, { data: abonos }] =
+  const [{ data: empresa }, { data: persona }, { data: unidad }, notaria, { data: abonos }, cuad] =
     await Promise.all([
       admin.schema('core').from('empresas').select('rfc').eq('id', DILESA_EMPRESA_ID).maybeSingle(),
       admin
@@ -327,6 +327,9 @@ export async function POST(_req: NextRequest, { params }: Params) {
         .eq('origen_tipo', 'venta_dilesa')
         .eq('origen_id', ventaId)
         .is('deleted_at', null),
+      // Cuadratura: alimenta el descuento perdonado del check liq_vs_pactado y
+      // el monto de la NC de los checks de facturación (se reusa abajo).
+      cargarCuadraturaVenta(admin, ventaId),
     ]);
 
   const empresaRfc = String((empresa as { rfc: string | null } | null)?.rfc ?? '');
@@ -352,6 +355,9 @@ export async function POST(_req: NextRequest, { params }: Params) {
     depositos: ((abonos ?? []) as { monto_total: number | null }[]).map((a) =>
       Number(a.monto_total ?? 0)
     ),
+    // Descuento perdonado (no cobrado): el hueco legítimo entre liquidaciones y
+    // valor pactado. El cheque a notaría girado NO perdona (entró y salió).
+    descuentoPerdonado: Math.max(0, (cuad?.descuentoAplicado ?? 0) - (cuad?.chequePagado ?? 0)),
   };
 
   // ── PDFs del ciclo ───────────────────────────────────────────────
@@ -447,7 +453,7 @@ export async function POST(_req: NextRequest, { params }: Params) {
     //    sin IA). El monto se calcula server-side (control fiscal — no se
     //    confía en un snapshot del cliente). Cuando la operación factura más
     //    de lo que DILESA realmente recibe, exige el XML y PDF de la NC.
-    const cuad = await cargarCuadraturaVenta(admin, ventaId);
+    //    (`cuad` se cargó arriba, junto con el expediente.)
     const { data: factDocs } = await admin
       .schema('erp')
       .from('adjuntos')

--- a/lib/dilesa/captura/pld-revision.test.ts
+++ b/lib/dilesa/captura/pld-revision.test.ts
@@ -12,8 +12,10 @@ import {
 /**
  * Fixture basado en un Informe de Avisos SPPLD real (anonimizable): venta
  * de casa en Nava por $899,000, escritura 188 ante notario 25, avalúo
- * $1,021,000, liquidada en dos transferencias que suman $897,378 (la
- * diferencia de $1,622 vs el pactado es un caso real — warning, no error).
+ * $1,021,000, liquidada en dos transferencias que suman $897,378. La
+ * diferencia de $1,622 vs el pactado es el descuento PERDONADO (no cobrado):
+ * descuento aplicado $15,000 − cheque a notaría $13,378. Con eso el aviso
+ * cuadra (caso real de Beto).
  */
 function extraccion(partial: Partial<ExtraccionPld> = {}): ExtraccionPld {
   return {
@@ -64,6 +66,9 @@ function expediente(partial: Partial<ExpedientePld> = {}): ExpedientePld {
     unidadM2Terreno: 105,
     unidadM2Construccion: 56.58,
     depositos: [261049.55, 636328.45],
+    // Descuento $15,000 (gastos escrituración), $13,378 girados a notaría →
+    // $1,622 perdonados = el hueco exacto entre liquidaciones y pactado.
+    descuentoPerdonado: 1622,
     ...partial,
   };
 }
@@ -102,15 +107,20 @@ describe('cruzarPldConExpediente — caso real cuadrado', () => {
     }
   });
 
-  it('la diferencia liquidaciones vs pactado ($1,622) queda como warning visible', () => {
-    const c = porClave(checks, 'liq_vs_pactado');
+  it('liq_vs_pactado pasa: el descuento perdonado ($1,622) explica el hueco', () => {
+    expect(porClave(checks, 'liq_vs_pactado')?.ok).toBe(true);
+  });
+
+  it('un hueco SIN descuento que lo explique sí queda como warning', () => {
+    const sinDesc = cruzarPldConExpediente(extraccion(), expediente({ descuentoPerdonado: 0 }));
+    const c = porClave(sinDesc, 'liq_vs_pactado');
     expect(c?.ok).toBe(false);
     expect(c?.severidad).toBe('warning');
     expect(c?.detalle).toContain('897,378');
   });
 
-  it('veredicto: advertencias (ningún error, un warning)', () => {
-    expect(veredictoDe(checks)).toBe('advertencias');
+  it('veredicto: verde (el caso real cuadra con el descuento)', () => {
+    expect(veredictoDe(checks)).toBe('verde');
   });
 });
 
@@ -181,7 +191,7 @@ describe('veredictoDe', () => {
   it('verde cuando todo pasa', () => {
     const checks = cruzarPldConExpediente(
       extraccion({ valorPactado: 897378 }),
-      expediente({ valorEscrituracion: 897378 })
+      expediente({ valorEscrituracion: 897378, descuentoPerdonado: 0 })
     );
     expect(veredictoDe(checks)).toBe('verde');
   });
@@ -386,8 +396,8 @@ describe('separarChecks (flujo en dos pasos)', () => {
     expect(informe).toHaveLength(informeChecks.length);
     expect(soloAcuse).toHaveLength(acuseChecks.length);
     expect(soloAcuse.every((c) => c.clave.startsWith('acuse_'))).toBe(true);
-    // El informe puede estar en advertencias mientras el acuse está en rojo.
-    expect(veredictoDe(informe)).toBe('advertencias');
+    // El informe puede estar en verde mientras el acuse está en rojo.
+    expect(veredictoDe(informe)).toBe('verde');
     expect(veredictoDe(soloAcuse)).toBe('rojo');
   });
 

--- a/lib/dilesa/captura/pld-revision.ts
+++ b/lib/dilesa/captura/pld-revision.ts
@@ -102,6 +102,15 @@ export type ExpedientePld = {
   unidadM2Construccion: number | null;
   /** Montos de los depósitos registrados (erp.cxc_pagos de la venta). */
   depositos: number[];
+  /**
+   * Descuento "perdonado" (no cobrado) = descuento aplicado − cheque a notaría
+   * girado, ≥ 0 (del motor de cuadratura). Las liquidaciones del aviso quedan
+   * por debajo del valor pactado EXACTAMENTE en este monto — es el descuento
+   * que no entró como pago (el cheque a notaría sí entró y luego salió). Sin
+   * esto, una operación con descuento marca un falso descuadre por el monto del
+   * descuento perdonado. 0 cuando no hay descuento.
+   */
+  descuentoPerdonado: number;
 };
 
 // ── Normalización ───────────────────────────────────────────────────────
@@ -332,16 +341,23 @@ export function cruzarPldConExpediente(ext: ExtraccionPld, exp: ExpedientePld): 
         )
   );
 
-  // 8. Liquidaciones vs valor pactado y vs depósitos registrados (warnings).
+  // 8. Liquidaciones vs valor pactado (neto de descuento) y vs depósitos
+  //    registrados (warnings). El valor pactado es el de escrituración; las
+  //    liquidaciones (lo realmente pagado) quedan por debajo en el descuento
+  //    PERDONADO (no cobrado) — ese hueco es legítimo, no un descuadre.
   const totalLiquidaciones = ext.liquidaciones.reduce((s, l) => s + (l.monto || 0), 0);
+  const perdonado = Math.max(0, exp.descuentoPerdonado);
+  const liquidacionesEsperadas = ext.valorPactado - perdonado;
   checks.push(
-    montosIguales(totalLiquidaciones, ext.valorPactado, 1)
-      ? ok('liq_vs_pactado', 'Σ liquidaciones = valor pactado', 'warning')
+    montosIguales(totalLiquidaciones, liquidacionesEsperadas, 1)
+      ? ok('liq_vs_pactado', 'Σ liquidaciones = valor pactado − descuento', 'warning')
       : falla(
           'liq_vs_pactado',
-          'Σ liquidaciones = valor pactado',
+          'Σ liquidaciones = valor pactado − descuento',
           'warning',
-          `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el valor pactado es ${money(ext.valorPactado)} (diferencia ${money(totalLiquidaciones - ext.valorPactado)}).`
+          perdonado > 0
+            ? `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; con el descuento perdonado de ${money(perdonado)} se esperaban ${money(liquidacionesEsperadas)} (valor pactado ${money(ext.valorPactado)}). Diferencia ${money(totalLiquidaciones - liquidacionesEsperadas)}.`
+            : `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el valor pactado es ${money(ext.valorPactado)} (diferencia ${money(totalLiquidaciones - ext.valorPactado)}).`
         )
   );
   const totalDepositos = exp.depositos.reduce((s, m) => s + (m || 0), 0);


### PR DESCRIPTION
## Problema (reportado por Beto)

La revisión IA de la Fase 13 seguía mostrando el "saldo pendiente" ($1,622 en el caso JOSUE DANIEL CRUZ VALVERDE) en el check **"Σ liquidaciones = valor pactado"**, aunque la cuadratura y el resumen ya lo muestran saldado tras [#890](https://github.com/beto-sudo/BSOP/pull/890).

**Causa:** ese check comparaba las liquidaciones del aviso PLD ($897,378) contra el valor pactado ($899,000) **sin restar el descuento**. El hueco de $1,622 es justo el descuento *perdonado* (no cobrado).

## Fix

El check ahora compara contra **`valor pactado − descuento perdonado`**, donde:
```
descuento perdonado = descuento aplicado − cheque a notaría girado   (≥ 0)
```
El cheque a notaría entró como pago y luego salió (no perdona); solo lo **no cobrado** perdona. En el caso real: `899,000 − (15,000 − 13,378) = 897,378` = las liquidaciones → **cuadra (verde)**.

- `ExpedientePld.descuentoPerdonado` nuevo, lo alimenta el route desde el motor de cuadratura (`descuentoAplicado − chequePagado`).
- El route carga la cuadratura una sola vez (se reusa en los checks de facturación).
- Si NO hay descuento que explique el hueco, sigue siendo **warning** (descuadre real preservado).

## Verificación

- El fixture del test ES el caso real de Beto → ahora **veredicto verde** (antes era "advertencias" por este check).
- Test nuevo: hueco sin descuento → sigue siendo warning. 30 tests de PLD verdes, 1,828 en total.

## Importante — el otro check rojo es legítimo

El check **"XML de nota de crédito capturado"** (rojo) es **independiente y correcto**: la operación facturó $899,000 pero DILESA recibió $884,000 → requiere **nota de crédito por $15,000**. El PDF de la NC ya está; falta subir el **XML** en Documentos y re-ejecutar. Eso NO es un bug — es un requisito fiscal real, no se toca aquí.

## Para ver el efecto

Tras el deploy, **re-ejecutar la revisión PLD** en la Fase 13 (el resultado se recalcula al correr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)