### PR TITLE
fix(dilesa-ventas): domicilio por blob + backfill INE — el gate KYC ya no marca al 99%

### DIFF
--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -265,7 +265,7 @@ function NuevaSolicitudForm() {
         .schema('erp')
         .from('personas')
         .select(
-          'id, nombre, apellido_paterno, apellido_materno, curp, rfc, numero_credencial_ine, telefono, email, fecha_nacimiento, nss, domicilio_calle, domicilio_numero_exterior, domicilio_numero_interior, domicilio_colonia, domicilio_codigo_postal, domicilio_ciudad, domicilio_estado, tipo_persona, nacionalidad, estado_civil, ocupacion, es_pep, forma_pago_kyc, uso_efectivo_kyc, conocimiento_dueno_beneficiario'
+          'id, nombre, apellido_paterno, apellido_materno, curp, rfc, numero_credencial_ine, telefono, email, fecha_nacimiento, nss, domicilio, domicilio_calle, domicilio_numero_exterior, domicilio_numero_interior, domicilio_colonia, domicilio_codigo_postal, domicilio_ciudad, domicilio_estado, tipo_persona, nacionalidad, estado_civil, ocupacion, es_pep, forma_pago_kyc, uso_efectivo_kyc, conocimiento_dueno_beneficiario'
         )
         .eq('empresa_id', DILESA_EMPRESA_ID)
         .eq('tipo', 'cliente')
@@ -398,6 +398,10 @@ function NuevaSolicitudForm() {
       fecha_nacimiento: fechaNacimiento,
       nss,
       numero_credencial_ine: numeroCredencialIne,
+      // Blob de domicilio: lo arrastra la persona seleccionada (el form solo
+      // edita los campos estructurados). Permite que el gate considere el
+      // domicilio completo aunque solo exista el blob de Coda.
+      domicilio: personaSeleccionadaInfo?.domicilio ?? null,
       domicilio_calle: domCalle,
       domicilio_numero_exterior: domNumExt,
       domicilio_numero_interior: domNumInt,
@@ -440,6 +444,7 @@ function NuevaSolicitudForm() {
       formaPagoKyc,
       usoEfectivoKyc,
       conocimientoDuenoBeneficiario,
+      personaSeleccionadaInfo,
     ]
   );
 

--- a/lib/dilesa/kyc-persona.test.ts
+++ b/lib/dilesa/kyc-persona.test.ts
@@ -19,6 +19,7 @@ function personaCompleta(over: Partial<PersonaKycSnapshot> = {}): PersonaKycSnap
     fecha_nacimiento: '1999-10-18',
     nss: '31149920329',
     numero_credencial_ine: '1659206621',
+    domicilio: null,
     domicilio_calle: 'HUITRON',
     domicilio_numero_exterior: 'S/N',
     domicilio_numero_interior: null,
@@ -72,6 +73,7 @@ describe('camposKycFaltantes', () => {
       fecha_nacimiento: null,
       nss: null,
       numero_credencial_ine: null,
+      domicilio: null,
       domicilio_calle: null,
       domicilio_numero_exterior: null,
       domicilio_numero_interior: null,
@@ -88,7 +90,8 @@ describe('camposKycFaltantes', () => {
       uso_efectivo_kyc: null,
       conocimiento_dueno_beneficiario: null,
     };
-    expect(camposKycFaltantes(vacia)).toHaveLength(19);
+    // 13 escalares obligatorios + 1 "Domicilio".
+    expect(camposKycFaltantes(vacia)).toHaveLength(14);
   });
 
   it('apellido_materno y número interior son opcionales (no bloquean)', () => {
@@ -97,6 +100,38 @@ describe('camposKycFaltantes', () => {
         personaCompleta({ apellido_materno: null, domicilio_numero_interior: null })
       )
     ).toEqual([]);
+  });
+
+  it('domicilio por blob de Coda cuenta como completo (sin estructurado)', () => {
+    expect(
+      camposKycFaltantes(
+        personaCompleta({
+          domicilio: 'HUITRON SIN NUMERO, EJIDO HUITRON, GOMEZ PALACIO, DURANGO, CP 35117',
+          domicilio_calle: null,
+          domicilio_numero_exterior: null,
+          domicilio_colonia: null,
+          domicilio_codigo_postal: null,
+          domicilio_ciudad: null,
+          domicilio_estado: null,
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it('sin domicilio alguno (ni blob ni estructurado) → "Domicilio" faltante', () => {
+    expect(
+      camposKycFaltantes(
+        personaCompleta({
+          domicilio: null,
+          domicilio_calle: null,
+          domicilio_numero_exterior: null,
+          domicilio_colonia: null,
+          domicilio_codigo_postal: null,
+          domicilio_ciudad: null,
+          domicilio_estado: null,
+        })
+      )
+    ).toEqual(['Domicilio']);
   });
 
   it('campos con default (tipo_persona, nacionalidad, es_pep, conocimiento) no bloquean', () => {

--- a/lib/dilesa/kyc-persona.ts
+++ b/lib/dilesa/kyc-persona.ts
@@ -13,6 +13,8 @@
  * la persona) y se testean aquí de forma pura.
  */
 
+import { domicilioTexto } from './kyc-efectivo';
+
 /** Subconjunto de columnas de `erp.personas` que toca la captura de venta. */
 export type PersonaKycSnapshot = {
   nombre: string | null;
@@ -25,6 +27,9 @@ export type PersonaKycSnapshot = {
   fecha_nacimiento: string | null;
   nss: string | null;
   numero_credencial_ine: string | null;
+  // Domicilio: blob histórico de Coda (`domicilio`) y/o campos estructurados.
+  // La completitud lo considera satisfecho si existe CUALQUIERA (ver abajo).
+  domicilio: string | null;
   domicilio_calle: string | null;
   domicilio_numero_exterior: string | null;
   domicilio_numero_interior: string | null;
@@ -43,14 +48,16 @@ export type PersonaKycSnapshot = {
 };
 
 /**
- * Campos obligatorios para arrancar una venta — espejo de `obligatoriosTexto`
- * del alta de cliente nuevo. Quedan FUERA a propósito:
- *   - `apellido_materno` y `domicilio_numero_interior`: legítimamente opcionales
- *     (hay personas con un solo apellido / domicilios sin número interior).
+ * Campos obligatorios (escalares) para arrancar una venta. El domicilio NO va
+ * aquí: se valida aparte porque se considera completo si existe el blob
+ * histórico de Coda (`domicilio`) O los campos estructurados — la mayoría de
+ * clientes migrados traen la dirección como blob y forzar re-capturar lo que
+ * ya tenemos sería ruido. Quedan FUERA a propósito:
+ *   - `apellido_materno` y `domicilio_numero_interior`: legítimamente opcionales.
  *   - `tipo_persona`, `nacionalidad`, `es_pep`, `conocimiento_dueno_beneficiario`:
  *     tienen default sensato (fisica / Mexicana / false / 'No'), nunca quedan
  *     "vacíos".
- * Si cambia la lista del alta, actualizar ambos lados.
+ * Si cambia la lista del alta de cliente nuevo, actualizar aquí también.
  */
 export const CAMPOS_KYC_OBLIGATORIOS: { col: keyof PersonaKycSnapshot; label: string }[] = [
   { col: 'nombre', label: 'Nombre' },
@@ -62,12 +69,6 @@ export const CAMPOS_KYC_OBLIGATORIOS: { col: keyof PersonaKycSnapshot; label: st
   { col: 'fecha_nacimiento', label: 'Fecha de nacimiento' },
   { col: 'nss', label: 'NSS' },
   { col: 'numero_credencial_ine', label: 'Número de credencial INE' },
-  { col: 'domicilio_calle', label: 'Calle' },
-  { col: 'domicilio_numero_exterior', label: 'Número exterior' },
-  { col: 'domicilio_colonia', label: 'Colonia' },
-  { col: 'domicilio_codigo_postal', label: 'Código postal' },
-  { col: 'domicilio_ciudad', label: 'Ciudad' },
-  { col: 'domicilio_estado', label: 'Estado' },
   { col: 'estado_civil', label: 'Estado civil' },
   { col: 'ocupacion', label: 'Ocupación' },
   { col: 'forma_pago_kyc', label: 'Forma de pago' },
@@ -81,10 +82,13 @@ function vacio(v: string | null | undefined): boolean {
 /** Etiquetas de los campos KYC obligatorios que la persona NO tiene. */
 export function camposKycFaltantes(p: PersonaKycSnapshot | null | undefined): string[] {
   if (!p) return [];
-  // Todas las columnas obligatorias son de texto (string | null).
-  return CAMPOS_KYC_OBLIGATORIOS.filter(({ col }) => vacio(p[col] as string | null)).map(
+  // Columnas escalares (todas de texto: string | null).
+  const faltantes = CAMPOS_KYC_OBLIGATORIOS.filter(({ col }) => vacio(p[col] as string | null)).map(
     ({ label }) => label
   );
+  // Domicilio: completo si hay blob de Coda O campos estructurados.
+  if (!domicilioTexto(p)) faltantes.push('Domicilio');
+  return faltantes;
 }
 
 /** `true` si la persona trae el expediente KYC obligatorio completo. */


### PR DESCRIPTION
## Contexto

Follow-up de [#997](https://github.com/beto-sudo/BSOP/pull/997). Al **probar el fix en vivo contra datos de prod**, el gate "Expediente incompleto" marcaba a **1317 de 1331 clientes (99%)** al reasignarlos — demasiado agresivo. Dos causas, ninguna real:

| Driver | Clientes | Realidad |
|---|---|---|
| Sin INE en la persona | 1316 | El INE vivía en `venta.ine_numero` (Coda, per-venta), no en la persona. |
| Sin domicilio estructurado | 1317 | Todos tienen dirección como blob (`erp.personas.domicilio`); **0 sin dirección alguna.** |

## Cambios

1. **Backfill del INE (ya aplicado a prod):** copié `venta.ine_numero → persona.numero_credencial_ine` para las **1314** personas recuperables (como se hizo con Juan Angel). Quedan 2 sin fuente.
2. **Domicilio por blob (este PR):** `camposKycFaltantes` ahora considera el domicilio completo si existe el blob de Coda **O** los campos estructurados (reusa `domicilioTexto`, espejo de la pantalla de detalle). El form arrastra el blob de la persona seleccionada al snapshot del gate.

Los campos FICU (estado civil, ocupación, forma de pago, uso de efectivo) **se siguen exigiendo** (decisión de Beto: forcing function de limpieza de datos).

## Verificación en vivo (datos reales de prod, post-cambios)

- `aun_sin_ine`: **1316 → 2**
- Clientes marcados incompletos: **1317 → 608** (los 608 son los gaps FICU reales que se decidió exigir; ~46%).
- Juan Angel: ahora cuenta como **completo** (su blob de domicilio satisface la dirección).

## Archivos
- `lib/dilesa/kyc-persona.ts` — domicilio fuera de la lista escalar, validado por blob-o-estructurado (+ 2 tests nuevos, 17 total).
- `app/dilesa/ventas/nueva/page.tsx` — el catálogo trae `domicilio`; el snapshot del gate arrastra el blob.

CI local: 6 checks verdes (1995 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)