### PR TITLE
feat(dilesa-cuadratura): captura del sobreprecio para gastos en la asignación (PR 2)

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -106,7 +106,7 @@ export async function GET(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, precio_asignacion, desglose_precio, created_at, ine_numero, estado, valuador_id, notario_id, es_pep, ocupacion, forma_pago, uso_efectivo, conocimiento_dueno_beneficiario, fecha_firma_programada, fase_posicion, fecha_escritura'
+      'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, sobreprecio_gastos_escrituracion, precio_asignacion, desglose_precio, created_at, ine_numero, estado, valuador_id, notario_id, es_pep, ocupacion, forma_pago, uso_efectivo, conocimiento_dueno_beneficiario, fecha_firma_programada, fase_posicion, fecha_escritura'
     )
     .eq('id', id)
     .is('deleted_at', null)
@@ -857,6 +857,9 @@ export async function GET(
     valorVentaFuturo: Number(c?.valor_venta_futuro ?? 0),
     costoCreditoAdicional: Number(c?.costo_credito_adicional ?? 0),
     productosAdicionales: Number(c?.productos_adicionales ?? venta.productos_adicionales ?? 0),
+    sobreprecioGastos: Number(
+      c?.sobreprecio_gastos_escrituracion ?? venta.sobreprecio_gastos_escrituracion ?? 0
+    ),
     precioVenta: Number(c?.precio_venta_total ?? venta.precio_asignacion ?? 0),
     enganche1pct: Number(c?.enganche_1pct ?? 0),
     isai2pct: Number(c?.isai_2pct ?? 0),

--- a/app/dilesa/ventas/[id]/page.tsx
+++ b/app/dilesa/ventas/[id]/page.tsx
@@ -180,6 +180,10 @@ function OperacionBody() {
                     value: fmtMoney(calculo.productos_adicionales) ?? '—',
                   },
                   {
+                    label: 'Sobreprecio gastos escrituración',
+                    value: fmtMoney(calculo.sobreprecio_gastos_escrituracion) ?? '—',
+                  },
+                  {
                     label: 'Precio de venta total',
                     value: fmtMoney(calculo.precio_venta_total) ?? '—',
                   },

--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -89,6 +89,7 @@ type CalculoPrecio = {
   costo_credito_adicional: number;
   zcu_exento?: boolean;
   productos_adicionales: number;
+  sobreprecio_gastos_escrituracion: number;
   precio_venta_total: number;
   apoyo_infonavit: number;
   monto_credito_titular: number;
@@ -145,10 +146,16 @@ function NuevaSolicitudForm() {
   const [promocionId, setPromocionId] = useState<string>('');
   const [montoCreditoTitular, setMontoCreditoTitular] = useState<string>('');
   const [montoCreditoCotitular, setMontoCreditoCotitular] = useState<string>('');
-  // Productos adicionales (paridad Coda): monto $ de extras del paquete que no
-  // están en `dilesa.productos` (closets, upgrades, mejoras puntuales). Se
-  // suma al precio total en `fn_calcular_precio_venta`. 0 si no hay.
+  // Productos adicionales: extras REALES del paquete que se le venden al cliente
+  // (closets, upgrades, mejoras puntuales). Suma al precio total y SÍ comisionan.
+  // 0 si no hay.
   const [productosAdicionales, setProductosAdicionales] = useState<string>('');
+  // Sobreprecio para gastos de escrituración: sube el precio para que el CRÉDITO
+  // absorba los gastos que el cliente no alcanza (cuando el crédito supera el valor
+  // de venta). Suma al precio pero NO comisiona. En blanco por defecto — el vendedor
+  // lo captura solo si hace falta (guía "hasta $X" = margen del crédito). Separado de
+  // productos_adicionales por ADR-045 D9.
+  const [sobreprecioGastos, setSobreprecioGastos] = useState<string>('');
   // La fecha + hora de la solicitud la setea el servidor al guardar (now()).
   // Importante para orden FIFO en Fase 2 cuando hay inventario limitado.
 
@@ -361,6 +368,7 @@ function NuevaSolicitudForm() {
         p_monto_credito_titular: Number(montoCreditoTitular) || 0,
         p_monto_credito_cotitular: Number(montoCreditoCotitular) || 0,
         p_productos_adicionales: Number(productosAdicionales) || 0,
+        p_sobreprecio_gastos_escrituracion: Number(sobreprecioGastos) || 0,
       });
       if (!active) return;
       if (error) {
@@ -380,7 +388,19 @@ function NuevaSolicitudForm() {
     montoCreditoTitular,
     montoCreditoCotitular,
     productosAdicionales,
+    sobreprecioGastos,
   ]);
+
+  // Margen del crédito disponible para el sobreprecio: lo que el crédito supera al
+  // precio SIN sobreprecio. Es la guía "hasta $X" del campo — pasarse de aquí dejaría
+  // un faltante que el crédito ya no cubre. 0 ⇒ el crédito no supera el valor de venta.
+  const margenSobreprecio = useMemo(() => {
+    if (!calculo || calculo.error) return 0;
+    const credito = (Number(montoCreditoTitular) || 0) + (Number(montoCreditoCotitular) || 0);
+    const precioSinSobreprecio =
+      calculo.precio_venta_total - (calculo.sobreprecio_gastos_escrituracion ?? 0);
+    return Math.max(0, credito - precioSinSobreprecio);
+  }, [calculo, montoCreditoTitular, montoCreditoCotitular]);
 
   // ── Proyectos con unidades disponibles + unidades del proyecto elegido ────
   const proyectosConUnidades = useMemo(() => {
@@ -605,6 +625,7 @@ function NuevaSolicitudForm() {
           monto_credito_titular: Number(montoCreditoTitular) || null,
           monto_credito_cotitular: Number(montoCreditoCotitular) || null,
           productos_adicionales: Number(productosAdicionales) || 0,
+          sobreprecio_gastos_escrituracion: Number(sobreprecioGastos) || 0,
           enganche_requerido: calculo?.enganche_1pct ?? null,
           gastos_escrituracion: calculo?.gastos_notariales_6pct ?? null,
           // La promo elegida define el Descuento Máximo Autorizado de la
@@ -1041,14 +1062,29 @@ function NuevaSolicitudForm() {
               required
             />
           </Field>
-          <Field label="Productos adicionales *">
+          <Field label="Productos adicionales">
             <Input
               type="number"
               value={productosAdicionales}
               onChange={(e) => setProductosAdicionales(e.target.value)}
-              placeholder="0 si no hay productos adicionales"
-              required
+              placeholder="0 — closets, upgrades, mejoras"
             />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Extras reales que se le venden al cliente. <strong>Sí comisionan.</strong>
+            </p>
+          </Field>
+          <Field label="Sobreprecio para gastos de escrituración">
+            <Input
+              type="number"
+              value={sobreprecioGastos}
+              onChange={(e) => setSobreprecioGastos(e.target.value)}
+              placeholder="0 — solo si el crédito alcanza"
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              {margenSobreprecio > 0
+                ? `Hasta ${money(margenSobreprecio)} del crédito para cubrir gastos que el cliente no alcanza. No comisiona.`
+                : 'Se llena solo si el crédito supera el valor de venta. No comisiona.'}
+            </p>
           </Field>
         </div>
       </Section>
@@ -1082,6 +1118,10 @@ function NuevaSolicitudForm() {
               value={money(calculo.costo_credito_adicional)}
             />
             <Row label="Productos adicionales" value={money(calculo.productos_adicionales ?? 0)} />
+            <Row
+              label="Sobreprecio gastos esc."
+              value={money(calculo.sobreprecio_gastos_escrituracion ?? 0)}
+            />
             <Row label="Precio de venta" value={money(calculo.precio_venta_total)} highlight />
             <Row label="Apoyo Infonavit" value={`− ${money(calculo.apoyo_infonavit)}`} />
             <Row label="Pago directo cliente" value={money(calculo.pago_directo)} highlight />

--- a/lib/dilesa/desglose-precio.ts
+++ b/lib/dilesa/desglose-precio.ts
@@ -16,6 +16,7 @@ export type DesglosePrecio = {
   costo_credito_adicional: number;
   zcu_exento?: boolean;
   productos_adicionales: number;
+  sobreprecio_gastos_escrituracion: number;
   precio_venta_total: number;
   apoyo_infonavit: number;
   pago_directo: number;

--- a/lib/dilesa/pdf/solicitud-asignacion.tsx
+++ b/lib/dilesa/pdf/solicitud-asignacion.tsx
@@ -40,7 +40,8 @@ export type SolicitudData = {
   valorEsquina: number;
   valorVentaFuturo: number;
   costoCreditoAdicional: number; // IMSS/Fovissste etc.
-  productosAdicionales: number; // monto $ extras declarados por vendedor (paridad Coda)
+  productosAdicionales: number; // productos reales del paquete (closets/upgrades); comisionan
+  sobreprecioGastos: number; // sobreprecio para gastos de escrituración (lo absorbe el crédito; no comisiona)
   // precio + cargos
   precioVenta: number;
   enganche1pct: number;
@@ -111,6 +112,7 @@ export function SolicitudAsignacionPDF({ data }: { data: SolicitudData }) {
         <DataRow label="VALOR VENTA FUTURO:" value={money(data.valorVentaFuturo)} />
         <DataRow label="IMSS/FOVISSSTE:" value={money(data.costoCreditoAdicional)} />
         <DataRow label="PRODUCTOS ADICIONALES:" value={money(data.productosAdicionales)} />
+        <DataRow label="SOBREPRECIO GASTOS ESC.:" value={money(data.sobreprecioGastos)} />
 
         <View style={styles.divider} />
 

--- a/scripts/dilesa-pdf-preview.tsx
+++ b/scripts/dilesa-pdf-preview.tsx
@@ -34,6 +34,7 @@ const solicitudData = {
   valorVentaFuturo: 992200,
   costoCreditoAdicional: 12000,
   productosAdicionales: 0,
+  sobreprecioGastos: 0,
   precioVenta: 1004200,
   enganche1pct: 10042,
   isai2pct: 20084,


### PR DESCRIPTION
## Qué

PR 2 del sprint **sobreprecio dividido**. La pantalla de **Solicitud de Asignación** ahora separa dos renglones (antes uno solo revolvía ambos):

- **Productos adicionales** — extras reales del paquete (closets, upgrades). *Comisionan.*
- **Sobreprecio para gastos de escrituración** (nuevo) — sube el precio para que el **crédito** absorba los gastos que el cliente no alcanza. *No comisiona.*

El sobreprecio va **en blanco** por defecto, con guía **"hasta $X"** = margen del crédito sobre el valor de venta (el vendedor lo captura solo si hace falta; nunca automático).

## Dónde se ve

- **Captura** (`nueva/page.tsx`): los dos campos con sus notas (qué comisiona, la guía del margen) + ambos en el preview "Cálculo de precio".
- **Detalle** de la venta (`[id]/page.tsx`): renglón del sobreprecio en el desglose.
- **PDF de solicitud** (`solicitud-asignacion.tsx`): renglón "SOBREPRECIO GASTOS ESC." (el documento que se firma queda coherente).

## Backend (ya en prod, [#991](https://github.com/beto-sudo/BSOP/pull/991))

La columna, el backfill y el motor ya están. Este PR es la **UI de captura** que faltaba. `fn_calcular_precio_venta` ya recibe el parámetro (suma al precio).

## Verificación

typecheck + lint + format + 1978 tests verdes.

## Nota

**Sin auto-merge** — es UI: déjenme ver el Preview de Vercel antes de mergear. Cuando lo apruebes, lo mergeo y te paso la explicación al equipo afinada a la pantalla real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)