### PR TITLE
feat(dilesa-atencion-clientes): pruebas de servicios + acta imprimible siempre

### DIFF
--- a/components/dilesa/recepcion-obra-drawer.tsx
+++ b/components/dilesa/recepcion-obra-drawer.tsx
@@ -445,7 +445,8 @@ export function RecepcionObraDrawer({
               />
             </div>
 
-            {/* Acta firmada: solo cuando el checklist está en verde */}
+            {/* Acta: imprimible en cualquier momento (para llevarla al recorrido o
+                recabar firmas); la recepción solo se cierra con el acta subida + verde. */}
             {!yaRecibida ? (
               <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--bg)]/30 p-3">
                 <div className="flex items-center justify-between">
@@ -456,30 +457,24 @@ export function RecepcionObraDrawer({
                     href={`/dilesa/construccion/${construccionId}/acta-recepcion`}
                     target="_blank"
                     rel="noreferrer"
-                    className={`inline-flex items-center gap-1 text-xs font-medium ${
-                      todoVerde
-                        ? 'text-[var(--accent)] underline'
-                        : 'pointer-events-none text-[var(--text)]/30'
-                    }`}
+                    className="inline-flex items-center gap-1 text-xs font-medium text-[var(--accent)] underline"
                   >
                     <Printer className="h-3.5 w-3.5" /> Imprimir acta
                   </a>
                 </div>
-                {!todoVerde ? (
-                  <p className="text-[11px] text-[var(--text)]/50">
-                    Disponible cuando el checklist esté todo en verde (sin observaciones).
-                  </p>
-                ) : (
-                  <WizardFileSlot
-                    role="acta_recepcion"
-                    label={
-                      actaSubida ? 'Acta firmada adjuntada — reemplazar' : 'Sube el acta firmada'
-                    }
-                    file={actaFile}
-                    onChange={(f) => void subirActa(f)}
-                    accept=".pdf,.jpg,.jpeg,.png,.webp,.heic"
-                  />
-                )}
+                <p className="text-[11px] text-[var(--text)]/50">
+                  Imprime el acta (sale con lo capturado), recábala firmada por Supervisor de Obra,
+                  Contratista y Atención a Clientes, y súbela aquí. Es obligatoria para recibir.
+                </p>
+                <WizardFileSlot
+                  role="acta_recepcion"
+                  label={
+                    actaSubida ? 'Acta firmada adjuntada — reemplazar' : 'Sube el acta firmada'
+                  }
+                  file={actaFile}
+                  onChange={(f) => void subirActa(f)}
+                  accept=".pdf,.jpg,.jpeg,.png,.webp,.heic"
+                />
               </div>
             ) : null}
 

--- a/lib/dilesa/recepcion-checklist.ts
+++ b/lib/dilesa/recepcion-checklist.ts
@@ -134,6 +134,15 @@ export const RECEPCION_CHECKLIST: readonly RecepcionChecklistSeccion[] = [
       { clave: 'pat_hidrosanitarias', etiqueta: 'Pruebas hidrosanitarias a municipal' },
     ],
   },
+  {
+    clave: 'pruebas_servicios',
+    titulo: 'Pruebas de servicios',
+    items: [
+      { clave: 'srv_agua', etiqueta: 'Prueba de agua — presión y sin fugas en toda la red' },
+      { clave: 'srv_luz', etiqueta: 'Prueba de luz — energización, medidor y centro de carga' },
+      { clave: 'srv_gas', etiqueta: 'Prueba de gas — hermeticidad de la instalación y suministro' },
+    ],
+  },
 ] as const;
 
 /** Total de ítems no opcionales (para el contador de avance del recorrido). */


### PR DESCRIPTION
Feedback de Ciori sobre el checklist pre-entrega de recepción.

## Firmas — ya estaban (aclaración)
El **acta imprimible** ya traía las 3 firmas: **Supervisor de Obra, Contratista y Atención a Clientes (EVAP)**. Ciori veía la captura en pantalla (sin firmas). Ajuste: el botón **"Imprimir acta" ahora está disponible en cualquier momento** (antes solo con el checklist en verde), para imprimirla, llevarla al recorrido y recabar firmas.

## Pruebas de agua, luz y gas — agregadas explícitas
Nueva sección **"Pruebas de servicios"** con 3 ítems claros (además de las pruebas ya embebidas por ubicación):
- **Prueba de agua** — presión y sin fugas en toda la red
- **Prueba de luz** — energización, medidor y centro de carga
- **Prueba de gas** — hermeticidad de la instalación y suministro

Aparecen tanto en el checklist (drawer) como en el acta imprimible.

Sin auto-merge — para que Ciori lo valide en el Preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)