### PR TITLE
feat(dilesa-cuadratura-sobreprecio): motor con modelo desglosado + fallback (Sprint 2b · ADR-045)

### DIFF
--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -395,4 +395,72 @@ describe('calcularCuadratura', () => {
       expect(c.cubierta).toBe(false); // pendiente a revisar
     });
   });
+
+  // ADR-045: modelo desglosado (venta nueva o en proceso). El "descuento" que
+  // reduce el saldo = promoción + sobreprecio; el desglose de cobertura de
+  // gastos sale en `coberturaGastos`. Caso MAYRA (FOVISSSTE, apoyo 0).
+  describe('modelo desglosado (ADR-045)', () => {
+    const mayra = (over = {}) =>
+      calcularCuadratura({
+        valorEscrituracion: 979070,
+        montoCreditoTitular: 979070,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 9387, // pagaré
+        montoChequeNotaria: 84038, // gastos completos (FOVISSSTE sin apoyo)
+        gastosEscrituracion: 84038,
+        apoyoInfonavit: 0,
+        precioBase: 899000,
+        incrementoCredito: 55419,
+        sobreprecioAdicionales: 24651,
+        promocionGastos: 15000,
+        depositos: [{ monto: 35000, directoCliente: true, tieneRecibo: true }],
+        proyectoNombre: 'Lomas de la Loma Este',
+        ...over,
+      });
+
+    it('MAYRA cuadra en 0 con el desglose (promoción + sobreprecio = descuento aplicado)', () => {
+      const c = mayra();
+      expect(c.tieneDesglose).toBe(true);
+      expect(c.descuentoAplicado).toBe(39651); // 15,000 promo + 24,651 sobreprecio
+      expect(c.montoDisponible).toBe(1023457); // 35,000 + 979,070 + 9,387
+      expect(c.saldoCobranza).toBe(-44387); // 979,070 − 1,023,457
+      expect(c.saldoCliente).toBe(0); // −44,387 − 39,651 + 84,038
+      expect(c.cubierta).toBe(true);
+    });
+
+    it('desglosa las 4 fuentes de cobertura de gastos', () => {
+      const c = mayra();
+      expect(c.coberturaGastos).toEqual({
+        gastosNetos: 84038,
+        apoyoInfonavit: 0,
+        promocion: 15000,
+        engancheCliente: 35000,
+        sobreprecio: 24651,
+        pagareNecesario: 9387, // 84,038 − 15,000 − 35,000 − 24,651
+      });
+    });
+
+    it('calcula el pagaré necesario aunque aún no se capture el crédito directo', () => {
+      // Antes de capturar el pagaré (CD=0) y el cheque: el faltante sigue siendo 9,387.
+      const c = mayra({ montoCreditoDirecto: 0, montoChequeNotaria: 0 });
+      expect(c.coberturaGastos?.pagareNecesario).toBe(9387);
+    });
+
+    it('FALLBACK: sin desglose, el mismo escenario usa descuento_total (idéntico al modelo viejo)', () => {
+      // Cerradas/legacy: sin promocionGastos/sobreprecioAdicionales, con el
+      // descuento mezclado en descuento_total. Debe dar el mismo saldo y NO
+      // exponer coberturaGastos.
+      const c = mayra({
+        promocionGastos: null,
+        sobreprecioAdicionales: null,
+        precioBase: null,
+        incrementoCredito: null,
+        descuentoOtorgadoTotal: 39651, // promoción + sobreprecio mezclados (modelo viejo)
+      });
+      expect(c.tieneDesglose).toBe(false);
+      expect(c.coberturaGastos).toBe(null);
+      expect(c.descuentoAplicado).toBe(39651);
+      expect(c.saldoCliente).toBe(0); // mismo resultado que el desglosado
+    });
+  });
 });

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -94,6 +94,18 @@ export type CuadraturaInput = {
   /** Para referencia (no entra al saldo). */
   precioAsignacion?: number | null;
   /**
+   * Desglose nuevo (ADR-045). Cuando vienen poblados (venta nueva o en proceso),
+   * el motor usa el MODELO DESGLOSADO: el "descuento" que cubre gastos =
+   * `promocionGastos` (bono, costo DILESA) + `sobreprecioAdicionales` (lo paga el
+   * crédito). Si son null/undefined (ventas cerradas/legacy), el motor cae al
+   * modelo viejo (`descuentoOtorgadoTotal` topado) — fallback que NO altera nada
+   * histórico. `precioBase`/`incrementoCredito` son para el panel de precio.
+   */
+  precioBase?: number | null;
+  incrementoCredito?: number | null;
+  sobreprecioAdicionales?: number | null;
+  promocionGastos?: number | null;
+  /**
    * Total del CFDI de la factura de ESCRITURACIÓN (Fase 13,
    * `dilesa.ventas.valor_facturado`) — la factura de la operación que coincide
    * con la escritura. El motor lo usa como el componente "factura de
@@ -147,6 +159,28 @@ export type Cuadratura = {
   descuentoReal: number;
   comisionVendedor: number;
   comisionGerencia: number;
+  /**
+   * ADR-045: true si la venta trae el desglose nuevo poblado (modelo
+   * desglosado). false ⇒ se usó el modelo viejo (fallback legacy/cerradas).
+   */
+  tieneDesglose: boolean;
+  /**
+   * Desglose de la cobertura del presupuesto notarial (las 4 fuentes), solo
+   * cuando `tieneDesglose`. `null` en ventas legacy/cerradas. Para el panel.
+   */
+  coberturaGastos: {
+    /** Gastos de escrituración netos del apoyo Infonavit (= cheque a notaría). */
+    gastosNetos: number;
+    apoyoInfonavit: number;
+    /** Promoción/bono de gastos (costo de DILESA). */
+    promocion: number;
+    /** Enganche/depósitos del cliente. */
+    engancheCliente: number;
+    /** Sobreprecio (productos adicionales) — lo paga el crédito. */
+    sobreprecio: number;
+    /** Pagaré necesario = faltante tras promoción + enganche + sobreprecio. */
+    pagareNecesario: number;
+  } | null;
   /**
    * Señal de doble conteo: depósitos fuente-cliente + crédito institución
    * exceden el valor de escrituración (+ gastos netos legítimos) por más del
@@ -213,12 +247,21 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   const saldoCobranza = round2(valorEscrituracion - montoDisponible);
 
   const descuentoOtorgadoTotal = n(i.descuentoOtorgadoTotal);
+  // ADR-045: con el desglose poblado (venta nueva o en proceso), el "descuento"
+  // que reduce el saldo = promoción (bono, costo DILESA) + sobreprecio (lo paga
+  // el crédito). Sin desglose (ventas cerradas/legacy) → modelo viejo:
+  // descuento_total topado al máximo autorizado. Fallback que NO altera nada
+  // histórico (los campos del desglose llegan null y el cálculo queda idéntico).
+  const tieneDesglose = i.promocionGastos != null || i.sobreprecioAdicionales != null;
+  const promocionGastos = n(i.promocionGastos);
+  const sobreprecioAdicionales = n(i.sobreprecioAdicionales);
   // Tope a lo autorizado desde el inicio: el saldo solo acredita el descuento
   // hasta el máximo CONFIABLE (promo de la solicitud). Sin tope confiable
   // (legacy) se aplica el otorgado completo. El exceso sobre el tope NO reduce
   // el saldo (queda como pendiente a revisar).
-  const descuentoAplicado =
-    i.descuentoMaximoAutorizado != null
+  const descuentoAplicado = tieneDesglose
+    ? round2(promocionGastos + sobreprecioAdicionales)
+    : i.descuentoMaximoAutorizado != null
       ? Math.min(descuentoOtorgadoTotal, Math.max(0, n(i.descuentoMaximoAutorizado)))
       : descuentoOtorgadoTotal;
   const gastosNetos = n(i.gastosEscrituracion) - n(i.apoyoInfonavit);
@@ -234,6 +277,29 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   // `chequePagado − excedenteDisponible`.
   const saldoCliente = round2(saldoCobranza - descuentoAplicado + chequePagado);
   const cubierta = saldoCliente <= TOLERANCIA_SALDO;
+
+  // ADR-045: desglose de las 4 fuentes que cubren el presupuesto notarial
+  // (gastos netos). Solo con desglose poblado; el pagaré es el faltante tras
+  // promoción + enganche del cliente + sobreprecio.
+  const gastosNetosR = round2(gastosNetos);
+  const pagareNecesario = tieneDesglose
+    ? round2(
+        Math.max(
+          0,
+          gastosNetosR - promocionGastos - depositosDirectoCliente - sobreprecioAdicionales
+        )
+      )
+    : 0;
+  const coberturaGastos = tieneDesglose
+    ? {
+        gastosNetos: gastosNetosR,
+        apoyoInfonavit: round2(n(i.apoyoInfonavit)),
+        promocion: round2(promocionGastos),
+        engancheCliente: round2(depositosDirectoCliente),
+        sobreprecio: round2(sobreprecioAdicionales),
+        pagareNecesario,
+      }
+    : null;
 
   // El crédito directo (pagaré) queda fuera: sus pagos sí son del cliente.
   const posibleDobleConteo =
@@ -297,6 +363,8 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     descuentoReal,
     comisionVendedor,
     comisionGerencia,
+    tieneDesglose,
+    coberturaGastos,
     posibleDobleConteo,
   };
 }


### PR DESCRIPTION
**Sprint 2, PR b/c** de `dilesa-cuadratura-sobreprecio` ([ADR-045](../adr/045_cuadratura_desglose_gastos_escrituracion.md)).

El motor `cuadratura.ts` reconoce el desglose nuevo cuando está poblado, y cae al modelo viejo cuando no (D7 fallback).

- **Inputs** nuevos opcionales: `precioBase`, `incrementoCredito`, `sobreprecioAdicionales`, `promocionGastos`. `tieneDesglose` = alguno poblado.
- **Saldo**: con desglose, el descuento que reduce el saldo = promoción + sobreprecio (separados); sin desglose, el `descuento_total` topado de siempre.
- **Salida** `coberturaGastos`: las 4 fuentes del presupuesto notarial + el pagaré necesario. `null` en legacy/cerradas.

## Verificación (lo que pide el ADR)
- **0 de 1312 ventas** tienen el desglose poblado hoy → todas usan el fallback → **comportamiento idéntico al actual**. Ningún histórico cambia.
- **26 tests** (4 nuevos): MAYRA cuadra en 0, las 4 fuentes, el pagaré necesario, y el fallback da exactamente lo mismo que el modelo viejo.
- typecheck ✅ · lint ✅ · format ✅ · 1872 tests ✅

El armado de inputs (`page.tsx`), el panel y la captura van en el PR c (siguiente). El motor solo no cambia nada visible hasta que se pueble el desglose por venta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)