### PR TITLE
feat(dilesa-portafolio-expediente): análisis de compra del terreno (snapshot financiero)

### DIFF
--- a/components/dilesa/activo-detail-drawer.tsx
+++ b/components/dilesa/activo-detail-drawer.tsx
@@ -28,7 +28,7 @@ import { useEffectiveUser } from '@/components/providers';
 import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 import { FileAttachments } from '@/components/file-attachments';
 import { regresarUnidadAlProyecto } from '@/app/dilesa/proyectos/actions';
-import { ACTIVO_TIPO_LABEL } from '@/lib/dilesa/portafolio';
+import { ACTIVO_TIPO_LABEL, computeTerrenoSnapshot } from '@/lib/dilesa/portafolio';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { FileText, Image as ImageIcon, Map as MapIcon, MapPin, Paperclip } from 'lucide-react';
 
@@ -307,6 +307,19 @@ export function ActivoDetailDrawer({
     ? Object.entries(satelite).filter(([k, v]) => !SAT_OMIT.has(k) && v != null && v !== '')
     : [];
 
+  // Snapshot financiero de compra (solo terrenos con datos de negociación).
+  const numOrNull = (v: unknown) => (v == null || v === '' ? null : Number(v));
+  const compra =
+    activo?.tipo === 'terreno' && satelite
+      ? computeTerrenoSnapshot({
+          areaM2: activo.area_m2,
+          areasAfectacionM2: numOrNull(satelite.areas_afectacion_m2),
+          precioSolicitadoM2: numOrNull(satelite.precio_solicitado_m2),
+          precioOfertadoM2: numOrNull(satelite.precio_ofertado_m2),
+          valorObjetivoCompra: numOrNull(satelite.valor_objetivo_compra),
+        })
+      : null;
+
   const handleRegresar = async () => {
     if (!origen) return;
     const r = await regresarUnidadAlProyecto(origen.id);
@@ -388,6 +401,41 @@ export function ActivoDetailDrawer({
                 <Field label="Número de escritura" value={activo.numero_escritura} />
                 <Field label="Clave catastral" value={activo.clave_catastral} />
               </DetailDrawerSection>
+
+              {compra ? (
+                <DetailDrawerSection title="Análisis de compra">
+                  <Field
+                    label="Área aprovechable"
+                    value={
+                      compra.aprovechableM2 != null ? `${compra.aprovechableM2.toFixed(2)} m²` : '—'
+                    }
+                  />
+                  <Field
+                    label="Valor solicitado"
+                    value={
+                      compra.valorSolicitado != null ? formatCurrency(compra.valorSolicitado) : '—'
+                    }
+                  />
+                  <Field
+                    label="Valor ofertado"
+                    value={
+                      compra.valorOfertado != null ? formatCurrency(compra.valorOfertado) : '—'
+                    }
+                  />
+                  <Field
+                    label="$/m² aprovechable"
+                    value={
+                      compra.precioM2Aprovechable != null
+                        ? formatCurrency(compra.precioM2Aprovechable)
+                        : '—'
+                    }
+                  />
+                  <Field
+                    label="Brecha de negociación"
+                    value={compra.brechaPct != null ? `${compra.brechaPct.toFixed(1)}%` : '—'}
+                  />
+                </DetailDrawerSection>
+              ) : null}
 
               {satEntries.length > 0 ? (
                 <DetailDrawerSection title="Detalle del inmueble">

--- a/lib/dilesa/portafolio.test.ts
+++ b/lib/dilesa/portafolio.test.ts
@@ -5,6 +5,7 @@ import {
   puedeLiberarse,
   isActivoTipo,
   slugifyDestino,
+  computeTerrenoSnapshot,
   ACTIVO_TIPOS,
 } from './portafolio';
 
@@ -71,5 +72,49 @@ describe('slugifyDestino', () => {
   it('devuelve cadena vacía si no hay caracteres usables', () => {
     expect(slugifyDestino('   ')).toBe('');
     expect(slugifyDestino('—/—')).toBe('');
+  });
+});
+
+describe('computeTerrenoSnapshot', () => {
+  it('devuelve null sin datos de negociación', () => {
+    expect(
+      computeTerrenoSnapshot({
+        areaM2: 5000,
+        areasAfectacionM2: 200,
+        precioSolicitadoM2: null,
+        precioOfertadoM2: null,
+        valorObjetivoCompra: null,
+      })
+    ).toBeNull();
+  });
+
+  it('deriva aprovechable, valores, $/m² aprovechable y brecha', () => {
+    const s = computeTerrenoSnapshot({
+      areaM2: 5000,
+      areasAfectacionM2: 1000,
+      precioSolicitadoM2: 800,
+      precioOfertadoM2: 700,
+      valorObjetivoCompra: 3200000,
+    });
+    expect(s).not.toBeNull();
+    expect(s!.aprovechableM2).toBe(4000); // 5000 - 1000
+    expect(s!.valorSolicitado).toBe(4000000); // 5000 * 800
+    expect(s!.valorOfertado).toBe(3500000); // 5000 * 700
+    expect(s!.precioM2Aprovechable).toBe(800); // 3200000 / 4000
+    expect(s!.brechaPct).toBeCloseTo(12.5); // (4M - 3.5M)/4M
+  });
+
+  it('cae al valor ofertado cuando no hay valor objetivo, y tolera datos faltantes', () => {
+    const s = computeTerrenoSnapshot({
+      areaM2: 1000,
+      areasAfectacionM2: null,
+      precioSolicitadoM2: null,
+      precioOfertadoM2: 500,
+      valorObjetivoCompra: null,
+    });
+    expect(s!.aprovechableM2).toBe(1000); // sin afectación
+    expect(s!.valorOfertado).toBe(500000);
+    expect(s!.precioM2Aprovechable).toBe(500); // base = ofertado / aprovechable
+    expect(s!.brechaPct).toBeNull(); // sin solicitado no hay brecha
   });
 });

--- a/lib/dilesa/portafolio.ts
+++ b/lib/dilesa/portafolio.ts
@@ -100,3 +100,48 @@ export function slugifyDestino(label: string): string {
     .replace(/[^a-z0-9]+/g, '_') // no alfanumérico → _
     .replace(/^_+|_+$/g, ''); // recorta _ de los extremos
 }
+
+/**
+ * Snapshot financiero de un terreno en evaluación de compra. Deriva las métricas
+ * que el comité usa para decidir: área aprovechable (área − afectaciones), valor
+ * solicitado vs ofertado, $/m² aprovechable (la métrica real para comparar
+ * terrenos) y la brecha de negociación. Devuelve `null` si no hay datos mínimos
+ * (ni precio solicitado ni valor objetivo). Recrea las columnas generadas que la
+ * vieja `dilesa.terrenos` de Coda tenía y se perdieron al plegar al satélite.
+ */
+export type TerrenoSnapshot = {
+  aprovechableM2: number | null;
+  valorSolicitado: number | null;
+  valorOfertado: number | null;
+  precioM2Aprovechable: number | null;
+  brechaPct: number | null;
+};
+
+export function computeTerrenoSnapshot(input: {
+  areaM2: number | null;
+  areasAfectacionM2: number | null;
+  precioSolicitadoM2: number | null;
+  precioOfertadoM2: number | null;
+  valorObjetivoCompra: number | null;
+}): TerrenoSnapshot | null {
+  const { areaM2, areasAfectacionM2, precioSolicitadoM2, precioOfertadoM2, valorObjetivoCompra } =
+    input;
+  // Sin nada de la negociación no hay snapshot que mostrar.
+  if (precioSolicitadoM2 == null && precioOfertadoM2 == null && valorObjetivoCompra == null) {
+    return null;
+  }
+  const aprovechableM2 = areaM2 != null ? Math.max(0, areaM2 - (areasAfectacionM2 ?? 0)) : null;
+  const valorSolicitado =
+    areaM2 != null && precioSolicitadoM2 != null ? areaM2 * precioSolicitadoM2 : null;
+  const valorOfertado =
+    areaM2 != null && precioOfertadoM2 != null ? areaM2 * precioOfertadoM2 : null;
+  // $/m² aprovechable: prioriza el valor objetivo; si no, el ofertado total.
+  const base = valorObjetivoCompra ?? valorOfertado;
+  const precioM2Aprovechable =
+    base != null && aprovechableM2 != null && aprovechableM2 > 0 ? base / aprovechableM2 : null;
+  const brechaPct =
+    valorSolicitado != null && valorOfertado != null && valorSolicitado > 0
+      ? ((valorSolicitado - valorOfertado) / valorSolicitado) * 100
+      : null;
+  return { aprovechableM2, valorSolicitado, valorOfertado, precioM2Aprovechable, brechaPct };
+}


### PR DESCRIPTION
## Iniciativa
`dilesa-portafolio-expediente` · evaluación de compra (parte 1). Sin migración.

## Cambios
- Sección **"Análisis de compra"** en la ficha del terreno: área aprovechable, valor solicitado vs ofertado, **$/m² aprovechable** (la métrica del comité) y brecha de negociación.
- Helper puro `computeTerrenoSnapshot` + tests (3 casos).

Cálculo en cliente desde los campos del satélite que ya existen. Los 6 checks en verde localmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)