### PR TITLE
feat(dilesa-ventas): estado (participio) + lo que sigue (infinitivo) en cada venta

### DIFF
--- a/components/dilesa/capturar-fase-header.tsx
+++ b/components/dilesa/capturar-fase-header.tsx
@@ -14,7 +14,7 @@
  */
 import { Badge } from '@/components/ui/badge';
 import { useVentaCapturaResumen } from '@/components/dilesa/venta-detalle/captura-shell';
-import { nombreFase } from '@/lib/dilesa/fases';
+import { accionFase } from '@/lib/dilesa/fases';
 
 function fmtFechaCorta(s: string | null): string | null {
   if (!s) return null;
@@ -37,7 +37,7 @@ export function CapturarFaseHeader({
     <header className="space-y-2">
       <div className="flex flex-wrap items-baseline gap-3">
         <h1 className="text-2xl font-semibold tracking-tight">
-          Fase {faseposicion} — {nombreFase(faseposicion)}
+          Fase {faseposicion} — {accionFase(faseposicion)}
         </h1>
         <Badge tone="neutral">Pipeline DILESA</Badge>
       </div>

--- a/components/dilesa/operacion-resumen.tsx
+++ b/components/dilesa/operacion-resumen.tsx
@@ -13,6 +13,7 @@
  */
 
 import type { Cuadratura } from '@/lib/dilesa/cuadratura';
+import { proximaFase } from '@/lib/dilesa/fases';
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
   style: 'currency',
@@ -55,6 +56,8 @@ export function OperacionResumen({
     fasePosicion != null && totalFases > 0
       ? Math.round((Math.min(fasePosicion, totalFases) / totalFases) * 100)
       : 0;
+  // "Lo que sigue" = la acción (infinitivo) de la fase posición+1.
+  const sig = proximaFase(fasePosicion);
 
   return (
     <section className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 sm:p-5">
@@ -97,6 +100,11 @@ export function OperacionResumen({
                   style={{ width: `${pct}%` }}
                 />
               </div>
+              {sig ? (
+                <p className="mt-1 text-[11px] text-[var(--text)]/55">
+                  Sigue: <span className="font-medium text-[var(--text)]/75">{sig.accion}</span>
+                </p>
+              ) : null}
             </div>
           ) : null}
         </Bloque>

--- a/components/dilesa/venta-detalle/boton-siguiente-fase.tsx
+++ b/components/dilesa/venta-detalle/boton-siguiente-fase.tsx
@@ -21,6 +21,7 @@ import { ArrowRight, Pencil } from 'lucide-react';
 import { usePermissions } from '@/components/providers';
 import { useVentaDetalle } from './provider';
 import { CAPTURA_MODULO_BY_POSICION } from './types';
+import { accionFase } from '@/lib/dilesa/fases';
 
 export function BotonSiguienteFase() {
   const { venta, pipelineRows } = useVentaDetalle();
@@ -40,13 +41,13 @@ export function BotonSiguienteFase() {
     <Link
       href={`/dilesa/ventas/${venta.id}/capturar/${siguiente.slugCaptura}`}
       className="inline-flex items-center gap-2 rounded-md bg-[var(--accent)] px-3 py-1.5 text-white transition-colors hover:bg-[var(--accent)]/90"
-      title={`Capturar la fase ${siguiente.pos} · ${siguiente.nombre}`}
+      title={`Capturar la fase ${siguiente.pos} · ${accionFase(siguiente.pos)}`}
     >
       <Pencil className="size-4 shrink-0" aria-hidden />
       <span className="flex flex-col text-left leading-tight">
         <span className="text-[10px] font-normal opacity-80">Siguiente fase</span>
         <span className="text-sm font-medium">
-          {siguiente.pos} · {siguiente.nombre}
+          {siguiente.pos} · {accionFase(siguiente.pos)}
         </span>
       </span>
       <ArrowRight className="size-4 shrink-0" aria-hidden />

--- a/components/dilesa/ventas-module.tsx
+++ b/components/dilesa/ventas-module.tsx
@@ -16,6 +16,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { useScopeVendedorDilesa } from '@/lib/dilesa/use-scope-vendedor';
 import { DataTable, ModuleKpiStrip, type Column, type ModuleKpi } from '@/components/module-page';
 import { Badge } from '@/components/ui/badge';
+import { proximaFase } from '@/lib/dilesa/fases';
 import { VENTA_ESTADO_CONFIG, VENTA_ESTADOS } from '@/lib/status-tokens';
 import { Input } from '@/components/ui/input';
 import {
@@ -408,16 +409,20 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
       label: 'Fase',
       type: 'custom',
       accessor: (v) => (v.estado === 'desasignada' ? -1 : (v.fase_posicion ?? 0)),
-      render: (v) =>
+      render: (v) => {
         // Si la venta está desasignada, no mostramos la fase — evita el
         // efecto contradictorio "Asignada + Desasignada" que Beto reportó.
-        v.estado === 'desasignada' ? (
-          <span className="text-[var(--text)]/30">—</span>
-        ) : v.fase_actual ? (
-          <Badge tone="neutral">{v.fase_actual}</Badge>
-        ) : (
-          <span>—</span>
-        ),
+        if (v.estado === 'desasignada') return <span className="text-[var(--text)]/30">—</span>;
+        if (!v.fase_actual) return <span>—</span>;
+        // Estado (participio) + "lo que sigue" (acción infinitivo de la fase+1).
+        const sig = proximaFase(v.fase_posicion);
+        return (
+          <div className="flex flex-col gap-0.5">
+            <Badge tone="neutral">{v.fase_actual}</Badge>
+            {sig ? <span className="text-[10px] text-[var(--text)]/50">→ {sig.accion}</span> : null}
+          </div>
+        );
+      },
     },
     { key: 'precio', label: 'Precio', type: 'currency' },
     {

--- a/lib/dilesa/fases.test.ts
+++ b/lib/dilesa/fases.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { FASES_VENTA, nombreFase, accionFase, proximaFase } from './fases';
+
+describe('fases.ts — estado (participio) vs acción (infinitivo)', () => {
+  it('las 17 fases tienen estado (nombre) y acción, en orden 1..17', () => {
+    expect(FASES_VENTA).toHaveLength(17);
+    expect(FASES_VENTA.map((f) => f.posicion)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+    ]);
+    for (const f of FASES_VENTA) {
+      expect(f.nombre.length).toBeGreaterThan(0);
+      expect(f.accion.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('nombreFase = estado (participio); accionFase = acción (infinitivo)', () => {
+    expect(nombreFase(11)).toBe('Escriturada');
+    expect(accionFase(11)).toBe('Escriturar');
+    expect(nombreFase(2)).toBe('Asignada');
+    expect(accionFase(2)).toBe('Asignar unidad');
+    // Fase 9 conserva el estado como nombre del documento.
+    expect(nombreFase(9)).toBe('Validación Patronal');
+    expect(accionFase(9)).toBe('Recabar validación patronal');
+  });
+
+  it('proximaFase = acción de la fase SIGUIENTE (posición + 1), sin desfase', () => {
+    // Una venta Escriturada (11) → lo que sigue es Detonar crédito (12).
+    expect(proximaFase(11)).toEqual({ posicion: 12, accion: 'Detonar crédito' });
+    expect(proximaFase(2)).toEqual({ posicion: 3, accion: 'Formalizar promesa' });
+  });
+
+  it('proximaFase es null en la fase final (17) y sin posición', () => {
+    expect(proximaFase(17)).toBeNull();
+    expect(proximaFase(null)).toBeNull();
+    expect(proximaFase(undefined)).toBeNull();
+  });
+});

--- a/lib/dilesa/fases.ts
+++ b/lib/dilesa/fases.ts
@@ -28,24 +28,69 @@ export type FaseVenta = {
   readonly slug: string;
 };
 
+// Cada fase tiene DOS formas: `nombre` (participio = el ESTADO, "lo que es", lo
+// que se persiste en DB) y `accion` (infinitivo = "lo que sigue / lo que se hace
+// para llegar a ella"). El estado se muestra en badges/lista/timeline; la acción
+// en el CTA "Siguiente fase", el título de la página de captura, y el chip
+// "Sigue: …" de cada venta (= la acción de la fase posición+1).
 export const FASES_VENTA = [
-  { posicion: 1, nombre: 'Asignación Solicitada', slug: '1-solicitud-asignacion' },
-  { posicion: 2, nombre: 'Asignada', slug: '2-asignada' },
-  { posicion: 3, nombre: 'Formalizada', slug: '3-formalizada' },
-  { posicion: 4, nombre: 'Avalúo Solicitado', slug: '4-solicitud-avaluo' },
-  { posicion: 5, nombre: 'Avalúo Cerrado', slug: '5-avaluo-cerrado' },
-  { posicion: 6, nombre: 'Inscrita', slug: '6-inscrita' },
-  { posicion: 7, nombre: 'Dictamen Solicitado', slug: '7-solicitud-dictamen' },
-  { posicion: 8, nombre: 'Dictaminada', slug: '8-dictaminada' },
-  { posicion: 9, nombre: 'Validación Patronal', slug: '9-validacion-patronal' },
-  { posicion: 10, nombre: 'Firmas Programadas', slug: '10-firmas-programadas' },
-  { posicion: 11, nombre: 'Escriturada', slug: '11-escriturada' },
-  { posicion: 12, nombre: 'Detonada', slug: '12-detonada' },
-  { posicion: 13, nombre: 'Facturada', slug: '13-facturada' },
-  { posicion: 14, nombre: 'Preparada para Entrega', slug: '14-preparada-entrega' },
-  { posicion: 15, nombre: 'Entregada', slug: '15-entregada' },
-  { posicion: 16, nombre: 'Conformidad del Cliente', slug: '16-conformidad' },
-  { posicion: 17, nombre: 'Operación Terminada', slug: '17-operacion-terminada' },
+  {
+    posicion: 1,
+    nombre: 'Asignación Solicitada',
+    accion: 'Solicitar asignación',
+    slug: '1-solicitud-asignacion',
+  },
+  { posicion: 2, nombre: 'Asignada', accion: 'Asignar unidad', slug: '2-asignada' },
+  { posicion: 3, nombre: 'Formalizada', accion: 'Formalizar promesa', slug: '3-formalizada' },
+  {
+    posicion: 4,
+    nombre: 'Avalúo Solicitado',
+    accion: 'Solicitar avalúo',
+    slug: '4-solicitud-avaluo',
+  },
+  { posicion: 5, nombre: 'Avalúo Cerrado', accion: 'Cerrar avalúo', slug: '5-avaluo-cerrado' },
+  { posicion: 6, nombre: 'Inscrita', accion: 'Inscribir crédito', slug: '6-inscrita' },
+  {
+    posicion: 7,
+    nombre: 'Dictamen Solicitado',
+    accion: 'Solicitar dictamen',
+    slug: '7-solicitud-dictamen',
+  },
+  { posicion: 8, nombre: 'Dictaminada', accion: 'Dictaminar', slug: '8-dictaminada' },
+  {
+    posicion: 9,
+    nombre: 'Validación Patronal',
+    accion: 'Recabar validación patronal',
+    slug: '9-validacion-patronal',
+  },
+  {
+    posicion: 10,
+    nombre: 'Firmas Programadas',
+    accion: 'Programar firmas',
+    slug: '10-firmas-programadas',
+  },
+  { posicion: 11, nombre: 'Escriturada', accion: 'Escriturar', slug: '11-escriturada' },
+  { posicion: 12, nombre: 'Detonada', accion: 'Detonar crédito', slug: '12-detonada' },
+  { posicion: 13, nombre: 'Facturada', accion: 'Facturar', slug: '13-facturada' },
+  {
+    posicion: 14,
+    nombre: 'Preparada para Entrega',
+    accion: 'Preparar entrega',
+    slug: '14-preparada-entrega',
+  },
+  { posicion: 15, nombre: 'Entregada', accion: 'Entregar', slug: '15-entregada' },
+  {
+    posicion: 16,
+    nombre: 'Conformidad del Cliente',
+    accion: 'Recabar conformidad',
+    slug: '16-conformidad',
+  },
+  {
+    posicion: 17,
+    nombre: 'Operación Terminada',
+    accion: 'Cerrar operación',
+    slug: '17-operacion-terminada',
+  },
 ] as const;
 
 export type FaseSlug = (typeof FASES_VENTA)[number]['slug'];
@@ -53,10 +98,31 @@ export type FaseSlug = (typeof FASES_VENTA)[number]['slug'];
 const NOMBRE_BY_POS: ReadonlyMap<number, string> = new Map(
   FASES_VENTA.map((f) => [f.posicion, f.nombre])
 );
+const ACCION_BY_POS: ReadonlyMap<number, string> = new Map(
+  FASES_VENTA.map((f) => [f.posicion, f.accion])
+);
 
-/** Nombre visible de una fase por su posición. Fallback defensivo si no existe. */
+/** Nombre/ESTADO visible de una fase (participio) por su posición. */
 export function nombreFase(posicion: number): string {
   return NOMBRE_BY_POS.get(posicion) ?? `Fase ${posicion}`;
+}
+
+/** ACCIÓN (infinitivo, "lo que se hace") de una fase por su posición. */
+export function accionFase(posicion: number): string {
+  return ACCION_BY_POS.get(posicion) ?? nombreFase(posicion);
+}
+
+/**
+ * "Lo que sigue" para una venta cuya última fase COMPLETADA es `fasePosicion`:
+ * la acción (infinitivo) de la fase siguiente. `null` si ya está en la 17
+ * (no hay siguiente) o si no hay posición.
+ */
+export function proximaFase(
+  fasePosicion: number | null | undefined
+): { posicion: number; accion: string } | null {
+  if (fasePosicion == null || fasePosicion >= 17) return null;
+  const siguiente = fasePosicion + 1;
+  return { posicion: siguiente, accion: accionFase(siguiente) };
 }
 
 /** Record posición → nombre, para lookups O(1) en server actions y rutas API. */


### PR DESCRIPTION
## Qué cambia

Cada venta ahora presenta **las dos cosas, cada una en su forma**:
- **Estado** (lo que ES) → participio, de la fase actual. *"Esta venta está Escriturada."*
- **Lo que sigue** (próximo hito) → infinitivo, de la fase **siguiente**. *"Sigue: Detonar crédito."*

Cada fase gana una segunda forma `accion` (infinitivo) en la fuente única `lib/dilesa/fases.ts`, junto a `nombre` (participio). **Sin migración**: el infinitivo vive solo en código; la DB sigue guardando el estado.

`"Lo que sigue"` = `accion` de la fase **posición + 1** (helper `proximaFase`), así no hay desfase: una venta *Escriturada* (11) muestra *Sigue: Detonar crédito* (12).

## Superficies (lo que pediste: Detalle + Lista + Captura)
- **Lista de ventas** — cada fila: `[11. Escriturada]` con `→ Detonar crédito` debajo.
- **Expediente (Zona A)** — badge de estado + chip `Sigue: Detonar crédito`.
- **Botón "Siguiente fase"** y **título de la página de captura** → infinitivo (es la acción que haces ahí: "Fase 11 — Escriturar").

Los badges/timeline/reportes siguen en **participio** (estado); solo las superficies de "acción/siguiente" usan infinitivo.

## Detalle de las acciones
Mismo set infinitivo de antes; fase 9 = **"Recabar validación patronal"** (tu elección). Fase 17 no tiene "siguiente".

## Verificación
typecheck ✓ · test:coverage **2021 tests** ✓ (test nuevo de `fases.ts`) · lint (0 errores) ✓ · format ✓. Sin migración → sin paso de DB.
