### PR TITLE
feat(dilesa-ventas): botón "Capturar siguiente fase" en la cabecera del expediente

### DIFF
--- a/components/dilesa/venta-detalle/boton-siguiente-fase.tsx
+++ b/components/dilesa/venta-detalle/boton-siguiente-fase.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+/**
+ * Botón "Capturar siguiente fase" — atajo de la cabecera del expediente de
+ * venta (Zona A) directo a la captura de la fase inmediata capturable.
+ *
+ * Reusa `pipelineRows` del provider (sin queries nuevas): la fase siguiente es
+ * la primera con `puedeCapturar` (previa cerrada, no alcanzada, venta no
+ * desasignada). El botón se oculta cuando:
+ *   - no hay fase capturable (venta desasignada, fase 17 ya cerrada, hueco), o
+ *   - el usuario no tiene write sobre el módulo de esa fase
+ *     (`CAPTURA_MODULO_BY_POSICION`) — paridad con el `<RequireAccess>` de la
+ *     página de captura, para no ofrecer un atajo que aterrice en un bloqueo.
+ *
+ * Diseño (opción C): botón apilado de 2 líneas — "Siguiente fase" + "N · Nombre"
+ * — compacto y robusto a nombres largos.
+ */
+
+import Link from 'next/link';
+import { ArrowRight, Pencil } from 'lucide-react';
+import { usePermissions } from '@/components/providers';
+import { useVentaDetalle } from './provider';
+import { CAPTURA_MODULO_BY_POSICION } from './types';
+
+export function BotonSiguienteFase() {
+  const { venta, pipelineRows } = useVentaDetalle();
+  const { permissions } = usePermissions();
+
+  if (!venta) return null;
+
+  const siguiente = pipelineRows.find((r) => r.puedeCapturar && r.slugCaptura);
+  if (!siguiente?.slugCaptura) return null;
+
+  const modulo = CAPTURA_MODULO_BY_POSICION[siguiente.pos];
+  const permitido =
+    permissions.isAdmin || (!!modulo && permissions.modulos.get(modulo)?.write === true);
+  if (!permitido) return null;
+
+  return (
+    <Link
+      href={`/dilesa/ventas/${venta.id}/capturar/${siguiente.slugCaptura}`}
+      className="inline-flex items-center gap-2 rounded-md bg-[var(--accent)] px-3 py-1.5 text-white transition-colors hover:bg-[var(--accent)]/90"
+      title={`Capturar la fase ${siguiente.pos} · ${siguiente.nombre}`}
+    >
+      <Pencil className="size-4 shrink-0" aria-hidden />
+      <span className="flex flex-col text-left leading-tight">
+        <span className="text-[10px] font-normal opacity-80">Siguiente fase</span>
+        <span className="text-sm font-medium">
+          {siguiente.pos} · {siguiente.nombre}
+        </span>
+      </span>
+      <ArrowRight className="size-4 shrink-0" aria-hidden />
+    </Link>
+  );
+}

--- a/components/dilesa/venta-detalle/shell.tsx
+++ b/components/dilesa/venta-detalle/shell.tsx
@@ -23,6 +23,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useVentaDetalle } from './provider';
 import { BackLink, HoldBanner } from './ui';
 import { VentaExpedienteTabs } from './tabs';
+import { BotonSiguienteFase } from './boton-siguiente-fase';
 import { FASES_ORDEN } from './types';
 
 export function VentaExpedienteShell({ children }: { children: ReactNode }) {
@@ -108,25 +109,29 @@ export function VentaExpedienteShell({ children }: { children: ReactNode }) {
             </p>
           ) : null}
         </div>
-        <div className="flex flex-wrap items-center gap-1.5">
-          {/* Si la venta está desasignada, NO mostramos el badge de fase — evita
-              el efecto contradictorio "2. Asignada · Desasignada". */}
-          {venta.fase_actual && venta.estado !== 'desasignada' ? (
-            <Badge tone="neutral">
-              {venta.fase_posicion ? `${venta.fase_posicion}. ` : ''}
-              {venta.fase_actual}
+        <div className="flex flex-col items-end gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-1.5">
+            {/* Si la venta está desasignada, NO mostramos el badge de fase — evita
+                el efecto contradictorio "2. Asignada · Desasignada". */}
+            {venta.fase_actual && venta.estado !== 'desasignada' ? (
+              <Badge tone="neutral">
+                {venta.fase_posicion ? `${venta.fase_posicion}. ` : ''}
+                {venta.fase_actual}
+              </Badge>
+            ) : null}
+            <Badge
+              tone={
+                VENTA_ESTADO_CONFIG[venta.estado as keyof typeof VENTA_ESTADO_CONFIG]?.tone ??
+                'neutral'
+              }
+            >
+              {VENTA_ESTADO_CONFIG[venta.estado as keyof typeof VENTA_ESTADO_CONFIG]?.label ??
+                venta.estado}
             </Badge>
-          ) : null}
-          <Badge
-            tone={
-              VENTA_ESTADO_CONFIG[venta.estado as keyof typeof VENTA_ESTADO_CONFIG]?.tone ??
-              'neutral'
-            }
-          >
-            {VENTA_ESTADO_CONFIG[venta.estado as keyof typeof VENTA_ESTADO_CONFIG]?.label ??
-              venta.estado}
-          </Badge>
-          {venta.tipo_credito ? <Badge tone="neutral">{venta.tipo_credito}</Badge> : null}
+            {venta.tipo_credito ? <Badge tone="neutral">{venta.tipo_credito}</Badge> : null}
+          </div>
+          {/* Atajo a la captura de la fase siguiente (si el usuario tiene permiso). */}
+          <BotonSiguienteFase />
         </div>
       </header>
 

--- a/components/dilesa/venta-detalle/types.ts
+++ b/components/dilesa/venta-detalle/types.ts
@@ -201,6 +201,36 @@ export const CAPTURAR_SLUG_BY_POSICION: Record<number, string> = {
 };
 
 /**
+ * Módulo de permiso (write) que gobierna la captura de cada fase — fuente de
+ * verdad: el `<RequireAccess modulo=… write>` de cada
+ * `app/dilesa/ventas/[id]/capturar/<slug>/page.tsx`. Se centraliza aquí para
+ * que el botón "Capturar siguiente fase" (cabecera del expediente) pueda
+ * ocultarse cuando el usuario no tiene el permiso de esa fase, sin navegar
+ * hasta el gate de la página. Mantener en sync con esas páginas.
+ *
+ * Nota: la Fase 2 (Asignada) se gobierna con `dilesa.ventas.autorizar` (la
+ * autorización de Dirección), no con un `faseNN_*`.
+ */
+export const CAPTURA_MODULO_BY_POSICION: Record<number, string> = {
+  2: 'dilesa.ventas.autorizar',
+  3: 'dilesa.ventas.fase03_formalizada',
+  4: 'dilesa.ventas.fase04_solicitud_avaluo',
+  5: 'dilesa.ventas.fase05_avaluo_cerrado',
+  6: 'dilesa.ventas.fase06_inscrita',
+  7: 'dilesa.ventas.fase07_solicitud_dictamen',
+  8: 'dilesa.ventas.fase08_dictaminada',
+  9: 'dilesa.ventas.fase09_validacion_patronal',
+  10: 'dilesa.ventas.fase10_firmas_programadas',
+  11: 'dilesa.ventas.fase11_escriturada',
+  12: 'dilesa.ventas.fase12_detonada',
+  13: 'dilesa.ventas.fase13_facturada',
+  14: 'dilesa.ventas.fase14_preparada_entrega',
+  15: 'dilesa.ventas.fase15_entregada',
+  16: 'dilesa.ventas.fase16_conformidad',
+  17: 'dilesa.ventas.fase17_operacion_terminada',
+};
+
+/**
  * Gate de apertura por fase cuando NO es la inmediata anterior. Beto
  * (2026-06-10): la preparación de entrega (14) arranca desde que se registra
  * la escritura (11) — no espera Detonada (12) ni Facturada (13).


### PR DESCRIPTION
## Qué agrega

Un botón en la **esquina superior derecha** del expediente de venta (debajo de los badges de estado) que lleva **directo a capturar la fase que sigue**.

Diseño = **opción C** del mock (botón apilado de 2 líneas: "Siguiente fase" + "N · Nombre") — compacto y robusto a nombres de fase largos.

## Cómo

- **Sin queries nuevas**: reusa `pipelineRows` del `VentaDetalleProvider`. La fase siguiente = la primera con `puedeCapturar` (fase previa cerrada, no alcanzada, venta no desasignada) — el mismo criterio del botón "Capturar fase" del tab Pipeline.
- **Gate de permiso**: el botón solo aparece si el usuario tiene `write` sobre el módulo de esa fase (`CAPTURA_MODULO_BY_POSICION`, nuevo mapa junto a `CAPTURAR_SLUG_BY_POSICION` en `types.ts`). Es paridad con el `<RequireAccess>` de cada página de captura — no se ofrece un atajo que aterrice en un bloqueo. (Fase 2 → `dilesa.ventas.autorizar`, no `faseNN_*`.)
- **Se oculta** cuando no hay fase capturable (venta desasignada, fase 17 ya cerrada) o sin permiso → la cabecera queda como hoy.
- Estilo accent sólido (`bg-[var(--accent)]`), consistente con los CTAs de juntas/wizard.

**Sin migración** (puro UI).

## Verificación
6 checks locales verdes: `typecheck`, `test:coverage` (141 archivos, 1891 tests), `lint` (0 errores), `format:check`, `initiatives:check`. `schema:check` N/A (cero DB).

> ⚠️ **UI visible — sin auto-merge.** Beto: revisa el Vercel Preview (entra a una venta; el botón sale arriba-derecha apuntando a la fase siguiente) y mergea si te cuadra.