### PR TITLE
feat(dilesa-ventas): pagaré firmado obligatorio en fase 8 (se mueve de la 10)

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
@@ -6,11 +6,10 @@
  * Gerencia Ventas (o Dirección) programa la fecha + hora de firma ya acordada
  * con el notario (que viene de Fase 7) y genera la Póliza de Garantía.
  *
- * ADR-048: el **crédito directo (pagaré) ya NO se captura aquí** — se define en
- * la dictaminación (fase 8), con el saldo REAL del Anexo B. Si la venta tiene
- * crédito directo, aquí solo se sube el **pagaré firmado** que se recaba en la
- * firma (rol `pagare`, el mismo que reconoce la fase Escriturar y
- * `rolesOpcionales`).
+ * ADR-048: el **crédito directo (pagaré) ya NO se captura aquí** — se define y se
+ * recaba firmado en la dictaminación (fase 8), con el saldo REAL del Anexo B
+ * (decisión Beto 2026-06-24). Esta fase solo programa la fecha/hora de firma y
+ * genera la Póliza de Garantía.
  *
  * Tasas / cobertura / plan de pagos: viven en la fase 8.
  *
@@ -32,20 +31,7 @@ import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
 import { marcarFase } from '@/lib/dilesa/captura/marcar-fase';
-import {
-  DocsFaseSection,
-  useDocsFaseColaborativos,
-  type SlotColaborativo,
-} from '@/components/dilesa/captura/docs-fase-colaborativos';
 import { getNotaria } from '@/lib/dilesa/notarios';
-
-const SLOTS_FASE: SlotColaborativo[] = [
-  {
-    rol: 'pagare',
-    label: 'Pagaré firmado (súbelo cuando lo tengas)',
-    requerido: false,
-  },
-];
 
 type VentaCtx = {
   id: string;
@@ -54,8 +40,6 @@ type VentaCtx = {
   fecha_firma_programada: string | null;
   hora_firma_programada: string | null;
   poliza_garantia_expedida_at: string | null;
-  // Definido en la fase 8 (ADR-048). Aquí solo decide si se pide el pagaré firmado.
-  monto_credito_directo: number | null;
 };
 
 const MESES_LARGO = [
@@ -95,7 +79,6 @@ function CapturarFase10Body() {
   const sb = useMemo(() => createSupabaseBrowserClient(), []);
   const { data: me } = useEffectiveUser();
   const ventaId = params.id;
-  const docsFase = useDocsFaseColaborativos(ventaId, SLOTS_FASE);
 
   const [venta, setVenta] = useState<VentaCtx | null>(null);
   const [notarioNombre, setNotarioNombre] = useState<string | null>(null);
@@ -128,7 +111,7 @@ function CapturarFase10Body() {
         .schema('dilesa')
         .from('ventas')
         .select(
-          'id, empresa_id, notario_id, fecha_firma_programada, hora_firma_programada, poliza_garantia_expedida_at, monto_credito_directo'
+          'id, empresa_id, notario_id, fecha_firma_programada, hora_firma_programada, poliza_garantia_expedida_at'
         )
         .eq('id', ventaId)
         .is('deleted_at', null)
@@ -187,7 +170,6 @@ function CapturarFase10Body() {
   const firmaCongelada = polizaExpedida || yaCerrada;
   const fechaBloqueada = firmaCongelada && !esDireccion;
   const tieneFechaPersistida = !!venta?.fecha_firma_programada;
-  const tieneCreditoDirecto = venta?.monto_credito_directo != null;
 
   // Persiste fecha/hora de firma sin cerrar la fase. Enciende la póliza con esa
   // fecha. Si el trigger la rechaza (congelada + rol no Dirección), avisa.
@@ -351,17 +333,6 @@ function CapturarFase10Body() {
     </span>
   ) : null;
 
-  // Sección del pagaré firmado (solo si la fase 8 definió un crédito directo).
-  const pagareSection = tieneCreditoDirecto ? (
-    <Section title="Pagaré firmado">
-      <p className="mb-3 text-xs text-[var(--text)]/60">
-        El crédito directo se definió en la dictaminación (fase 8). Imprime el pagaré desde ahí,
-        recábalo firmado en la firma y súbelo aquí.
-      </p>
-      <DocsFaseSection state={docsFase} titulo="Pagaré firmado" />
-    </Section>
-  ) : null;
-
   return (
     <div className="container mx-auto max-w-6xl space-y-6 px-4 py-6">
       <CapturarFaseHeader
@@ -388,8 +359,6 @@ function CapturarFase10Body() {
             </p>
             {polizaButton}
           </Section>
-
-          {pagareSection}
 
           {esDireccion ? (
             <Section title="Reprogramar firma (Dirección)">
@@ -499,8 +468,6 @@ function CapturarFase10Body() {
             ) : null}
             {polizaButton}
           </Section>
-
-          {pagareSection}
 
           <div className="flex items-center justify-end gap-3">
             <Link

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -48,6 +48,18 @@ import {
   CreditoDirectoCaptura,
   type PlanPagoJson,
 } from '@/components/dilesa/captura/credito-directo-captura';
+import {
+  DocsFaseSection,
+  useDocsFaseColaborativos,
+  type SlotColaborativo,
+} from '@/components/dilesa/captura/docs-fase-colaborativos';
+
+// Pagaré firmado (decisión Beto 2026-06-24): el documento se recaba en la
+// dictaminación (no en la firma). Mismo adjunto (rol `pagare`) que reconoce la
+// fase Escriturar; obligatorio para cerrar la fase cuando hay crédito directo.
+const SLOTS_PAGARE: SlotColaborativo[] = [
+  { rol: 'pagare', label: 'Pagaré firmado por el cliente', requerido: true },
+];
 
 type VentaCtx = {
   id: string;
@@ -133,6 +145,8 @@ function CapturarFase8Body() {
   // pagaré (ADR-048: el cierre financiero se cuadra aquí, con los datos reales).
   const resumen = useVentaCapturaResumen();
   const { data: me } = useEffectiveUser();
+  // Pagaré firmado: estado del adjunto colaborativo (rol `pagare`) — gate del cierre.
+  const docsPagare = useDocsFaseColaborativos(ventaId, SLOTS_PAGARE);
 
   const [venta, setVenta] = useState<VentaCtx | null>(null);
   // El crédito directo (pagaré) reporta su estado "guardado" para el gate del
@@ -409,6 +423,16 @@ function CapturarFase8Body() {
         });
         return;
       }
+      // El pagaré firmado se recaba en la dictaminación (decisión Beto 2026-06-24):
+      // obligatorio para cerrar la fase cuando la operación lleva crédito directo.
+      if (cob && cob.pagareNecesario > 0.0049 && docsPagare.faltantes.length > 0) {
+        toast.add({
+          title: 'Falta el pagaré firmado',
+          description: 'Sube el pagaré firmado por el cliente antes de cerrar la dictaminación.',
+          type: 'error',
+        });
+        return;
+      }
       // Re-firma pendiente (ADR-048 D5): si el precio dictaminado difiere del de los
       // documentos firmados, no se avanza hasta re-firmar Solicitud + Promesa.
       const valorN = Number(valorEscrituracion) || 0;
@@ -503,6 +527,7 @@ function CapturarFase8Body() {
       valorEscrituracion,
       adjuntosNotariales,
       cdGuardado,
+      docsPagare,
       me,
       resumen,
       router,
@@ -737,6 +762,20 @@ function CapturarFase8Body() {
   const saldoCD = cobGastos ? cobGastos.pagareNecesario : 0;
   const aplicaCD = saldoCD > 0.0049;
 
+  // Pagaré firmado (decisión Beto 2026-06-24): se recaba en la dictaminación, no
+  // en la firma. Obligatorio para cerrar la fase cuando hay crédito directo (el
+  // gate vive en onSubmit). Reusado en ambos forms (cierre y "ya cerrada") para
+  // que las ventas ya dictaminadas también puedan subirlo.
+  const pagareFirmadoSection = aplicaCD ? (
+    <Section title="Pagaré firmado">
+      <p className="mb-3 text-xs text-[var(--text)]/60">
+        Imprime el pagaré del crédito directo (sección de arriba), recábalo firmado por el cliente y
+        súbelo aquí. Es obligatorio para cerrar la dictaminación.
+      </p>
+      <DocsFaseSection state={docsPagare} titulo="Pagaré firmado" />
+    </Section>
+  ) : null;
+
   // Re-firma de documentos (ADR-048 D5): el precio dictaminado capturado difiere
   // del que tienen los documentos firmados vigentes → hay que re-firmar Solicitud
   // + Promesa antes de avanzar. El snapshot se actualiza al confirmar la re-firma.
@@ -964,6 +1003,8 @@ function CapturarFase8Body() {
               </Section>
             ) : null}
 
+            {pagareFirmadoSection}
+
             {refirmaSection}
 
             <div className="flex items-center justify-end gap-3">
@@ -1167,6 +1208,8 @@ function CapturarFase8Body() {
               />
             </Section>
           ) : null}
+
+          {pagareFirmadoSection}
 
           {refirmaSection}
 

--- a/docs/adr/048_cierre_financiero_dictaminacion.md
+++ b/docs/adr/048_cierre_financiero_dictaminacion.md
@@ -28,6 +28,8 @@ Flujo de fases (no cambia): `… 7 Solicitud Dictamen → 8 Dictaminada → 9 Va
 
 **D6 — La congelación del precio (regla 2026-06-15) cede en la dictaminación.** El precio se congela al asignar para que reglas globales (ZCU, +6%) no re-tarifen ventas viejas; la dictaminación es la **excepción legítima** — ahí llegan los datos reales y Dirección puede ajustar el precio, condicionado a la re-firma de D5. Una sesión futura NO debe tratar este ajuste como violación de la congelación.
 
+**D7 — El pagaré firmado también se recaba en la fase 8 (decisión Beto 2026-06-24).** D1/D4 movieron a la fase 8 la **definición** del pagaré (monto/plan/tasas), pero el **documento firmado** (adjunto rol `pagare`) había quedado como slot opcional en la fase 10 — un cabo suelto. Se **mueve el slot a la fase 8** y se vuelve **obligatorio para cerrar la dictaminación cuando la operación lleva crédito directo** (`coberturaGastos.pagareNecesario > 0`): no se cierra la fase 8 sin el pagaré firmado subido. El slot sale de la fase 10. El adjunto es por rol y vive en el expediente, así que sigue visible en la fase Escriturar; las ventas ya dictaminadas (fase ≥ 8) lo suben desde la vista "fase ya cerrada" de la 8. Razón: el cliente firma el pagaré en la dictaminación, cuando acepta el crédito directo — recabarlo ahí evita cerrar el cierre financiero sin el documento que lo respalda.
+
 ## Migración
 
 Las ventas en **fase 10 (pagaré) que aún no programan firmas** se **regresan a la fase 8** (`regresarAFase`, ya existe) para cuadrar ahí, **conservando los documentos ya subidos**. Vuelven a pasar por dictaminación con el flujo nuevo. Las que ya programaron firmas o escrituraron no se tocan.


### PR DESCRIPTION
## Qué

El requisito del **pagaré firmado** vivía solo en la **fase 10 (Programar firmas)**, pero ADR-048 ya había movido la *definición* del crédito directo a la **fase 8 (Dictaminar)**. Faltó mover el *documento firmado* — cabo suelto que detectó Beto.

Este PR lo mueve a la fase 8 y lo hace **obligatorio** (decisión Beto 2026-06-24, respondiendo dos preguntas: *mover* a la 8 + *obligatorio* para cerrar).

## Cambios

- **Fase 8 (Dictaminar):** slot "Pagaré firmado" (rol `pagare`, requerido) tras el bloque de crédito directo, presente en el form de cierre **y** en el de "ya cerrada" (para ventas ya dictaminadas, p.ej. migradas de Coda que saltaron la fase). Gate en `onSubmit`: no se cierra la dictaminación sin el pagaré firmado **cuando hay crédito directo** (`coberturaGastos.pagareNecesario > 0`).
- **Fase 10 (Programar firmas):** se elimina el slot del pagaré y todas sus referencias (`SLOTS_FASE`, hook, `tieneCreditoDirecto`, `monto_credito_directo` del select/type, sección en ambos forms). Queda solo fecha/hora de firma + Póliza de Garantía.
- **ADR-048:** nueva decisión **D7** que registra el cambio.

El adjunto es por rol y vive en el expediente, así que sigue visible en la fase **Escriturar**; subirlo en la fase 8 lo refleja ahí.

## Verificación local (5/6 checks)

- ✅ typecheck · ✅ test:coverage (159 archivos / 2017 tests) · ✅ lint (0 errores) · ✅ format:check · ✅ initiatives:check
- schema:check: no aplica (sin cambios de DB/schema/SCHEMA_REF); CI lo corre igual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)