### PR TITLE
fix(dilesa-ventas): bloquea abono sin plan de pagos + avisa flotación 100% (caso Arizpe Luna)

### DIFF
--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -21,6 +21,7 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  AlertTriangle,
   ArrowLeft,
   Check,
   Circle,
@@ -1656,6 +1657,21 @@ function DetailInner() {
               </p>
             ) : (
               <div className="space-y-6">
+                {saldoFavor > 0 ? (
+                  <div className="flex items-start gap-2 rounded-lg border border-amber-400/50 bg-amber-50 p-3 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <div className="space-y-1">
+                      <p className="font-medium">
+                        Hay {moneyFmt.format(saldoFavor)} en abonos sin aplicar (saldo a favor).
+                      </p>
+                      <p>
+                        {cargos.length === 0
+                          ? 'La venta no tiene plan de pagos, así que los abonos quedaron flotando: no bajaron saldo ni avanzaron la fase. Genera el plan de pagos; los abonos ya registrados deben re-aplicarse manualmente (revísalo con quien lleva CxC).'
+                          : 'El monto excede los cargos abiertos. Verifica el plan de pagos o el monto capturado.'}
+                      </p>
+                    </div>
+                  </div>
+                ) : null}
                 <div className="flex flex-wrap gap-x-8 gap-y-3">
                   <ResumenItem label="A cobrar" value={moneyFmt.format(totalACobrar)} />
                   <ResumenItem label="Cobrado" value={moneyFmt.format(totalCobrado)} />

--- a/components/dilesa/abono-capture-drawer.tsx
+++ b/components/dilesa/abono-capture-drawer.tsx
@@ -25,10 +25,18 @@
  * Si el abono es de institución y la venta ya está detonada (o se detona
  * con este abono), el comprobante se copia solo al expediente de la venta
  * (trigger sobre `comprobante_adjunto_id`, migración 20260612173513).
+ *
+ * Gate "sin plan de pagos" (2026-06-17, incidente Arizpe Luna): si la venta
+ * no tiene cargos (`erp.cxc_cargos` vacío), el FIFO del RPC no encuentra qué
+ * cubrir y el abono queda 100% flotando (saldo a favor) sin avanzar la fase —
+ * y se puede repetir, duplicando depósitos en silencio. El drawer bloquea el
+ * submit y ofrece generar el plan ahí mismo (`dilesa.fn_generar_plan_pagos`).
+ * Además, si tras registrar el abono quedó sin aplicarse (plan ya saldado),
+ * avisa fuerte en vez de un "registrado" plano.
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, CheckCircle2, Pencil, Plus } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Loader2, Pencil, Plus } from 'lucide-react';
 import { z } from 'zod';
 
 import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
@@ -50,6 +58,7 @@ import {
 } from '@/lib/dilesa/cxc/cfdi-recibo';
 import {
   abonoCubreMayormenteInstitucion,
+  abonoQuedariaSinAplicar,
   sugerirFuenteAbono,
   type CargoAbiertoFuente,
 } from '@/lib/dilesa/cxc/fuente-abono';
@@ -129,9 +138,14 @@ export function AbonoCaptureDrawer({
   // si viene `undefined` (p.ej. Cobranza · Pagos), se resuelve aquí desde
   // erp.personas — sin él, la verificación del recibo caería al nombre.
   const [rfcResuelto, setRfcResuelto] = useState<string | null>(null);
-  // Cargos abiertos de la venta en el orden FIFO del RPC — sugieren la fuente
-  // del abono y alimentan el aviso de etiqueta vs lo que va a cubrir.
-  const [cargosAbiertos, setCargosAbiertos] = useState<CargoAbiertoFuente[] | null>(null);
+  // Cargos de la venta (todos, no solo los abiertos) en el orden FIFO del RPC.
+  // Sirven para: (a) sugerir la fuente del abono y el aviso de etiqueta, (b)
+  // detectar que la venta NO tiene plan de pagos (lista vacía → `sinPlan`).
+  // `null` = aún cargando (no decidir el gate hasta saberlo).
+  const [cargosVenta, setCargosVenta] = useState<CargoAbiertoFuente[] | null>(null);
+  // Bump tras generar el plan inline → re-fetch de cargos sin reabrir el drawer.
+  const [cargosRefreshKey, setCargosRefreshKey] = useState(0);
+  const [generandoPlan, setGenerandoPlan] = useState(false);
   const form = useZodForm({ schema: AbonoSchema, defaultValues: defaults });
 
   // RFC de la empresa (emisor esperado del recibo) — 1 fetch por apertura.
@@ -173,10 +187,10 @@ export function AbonoCaptureDrawer({
 
   const rfcCliente = clienteRfc !== undefined ? clienteRfc : rfcResuelto;
 
-  // Cargos abiertos en cada apertura (los saldos cambian con cada abono;
-  // `reset()` limpia al cerrar). Si lo siguiente por cubrir espera pago de
-  // institución, el abono casi seguro es la disposición del crédito →
-  // pre-selecciona la fuente.
+  // Cargos en cada apertura (los saldos cambian con cada abono; `reset()`
+  // limpia al cerrar) y tras generar el plan inline (`cargosRefreshKey`). Si
+  // lo siguiente por cubrir espera pago de institución, el abono casi seguro
+  // es la disposición del crédito → pre-selecciona la fuente.
   useEffect(() => {
     if (!open) return;
     let activo = true;
@@ -189,7 +203,6 @@ export function AbonoCaptureDrawer({
         .eq('origen_tipo', 'venta_dilesa')
         .eq('origen_id', ventaId)
         .neq('estado', 'cancelado')
-        .gt('saldo', 0)
         .is('deleted_at', null)
         .order('fecha_vencimiento', { ascending: true, nullsFirst: false })
         .order('numero', { ascending: true });
@@ -198,7 +211,7 @@ export function AbonoCaptureDrawer({
         saldo: Number(c.saldo),
         fuente_esperada: c.fuente_esperada,
       }));
-      setCargosAbiertos(cargos);
+      setCargosVenta(cargos);
       if (!form.formState.dirtyFields.fuente && sugerirFuenteAbono(cargos) === 'institucion') {
         form.setValue('fuente', 'institucion');
       }
@@ -206,18 +219,44 @@ export function AbonoCaptureDrawer({
     return () => {
       activo = false;
     };
-  }, [open, ventaId, form]);
+  }, [open, ventaId, form, cargosRefreshKey]);
+
+  // Venta sin plan de pagos: cero cargos. Hasta que `cargosVenta` resuelve
+  // (`null`) no decidimos, para no parpadear el bloqueo mientras carga.
+  const sinPlan = cargosVenta !== null && cargosVenta.length === 0;
 
   const fuenteSel = form.watch('fuente');
   const montoStr = form.watch('monto');
   const avisoFuenteCliente = useMemo(() => {
-    if (fuenteSel !== 'cliente' || !cargosAbiertos?.length) return false;
-    return abonoCubreMayormenteInstitucion(cargosAbiertos, Number(montoStr));
-  }, [fuenteSel, montoStr, cargosAbiertos]);
+    if (fuenteSel !== 'cliente' || !cargosVenta?.length) return false;
+    return abonoCubreMayormenteInstitucion(cargosVenta, Number(montoStr));
+  }, [fuenteSel, montoStr, cargosVenta]);
+
+  const handleGenerarPlanInline = async () => {
+    setGenerandoPlan(true);
+    try {
+      const sb = createSupabaseBrowserClient();
+      const { error } = await sb
+        .schema('dilesa')
+        .rpc('fn_generar_plan_pagos', { p_venta_id: ventaId });
+      if (error) {
+        toast.add({
+          title: 'No se pudo generar el plan',
+          description: getSupabaseErrorMessage(error, 'Error en el RPC.'),
+          type: 'error',
+        });
+        return;
+      }
+      toast.add({ title: 'Plan de pagos generado', type: 'success' });
+      setCargosRefreshKey((k) => k + 1);
+    } finally {
+      setGenerandoPlan(false);
+    }
+  };
 
   const reset = () => {
     form.reset(defaults);
-    setCargosAbiertos(null);
+    setCargosVenta(null);
     setComprobante(null);
     setRecibo(null);
     setReciboXml(null);
@@ -277,6 +316,15 @@ export function AbonoCaptureDrawer({
   };
 
   const handleSubmit = async (values: AbonoValues) => {
+    if (sinPlan) {
+      toast.add({
+        title: 'Genera el plan de pagos primero',
+        description:
+          'Esta venta no tiene cargos: el abono quedaría flotando sin aplicarse y sin avanzar la fase.',
+        type: 'error',
+      });
+      return;
+    }
     if (parsed && verif && !verif.receptorCoincide && !confirmaOtroReceptor) {
       toast.add({
         title: 'El recibo es de otro receptor',
@@ -416,7 +464,19 @@ export function AbonoCaptureDrawer({
       }
     }
 
-    toast.add({ title: 'Abono registrado', type: 'success' });
+    // Aviso fuerte si el abono quedó 100% sin aplicar (saldo a favor = monto):
+    // con el gate `sinPlan` activo esto solo ocurre con el plan ya saldado,
+    // pero el operador debe enterarse en vez de ver un "registrado" plano.
+    if (abonoQuedariaSinAplicar(cargosVenta ?? [], Number(values.monto))) {
+      toast.add({
+        title: 'Abono registrado, pero quedó sin aplicar',
+        description:
+          'No hay cargos abiertos que cubrir: el monto quedó como saldo a favor. Revisa el plan de pagos de la venta.',
+        type: 'warning',
+      });
+    } else {
+      toast.add({ title: 'Abono registrado', type: 'success' });
+    }
     reset();
     onOpenChange(false);
     onDone();
@@ -432,6 +492,32 @@ export function AbonoCaptureDrawer({
     >
       <DetailDrawerContent>
         <Form form={form} onSubmit={handleSubmit} className="space-y-5">
+          {sinPlan ? (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-400/50 bg-amber-50 p-3 text-xs text-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="space-y-2">
+                <p className="font-medium">Esta venta no tiene plan de pagos.</p>
+                <p>
+                  Sin cargos abiertos, el abono quedaría flotando sin aplicarse (saldo a favor) y no
+                  avanzaría la fase. Genera el plan de pagos antes de registrar abonos.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void handleGenerarPlanInline()}
+                  disabled={generandoPlan}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-amber-500/60 bg-amber-100 px-3 py-1.5 font-medium text-amber-900 hover:bg-amber-200 disabled:opacity-60 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/60"
+                >
+                  {generandoPlan ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Plus className="h-3.5 w-3.5" />
+                  )}
+                  {generandoPlan ? 'Generando…' : 'Generar plan de pagos'}
+                </button>
+              </div>
+            </div>
+          ) : null}
+
           <div>
             <span className="mb-1.5 block text-xs font-medium text-[var(--text)]">
               Recibo de caja (CFDI)
@@ -636,6 +722,7 @@ export function AbonoCaptureDrawer({
             submitLabel="Registrar abono"
             submittingLabel="Registrando..."
             submitIcon={<Plus className="h-4 w-4" />}
+            submitDisabled={sinPlan}
             onCancel={() => handleOpenChange(false)}
             stretch
           />

--- a/docs/planning/dilesa-ventas-expediente.md
+++ b/docs/planning/dilesa-ventas-expediente.md
@@ -7,7 +7,7 @@
 **Próximo hito:** — (cerrada: cutover Coda de ventas completado 2026-06-11 — paridad certificada, daily apagado, equipo de ventas con usuarios/perfiles activos. Coda queda read-only de consulta)
 **Dueño:** Beto
 **Creada:** 2026-06-09
-**Última actualización:** 2026-06-15 (follow-up: Saldo efectivo — el descuento autorizado y el cheque a notaría girado entran al saldo de la cuadratura; antes el saldo era ciego al descuento y un descuento perdonado se veía como deuda)
+**Última actualización:** 2026-06-17 (follow-up UX: el drawer de abono bloquea el registro cuando la venta no tiene plan de pagos y lo ofrece generar ahí mismo; aviso fuerte si un abono queda 100% sin aplicar; banner de saldo a favor en Estado de cuenta. Cierra el hueco que dejó depósitos flotando + duplicados en la venta Arizpe Luna)
 
 ## Problema
 
@@ -153,6 +153,30 @@ expediente, copiloto), no reescritura.
 
 ## Bitácora
 
+- **2026-06-17 (follow-up UX — abono sin plan de pagos):** Cerrado el hueco que
+  permitía registrar un abono en una venta **sin plan de pagos** (cero cargos en
+  `erp.cxc_cargos`): el FIFO de `erp.cxc_pago_registrar` no encontraba qué
+  cubrir y el abono quedaba 100% flotando (saldo a favor) sin avanzar la fase —
+  y se podía repetir, duplicando depósitos en silencio. Incidente real: venta de
+  **Luis Gerardo Arizpe Luna** — Cobranza capturó el depósito Infonavit dos veces
+  (16 y 17-jun, $908,999.71 c/u, fuente institución); ambos flotaron y la venta
+  se quedó clavada en **Fase 11** porque la detonación (F12) solo dispara al
+  insertar en `erp.cxc_pago_aplicaciones`, que sin cargos nunca ocurrió.
+  Corrección, todo en UI (sin tocar el RPC ni la DB): (1) el drawer de abono
+  bloquea el submit cuando la venta no tiene cargos y ofrece **generar el plan
+  ahí mismo** (`dilesa.fn_generar_plan_pagos`) — al generarlo antes de registrar,
+  el FIFO aplica y la detonación dispara normal; (2) aviso fuerte (toast) si un
+  abono recién registrado quedó 100% sin aplicar (plan ya saldado); (3) banner en
+  Estado de cuenta cuando hay saldo a favor, con texto distinto si la venta no
+  tiene plan. Helper puro `abonoQuedariaSinAplicar` + tests
+  (`lib/dilesa/cxc/fuente-abono.ts`). Archivos:
+  `components/dilesa/abono-capture-drawer.tsx`, `app/dilesa/ventas/[id]/page.tsx`.
+  Decisión: **NO** auto-generar el plan dentro de `cxc_pago_registrar` (opción 3
+  evaluada y descartada) — acoplar la originación del plan a un RPC financiero
+  SECURITY DEFINER esconde errores de datos (venta sin `valor_escrituracion`,
+  fecha de escritura nula) y genera cargos de forma implícita; el gate explícito
+  en UI mantiene al humano en el lazo y surfacea los errores del RPC. (PR
+  pendiente de merge.)
 - **2026-06-15 (follow-up financiero):** **Saldo efectivo** — el saldo de la
   cuadratura ahora considera el descuento autorizado y el cheque a notaría
   girado, no solo efectivo+crédito. Antes el saldo era ciego al descuento, así

--- a/lib/dilesa/cxc/fuente-abono.test.ts
+++ b/lib/dilesa/cxc/fuente-abono.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   abonoCubreMayormenteInstitucion,
+  abonoQuedariaSinAplicar,
   repartirAbonoFifo,
   sugerirFuenteAbono,
   type CargoAbiertoFuente,
@@ -74,5 +75,35 @@ describe('abonoCubreMayormenteInstitucion', () => {
   it('no avisa sin monto o sin cargos abiertos', () => {
     expect(abonoCubreMayormenteInstitucion(cargosDisposicionPendiente, 0)).toBe(false);
     expect(abonoCubreMayormenteInstitucion([], 100000)).toBe(false);
+  });
+});
+
+describe('abonoQuedariaSinAplicar', () => {
+  it('detecta el abono que flota 100% sin plan de pagos (incidente Arizpe Luna)', () => {
+    expect(abonoQuedariaSinAplicar([], 908999.71)).toBe(true);
+  });
+
+  it('detecta el abono que flota con el plan ya saldado (todos los cargos en 0)', () => {
+    expect(
+      abonoQuedariaSinAplicar(
+        [
+          { saldo: 0, fuente_esperada: 'cliente' },
+          { saldo: 0, fuente_esperada: 'institucion' },
+        ],
+        50000
+      )
+    ).toBe(true);
+  });
+
+  it('no marca cuando algún cargo abierto absorbe parte del abono', () => {
+    expect(abonoQuedariaSinAplicar(cargosDisposicionPendiente, 700000)).toBe(false);
+    // Excedente sobre un único cargo: aplica algo → no es flotación total.
+    expect(abonoQuedariaSinAplicar([{ saldo: 10000, fuente_esperada: 'cliente' }], 12500)).toBe(
+      false
+    );
+  });
+
+  it('no marca con monto no positivo', () => {
+    expect(abonoQuedariaSinAplicar([], 0)).toBe(false);
   });
 });

--- a/lib/dilesa/cxc/fuente-abono.ts
+++ b/lib/dilesa/cxc/fuente-abono.ts
@@ -60,3 +60,17 @@ export function abonoCubreMayormenteInstitucion(
   const r = repartirAbonoFifo(cargos, monto);
   return r.institucion > r.cliente;
 }
+
+/**
+ * ¿El abono quedaría 100% sin aplicar (saldo a favor = monto total)? Pasa
+ * cuando la venta no tiene ningún cargo abierto que el FIFO del RPC pueda
+ * cubrir: el dinero queda flotando sin bajar saldo y sin disparar el trigger
+ * de detonación de fase. El caso más común es una venta SIN plan de pagos
+ * (cero cargos), donde un abono se captura sin efecto y se puede duplicar en
+ * silencio (incidente Arizpe Luna 2026-06-17). Espejo del FIFO del RPC.
+ */
+export function abonoQuedariaSinAplicar(cargos: CargoAbiertoFuente[], monto: number): boolean {
+  if (!(monto > 0)) return false;
+  const r = repartirAbonoFifo(cargos, monto);
+  return r.cliente + r.institucion <= 0;
+}


### PR DESCRIPTION
## Problema

Registrar un abono en el Estado de cuenta de una venta DILESA **sin plan de pagos** (cero cargos en `erp.cxc_cargos`) dejaba el pago **100% flotando**: el FIFO de `erp.cxc_pago_registrar` no encontraba ningún cargo abierto, el dinero quedaba como saldo a favor **sin error ni aviso**, y se podía repetir → depósitos duplicados en silencio. Como la Fase 12 (Detonada) solo se cierra vía el trigger `dilesa.fn_detonar_venta_desde_cxc` (que dispara al insertar en `erp.cxc_pago_aplicaciones`), sin cargo no hay aplicación y la venta se queda clavada en Fase 11 con el dinero capturado.

**Incidente real:** venta de Luis Gerardo Arizpe Luna (`037b5538-…`) — Cobranza capturó el depósito Infonavit dos veces (16 y 17-jun, $908,999.71 c/u, fuente institución); ambos flotaron y la venta quedó en Fase 11. Ya se corrigió a mano; este PR previene reincidencia.

## Solución (100% en UI — sin tocar el RPC ni la DB)

1. **Bloqueo + generar plan inline** ([abono-capture-drawer.tsx](components/dilesa/abono-capture-drawer.tsx)): si la venta no tiene cargos, el drawer bloquea el submit (`submitDisabled` + guard en `handleSubmit`) y muestra un banner con botón **«Generar plan de pagos»** que llama `dilesa.fn_generar_plan_pagos`. Al generar el plan **antes** de registrar, el FIFO aplica y la detonación dispara normal.
2. **Aviso fuerte de flotación 100%**: tras registrar, si el abono quedó 100% sin aplicar (caso residual: plan ya saldado), toast `warning` en vez de un «registrado» plano.
3. **Banner en Estado de cuenta** ([page.tsx](app/dilesa/ventas/[id]/page.tsx)): cuando hay saldo a favor, banner ámbar; con texto distinto si la venta no tiene plan (surfacea el estado del incidente).
4. **Helper puro + tests**: `abonoQuedariaSinAplicar` en [fuente-abono.ts](lib/dilesa/cxc/fuente-abono.ts), espejo del FIFO del RPC.

## Opción 3 evaluada y descartada

Auto-generar el plan dentro de `cxc_pago_registrar`: acoplar la originación del plan a un RPC financiero SECURITY DEFINER esconde errores de datos (venta sin `valor_escrituracion`, fecha de escritura nula) y genera cargos de forma implícita. El gate explícito en UI mantiene al humano en el lazo y surfacea los errores del RPC.

## Verificación

Los 6 checks de CI corridos localmente: typecheck ✅ · test:coverage (1868 tests) ✅ · lint (0 errores) ✅ · format:check ✅ · initiatives:check ✅ · schema:check (vs prod, sin drift) ✅. 13 tests nuevos/actualizados en `fuente-abono.test.ts`.

Iniciativa: `dilesa-ventas-expediente` (bitácora actualizada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)