### PR TITLE
docs(claude): norma anti-drift del ledger de migraciones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,41 @@ header — restaurar antes de mergear.
   `SUPABASE_DB_URL` está set. Drift entre `SCHEMA_REF.md` y la DB viva confunde
   a sesiones futuras.
 
+### Aplicar migración por MCP → registrar de una vez (anti-drift del ledger)
+
+> Norma 2026-06-17 (Beto): cortar de raíz el drift del historial de migraciones.
+
+`apply_migration` (MCP) / `execute_sql` / `psql` registran la migración en
+`supabase_migrations.schema_migrations` con el **timestamp de aplicación**, NO
+con el timestamp del nombre del archivo (`db:new`). El `name` sí se conserva.
+Cada aplicación así deja un par divergente: el archivo queda **local-only** (sin
+registrar) y la versión aplicada queda como **huérfano remoto**. Acumulado entre
+sesiones, esto **rompe `supabase db push`** ("Remote migration versions not found"
+/ re-aplica archivos) y puede tumbar el **Supabase Preview branch** de todos los
+PRs.
+
+**Regla:** cuando apliques a prod por fuera de `supabase db push`, **reconciliá
+el ledger en la misma sesión**, apenas apliques:
+
+1. Lee el timestamp huérfano que generó el MCP (matchea por `name`):
+   `SELECT version, name FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 5;`
+2. Reconciliá (solo toca la tabla de tracking, no el schema ni datos):
+   ```bash
+   supabase migration repair --db-url "$SUPABASE_DB_URL" --status applied <ts-archivo>
+   supabase migration repair --db-url "$SUPABASE_DB_URL" --status reverted <ts-huérfano-MCP>
+   ```
+3. Verificá 1:1: `supabase migration list --db-url "$SUPABASE_DB_URL"` sin
+   local-only ni remote-only.
+
+**Diagnóstico de drift acumulado:** `migration list` muestra los pares (file-ts
+en una columna, huérfano-ts en la otra); emparejá por **`name`** (el timestamp
+difiere, el name no). **Antes** de registrar un `--status applied`, verificá que
+el efecto del archivo YA esté en prod (tabla/columna/función/trigger/índice/dato
+existe — SELECT de introspección). **Límite del CLI:** `migration repair` se
+atraganta con muchas versiones en un solo comando → **lotes de ≤5**. Es cambio en
+prod (tracking compartido) → **OK verbal de Beto**. Detalle operativo y casos
+borde en la memoria `reference_bsop_merge_flow_multisesion`.
+
 ### Liberación de módulo nuevo (RBAC sync) — ADR-014
 
 Al liberar un módulo (page nuevo bajo `app/<empresa>/` con URL en sidebar, o


### PR DESCRIPTION
## Qué

Establece en `CLAUDE.md` (§ Reglas DB) la norma para cortar de raíz el drift recurrente del historial de migraciones, que ha roto CI/`db push` en sesiones pasadas.

**Causa:** `apply_migration` (MCP) / `execute_sql` / `psql` registran la migración en `supabase_migrations.schema_migrations` con el **timestamp de aplicación**, no con el del archivo `db:new`. Cada aplicación así deja un par divergente (archivo *local-only* + huérfano remoto). Acumulado entre sesiones → rompe `supabase db push` y el Supabase Preview branch de todos los PRs.

**Norma:** tras aplicar a prod por fuera de `db push`, reconciliar el ledger **en la misma sesión**:
1. Leer el huérfano que generó el MCP (matchear por `name`).
2. `supabase migration repair --status applied <ts-archivo>` + `--status reverted <ts-huérfano>`.
3. Verificar 1:1 con `migration list`.

Con gotchas: verificar que el efecto ya esté en prod antes de `--status applied`, y **lotes de ≤5** (el CLI se atraganta con muchas versiones).

## Contexto

Hoy se curó el drift acumulado del 13–17 jun: **21 pares** reconciliados (3 + 18), cada uno con verificación **archivo-por-archivo** de que su efecto ya estaba en prod (introspección read-only vía 2 workflows de 18+9 agentes). Ledger final: **0 local-only, 0 remote-only**. Detalle operativo en la memoria `reference_bsop_merge_flow_multisesion`.

Docs-only. Sin cambios de código/schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)