### PR TITLE
docs(manual-usuario): refresh del manual DILESA + Atención a Clientes y Promociones

### DIFF
--- a/content/manual/dilesa/atencion_clientes.md
+++ b/content/manual/dilesa/atencion_clientes.md
@@ -1,0 +1,83 @@
+---
+titulo: 'Atención a Clientes'
+modulo: dilesa.atencion_clientes
+version: '1.0.0'
+actualizado: '2026-06-16'
+---
+
+## ¿Qué es y para qué sirve?
+
+Es la **bandeja de trabajo de Atención a Clientes**: una sola pantalla con todo
+lo que tienes pendiente en el tramo final de la operación —recibir la obra al
+contratista, preparar y entregar la vivienda, y cerrar la conformidad del
+cliente—, ordenado por momento.
+
+No se captura nada aquí: la bandeja es una **vista** sobre datos que ya viven en
+otras pantallas. Cada tarjeta es un atajo que te lleva justo a donde se actúa
+(la obra, la fase de la venta o la encuesta), para que no andes buscando.
+
+## Cómo llegar
+
+**Sidebar → DILESA → Inmobiliario → Atención a Clientes.**
+
+## Las cuatro colas
+
+La bandeja agrupa el trabajo en cuatro colas, en el orden en que ocurre. El
+número en cada encabezado es cuántos pendientes tienes; si una cola está vacía
+muestra "Nada pendiente aquí 🎉".
+
+- **Obras por recibir** — construcción terminada, lista para recibir al
+  contratista. La tarjeta te lleva a la **obra** (Construcción) para programar la
+  cita de recepción o levantar el acta. El badge dice si está _sin programar_,
+  _programada_ (con su fecha) o _con observaciones_.
+- **Pre-entrega pendiente** — ventas ya escrituradas, listas para la **revisión
+  pre-entrega**. La tarjeta abre la **Fase 14** de esa venta.
+- **Entrega pendiente** — la pre-entrega ya se hizo; falta **entregar la
+  vivienda** al cliente. La tarjeta abre la **Fase 15**.
+- **Encuesta sin responder** — la conformidad del cliente está pendiente de
+  respuesta. La tarjeta abre la **Fase 16**. El badge dice si la encuesta está
+  _programada_ o ya _enviada_ (y cuántos intentos de envío lleva).
+
+## Los indicadores de arriba
+
+La tira de indicadores resume cómo va el departamento:
+
+- **Obras por recibir** y **Por entregar** — cuánto tienes en cola.
+- **Encuestas pendientes** — conformidades sin responder.
+- **NPS** — el _Net Promoter Score_ promedio de las encuestas respondidas (verde
+  ≥ 9, ámbar 7-8, rojo abajo de 7). Aparece "—" si aún no hay respuestas.
+- **Satisfacción vivienda** — calificación promedio de la vivienda (de 1 a 5),
+  con cuántas respuestas la sustentan.
+
+## Lo que puedes hacer
+
+- **Abrir un pendiente** — clic en cualquier tarjeta para ir a la pantalla donde
+  se trabaja (la obra o la fase correspondiente de la venta).
+- **Recibir la obra** — desde la tarjeta de "Obras por recibir" llegas a la obra,
+  donde programas la cita y levantas el **acta de recepción** (con o sin
+  observaciones). Eso es lo que mueve la unidad hacia la entrega.
+
+## Preguntas frecuentes
+
+**¿Por qué una venta aparece en "Entrega" y no en "Pre-entrega"?**
+Porque su pre-entrega (Fase 14) ya se cerró. Las colas siguen el orden del
+proceso: una venta baja a la siguiente cola conforme cierras su fase.
+
+**Marqué una obra como recibida pero sigue en "Obras por recibir".**
+Revisa que el acta de recepción haya quedado guardada en la obra. Mientras la
+recepción no se cierre, la unidad permanece en la cola.
+
+**¿El NPS y la satisfacción de dónde salen?**
+De las encuestas de conformidad (Fase 16) que los clientes responden. Solo
+cuentan las respondidas; por eso el indicador muestra cuántas respuestas hay.
+
+**Una tarjeta dice "(cliente sin nombre)".**
+La venta no tiene el nombre del cliente capturado todavía. Igual puedes abrirla;
+conviene completar el dato en el expediente de la venta.
+
+## Si algo no cuadra
+
+La bandeja solo refleja lo que hay en las otras pantallas: si un pendiente se ve
+mal (una obra que ya recibiste, una venta en la cola equivocada), el dato a
+corregir está en la obra o en la fase de la venta, no aquí. Anota la unidad o el
+cliente y avisa a Dirección para que quede rastro de la corrección.

--- a/content/manual/dilesa/cobranza/pagos.md
+++ b/content/manual/dilesa/cobranza/pagos.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'CxC — Pagos'
 modulo: dilesa.cobranza.pagos
-version: '1.0.0'
-actualizado: '2026-06-07'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -23,6 +23,17 @@ aplica solo a los **cargos abiertos** de esa venta.
    Institución), y opcionalmente **forma de pago**, **referencia**, **notas** y el
    **comprobante**.
 4. **Registrar abono** — queda aplicado a los cargos abiertos de esa venta.
+
+## El recibo de caja (XML del SAT)
+
+Si el abono tiene su **recibo de caja en XML** (CFDI de pago), súbelo: el sistema
+lo lee y **llena solos** la fecha, el monto, la forma de pago y la referencia
+—solo confirmas o corriges lo que haga falta—, y guarda el folio fiscal (UUID)
+para que no se registre dos veces. Los campos que vienen del XML quedan
+bloqueados para evitar errores de captura.
+
+Si el receptor del recibo no es exactamente el cliente de la venta (por ejemplo
+un coacreditado), el sistema pide que lo confirmes y deja constancia.
 
 ## La "fuente" del abono
 

--- a/content/manual/dilesa/construccion/obras.md
+++ b/content/manual/dilesa/construccion/obras.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Construcción — Obras'
 modulo: dilesa.construccion.obras
-version: 1.0.0
-actualizado: 2026-06-07
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -62,6 +62,33 @@ Abajo, un contador te dice **"X de Y obras"** (cuántas quedaron tras filtrar).
 | **Seguro calidad** | Pasó la inspección de seguro de calidad.        |
 | **Extraída**       | Unidad ya liberada (venta completada).          |
 | **Cancelada**      | Obra cancelada.                                 |
+
+## Recepción de obra (Atención a Clientes)
+
+Una obra al **100% de avance no pasa sola a entrega**: primero hay que
+**recibirla al contratista**. Eso lo hace Atención a Clientes desde el **detalle
+de la obra**, con un botón que cambia según en qué punto va la recepción:
+
+1. **Programar recepción** — agenda la fecha de la cita con el contratista.
+   (Mientras la obra no llega al 100%, el botón aparece bloqueado e indica
+   cuántas tareas faltan.)
+2. **Continuar recepción** — abre el recorrido: un **checklist** por zonas
+   (exterior, planta baja, planta alta, azotea, patio) donde marcas cada punto
+   como _cumple_, _con observación_ o _no aplica_, con notas. **Guardar avance**
+   lo deja a medias sin cerrar; si hay observaciones, la obra queda **"con
+   observaciones"** hasta que el contratista corrija.
+3. **Recibir obra** — solo se habilita cuando el checklist está todo en verde y
+   ya subiste el **acta de recepción firmada**. Al recibir, la obra se libera
+   para la entrega.
+
+El **acta de recepción** se imprime desde el mismo recorrido (sale con el
+membrete de DILESA, los datos de la unidad, el checklist lleno y los espacios de
+firma de Supervisor, Contratista y Atención a Clientes); se firma en papel, se
+escanea y se sube.
+
+Los pendientes de recepción también aparecen en la bandeja de **Atención a
+Clientes** (cola "Obras por recibir"), con el badge _sin programar_ /
+_programada_ / _con observaciones_.
 
 ## Preguntas frecuentes
 

--- a/content/manual/dilesa/cxp/pagos.md
+++ b/content/manual/dilesa/cxp/pagos.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'CxP — Pagos'
 modulo: dilesa.cxp.pagos
-version: '1.0.0'
-actualizado: '2026-06-07'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -32,6 +32,15 @@ por estado.
 
 Clic en un renglón abre el detalle: método, referencia, cuenta, fechas, y las
 **facturas aplicadas** a ese pago.
+
+### Control por partida
+
+Cuando las facturas del pago están ligadas a una **partida** de obra, el detalle
+muestra un bloque de **Control por partida**: para cada partida ves lo
+**contratado** (del contrato vigente, o el presupuesto aprobado si no hay
+contrato), lo **abonado antes**, **este pago** y **cómo queda** (total abonado y
+qué porcentaje del contratado representa), con el **historial** de abonos
+anteriores. Sirve para no pasarte de lo contratado en una partida.
 
 ## Estados
 

--- a/content/manual/dilesa/ventas/clientes.md
+++ b/content/manual/dilesa/ventas/clientes.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Ventas — Clientes'
 modulo: dilesa.ventas.clientes
-version: '1.0.0'
-actualizado: '2026-06-07'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -25,8 +25,10 @@ Cada renglón es un cliente: **Cliente** (nombre + email/teléfono), **# ventas*
 
 - **Buscar / filtrar** — por nombre, o por proyecto donde compró.
 - **Abrir un cliente** — clic en el renglón para ver su **detalle**: datos de
-  contacto y la línea de tiempo de **todas sus ventas** (con proyecto, fecha,
-  vendedor, fase, estado y monto). Desde ahí puedes entrar a cada venta.
+  contacto e identificación (**CURP** e **INE**) y la línea de tiempo de **todas
+  sus ventas** (con proyecto, fecha, vendedor, fase, estado y monto). Desde ahí
+  puedes entrar a cada venta. La cabecera del cliente —con su CURP e INE—
+  acompaña también a cada pantalla de la venta.
 
 ## Preguntas frecuentes
 

--- a/content/manual/dilesa/ventas/expediente.md
+++ b/content/manual/dilesa/ventas/expediente.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Ventas — Expediente de Operación'
 modulo: dilesa.ventas
-version: '1.0.0'
-actualizado: '2026-06-11'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -19,31 +19,63 @@ lista (o desde Clientes → el cliente → su venta).
 
 ## Las partes de la pantalla
 
-- **Cabecera (siempre visible)** — cliente, vivienda (proyecto · manzana/lote ·
-  prototipo), datos comerciales (precio, vendedor) y la **mini-cuadratura**:
-  Precio | Crédito | Depósitos | Crédito directo | **Saldo**. El semáforo verde
-  significa que el dinero ya cubre el valor de la operación.
+- **Cabecera (siempre visible)** — cliente (con CURP e **INE**), vivienda
+  (proyecto · manzana/lote · prototipo), datos comerciales (precio, vendedor) y
+  la **mini-cuadratura**: Precio | Crédito | Depósitos | Crédito directo |
+  **Saldo**. El semáforo verde significa que el dinero ya cubre el valor de la
+  operación. Cuando la operación cierra (Fase 17), la cabecera muestra el badge
+  **Terminada**.
 - **Línea de tiempo (las 17 fases)** — agrupadas en 5 etapas: **Comercial**
   (1-3), **Crédito** (4-9), **Cierre legal** (10-12), **Administrativo** (13) y
   **Entrega** (14-17). Cada fase muestra ✓ si ya se cerró y su fecha.
 - **Pestañas**:
   - **Operación** — datos del cliente y de la venta + el pipeline con sus
     documentos (los chips grises son documentos que faltan).
-  - **Cuadratura** — todo el dinero de la operación reconciliado.
+  - **Cuadratura** — todo el dinero de la operación reconciliado (ver abajo).
   - **Documentos** — el expediente digital agrupado por etapa.
   - **Bitácora** — quién cerró cada fase y cuándo.
+
+## La Cuadratura (cómo se lee el saldo)
+
+La Cuadratura concilia el dinero contra el **valor de escrituración**. El número
+que importa es el **saldo efectivo**: lo que realmente falta por cubrir.
+
+- **Saldo de cobranza** — valor de escrituración menos lo recibido (depósitos +
+  crédito + crédito directo). Es el saldo "en crudo", para auditoría.
+- **Descuento aplicado** — el descuento otorgado al cliente, **topado al máximo
+  de la promoción**. Lo que se perdona ya no cuenta como deuda.
+- **Cheque a notaría** — el cheque realmente girado (capturado en la Fase 11).
+
+El **saldo efectivo** es el saldo de cobranza menos el descuento aplicado más el
+cheque girado. Si queda en cero (con una pequeña tolerancia que absorbe
+redondeos), la operación está **cubierta**.
+
+> **Editar los descuentos es solo de Dirección.** Los montos de descuento se
+> ajustan desde la pestaña Cuadratura; el cambio queda auditado. Cuando una
+> venta tiene factura, la Cuadratura toma el **valor facturado** y la **nota de
+> crédito del CFDI** (no de una estimación).
 
 ## Cómo avanzo una venta de fase
 
 1. En el pipeline, ubica la **fase actual** (la primera sin ✓).
-2. Clic en **Capturar** — se abre la pantalla de esa fase con sus campos y
+2. Clic en **Capturar fase** — se abre la pantalla de esa fase con sus campos y
    documentos. (Cada fase tiene su propia ayuda: abre el "?" estando ahí.)
-3. Llena lo requerido, sube el PDF si la fase lo pide y **guarda**: la fase se
-   cierra con fecha y tu nombre queda en la Bitácora.
+3. Llena lo requerido y sube los documentos: **cada documento se guarda en el
+   expediente en cuanto lo subes** (no se pierde si sales sin cerrar, y queda
+   registrado quién lo subió). Cuando la fase tiene todo, **guarda**: se cierra
+   con fecha y tu nombre en la Bitácora.
 
-Las fases se cierran **en orden**. Si el botón Capturar no aparece, o la fase
-anterior sigue abierta, o tu perfil no captura esa fase (cada fase tiene su
+Como los documentos se guardan al subirse, **varias personas pueden ir
+aportando** a una misma fase en momentos distintos antes de cerrarla.
+
+Las fases se cierran **en orden**. Si el botón Capturar no aparece, es porque la
+fase anterior sigue abierta, o tu perfil no captura esa fase (cada fase tiene su
 responsable — ver la tabla de abajo).
+
+**Ver o corregir una fase cerrada.** Las fases ya cerradas muestran el botón
+**"Ver / corregir"**: puedes consultarlas y, en las que lo permiten (por
+ejemplo el número de escritura en la Fase 11), corregir un dato sin reabrir el
+proceso. La corrección queda registrada.
 
 ## ¿Qué fase le toca a quién?
 

--- a/content/manual/dilesa/ventas/fase01_solicitud.md
+++ b/content/manual/dilesa/ventas/fase01_solicitud.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Fase 1 — Solicitud de Asignación'
 modulo: dilesa.ventas.fase01_solicitud
-version: '1.0.0'
-actualizado: '2026-06-11'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es esta fase?
@@ -20,7 +20,9 @@ vivienda disponible).
 ## Qué se captura
 
 - **El cliente** — datos personales y de contacto. Si ya existe, el sistema lo
-  encuentra por CURP y no lo duplica. Se llena también el cuestionario de
+  encuentra por CURP y no lo duplica; al seleccionarlo se despliega una **ficha
+  informativa** con su nombre, teléfono, email, CURP e **INE**, para que
+  confirmes que es la persona correcta. Se llena también el cuestionario de
   conocimiento del cliente (FICU/PLD): forma de pago, ocupación, estado civil.
 - **La vivienda** — se elige de las disponibles; el sistema calcula el precio
   con el tipo de crédito (los costos del crédito se suman solos; en casas con
@@ -45,3 +47,8 @@ el lugar. La autorización (F2) solo procede para el líder de la cola.
 **¿El precio lo puedo cambiar?**
 El precio sale del sistema (lista + cargos del crédito). Los descuentos se
 manejan aparte y con autorización — habla con tu gerente.
+
+**¿De dónde sale el tope de descuento de la venta?**
+De la **promoción** que aplica a la solicitud: su monto es el máximo de descuento
+autorizado que después respeta la Cuadratura. (El catálogo de promociones lo
+administra Dirección en la pestaña **Promociones** de Ventas.)

--- a/content/manual/dilesa/ventas/fase02_asignada.md
+++ b/content/manual/dilesa/ventas/fase02_asignada.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Fase 2 — Asignada (autorización)'
 modulo: dilesa.ventas.autorizar
-version: '1.0.0'
-actualizado: '2026-06-11'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es esta fase?
@@ -24,6 +24,14 @@ formalmente asignada al cliente.
 
 Se revisan los 4 documentos (se pueden abrir y también subir aquí si falta
 alguno) y se pulsa **Autorizar asignación**. La venta pasa a fase Asignada.
+
+## El precio se congela al autorizar
+
+Al autorizar la asignación, el **desglose de precio queda congelado** en la
+venta (valor comercial, excedentes, extras, costos del crédito y total). A
+partir de ahí el detalle y el PDF de la solicitud muestran **ese** desglose: si
+después cambian las reglas de tarifación o una promoción, **no se re-tarifan**
+las ventas ya asignadas — los cambios solo aplican a ventas nuevas.
 
 ## Al cerrar
 

--- a/content/manual/dilesa/ventas/fase11_escriturada.md
+++ b/content/manual/dilesa/ventas/fase11_escriturada.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Fase 11 — Escriturada'
 modulo: dilesa.ventas.fase11_escriturada
-version: '1.0.0'
-actualizado: '2026-06-11'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es esta fase?
@@ -19,10 +19,19 @@ Fase 10 (Firmas Programadas) cerrada.
 ## Qué se captura
 
 - **Fecha de la escritura**.
-- **Número de escritura** (opcional).
+- **Número de instrumento público** — el número que asigna el **notario**, no el
+  folio interno de DILESA. Es importante: la revisión PLD de la Fase 13 cruza
+  este número contra el aviso, así que tiene que ser el del notario.
 - **Número y monto del cheque a notaría** (el monto entra a la cuadratura).
 
 Sin documentos requeridos.
+
+## Corregir después de cerrar
+
+Aunque la fase ya esté cerrada, el **número y la fecha de la escritura** se
+pueden corregir desde **"Ver / corregir"** en el expediente, sin reabrir el
+proceso. Si la venta ya pasó la revisión PLD de la Fase 13, esa revisión tendrá
+que volver a correrse.
 
 ## Al cerrar
 

--- a/content/manual/dilesa/ventas/fase12_detonada.md
+++ b/content/manual/dilesa/ventas/fase12_detonada.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Fase 12 — Detonada'
 modulo: dilesa.ventas.fase12_detonada
-version: '1.1.0'
-actualizado: '2026-06-11'
+version: '1.2.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es esta fase?
@@ -28,6 +28,10 @@ el comprobante se copia al expediente.
 Es el **respaldo manual** para casos fuera del camino normal (igual que la
 captura manual del dictamen en F8). Requiere Fase 11 cerrada y captura fecha,
 monto y comprobante a mano.
+
+El cierre manual es **solo de Dirección** (es una salida de excepción, no el
+flujo normal). Si no eres Dirección, la pantalla te guía a registrar el abono en
+**Cobranza** —que es lo que detona la venta sola— en vez de cerrar a mano.
 
 ## Preguntas frecuentes
 

--- a/content/manual/dilesa/ventas/fase13_facturada.md
+++ b/content/manual/dilesa/ventas/fase13_facturada.md
@@ -1,15 +1,15 @@
 ---
 titulo: 'Fase 13 — Facturada'
 modulo: dilesa.ventas.fase13_facturada
-version: '1.0.0'
-actualizado: '2026-06-11'
+version: '2.0.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es esta fase?
 
-Contabilidad **registra la facturación** de la operación: sube la factura (y
-nota de crédito / aviso PLD si aplican) y captura los montos finales de la
-cuadratura.
+Contabilidad **registra la facturación** de la operación ante el SAT y deja en
+regla el aviso de **PLD** (Prevención de Lavado de Dinero): sube los XML
+fiscales, revisa el aviso, lo presenta en el portal y guarda el acuse.
 
 **Quién la captura:** Contabilidad (también Gerencia Ventas y Dirección).
 
@@ -17,13 +17,74 @@ cuadratura.
 
 Fase 12 (Detonada) cerrada.
 
-## Qué se captura
+## Los documentos (se guardan al subirse)
 
-- **Factura** (PDF, requerida) · **Nota de crédito** y **Aviso PLD** (opcionales).
-- **Valor de escrituración** (requerido — contra él se mide la cuadratura),
-  valor real venta DILESA, valor facturado y monto de la nota de crédito.
-- Los **depósitos del cliente** se muestran como referencia (de Cobranza).
+No hace falta cerrar la fase para que un documento quede guardado: **cada
+archivo se guarda en el expediente en cuanto lo subes**, con tu nombre y la
+fecha. Así varias personas pueden ir aportando documentos sin perder el trabajo,
+y "Cambiar" conserva las versiones anteriores.
+
+- **XML de la factura (CFDI)** — requerido. Al subirlo el sistema lo **valida
+  solo**: que el emisor sea DILESA, el receptor sea el cliente de la venta, que
+  esté timbrado y que el folio fiscal no esté usado en otra venta. Si algo no
+  cuadra, lo rechaza y te dice por qué.
+- **PDF de la factura** — opcional (el documento fiscal es el XML).
+- **XML / PDF de la nota de crédito** — solo si la operación lleva nota de
+  crédito.
+- **PDF del Aviso PLD** — se habilita cuando ya hay XML de factura válido.
+- **PDF del Acuse de envío PLD** — se habilita hasta que la revisión del aviso
+  quede en verde (ver abajo).
+
+> Los montos —**valor facturado** y **monto de la nota de crédito**— se sacan
+> **del XML**, no se capturan a mano. El valor de escrituración viene de la
+> Fase 8 y es contra el que se mide la cuadratura.
+
+## El ciclo PLD, en dos pasos
+
+### Paso 1 — Revisar el aviso
+
+1. Sube el XML de la factura y el **PDF del Aviso PLD**.
+2. Pulsa **Revisar operación**: el sistema lee el aviso con IA y lo **cruza
+   contra el expediente** (sujeto obligado, datos del cliente, valor pactado vs.
+   escrituración, domicilio y metros, notario e instrumento de la Fase 11,
+   avalúo, depósitos, plazo del aviso…).
+3. Si todo sale **en verde**, el aviso queda **congelado** (ya no se puede
+   cambiar; solo Dirección podría reemplazarlo) y aparece el aviso de
+   **"preséntalo en el portal SPPLD"**. Se habilita el slot del acuse.
+4. Si algo sale en rojo, la pantalla te dice qué — corrige el dato o el
+   documento y vuelve a revisar.
+
+### Paso 2 — Acuse y cierre
+
+5. Presenta el aviso en el portal **SPPLD** y sube el **Acuse de envío**.
+6. El sistema revisa el acuse (que el estatus sea **ACEPTADO**, que corresponda
+   a este aviso y dentro del plazo legal).
+7. Con la revisión del aviso **y** del acuse en verde, se habilita **Cerrar
+   Fase 13**.
 
 ## Al cerrar
 
-La operación pasa a la etapa de **Entrega** (fases 14-17).
+Validaciones de cierre:
+
+- **Nota de crédito documentada** si la cuadratura la pide (cuando el monto de
+  nota de crédito es mayor a cero).
+- Revisión PLD vigente en verde.
+
+Si la revisión no está en verde, **Dirección** puede autorizar el cierre con un
+**motivo** (queda en el rastro de auditoría); los demás roles solo ven el aviso
+de que falta autorización.
+
+La operación pasa a la etapa de **Entrega** (fases 14-17). Cuando más adelante
+se cierra la Fase 17, la venta pasa a estado **Terminada**.
+
+## Después de cerrar
+
+Con la fase cerrada los documentos quedan congelados: **solo Dirección** puede
+reemplazar un archivo (vuelve a versionar y obliga a re-revisar el PLD). Para
+entrar a una fase ya cerrada usa **"Ver / corregir"** desde el expediente.
+
+## Si algo no cuadra
+
+Si la revisión marca un dato en rojo que tú sabes correcto (por ejemplo el
+número de instrumento), revisa la Fase 11: el número que cruza el PLD es el
+**del notario**, no el folio interno. Corrige ahí y vuelve a revisar.

--- a/content/manual/dilesa/ventas/fase14_preparada_entrega.md
+++ b/content/manual/dilesa/ventas/fase14_preparada_entrega.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Fase 14 — Preparada para Entrega'
 modulo: dilesa.ventas.fase14_preparada_entrega
-version: '1.0.0'
-actualizado: '2026-06-11'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es esta fase?
@@ -15,7 +15,12 @@ Pre-Entrega antes de entregarla al cliente.
 ## Requisitos
 
 Puede arrancar desde que la venta está **Escriturada (11)** — no espera
-Detonada ni Facturada.
+Detonada ni Facturada. En la práctica, la vivienda ya debió **recibirse al
+contratista** (recepción de obra, en Construcción) antes de prepararla para
+entrega.
+
+> Este pendiente aparece en la bandeja de **Atención a Clientes** (cola
+> "Pre-entrega"), que te trae directo a esta pantalla.
 
 ## Cómo se trabaja
 

--- a/content/manual/dilesa/ventas/fase15_entregada.md
+++ b/content/manual/dilesa/ventas/fase15_entregada.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Fase 15 — Entregada'
 modulo: dilesa.ventas.fase15_entregada
-version: '1.0.0'
-actualizado: '2026-06-11'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es esta fase?
@@ -16,6 +16,9 @@ Atención a Clientes, y se sube el documento firmado.
 ## Requisitos
 
 Fase 14 (Preparada para Entrega) cerrada.
+
+> Este pendiente aparece en la bandeja de **Atención a Clientes** (cola
+> "Entrega"), que te trae directo a esta pantalla.
 
 ## Cómo se trabaja
 

--- a/content/manual/dilesa/ventas/fase17_operacion_terminada.md
+++ b/content/manual/dilesa/ventas/fase17_operacion_terminada.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Fase 17 — Operación Terminada'
 modulo: dilesa.ventas.fase17_operacion_terminada
-version: '1.0.0'
-actualizado: '2026-06-11'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es esta fase?
@@ -29,3 +29,11 @@ cierre.
 Si las 4 están en verde, el botón de cierre se habilita y la operación queda
 **Terminada**. Si algo falta, la pantalla te dice exactamente qué es — igual
 que el copiloto del expediente.
+
+## Qué cambia al terminar
+
+Al cerrar esta fase, la venta pasa a estado **Terminada** y **sale del pipeline
+vivo**: ya no aparece en las tarjetas de Fases ni en la lista de Ventas con el
+filtro por defecto (Activas) — la encuentras con el filtro "Terminadas" o
+"Todos". Sigue recibiendo las encuestas de conformidad programadas. Si hubo un
+error, **Dirección** puede regresarla a una fase anterior y vuelve a Activa.

--- a/content/manual/dilesa/ventas/fases.md
+++ b/content/manual/dilesa/ventas/fases.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Ventas — Fases'
 modulo: dilesa.ventas.fases
-version: '1.0.0'
-actualizado: '2026-06-07'
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -35,8 +35,11 @@ recalculan con los filtros.
 ## Preguntas frecuentes
 
 **¿Por qué una venta no aparece en ninguna fase?**
-Solo se cuentan las ventas **activas**. Y si a una venta le falta su fase actual,
-no se ubica en ninguna tarjeta (aparece un aviso de dato faltante).
+Solo se cuentan las ventas en estado **Activa** (el pipeline vivo). Las
+operaciones **Terminadas** (con la Fase 17 cerrada) salen del conteo — para
+verlas, usa la lista de Ventas con el filtro de estado en "Terminadas" o
+"Todos". Y si a una venta activa le falta su fase actual, no se ubica en ninguna
+tarjeta (aparece un aviso de dato faltante).
 
 **El filtro de "mes" ¿es por avance de fase?**
 No: es por el **mes en que se creó** la venta. Sirve para ver cohortes de ventas

--- a/content/manual/dilesa/ventas/lista.md
+++ b/content/manual/dilesa/ventas/lista.md
@@ -1,8 +1,8 @@
 ---
 titulo: 'Ventas — Lista'
 modulo: dilesa.ventas.lista
-version: 1.0.0
-actualizado: 2026-06-07
+version: '1.1.0'
+actualizado: '2026-06-16'
 ---
 
 ## ¿Qué es y para qué sirve?
@@ -35,6 +35,9 @@ pestañas de arriba.
 
 - **Buscador** (arriba) — escribe nombre del comprador, unidad o proyecto para
   filtrar al instante.
+- **Filtro de estado** — por defecto la lista muestra las ventas **Activas** (el
+  pipeline vivo). Cámbialo a **Terminadas** (operaciones cerradas en Fase 17),
+  **Desasignadas**, **Expiradas** o **Todos** para ver el histórico.
 - **Rango de fechas** — acota la lista a un periodo (desde / hasta). Los
   indicadores de arriba (los KPIs) se recalculan solos con lo que dejes
   filtrado.

--- a/content/manual/dilesa/ventas/promociones.md
+++ b/content/manual/dilesa/ventas/promociones.md
@@ -1,0 +1,79 @@
+---
+titulo: 'Ventas — Promociones'
+modulo: dilesa.ventas.promociones
+version: '1.0.0'
+actualizado: '2026-06-16'
+---
+
+## ¿Qué es y para qué sirve?
+
+Es el **catálogo de promociones de venta**. Cada promoción define un **tope de
+descuento autorizado** para uno o varios prototipos. Cuando se captura una
+venta, el sistema **auto-asigna** la promoción que aplica y usa su monto como
+límite: el descuento que finalmente entra a la cuadratura es
+`mínimo(lo otorgado al cliente, el tope de la promo)`. Así el descuento nunca
+rebasa lo autorizado.
+
+## Cómo llegar
+
+**Sidebar → DILESA → Inmobiliario → Ventas → pestaña _Promociones_.**
+
+## La tarjeta de promoción, dato por dato
+
+Cada promo se ve como una tarjeta:
+
+- **Nombre** y **estado** (_Activa_ / _Inactiva_). Solo las activas y vigentes se
+  auto-asignan a ventas nuevas.
+- **Monto** — el **tope de descuento** en pesos. No es lo que se descuenta
+  siempre; es el máximo que la cuadratura permite aplicar.
+- **Prototipos aplicables** — a qué prototipos aplica. Si dice **"Todos los
+  prototipos"** (no se eligió ninguno), aplica a toda la oferta.
+- **Vigencia** — rango de fechas en que la promo está vigente. Sin fechas, no
+  caduca.
+
+## Lo que puedes hacer
+
+> Crear, editar y activar/desactivar promociones es **solo para Dirección**
+> (igual que los topes de descuento en la Cuadratura). Los demás perfiles ven el
+> catálogo en modo lectura.
+
+- **Nueva promoción** — captura nombre, monto (tope), descripción, vigencia y los
+  prototipos a los que aplica (ninguno = todos). Nace activa.
+- **Editar** — ajusta cualquier dato de una promo existente.
+- **Activar / Desactivar** — prende o apaga la promo sin borrarla. Una promo
+  inactiva deja de auto-asignarse a ventas nuevas.
+- **Refrescar** — recarga el catálogo.
+
+## Cómo se aplica a una venta
+
+1. Al **capturar una venta** (Fase 1), el sistema busca una promo **activa,
+   vigente y aplicable al prototipo** de esa unidad y la asigna sola.
+2. En la **Cuadratura**, el descuento que se aplica es el menor entre lo otorgado
+   al cliente y el tope de la promo.
+3. El **desglose de precio se congela al asignar** la venta (Fase 2): cambiar una
+   promo después **no re-tarifa** ventas ya asignadas — solo afecta ventas nuevas.
+
+## Preguntas frecuentes
+
+**Cambié el monto de una promo y una venta vieja no cambió. ¿Por qué?**
+Es lo correcto: el precio y el descuento se congelan cuando la venta se asigna.
+Las ediciones al catálogo solo aplican a ventas capturadas de ahí en adelante.
+
+**¿Qué pasa si dos promos podrían aplicar al mismo prototipo?**
+El catálogo está pensado para que cada prototipo tenga su promo vigente clara.
+Si ves un solape, desactiva la que no quieras que se use.
+
+**Dejé los prototipos vacíos sin querer.**
+Vacío significa "todos los prototipos". Edita la promo y selecciona solo los que
+correspondan.
+
+**No me aparece el botón "Nueva promoción".**
+La administración del catálogo es solo de Dirección. Si necesitas un alta o un
+cambio, pásalo con Dirección.
+
+## Si algo no cuadra
+
+Si una venta entró con un descuento distinto al esperado, revisa en su
+**Cuadratura** qué promo se le asignó y con qué tope; recuerda que manda el menor
+entre lo otorgado y el tope. Si el catálogo tiene una promo mal capturada,
+solo Dirección puede corregirla — anota el nombre de la promo y avísale.

--- a/docs/planning/manual-usuario.md
+++ b/docs/planning/manual-usuario.md
@@ -7,7 +7,7 @@
 **Próximo hito:** — (cerrada; el rollout a RDB/ANSA/COAGAN/Nigropetense se promoverá como iniciativa propia cuando Beto lo decida, con `content/manual/README.md` como receta)
 **Dueño:** Beto
 **Creada:** 2026-06-07
-**Última actualización:** 2026-06-12 (hardening en #854: ayuda filtrada por permisos D9 + PDF solo Dirección con marca de confidencialidad D10)
+**Última actualización:** 2026-06-16 (refresh de contenido bajo la regla M6: docs al día con los cambios de DILESA del 11-16 jun + 2 superficies nuevas — Atención a Clientes y Promociones)
 
 ## Problema
 
@@ -256,3 +256,21 @@ cero `manual|ayuda|help` en `app/` o `components/`).
   drawer del "?" (la portada era URL-only; Beto no la encontraba). Decisiones
   D9 (RBAC por doc) y D10 (export solo Dirección + watermark) registradas;
   ADR-043 M4/M8 enmendados.
+- **2026-06-16** — **Refresh de contenido (regla M6).** El contenido quedó
+  congelado el 11-jun mientras DILESA shippeaba mucho del 11 al 16; los PRs de
+  feature no actualizaron su `.md`, así que se barrió el drift de un jalón.
+  **2 docs nuevos** para superficies sin ayuda: `atencion_clientes.md` (bandeja
+  de Atención a Clientes — recepción de obra/pre-entrega/entrega/encuesta, grupo
+  nuevo `atencion_clientes` en `lib/manual/groups.ts`) y `ventas/promociones.md`
+  (catálogo de topes de descuento). **13 docs actualizados** por cambios de
+  negocio: cuadratura con saldo efectivo (descuento topado + cheque) y
+  Valor Facturado/Nota de Crédito del CFDI (`expediente`, `fase13` reescrita,
+  `fase12` cierre solo Dirección), captura colaborativa + ciclo PLD en dos pasos
+  (`expediente`, `fase13`), recibo de caja XML en CxC (`cobranza/pagos`),
+  desglose de precio congelado al asignar (`fase02`), ficha informativa + INE
+  (`fase01`, `clientes`), instrumento público del notario + corrección
+  post-cierre (`fase11`), estado `terminada` fuera del pipeline vivo (`fases`,
+  `lista`, `fase17`), flujo de recepción de obra (`construccion/obras`, `fase14`,
+  `fase15`) y control por partida en el pago (`cxp/pagos`). Ya estaban al día:
+  `fase10` (póliza con fecha de firma) y `saldos-bancos` (rename "Bancos").
+  Borradores generados leyendo el código vivo + los diffs de cada PR.

--- a/lib/manual/groups.ts
+++ b/lib/manual/groups.ts
@@ -32,6 +32,7 @@ export const MANUAL_GROUPS: ManualGroup[] = [
   { key: 'ventas', label: 'Ventas' },
   { key: 'construccion', label: 'Construcción' },
   { key: 'ruv', label: 'RUV' },
+  { key: 'atencion_clientes', label: 'Atención a Clientes' },
 ];
 
 const GROUP_ORDER = new Map(MANUAL_GROUPS.map((g, i) => [g.key, i]));


### PR DESCRIPTION
## Qué

El contenido del manual de usuario in-app de DILESA quedó congelado el **11-jun** mientras DILESA shippeaba del 11 al 16. Los PRs de feature no actualizaron su `.md` (regla M6 del planning doc), así que se barrió el drift de un jalón + se cubrieron 2 superficies que no tenían ayuda.

> **Para revisar:** soy fiel al código, pero el negocio lo conoces tú. Échale un ojo en el **Vercel Preview** (botón "?" en cada pantalla y la portada `/dilesa/manual`), sobre todo a la **Cuadratura** (saldo efectivo), la **Fase 13** (ciclo PLD) y la **recepción de obra**. Lo dejé **sin auto-merge** para que lo apruebes — es la regla D2 de la iniciativa (Beto revisa el contenido en preview).

## Superficies nuevas

- **Atención a Clientes** (`atencion_clientes.md`) — la bandeja de Ciori: obras por recibir, pre-entrega, entrega, encuesta + KPIs (NPS, satisfacción). Grupo nuevo `atencion_clientes` en `lib/manual/groups.ts`.
- **Ventas → Promociones** (`ventas/promociones.md`) — catálogo de topes de descuento (auto-asignación, `min(otorgado, tope)`, admin solo Dirección).

## Docs actualizados (13)

| Doc | Cambio |
|---|---|
| `ventas/expediente` | Saldo efectivo de Cuadratura (descuento topado + cheque), Valor Facturado/NC del CFDI, captura colaborativa, "Ver/corregir", badge Terminada, INE en cabecera |
| `ventas/fase13_facturada` | **Reescrito**: XML CFDI, montos automáticos, ciclo PLD en dos pasos (revisar → congelar → presentar → acuse), gate de cierre |
| `ventas/fase12_detonada` | Cierre manual solo Dirección |
| `ventas/fase02_asignada` | Desglose de precio se congela al asignar (no re-tarifa ventas anteriores) |
| `ventas/fase01_solicitud` | Ficha informativa del cliente (INE/contacto) + tope de descuento de la promo |
| `ventas/fase11_escriturada` | Número de instrumento público del **notario** + corrección post-cierre |
| `ventas/fases`, `ventas/lista`, `ventas/fase17` | Estado `terminada` fuera del pipeline vivo + filtro de estado |
| `ventas/clientes` | INE en datos del cliente |
| `cobranza/pagos` | Recibo de caja XML con extracción automática |
| `construccion/obras`, `ventas/fase14`, `ventas/fase15` | Flujo de recepción de obra (programar → checklist → acta → recibir) + conexión con la bandeja |
| `cxp/pagos` | Control por partida en el drawer del pago |

Ya estaban al día (no se tocaron): `fase10` (póliza con fecha de firma) y `saldos-bancos` (rename "Bancos").

## Verificación

6 checks locales: typecheck ✅ · test:coverage ✅ (1847 tests) ✅ · lint ✅ (0 errores) · format:check ✅ · initiatives:check ✅ · schema:check N/A (sin cambios de DB). Tests del manual: 30/30 (groups/load/access/search/help-routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)