### PR TITLE
fix(dilesa-ventas): deriva enganche/ISAI/gastos del total en la solicitud (históricas mostraban $0)

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -862,7 +862,15 @@ export async function GET(
     isai2pct: Number(c?.isai_2pct ?? 0),
     gastosNotariales6pct: Number(c?.gastos_notariales_6pct ?? 0),
     tipoCredito: venta.tipo_credito ?? '',
-    pagoDirecto: Number(c?.pago_directo ?? 0) + Number(c?.apoyo_infonavit ?? 0),
+    // Nuevas: pago_directo del snapshot + apoyo (= precio − créditos).
+    // Históricas (sin pago_directo congelado): derivar precio − créditos para
+    // no mostrar $0. Ambas rutas dan el mismo número.
+    pagoDirecto:
+      typeof c?.pago_directo === 'number'
+        ? Number(c.pago_directo) + Number(c.apoyo_infonavit ?? 0)
+        : Number(c?.precio_venta_total ?? venta.precio_asignacion ?? 0) -
+          Number(venta.monto_credito_titular ?? 0) -
+          Number(venta.monto_credito_cotitular ?? 0),
     montoCreditoTitular: Number(venta.monto_credito_titular ?? 0),
     montoCreditoCotitular: Number(venta.monto_credito_cotitular ?? 0),
     totalPagosDisponibles: Number(c?.precio_venta_total ?? venta.precio_asignacion ?? 0),

--- a/lib/dilesa/desglose-precio.test.ts
+++ b/lib/dilesa/desglose-precio.test.ts
@@ -71,6 +71,24 @@ describe('leerDesglose', () => {
     expect(snap?.origen).toBe('backfill_contrato');
     expect(snap?.precio_venta_total).toBe(1021000);
     expect(snap?.costo_credito_adicional).toBeUndefined();
+    // Enganche/ISAI/gastos se derivan del total (no estaban en el backfill) —
+    // si no, la solicitud/PDF los mostraba en $0.
+    expect(snap?.enganche_1pct).toBe(10210);
+    expect(snap?.isai_2pct).toBe(20420);
+    expect(snap?.gastos_notariales_6pct).toBe(61260);
+  });
+
+  it('preserva enganche/ISAI/gastos guardados (no re-deriva en ventas nuevas)', () => {
+    const snap = leerDesglose({
+      precio_venta_total: 1000000,
+      enganche_1pct: 5,
+      isai_2pct: 7,
+      gastos_notariales_6pct: 9,
+      componentes_detallados: true,
+    });
+    expect(snap?.enganche_1pct).toBe(5);
+    expect(snap?.isai_2pct).toBe(7);
+    expect(snap?.gastos_notariales_6pct).toBe(9);
   });
 
   it('round-trip: congelar y luego leer preserva el total y marca detallado', () => {

--- a/lib/dilesa/desglose-precio.ts
+++ b/lib/dilesa/desglose-precio.ts
@@ -71,9 +71,20 @@ export function leerDesglose(json: unknown): DesglosePrecioSnapshot | null {
   if (!json || typeof json !== 'object' || Array.isArray(json)) return null;
   const obj = json as Record<string, unknown>;
   if (typeof obj.precio_venta_total !== 'number') return null;
+  const total = obj.precio_venta_total;
+  const num = (k: string, factor: number): number =>
+    typeof obj[k] === 'number' ? (obj[k] as number) : total * factor;
   return {
     ...obj,
-    precio_venta_total: obj.precio_venta_total,
+    precio_venta_total: total,
+    // Enganche 1% / ISAI 2% / gastos notariales 6% son % FIJOS del total
+    // congelado — derivaciones puras, no dependen de reglas (ZCU/+6%). Se
+    // computan del total cuando faltan para que las históricas (backfill sin
+    // componentes) no muestren $0 en la solicitud/PDF. En ventas nuevas el
+    // valor guardado ya es total×%, así que el resultado es idéntico.
+    enganche_1pct: num('enganche_1pct', 0.01),
+    isai_2pct: num('isai_2pct', 0.02),
+    gastos_notariales_6pct: num('gastos_notariales_6pct', 0.06),
     componentes_detallados: obj.componentes_detallados === true,
     origen: obj.origen === 'asignacion' ? 'asignacion' : 'backfill_contrato',
   } as DesglosePrecioSnapshot;


### PR DESCRIPTION
## Problema (regresión de #900)

En el PDF de **solicitud-asignación** de una venta **histórica** (backfill), los campos **Enganche 1%**, **ISAI 2%** y **Gastos notariales 6%** salían en **$0**. Ejemplo: M12-L22 con precio de venta $1,043,761 mostraba enganche/ISAI/gastos = $0.

Causa: el snapshot `desglose_precio` de las históricas solo congeló el **total** (`componentes_detallados: false`), y el PDF leía esos tres campos del snapshot → ausentes → 0.

## Fix

Esos tres son **% fijos del total** (1% / 2% / 6%) — derivaciones puras, **independientes** de las reglas (ZCU/+6%). Se computan del total congelado en `leerDesglose` cuando faltan:

- `enganche_1pct = total × 0.01`, `isai_2pct = total × 0.02`, `gastos_notariales_6pct = total × 0.06`.
- `pago_directo` también se deriva (`precio − créditos`) para históricas.
- **Ventas nuevas: sin cambio** — el snapshot ya trae estos valores (= total×%), el resultado es idéntico.

Para M12-L22 ahora: enganche **$10,438**, ISAI **$20,875**, gastos **$62,626**, pago directo **$0** (crédito cubre el total).

## Sin cambios de DB

Solo lógica de derivación. `leerDesglose` + el PDF. 8 tests en `desglose-precio.test.ts` (derivación de históricas + preservación en nuevas). 6 checks de CI verde en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)