### PR TITLE
feat(dilesa-ventas): renombrar fases de venta a convención «acción a realizar» + fuente única

### DIFF
--- a/app/api/dilesa/encuesta/[token]/route.test.ts
+++ b/app/api/dilesa/encuesta/[token]/route.test.ts
@@ -123,7 +123,7 @@ describe('POST /api/dilesa/encuesta/[token]', () => {
     });
 
     const insFase = inserts.find((i) => i.tabla === 'venta_fases');
-    expect(insFase?.row).toMatchObject({ posicion: 16, fase: 'Conformidad del Cliente' });
+    expect(insFase?.row).toMatchObject({ posicion: 16, fase: 'Recabar conformidad' });
 
     const upVenta = updates.find((u) => u.tabla === 'ventas');
     expect(upVenta?.patch).toMatchObject({ fase_posicion: 16 });

--- a/app/api/dilesa/encuesta/[token]/route.ts
+++ b/app/api/dilesa/encuesta/[token]/route.ts
@@ -14,9 +14,10 @@ import { NextResponse } from 'next/server';
 import { verifyEncuestaToken } from '@/lib/dilesa/encuesta-token';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { nombreFase } from '@/lib/dilesa/fases';
 
-const FASE_NOMBRE = 'Conformidad del Cliente';
 const FASE_POSICION = 16;
+const FASE_NOMBRE = nombreFase(FASE_POSICION);
 
 export async function POST(req: Request, { params }: { params: Promise<{ token: string }> }) {
   const { token } = await params;

--- a/app/api/dilesa/notario/dictamen/[token]/route.ts
+++ b/app/api/dilesa/notario/dictamen/[token]/route.ts
@@ -126,7 +126,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ token: str
   const posiciones = new Set<number>((fases ?? []).map((f) => f.posicion as number));
   if (!posiciones.has(7)) {
     return NextResponse.json(
-      { ok: false, error: 'La Fase 7 (Solicitud de Dictaminación) no está cerrada.' },
+      { ok: false, error: 'La Fase 7 (Solicitar dictamen) no está cerrada.' },
       { status: 409 }
     );
   }

--- a/app/api/dilesa/valuador/avaluo/[token]/route.ts
+++ b/app/api/dilesa/valuador/avaluo/[token]/route.ts
@@ -31,6 +31,7 @@ import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { verifyAvaluoToken } from '@/lib/dilesa/avaluo-token';
 import { buildAdjuntoPath } from '@/lib/storage/path';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { nombreFase } from '@/lib/dilesa/fases';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -130,7 +131,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ token: str
   const posiciones = new Set<number>((fases ?? []).map((f) => f.posicion as number));
   if (!posiciones.has(4)) {
     return NextResponse.json(
-      { ok: false, error: 'La Fase 4 (Solicitud de Avalúo) no está cerrada.' },
+      { ok: false, error: 'La Fase 4 (Solicitar avalúo) no está cerrada.' },
       { status: 409 }
     );
   }
@@ -201,7 +202,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ token: str
     .update({
       monto_avaluo: monto,
       fecha_avaluo_cerrado: fecha,
-      fase_actual: 'Avalúo Cerrado',
+      fase_actual: nombreFase(5),
       fase_posicion: 5,
     })
     .eq('id', ventaId);
@@ -220,7 +221,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ token: str
     .insert({
       empresa_id: DILESA_EMPRESA_ID,
       venta_id: ventaId,
-      fase: 'Avalúo Cerrado',
+      fase: nombreFase(5),
       posicion: 5,
       fecha: new Date().toISOString().slice(0, 10),
       registrado_por: null,

--- a/app/api/dilesa/ventas/[ventaId]/cerrar-fase13/route.ts
+++ b/app/api/dilesa/ventas/[ventaId]/cerrar-fase13/route.ts
@@ -33,6 +33,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { nombreFase } from '@/lib/dilesa/fases';
 import { checkDireccionEmpresa } from '@/lib/auth/direccion-gate';
 import { leerCfdiMetadata } from '@/lib/dilesa/captura/cfdi-validacion';
 import { cargarCuadraturaVenta } from '@/lib/dilesa/cuadratura-server';
@@ -116,7 +117,7 @@ export async function POST(req: NextRequest, { params }: Params) {
   const posiciones = ((fasesRows ?? []) as { posicion: number }[]).map((f) => f.posicion);
   if (!posiciones.includes(12)) {
     return NextResponse.json(
-      { ok: false, error: 'La Fase 12 (Detonada) no está cerrada.' },
+      { ok: false, error: 'La Fase 12 (Detonar crédito) no está cerrada.' },
       { status: 409 }
     );
   }
@@ -263,7 +264,7 @@ export async function POST(req: NextRequest, { params }: Params) {
   // Caché de posición: solo avanza, nunca retrocede (mismo criterio que
   // marcarFase).
   if (FASE > (venta.fase_posicion ?? 0)) {
-    campos.fase_actual = 'Facturada';
+    campos.fase_actual = nombreFase(FASE);
     campos.fase_posicion = FASE;
   }
   if (Object.keys(campos).length > 0) {
@@ -286,7 +287,7 @@ export async function POST(req: NextRequest, { params }: Params) {
     .insert({
       empresa_id: DILESA_EMPRESA_ID,
       venta_id: ventaId,
-      fase: 'Facturada',
+      fase: nombreFase(FASE),
       posicion: FASE,
       fecha: new Date().toISOString().slice(0, 10),
       registrado_por: user.id,

--- a/app/dilesa/atencion-clientes/page.tsx
+++ b/app/dilesa/atencion-clientes/page.tsx
@@ -109,7 +109,7 @@ function UrgenciaChip({ venta }: { venta: VentaEntrega }) {
       ? 'Falta pago'
       : enEntrega
         ? 'Entregar'
-        : (venta.fase_actual ?? (venta.pago_detonado ? 'Detonada' : 'Escriturada'));
+        : (venta.fase_actual ?? (venta.pago_detonado ? 'Detonar crédito' : 'Escriturar'));
   return (
     <Badge tone={urgenciaTono(venta)}>
       <Icono />

--- a/app/dilesa/ventas/[id]/actions.ts
+++ b/app/dilesa/ventas/[id]/actions.ts
@@ -23,26 +23,7 @@ import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { sendHoldEmail, type HoldEmailContext } from '@/lib/dilesa/hold-emails';
 import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
-
-const FASES_CANONICAS: Record<number, string> = {
-  1: 'Solicitud de Asignación',
-  2: 'Asignada',
-  3: 'Formalizada',
-  4: 'Solicitud de Avalúo',
-  5: 'Avalúo Cerrado',
-  6: 'Inscrita',
-  7: 'Solicitud de Dictaminación',
-  8: 'Dictaminada',
-  9: 'Validación Patronal',
-  10: 'Firmas Programadas',
-  11: 'Escriturada',
-  12: 'Detonada',
-  13: 'Facturada',
-  14: 'Preparada para Entrega',
-  15: 'Entregada',
-  16: 'Comisión Pagada',
-  17: 'Operación Terminada',
-};
+import { FASES_NOMBRE_BY_POS } from '@/lib/dilesa/fases';
 
 export type ActionResult =
   | {
@@ -274,7 +255,7 @@ async function regresarAFaseInner(
   if (motivoTrim.length < 5) {
     return { ok: false, error: 'El motivo es obligatorio (mínimo 5 caracteres).' };
   }
-  const faseNombre = FASES_CANONICAS[faseDestino];
+  const faseNombre = FASES_NOMBRE_BY_POS[faseDestino];
   if (!faseNombre) {
     return { ok: false, error: `Fase destino inválida: ${faseDestino}` };
   }

--- a/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 10 — Firmas Programadas.
+ * Captura Fase 10 — Programar firmas.
  *
  * Gerencia Ventas (o Dirección) programa la fecha + hora de firma ya acordada
  * con el notario (que viene de Fase 7) y genera la Póliza de Garantía.
@@ -9,7 +9,7 @@
  * ADR-048: el **crédito directo (pagaré) ya NO se captura aquí** — se define en
  * la dictaminación (fase 8), con el saldo REAL del Anexo B. Si la venta tiene
  * crédito directo, aquí solo se sube el **pagaré firmado** que se recaba en la
- * firma (rol `pagare`, el mismo que reconoce la fase Escriturada y
+ * firma (rol `pagare`, el mismo que reconoce la fase Escriturar y
  * `rolesOpcionales`).
  *
  * Tasas / cobertura / plan de pagos: viven en la fase 8.
@@ -263,7 +263,6 @@ function CapturarFase10Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Firmas Programadas',
         faseposicion: 10,
         docs: [], // el pagaré (si se subió) ya vive en el expediente
         // Si la fecha está bloqueada (póliza ya expedida y no eres Dirección)
@@ -312,7 +311,7 @@ function CapturarFase10Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={10} faseNombre="Firmas Programadas" />
+        <CapturarFaseHeader faseposicion={10} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -367,7 +366,6 @@ function CapturarFase10Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={10}
-        faseNombre="Firmas Programadas"
         descripcion="Programa la fecha y hora de firma acordada con el notario y genera la Póliza de Garantía."
       />
 
@@ -378,8 +376,8 @@ function CapturarFase10Body() {
             title="Fase 10 ya está cerrada"
             body={
               fechaFirmaLabel
-                ? `Firma programada para el ${fechaFirmaLabel}. La siguiente fase es Escriturada.`
-                : 'Esta venta ya tiene la firma programada. La siguiente fase es Escriturada.'
+                ? `Firma programada para el ${fechaFirmaLabel}. La siguiente fase es Escriturar.`
+                : 'Esta venta ya tiene la firma programada. La siguiente fase es Escriturar.'
             }
           />
 

--- a/app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 11 — Escriturada (Sprint 7i).
+ * Captura Fase 11 — Escriturar (Sprint 7i).
  *
  * Tras la firma en notaría, las escrituras llegan a Dirección (Beto, o quien
  * de Dirección esté) para firmar. Se registra:
@@ -14,7 +14,7 @@
  *
  * Sin documentos requeridos.
  *
- * Enforcement: Fase 10 (Firmas Programadas) debe estar cerrada.
+ * Enforcement: Fase 10 (Programar firmas) debe estar cerrada.
  * Acceso: `dilesa.ventas.fase11_escriturada` (Gerencia Ventas + Dirección).
  */
 
@@ -181,7 +181,6 @@ function CapturarFase11Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Escriturada',
         faseposicion: 11,
         docs: [],
         camposVenta: {
@@ -285,7 +284,7 @@ function CapturarFase11Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={11} faseNombre="Escriturada" />
+        <CapturarFaseHeader faseposicion={11} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -297,7 +296,6 @@ function CapturarFase11Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={11}
-        faseNombre="Escriturada"
         descripcion="Registra la escrituración: fecha de escritura y el cheque enviado a la notaría (número y monto)."
       />
 
@@ -306,7 +304,7 @@ function CapturarFase11Body() {
           <Banner
             tone="success"
             title="Fase 11 ya está cerrada"
-            body="Esta venta ya está escriturada. La siguiente fase es Detonada. Si el número o la fecha de la escritura quedaron mal capturados (ej. folio interno en lugar del instrumento del notario), corrígelos aquí — la revisión PLD de la Fase 13 los cruza contra el aviso."
+            body="Esta venta ya está escriturada. La siguiente fase es Detonar crédito. Si el número o la fecha de la escritura quedaron mal capturados (ej. folio interno en lugar del instrumento del notario), corrígelos aquí — la revisión PLD de la Fase 13 los cruza contra el aviso."
           />
           <form onSubmit={onActualizarEscritura} className="space-y-6">
             <Section title="Corregir datos de la escritura">
@@ -349,7 +347,7 @@ function CapturarFase11Body() {
       ) : fase10Cerrada === false ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 10 (Firmas Programadas)"
+          title="Falta cerrar Fase 10 (Programar firmas)"
           body={
             <>
               Antes de registrar la escrituración, programa la firma (Fase 10). Vuelve al detalle y

--- a/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Fase 12 — Detonada. GUÍA a Cobranza + cierre manual SOLO Dirección.
+ * Fase 12 — Detonar crédito. GUÍA a Cobranza + cierre manual SOLO Dirección.
  *
  * "Detonar" el crédito = la institución libera el recurso y DILESA recibe el
  * depósito. El camino ÚNICO normal (2026-06-11) es: Contabilidad registra el
@@ -16,7 +16,7 @@
  * cierre de emergencia exclusivo de Dirección/admin, con advertencia de que
  * NO registra el dinero en Cobranza.
  *
- * Enforcement: Fase 11 (Escriturada) debe estar cerrada.
+ * Enforcement: Fase 11 (Escriturar) debe estar cerrada.
  * Acceso: `dilesa.ventas.fase12_detonada` (Contabilidad + Gerencia Ventas +
  * Dirección); el form de emergencia además exige Dirección
  * (`EffectiveUser.direccionEmpresaIds` o admin global).
@@ -188,7 +188,6 @@ function CapturarFase12Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Detonada',
         faseposicion: 12,
         docs: [], // el comprobante ya vive en el expediente (subida incremental)
         camposVenta: {
@@ -232,7 +231,7 @@ function CapturarFase12Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={12} faseNombre="Detonada" />
+        <CapturarFaseHeader faseposicion={12} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -244,7 +243,6 @@ function CapturarFase12Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={12}
-        faseNombre="Detonada"
         descripcion="Registra la detonación del crédito (el depósito recibido) y sube el comprobante."
       />
 
@@ -252,12 +250,12 @@ function CapturarFase12Body() {
         <Banner
           tone="success"
           title="Fase 12 ya está cerrada"
-          body="Esta venta ya está detonada. La siguiente fase es Facturada."
+          body="Esta venta ya está detonada. La siguiente fase es Facturar."
         />
       ) : fase11Cerrada === false ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 11 (Escriturada)"
+          title="Falta cerrar Fase 11 (Escriturar)"
           body={
             <>
               Antes de registrar la detonación, la venta debe estar escriturada. Vuelve al detalle y

--- a/app/dilesa/ventas/[id]/capturar/13-facturada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/13-facturada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 13 — Facturada (captura colaborativa + XML CFDI: Sprints 1-2
+ * Captura Fase 13 — Facturar (captura colaborativa + XML CFDI: Sprints 1-2
  * de `dilesa-ventas-captura-colaborativa`).
  *
  * Sprint 1 — colaborativo: cada documento PERSISTE AL SUBIRSE
@@ -25,7 +25,7 @@
  *     venta. Errores bloquean la subida; warnings quedan visibles y
  *     persistidos en `erp.adjuntos.metadata`.
  *   - NADA se captura a mano en esta pantalla: `valor_escrituracion` viene
- *     de la Fase 8 (Dictaminada) y aquí solo se muestra; `valor_facturado`
+ *     de la Fase 8 (Dictaminar) y aquí solo se muestra; `valor_facturado`
  *     y `monto_nota_credito` se derivan del XML vigente. Corregir un monto
  *     = subir el XML correcto (queda versionado — esa es la auditoría).
  *     Las ventas históricas (sin XML) conservan sus montos migrados: el
@@ -42,7 +42,7 @@
  * aviso + cargar el acuse; la revisión con acuse completa el ciclo y solo
  * entonces se prende el cierre.
  *
- * Enforcement: Fase 12 (Detonada) debe estar cerrada.
+ * Enforcement: Fase 12 (Detonar crédito) debe estar cerrada.
  * Acceso: `dilesa.ventas.fase13_facturada` (Contabilidad + Gerencia Ventas +
  * Dirección).
  */
@@ -659,7 +659,7 @@ function CapturarFase13Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={13} faseNombre="Facturada" />
+        <CapturarFaseHeader faseposicion={13} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -674,7 +674,6 @@ function CapturarFase13Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={13}
-        faseNombre="Facturada"
         descripcion="Sube el XML de la factura (y nota de crédito / aviso PLD si aplican). Cada documento se valida y se guarda al subirse; los montos del CFDI se llenan solos."
       />
 
@@ -687,7 +686,7 @@ function CapturarFase13Body() {
       ) : bloqueadaPorFase12 ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 12 (Detonada)"
+          title="Falta cerrar Fase 12 (Detonar crédito)"
           body={
             <>
               Antes de facturar, la venta debe estar detonada (depósito recibido). Vuelve al detalle
@@ -878,8 +877,8 @@ function CapturarFase13Body() {
                 <MontoDerivado valor={venta.valor_escrituracion} />
                 <Hint>
                   {venta.valor_escrituracion == null
-                    ? 'Falta — se captura en la Fase 8 (Dictaminada).'
-                    : 'Capturado en la Fase 8 (Dictaminada).'}
+                    ? 'Falta — se captura en la Fase 8 (Dictaminar).'
+                    : 'Capturado en la Fase 8 (Dictaminar).'}
                 </Hint>
               </Field>
               <Field label="Valor real venta Dilesa (calculado)">

--- a/app/dilesa/ventas/[id]/capturar/14-preparada-entrega/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/14-preparada-entrega/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 14 — Preparada para Entrega (dilesa-ventas-expediente S5).
+ * Captura Fase 14 — Preparar entrega (dilesa-ventas-expediente S5).
  *
  * El equipo de Calidad y Entrega revisa la vivienda con el Checklist
  * Pre-Entrega: lo imprime desde aquí (PDF prellenado con vivienda + cliente),
@@ -9,11 +9,11 @@
  * Subirlo cierra la fase.
  *
  * Gate especial (Beto, 2026-06-10): la preparación puede hacerse desde que se
- * registra la escritura (Fase 11) — NO espera Detonada (12) ni Facturada (13).
+ * registra la escritura (Fase 11) — NO espera Detonar crédito (12) ni Facturar (13).
  *
  * Captura:
  *   - Doc requerido: rol `checklist_pre_entrega` (checklist firmado).
- *     Coincide con `FASE_ROLES['Preparada para Entrega']` en el detalle.
+ *     Coincide con `FASE_ROLES[14]` en el detalle.
  *   - Notas opcionales → `venta_fases.notas`.
  *
  * Acceso: `dilesa.ventas.fase14_preparada_entrega` (escritura: Obra +
@@ -145,7 +145,6 @@ function CapturarFase14Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Preparada para Entrega',
         faseposicion: 14,
         docs: [], // el documento ya vive en el expediente (subida incremental)
         camposVenta: {},
@@ -186,7 +185,7 @@ function CapturarFase14Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={14} faseNombre="Preparada para Entrega" />
+        <CapturarFaseHeader faseposicion={14} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -198,7 +197,6 @@ function CapturarFase14Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={14}
-        faseNombre="Preparada para Entrega"
         descripcion="Calidad y Entrega revisa la vivienda con el checklist impreso y sube el escaneado firmado."
       />
 
@@ -206,16 +204,16 @@ function CapturarFase14Body() {
         <Banner
           tone="success"
           title="Fase 14 ya está cerrada"
-          body="Esta vivienda ya quedó preparada para entrega. La siguiente fase es Entregada."
+          body="Esta vivienda ya quedó preparada para entrega. La siguiente fase es Entregar."
         />
       ) : !fase11Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 11 (Escriturada)"
+          title="Falta cerrar Fase 11 (Escriturar)"
           body={
             <>
               La preparación de entrega puede hacerse desde que se registra la escritura — sin
-              esperar Detonada ni Facturada. Vuelve al detalle y captura la Fase 11 primero.
+              esperar Detonar crédito ni Facturar. Vuelve al detalle y captura la Fase 11 primero.
             </>
           }
           extra={

--- a/app/dilesa/ventas/[id]/capturar/15-entregada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/15-entregada/page.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 /**
- * Captura Fase 15 — Entregada (dilesa-ventas-expediente S5).
+ * Captura Fase 15 — Entregar (dilesa-ventas-expediente S5).
  *
  * La entrega física de la vivienda al cliente: se imprime el Checklist para
  * Entrega de Vivienda (PDF prellenado), se recorre la casa con el cliente
  * palomeando SÍ/NO, firman el CLIENTE y Atención a Clientes, se escanea y se
  * sube el PDF firmado. Subirlo cierra la fase.
  *
- * Gate: Fase 14 (Preparada para Entrega) debe estar cerrada.
+ * Gate: Fase 14 (Preparar entrega) debe estar cerrada.
  *
  * Captura:
  *   - Doc requerido: rol `checklist_entrega` (checklist firmado por cliente).
- *     Coincide con `FASE_ROLES['Entregada']` en el detalle.
+ *     Coincide con `FASE_ROLES[15]` en el detalle.
  *   - Notas opcionales → `venta_fases.notas`.
  *
  * Acceso: `dilesa.ventas.fase15_entregada` (escritura: Vendedor + Dirección;
@@ -68,7 +68,7 @@ function CapturarFase15Body() {
 
   const [venta, setVenta] = useState<VentaCtx | null>(null);
   const [fase14Cerrada, setFase14Cerrada] = useState<boolean | null>(null);
-  // F12 (Detonada) = el pago recibido. No se entrega sin pago.
+  // F12 (Detonar crédito) = el pago recibido. No se entrega sin pago.
   const [fase12Cerrada, setFase12Cerrada] = useState<boolean | null>(null);
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
 
@@ -151,7 +151,6 @@ function CapturarFase15Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Entregada',
         faseposicion: 15,
         docs: [], // el documento ya vive en el expediente (subida incremental)
         camposVenta: {},
@@ -192,7 +191,7 @@ function CapturarFase15Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={15} faseNombre="Entregada" />
+        <CapturarFaseHeader faseposicion={15} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -204,7 +203,6 @@ function CapturarFase15Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={15}
-        faseNombre="Entregada"
         descripcion="Entrega física al cliente: checklist impreso, recorrido, firmas y escaneado."
       />
 
@@ -212,12 +210,12 @@ function CapturarFase15Body() {
         <Banner
           tone="success"
           title="Fase 15 ya está cerrada"
-          body="Esta vivienda ya fue entregada al cliente. La siguiente fase es Comisión Pagada."
+          body="Esta vivienda ya fue entregada al cliente. La siguiente fase es Recabar conformidad."
         />
       ) : !fase14Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 14 (Preparada para Entrega)"
+          title="Falta cerrar Fase 14 (Preparar entrega)"
           body={
             <>
               Antes de entregar al cliente, Calidad y Entrega debe dejar la vivienda preparada
@@ -236,7 +234,7 @@ function CapturarFase15Body() {
       ) : !fase12Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta el pago (Fase 12 — Detonada)"
+          title="Falta el pago (Fase 12 — Detonar crédito)"
           body={
             <>
               No se puede entregar la vivienda sin haber recibido el pago. El pago lo registra

--- a/app/dilesa/ventas/[id]/capturar/16-conformidad/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/16-conformidad/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 16 — Conformidad del Cliente (dilesa-ventas-expediente S5).
+ * Captura Fase 16 — Recabar conformidad (dilesa-ventas-expediente S5).
  *
  * La fase normalmente se cierra SOLA: al cerrar F15 se programa la encuesta
  * (entrega + 2 días), el cron la envía/recuerda, y la respuesta del cliente
@@ -240,7 +240,6 @@ function CapturarFase16Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Conformidad del Cliente',
         faseposicion: 16,
         docs: [],
         camposVenta: {},
@@ -292,7 +291,6 @@ function CapturarFase16Body() {
     }
     const result = await marcarFase(sb, {
       ventaId: venta.id,
-      faseNombre: 'Conformidad del Cliente',
       faseposicion: 16,
       docs: [],
       camposVenta: {},
@@ -325,7 +323,7 @@ function CapturarFase16Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={16} faseNombre="Conformidad del Cliente" />
+        <CapturarFaseHeader faseposicion={16} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -340,14 +338,13 @@ function CapturarFase16Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={16}
-        faseNombre="Conformidad del Cliente"
         descripcion="Encuesta posventa: se envía sola tras la entrega; aquí se monitorea el ciclo y se captura por teléfono si hace falta."
       />
 
       {!fase15Cerrada && !yaCerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 15 (Entregada)"
+          title="Falta cerrar Fase 15 (Entregar)"
           body="Al cerrar la entrega, la encuesta se programa automáticamente (entrega + 2 días)."
           extra={
             <Link
@@ -439,7 +436,7 @@ function CapturarFase16Body() {
             <Banner
               tone="success"
               title="Fase 16 ya está cerrada"
-              body="La conformidad del cliente quedó registrada. La siguiente fase es Operación Terminada."
+              body="La conformidad del cliente quedó registrada. La siguiente fase es Cerrar operación."
             />
           ) : !respondida ? (
             <>

--- a/app/dilesa/ventas/[id]/capturar/17-operacion-terminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/17-operacion-terminada/page.tsx
@@ -170,7 +170,7 @@ function CapturarFase17Body() {
       const cargados = new Set(((adjRes.data ?? []) as { rol: string }[]).map((a) => a.rol));
       const opcionales = rolesOpcionales(v);
       const docsFaltantes = FASES_PIPELINE.flatMap((f) =>
-        (FASE_ROLES[f.nombre] ?? [])
+        (FASE_ROLES[f.posicion] ?? [])
           .filter((rol) => !cargados.has(rol) && !opcionales.has(rol))
           .map((rol) => ({ fase: f.nombre, rol, label: ROL_LABEL[rol] ?? rol }))
       );
@@ -208,7 +208,6 @@ function CapturarFase17Body() {
 
     const result = await marcarFase(sb, {
       ventaId: venta.id,
-      faseNombre: 'Operación Terminada',
       faseposicion: 17,
       docs: [],
       camposVenta: {},
@@ -226,7 +225,7 @@ function CapturarFase17Body() {
       return;
     }
     toast.add({
-      title: 'Operación Terminada 🎉',
+      title: '¡Operación cerrada! 🎉',
       description: 'El expediente quedó sellado. Felicidades por otra entrega completa.',
       type: 'success',
     });
@@ -246,7 +245,7 @@ function CapturarFase17Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={17} faseNombre="Operación Terminada" />
+        <CapturarFaseHeader faseposicion={17} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -258,7 +257,6 @@ function CapturarFase17Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={17}
-        faseNombre="Operación Terminada"
         descripcion="El sello final: el copiloto verifica el expediente y habilita el cierre."
       />
 
@@ -317,7 +315,7 @@ function CapturarFase17Body() {
                 </>
               ) : (
                 <>
-                  <PartyPopper className="mr-2 size-4" /> Marcar Operación Terminada
+                  <PartyPopper className="mr-2 size-4" /> Cerrar operación
                 </>
               )}
             </Button>

--- a/app/dilesa/ventas/[id]/capturar/2-asignada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/2-asignada/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 /**
- * Captura Fase 2 — Asignada.
+ * Captura Fase 2 — Asignar unidad.
  *
  * Cierra la fase de Asignación: el líder del hold subió todos los
  * documentos firmados del expediente, y Dirección (o el rol autorizador
  * configurado, ej. Nelcy) revisa que esté todo en regla y autoriza la
- * asignación. La venta pasa a `fase_actual='Asignada'` / `fase_posicion=2`.
+ * asignación. La venta pasa a `fase_actual='Asignar unidad'` / `fase_posicion=2`.
  *
  * Acceso: gate por `dilesa.ventas.autorizar` (RBAC nuevo, ver migración
  * 20260528191807). Solo Dirección + el rol de Nelcy lo tienen.
@@ -233,11 +233,10 @@ function CapturarFase2Body() {
         .map(([rol, archivo]) => ({ rol, archivo }));
       const res = await marcarFase(sb, {
         ventaId,
-        faseNombre: 'Asignada',
         faseposicion: 2,
         docs,
         camposVenta: {
-          fase_actual: 'Asignada',
+          fase_actual: 'Asignar unidad',
           fase_posicion: 2,
         },
         notas: null,
@@ -272,7 +271,7 @@ function CapturarFase2Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={2} faseNombre="Asignada" />
+        <CapturarFaseHeader faseposicion={2} />
         <p className="rounded-lg bg-red-500/10 px-4 py-3 text-sm text-red-600 dark:text-red-400">
           {error ?? 'Venta no encontrada.'}
         </p>
@@ -287,7 +286,6 @@ function CapturarFase2Body() {
           el autorizador necesita para revisar antes de asignar. */}
       <CapturarFaseHeader
         faseposicion={2}
-        faseNombre="Asignada"
         descripcion="Revisa el expediente completo y los datos de la operación, y autoriza la asignación de la unidad."
       />
 

--- a/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 3 — Formalizada (Sprint 7c piloto).
+ * Captura Fase 3 — Formalizar promesa (Sprint 7c piloto).
  *
  * Cierra la fase de Formalización: el cliente firmó el contrato de
  * promesa de compraventa que el vendedor descargó/imprimió de
@@ -199,7 +199,6 @@ function CapturarFase3Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Formalizada',
         faseposicion: 3,
         docs: [], // el documento ya vive en el expediente (subida incremental)
         camposVenta: {
@@ -225,7 +224,7 @@ function CapturarFase3Body() {
       }
       toast.add({
         title: 'Fase 3 cerrada',
-        description: 'Fase 4 (Solicitud de Avalúo) está disponible.',
+        description: 'Fase 4 (Solicitar avalúo) está disponible.',
         type: 'success',
       });
       router.push(`/dilesa/ventas/${venta.id}`);
@@ -247,7 +246,7 @@ function CapturarFase3Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={3} faseNombre="Formalizada" />
+        <CapturarFaseHeader faseposicion={3} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -259,7 +258,6 @@ function CapturarFase3Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={3}
-        faseNombre="Formalizada"
         descripcion="Cliente firmó el contrato de promesa de compraventa. Sube el PDF firmado y captura precio + fecha."
       />
 
@@ -267,12 +265,12 @@ function CapturarFase3Body() {
         <Banner
           tone="success"
           title="Fase 3 ya está cerrada"
-          body="Esta venta ya pasó por Formalizada. Si necesitas corregir algo, contacta al comité para reabrir la fase."
+          body="Esta venta ya pasó por Formalizar promesa. Si necesitas corregir algo, contacta al comité para reabrir la fase."
         />
       ) : !fase2Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 2 (Asignada)"
+          title="Falta cerrar Fase 2 (Asignar unidad)"
           body={
             <>
               Antes de capturar Formalizada, asegúrate de tener la asignación del comité. Vuelve al

--- a/app/dilesa/ventas/[id]/capturar/4-solicitud-avaluo/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/4-solicitud-avaluo/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 /**
- * Captura Fase 4 — Solicitud de Avalúo (Sprint 7d).
+ * Captura Fase 4 — Solicitar avalúo (Sprint 7d).
  *
- * Cierra la fase de Solicitud de Avalúo: Gerencia Ventas (o Dirección)
+ * Cierra la fase de Solicitar avalúo: Gerencia Ventas (o Dirección)
  * asigna una casa valuadora del catálogo (`erp.personas` con
  * `tipo='valuador'`) y dispara el email de solicitud al valuador.
  *
@@ -162,7 +162,6 @@ function CapturarFase4Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Solicitud de Avalúo',
         faseposicion: 4,
         docs: [],
         camposVenta: {
@@ -220,7 +219,7 @@ function CapturarFase4Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={4} faseNombre="Solicitud de Avalúo" />
+        <CapturarFaseHeader faseposicion={4} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -234,7 +233,6 @@ function CapturarFase4Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={4}
-        faseNombre="Solicitud de Avalúo"
         descripcion="Asigna una casa valuadora y dispara el email con los datos del inmueble y del cliente."
       />
 
@@ -242,12 +240,12 @@ function CapturarFase4Body() {
         <Banner
           tone="success"
           title="Fase 4 ya está cerrada"
-          body="Esta venta ya pasó por Solicitud de Avalúo. La siguiente fase es Avalúo Cerrado."
+          body="Esta venta ya pasó por Solicitar avalúo. La siguiente fase es Cerrar avalúo."
         />
       ) : !fase3Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 3 (Formalizada)"
+          title="Falta cerrar Fase 3 (Formalizar promesa)"
           body={
             <>
               Antes de solicitar el avalúo, asegúrate de que el contrato de promesa esté firmado y

--- a/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 /**
- * Captura Fase 5 — Avalúo Cerrado (Sprint 7d).
+ * Captura Fase 5 — Cerrar avalúo (Sprint 7d).
  *
- * Cierra la fase de Avalúo Cerrado: Gerencia Ventas (o Dirección)
+ * Cierra la fase de Cerrar avalúo: Gerencia Ventas (o Dirección)
  * registra el monto dictaminado y sube el PDF del avalúo comercial
  * entregado por el valuador.
  *
@@ -11,7 +11,7 @@
  *   - `monto_avaluo` → monto dictaminado por la casa valuadora
  *   - `fecha_avaluo_cerrado` → fecha del cierre (default hoy)
  *   - Doc requerido: rol `avaluo_comercial` (PDF firmado por el
- *     valuador). Coincide con `FASE_ROLES['Avalúo Cerrado']` en el
+ *     valuador). Coincide con `FASE_ROLES[5]` en el
  *     detalle de venta.
  *
  * Captura colaborativa (Sprint 4b de `dilesa-ventas-captura-colaborativa`):
@@ -190,7 +190,6 @@ function CapturarFase5Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Avalúo Cerrado',
         faseposicion: 5,
         docs: [], // el avalúo ya vive en el expediente (subida incremental)
         camposVenta: {
@@ -234,7 +233,7 @@ function CapturarFase5Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={5} faseNombre="Avalúo Cerrado" />
+        <CapturarFaseHeader faseposicion={5} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -246,7 +245,6 @@ function CapturarFase5Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={5}
-        faseNombre="Avalúo Cerrado"
         descripcion="Registra el monto dictaminado por la casa valuadora y sube el PDF del avalúo."
       />
 
@@ -254,12 +252,12 @@ function CapturarFase5Body() {
         <Banner
           tone="success"
           title="Fase 5 ya está cerrada"
-          body="Esta venta ya pasó por Avalúo Cerrado. La siguiente fase es Dictaminación."
+          body="Esta venta ya pasó por Cerrar avalúo. La siguiente fase es Dictaminación."
         />
       ) : !fase4Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 4 (Solicitud de Avalúo)"
+          title="Falta cerrar Fase 4 (Solicitar avalúo)"
           body={
             <>
               Antes de capturar el avalúo, asegúrate de haber enviado la solicitud al valuador.

--- a/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 6 — Inscrita (Sprint 7e).
+ * Captura Fase 6 — Inscribir crédito (Sprint 7e).
  *
  * Cierra la fase de Inscripción del crédito: el banco entregó la(s)
  * Constancia(s) de Crédito con el monto APROBADO. Gerencia Ventas (o
@@ -229,7 +229,6 @@ function CapturarFase6Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Inscrita',
         faseposicion: 6,
         docs,
         camposVenta: {
@@ -290,7 +289,7 @@ function CapturarFase6Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={6} faseNombre="Inscrita" />
+        <CapturarFaseHeader faseposicion={6} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -302,7 +301,6 @@ function CapturarFase6Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={6}
-        faseNombre="Inscrita"
         descripcion="Banco entregó la(s) Constancia(s) de Crédito. Sube los PDFs y confirma los montos aprobados."
       />
 
@@ -310,12 +308,12 @@ function CapturarFase6Body() {
         <Banner
           tone="success"
           title="Fase 6 ya está cerrada"
-          body="Esta venta ya pasó por Inscrita. La siguiente fase es Solicitud de Dictaminación."
+          body="Esta venta ya pasó por Inscribir crédito. La siguiente fase es Solicitar dictamen."
         />
       ) : !fase5Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 5 (Avalúo Cerrado)"
+          title="Falta cerrar Fase 5 (Cerrar avalúo)"
           body={
             <>
               Antes de inscribir el crédito, captura primero el avalúo entregado por la casa

--- a/app/dilesa/ventas/[id]/capturar/7-solicitud-dictamen/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/7-solicitud-dictamen/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 7 — Solicitud de Dictaminación (Sprint 7f).
+ * Captura Fase 7 — Solicitar dictamen (Sprint 7f).
  *
  * Cierra la fase de Solicitud de Dictamen: Gerencia Ventas (o Dirección)
  * asigna una notaría del catálogo de proveedores (`erp.proveedores` con
@@ -13,7 +13,7 @@
  *   - `fecha_solicitud_dictamen` → fecha del cierre (default hoy)
  *   - Sin doc requerido (el dictamen llega en Fase 8)
  *
- * Enforcement: Fase 6 (Inscrita) debe estar cerrada.
+ * Enforcement: Fase 6 (Inscribir crédito) debe estar cerrada.
  *
  * Acceso: `dilesa.ventas.fase07_solicitud_dictamen` (Gerencia Ventas +
  * Dirección por default — backfill de la migración).
@@ -146,7 +146,6 @@ function CapturarFase7Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Solicitud de Dictaminación',
         faseposicion: 7,
         docs: [],
         camposVenta: {
@@ -206,7 +205,7 @@ function CapturarFase7Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={7} faseNombre="Solicitud de Dictaminación" />
+        <CapturarFaseHeader faseposicion={7} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -220,7 +219,6 @@ function CapturarFase7Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={7}
-        faseNombre="Solicitud de Dictaminación"
         descripcion="Asigna una notaría y dispara el email con los datos del cliente, inmueble y crédito."
       />
 
@@ -228,12 +226,12 @@ function CapturarFase7Body() {
         <Banner
           tone="success"
           title="Fase 7 ya está cerrada"
-          body="Esta venta ya pasó por Solicitud de Dictaminación. La siguiente fase es Dictaminada."
+          body="Esta venta ya pasó por Solicitar dictamen. La siguiente fase es Dictaminar."
         />
       ) : !fase6Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 6 (Inscrita)"
+          title="Falta cerrar Fase 6 (Inscribir crédito)"
           body={
             <>
               Antes de solicitar dictamen, captura primero las Constancias de Crédito. Vuelve al

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 8 — Dictaminada (cierre financiero, ADR-048).
+ * Captura Fase 8 — Dictaminar (cierre financiero, ADR-048).
  *
  * Gerencia/notario suben la Carta de Instrucción + el Anexo B (por el magic
  * link del notario o aquí), la IA pre-llena los números y **Dirección cuadra la
@@ -21,7 +21,7 @@
  * verificación cruzada (NSS, nombre, domicilio vs unidad, CLABE de DILESA).
  * Nada se escribe a la venta hasta "Guardar" — la precarga es editable.
  *
- * Enforcement: Fase 7 (Solicitud de Dictaminación) debe estar cerrada.
+ * Enforcement: Fase 7 (Solicitar dictamen) debe estar cerrada.
  *
  * Acceso: `dilesa.ventas.fase08_dictaminada` (Gerencia Ventas + Dirección).
  */
@@ -460,7 +460,6 @@ function CapturarFase8Body() {
         docs.push({ rol: 'condiciones_financieras', archivo: archivoCondiciones });
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Dictaminada',
         faseposicion: 8,
         docs,
         camposVenta: {
@@ -761,7 +760,7 @@ function CapturarFase8Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={8} faseNombre="Dictaminada" />
+        <CapturarFaseHeader faseposicion={8} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -840,7 +839,6 @@ function CapturarFase8Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={8}
-        faseNombre="Dictaminada"
         descripcion="Captura manual del dictamen (cuando el notario no usa el magic link del email)."
       />
 
@@ -997,7 +995,7 @@ function CapturarFase8Body() {
       ) : !fase7Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 7 (Solicitud de Dictaminación)"
+          title="Falta cerrar Fase 7 (Solicitar dictamen)"
           body={
             <>
               Antes de capturar el dictamen, asegúrate de haber enviado la solicitud al notario.
@@ -1090,7 +1088,7 @@ function CapturarFase8Body() {
 
           <Section title="Confirmar datos del crédito">
             <p className="mb-3 text-xs text-[var(--text)]/50">
-              Acarreados de Inscrita (Fase 6). Confirma o corrige si el banco cambió algo.
+              Acarreados de Inscribir crédito (Fase 6). Confirma o corrige si el banco cambió algo.
             </p>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Field label="Monto Crédito Titular">

--- a/app/dilesa/ventas/[id]/capturar/9-validacion-patronal/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/9-validacion-patronal/page.tsx
@@ -11,9 +11,9 @@
  * Captura:
  *   - `fecha_validacion_patronal` → fecha del documento (default hoy)
  *   - Doc requerido: rol `validacion_patronal` (PDF de la validación).
- *     Coincide con `FASE_ROLES['Validación Patronal']` en el detalle.
+ *     Coincide con `FASE_ROLES[9]` en el detalle.
  *
- * Enforcement: Fase 8 (Dictaminada) debe estar cerrada.
+ * Enforcement: Fase 8 (Dictaminar) debe estar cerrada.
  *
  * Acceso: `dilesa.ventas.fase09_validacion_patronal` (Gerencia Ventas +
  * Dirección por default — backfill de la migración).
@@ -152,7 +152,6 @@ function CapturarFase9Body() {
 
       const result = await marcarFase(sb, {
         ventaId: venta.id,
-        faseNombre: 'Validación Patronal',
         faseposicion: 9,
         docs: [], // el documento ya vive en el expediente (subida incremental)
         camposVenta: {
@@ -196,7 +195,7 @@ function CapturarFase9Body() {
   if (error || !venta) {
     return (
       <div className="container mx-auto max-w-6xl space-y-4 px-4 py-6">
-        <CapturarFaseHeader faseposicion={9} faseNombre="Validación Patronal" />
+        <CapturarFaseHeader faseposicion={9} />
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
           {error ?? 'Venta no encontrada.'}
         </div>
@@ -208,7 +207,6 @@ function CapturarFase9Body() {
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
         faseposicion={9}
-        faseNombre="Validación Patronal"
         descripcion="Sube el PDF de la Validación Patronal que el patrón le entrega al empleado."
       />
 
@@ -216,12 +214,12 @@ function CapturarFase9Body() {
         <Banner
           tone="success"
           title="Fase 9 ya está cerrada"
-          body="Esta venta ya pasó por Validación Patronal. La siguiente fase es Firmas Programadas."
+          body="Esta venta ya pasó por Validación Patronal. La siguiente fase es Programar firmas."
         />
       ) : !fase8Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 8 (Dictaminada)"
+          title="Falta cerrar Fase 8 (Dictaminar)"
           body={
             <>
               Antes de subir la Validación Patronal, la venta debe estar dictaminada. Vuelve al

--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -39,6 +39,7 @@ import { evaluarRiesgo } from '@/lib/dilesa/ficu/riesgo';
 import { calcularExpiraAt } from '@/lib/dilesa/hold-cola';
 import { buildAdjuntoPath } from '@/lib/storage/path';
 import { congelarDesglose } from '@/lib/dilesa/desglose-precio';
+import { nombreFase } from '@/lib/dilesa/fases';
 import {
   camposKycFaltantes,
   buildPersonaKycPayload,
@@ -745,7 +746,7 @@ function NuevaSolicitudForm() {
           vendedor_usuario_id: user?.id ?? null,
           vendedor: vendedorSnapshot,
           estado: 'activa',
-          fase_actual: 'Solicitud de Asignación',
+          fase_actual: nombreFase(1),
           fase_posicion: 1,
           // Hold de inventario: 2 días hábiles MX desde ahora. La columna
           // `expira_at` la consume el cron de expiración + los banners UI.
@@ -790,14 +791,14 @@ function NuevaSolicitudForm() {
 
       const ventaId = vIns.id as string;
 
-      // 4) Primera fila de venta_fases (Solicitud de Asignación, fecha hoy)
+      // 4) Primera fila de venta_fases (Solicitar asignación, fecha hoy)
       const { error: fErr } = await sb
         .schema('dilesa')
         .from('venta_fases')
         .insert({
           empresa_id: DILESA_EMPRESA_ID,
           venta_id: ventaId,
-          fase: 'Solicitud de Asignación',
+          fase: nombreFase(1),
           posicion: 1,
           // fecha (date) = hoy; created_at (timestamptz) = now() vía default.
           // Para FIFO en Fase 2 se ordena por created_at, que conserva la hora.

--- a/components/dilesa/capturar-fase-header.tsx
+++ b/components/dilesa/capturar-fase-header.tsx
@@ -14,6 +14,7 @@
  */
 import { Badge } from '@/components/ui/badge';
 import { useVentaCapturaResumen } from '@/components/dilesa/venta-detalle/captura-shell';
+import { nombreFase } from '@/lib/dilesa/fases';
 
 function fmtFechaCorta(s: string | null): string | null {
   if (!s) return null;
@@ -24,11 +25,9 @@ function fmtFechaCorta(s: string | null): string | null {
 
 export function CapturarFaseHeader({
   faseposicion,
-  faseNombre,
   descripcion,
 }: {
   faseposicion: number;
-  faseNombre: string;
   descripcion?: string;
 }) {
   const resumen = useVentaCapturaResumen();
@@ -38,7 +37,7 @@ export function CapturarFaseHeader({
     <header className="space-y-2">
       <div className="flex flex-wrap items-baseline gap-3">
         <h1 className="text-2xl font-semibold tracking-tight">
-          Fase {faseposicion} — {faseNombre}
+          Fase {faseposicion} — {nombreFase(faseposicion)}
         </h1>
         <Badge tone="neutral">Pipeline DILESA</Badge>
       </div>

--- a/components/dilesa/copiloto-cierre.tsx
+++ b/components/dilesa/copiloto-cierre.tsx
@@ -43,7 +43,7 @@ export function CopilotoCierre({
         <div className="flex items-center gap-2">
           <PartyPopper className="size-5 text-emerald-600 dark:text-emerald-400" />
           <h3 className="text-sm font-semibold text-emerald-900 dark:text-emerald-100">
-            Operación Terminada{fecha17 ? ` · ${fecha17}` : ''}
+            Operación cerrada{fecha17 ? ` · ${fecha17}` : ''}
           </h3>
         </div>
         <p className="mt-1 text-xs text-emerald-900/80 dark:text-emerald-100/80">
@@ -109,7 +109,7 @@ export function CopilotoCierre({
           href={`/dilesa/ventas/${ventaId}/capturar/17-operacion-terminada`}
           className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700"
         >
-          Marcar Operación Terminada
+          Cerrar operación
           <ChevronRight className="size-4" />
         </Link>
       ) : null}

--- a/components/dilesa/venta-detalle/provider.tsx
+++ b/components/dilesa/venta-detalle/provider.tsx
@@ -625,7 +625,7 @@ export function VentaDetalleProvider({
     const posicionesAlcanzadas = new Set(fases.map((f) => f.posicion));
     return FASES_ORDEN.map(({ pos, nombre }) => {
       const f = fasesByPos.get(pos);
-      const roles = FASE_ROLES[nombre] ?? [];
+      const roles = FASE_ROLES[pos] ?? [];
       const cargados = roles.flatMap((r) =>
         (adjuntosPorRolMap.get(r) ?? []).map((a) => ({ ...a, rol: r }))
       );

--- a/components/dilesa/venta-detalle/types.ts
+++ b/components/dilesa/venta-detalle/types.ts
@@ -9,6 +9,7 @@
  */
 import type { BadgeTone } from '@/components/ui/badge';
 import type { Json } from '@/types/supabase';
+import { FASES_VENTA } from '@/lib/dilesa/fases';
 
 export type Venta = {
   id: string;
@@ -240,26 +241,15 @@ export const GATE_PREVIA_OVERRIDE: Record<number, number> = {
   14: 11,
 };
 
-/** Las 17 fases canónicas en orden — para mostrar incluso las no alcanzadas. */
-export const FASES_ORDEN: Array<{ pos: number; nombre: string }> = [
-  { pos: 1, nombre: 'Solicitud de Asignación' },
-  { pos: 2, nombre: 'Asignada' },
-  { pos: 3, nombre: 'Formalizada' },
-  { pos: 4, nombre: 'Solicitud de Avalúo' },
-  { pos: 5, nombre: 'Avalúo Cerrado' },
-  { pos: 6, nombre: 'Inscrita' },
-  { pos: 7, nombre: 'Solicitud de Dictaminación' },
-  { pos: 8, nombre: 'Dictaminada' },
-  { pos: 9, nombre: 'Validación Patronal' },
-  { pos: 10, nombre: 'Firmas Programadas' },
-  { pos: 11, nombre: 'Escriturada' },
-  { pos: 12, nombre: 'Detonada' },
-  { pos: 13, nombre: 'Facturada' },
-  { pos: 14, nombre: 'Preparada para Entrega' },
-  { pos: 15, nombre: 'Entregada' },
-  { pos: 16, nombre: 'Conformidad del Cliente' },
-  { pos: 17, nombre: 'Operación Terminada' },
-];
+/**
+ * Las 17 fases canónicas en orden — para mostrar incluso las no alcanzadas.
+ * Derivada de la fuente única `lib/dilesa/fases.ts`: renombrar una fase se hace
+ * allí, no aquí.
+ */
+export const FASES_ORDEN: Array<{ pos: number; nombre: string }> = FASES_VENTA.map((f) => ({
+  pos: f.posicion,
+  nombre: f.nombre,
+}));
 
 /**
  * Las 17 fases agrupadas en 5 macro-etapas (Zona B del Expediente de

--- a/lib/dilesa/captura/fase-roles.ts
+++ b/lib/dilesa/captura/fase-roles.ts
@@ -7,27 +7,30 @@
  * Iniciativa dilesa-ventas-expediente (movido del detalle en S4).
  */
 
-export const FASE_ROLES: Record<string, string[]> = {
-  'Solicitud de Asignación': ['solicitud_asignacion'],
-  Asignada: ['solicitud_asignacion', 'expediente_digital', 'ficu', 'aviso_privacidad'],
-  Formalizada: ['contrato_promesa'],
-  'Solicitud de Avalúo': [],
-  'Avalúo Cerrado': ['avaluo_comercial'],
-  // Beto: las Constancias de Crédito (titular + co-titular) van en Inscrita
-  // (el banco las entrega al inscribir el crédito). La Carta de instrucción
-  // notarial queda en Dictaminada (sale después con el dictamen jurídico).
-  Inscrita: ['constancia_credito_titular', 'constancia_credito_cotitular'],
-  'Solicitud de Dictaminación': ['aprobacion_credito'],
-  Dictaminada: ['carta_instruccion_notarial', 'condiciones_financieras'],
-  'Validación Patronal': ['validacion_patronal'],
-  'Firmas Programadas': [],
-  Escriturada: ['pagare'],
-  Detonada: ['imagen_detonacion'],
-  Facturada: ['factura', 'nota_credito', 'aviso_pld'],
-  'Preparada para Entrega': ['checklist_pre_entrega'],
-  Entregada: ['checklist_entrega'],
-  'Conformidad del Cliente': [],
-  'Operación Terminada': [],
+// Llaveado por POSICIÓN (1–17), no por nombre: los renombres de fase (que viven
+// en `lib/dilesa/fases.ts`) no tocan este mapa. El comentario al lado de cada
+// entrada recuerda qué fase es.
+export const FASE_ROLES: Record<number, string[]> = {
+  1: ['solicitud_asignacion'], // Solicitar asignación
+  2: ['solicitud_asignacion', 'expediente_digital', 'ficu', 'aviso_privacidad'], // Asignar unidad
+  3: ['contrato_promesa'], // Formalizar promesa
+  4: [], // Solicitar avalúo
+  5: ['avaluo_comercial'], // Cerrar avalúo
+  // Beto: las Constancias de Crédito (titular + co-titular) van al inscribir el
+  // crédito (pos 6) — el banco las entrega ahí. La Carta de instrucción notarial
+  // queda en el dictamen (pos 8, sale después con el dictamen jurídico).
+  6: ['constancia_credito_titular', 'constancia_credito_cotitular'], // Inscribir crédito
+  7: ['aprobacion_credito'], // Solicitar dictamen
+  8: ['carta_instruccion_notarial', 'condiciones_financieras'], // Dictaminar
+  9: ['validacion_patronal'], // Validación Patronal
+  10: [], // Programar firmas
+  11: ['pagare'], // Escriturar
+  12: ['imagen_detonacion'], // Detonar crédito
+  13: ['factura', 'nota_credito', 'aviso_pld'], // Facturar
+  14: ['checklist_pre_entrega'], // Preparar entrega
+  15: ['checklist_entrega'], // Entregar
+  16: [], // Recabar conformidad
+  17: [], // Cerrar operación
 };
 
 export const ROL_LABEL: Record<string, string> = {

--- a/lib/dilesa/captura/marcar-fase.test.ts
+++ b/lib/dilesa/captura/marcar-fase.test.ts
@@ -82,7 +82,6 @@ function fakeFile(name = 'contrato.pdf', size = 1024): File {
 describe('marcarFase', () => {
   const baseInput = {
     ventaId: '550e8400-e29b-41d4-a716-446655440000',
-    faseNombre: 'Formalizada',
     faseposicion: 3,
     docs: [{ rol: 'contrato_promesa', archivo: fakeFile() }],
     camposVenta: { precio_asignacion: 1_021_000 },
@@ -169,8 +168,8 @@ describe('FASES_PIPELINE', () => {
     // Los nombres deben ser EXACTAMENTE los de la DB para que el INSERT
     // funcione. Si la migración cambia el seed, romper aquí intencionalmente.
     const nombres = FASES_PIPELINE.map((f) => f.nombre);
-    expect(nombres).toContain('Solicitud de Asignación');
-    expect(nombres).toContain('Formalizada');
-    expect(nombres).toContain('Operación Terminada');
+    expect(nombres).toContain('Solicitar asignación');
+    expect(nombres).toContain('Formalizar promesa');
+    expect(nombres).toContain('Cerrar operación');
   });
 });

--- a/lib/dilesa/captura/marcar-fase.ts
+++ b/lib/dilesa/captura/marcar-fase.ts
@@ -24,6 +24,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { buildAdjuntoPath } from '@/lib/storage/path';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { FASES_VENTA, nombreFase, type FaseSlug } from '@/lib/dilesa/fases';
 
 export type DocCaptura = {
   /** Rol del adjunto (ej. 'contrato_promesa', 'aviso_pld', 'factura'). */
@@ -34,8 +35,7 @@ export type DocCaptura = {
 
 export type MarcarFaseInput = {
   ventaId: string;
-  /** Nombre canónico de la fase (debe coincidir con `dilesa.venta_fase_catalogo.nombre`). */
-  faseNombre: string;
+  /** Posición de la fase (1–17). El nombre se deriva de `lib/dilesa/fases.ts`. */
   faseposicion: number;
   /** Documentos a subir + crear como `erp.adjuntos`. */
   docs: DocCaptura[];
@@ -66,7 +66,7 @@ export async function marcarFase(
   sb: SupabaseClient,
   input: MarcarFaseInput
 ): Promise<MarcarFaseResult> {
-  const { ventaId, faseNombre, faseposicion, docs, camposVenta, notas, registradoPor } = input;
+  const { ventaId, faseposicion, docs, camposVenta, notas, registradoPor } = input;
   let adjuntosCreados = 0;
 
   // 1) Subir archivos a Storage + 2) insertar en erp.adjuntos
@@ -134,7 +134,7 @@ export async function marcarFase(
     .maybeSingle();
   const posActual = (ventaActual?.fase_posicion as number | null) ?? 0;
   if (faseposicion > posActual) {
-    camposParaUpdate.fase_actual = faseNombre;
+    camposParaUpdate.fase_actual = nombreFase(faseposicion);
     camposParaUpdate.fase_posicion = faseposicion;
   }
   if (Object.keys(camposParaUpdate).length > 0) {
@@ -159,7 +159,7 @@ export async function marcarFase(
     .insert({
       empresa_id: DILESA_EMPRESA_ID,
       venta_id: ventaId,
-      fase: faseNombre,
+      fase: nombreFase(faseposicion),
       posicion: faseposicion,
       fecha: new Date().toISOString().slice(0, 10),
       registrado_por: registradoPor,
@@ -179,28 +179,10 @@ export async function marcarFase(
 }
 
 /**
- * Catálogo central de fases — index 0 = Fase 1. Replica `FASES_ORDEN` de
- * `app/dilesa/ventas/[id]/page.tsx` pero como TS (no JSX) para que el
- * helper sea reusable en server actions futuros.
+ * Catálogo de fases para captura — alias de la fuente única `lib/dilesa/fases.ts`.
+ * Conserva la forma `{ posicion, nombre, slug }` que consumen el copiloto de
+ * cierre y el resumen de captura.
  */
-export const FASES_PIPELINE = [
-  { posicion: 1, nombre: 'Solicitud de Asignación', slug: '1-solicitud-asignacion' },
-  { posicion: 2, nombre: 'Asignada', slug: '2-asignada' },
-  { posicion: 3, nombre: 'Formalizada', slug: '3-formalizada' },
-  { posicion: 4, nombre: 'Solicitud de Avalúo', slug: '4-solicitud-avaluo' },
-  { posicion: 5, nombre: 'Avalúo Cerrado', slug: '5-avaluo-cerrado' },
-  { posicion: 6, nombre: 'Inscrita', slug: '6-inscrita' },
-  { posicion: 7, nombre: 'Solicitud de Dictaminación', slug: '7-solicitud-dictamen' },
-  { posicion: 8, nombre: 'Dictaminada', slug: '8-dictaminada' },
-  { posicion: 9, nombre: 'Validación Patronal', slug: '9-validacion-patronal' },
-  { posicion: 10, nombre: 'Firmas Programadas', slug: '10-firmas-programadas' },
-  { posicion: 11, nombre: 'Escriturada', slug: '11-escriturada' },
-  { posicion: 12, nombre: 'Detonada', slug: '12-detonada' },
-  { posicion: 13, nombre: 'Facturada', slug: '13-facturada' },
-  { posicion: 14, nombre: 'Preparada para Entrega', slug: '14-preparada-entrega' },
-  { posicion: 15, nombre: 'Entregada', slug: '15-entregada' },
-  { posicion: 16, nombre: 'Conformidad del Cliente', slug: '16-conformidad' },
-  { posicion: 17, nombre: 'Operación Terminada', slug: '17-operacion-terminada' },
-] as const;
+export const FASES_PIPELINE = FASES_VENTA;
 
-export type FaseSlug = (typeof FASES_PIPELINE)[number]['slug'];
+export type { FaseSlug };

--- a/lib/dilesa/copiloto-cierre.test.ts
+++ b/lib/dilesa/copiloto-cierre.test.ts
@@ -48,8 +48,8 @@ describe('evaluarCierre', () => {
     const r = evaluarCierre({
       ...BASE,
       docsFaltantes: [
-        { fase: 'Facturada', rol: 'factura', label: 'Factura' },
-        { fase: 'Escriturada', rol: 'pagare', label: 'Pagaré' },
+        { fase: 'Facturar', rol: 'factura', label: 'Factura' },
+        { fase: 'Escriturar', rol: 'pagare', label: 'Pagaré' },
       ],
     });
     expect(r.items[1]!.ok).toBe(false);

--- a/lib/dilesa/fases.ts
+++ b/lib/dilesa/fases.ts
@@ -1,0 +1,62 @@
+/**
+ * Fuente ÚNICA de las fases del pipeline de ventas DILESA.
+ *
+ * La identidad de una fase es su POSICIÓN (1–17): estable y cableada en los
+ * triggers de DB (estado terminada=17, plan CxC 2–11, encuesta/entrega 15…).
+ * El `nombre` es solo la etiqueta visible — se renombra editando SOLO este
+ * archivo + una migración que reescribe `venta_fase_catalogo` y el historial
+ * (`venta_fases.fase`, `ventas.fase_actual`) por posición. El `slug` es la
+ * carpeta de captura (`/dilesa/ventas/[id]/capturar/<slug>`): una URL estable
+ * que NO cambia con los renombres.
+ *
+ * Convención de nombres (2026-06-24, Beto): "acción a realizar" — el nombre
+ * dice qué hay que hacer para avanzar (Asignar, Escriturar, Entregar), salvo
+ * "Validación Patronal" que conserva el nombre del documento.
+ *
+ * Todo lo demás deriva de aquí: las vistas (FASES_ORDEN en el detalle,
+ * FASES_PIPELINE en captura), el lookup posición→nombre y el mapa documental
+ * FASE_ROLES (llaveado por posición). Una sola lista que mantener. Sin imports
+ * con efectos → importable desde client y server.
+ */
+
+export type FaseVenta = {
+  readonly posicion: number;
+  readonly nombre: string;
+  readonly slug: string;
+};
+
+export const FASES_VENTA = [
+  { posicion: 1, nombre: 'Solicitar asignación', slug: '1-solicitud-asignacion' },
+  { posicion: 2, nombre: 'Asignar unidad', slug: '2-asignada' },
+  { posicion: 3, nombre: 'Formalizar promesa', slug: '3-formalizada' },
+  { posicion: 4, nombre: 'Solicitar avalúo', slug: '4-solicitud-avaluo' },
+  { posicion: 5, nombre: 'Cerrar avalúo', slug: '5-avaluo-cerrado' },
+  { posicion: 6, nombre: 'Inscribir crédito', slug: '6-inscrita' },
+  { posicion: 7, nombre: 'Solicitar dictamen', slug: '7-solicitud-dictamen' },
+  { posicion: 8, nombre: 'Dictaminar', slug: '8-dictaminada' },
+  { posicion: 9, nombre: 'Validación Patronal', slug: '9-validacion-patronal' },
+  { posicion: 10, nombre: 'Programar firmas', slug: '10-firmas-programadas' },
+  { posicion: 11, nombre: 'Escriturar', slug: '11-escriturada' },
+  { posicion: 12, nombre: 'Detonar crédito', slug: '12-detonada' },
+  { posicion: 13, nombre: 'Facturar', slug: '13-facturada' },
+  { posicion: 14, nombre: 'Preparar entrega', slug: '14-preparada-entrega' },
+  { posicion: 15, nombre: 'Entregar', slug: '15-entregada' },
+  { posicion: 16, nombre: 'Recabar conformidad', slug: '16-conformidad' },
+  { posicion: 17, nombre: 'Cerrar operación', slug: '17-operacion-terminada' },
+] as const;
+
+export type FaseSlug = (typeof FASES_VENTA)[number]['slug'];
+
+const NOMBRE_BY_POS: ReadonlyMap<number, string> = new Map(
+  FASES_VENTA.map((f) => [f.posicion, f.nombre])
+);
+
+/** Nombre visible de una fase por su posición. Fallback defensivo si no existe. */
+export function nombreFase(posicion: number): string {
+  return NOMBRE_BY_POS.get(posicion) ?? `Fase ${posicion}`;
+}
+
+/** Record posición → nombre, para lookups O(1) en server actions y rutas API. */
+export const FASES_NOMBRE_BY_POS: Readonly<Record<number, string>> = Object.fromEntries(
+  FASES_VENTA.map((f) => [f.posicion, f.nombre])
+);

--- a/lib/dilesa/kpis/fases.test.ts
+++ b/lib/dilesa/kpis/fases.test.ts
@@ -31,7 +31,7 @@ describe('deriveFasesKpis (DILESA Fases — ADR-034)', () => {
       v({ estado: 'activa' }),
       v({ estado: 'activa' }),
       v({ estado: 'desasignada' }),
-      v({ estado: 'terminada', fase_actual: 'Operación Terminada', fase_posicion: 17 }),
+      v({ estado: 'terminada', fase_actual: 'Cerrar operación', fase_posicion: 17 }),
     ];
     expect(deriveFasesKpis(rows, { now: NOW })[0]?.value).toBe(2);
   });

--- a/lib/dilesa/pdf/checklist-entrega.tsx
+++ b/lib/dilesa/pdf/checklist-entrega.tsx
@@ -256,7 +256,7 @@ export function ChecklistEntregaPDF({ data }: { data: ChecklistEntregaData }) {
         <Text style={local.leyenda}>
           La vivienda queda preparada para entrega una vez verificados todos los puntos. El
           checklist firmado se digitaliza y se archiva en el expediente de la operación (Fase 14 —
-          Preparada para Entrega).
+          Preparar entrega).
         </Text>
 
         <FooterBand />

--- a/lib/dilesa/reportes/estancadas.test.ts
+++ b/lib/dilesa/reportes/estancadas.test.ts
@@ -5,7 +5,7 @@ import type { EstancadaRow } from './estancadas-data';
 function row(p: Partial<EstancadaRow>): EstancadaRow {
   return {
     ventaId: p.ventaId ?? 'x',
-    faseActual: p.faseActual ?? 'Avalúo Cerrado',
+    faseActual: p.faseActual ?? 'Cerrar avalúo',
     fasePosicion: p.fasePosicion ?? 5,
     fechaFaseActual: p.fechaFaseActual ?? '2026-06-01',
     diasEnFase: p.diasEnFase ?? 0,

--- a/lib/dilesa/reportes/pipeline-por-fase.test.ts
+++ b/lib/dilesa/reportes/pipeline-por-fase.test.ts
@@ -9,9 +9,9 @@ import {
 
 const FASES: FaseCatalogo[] = [
   // A propósito desordenadas para verificar el sort por posición.
-  { posicion: 2, nombre: 'Asignada', rol: 'Gerencia General' },
-  { posicion: 1, nombre: 'Solicitud de Asignación', rol: 'Todos' },
-  { posicion: 3, nombre: 'Formalizada', rol: 'Gerencia General' },
+  { posicion: 2, nombre: 'Asignar unidad', rol: 'Gerencia General' },
+  { posicion: 1, nombre: 'Solicitar asignación', rol: 'Todos' },
+  { posicion: 3, nombre: 'Formalizar promesa', rol: 'Gerencia General' },
 ];
 
 describe('construirPipelinePorFase', () => {
@@ -26,37 +26,37 @@ describe('construirPipelinePorFase', () => {
 
   it('cuenta y suma monto solo de ventas activas, por fase', () => {
     const ventas: VentaPipeline[] = [
-      { estado: 'activa', fase_actual: 'Asignada', precio: 100 },
-      { estado: 'activa', fase_actual: 'Asignada', precio: 200 },
-      { estado: 'activa', fase_actual: 'Formalizada', precio: 50 },
-      { estado: 'desasignada', fase_actual: 'Asignada', precio: 999 }, // excluida
+      { estado: 'activa', fase_actual: 'Asignar unidad', precio: 100 },
+      { estado: 'activa', fase_actual: 'Asignar unidad', precio: 200 },
+      { estado: 'activa', fase_actual: 'Formalizar promesa', precio: 50 },
+      { estado: 'desasignada', fase_actual: 'Asignar unidad', precio: 999 }, // excluida
     ];
     const res = construirPipelinePorFase(FASES, ventas);
-    const asignada = res.filas.find((f) => f.fase === 'Asignada')!;
+    const asignada = res.filas.find((f) => f.fase === 'Asignar unidad')!;
     expect(asignada.ventas).toBe(2);
     expect(asignada.monto).toBe(300);
     expect(res.totalVentas).toBe(3);
     expect(res.totalMonto).toBe(350);
-    expect(res.faseCuello).toBe('Asignada');
+    expect(res.faseCuello).toBe('Asignar unidad');
   });
 
   it('trata precio null como 0 en el monto pero cuenta la venta', () => {
     const ventas: VentaPipeline[] = [
-      { estado: 'activa', fase_actual: 'Formalizada', precio: null },
+      { estado: 'activa', fase_actual: 'Formalizar promesa', precio: null },
     ];
     const res = construirPipelinePorFase(FASES, ventas);
-    const f = res.filas.find((x) => x.fase === 'Formalizada')!;
+    const f = res.filas.find((x) => x.fase === 'Formalizar promesa')!;
     expect(f.ventas).toBe(1);
     expect(f.monto).toBe(0);
   });
 
   it('calcula los shares (pctVentas/pctMonto) sobre los totales', () => {
     const ventas: VentaPipeline[] = [
-      { estado: 'activa', fase_actual: 'Asignada', precio: 75 },
-      { estado: 'activa', fase_actual: 'Formalizada', precio: 25 },
+      { estado: 'activa', fase_actual: 'Asignar unidad', precio: 75 },
+      { estado: 'activa', fase_actual: 'Formalizar promesa', precio: 25 },
     ];
     const res = construirPipelinePorFase(FASES, ventas);
-    const asignada = res.filas.find((f) => f.fase === 'Asignada')!;
+    const asignada = res.filas.find((f) => f.fase === 'Asignar unidad')!;
     expect(asignada.pctVentas).toBeCloseTo(0.5);
     expect(asignada.pctMonto).toBeCloseTo(0.75);
   });
@@ -74,7 +74,7 @@ describe('filtrarVentas', () => {
   const base: VentaReporte[] = [
     {
       estado: 'activa',
-      fase_actual: 'Asignada',
+      fase_actual: 'Asignar unidad',
       precio: 100,
       proyectoId: 'p1',
       vendedor: 'Ana',
@@ -82,7 +82,7 @@ describe('filtrarVentas', () => {
     },
     {
       estado: 'activa',
-      fase_actual: 'Formalizada',
+      fase_actual: 'Formalizar promesa',
       precio: 200,
       proyectoId: 'p2',
       vendedor: 'Beto',
@@ -90,7 +90,7 @@ describe('filtrarVentas', () => {
     },
     {
       estado: 'activa',
-      fase_actual: 'Asignada',
+      fase_actual: 'Asignar unidad',
       precio: 300,
       proyectoId: 'p1',
       vendedor: 'Beto',

--- a/lib/dilesa/resumen-consejo-email.test.ts
+++ b/lib/dilesa/resumen-consejo-email.test.ts
@@ -197,13 +197,13 @@ describe('renderResumenConsejoHtml — 4 secciones', () => {
     const html = renderResumenConsejoHtml(
       {
         ...EMPTY,
-        tuberiaViva: [{ fase: 'Formalizada', clientes: 20, valor: 22000000 }],
+        tuberiaViva: [{ fase: 'Formalizar promesa', clientes: 20, valor: 22000000 }],
         tuberiaHistorico: { clientes: 1093, valor: 1060000000 },
       },
       { fechaTitulo: 'x' }
     );
     expect(html).toContain('Pipeline de Ventas (vivo)');
-    expect(html).toContain('Formalizada');
+    expect(html).toContain('Formalizar promesa');
     expect(html).toContain('Histórico acumulado: 1,093 operaciones');
   });
 
@@ -228,41 +228,41 @@ describe('renderResumenConsejoHtml — 4 secciones', () => {
 
 describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
   const CAT = [
-    { nombre: 'Asignada', posicion: 2 },
-    { nombre: 'Solicitud de Asignación', posicion: 1 },
-    { nombre: 'Operación Terminada', posicion: 17 },
+    { nombre: 'Asignar unidad', posicion: 2 },
+    { nombre: 'Solicitar asignación', posicion: 1 },
+    { nombre: 'Cerrar operación', posicion: 17 },
   ];
 
   it('agrupa activas por fase (solo con clientes) y manda terminadas al histórico', () => {
     const { viva, historico } = armarTuberiaSplit(CAT, [
       {
         estado: 'activa',
-        fase_actual: 'Asignada',
+        fase_actual: 'Asignar unidad',
         valor_escrituracion: 1000,
         precio_asignacion: 9999,
       },
       {
         estado: 'activa',
-        fase_actual: 'Asignada',
+        fase_actual: 'Asignar unidad',
         valor_escrituracion: 500,
         precio_asignacion: 9999,
       },
       {
         estado: 'terminada',
-        fase_actual: 'Operación Terminada',
+        fase_actual: 'Cerrar operación',
         valor_escrituracion: 2000,
         precio_asignacion: 9999,
       },
       {
         estado: 'terminada',
-        fase_actual: 'Operación Terminada',
+        fase_actual: 'Cerrar operación',
         valor_escrituracion: 1000,
         precio_asignacion: 9999,
       },
     ]);
     // Solo la fase con clientes vivos; las fases en 0 se filtran del funnel.
     // `valor_escrituracion` tiene precedencia sobre `precio_asignacion` (el 9999 se ignora).
-    expect(viva).toEqual([{ fase: 'Asignada', clientes: 2, valor: 1500 }]);
+    expect(viva).toEqual([{ fase: 'Asignar unidad', clientes: 2, valor: 1500 }]);
     expect(historico).toEqual({ clientes: 2, valor: 3000 });
   });
 
@@ -270,19 +270,19 @@ describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
     const { viva } = armarTuberiaSplit(CAT, [
       {
         estado: 'activa',
-        fase_actual: 'Asignada',
+        fase_actual: 'Asignar unidad',
         valor_escrituracion: null,
         precio_asignacion: 800,
       },
       {
         estado: 'activa',
-        fase_actual: 'Asignada',
+        fase_actual: 'Asignar unidad',
         valor_escrituracion: 1200,
         precio_asignacion: 1000,
       },
     ]);
     // 800 (fallback a precio_asignacion) + 1200 (valor_escrituracion gana) = 2000.
-    expect(viva).toEqual([{ fase: 'Asignada', clientes: 2, valor: 2000 }]);
+    expect(viva).toEqual([{ fase: 'Asignar unidad', clientes: 2, valor: 2000 }]);
   });
 
   it('junta en "Sin fase asignada" las activas con fase NULL o fuera de catálogo', () => {
@@ -302,13 +302,13 @@ describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
     const { viva, historico } = armarTuberiaSplit(CAT, [
       {
         estado: 'desasignada',
-        fase_actual: 'Asignada',
+        fase_actual: 'Asignar unidad',
         valor_escrituracion: 999,
         precio_asignacion: 999,
       },
       {
         estado: 'expirada',
-        fase_actual: 'Asignada',
+        fase_actual: 'Asignar unidad',
         valor_escrituracion: 111,
         precio_asignacion: 111,
       },

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -918,11 +918,11 @@ export async function fetchResumenConsejoData(
       .is('deleted_at', null),
     dilesa
       .from('venta_fases')
-      .select('venta_id,fase,fecha')
+      .select('venta_id,posicion,fecha')
       .eq('empresa_id', empresaId)
       .is('deleted_at', null)
       .gte('fecha', inicioMes)
-      .in('fase', ['Asignada', 'Escriturada']),
+      .in('posicion', [2, 11]),
     dilesa.from('v_contratista_obra').select('*').eq('empresa_id', empresaId),
     erp.from('v_cuenta_saldo_actual').select('*').eq('empresa_id', empresaId),
     dilesa
@@ -930,7 +930,7 @@ export async function fetchResumenConsejoData(
       .select('venta_id')
       .eq('empresa_id', empresaId)
       .is('deleted_at', null)
-      .eq('fase', 'Asignada')
+      .eq('posicion', 2)
       .gte('fecha', inicio3m),
   ]);
 
@@ -1007,7 +1007,7 @@ export async function fetchResumenConsejoData(
     );
     const acc = new Map<string, AsignacionRow>();
     for (const f of fasesMesRes.data ?? []) {
-      const ff = f as { venta_id: string; fase: string };
+      const ff = f as { venta_id: string; posicion: number | null };
       const v = ventaInfo.get(ff.venta_id) as Record<string, unknown> | undefined;
       if (!v) continue;
       const proto = protoNombre.get(unidadProto.get(v.unidad_id as string) ?? '') ?? '—';
@@ -1018,10 +1018,10 @@ export async function fetchResumenConsejoData(
         escrituras_mes: 0,
         monto_escrituras: 0,
       };
-      if (ff.fase === 'Asignada') {
+      if (ff.posicion === 2) {
         row.asignaciones_mes += 1;
         row.monto_asignaciones += Number(v.precio_asignacion ?? 0);
-      } else if (ff.fase === 'Escriturada') {
+      } else if (ff.posicion === 11) {
         row.escrituras_mes += 1;
         row.monto_escrituras += Number(v.valor_escrituracion ?? 0);
       }

--- a/lib/dilesa/resumen-consejo-kpis.test.ts
+++ b/lib/dilesa/resumen-consejo-kpis.test.ts
@@ -59,8 +59,8 @@ describe('armarKpis — agregación pura', () => {
     const kpis = armarKpis({
       ...RAW_VACIO,
       fasesHoy: [
-        { venta_id: 'v1', fase: 'Asignada' },
-        { venta_id: 'v2', fase: 'Escriturada' },
+        { venta_id: 'v1', posicion: 2 },
+        { venta_id: 'v2', posicion: 11 },
       ],
       ventaMontos: [
         { id: 'v1', precio_asignacion: 100, valor_escrituracion: null },
@@ -136,8 +136,8 @@ describe('computeKpisDelDia — wiring de queries', () => {
     const sb = makeSupabase({
       venta_fases: {
         data: [
-          { venta_id: 'v1', fase: 'Asignada' },
-          { venta_id: 'v2', fase: 'Escriturada' },
+          { venta_id: 'v1', posicion: 2 },
+          { venta_id: 'v2', posicion: 11 },
         ],
       },
       ventas: {

--- a/lib/dilesa/resumen-consejo-kpis.ts
+++ b/lib/dilesa/resumen-consejo-kpis.ts
@@ -29,7 +29,7 @@ export type KpisDelDia = {
 
 /** Filas crudas que alimentan `armarKpis` (ya fetcheadas). */
 export type KpisRaw = {
-  fasesHoy: { venta_id: string; fase: string }[];
+  fasesHoy: { venta_id: string; posicion: number | null }[];
   ventaMontos: {
     id: string;
     precio_asignacion: number | null;
@@ -79,10 +79,12 @@ export function armarKpis(raw: KpisRaw): KpisDelDia {
   let escrituras_hoy_monto = 0;
   for (const f of raw.fasesHoy) {
     const v = montoPorVenta.get(f.venta_id);
-    if (f.fase === 'Asignada') {
+    if (f.posicion === 2) {
+      // Asignar unidad (fase 2) = venta nueva del día.
       ventas_hoy_n += 1;
       ventas_hoy_monto += Number(v?.precio_asignacion ?? 0);
-    } else if (f.fase === 'Escriturada') {
+    } else if (f.posicion === 11) {
+      // Escriturar (fase 11) = escritura del día.
       escrituras_hoy_n += 1;
       escrituras_hoy_monto += Number(v?.valor_escrituracion ?? 0);
     }
@@ -144,11 +146,11 @@ export async function computeKpisDelDia(
   const [fasesRes, pagosRes, cargosRes, saldosRes, obraRes] = await Promise.all([
     dilesa
       .from('venta_fases')
-      .select('venta_id,fase')
+      .select('venta_id,posicion')
       .eq('empresa_id', empresaId)
       .is('deleted_at', null)
       .eq('fecha', fechaLocal)
-      .in('fase', ['Asignada', 'Escriturada']),
+      .in('posicion', [2, 11]),
     erp
       .from('cxc_pagos')
       .select('monto_total')
@@ -170,7 +172,7 @@ export async function computeKpisDelDia(
       .eq('estado', 'en_progreso'),
   ]);
 
-  const fasesHoy = (fasesRes.data ?? []) as { venta_id: string; fase: string }[];
+  const fasesHoy = (fasesRes.data ?? []) as { venta_id: string; posicion: number | null }[];
   const ventaIds = [...new Set(fasesHoy.map((f) => f.venta_id))];
   const ventaMontos = ventaIds.length
     ? ((

--- a/supabase/migrations/20260624162109_dilesa_rename_fases_venta_accion.sql
+++ b/supabase/migrations/20260624162109_dilesa_rename_fases_venta_accion.sql
@@ -1,0 +1,104 @@
+-- ╭─ 20260624162109_dilesa_rename_fases_venta_accion ─╮
+-- Renombre de las 17 fases de venta DILESA a la convención "acción a realizar"
+-- (Beto, 2026-06-24). La identidad de la fase es su POSICIÓN (1–17), estable y
+-- cableada en triggers (estado terminada=17, plan CxC 2–11, encuesta/entrega 15…);
+-- aquí solo cambian las ETIQUETAS. Reescribe el catálogo Y el historial
+-- (`venta_fases.fase`, `ventas.fase_actual`) por posición para que ninguna fila
+-- conserve el nombre viejo. La fuente en código es `lib/dilesa/fases.ts`.
+--
+-- NULL-safe / idempotente: scopeado a la empresa 'dilesa' vía JOIN; en el
+-- Supabase Preview branch (sin datos de prod) cada UPDATE afecta 0 filas. Los
+-- guards `IS DISTINCT FROM` hacen que re-correrla no cambie nada.
+--
+-- Mapa pos → nombre nuevo:
+--   1 Solicitar asignación · 2 Asignar unidad · 3 Formalizar promesa
+--   4 Solicitar avalúo · 5 Cerrar avalúo · 6 Inscribir crédito
+--   7 Solicitar dictamen · 8 Dictaminar · 9 Validación Patronal (sin cambio)
+--   10 Programar firmas · 11 Escriturar · 12 Detonar crédito · 13 Facturar
+--   14 Preparar entrega · 15 Entregar · 16 Recabar conformidad · 17 Cerrar operación
+
+BEGIN;
+
+-- 1) Backfill defensivo de `posicion` en filas históricas que la tengan NULL,
+--    emparejando por el nombre VIEJO contra el catálogo aún sin renombrar. Así
+--    los pasos 4/5 (por posición) cubren también el historial migrado de Coda.
+UPDATE dilesa.venta_fases vf
+SET posicion = c.posicion
+FROM dilesa.venta_fase_catalogo c
+WHERE vf.posicion IS NULL
+  AND vf.empresa_id = c.empresa_id
+  AND vf.fase = c.nombre
+  AND c.deleted_at IS NULL;
+
+-- 2) Renombrar el catálogo por posición (la fuente del nombre visible en DB).
+UPDATE dilesa.venta_fase_catalogo c
+SET nombre = m.nombre
+FROM (
+  VALUES
+    (1, 'Solicitar asignación'),
+    (2, 'Asignar unidad'),
+    (3, 'Formalizar promesa'),
+    (4, 'Solicitar avalúo'),
+    (5, 'Cerrar avalúo'),
+    (6, 'Inscribir crédito'),
+    (7, 'Solicitar dictamen'),
+    (8, 'Dictaminar'),
+    (9, 'Validación Patronal'),
+    (10, 'Programar firmas'),
+    (11, 'Escriturar'),
+    (12, 'Detonar crédito'),
+    (13, 'Facturar'),
+    (14, 'Preparar entrega'),
+    (15, 'Entregar'),
+    (16, 'Recabar conformidad'),
+    (17, 'Cerrar operación')
+) AS m(posicion, nombre)
+WHERE c.posicion = m.posicion
+  AND c.empresa_id = (SELECT id FROM core.empresas WHERE slug = 'dilesa')
+  AND c.nombre IS DISTINCT FROM m.nombre;
+
+-- 3) Descripción de las fases con matiz que Beto explicó (queda como ayuda en el
+--    catálogo; hoy el campo estaba vacío).
+UPDATE dilesa.venta_fase_catalogo c
+SET descripcion = m.descripcion
+FROM (
+  VALUES
+    (3, 'Formalizar la promesa de compraventa con el cliente.'),
+    (6, 'Inscripción del crédito ante la notaría.'),
+    (9, 'Documento que valida que se le otorgará el crédito al trabajador y que la empresa aplicará el descuento vía nómina.')
+) AS m(posicion, descripcion)
+WHERE c.posicion = m.posicion
+  AND c.empresa_id = (SELECT id FROM core.empresas WHERE slug = 'dilesa')
+  AND c.descripcion IS DISTINCT FROM m.descripcion;
+
+-- 4) Reescribir el historial del pipeline (`venta_fases.fase`) por posición. El
+--    guard NOT EXISTS evita violar el UNIQUE(venta_id, fase) si una venta tuviera
+--    dos filas en la misma posición con nombres distintos (ej. residuo del
+--    renombre histórico de la fase 16); esa fila rara se deja como está.
+UPDATE dilesa.venta_fases vf
+SET fase = c.nombre
+FROM dilesa.venta_fase_catalogo c
+WHERE vf.empresa_id = c.empresa_id
+  AND vf.posicion = c.posicion
+  AND c.deleted_at IS NULL
+  AND vf.fase IS DISTINCT FROM c.nombre
+  AND NOT EXISTS (
+    SELECT 1
+    FROM dilesa.venta_fases vf2
+    WHERE vf2.venta_id = vf.venta_id
+      AND vf2.fase = c.nombre
+      AND vf2.id <> vf.id
+  );
+
+-- 5) Reescribir el caché de fase actual en `ventas.fase_actual` por posición.
+UPDATE dilesa.ventas v
+SET fase_actual = c.nombre
+FROM dilesa.venta_fase_catalogo c
+WHERE v.empresa_id = c.empresa_id
+  AND v.fase_posicion = c.posicion
+  AND c.deleted_at IS NULL
+  AND v.fase_actual IS DISTINCT FROM c.nombre;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Qué cambia

Renombra las **17 fases del pipeline de ventas DILESA** de la mezcla actual
(participios + "Solicitud de…" + estados) a una convención única: **la acción
que se realiza para avanzar**.

| Pos | Antes | Ahora | Pos | Antes | Ahora |
|----|----|----|----|----|----|
| 1 | Solicitud de Asignación | **Solicitar asignación** | 10 | Firmas Programadas | **Programar firmas** |
| 2 | Asignada | **Asignar unidad** | 11 | Escriturada | **Escriturar** |
| 3 | Formalizada | **Formalizar promesa** | 12 | Detonada | **Detonar crédito** |
| 4 | Solicitud de Avalúo | **Solicitar avalúo** | 13 | Facturada | **Facturar** |
| 5 | Avalúo Cerrado | **Cerrar avalúo** | 14 | Preparada para Entrega | **Preparar entrega** |
| 6 | Inscrita | **Inscribir crédito** | 15 | Entregada | **Entregar** |
| 7 | Solicitud de Dictaminación | **Solicitar dictamen** | 16 | Conformidad del Cliente | **Recabar conformidad** |
| 8 | Dictaminada | **Dictaminar** | 17 | Operación Terminada | **Cerrar operación** |
| 9 | Validación Patronal | **Validación Patronal** (sin cambio — nombre del documento) | | | |

## Cómo (centralización = blindaje)

- **Fuente única** `lib/dilesa/fases.ts` (posición → nombre + slug). `FASES_ORDEN`,
  `FASES_PIPELINE` y el mapa de `actions.ts` derivan de ahí — se eliminan 3 copias.
- **`FASE_ROLES`** (qué documentos exige cada fase) y los **filtros del correo al
  Consejo** pasan de llave-por-nombre a **llave-por-posición**. Antes un renombre
  los rompía en silencio; ahora son inmunes.
- **`CapturarFaseHeader`** y **`marcarFase`** derivan el nombre de la `posicion`
  (se quitó el parámetro de nombre): es **imposible** escribir un nombre
  incongruente en el historial.
- **Migración** `20260624162109`: reescribe `venta_fase_catalogo` + el historial
  (`venta_fases.fase`, `ventas.fase_actual`) por posición, y pobla la
  `descripcion` de F3/F6/F9 con la explicación de negocio. **No toca posiciones
  ni triggers** (estado terminada=17, plan CxC 2–11, encuesta/entrega 15 siguen
  intactos). NULL-safe e idempotente.

Próximo renombre futuro = editar una línea en `fases.ts` + una migración análoga.

## Qué NO cambia
URLs de captura, slugs RBAC (`faseNN_*`), posiciones, triggers, estados de unidad
(`unidades.estado`), KPIs de conteo, y los **nombres de documento** ("Solicitud de
Asignación"/"Promesa de Compraventa" como PDFs y labels de carga).

## Verificación
- typecheck ✓ · test:coverage **2014 tests** ✓ · lint (0 errores) ✓ · format ✓ ·
  initiatives ✓ · schema:check (sin drift — migración solo-datos) ✓
- `fases.ts` 100% líneas; 103 tests del dominio DILESA tocados pasan.

## ⚠️ Coordinación de la migración a prod
La migración reescribe el catálogo y el historial. Como el código nuevo lee/escribe
nombres nuevos, **catálogo y `fase_actual` deben quedar consistentes al desplegar**.
El Supabase Preview branch la aplica solo (el preview muestra todo end-to-end). Para
**prod**: aplicarla con `supabase db push` coordinado con el merge (OK verbal de Beto).
