### PR TITLE
feat(dilesa-ventas): Escrituración (F11) — fecha en blanco + número de escritura obligatorio

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx
@@ -72,9 +72,9 @@ function CapturarFase11Body() {
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
 
   const [numeroEscritura, setNumeroEscritura] = useState<string>('');
-  const [fechaEscritura, setFechaEscritura] = useState<string>(
-    new Date().toISOString().slice(0, 10)
-  );
+  // En blanco a propósito: la fecha de escritura debe seleccionarse a mano
+  // (no asumir "hoy") para que sea la fecha real del instrumento.
+  const [fechaEscritura, setFechaEscritura] = useState<string>('');
   const [numeroCheque, setNumeroCheque] = useState<string>('');
   const [montoCheque, setMontoCheque] = useState<string>('');
 
@@ -191,6 +191,14 @@ function CapturarFase11Body() {
         });
         return;
       }
+      if (!numeroEscritura.trim()) {
+        toast.add({
+          title: 'Falta el número de escritura',
+          description: 'Captura el número de instrumento público del notario.',
+          type: 'error',
+        });
+        return;
+      }
       if (!numeroCheque.trim()) {
         toast.add({
           title: 'Falta el número de cheque',
@@ -219,7 +227,7 @@ function CapturarFase11Body() {
         faseposicion: 11,
         docs: [],
         camposVenta: {
-          numero_escritura: numeroEscritura.trim() || null,
+          numero_escritura: numeroEscritura.trim(),
           fecha_escritura: fechaEscritura,
           numero_cheque_notaria: numeroCheque.trim(),
           monto_cheque_notaria: monto,
@@ -271,13 +279,20 @@ function CapturarFase11Body() {
         });
         return;
       }
+      if (!numeroEscritura.trim()) {
+        toast.add({
+          title: 'Falta el número de escritura',
+          type: 'error',
+        });
+        return;
+      }
       setSubmitting(true);
       const { error: upErr } = await sb
         .schema('dilesa')
         .from('ventas')
         .update({
           fecha_escritura: fechaEscritura,
-          numero_escritura: numeroEscritura.trim() || null,
+          numero_escritura: numeroEscritura.trim(),
         })
         .eq('id', venta.id);
       setSubmitting(false);
@@ -355,10 +370,11 @@ function CapturarFase11Body() {
                     required
                   />
                 </Field>
-                <Field label="Número de instrumento público (escritura)">
+                <Field label="Número de instrumento público (escritura) *">
                   <Input
                     value={numeroEscritura}
                     onChange={(e) => setNumeroEscritura(e.target.value)}
+                    required
                     placeholder="Número que asigna el notario, ej. 206"
                   />
                   <Hint>
@@ -412,10 +428,11 @@ function CapturarFase11Body() {
                   required
                 />
               </Field>
-              <Field label="Número de instrumento público (escritura)">
+              <Field label="Número de instrumento público (escritura) *">
                 <Input
                   value={numeroEscritura}
                   onChange={(e) => setNumeroEscritura(e.target.value)}
+                  required
                   placeholder="Número que asigna el notario, ej. 206"
                 />
                 <Hint>


### PR DESCRIPTION
## Qué cambia

En la captura de la **Fase 11 — Escriturada** de ventas DILESA ([app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx](app/dilesa/ventas/%5Bid%5D/capturar/11-escriturada/page.tsx)):

1. **Fecha de escritura en blanco por default.** Antes se prellenaba con la fecha de hoy (`new Date()`), lo que arriesgaba registrar una fecha que no es la real del instrumento. Ahora arranca vacía y obliga a seleccionarla a mano (sigue siendo obligatoria para guardar).
2. **Número de escritura ahora obligatorio.** Pasa de opcional (`|| null`) a requerido para poder avanzar de fase. Aplica también al modo corrección post-cierre (mismo campo, para no permitir borrarlo después).
3. Número de cheque y monto de cheque ya eran obligatorios — sin cambio.

## Alcance

- Solo validación de captura (UI: `required` en inputs + chequeo en `onSubmit` con toast claro).
- **No** se toca el schema: `dilesa.ventas.numero_escritura` sigue `nullable` para no romper ventas migradas con folio interno vacío.

## Verificación

- typecheck ✓ · lint ✓ (0 errores) · format ✓ · test:coverage ✓ (1879 tests)

Lo dejo **sin auto-merge** por ser cambio de UI — revisa el Vercel Preview y mergea cuando quede.

🤖 Generated with [Claude Code](https://claude.com/claude-code)