### PR TITLE
feat(dilesa-cuadratura): UI de re-firma de documentos (PR B)

### DIFF
--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -106,7 +106,7 @@ export async function GET(
     .schema('dilesa')
     .from('ventas')
     .select(
-      'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, sobreprecio_gastos_escrituracion, precio_asignacion, desglose_precio, created_at, ine_numero, estado, valuador_id, notario_id, es_pep, ocupacion, forma_pago, uso_efectivo, conocimiento_dueno_beneficiario, fecha_firma_programada, fase_posicion, fecha_escritura'
+      'id, empresa_id, persona_id, unidad_id, vendedor_usuario_id, tipo_credito, vendedor, monto_credito_titular, monto_credito_cotitular, productos_adicionales, sobreprecio_gastos_escrituracion, precio_asignacion, valor_escrituracion, precio_documentos_firmados, desglose_precio, created_at, ine_numero, estado, valuador_id, notario_id, es_pep, ocupacion, forma_pago, uso_efectivo, conocimiento_dueno_beneficiario, fecha_firma_programada, fase_posicion, fecha_escritura'
     )
     .eq('id', id)
     .is('deleted_at', null)
@@ -697,9 +697,17 @@ export async function GET(
     // créditos (que omite enganche, gastos notariales y pago directo).
     // Usamos `precio_asignacion` (snapshot persistido del cálculo) y
     // fallback a la suma de créditos solo si no está disponible.
-    const precio =
+    const precioBaseProm =
       Number(venta.precio_asignacion ?? 0) ||
       Number(venta.monto_credito_titular ?? 0) + Number(venta.monto_credito_cotitular ?? 0);
+    // Opción A (ADR-048 D5): la promesa re-firmada sale con el valor dictaminado
+    // cuando difiere del que tienen los documentos firmados vigentes.
+    const precio =
+      venta.valor_escrituracion != null &&
+      venta.precio_documentos_firmados != null &&
+      Math.abs(Number(venta.valor_escrituracion) - Number(venta.precio_documentos_firmados)) > 0.5
+        ? Number(venta.valor_escrituracion)
+        : precioBaseProm;
     const arras1pct = Math.round(precio * 0.01);
     const arras10pct = Math.round(precio * 0.1);
     const modeloSufijo = productoFull?.nombre ? (productoFull.nombre.split('-').pop() ?? '') : '';
@@ -847,6 +855,17 @@ export async function GET(
     .join('');
   const folio = `${iniciales}-${identificacionInventario}-${fechaCreado.toLocaleString('es-MX', { timeZone: 'America/Matamoros' })}`;
 
+  // Opción A (ADR-048 D5): si el precio dictaminado difiere del que tienen los
+  // documentos firmados vigentes, el PDF re-firmado sale con el valor dictaminado
+  // (sin tocar el precio congelado). Si no, usa el congelado del snapshot.
+  const precioCongelado = Number(c?.precio_venta_total ?? venta.precio_asignacion ?? 0);
+  const precioVigente =
+    venta.valor_escrituracion != null &&
+    venta.precio_documentos_firmados != null &&
+    Math.abs(Number(venta.valor_escrituracion) - Number(venta.precio_documentos_firmados)) > 0.5
+      ? Number(venta.valor_escrituracion)
+      : precioCongelado;
+
   const data: SolicitudData = {
     fechaTexto,
     asesorVentas: vendedorNombre.toUpperCase(),
@@ -860,7 +879,7 @@ export async function GET(
     sobreprecioGastos: Number(
       c?.sobreprecio_gastos_escrituracion ?? venta.sobreprecio_gastos_escrituracion ?? 0
     ),
-    precioVenta: Number(c?.precio_venta_total ?? venta.precio_asignacion ?? 0),
+    precioVenta: precioVigente,
     enganche1pct: Number(c?.enganche_1pct ?? 0),
     isai2pct: Number(c?.isai_2pct ?? 0),
     gastosNotariales6pct: Number(c?.gastos_notariales_6pct ?? 0),
@@ -871,12 +890,12 @@ export async function GET(
     pagoDirecto:
       typeof c?.pago_directo === 'number'
         ? Number(c.pago_directo) + Number(c.apoyo_infonavit ?? 0)
-        : Number(c?.precio_venta_total ?? venta.precio_asignacion ?? 0) -
+        : precioVigente -
           Number(venta.monto_credito_titular ?? 0) -
           Number(venta.monto_credito_cotitular ?? 0),
     montoCreditoTitular: Number(venta.monto_credito_titular ?? 0),
     montoCreditoCotitular: Number(venta.monto_credito_cotitular ?? 0),
-    totalPagosDisponibles: Number(c?.precio_venta_total ?? venta.precio_asignacion ?? 0),
+    totalPagosDisponibles: precioVigente,
     clienteNombre: `${clienteNombre} (${identificacionInventario})`,
     folio,
     fraccionamiento: '',

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -55,6 +55,7 @@ type VentaCtx = {
   persona_id: string;
   unidad_id: string | null;
   notario_id: string | null;
+  tipo_credito: string | null;
   credito_titular_ref: string | null;
   credito_cotitular_ref: string | null;
   monto_credito_titular: number | null;
@@ -306,7 +307,7 @@ function CapturarFase8Body() {
         .schema('dilesa')
         .from('ventas')
         .select(
-          'id, empresa_id, persona_id, unidad_id, notario_id, credito_titular_ref, credito_cotitular_ref, monto_credito_titular, monto_credito_cotitular, gastos_escrituracion, valor_escrituracion, precio_asignacion, precio_documentos_firmados, monto_credito_directo, cd_plan_pagos, cd_tiie28_pct, cd_spread_ordinario_pct, cd_fecha_suscripcion, cd_aval_nombre, cd_aval_domicilio'
+          'id, empresa_id, persona_id, unidad_id, notario_id, tipo_credito, credito_titular_ref, credito_cotitular_ref, monto_credito_titular, monto_credito_cotitular, gastos_escrituracion, valor_escrituracion, precio_asignacion, precio_documentos_firmados, monto_credito_directo, cd_plan_pagos, cd_tiie28_pct, cd_spread_ordinario_pct, cd_fecha_suscripcion, cd_aval_nombre, cd_aval_domicilio'
         )
         .eq('id', ventaId)
         .is('deleted_at', null)
@@ -431,6 +432,19 @@ function CapturarFase8Body() {
         toast.add({
           title: 'Falta la Carta de Instrucción',
           description: 'Sube el PDF entregado por el notario (o pídele que lo suba por su enlace).',
+          type: 'error',
+        });
+        return;
+      }
+      // Anexo B (Condiciones Financieras) obligatorio en créditos Infonavit
+      // (Beto 2026-06-23). De aquí en adelante; las ya cerradas se quedan.
+      const esInfonavit = (venta.tipo_credito ?? '').toLowerCase().includes('infonavit');
+      const condicionesSubida = adjuntosNotariales.some((a) => a.rol === 'condiciones_financieras');
+      if (esInfonavit && !archivoCondiciones && !condicionesSubida) {
+        toast.add({
+          title: 'Falta el Anexo B',
+          description:
+            'Las Condiciones Financieras (Anexo B) son obligatorias en créditos Infonavit.',
           type: 'error',
         });
         return;
@@ -731,6 +745,8 @@ function CapturarFase8Body() {
   const precioDocs = venta?.precio_documentos_firmados ?? null;
   const precioCambio =
     valorEscrNum > 0 && precioDocs != null && Math.abs(valorEscrNum - precioDocs) > 0.5;
+  // Anexo B obligatorio en créditos Infonavit (Beto 2026-06-23, de aquí en adelante).
+  const esInfonavitVenta = (venta?.tipo_credito ?? '').toLowerCase().includes('infonavit');
 
   if (loading) {
     return (
@@ -1016,7 +1032,11 @@ function CapturarFase8Body() {
                 }}
               />
               <FileSlot
-                label="Condiciones Financieras Definitivas — Anexo B (opcional)"
+                label={
+                  esInfonavitVenta
+                    ? 'Condiciones Financieras Definitivas — Anexo B *'
+                    : 'Condiciones Financieras Definitivas — Anexo B (opcional)'
+                }
                 archivo={archivoCondiciones}
                 onChange={(f) => {
                   setArchivoCondiciones(f);

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -61,6 +61,10 @@ type VentaCtx = {
   monto_credito_cotitular: number | null;
   gastos_escrituracion: number | null;
   valor_escrituracion: number | null;
+  // Re-firma de documentos (ADR-048 D5): si el precio dictaminado difiere del que
+  // tienen los documentos firmados vigentes, hay que re-firmar Solicitud + Promesa.
+  precio_asignacion: number | null;
+  precio_documentos_firmados: number | null;
   // Crédito directo (pagaré) — se captura aquí desde el rediseño ADR-048.
   monto_credito_directo: number | null;
   cd_plan_pagos: PlanPagoJson[] | null;
@@ -133,6 +137,11 @@ function CapturarFase8Body() {
   // El crédito directo (pagaré) reporta su estado "guardado" para el gate del
   // cierre de la fase cuando hay saldo.
   const [cdGuardado, setCdGuardado] = useState(false);
+  // Re-firma de documentos (ADR-048 D5): los 2 PDF firmados que sube el gerente
+  // cuando el precio dictaminado cambió respecto al de los documentos firmados.
+  const [archivoSolicitudRef, setArchivoSolicitudRef] = useState<File | null>(null);
+  const [archivoPromesaRef, setArchivoPromesaRef] = useState<File | null>(null);
+  const [confirmandoRefirma, setConfirmandoRefirma] = useState(false);
   const [notarioNombre, setNotarioNombre] = useState<string | null>(null);
   const [fase7Cerrada, setFase7Cerrada] = useState<boolean | null>(null);
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
@@ -297,7 +306,7 @@ function CapturarFase8Body() {
         .schema('dilesa')
         .from('ventas')
         .select(
-          'id, empresa_id, persona_id, unidad_id, notario_id, credito_titular_ref, credito_cotitular_ref, monto_credito_titular, monto_credito_cotitular, gastos_escrituracion, valor_escrituracion, monto_credito_directo, cd_plan_pagos, cd_tiie28_pct, cd_spread_ordinario_pct, cd_fecha_suscripcion, cd_aval_nombre, cd_aval_domicilio'
+          'id, empresa_id, persona_id, unidad_id, notario_id, credito_titular_ref, credito_cotitular_ref, monto_credito_titular, monto_credito_cotitular, gastos_escrituracion, valor_escrituracion, precio_asignacion, precio_documentos_firmados, monto_credito_directo, cd_plan_pagos, cd_tiie28_pct, cd_spread_ordinario_pct, cd_fecha_suscripcion, cd_aval_nombre, cd_aval_domicilio'
         )
         .eq('id', ventaId)
         .is('deleted_at', null)
@@ -395,6 +404,22 @@ function CapturarFase8Body() {
           title: 'Falta configurar el crédito directo',
           description:
             'Hay un saldo por cubrir. Guarda el crédito directo (pagaré) antes de cerrar la fase.',
+          type: 'error',
+        });
+        return;
+      }
+      // Re-firma pendiente (ADR-048 D5): si el precio dictaminado difiere del de los
+      // documentos firmados, no se avanza hasta re-firmar Solicitud + Promesa.
+      const valorN = Number(valorEscrituracion) || 0;
+      if (
+        venta.precio_documentos_firmados != null &&
+        valorN > 0 &&
+        Math.abs(valorN - venta.precio_documentos_firmados) > 0.5
+      ) {
+        toast.add({
+          title: 'Re-firma de documentos pendiente',
+          description:
+            'El precio cambió: re-firma la Solicitud y la Promesa con el precio nuevo antes de avanzar.',
           type: 'error',
         });
         return;
@@ -582,6 +607,112 @@ function CapturarFase8Body() {
     ]
   );
 
+  // Re-firma de documentos (ADR-048 D5): sube los 2 documentos firmados nuevos,
+  // marca los anteriores como sustituidos (no se borran — auditoría LFPIORPI) y
+  // actualiza el snapshot al precio dictaminado para que no se vuelva a pedir.
+  const confirmarRefirma = useCallback(async () => {
+    if (!venta) return;
+    const valorNum = Number(valorEscrituracion) || 0;
+    if (valorNum <= 0) return;
+    if (!archivoSolicitudRef || !archivoPromesaRef) {
+      toast.add({
+        title: 'Faltan los documentos firmados',
+        description: 'Sube la Solicitud de Asignación y la Promesa de Compraventa firmadas.',
+        type: 'error',
+      });
+      return;
+    }
+    setConfirmandoRefirma(true);
+    const { data: userRes } = await sb.auth.getUser();
+    const userId = userRes?.user?.id ?? null;
+
+    // 1. Documentos vigentes (no sustituidos) de estos 2 roles = los que se reemplazan.
+    const { data: vigentes } = await sb
+      .schema('erp')
+      .from('adjuntos')
+      .select('id')
+      .eq('entidad_tipo', 'venta')
+      .eq('entidad_id', venta.id)
+      .in('rol', ['solicitud_asignacion', 'contrato_promesa'])
+      .is('sustituido_at', null);
+    const idsViejos = (vigentes ?? []).map((a) => a.id as string);
+
+    // 2. Subir los 2 documentos nuevos.
+    const subir = async (archivo: File, rol: string): Promise<boolean> => {
+      const path = buildAdjuntoPath({
+        empresa: 'dilesa',
+        entidad: 'ventas',
+        entidadId: venta.id,
+        filename: archivo.name,
+      });
+      const { error: upErr } = await sb.storage
+        .from('adjuntos')
+        .upload(path, archivo, { contentType: archivo.type || 'application/pdf', upsert: false });
+      if (upErr) return false;
+      const { error: insErr } = await sb
+        .schema('erp')
+        .from('adjuntos')
+        .insert({
+          empresa_id: DILESA_EMPRESA_ID,
+          entidad_tipo: 'venta',
+          entidad_id: venta.id,
+          rol,
+          nombre: archivo.name,
+          url: path,
+          tipo_mime: archivo.type || null,
+          tamano_bytes: archivo.size,
+          uploaded_by: userId,
+        });
+      return !insErr;
+    };
+    const okS = await subir(archivoSolicitudRef, 'solicitud_asignacion');
+    const okP = await subir(archivoPromesaRef, 'contrato_promesa');
+    if (!okS || !okP) {
+      setConfirmandoRefirma(false);
+      toast.add({
+        title: 'No se pudieron subir los documentos',
+        description: 'Intenta de nuevo.',
+        type: 'error',
+      });
+      return;
+    }
+
+    // 3. Marcar los anteriores como sustituidos (siguen en el expediente).
+    if (idsViejos.length > 0) {
+      await sb
+        .schema('erp')
+        .from('adjuntos')
+        .update({ sustituido_at: new Date().toISOString() })
+        .in('id', idsViejos);
+    }
+
+    // 4. Snapshot = precio dictaminado (cierra la re-firma) + persiste el valor.
+    const { error: upVErr } = await sb
+      .schema('dilesa')
+      .from('ventas')
+      .update({ precio_documentos_firmados: valorNum, valor_escrituracion: valorNum })
+      .eq('id', venta.id);
+    setConfirmandoRefirma(false);
+    if (upVErr) {
+      toast.add({
+        title: 'No se pudo cerrar la re-firma',
+        description: getSupabaseErrorMessage(upVErr, 'Error desconocido.'),
+        type: 'error',
+      });
+      return;
+    }
+    setVenta((v) =>
+      v ? { ...v, precio_documentos_firmados: valorNum, valor_escrituracion: valorNum } : v
+    );
+    setArchivoSolicitudRef(null);
+    setArchivoPromesaRef(null);
+    toast.add({
+      title: 'Re-firma confirmada',
+      description: 'Documentos actualizados con el precio nuevo. Ya puedes avanzar la fase.',
+      type: 'success',
+    });
+  }, [archivoPromesaRef, archivoSolicitudRef, sb, toast, valorEscrituracion, venta]);
+
   // Gate de Dirección (ADR-048): solo Dirección (o admin) cuadra y cierra la
   // fase. Gerencia sube el dictamen + pre-llena, pero el cierre lo hace Dirección.
   const esDireccion =
@@ -592,6 +723,14 @@ function CapturarFase8Body() {
   const cobGastos = cuadratura?.coberturaGastos ?? null;
   const saldoCD = cobGastos ? cobGastos.pagareNecesario : 0;
   const aplicaCD = saldoCD > 0.0049;
+
+  // Re-firma de documentos (ADR-048 D5): el precio dictaminado capturado difiere
+  // del que tienen los documentos firmados vigentes → hay que re-firmar Solicitud
+  // + Promesa antes de avanzar. El snapshot se actualiza al confirmar la re-firma.
+  const valorEscrNum = Number(valorEscrituracion) || 0;
+  const precioDocs = venta?.precio_documentos_firmados ?? null;
+  const precioCambio =
+    valorEscrNum > 0 && precioDocs != null && Math.abs(valorEscrNum - precioDocs) > 0.5;
 
   if (loading) {
     return (
@@ -613,6 +752,73 @@ function CapturarFase8Body() {
       </div>
     );
   }
+
+  // Re-firma de documentos (ADR-048 D5): solo cuando el precio dictaminado difiere
+  // del de los documentos firmados. Se reusa en ambos forms (cierre y "ya cerrada").
+  const refirmaSection = precioCambio ? (
+    <Section title="Re-firma de documentos requerida">
+      <div className="mb-3 rounded-md border border-amber-400/40 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+        El precio cambió de <strong>{money(precioDocs ?? 0)}</strong> a{' '}
+        <strong>{money(valorEscrNum)}</strong>. La Solicitud de Asignación y la Promesa de
+        Compraventa firmadas quedaron desactualizadas — re-fírmalas con el precio nuevo antes de
+        avanzar la fase.
+      </div>
+      <div className="mb-4 flex flex-wrap gap-2">
+        <a
+          href={`/api/dilesa/ventas/${venta.id}/pdf/solicitud-asignacion`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-xs font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40"
+        >
+          <Upload className="h-3.5 w-3.5" /> Imprimir Solicitud (precio nuevo)
+        </a>
+        <a
+          href={`/api/dilesa/ventas/${venta.id}/pdf/promesa-compraventa`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-xs font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40"
+        >
+          <Upload className="h-3.5 w-3.5" /> Imprimir Promesa (precio nuevo)
+        </a>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <FileSlot
+          label="Solicitud de Asignación firmada *"
+          archivo={archivoSolicitudRef}
+          onChange={setArchivoSolicitudRef}
+        />
+        <FileSlot
+          label="Promesa de Compraventa firmada *"
+          archivo={archivoPromesaRef}
+          onChange={setArchivoPromesaRef}
+        />
+      </div>
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          onClick={confirmarRefirma}
+          disabled={
+            confirmandoRefirma || !esDireccion || !archivoSolicitudRef || !archivoPromesaRef
+          }
+        >
+          {confirmandoRefirma ? (
+            <>
+              <Loader2 className="mr-2 size-4 animate-spin" /> Confirmando…
+            </>
+          ) : (
+            <>
+              <Save className="mr-2 size-4" /> Confirmar re-firma
+            </>
+          )}
+        </Button>
+        {!esDireccion ? (
+          <span className="text-xs text-amber-700 dark:text-amber-300">
+            Solo Dirección confirma la re-firma.
+          </span>
+        ) : null}
+      </div>
+    </Section>
+  ) : null;
 
   return (
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
@@ -743,6 +949,8 @@ function CapturarFase8Body() {
                 />
               </Section>
             ) : null}
+
+            {refirmaSection}
 
             <div className="flex items-center justify-end gap-3">
               {!esDireccion ? (
@@ -941,6 +1149,8 @@ function CapturarFase8Body() {
               />
             </Section>
           ) : null}
+
+          {refirmaSection}
 
           <div className="flex items-center justify-end gap-3">
             {!esDireccion ? (


### PR DESCRIPTION
## Qué (PR B UI — cierra el sprint [ADR-048](docs/adr/048_cierre_financiero_dictaminacion.md))

Cuando Dirección dictamina un **precio distinto** al que tienen los documentos firmados, la fase 8 exige re-firmar la Solicitud de Asignación y la Promesa de Compraventa.

- **Detección:** `valor_escrituracion ≠ precio_documentos_firmados` (el snapshot, no el congelado → sin bucle).
- **Sección de re-firma:** aviso (precio pasó de X a Y) + imprimir Solicitud/Promesa **con el precio nuevo** + subir los 2 firmados + **Confirmar re-firma**.
- **Confirmar:** marca los documentos anteriores como `sustituido_at` (no se borran — auditoría) y actualiza el snapshot al precio nuevo (cierra la re-firma).
- **Bloqueo:** no se avanza/cierra la fase hasta resolver la re-firma. Solo **Dirección** confirma.
- **PDF Opción A:** Solicitud y Promesa salen con `valor_escrituracion` cuando difiere del congelado, **sin tocar** el precio congelado.

## Verificación

typecheck + lint + tests del motor verdes. **Sin auto-merge** — es UI; revisa el Preview con una venta de cambio de precio. Universo hoy: 3 ventas (M10-L8, M10-L29, M3-L6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)