### PR TITLE
fix(dilesa-construccion): timeout en Estimaciones para operadores no-admin

### DIFF
--- a/components/dilesa/estimaciones-module.tsx
+++ b/components/dilesa/estimaciones-module.tsx
@@ -123,22 +123,23 @@ export function EstimacionesModule({ empresaId }: { empresaId: string }) {
   }> => {
     const sb = createSupabaseBrowserClient();
 
-    // 4 queries paralelas: estimaciones + estimacion_tareas (count) +
+    // 3 queries paralelas: estimaciones (con conteo embebido de tareas) +
     // personas (contratistas, cross-schema) + datos satellite (abrev).
-    const [eRes, etRes, personasRes, datosRes] = await Promise.all([
+    //
+    // El conteo de tareas va embebido (`estimacion_tareas(count)`) en vez de
+    // bajar las ~130k filas de estimacion_tareas para contarlas en JS: el
+    // servidor agrega vía el FK estimacion_id y solo devuelve un número por
+    // estimación (paga RLS una vez gracias al fix set-membership de la política
+    // estimacion_tareas_rls_select — ver migración 20260624180340).
+    const [eRes, personasRes, datosRes] = await Promise.all([
       sb
         .schema('dilesa')
         .from('estimaciones')
         .select(
-          'id, codigo, fecha_cierre, fecha_pago_programado, contratista_id, monto_bruto, monto_neto, estado, pagada_at'
+          'id, codigo, fecha_cierre, fecha_pago_programado, contratista_id, monto_bruto, monto_neto, estado, pagada_at, estimacion_tareas(count)'
         )
         .eq('empresa_id', empresaId)
         .is('deleted_at', null),
-      sb
-        .schema('dilesa')
-        .from('estimacion_tareas')
-        .select('estimacion_id')
-        .eq('empresa_id', empresaId),
       sb
         .schema('erp')
         .from('personas')
@@ -153,7 +154,7 @@ export function EstimacionesModule({ empresaId }: { empresaId: string }) {
         .is('deleted_at', null),
     ]);
 
-    const firstErr = eRes.error ?? etRes.error ?? personasRes.error ?? datosRes.error;
+    const firstErr = eRes.error ?? personasRes.error ?? datosRes.error;
     if (firstErr) {
       return {
         error: getSupabaseErrorMessage(firstErr, 'No se pudieron cargar las estimaciones.'),
@@ -170,12 +171,6 @@ export function EstimacionesModule({ empresaId }: { empresaId: string }) {
       abrevMap.set(d.persona_id as string, (d.abreviacion as string | null) ?? null);
     }
 
-    const tareasByEstim = new Map<string, number>();
-    for (const t of etRes.data ?? []) {
-      const eid = t.estimacion_id as string;
-      tareasByEstim.set(eid, (tareasByEstim.get(eid) ?? 0) + 1);
-    }
-
     const rows: EstimacionRow[] = (eRes.data ?? []).map((e) => {
       const cid = e.contratista_id as string;
       return {
@@ -190,7 +185,7 @@ export function EstimacionesModule({ empresaId }: { empresaId: string }) {
         pagada_at: (e.pagada_at as string | null) ?? null,
         contratistaNombre: personaMap.get(cid) ?? '(sin contratista)',
         contratistaAbreviacion: abrevMap.get(cid) ?? null,
-        tareasCount: tareasByEstim.get(e.id as string) ?? 0,
+        tareasCount: Number((e.estimacion_tareas as { count: number }[] | null)?.[0]?.count ?? 0),
       };
     });
 

--- a/supabase/migrations/20260624180340_estimacion_tareas_rls_set_membership.sql
+++ b/supabase/migrations/20260624180340_estimacion_tareas_rls_set_membership.sql
@@ -1,0 +1,25 @@
+-- ╭─ 20260624180340_estimacion_tareas_rls_set_membership ─╮
+-- Perf RLS: la política SELECT de dilesa.estimacion_tareas usaba
+-- `core.fn_has_empresa(empresa_id)` — una función con argumento de COLUMNA,
+-- que Postgres evalúa POR FILA (aunque sea STABLE). Con 129k+ filas, un
+-- operador no-admin (p.ej. el rol "Dirección" de DILESA) gatillaba 129k
+-- llamadas a la función → ~7.1s, pasando el statement_timeout de 8s del rol
+-- `authenticated` → "canceling statement due to statement timeout". El admin
+-- no lo veía porque `fn_is_admin()` cortocircuita el OR a true constante.
+--
+-- Fix: set-membership. `empresa_id IN (SELECT core.fn_current_empresa_ids())`
+-- evalúa el subquery UNA sola vez (InitPlan), no por fila → ~40ms.
+-- Autorización IDÉNTICA: fn_current_empresa_ids() corre el mismo join con los
+-- mismos filtros (u.activo + ue.activo) que fn_has_empresa. El override de
+-- admin se preserva. ALTER POLICY conserva rol (PUBLIC), cmd (SELECT) y
+-- permissive; solo reemplaza el predicado USING.
+
+BEGIN;
+
+ALTER POLICY estimacion_tareas_rls_select ON dilesa.estimacion_tareas
+  USING (
+    empresa_id IN (SELECT core.fn_current_empresa_ids())
+    OR core.fn_is_admin()
+  );
+
+COMMIT;


### PR DESCRIPTION
## Problema

A los operadores **no-admin** (p.ej. Michelle, rol *Dirección* de DILESA) el tab **Construcción → Estimaciones** les fallaba con `canceling statement due to statement timeout`. A un admin (Beto) le cargaba bien.

## Causa raíz

La política RLS SELECT de `dilesa.estimacion_tareas` (129,629 filas) usaba `core.fn_has_empresa(empresa_id)` — una función con argumento de **columna**, que Postgres evalúa **por fila** aunque sea `STABLE`.

- **Admin:** `fn_is_admin()` cortocircuita el `OR` a `true` constante → 0 llamadas por fila → rápido.
- **No-admin:** evalúa `fn_has_empresa` **129,629 veces** → ~7.1s, pasando el `statement_timeout = 8s` del rol `authenticated`.

Medido simulando el rol de Michelle (`EXPLAIN ANALYZE` en prod):

| Query | Antes | Después |
|---|---|---|
| Scan crudo de `estimacion_tareas` | 7,094 ms ❌ | 1,095 ms ✅ |
| **Conteo embebido (lo que corre la página)** | 6,133 ms ❌ | **257 ms** ✅ |

## Fix

**1. Migración `20260624180340` (DB).** `ALTER POLICY estimacion_tareas_rls_select` a set-membership:

```sql
empresa_id IN (SELECT core.fn_current_empresa_ids()) OR core.fn_is_admin()
```

El subquery se evalúa **una vez** (InitPlan / hashed SubPlan), no por fila. **Autorización idéntica**: `fn_current_empresa_ids()` corre el mismo join con los mismos filtros (`u.activo` + `ue.activo`) que `fn_has_empresa`; override de admin preservado. `ALTER POLICY` conserva rol (PUBLIC), cmd (SELECT) y permissive.

**2. App (`estimaciones-module.tsx`).** Conteo de tareas vía embed `estimacion_tareas(count)` en vez de bajar las ~130k filas al browser para contarlas en JS. Server-side, vía el FK `estimacion_id`.

## Estado

- Migración **ya aplicada a prod** (OK verbal de Beto) + **ledger reconciliado** (`migration repair`, par 1:1). Michelle ya puede trabajar; el app fix llega con el deploy.
- 6 checks de CI verdes localmente (typecheck, test:coverage 2017/2017, lint, format, initiatives, schema).

## Nota cross-sesión

El patrón `fn_has_empresa(<columna>)` está en **352 políticas** de BSOP — deuda latente que reaparecerá conforme crezcan otras tablas grandes. Candidato a iniciativa de barrido (set-membership generalizado), aparte de este hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)