### PR TITLE
fix(dilesa-ventas): nombres de fase de vuelta a participio (arregla desfase por uno)

### DIFF
--- a/app/api/dilesa/encuesta/[token]/route.test.ts
+++ b/app/api/dilesa/encuesta/[token]/route.test.ts
@@ -123,7 +123,7 @@ describe('POST /api/dilesa/encuesta/[token]', () => {
     });
 
     const insFase = inserts.find((i) => i.tabla === 'venta_fases');
-    expect(insFase?.row).toMatchObject({ posicion: 16, fase: 'Recabar conformidad' });
+    expect(insFase?.row).toMatchObject({ posicion: 16, fase: 'Conformidad del Cliente' });
 
     const upVenta = updates.find((u) => u.tabla === 'ventas');
     expect(upVenta?.patch).toMatchObject({ fase_posicion: 16 });

--- a/app/dilesa/atencion-clientes/page.tsx
+++ b/app/dilesa/atencion-clientes/page.tsx
@@ -109,7 +109,7 @@ function UrgenciaChip({ venta }: { venta: VentaEntrega }) {
       ? 'Falta pago'
       : enEntrega
         ? 'Entregar'
-        : (venta.fase_actual ?? (venta.pago_detonado ? 'Detonar crédito' : 'Escriturar'));
+        : (venta.fase_actual ?? (venta.pago_detonado ? 'Detonada' : 'Escriturada'));
   return (
     <Badge tone={urgenciaTono(venta)}>
       <Icono />

--- a/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/10-firmas-programadas/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 10 — Programar firmas.
+ * Captura Fase 10 — Firmas Programadas.
  *
  * Gerencia Ventas (o Dirección) programa la fecha + hora de firma ya acordada
  * con el notario (que viene de Fase 7) y genera la Póliza de Garantía.
@@ -9,7 +9,7 @@
  * ADR-048: el **crédito directo (pagaré) ya NO se captura aquí** — se define en
  * la dictaminación (fase 8), con el saldo REAL del Anexo B. Si la venta tiene
  * crédito directo, aquí solo se sube el **pagaré firmado** que se recaba en la
- * firma (rol `pagare`, el mismo que reconoce la fase Escriturar y
+ * firma (rol `pagare`, el mismo que reconoce la fase Escriturada y
  * `rolesOpcionales`).
  *
  * Tasas / cobertura / plan de pagos: viven en la fase 8.
@@ -376,8 +376,8 @@ function CapturarFase10Body() {
             title="Fase 10 ya está cerrada"
             body={
               fechaFirmaLabel
-                ? `Firma programada para el ${fechaFirmaLabel}. La siguiente fase es Escriturar.`
-                : 'Esta venta ya tiene la firma programada. La siguiente fase es Escriturar.'
+                ? `Firma programada para el ${fechaFirmaLabel}. La siguiente fase es Escriturada.`
+                : 'Esta venta ya tiene la firma programada. La siguiente fase es Escriturada.'
             }
           />
 

--- a/app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 11 — Escriturar (Sprint 7i).
+ * Captura Fase 11 — Escriturada (Sprint 7i).
  *
  * Tras la firma en notaría, las escrituras llegan a Dirección (Beto, o quien
  * de Dirección esté) para firmar. Se registra:
@@ -14,7 +14,7 @@
  *
  * Sin documentos requeridos.
  *
- * Enforcement: Fase 10 (Programar firmas) debe estar cerrada.
+ * Enforcement: Fase 10 (Firmas Programadas) debe estar cerrada.
  * Acceso: `dilesa.ventas.fase11_escriturada` (Gerencia Ventas + Dirección).
  */
 
@@ -304,7 +304,7 @@ function CapturarFase11Body() {
           <Banner
             tone="success"
             title="Fase 11 ya está cerrada"
-            body="Esta venta ya está escriturada. La siguiente fase es Detonar crédito. Si el número o la fecha de la escritura quedaron mal capturados (ej. folio interno en lugar del instrumento del notario), corrígelos aquí — la revisión PLD de la Fase 13 los cruza contra el aviso."
+            body="Esta venta ya está escriturada. La siguiente fase es Detonada. Si el número o la fecha de la escritura quedaron mal capturados (ej. folio interno en lugar del instrumento del notario), corrígelos aquí — la revisión PLD de la Fase 13 los cruza contra el aviso."
           />
           <form onSubmit={onActualizarEscritura} className="space-y-6">
             <Section title="Corregir datos de la escritura">
@@ -347,7 +347,7 @@ function CapturarFase11Body() {
       ) : fase10Cerrada === false ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 10 (Programar firmas)"
+          title="Falta cerrar Fase 10 (Firmas Programadas)"
           body={
             <>
               Antes de registrar la escrituración, programa la firma (Fase 10). Vuelve al detalle y

--- a/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Fase 12 — Detonar crédito. GUÍA a Cobranza + cierre manual SOLO Dirección.
+ * Fase 12 — Detonada. GUÍA a Cobranza + cierre manual SOLO Dirección.
  *
  * "Detonar" el crédito = la institución libera el recurso y DILESA recibe el
  * depósito. El camino ÚNICO normal (2026-06-11) es: Contabilidad registra el
@@ -16,7 +16,7 @@
  * cierre de emergencia exclusivo de Dirección/admin, con advertencia de que
  * NO registra el dinero en Cobranza.
  *
- * Enforcement: Fase 11 (Escriturar) debe estar cerrada.
+ * Enforcement: Fase 11 (Escriturada) debe estar cerrada.
  * Acceso: `dilesa.ventas.fase12_detonada` (Contabilidad + Gerencia Ventas +
  * Dirección); el form de emergencia además exige Dirección
  * (`EffectiveUser.direccionEmpresaIds` o admin global).
@@ -250,12 +250,12 @@ function CapturarFase12Body() {
         <Banner
           tone="success"
           title="Fase 12 ya está cerrada"
-          body="Esta venta ya está detonada. La siguiente fase es Facturar."
+          body="Esta venta ya está detonada. La siguiente fase es Facturada."
         />
       ) : fase11Cerrada === false ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 11 (Escriturar)"
+          title="Falta cerrar Fase 11 (Escriturada)"
           body={
             <>
               Antes de registrar la detonación, la venta debe estar escriturada. Vuelve al detalle y

--- a/app/dilesa/ventas/[id]/capturar/13-facturada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/13-facturada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 13 — Facturar (captura colaborativa + XML CFDI: Sprints 1-2
+ * Captura Fase 13 — Facturada (captura colaborativa + XML CFDI: Sprints 1-2
  * de `dilesa-ventas-captura-colaborativa`).
  *
  * Sprint 1 — colaborativo: cada documento PERSISTE AL SUBIRSE
@@ -25,7 +25,7 @@
  *     venta. Errores bloquean la subida; warnings quedan visibles y
  *     persistidos en `erp.adjuntos.metadata`.
  *   - NADA se captura a mano en esta pantalla: `valor_escrituracion` viene
- *     de la Fase 8 (Dictaminar) y aquí solo se muestra; `valor_facturado`
+ *     de la Fase 8 (Dictaminada) y aquí solo se muestra; `valor_facturado`
  *     y `monto_nota_credito` se derivan del XML vigente. Corregir un monto
  *     = subir el XML correcto (queda versionado — esa es la auditoría).
  *     Las ventas históricas (sin XML) conservan sus montos migrados: el
@@ -42,7 +42,7 @@
  * aviso + cargar el acuse; la revisión con acuse completa el ciclo y solo
  * entonces se prende el cierre.
  *
- * Enforcement: Fase 12 (Detonar crédito) debe estar cerrada.
+ * Enforcement: Fase 12 (Detonada) debe estar cerrada.
  * Acceso: `dilesa.ventas.fase13_facturada` (Contabilidad + Gerencia Ventas +
  * Dirección).
  */
@@ -686,7 +686,7 @@ function CapturarFase13Body() {
       ) : bloqueadaPorFase12 ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 12 (Detonar crédito)"
+          title="Falta cerrar Fase 12 (Detonada)"
           body={
             <>
               Antes de facturar, la venta debe estar detonada (depósito recibido). Vuelve al detalle
@@ -877,8 +877,8 @@ function CapturarFase13Body() {
                 <MontoDerivado valor={venta.valor_escrituracion} />
                 <Hint>
                   {venta.valor_escrituracion == null
-                    ? 'Falta — se captura en la Fase 8 (Dictaminar).'
-                    : 'Capturado en la Fase 8 (Dictaminar).'}
+                    ? 'Falta — se captura en la Fase 8 (Dictaminada).'
+                    : 'Capturado en la Fase 8 (Dictaminada).'}
                 </Hint>
               </Field>
               <Field label="Valor real venta Dilesa (calculado)">

--- a/app/dilesa/ventas/[id]/capturar/14-preparada-entrega/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/14-preparada-entrega/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 14 — Preparar entrega (dilesa-ventas-expediente S5).
+ * Captura Fase 14 — Preparada para Entrega (dilesa-ventas-expediente S5).
  *
  * El equipo de Calidad y Entrega revisa la vivienda con el Checklist
  * Pre-Entrega: lo imprime desde aquí (PDF prellenado con vivienda + cliente),
@@ -9,7 +9,7 @@
  * Subirlo cierra la fase.
  *
  * Gate especial (Beto, 2026-06-10): la preparación puede hacerse desde que se
- * registra la escritura (Fase 11) — NO espera Detonar crédito (12) ni Facturar (13).
+ * registra la escritura (Fase 11) — NO espera Detonada (12) ni Facturada (13).
  *
  * Captura:
  *   - Doc requerido: rol `checklist_pre_entrega` (checklist firmado).
@@ -204,16 +204,16 @@ function CapturarFase14Body() {
         <Banner
           tone="success"
           title="Fase 14 ya está cerrada"
-          body="Esta vivienda ya quedó preparada para entrega. La siguiente fase es Entregar."
+          body="Esta vivienda ya quedó preparada para entrega. La siguiente fase es Entregada."
         />
       ) : !fase11Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 11 (Escriturar)"
+          title="Falta cerrar Fase 11 (Escriturada)"
           body={
             <>
               La preparación de entrega puede hacerse desde que se registra la escritura — sin
-              esperar Detonar crédito ni Facturar. Vuelve al detalle y captura la Fase 11 primero.
+              esperar Detonada ni Facturada. Vuelve al detalle y captura la Fase 11 primero.
             </>
           }
           extra={

--- a/app/dilesa/ventas/[id]/capturar/15-entregada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/15-entregada/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 /**
- * Captura Fase 15 — Entregar (dilesa-ventas-expediente S5).
+ * Captura Fase 15 — Entregada (dilesa-ventas-expediente S5).
  *
  * La entrega física de la vivienda al cliente: se imprime el Checklist para
  * Entrega de Vivienda (PDF prellenado), se recorre la casa con el cliente
  * palomeando SÍ/NO, firman el CLIENTE y Atención a Clientes, se escanea y se
  * sube el PDF firmado. Subirlo cierra la fase.
  *
- * Gate: Fase 14 (Preparar entrega) debe estar cerrada.
+ * Gate: Fase 14 (Preparada para Entrega) debe estar cerrada.
  *
  * Captura:
  *   - Doc requerido: rol `checklist_entrega` (checklist firmado por cliente).
@@ -68,7 +68,7 @@ function CapturarFase15Body() {
 
   const [venta, setVenta] = useState<VentaCtx | null>(null);
   const [fase14Cerrada, setFase14Cerrada] = useState<boolean | null>(null);
-  // F12 (Detonar crédito) = el pago recibido. No se entrega sin pago.
+  // F12 (Detonada) = el pago recibido. No se entrega sin pago.
   const [fase12Cerrada, setFase12Cerrada] = useState<boolean | null>(null);
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
 
@@ -210,12 +210,12 @@ function CapturarFase15Body() {
         <Banner
           tone="success"
           title="Fase 15 ya está cerrada"
-          body="Esta vivienda ya fue entregada al cliente. La siguiente fase es Recabar conformidad."
+          body="Esta vivienda ya fue entregada al cliente. La siguiente fase es Conformidad del Cliente."
         />
       ) : !fase14Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 14 (Preparar entrega)"
+          title="Falta cerrar Fase 14 (Preparada para Entrega)"
           body={
             <>
               Antes de entregar al cliente, Calidad y Entrega debe dejar la vivienda preparada
@@ -234,7 +234,7 @@ function CapturarFase15Body() {
       ) : !fase12Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta el pago (Fase 12 — Detonar crédito)"
+          title="Falta el pago (Fase 12 — Detonada)"
           body={
             <>
               No se puede entregar la vivienda sin haber recibido el pago. El pago lo registra

--- a/app/dilesa/ventas/[id]/capturar/16-conformidad/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/16-conformidad/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 16 — Recabar conformidad (dilesa-ventas-expediente S5).
+ * Captura Fase 16 — Conformidad del Cliente (dilesa-ventas-expediente S5).
  *
  * La fase normalmente se cierra SOLA: al cerrar F15 se programa la encuesta
  * (entrega + 2 días), el cron la envía/recuerda, y la respuesta del cliente
@@ -344,7 +344,7 @@ function CapturarFase16Body() {
       {!fase15Cerrada && !yaCerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 15 (Entregar)"
+          title="Falta cerrar Fase 15 (Entregada)"
           body="Al cerrar la entrega, la encuesta se programa automáticamente (entrega + 2 días)."
           extra={
             <Link
@@ -436,7 +436,7 @@ function CapturarFase16Body() {
             <Banner
               tone="success"
               title="Fase 16 ya está cerrada"
-              body="La conformidad del cliente quedó registrada. La siguiente fase es Cerrar operación."
+              body="La conformidad del cliente quedó registrada. La siguiente fase es Operación Terminada."
             />
           ) : !respondida ? (
             <>

--- a/app/dilesa/ventas/[id]/capturar/17-operacion-terminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/17-operacion-terminada/page.tsx
@@ -225,7 +225,7 @@ function CapturarFase17Body() {
       return;
     }
     toast.add({
-      title: '¡Operación cerrada! 🎉',
+      title: 'Operación Terminada 🎉',
       description: 'El expediente quedó sellado. Felicidades por otra entrega completa.',
       type: 'success',
     });
@@ -315,7 +315,7 @@ function CapturarFase17Body() {
                 </>
               ) : (
                 <>
-                  <PartyPopper className="mr-2 size-4" /> Cerrar operación
+                  <PartyPopper className="mr-2 size-4" /> Marcar Operación Terminada
                 </>
               )}
             </Button>

--- a/app/dilesa/ventas/[id]/capturar/2-asignada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/2-asignada/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 /**
- * Captura Fase 2 — Asignar unidad.
+ * Captura Fase 2 — Asignada.
  *
  * Cierra la fase de Asignación: el líder del hold subió todos los
  * documentos firmados del expediente, y Dirección (o el rol autorizador
  * configurado, ej. Nelcy) revisa que esté todo en regla y autoriza la
- * asignación. La venta pasa a `fase_actual='Asignar unidad'` / `fase_posicion=2`.
+ * asignación. La venta pasa a `fase_actual='Asignada'` / `fase_posicion=2`.
  *
  * Acceso: gate por `dilesa.ventas.autorizar` (RBAC nuevo, ver migración
  * 20260528191807). Solo Dirección + el rol de Nelcy lo tienen.
@@ -236,7 +236,7 @@ function CapturarFase2Body() {
         faseposicion: 2,
         docs,
         camposVenta: {
-          fase_actual: 'Asignar unidad',
+          fase_actual: 'Asignada',
           fase_posicion: 2,
         },
         notas: null,

--- a/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 3 — Formalizar promesa (Sprint 7c piloto).
+ * Captura Fase 3 — Formalizada (Sprint 7c piloto).
  *
  * Cierra la fase de Formalización: el cliente firmó el contrato de
  * promesa de compraventa que el vendedor descargó/imprimió de
@@ -224,7 +224,7 @@ function CapturarFase3Body() {
       }
       toast.add({
         title: 'Fase 3 cerrada',
-        description: 'Fase 4 (Solicitar avalúo) está disponible.',
+        description: 'Fase 4 (Avalúo Solicitado) está disponible.',
         type: 'success',
       });
       router.push(`/dilesa/ventas/${venta.id}`);
@@ -265,12 +265,12 @@ function CapturarFase3Body() {
         <Banner
           tone="success"
           title="Fase 3 ya está cerrada"
-          body="Esta venta ya pasó por Formalizar promesa. Si necesitas corregir algo, contacta al comité para reabrir la fase."
+          body="Esta venta ya pasó por Formalizada. Si necesitas corregir algo, contacta al comité para reabrir la fase."
         />
       ) : !fase2Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 2 (Asignar unidad)"
+          title="Falta cerrar Fase 2 (Asignada)"
           body={
             <>
               Antes de capturar Formalizada, asegúrate de tener la asignación del comité. Vuelve al

--- a/app/dilesa/ventas/[id]/capturar/4-solicitud-avaluo/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/4-solicitud-avaluo/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 /**
- * Captura Fase 4 — Solicitar avalúo (Sprint 7d).
+ * Captura Fase 4 — Avalúo Solicitado (Sprint 7d).
  *
- * Cierra la fase de Solicitar avalúo: Gerencia Ventas (o Dirección)
+ * Cierra la fase de Avalúo Solicitado: Gerencia Ventas (o Dirección)
  * asigna una casa valuadora del catálogo (`erp.personas` con
  * `tipo='valuador'`) y dispara el email de solicitud al valuador.
  *
@@ -240,12 +240,12 @@ function CapturarFase4Body() {
         <Banner
           tone="success"
           title="Fase 4 ya está cerrada"
-          body="Esta venta ya pasó por Solicitar avalúo. La siguiente fase es Cerrar avalúo."
+          body="Esta venta ya pasó por Avalúo Solicitado. La siguiente fase es Avalúo Cerrado."
         />
       ) : !fase3Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 3 (Formalizar promesa)"
+          title="Falta cerrar Fase 3 (Formalizada)"
           body={
             <>
               Antes de solicitar el avalúo, asegúrate de que el contrato de promesa esté firmado y

--- a/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 /**
- * Captura Fase 5 — Cerrar avalúo (Sprint 7d).
+ * Captura Fase 5 — Avalúo Cerrado (Sprint 7d).
  *
- * Cierra la fase de Cerrar avalúo: Gerencia Ventas (o Dirección)
+ * Cierra la fase de Avalúo Cerrado: Gerencia Ventas (o Dirección)
  * registra el monto dictaminado y sube el PDF del avalúo comercial
  * entregado por el valuador.
  *
@@ -252,12 +252,12 @@ function CapturarFase5Body() {
         <Banner
           tone="success"
           title="Fase 5 ya está cerrada"
-          body="Esta venta ya pasó por Cerrar avalúo. La siguiente fase es Dictaminación."
+          body="Esta venta ya pasó por Avalúo Cerrado. La siguiente fase es Dictaminación."
         />
       ) : !fase4Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 4 (Solicitar avalúo)"
+          title="Falta cerrar Fase 4 (Avalúo Solicitado)"
           body={
             <>
               Antes de capturar el avalúo, asegúrate de haber enviado la solicitud al valuador.

--- a/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 6 — Inscribir crédito (Sprint 7e).
+ * Captura Fase 6 — Inscrita (Sprint 7e).
  *
  * Cierra la fase de Inscripción del crédito: el banco entregó la(s)
  * Constancia(s) de Crédito con el monto APROBADO. Gerencia Ventas (o
@@ -308,12 +308,12 @@ function CapturarFase6Body() {
         <Banner
           tone="success"
           title="Fase 6 ya está cerrada"
-          body="Esta venta ya pasó por Inscribir crédito. La siguiente fase es Solicitar dictamen."
+          body="Esta venta ya pasó por Inscrita. La siguiente fase es Dictamen Solicitado."
         />
       ) : !fase5Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 5 (Cerrar avalúo)"
+          title="Falta cerrar Fase 5 (Avalúo Cerrado)"
           body={
             <>
               Antes de inscribir el crédito, captura primero el avalúo entregado por la casa

--- a/app/dilesa/ventas/[id]/capturar/7-solicitud-dictamen/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/7-solicitud-dictamen/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 7 — Solicitar dictamen (Sprint 7f).
+ * Captura Fase 7 — Dictamen Solicitado (Sprint 7f).
  *
  * Cierra la fase de Solicitud de Dictamen: Gerencia Ventas (o Dirección)
  * asigna una notaría del catálogo de proveedores (`erp.proveedores` con
@@ -13,7 +13,7 @@
  *   - `fecha_solicitud_dictamen` → fecha del cierre (default hoy)
  *   - Sin doc requerido (el dictamen llega en Fase 8)
  *
- * Enforcement: Fase 6 (Inscribir crédito) debe estar cerrada.
+ * Enforcement: Fase 6 (Inscrita) debe estar cerrada.
  *
  * Acceso: `dilesa.ventas.fase07_solicitud_dictamen` (Gerencia Ventas +
  * Dirección por default — backfill de la migración).
@@ -226,12 +226,12 @@ function CapturarFase7Body() {
         <Banner
           tone="success"
           title="Fase 7 ya está cerrada"
-          body="Esta venta ya pasó por Solicitar dictamen. La siguiente fase es Dictaminar."
+          body="Esta venta ya pasó por Dictamen Solicitado. La siguiente fase es Dictaminada."
         />
       ) : !fase6Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 6 (Inscribir crédito)"
+          title="Falta cerrar Fase 6 (Inscrita)"
           body={
             <>
               Antes de solicitar dictamen, captura primero las Constancias de Crédito. Vuelve al

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 /**
- * Captura Fase 8 — Dictaminar (cierre financiero, ADR-048).
+ * Captura Fase 8 — Dictaminada (cierre financiero, ADR-048).
  *
  * Gerencia/notario suben la Carta de Instrucción + el Anexo B (por el magic
  * link del notario o aquí), la IA pre-llena los números y **Dirección cuadra la
@@ -21,7 +21,7 @@
  * verificación cruzada (NSS, nombre, domicilio vs unidad, CLABE de DILESA).
  * Nada se escribe a la venta hasta "Guardar" — la precarga es editable.
  *
- * Enforcement: Fase 7 (Solicitar dictamen) debe estar cerrada.
+ * Enforcement: Fase 7 (Dictamen Solicitado) debe estar cerrada.
  *
  * Acceso: `dilesa.ventas.fase08_dictaminada` (Gerencia Ventas + Dirección).
  */
@@ -995,7 +995,7 @@ function CapturarFase8Body() {
       ) : !fase7Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 7 (Solicitar dictamen)"
+          title="Falta cerrar Fase 7 (Dictamen Solicitado)"
           body={
             <>
               Antes de capturar el dictamen, asegúrate de haber enviado la solicitud al notario.
@@ -1088,7 +1088,7 @@ function CapturarFase8Body() {
 
           <Section title="Confirmar datos del crédito">
             <p className="mb-3 text-xs text-[var(--text)]/50">
-              Acarreados de Inscribir crédito (Fase 6). Confirma o corrige si el banco cambió algo.
+              Acarreados de Inscrita (Fase 6). Confirma o corrige si el banco cambió algo.
             </p>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Field label="Monto Crédito Titular">

--- a/app/dilesa/ventas/[id]/capturar/9-validacion-patronal/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/9-validacion-patronal/page.tsx
@@ -13,7 +13,7 @@
  *   - Doc requerido: rol `validacion_patronal` (PDF de la validación).
  *     Coincide con `FASE_ROLES[9]` en el detalle.
  *
- * Enforcement: Fase 8 (Dictaminar) debe estar cerrada.
+ * Enforcement: Fase 8 (Dictaminada) debe estar cerrada.
  *
  * Acceso: `dilesa.ventas.fase09_validacion_patronal` (Gerencia Ventas +
  * Dirección por default — backfill de la migración).
@@ -214,12 +214,12 @@ function CapturarFase9Body() {
         <Banner
           tone="success"
           title="Fase 9 ya está cerrada"
-          body="Esta venta ya pasó por Validación Patronal. La siguiente fase es Programar firmas."
+          body="Esta venta ya pasó por Validación Patronal. La siguiente fase es Firmas Programadas."
         />
       ) : !fase8Cerrada ? (
         <Banner
           tone="warning"
-          title="Falta cerrar Fase 8 (Dictaminar)"
+          title="Falta cerrar Fase 8 (Dictaminada)"
           body={
             <>
               Antes de subir la Validación Patronal, la venta debe estar dictaminada. Vuelve al

--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -791,7 +791,7 @@ function NuevaSolicitudForm() {
 
       const ventaId = vIns.id as string;
 
-      // 4) Primera fila de venta_fases (Solicitar asignación, fecha hoy)
+      // 4) Primera fila de venta_fases (Asignación Solicitada, fecha hoy)
       const { error: fErr } = await sb
         .schema('dilesa')
         .from('venta_fases')

--- a/components/dilesa/copiloto-cierre.tsx
+++ b/components/dilesa/copiloto-cierre.tsx
@@ -43,7 +43,7 @@ export function CopilotoCierre({
         <div className="flex items-center gap-2">
           <PartyPopper className="size-5 text-emerald-600 dark:text-emerald-400" />
           <h3 className="text-sm font-semibold text-emerald-900 dark:text-emerald-100">
-            Operación cerrada{fecha17 ? ` · ${fecha17}` : ''}
+            Operación Terminada{fecha17 ? ` · ${fecha17}` : ''}
           </h3>
         </div>
         <p className="mt-1 text-xs text-emerald-900/80 dark:text-emerald-100/80">
@@ -109,7 +109,7 @@ export function CopilotoCierre({
           href={`/dilesa/ventas/${ventaId}/capturar/17-operacion-terminada`}
           className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700"
         >
-          Cerrar operación
+          Marcar Operación Terminada
           <ChevronRight className="size-4" />
         </Link>
       ) : null}

--- a/lib/dilesa/captura/fase-roles.ts
+++ b/lib/dilesa/captura/fase-roles.ts
@@ -11,26 +11,26 @@
 // en `lib/dilesa/fases.ts`) no tocan este mapa. El comentario al lado de cada
 // entrada recuerda qué fase es.
 export const FASE_ROLES: Record<number, string[]> = {
-  1: ['solicitud_asignacion'], // Solicitar asignación
-  2: ['solicitud_asignacion', 'expediente_digital', 'ficu', 'aviso_privacidad'], // Asignar unidad
-  3: ['contrato_promesa'], // Formalizar promesa
-  4: [], // Solicitar avalúo
-  5: ['avaluo_comercial'], // Cerrar avalúo
+  1: ['solicitud_asignacion'], // Asignación Solicitada
+  2: ['solicitud_asignacion', 'expediente_digital', 'ficu', 'aviso_privacidad'], // Asignada
+  3: ['contrato_promesa'], // Formalizada
+  4: [], // Avalúo Solicitado
+  5: ['avaluo_comercial'], // Avalúo Cerrado
   // Beto: las Constancias de Crédito (titular + co-titular) van al inscribir el
   // crédito (pos 6) — el banco las entrega ahí. La Carta de instrucción notarial
   // queda en el dictamen (pos 8, sale después con el dictamen jurídico).
-  6: ['constancia_credito_titular', 'constancia_credito_cotitular'], // Inscribir crédito
-  7: ['aprobacion_credito'], // Solicitar dictamen
-  8: ['carta_instruccion_notarial', 'condiciones_financieras'], // Dictaminar
+  6: ['constancia_credito_titular', 'constancia_credito_cotitular'], // Inscrita
+  7: ['aprobacion_credito'], // Dictamen Solicitado
+  8: ['carta_instruccion_notarial', 'condiciones_financieras'], // Dictaminada
   9: ['validacion_patronal'], // Validación Patronal
-  10: [], // Programar firmas
-  11: ['pagare'], // Escriturar
-  12: ['imagen_detonacion'], // Detonar crédito
-  13: ['factura', 'nota_credito', 'aviso_pld'], // Facturar
-  14: ['checklist_pre_entrega'], // Preparar entrega
-  15: ['checklist_entrega'], // Entregar
-  16: [], // Recabar conformidad
-  17: [], // Cerrar operación
+  10: [], // Firmas Programadas
+  11: ['pagare'], // Escriturada
+  12: ['imagen_detonacion'], // Detonada
+  13: ['factura', 'nota_credito', 'aviso_pld'], // Facturada
+  14: ['checklist_pre_entrega'], // Preparada para Entrega
+  15: ['checklist_entrega'], // Entregada
+  16: [], // Conformidad del Cliente
+  17: [], // Operación Terminada
 };
 
 export const ROL_LABEL: Record<string, string> = {

--- a/lib/dilesa/captura/marcar-fase.test.ts
+++ b/lib/dilesa/captura/marcar-fase.test.ts
@@ -168,8 +168,8 @@ describe('FASES_PIPELINE', () => {
     // Los nombres deben ser EXACTAMENTE los de la DB para que el INSERT
     // funcione. Si la migración cambia el seed, romper aquí intencionalmente.
     const nombres = FASES_PIPELINE.map((f) => f.nombre);
-    expect(nombres).toContain('Solicitar asignación');
-    expect(nombres).toContain('Formalizar promesa');
-    expect(nombres).toContain('Cerrar operación');
+    expect(nombres).toContain('Asignación Solicitada');
+    expect(nombres).toContain('Formalizada');
+    expect(nombres).toContain('Operación Terminada');
   });
 });

--- a/lib/dilesa/copiloto-cierre.test.ts
+++ b/lib/dilesa/copiloto-cierre.test.ts
@@ -48,8 +48,8 @@ describe('evaluarCierre', () => {
     const r = evaluarCierre({
       ...BASE,
       docsFaltantes: [
-        { fase: 'Facturar', rol: 'factura', label: 'Factura' },
-        { fase: 'Escriturar', rol: 'pagare', label: 'Pagaré' },
+        { fase: 'Facturada', rol: 'factura', label: 'Factura' },
+        { fase: 'Escriturada', rol: 'pagare', label: 'Pagaré' },
       ],
     });
     expect(r.items[1]!.ok).toBe(false);

--- a/lib/dilesa/fases.ts
+++ b/lib/dilesa/fases.ts
@@ -9,9 +9,12 @@
  * carpeta de captura (`/dilesa/ventas/[id]/capturar/<slug>`): una URL estable
  * que NO cambia con los renombres.
  *
- * Convención de nombres (2026-06-24, Beto): "acción a realizar" — el nombre
- * dice qué hay que hacer para avanzar (Asignar, Escriturar, Entregar), salvo
- * "Validación Patronal" que conserva el nombre del documento.
+ * Convención de nombres (2026-06-24, Beto): participio / hito alcanzado — el
+ * nombre describe lo que YA se completó en cada paso (Asignada, Escriturada,
+ * Entregada). Se probó el infinitivo ("acción a realizar") pero causaba un
+ * desfase por uno en los badges de estado: `fase_actual` es la última fase
+ * COMPLETADA, no la pendiente, así que una venta "Escriturar" ya había
+ * escriturado. "Validación Patronal" conserva el nombre del documento.
  *
  * Todo lo demás deriva de aquí: las vistas (FASES_ORDEN en el detalle,
  * FASES_PIPELINE en captura), el lookup posición→nombre y el mapa documental
@@ -26,23 +29,23 @@ export type FaseVenta = {
 };
 
 export const FASES_VENTA = [
-  { posicion: 1, nombre: 'Solicitar asignación', slug: '1-solicitud-asignacion' },
-  { posicion: 2, nombre: 'Asignar unidad', slug: '2-asignada' },
-  { posicion: 3, nombre: 'Formalizar promesa', slug: '3-formalizada' },
-  { posicion: 4, nombre: 'Solicitar avalúo', slug: '4-solicitud-avaluo' },
-  { posicion: 5, nombre: 'Cerrar avalúo', slug: '5-avaluo-cerrado' },
-  { posicion: 6, nombre: 'Inscribir crédito', slug: '6-inscrita' },
-  { posicion: 7, nombre: 'Solicitar dictamen', slug: '7-solicitud-dictamen' },
-  { posicion: 8, nombre: 'Dictaminar', slug: '8-dictaminada' },
+  { posicion: 1, nombre: 'Asignación Solicitada', slug: '1-solicitud-asignacion' },
+  { posicion: 2, nombre: 'Asignada', slug: '2-asignada' },
+  { posicion: 3, nombre: 'Formalizada', slug: '3-formalizada' },
+  { posicion: 4, nombre: 'Avalúo Solicitado', slug: '4-solicitud-avaluo' },
+  { posicion: 5, nombre: 'Avalúo Cerrado', slug: '5-avaluo-cerrado' },
+  { posicion: 6, nombre: 'Inscrita', slug: '6-inscrita' },
+  { posicion: 7, nombre: 'Dictamen Solicitado', slug: '7-solicitud-dictamen' },
+  { posicion: 8, nombre: 'Dictaminada', slug: '8-dictaminada' },
   { posicion: 9, nombre: 'Validación Patronal', slug: '9-validacion-patronal' },
-  { posicion: 10, nombre: 'Programar firmas', slug: '10-firmas-programadas' },
-  { posicion: 11, nombre: 'Escriturar', slug: '11-escriturada' },
-  { posicion: 12, nombre: 'Detonar crédito', slug: '12-detonada' },
-  { posicion: 13, nombre: 'Facturar', slug: '13-facturada' },
-  { posicion: 14, nombre: 'Preparar entrega', slug: '14-preparada-entrega' },
-  { posicion: 15, nombre: 'Entregar', slug: '15-entregada' },
-  { posicion: 16, nombre: 'Recabar conformidad', slug: '16-conformidad' },
-  { posicion: 17, nombre: 'Cerrar operación', slug: '17-operacion-terminada' },
+  { posicion: 10, nombre: 'Firmas Programadas', slug: '10-firmas-programadas' },
+  { posicion: 11, nombre: 'Escriturada', slug: '11-escriturada' },
+  { posicion: 12, nombre: 'Detonada', slug: '12-detonada' },
+  { posicion: 13, nombre: 'Facturada', slug: '13-facturada' },
+  { posicion: 14, nombre: 'Preparada para Entrega', slug: '14-preparada-entrega' },
+  { posicion: 15, nombre: 'Entregada', slug: '15-entregada' },
+  { posicion: 16, nombre: 'Conformidad del Cliente', slug: '16-conformidad' },
+  { posicion: 17, nombre: 'Operación Terminada', slug: '17-operacion-terminada' },
 ] as const;
 
 export type FaseSlug = (typeof FASES_VENTA)[number]['slug'];

--- a/lib/dilesa/kpis/fases.test.ts
+++ b/lib/dilesa/kpis/fases.test.ts
@@ -31,7 +31,7 @@ describe('deriveFasesKpis (DILESA Fases — ADR-034)', () => {
       v({ estado: 'activa' }),
       v({ estado: 'activa' }),
       v({ estado: 'desasignada' }),
-      v({ estado: 'terminada', fase_actual: 'Cerrar operación', fase_posicion: 17 }),
+      v({ estado: 'terminada', fase_actual: 'Operación Terminada', fase_posicion: 17 }),
     ];
     expect(deriveFasesKpis(rows, { now: NOW })[0]?.value).toBe(2);
   });

--- a/lib/dilesa/pdf/checklist-entrega.tsx
+++ b/lib/dilesa/pdf/checklist-entrega.tsx
@@ -256,7 +256,7 @@ export function ChecklistEntregaPDF({ data }: { data: ChecklistEntregaData }) {
         <Text style={local.leyenda}>
           La vivienda queda preparada para entrega una vez verificados todos los puntos. El
           checklist firmado se digitaliza y se archiva en el expediente de la operación (Fase 14 —
-          Preparar entrega).
+          Preparada para Entrega).
         </Text>
 
         <FooterBand />

--- a/lib/dilesa/reportes/estancadas.test.ts
+++ b/lib/dilesa/reportes/estancadas.test.ts
@@ -5,7 +5,7 @@ import type { EstancadaRow } from './estancadas-data';
 function row(p: Partial<EstancadaRow>): EstancadaRow {
   return {
     ventaId: p.ventaId ?? 'x',
-    faseActual: p.faseActual ?? 'Cerrar avalúo',
+    faseActual: p.faseActual ?? 'Avalúo Cerrado',
     fasePosicion: p.fasePosicion ?? 5,
     fechaFaseActual: p.fechaFaseActual ?? '2026-06-01',
     diasEnFase: p.diasEnFase ?? 0,

--- a/lib/dilesa/reportes/pipeline-por-fase.test.ts
+++ b/lib/dilesa/reportes/pipeline-por-fase.test.ts
@@ -9,9 +9,9 @@ import {
 
 const FASES: FaseCatalogo[] = [
   // A propósito desordenadas para verificar el sort por posición.
-  { posicion: 2, nombre: 'Asignar unidad', rol: 'Gerencia General' },
-  { posicion: 1, nombre: 'Solicitar asignación', rol: 'Todos' },
-  { posicion: 3, nombre: 'Formalizar promesa', rol: 'Gerencia General' },
+  { posicion: 2, nombre: 'Asignada', rol: 'Gerencia General' },
+  { posicion: 1, nombre: 'Asignación Solicitada', rol: 'Todos' },
+  { posicion: 3, nombre: 'Formalizada', rol: 'Gerencia General' },
 ];
 
 describe('construirPipelinePorFase', () => {
@@ -26,37 +26,37 @@ describe('construirPipelinePorFase', () => {
 
   it('cuenta y suma monto solo de ventas activas, por fase', () => {
     const ventas: VentaPipeline[] = [
-      { estado: 'activa', fase_actual: 'Asignar unidad', precio: 100 },
-      { estado: 'activa', fase_actual: 'Asignar unidad', precio: 200 },
-      { estado: 'activa', fase_actual: 'Formalizar promesa', precio: 50 },
-      { estado: 'desasignada', fase_actual: 'Asignar unidad', precio: 999 }, // excluida
+      { estado: 'activa', fase_actual: 'Asignada', precio: 100 },
+      { estado: 'activa', fase_actual: 'Asignada', precio: 200 },
+      { estado: 'activa', fase_actual: 'Formalizada', precio: 50 },
+      { estado: 'desasignada', fase_actual: 'Asignada', precio: 999 }, // excluida
     ];
     const res = construirPipelinePorFase(FASES, ventas);
-    const asignada = res.filas.find((f) => f.fase === 'Asignar unidad')!;
+    const asignada = res.filas.find((f) => f.fase === 'Asignada')!;
     expect(asignada.ventas).toBe(2);
     expect(asignada.monto).toBe(300);
     expect(res.totalVentas).toBe(3);
     expect(res.totalMonto).toBe(350);
-    expect(res.faseCuello).toBe('Asignar unidad');
+    expect(res.faseCuello).toBe('Asignada');
   });
 
   it('trata precio null como 0 en el monto pero cuenta la venta', () => {
     const ventas: VentaPipeline[] = [
-      { estado: 'activa', fase_actual: 'Formalizar promesa', precio: null },
+      { estado: 'activa', fase_actual: 'Formalizada', precio: null },
     ];
     const res = construirPipelinePorFase(FASES, ventas);
-    const f = res.filas.find((x) => x.fase === 'Formalizar promesa')!;
+    const f = res.filas.find((x) => x.fase === 'Formalizada')!;
     expect(f.ventas).toBe(1);
     expect(f.monto).toBe(0);
   });
 
   it('calcula los shares (pctVentas/pctMonto) sobre los totales', () => {
     const ventas: VentaPipeline[] = [
-      { estado: 'activa', fase_actual: 'Asignar unidad', precio: 75 },
-      { estado: 'activa', fase_actual: 'Formalizar promesa', precio: 25 },
+      { estado: 'activa', fase_actual: 'Asignada', precio: 75 },
+      { estado: 'activa', fase_actual: 'Formalizada', precio: 25 },
     ];
     const res = construirPipelinePorFase(FASES, ventas);
-    const asignada = res.filas.find((f) => f.fase === 'Asignar unidad')!;
+    const asignada = res.filas.find((f) => f.fase === 'Asignada')!;
     expect(asignada.pctVentas).toBeCloseTo(0.5);
     expect(asignada.pctMonto).toBeCloseTo(0.75);
   });
@@ -74,7 +74,7 @@ describe('filtrarVentas', () => {
   const base: VentaReporte[] = [
     {
       estado: 'activa',
-      fase_actual: 'Asignar unidad',
+      fase_actual: 'Asignada',
       precio: 100,
       proyectoId: 'p1',
       vendedor: 'Ana',
@@ -82,7 +82,7 @@ describe('filtrarVentas', () => {
     },
     {
       estado: 'activa',
-      fase_actual: 'Formalizar promesa',
+      fase_actual: 'Formalizada',
       precio: 200,
       proyectoId: 'p2',
       vendedor: 'Beto',
@@ -90,7 +90,7 @@ describe('filtrarVentas', () => {
     },
     {
       estado: 'activa',
-      fase_actual: 'Asignar unidad',
+      fase_actual: 'Asignada',
       precio: 300,
       proyectoId: 'p1',
       vendedor: 'Beto',

--- a/lib/dilesa/resumen-consejo-email.test.ts
+++ b/lib/dilesa/resumen-consejo-email.test.ts
@@ -197,13 +197,13 @@ describe('renderResumenConsejoHtml — 4 secciones', () => {
     const html = renderResumenConsejoHtml(
       {
         ...EMPTY,
-        tuberiaViva: [{ fase: 'Formalizar promesa', clientes: 20, valor: 22000000 }],
+        tuberiaViva: [{ fase: 'Formalizada', clientes: 20, valor: 22000000 }],
         tuberiaHistorico: { clientes: 1093, valor: 1060000000 },
       },
       { fechaTitulo: 'x' }
     );
     expect(html).toContain('Pipeline de Ventas (vivo)');
-    expect(html).toContain('Formalizar promesa');
+    expect(html).toContain('Formalizada');
     expect(html).toContain('Histórico acumulado: 1,093 operaciones');
   });
 
@@ -228,41 +228,41 @@ describe('renderResumenConsejoHtml — 4 secciones', () => {
 
 describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
   const CAT = [
-    { nombre: 'Asignar unidad', posicion: 2 },
-    { nombre: 'Solicitar asignación', posicion: 1 },
-    { nombre: 'Cerrar operación', posicion: 17 },
+    { nombre: 'Asignada', posicion: 2 },
+    { nombre: 'Asignación Solicitada', posicion: 1 },
+    { nombre: 'Operación Terminada', posicion: 17 },
   ];
 
   it('agrupa activas por fase (solo con clientes) y manda terminadas al histórico', () => {
     const { viva, historico } = armarTuberiaSplit(CAT, [
       {
         estado: 'activa',
-        fase_actual: 'Asignar unidad',
+        fase_actual: 'Asignada',
         valor_escrituracion: 1000,
         precio_asignacion: 9999,
       },
       {
         estado: 'activa',
-        fase_actual: 'Asignar unidad',
+        fase_actual: 'Asignada',
         valor_escrituracion: 500,
         precio_asignacion: 9999,
       },
       {
         estado: 'terminada',
-        fase_actual: 'Cerrar operación',
+        fase_actual: 'Operación Terminada',
         valor_escrituracion: 2000,
         precio_asignacion: 9999,
       },
       {
         estado: 'terminada',
-        fase_actual: 'Cerrar operación',
+        fase_actual: 'Operación Terminada',
         valor_escrituracion: 1000,
         precio_asignacion: 9999,
       },
     ]);
     // Solo la fase con clientes vivos; las fases en 0 se filtran del funnel.
     // `valor_escrituracion` tiene precedencia sobre `precio_asignacion` (el 9999 se ignora).
-    expect(viva).toEqual([{ fase: 'Asignar unidad', clientes: 2, valor: 1500 }]);
+    expect(viva).toEqual([{ fase: 'Asignada', clientes: 2, valor: 1500 }]);
     expect(historico).toEqual({ clientes: 2, valor: 3000 });
   });
 
@@ -270,19 +270,19 @@ describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
     const { viva } = armarTuberiaSplit(CAT, [
       {
         estado: 'activa',
-        fase_actual: 'Asignar unidad',
+        fase_actual: 'Asignada',
         valor_escrituracion: null,
         precio_asignacion: 800,
       },
       {
         estado: 'activa',
-        fase_actual: 'Asignar unidad',
+        fase_actual: 'Asignada',
         valor_escrituracion: 1200,
         precio_asignacion: 1000,
       },
     ]);
     // 800 (fallback a precio_asignacion) + 1200 (valor_escrituracion gana) = 2000.
-    expect(viva).toEqual([{ fase: 'Asignar unidad', clientes: 2, valor: 2000 }]);
+    expect(viva).toEqual([{ fase: 'Asignada', clientes: 2, valor: 2000 }]);
   });
 
   it('junta en "Sin fase asignada" las activas con fase NULL o fuera de catálogo', () => {
@@ -302,13 +302,13 @@ describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
     const { viva, historico } = armarTuberiaSplit(CAT, [
       {
         estado: 'desasignada',
-        fase_actual: 'Asignar unidad',
+        fase_actual: 'Asignada',
         valor_escrituracion: 999,
         precio_asignacion: 999,
       },
       {
         estado: 'expirada',
-        fase_actual: 'Asignar unidad',
+        fase_actual: 'Asignada',
         valor_escrituracion: 111,
         precio_asignacion: 111,
       },

--- a/lib/dilesa/resumen-consejo-kpis.ts
+++ b/lib/dilesa/resumen-consejo-kpis.ts
@@ -80,11 +80,11 @@ export function armarKpis(raw: KpisRaw): KpisDelDia {
   for (const f of raw.fasesHoy) {
     const v = montoPorVenta.get(f.venta_id);
     if (f.posicion === 2) {
-      // Asignar unidad (fase 2) = venta nueva del día.
+      // Asignada (fase 2) = venta nueva del día.
       ventas_hoy_n += 1;
       ventas_hoy_monto += Number(v?.precio_asignacion ?? 0);
     } else if (f.posicion === 11) {
-      // Escriturar (fase 11) = escritura del día.
+      // Escriturada (fase 11) = escritura del día.
       escrituras_hoy_n += 1;
       escrituras_hoy_monto += Number(v?.valor_escrituracion ?? 0);
     }

--- a/supabase/migrations/20260624183603_dilesa_fases_venta_participio.sql
+++ b/supabase/migrations/20260624183603_dilesa_fases_venta_participio.sql
@@ -1,0 +1,89 @@
+-- ╭─ 20260624183603_dilesa_fases_venta_participio ─╮
+-- Revert de las 17 fases de venta DILESA: de infinitivo ("acción a realizar",
+-- migración 20260624162109) de vuelta a PARTICIPIO / hito alcanzado. El
+-- infinitivo causaba un desfase por uno en los badges de estado: `fase_actual`
+-- es la última fase COMPLETADA, así que una venta "Escriturar" ya había
+-- escriturado. Se vuelve al participio (decisión Beto 2026-06-24), arreglando de
+-- paso la mezcla original: los 3 "Solicitud de…" quedan como estado uniforme
+-- ("Asignación Solicitada", "Avalúo Solicitado", "Dictamen Solicitado").
+--
+-- Solo reescribe ETIQUETAS por posición (catálogo + historial). NO toca
+-- posiciones, triggers, ni el modelo. NULL-safe / idempotente (scopeado a
+-- 'dilesa'; en el Preview branch sin datos cada UPDATE afecta 0 filas).
+--
+-- Mapa pos → nombre:
+--   1 Asignación Solicitada · 2 Asignada · 3 Formalizada · 4 Avalúo Solicitado
+--   5 Avalúo Cerrado · 6 Inscrita · 7 Dictamen Solicitado · 8 Dictaminada
+--   9 Validación Patronal · 10 Firmas Programadas · 11 Escriturada · 12 Detonada
+--   13 Facturada · 14 Preparada para Entrega · 15 Entregada
+--   16 Conformidad del Cliente · 17 Operación Terminada
+
+BEGIN;
+
+-- 1) Backfill defensivo de `posicion` en filas con posicion NULL (en prod hoy
+--    son 0; queda por idempotencia/Preview), emparejando por el nombre vigente.
+UPDATE dilesa.venta_fases vf
+SET posicion = c.posicion
+FROM dilesa.venta_fase_catalogo c
+WHERE vf.posicion IS NULL
+  AND vf.empresa_id = c.empresa_id
+  AND vf.fase = c.nombre
+  AND c.deleted_at IS NULL;
+
+-- 2) Renombrar el catálogo por posición (la fuente del nombre visible en DB).
+UPDATE dilesa.venta_fase_catalogo c
+SET nombre = m.nombre
+FROM (
+  VALUES
+    (1, 'Asignación Solicitada'),
+    (2, 'Asignada'),
+    (3, 'Formalizada'),
+    (4, 'Avalúo Solicitado'),
+    (5, 'Avalúo Cerrado'),
+    (6, 'Inscrita'),
+    (7, 'Dictamen Solicitado'),
+    (8, 'Dictaminada'),
+    (9, 'Validación Patronal'),
+    (10, 'Firmas Programadas'),
+    (11, 'Escriturada'),
+    (12, 'Detonada'),
+    (13, 'Facturada'),
+    (14, 'Preparada para Entrega'),
+    (15, 'Entregada'),
+    (16, 'Conformidad del Cliente'),
+    (17, 'Operación Terminada')
+) AS m(posicion, nombre)
+WHERE c.posicion = m.posicion
+  AND c.empresa_id = (SELECT id FROM core.empresas WHERE slug = 'dilesa')
+  AND c.nombre IS DISTINCT FROM m.nombre;
+
+-- 3) Reescribir el historial del pipeline (`venta_fases.fase`) por posición. El
+--    guard NOT EXISTS evita violar el UNIQUE(venta_id, fase) si una venta tuviera
+--    dos filas en la misma posición con nombres distintos (esa fila rara se deja).
+UPDATE dilesa.venta_fases vf
+SET fase = c.nombre
+FROM dilesa.venta_fase_catalogo c
+WHERE vf.empresa_id = c.empresa_id
+  AND vf.posicion = c.posicion
+  AND c.deleted_at IS NULL
+  AND vf.fase IS DISTINCT FROM c.nombre
+  AND NOT EXISTS (
+    SELECT 1
+    FROM dilesa.venta_fases vf2
+    WHERE vf2.venta_id = vf.venta_id
+      AND vf2.fase = c.nombre
+      AND vf2.id <> vf.id
+  );
+
+-- 4) Reescribir el caché de fase actual en `ventas.fase_actual` por posición.
+UPDATE dilesa.ventas v
+SET fase_actual = c.nombre
+FROM dilesa.venta_fase_catalogo c
+WHERE v.empresa_id = c.empresa_id
+  AND v.fase_posicion = c.posicion
+  AND c.deleted_at IS NULL
+  AND v.fase_actual IS DISTINCT FROM c.nombre;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Qué cambia

Revierte los nombres de las 17 fases de venta de **infinitivo → participio (hito alcanzado)**. El infinitivo (#1006) causaba un **desfase por uno** en los badges de estado: `fase_actual` guarda la última fase **completada**, así que una venta etiquetada "Escriturar" en realidad **ya había escriturado**.

| Pos | #1006 (infinitivo) | Ahora (participio) | Pos | #1006 | Ahora |
|----|----|----|----|----|----|
| 1 | Solicitar asignación | **Asignación Solicitada** | 10 | Programar firmas | **Firmas Programadas** |
| 2 | Asignar unidad | **Asignada** | 11 | Escriturar | **Escriturada** |
| 3 | Formalizar promesa | **Formalizada** | 12 | Detonar crédito | **Detonada** |
| 4 | Solicitar avalúo | **Avalúo Solicitado** | 13 | Facturar | **Facturada** |
| 5 | Cerrar avalúo | **Avalúo Cerrado** | 14 | Preparar entrega | **Preparada para Entrega** |
| 6 | Inscribir crédito | **Inscrita** | 15 | Entregar | **Entregada** |
| 7 | Solicitar dictamen | **Dictamen Solicitado** | 16 | Recabar conformidad | **Conformidad del Cliente** |
| 8 | Dictaminar | **Dictaminada** | 17 | Cerrar operación | **Operación Terminada** |
| 9 | Validación Patronal | **Validación Patronal** (sin cambio) | | | |

De paso arregla la mezcla original que motivó todo: los tres "Solicitud de…" quedan uniformes como estado ("X Solicitado/a"), así los 17 son del mismo tipo.

## Por qué participio es lo correcto
El badge de estado lee "esta venta está **Escriturada**" (lo que ya pasó). Lo de "qué sigue" lo cubren el botón **"Siguiente fase"** y los títulos de las páginas de captura (que toman la fase *capturable*, no la completada), así que esos siguen leyéndose hacia adelante.

## Lo que NO cambia
**La estructura se mantiene**: `lib/dilesa/fases.ts` sigue siendo la fuente única, `FASE_ROLES` y los filtros del Consejo siguen por **posición**, `marcarFase` deriva el nombre de la posición. Tampoco cambian posiciones, triggers, slugs RBAC ni URLs. Solo etiquetas.

## Verificación
typecheck ✓ · test:coverage **2017 tests** ✓ · lint (0 errores) ✓ · format ✓ · schema:check (sin drift) ✓

## ⚠️ Migración a prod
`20260624183603` reescribe catálogo + historial (1,210 ventas + 15,435 filas) por posición, infinitivo → participio. Idempotente. La aplico con `db push` coordinada con el merge (mismo flujo que #1006).
