### PR TITLE
fix(dilesa): Valor Facturado = escrituración + enganche (2 CFDIs) → NC correcta

### DIFF
--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -40,10 +40,12 @@ describe('calcularCuadratura', () => {
     expect(c.comisionVendedor).toBe(8990); // 899,000 × 1.0% (no Loma Verde)
   });
 
-  // Con factura emitida (decisión Beto 2026-06-13): el Valor Facturado es el
-  // del CFDI real y la NC se deriva de él (facturado real − valor real), no del
-  // estimado de la fórmula. El estimado queda expuesto como *Sugerido.
-  it('toma el Valor Facturado del CFDI cuando se pasa y deriva la NC de él', () => {
+  // Modelo confirmado por Beto 2026-06-15: el enganche se factura con su propio
+  // recibo-CFDI y la operación se factura por la escrituración → el Valor
+  // Facturado SUMA ambos. La factura de escrituración usa el total del CFDI real
+  // cuando difiere del valor de escrituración; el estimado (con el valor de
+  // escrituración) queda como *Sugerido.
+  it('suma la factura de escrituración (CFDI) + el recibo-CFDI del enganche', () => {
     const c = calcularCuadratura({
       valorEscrituracion: 899000,
       montoCreditoTitular: 636328.45,
@@ -51,18 +53,39 @@ describe('calcularCuadratura', () => {
       montoCreditoDirecto: 0,
       montoChequeNotaria: 13378,
       gastosEscrituracion: null,
-      valorFacturadoReal: 1150000, // total del CFDI de factura (≠ estimado)
+      valorFacturadoReal: 900000, // CFDI de escrituración (≠ valor escritura, para probar que se usa)
+      depositos: [
+        { monto: 261049.55, directoCliente: true, tieneRecibo: true }, // enganche con recibo-CFDI
+        { monto: 636328.45, directoCliente: false, tieneRecibo: false }, // crédito: no factura
+      ],
+      proyectoNombre: 'Lomas del Sol',
+    });
+    expect(c.valorFacturado).toBe(1161049.55); // 900,000 (CFDI) + 261,049.55 (enganche)
+    expect(c.valorFacturadoSugerido).toBe(1160049.55); // 899,000 (escritura) + 261,049.55
+    expect(c.valorRealVentaDilesa).toBe(884000); // 897,378 − 13,378
+    expect(c.montoNotaCredito).toBe(277049.55); // 1,161,049.55 − 884,000
+    expect(c.montoNotaCreditoSugerido).toBe(276049.55); // 1,160,049.55 − 884,000
+  });
+
+  // Caso real Beto (Josue): el CFDI de escrituración coincide con la escritura,
+  // así que el facturado = escrituración + enganche = 1,160,049.55 y la NC =
+  // 276,049.55 (= enganche 261,049.55 + descuento 15,000).
+  it('caso Josue: NC = enganche + descuento cuando el CFDI coincide con la escritura', () => {
+    const c = calcularCuadratura({
+      valorEscrituracion: 899000,
+      montoCreditoTitular: 636328.45,
+      montoCreditoCotitular: 0,
+      montoCreditoDirecto: 0,
+      montoChequeNotaria: 13378,
+      gastosEscrituracion: null,
+      valorFacturadoReal: 899000, // el CFDI coincide con la escritura
       depositos: [
         { monto: 261049.55, directoCliente: true, tieneRecibo: true },
         { monto: 636328.45, directoCliente: false, tieneRecibo: false },
       ],
-      proyectoNombre: 'Lomas del Sol',
     });
-    expect(c.valorFacturado).toBe(1150000); // del CFDI, no el estimado
-    expect(c.valorFacturadoSugerido).toBe(1160049.55); // estimado de la fórmula
-    expect(c.valorRealVentaDilesa).toBe(884000); // 897,378 − 13,378
-    expect(c.montoNotaCredito).toBe(266000); // 1,150,000 − 884,000 (facturado REAL)
-    expect(c.montoNotaCreditoSugerido).toBe(276049.55); // 1,160,049.55 − 884,000
+    expect(c.valorFacturado).toBe(1160049.55);
+    expect(c.montoNotaCredito).toBe(276049.55); // 261,049.55 enganche + 15,000 descuento
   });
 
   // Sin `valorFacturadoReal`, el efectivo == el sugerido (estimado de la fórmula).

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -30,12 +30,17 @@
  *                                Monto Disponible − Valor Escrituración
  *                                + Descuento Otorgado Total).
  *   Valor Real Venta Dilesa   = Depósitos Recibidos − Cheque Notaría + Pagaré.
- *   Valor Facturado           = el del CFDI de factura cuando ya hay factura
- *                               (`valorFacturadoReal`); si no, el ESTIMADO de
- *                               respaldo = Valor Escrituración + Σ depósitos
- *                               del cliente (con recibo). El estimado se
- *                               expone como `valorFacturadoSugerido`.
+ *   Valor Facturado           = SUMA de los CFDIs timbrados: la factura de la
+ *                               escrituración (el CFDI real `valorFacturadoReal`
+ *                               si existe, si no el Valor Escrituración) + Σ
+ *                               depósitos del cliente con recibo (cada enganche
+ *                               se factura con su propio recibo-CFDI). El
+ *                               estimado de respaldo (con el valor de
+ *                               escrituración) se expone como
+ *                               `valorFacturadoSugerido`.
  *   Monto Nota de Crédito     = Valor Facturado − Valor Real Venta Dilesa.
+ *                               (acredita de vuelta el enganche facturado dos
+ *                               veces + el descuento.)
  *                               Es un DERIVADO, no el total del CFDI de NC: con
  *                               factura real usa el facturado real; la Fase 13
  *                               valida aparte que el CFDI de NC coincida.
@@ -89,13 +94,15 @@ export type CuadraturaInput = {
   /** Para referencia (no entra al saldo). */
   precioAsignacion?: number | null;
   /**
-   * Valor Facturado AUTORITATIVO del CFDI de factura (Fase 13,
-   * `dilesa.ventas.valor_facturado`). Cuando se pasa, el motor lo usa como
-   * `valorFacturado` y deriva de él el `montoNotaCredito` (NC = facturado real
-   * − valor real venta DILESA). null/undefined ⇒ aún no hay factura: el motor
-   * cae al estimado de la fórmula de Coda. Solo pasarlo cuando exista el
-   * adjunto `factura_xml` (un snapshot de Coda en `valor_facturado` = valor de
-   * escrituración NO es una factura real).
+   * Total del CFDI de la factura de ESCRITURACIÓN (Fase 13,
+   * `dilesa.ventas.valor_facturado`) — la factura de la operación que coincide
+   * con la escritura. El motor lo usa como el componente "factura de
+   * escrituración" del Valor Facturado y le SUMA los recibos-CFDI del enganche
+   * (depósitos del cliente con recibo). null/undefined ⇒ aún no hay factura: usa
+   * el valor de escrituración. Solo pasarlo cuando exista el adjunto
+   * `factura_xml` (un snapshot de Coda en `valor_facturado` = escrituración no
+   * es una factura real, pero como coincide con la escritura el resultado es el
+   * mismo).
    */
   valorFacturadoReal?: number | null;
   depositos: DepositoCuadratura[];
@@ -225,11 +232,21 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   const valorRealVentaDilesa = round2(
     depositosRecibidos - chequeNotariaUsado + montoCreditoDirecto
   );
-  // Estimado de la fórmula (respaldo pre-factura). Cuando ya hay CFDI de
-  // factura, el valor REAL del XML manda y la NC se deriva de él.
+  // Valor Facturado = SUMA de los CFDIs timbrados de la operación: la factura de
+  // la escrituración + los recibos de caja con CFDI del enganche (cada depósito
+  // del cliente con recibo se factura aparte). La factura de escrituración toma
+  // el total del CFDI real cuando existe (`valorFacturadoReal`), si no el valor
+  // de escrituración. El enganche se factura primero (su recibo-CFDI) y la
+  // factura de la operación coincide con la escritura; la NC acredita de vuelta
+  // el enganche + el descuento para que el neto cuadre con el Valor Real.
+  // (Modelo confirmado por Beto 2026-06-15. Antes se usaba SOLO el CFDI de la
+  // escrituración y se dejaba fuera el enganche → NC subvaluada.)
+  const facturaEscrituracion =
+    i.valorFacturadoReal != null ? round2(n(i.valorFacturadoReal)) : valorEscrituracion;
+  const valorFacturado = round2(facturaEscrituracion + depositosConRecibo);
+  // Estimado de respaldo: mismo cálculo con el valor de escrituración en vez del
+  // CFDI real. Igual al efectivo salvo que el CFDI de escrituración difiera.
   const valorFacturadoSugerido = round2(valorEscrituracion + depositosConRecibo);
-  const valorFacturado =
-    i.valorFacturadoReal != null ? round2(n(i.valorFacturadoReal)) : valorFacturadoSugerido;
   const montoNotaCredito = round2(valorFacturado - valorRealVentaDilesa);
   const montoNotaCreditoSugerido = round2(valorFacturadoSugerido - valorRealVentaDilesa);
   const descuentoReal = round2(valorEscrituracion - valorRealVentaDilesa);


### PR DESCRIPTION
## Problema (reportado por Beto)

La Nota de Crédito requerida en la revisión PLD de la Fase 13 se mostraba en **$15,000** (bloqueando el cierre con un monto equivocado), cuando la verdad de Beto es **$276,049.55**.

**Causa:** el motor usaba **solo el CFDI de la escrituración** ($899,000) como Valor Facturado e **ignoraba el recibo-CFDI del enganche** ($261,049.55). Eso dejaba la NC en $15,000 (solo el descuento) en vez de $276,049.55.

## Modelo real (confirmado por Beto)

Cuando el cliente da enganche se expide un **recibo de caja CON CFDI**; después se factura la operación completa (coincide con la escritura). Son **2 CFDIs** y suman el facturado:

```
Valor Facturado = factura escrituración (CFDI real, o valor escritura)
                + Σ depósitos del cliente con recibo  (recibo-CFDI del enganche)
Nota de Crédito = Valor Facturado − Valor Real Venta DILESA
```

**Josue:** `899,000 + 261,049.55 = 1,160,049.55` facturado; **NC = 276,049.55** (= 261,049.55 enganche + 15,000 descuento). Cuadra con la hoja de Beto.

## Qué pasó

Esto revierte el efecto de la decisión del **2026-06-13** ("usar solo el CFDI cuando hay factura"), que dejaba fuera el enganche. La fórmula de respaldo del motor (`valorFacturadoSugerido`) ya calculaba el total correcto — ahora el valor efectivo también, usando el CFDI real para el componente de escrituración cuando difiere del valor de escritura. (No es de los cambios de saldo/PLD de esta semana; aquellos no tocaban el facturado.)

## Impacto prod (verificado)

Solo **4 ventas** tienen `factura_xml` y **solo 1 (Josue)** tiene enganche con recibo → solo su NC cambia (15,000 → 276,049.55, lo correcto). Las otras 3 no se mueven.

## Verificación

- Tests con números exactos: caso Josue (NC 276,049.55) + caso CFDI ≠ escritura (usa el CFDI para el componente de escrituración). 18 tests de cuadratura verdes, 1,829 en total, `cuadratura.ts` 100%.

## Para ver el efecto
Tras deploy, **re-ejecutar la revisión PLD** en Fase 13: la NC requerida será $276,049.55. Al subir el XML de la NC (por ese monto) el check pasa a verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)