### PR TITLE
docs(ADR-045): incorpora decisiones de Beto (columnas nuevas + promoción del catálogo)

### DIFF
--- a/docs/adr/045_cuadratura_desglose_gastos_escrituracion.md
+++ b/docs/adr/045_cuadratura_desglose_gastos_escrituracion.md
@@ -12,7 +12,7 @@
 
 La cuadratura de una venta DILESA tiene que explicar cómo se paga el **presupuesto notarial** (gastos de escrituración). El modelo de Coda (validado contra el Excel maestro "Relación Gastos Escrituración y Participación Dilesa", hoja LDLE, 302 ventas, 2026-06-17) lo cubre con **cuatro fuentes**:
 
-1. **Promoción DILESA** (el "bono", 15,000 estándar) — descuento comercial que **le cuesta a DILESA**.
+1. **Promoción DILESA** (el "bono", 15,000 estándar) — beneficio comercial que **le cuesta a DILESA**.
 2. **Enganche del cliente** (depósitos).
 3. **Sobreprecio / productos adicionales** — inflado en el precio; **lo paga el crédito** de la institución (no le cuesta a DILESA).
 4. **Pagaré** — el residual que el cliente firma a pagar.
@@ -38,15 +38,15 @@ Presupuesto notarial             84,038
 
 Con el modelo viejo, para cuadrar había que inflar el "descuento" a 39,651 (15,000 + 24,651) — mezclando los dos conceptos. Con el modelo desglosado, el **descuento queda en 15,000** (solo la promoción) y el sobreprecio vive aparte.
 
-**Lo que ya existe y ayuda:** el jsonb `dilesa.ventas.desglose_precio` ya modela la cadena de precio cuando `componentes_detallados=true` (5 ventas nativas, origen `asignacion`): trae `valor_comercial`, `gastos_notariales_6pct`, `productos_adicionales`, `costo_credito_adicional`, `apoyo_infonavit`, `precio_venta_total`, etc. Las 626 ventas legacy (`backfill_contrato`) solo tienen `valor_comercial` + `precio_venta_total` (sub-pobladas).
+**Lo que ya existe:** el jsonb `dilesa.ventas.desglose_precio` modela la cadena de precio cuando `componentes_detallados=true` (5 ventas nativas, origen `asignacion`): trae `valor_comercial`, `gastos_notariales_6pct`, `productos_adicionales`, `costo_credito_adicional`, `apoyo_infonavit`, `precio_venta_total`. Las 626 ventas legacy (`backfill_contrato`) solo tienen `valor_comercial` + `precio_venta_total` (sub-pobladas). El módulo `dilesa.promociones` ya tiene la promo por prototipo (`productos_aplicables`, `monto`); hoy: "Bono de hasta $15,000 en gastos de escrituración".
 
 ## Decisión
 
-**D1 — Separar promoción de sobreprecio.** El `descuento_*` representa **solo descuentos comerciales** (incluida la promoción de gastos / bono). El **sobreprecio (productos adicionales) NO es descuento**: vive en el precio (`desglose_precio.productos_adicionales`) y lo paga el crédito. Dejar de sumarlos juntos.
+**D1 — Separar promoción, sobreprecio y descuento comercial.** Son tres conceptos distintos que hoy se mezclan: la **promoción** (bono, costo de DILESA), el **sobreprecio** (productos adicionales, lo paga el crédito) y el **descuento comercial** (rebaja real al precio, 0 en MAYRA). Cada uno con su campo propio; dejar de sumarlos en `descuento_total`.
 
-**D2 — Las 4 fuentes, cada una con su hogar de datos** (ver spec). El motor de cuadratura suma las cuatro para cubrir el cheque; el pagaré es el faltante.
+**D2 — Las 4 fuentes, cada una con su hogar de datos** (ver spec). El motor suma las cuatro para cubrir el cheque; el pagaré es el faltante.
 
-**D3 — La cadena de precio vive en `desglose_precio` jsonb** (enriquecerlo/poblarlo para legacy), no en columnas nuevas sueltas. Reconciliar el `valor_comercial` genérico del prototipo (920,000 para MAYRA) con el **precio base real** de la venta (899,000).
+**D3 — Columnas nuevas para el desglose operativo + `desglose_precio` jsonb como snapshot de auditoría** (decisión Beto 2026-06-17). Los componentes que el motor, la utilidad/participación y los reportes consultan van como **columnas** en `dilesa.ventas` (consultables, type-safe, con constraints): `precio_base`, `incremento_credito`, `sobreprecio_adicionales`, `promocion_gastos_monto`. El jsonb `desglose_precio` se conserva como el **snapshot completo del cálculo al asignar** (auditoría: zcu, esquina, metros excedentes, etc.). Todo se **congela al momento de asignar** — MAYRA se asignó en base 899,000 aunque el prototipo hoy esté en 920,000; el dato bueno es el de la asignación.
 
 **D4 — Fórmulas del motor (objetivo):**
 
@@ -59,39 +59,44 @@ cubierta            = promoción + enganche + sobreprecio + pagaré ≈ gastos_n
 
 **D5 — Diseño antes de código.** Este ADR se aprueba antes de tocar el motor (regla dura de Beto: nada financiero sin su OK).
 
+**D6 — La promoción de gastos viene del módulo `dilesa.promociones`** (decisión Beto 2026-06-17), no hardcodeada ni mezclada en `descuento`. Aplica por prototipo (`promociones.productos_aplicables`), vigente al asignar; el `monto` se **congela** en `ventas.promocion_gastos_monto` (vinculado por `promocion_id`, que ya existe). Puede variar por prototipo/temporada según el catálogo.
+
 ## Spec de campos
 
-| Concepto                                | Hogar de datos                                                            | Captura / Deriva                             | Estado hoy                                                            |
-| --------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------- |
-| Precio base asignación                  | `desglose_precio.valor_comercial` (reconciliar con base real de la venta) | capturado (asignación)                       | legacy trae el genérico del prototipo (920k), no el base real (899k)  |
-| Incremento crédito (+6% FOVISSSTE/IMSS) | `desglose_precio.gastos_notariales_6pct`                                  | derivado (pct catálogo × base)               | poblado solo en nativas                                               |
-| Sobreprecio / productos adicionales     | `desglose_precio.productos_adicionales`                                   | capturado                                    | 0 / no poblado en legacy ⚠️                                           |
-| Precio de escrituración                 | `ventas.valor_escrituracion` (= `desglose_precio.precio_venta_total`)     | derivado (suma de la cadena)                 | ✓ existe                                                              |
-| Apoyo Infonavit                         | `tipos_credito.apoyo_infonavit_monto`                                     | derivado (catálogo: 30k Infonavit / 0 resto) | ✓                                                                     |
-| Promoción / bono de gastos              | `ventas.descuento_gastos_escrituracion`                                   | capturado                                    | hoy mezcla promoción + sobreprecio ⚠️ → debe ser solo promoción (15k) |
-| Enganche aplicado a gastos              | `erp.cxc_pagos` (fuente cliente)                                          | capturado                                    | ✓ existe                                                              |
-| Pagaré                                  | `ventas.monto_credito_directo`                                            | capturado (= faltante)                       | ✓ existe                                                              |
-| Cheque a notaría                        | `ventas.monto_cheque_notaria`                                             | capturado (fase 11)                          | ✓ existe (= gastos − apoyo)                                           |
+| Concepto                                | Hogar de datos                                                             | Captura / Deriva                             | Estado hoy                                                                               |
+| --------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Precio base asignación                  | `ventas.precio_base` **(columna nueva)**, congelado al asignar             | capturado / snapshot                         | no existe; solo el genérico del prototipo (920k) en `desglose_precio.valor_comercial` ⚠️ |
+| Incremento crédito (+6% FOVISSSTE/IMSS) | `ventas.incremento_credito` **(columna nueva)**, congelado                 | derivado al asignar (pct catálogo × base)    | no existe como columna                                                                   |
+| Sobreprecio / productos adicionales     | `ventas.sobreprecio_adicionales` **(columna nueva)**                       | capturado al asignar                         | mezclado en `descuento` ⚠️                                                               |
+| Precio de escrituración                 | `ventas.valor_escrituracion`                                               | derivado (base + incremento + sobreprecio)   | ✓ existe                                                                                 |
+| Apoyo Infonavit                         | `tipos_credito.apoyo_infonavit_monto`                                      | derivado (catálogo: 30k Infonavit / 0 resto) | ✓                                                                                        |
+| Promoción / bono de gastos              | `ventas.promocion_gastos_monto` **(columna nueva)** ← `dilesa.promociones` | derivado del catálogo + congelado            | hoy en `descuento_gastos_escrituracion`, mezclado ⚠️ → migrar                            |
+| Descuento comercial al precio           | `ventas.descuento_total` (queda solo para esto)                            | capturado                                    | 0 en MAYRA                                                                               |
+| Enganche aplicado a gastos              | `erp.cxc_pagos` (fuente cliente)                                           | capturado                                    | ✓ existe                                                                                 |
+| Pagaré                                  | `ventas.monto_credito_directo`                                             | capturado (= faltante)                       | ✓ existe                                                                                 |
+| Cheque a notaría                        | `ventas.monto_cheque_notaria`                                              | capturado (fase 11)                          | ✓ existe (= gastos − apoyo)                                                              |
+| Snapshot del cálculo                    | `ventas.desglose_precio` (jsonb)                                           | snapshot al asignar (auditoría)              | ✓ existe — pasa a ser solo trazabilidad                                                  |
 
-El **panel de cuadratura** muestra dos bloques: "Formación del precio de escrituración" (la cadena) y "Cobertura del presupuesto notarial" (las 4 fuentes, cada una etiquetada por quién la paga: cliente / crédito / DILESA), más un resumen "quién financia los gastos" que separa el costo real de DILESA (solo la promoción) del pass-through del crédito.
+Constraint sugerido (trigger/app): `valor_escrituracion = precio_base + incremento_credito + sobreprecio_adicionales`. El **panel de cuadratura** muestra dos bloques — "Formación del precio de escrituración" (la cadena) y "Cobertura del presupuesto notarial" (las 4 fuentes etiquetadas por quién paga: cliente / crédito / DILESA) — más un resumen "quién financia los gastos" que separa el costo real de DILESA (solo la promoción) del pass-through del crédito.
 
 ## Migración de datos legacy
 
-1. **`descuento_gastos_escrituracion` = solo la promoción.** Para las ventas donde se mezcló (descuento > promoción estándar), separar: promoción = 15,000 (el bono estándar; confirmar caso por caso), el excedente → `productos_adicionales`.
-2. **Poblar `desglose_precio` detallado** en las 626 legacy: `productos_adicionales = valor_escrituracion − precio_interno` (donde se conozca el precio interno) y `valor_comercial` = base real (no el genérico del prototipo).
+1. **Separar el `descuento` mezclado:** la promoción (`promocion_gastos_monto`) sale del catálogo `dilesa.promociones` por prototipo (15,000 estándar); el excedente que estaba en `descuento_*` → `sobreprecio_adicionales`. `descuento_total` queda solo con descuento comercial real (típicamente 0).
+2. **Poblar las columnas nuevas** (`precio_base`, `incremento_credito`, `sobreprecio_adicionales`) en las legacy. El `precio_base` debe ser el **real al asignar**, no el genérico del prototipo — revisar cuántas legacy de Coda tienen el base desactualizado (deberían ser pocas; caso por caso con Beto).
 3. **Sin tocar el saldo de las que ya cuadran** sin verificación adversarial contra las ~230 escrituradas.
-4. Caso MAYRA: descuento se queda en **15,000** (la promoción, ya correcta — **no** subirlo a 39,651 como se había planteado con el modelo viejo); poblar `productos_adicionales = 24,651`; capturar pagaré 9,387 y cheque 84,038.
+4. **Caso MAYRA:** `precio_base` 899,000, `incremento_credito` 55,419, `sobreprecio_adicionales` 24,651, `promocion_gastos_monto` 15,000, `descuento_total` 0, pagaré 9,387, cheque 84,038. (El descuento **no** se sube a 39,651 — eso era el workaround del modelo viejo.)
 
 ## Alternativas consideradas
 
-- **Columnas nuevas sueltas** (`precio_base`, `incremento_credito`, …) en `ventas`: descartado — la cadena de precio ya tiene contenedor (`desglose_precio` jsonb) y `fn_calcular_precio_venta` ya produce esos componentes. Enriquecer el jsonb evita columnas redundantes.
-- **Tabla de cuadratura dedicada** (`dilesa.venta_cuadratura`): sobre-ingeniería para v1 — los campos caben en `ventas` + `desglose_precio` + `cxc_pagos`. Reconsiderar si el modelo crece.
+- **Todo en el jsonb `desglose_precio`** (sin columnas nuevas): descartado — el modelo financiero alimenta utilidad, cuadratura y reportes al Consejo; cavar en jsonb no es consultable ni type-safe ni admite constraints. El jsonb se conserva como snapshot de auditoría, no como fuente operativa.
+- **Tabla de cuadratura dedicada** (`dilesa.venta_cuadratura`): sobre-ingeniería para v1 — los campos caben en `ventas` + `cxc_pagos` + catálogo de promociones. Reconsiderar si el modelo crece.
 - **Mantener todo en `descuento`** (status quo): rechazado — es la causa de la utilidad subestimada.
 
 ## Consecuencias
 
 - **Utilidad/participación DILESA correcta:** ingreso = precio interno (954,419 en MAYRA), del que solo resta la promoción (15,000) + costo + comisiones; el sobreprecio deja de castigarla.
 - **El pagaré sale al monto real** (9,387 en MAYRA, no 34,038) porque el motor reconoce el sobreprecio como fuente.
-- **Migración delicada:** separar promoción/sobreprecio en el histórico requiere criterio y OK de Beto caso por caso.
+- **Migración delicada:** separar promoción/sobreprecio/descuento en el histórico requiere criterio y OK de Beto caso por caso.
 - **Toca superficies sensibles** (correo al Consejo, copiloto de cierre, nota de crédito, utilidad). Verificación adversarial contra las 230 escrituradas obligatoria antes de mergear el motor.
 - El `valor_facturado` y la nota de crédito (modelo total + NC, confirmado por Beto) no cambian su lógica; sí se corrige el `valorRealVentaDilesa` que hoy sale negativo.
+- **Captura nueva:** las nuevas asignaciones guardan todo el desglose congelado desde el inicio (cierra el gap que dejó MAYRA).


### PR DESCRIPTION
Corrige el ADR-045 mergeado en [#932](https://github.com/beto-sudo/BSOP/pull/932), que quedó con la versión inicial (D3 = jsonb) porque se mergeó mientras yo incorporaba tus respuestas.

Aplica tus 3 decisiones:
1. **Columnas nuevas** para el desglose operativo (`precio_base`, `incremento_credito`, `sobreprecio_adicionales`, `promocion_gastos_monto`) + `desglose_precio` jsonb como snapshot de auditoría. (D3)
2. **Promoción de gastos desde `dilesa.promociones`** (por prototipo), congelada al asignar; `descuento_*` solo para rebajas al precio. (D6)
3. **Precio base congelado al asignar** (MAYRA 899k, no el 920k actual del prototipo); migración revisa las legacy.

Spec de campos y Alternativas corregidas (columnas elegidas, jsonb-solo descartado). Solo docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)