### PR TITLE
fix(dilesa-ventas): docs opcionales no aparecen como faltantes + pagaré fase 10 usa rol `pagare`

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
@@ -19,7 +19,9 @@
  * Captura:
  *   - `fecha_firma_programada` + `hora_firma_programada`
  *   - Crédito directo (si aplica): monto, plan de pagos (jsonb), tasas, aval.
- *   - Doc opcional: pagaré firmado (rol `pagare_credito_directo`).
+ *   - Doc opcional: pagaré firmado (rol `pagare`, el mismo que reconoce la fase
+ *     Escriturada y `rolesOpcionales` — así el pagaré subido aquí aparece como
+ *     cargado en el pipeline y no se pide de nuevo).
  *
  * Enforcement: Fase 9 (Validación Patronal) cerrada. Si hay saldo, el crédito
  * directo debe estar configurado para cerrar la fase.
@@ -48,7 +50,7 @@ import {
 
 const SLOTS_FASE: SlotColaborativo[] = [
   {
-    rol: 'pagare_credito_directo',
+    rol: 'pagare',
     label: 'Pagaré firmado (súbelo cuando lo tengas)',
     requerido: false,
   },

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -808,6 +808,24 @@ function DetailInner() {
     [adjuntosPorRolMap]
   );
 
+  // Roles documentales que esta venta NO amerita (pagaré sin crédito directo,
+  // constancia de co-titular sin co-titular, nota de crédito sin monto, anexo
+  // de condiciones financieras fuera de INFONAVIT). El pipeline y el copiloto
+  // los excluyen de "faltantes" para no exhibir un doc fantasma que la
+  // operación no requiere.
+  const rolesOpc = useMemo(
+    () =>
+      venta
+        ? rolesOpcionales({
+            monto_credito_cotitular: venta.monto_credito_cotitular,
+            monto_credito_directo: venta.monto_credito_directo,
+            monto_nota_credito: venta.monto_nota_credito,
+            tipo_credito: venta.tipo_credito,
+          })
+        : new Set<string>(),
+    [venta]
+  );
+
   // Pipeline combinado: una fila por cada una de las 17 fases, con su
   // fecha (si alcanzada), docs cargados (clickeables) y docs faltantes
   // (chip outline gris). Es el "lugar donde se avanza fase por fase
@@ -825,7 +843,10 @@ function DetailInner() {
         (adjuntosPorRolMap.get(r) ?? []).map((a) => ({ ...a, rol: r }))
       );
       const rolesCargados = new Set(cargados.map((a) => a.rol));
-      const faltantes = roles.filter((r) => !rolesCargados.has(r));
+      // Un rol es faltante solo si la venta lo amerita (no está en `rolesOpc`):
+      // así el pipeline no pinta el chip "Pagaré" en una venta sin crédito
+      // directo, etc. — mismo criterio que el copiloto de cierre.
+      const faltantes = roles.filter((r) => !rolesCargados.has(r) && !rolesOpc.has(r));
       const slugCaptura = CAPTURAR_SLUG_BY_POSICION[pos];
       const previaCerrada =
         pos === 1 || posicionesAlcanzadas.has(GATE_PREVIA_OVERRIDE[pos] ?? pos - 1);
@@ -847,7 +868,7 @@ function DetailInner() {
         previaCerrada,
       };
     });
-  }, [fases, adjuntosPorRolMap, venta?.estado]);
+  }, [fases, adjuntosPorRolMap, venta?.estado, rolesOpc]);
 
   const pipelineAlcanzadas = useMemo(
     () => pipelineRows.filter((r) => r.alcanzada).length,
@@ -916,17 +937,11 @@ function DetailInner() {
 
   // Copiloto de cierre (S4): qué falta para Operación Terminada.
   const copiloto = useMemo(() => {
-    const opcionales = venta
-      ? rolesOpcionales({
-          monto_credito_cotitular: venta.monto_credito_cotitular,
-          monto_credito_directo: venta.monto_credito_directo,
-          monto_nota_credito: venta.monto_nota_credito,
-          tipo_credito: venta.tipo_credito,
-        })
-      : new Set<string>();
+    // `pipelineRows.faltantes` ya excluye `rolesOpc`; el filtro aquí es
+    // defensivo (un rol opcional nunca debe contar como pendiente de cierre).
     const docsFaltantes = pipelineRows.flatMap((r) =>
       r.faltantes
-        .filter((rol) => !opcionales.has(rol))
+        .filter((rol) => !rolesOpc.has(rol))
         .map((rol) => ({ fase: r.nombre, rol, label: ROL_LABEL[rol] ?? rol }))
     );
     return evaluarCierre(
@@ -938,7 +953,7 @@ function DetailInner() {
       },
       (n) => moneyFmt.format(n)
     );
-  }, [venta, pipelineRows, cuadratura]);
+  }, [venta, pipelineRows, cuadratura, rolesOpc]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Contexto

Reporte: el cliente **MAYRA ALEJANDRA GOMEZ TERRAZAS** se regresó de fase porque "se les pasó registrar un pagaré"; al volver a fase 10 el pagaré no aparecía.

**Diagnóstico:** no había pagaré que registrar. MAYRA tiene crédito FOVISSSTE al 100% del precio → no hay crédito directo → no hay pagaré. Lo que confundió al operador fue un **chip "Pagaré" fantasma** en el pipeline del detalle (fase Escriturada), que se mostraba como faltante aunque la venta no lo amerita.

## Cambios

1. **Pipeline del detalle respeta `rolesOpcionales`.** `pipelineRows.faltantes` ahora excluye los roles opcionales que la venta no amerita (pagaré sin crédito directo, constancia co-titular sin co-titular, NC sin monto, condiciones financieras fuera de INFONAVIT) — mismo criterio que ya usaba el copiloto de cierre. Memo `rolesOpc` compartido entre ambos.
2. **Slot de pagaré de Fase 10 cambia de rol `pagare_credito_directo` → `pagare`.** Es el rol que esperan `FASE_ROLES['Escriturada']`, `rolesOpcionales` y los **23 adjuntos históricos** (0 usaban el rol viejo). Antes, el pagaré subido en Fase 10 nunca matcheaba el chip de Escriturada (quedaba faltante para siempre en ventas con crédito directo real).

Sin migración de datos: no existe ningún adjunto con el rol viejo en prod.

## Qué NO toca

El comportamiento de **regreso de fase** es correcto (soft-delete de `venta_fases`, conserva adjuntos y montos). Y el descuadre de la cuadratura del sobreprecio de MAYRA es un tema aparte (la pieza que falta — el cheque a notaría — se captura en fase 11; ver discusión en la sesión).

## Verificación

`typecheck` ✅ · `lint` (0 errores) ✅ · `format:check` ✅ · `test:coverage` 1864 tests ✅

**Revisar en Preview:** abrir la venta de MAYRA → el chip "Pagaré" ya no aparece como faltante en Escriturada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)