### PR TITLE
feat(dilesa-cuadratura): la asignación persiste el desglose escalar (la raíz)

### DIFF
--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -610,6 +610,21 @@ function NuevaSolicitudForm() {
           // La promo elegida define el Descuento Máximo Autorizado de la
           // cuadratura (promociones.monto) — FK, ya no texto en notas.
           promocion_id: promocionId || null,
+          // Desglose escalar (ADR-045 + geometría 20260618): lo que LEE el motor
+          // de cuadratura. La venta nace poblada desde el mismo
+          // `fn_calcular_precio_venta`, así usa el modelo desglosado desde la
+          // asignación y NO necesita backfill (el `desglose_precio` jsonb de
+          // arriba es el snapshot para el PDF/detalle; estos escalares son los
+          // que consume `lib/dilesa/cuadratura.ts`). precio_base = valor
+          // comercial; la geometría y el +6% en sus columnas; la promoción = el
+          // bono de la promo elegida (0 si no hay).
+          precio_base: calculo?.valor_comercial ?? null,
+          incremento_credito: calculo?.costo_credito_adicional ?? null,
+          valor_excedente_terreno: calculo?.valor_excedente_terreno ?? null,
+          valor_frente_verde: calculo?.valor_frente_verde ?? null,
+          valor_esquina: calculo?.valor_esquina ?? null,
+          valor_venta_futuro: calculo?.valor_venta_futuro ?? null,
+          promocion_gastos_monto: promociones.find((p) => p.id === promocionId)?.monto ?? 0,
         })
         .select('id')
         .single();


### PR DESCRIPTION
**La raíz** del flujo: que las ventas nuevas nazcan con el desglose poblado y no necesiten backfill.

## El gap
La asignación (`nueva/page.tsx`) ya congelaba el `desglose_precio` (jsonb, PR #900) — por eso parecía listo. Pero el motor de cuadratura nuevo lee las **columnas escalares** (`precio_base`, `incremento_credito`, `valor_excedente_terreno/frente_verde/esquina/venta_futuro`, `promocion_gastos_monto`), que el insert **no escribía**. Una venta nueva quedaba sin ellas → `tieneDesglose=false` → modelo legacy.

## El fix
El insert ahora persiste esos escalares desde el mismo `fn_calcular_precio_venta` que ya se computa: `precio_base` = valor comercial, incremento = costo del crédito (+6%), la geometría en sus columnas, y `promocion_gastos_monto` = el bono de la promo elegida. La venta usa el modelo desglosado desde la asignación.

Sin cambio visual (es lógica de persistencia). Para verificar: asignar una venta de prueba y abrir su Cuadratura — debe salir desglosada, no legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)