### PR TITLE
feat(dilesa-ventas): fase 5 exige seguro de calidad (orden + solicitud) en Infonavit/Cofinavit

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
@@ -10,9 +10,12 @@
  * Captura:
  *   - `monto_avaluo` → monto dictaminado por la casa valuadora
  *   - `fecha_avaluo_cerrado` → fecha del cierre (default hoy)
- *   - Doc requerido: rol `avaluo_comercial` (PDF firmado por el
- *     valuador). Coincide con `FASE_ROLES[5]` en el
- *     detalle de venta.
+ *   - Docs requeridos (rol en `erp.adjuntos`, coinciden con `FASE_ROLES[5]`):
+ *       · `avaluo_comercial` — PDF firmado por el valuador (siempre).
+ *       · `orden_pago_seguro_calidad` — PDF de la orden de pago del seguro de
+ *         calidad (RUV). Solo Infonavit/Cofinavit (`requiereSeguroCalidad`).
+ *       · `solicitud_pago_seguro_calidad` — imagen de la solicitud de pago del
+ *         seguro (trae la referencia de la vivienda). Solo Infonavit/Cofinavit.
  *
  * Captura colaborativa (Sprint 4b de `dilesa-ventas-captura-colaborativa`):
  * el documento persiste AL SUBIRSE con quién/cuándo; el cierre valida contra
@@ -42,10 +45,7 @@ import {
   useDocsFaseColaborativos,
   type SlotColaborativo,
 } from '@/components/dilesa/captura/docs-fase-colaborativos';
-
-const SLOTS_F5: SlotColaborativo[] = [
-  { rol: 'avaluo_comercial', label: 'Avalúo Comercial firmado por el valuador', requerido: true },
-];
+import { requiereSeguroCalidad } from '@/lib/dilesa/captura/fase-roles';
 
 type VentaCtx = {
   id: string;
@@ -53,6 +53,7 @@ type VentaCtx = {
   unidad_id: string | null;
   monto_avaluo: number | null;
   valuador_id: string | null;
+  tipo_credito: string | null;
 };
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
@@ -83,7 +84,35 @@ function CapturarFase5Body() {
   const [fase4Cerrada, setFase4Cerrada] = useState<boolean | null>(null);
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
 
-  const docsFase = useDocsFaseColaborativos(ventaId, SLOTS_F5);
+  // Slots por tipo de crédito: el avalúo va siempre; los 2 del seguro de
+  // calidad (RUV) solo se exigen en Infonavit/Cofinavit. La longitud del array
+  // cambia con `tipo_credito`, así que el hook recalcula `faltantes` al cargar
+  // la venta (su `slotsKey` se llavea por los roles presentes).
+  const slotsF5 = useMemo<SlotColaborativo[]>(() => {
+    const slots: SlotColaborativo[] = [
+      {
+        rol: 'avaluo_comercial',
+        label: 'Avalúo Comercial firmado por el valuador',
+        requerido: true,
+      },
+    ];
+    if (requiereSeguroCalidad(venta?.tipo_credito ?? null)) {
+      slots.push(
+        {
+          rol: 'orden_pago_seguro_calidad',
+          label: 'Orden de pago del seguro de calidad (PDF)',
+          requerido: true,
+        },
+        {
+          rol: 'solicitud_pago_seguro_calidad',
+          label: 'Solicitud de pago del seguro de calidad (referencia de la vivienda)',
+          requerido: true,
+        }
+      );
+    }
+    return slots;
+  }, [venta?.tipo_credito]);
+  const docsFase = useDocsFaseColaborativos(ventaId, slotsF5);
   const [montoAvaluo, setMontoAvaluo] = useState<string>('');
   const [fechaAvaluo, setFechaAvaluo] = useState<string>(new Date().toISOString().slice(0, 10));
 
@@ -103,7 +132,7 @@ function CapturarFase5Body() {
       const { data: vRow, error: vErr } = await sb
         .schema('dilesa')
         .from('ventas')
-        .select('id, persona_id, unidad_id, monto_avaluo, valuador_id')
+        .select('id, persona_id, unidad_id, monto_avaluo, valuador_id, tipo_credito')
         .eq('id', ventaId)
         .is('deleted_at', null)
         .maybeSingle();
@@ -167,9 +196,10 @@ function CapturarFase5Body() {
       e.preventDefault();
       if (!venta) return;
       if (docsFase.faltantes.length > 0) {
+        const faltan = docsFase.faltantes.map((rol) => docsFase.labelDe(rol)).join(', ');
         toast.add({
-          title: 'Falta el documento del avalúo',
-          description: 'Sube el PDF del avalúo comercial — queda guardado al subirlo.',
+          title: docsFase.faltantes.length === 1 ? 'Falta un documento' : 'Faltan documentos',
+          description: `Sube en el expediente: ${faltan}. Quedan guardados al subirlos.`,
           type: 'error',
         });
         return;
@@ -216,7 +246,7 @@ function CapturarFase5Body() {
       });
       router.push(`/dilesa/ventas/${venta.id}`);
     },
-    [docsFase.faltantes, fechaAvaluo, montoAvaluo, router, sb, toast, venta]
+    [docsFase, fechaAvaluo, montoAvaluo, router, sb, toast, venta]
   );
 
   // ── Render ───────────────────────────────────────────────────────
@@ -282,7 +312,7 @@ function CapturarFase5Body() {
             </div>
           ) : null}
 
-          <DocsFaseSection state={docsFase} titulo="Documento del avalúo" />
+          <DocsFaseSection state={docsFase} titulo="Documentos" />
 
           <Section title="Datos del avalúo">
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/lib/dilesa/captura/fase-roles.ts
+++ b/lib/dilesa/captura/fase-roles.ts
@@ -15,7 +15,9 @@ export const FASE_ROLES: Record<number, string[]> = {
   2: ['solicitud_asignacion', 'expediente_digital', 'ficu', 'aviso_privacidad'], // Asignada
   3: ['contrato_promesa'], // Formalizada
   4: [], // Avalúo Solicitado
-  5: ['avaluo_comercial'], // Avalúo Cerrado
+  // Avalúo Cerrado. Los 2 docs del seguro de calidad (RUV) solo se EXIGEN en
+  // créditos Infonavit/Cofinavit — `rolesOpcionales` los exime en el resto.
+  5: ['avaluo_comercial', 'orden_pago_seguro_calidad', 'solicitud_pago_seguro_calidad'],
   // Beto: las Constancias de Crédito (titular + co-titular) van al inscribir el
   // crédito (pos 6) — el banco las entrega ahí. La Carta de instrucción notarial
   // queda en el dictamen (pos 8, sale después con el dictamen jurídico).
@@ -40,6 +42,8 @@ export const ROL_LABEL: Record<string, string> = {
   constancia_credito_cotitular: 'Constancia de crédito (co-titular)',
   aviso_pld: 'Aviso PLD',
   avaluo_comercial: 'Avalúo comercial',
+  orden_pago_seguro_calidad: 'Orden de pago del seguro de calidad',
+  solicitud_pago_seguro_calidad: 'Solicitud de pago del seguro de calidad',
   contrato_promesa: 'Contrato promesa de compraventa',
   solicitud_asignacion: 'Solicitud de asignación',
   recibos_caja: 'Recibos de caja',
@@ -64,12 +68,25 @@ export type VentaFlagsDocs = {
 };
 
 /**
+ * El seguro de calidad (RUV) solo es obligatorio en créditos Infonavit —
+ * incluye Cofinavit, que es cofinanciamiento Infonavit + banco (Beto,
+ * 2026-06-24). En Fovissste, bancario y contado no aplica. Criterio aparte de
+ * `condiciones_financieras` (Anexo B), que sí excluye a Cofinavit.
+ */
+export function requiereSeguroCalidad(tipoCredito: string | null): boolean {
+  const t = (tipoCredito ?? '').toLowerCase();
+  return t.includes('infonavit') || t.includes('cofinavit');
+}
+
+/**
  * Roles que NO se exigen para el cierre porque la venta no los amerita:
  * - constancia co-titular: solo si hay crédito de co-titular.
  * - pagaré: solo si hay crédito directo (CD).
  * - nota de crédito: solo si el monto de nota de crédito es > 0.
  * - condiciones financieras (Anexo B): formato INFONAVIT — en otros créditos
  *   el notario no lo manda.
+ * - orden/solicitud del seguro de calidad: solo en créditos Infonavit/Cofinavit
+ *   (ver `requiereSeguroCalidad`).
  */
 export function rolesOpcionales(v: VentaFlagsDocs): Set<string> {
   const opc = new Set<string>();
@@ -84,6 +101,10 @@ export function rolesOpcionales(v: VentaFlagsDocs): Set<string> {
   }
   if (!(v.tipo_credito ?? '').toLowerCase().includes('infonavit')) {
     opc.add('condiciones_financieras');
+  }
+  if (!requiereSeguroCalidad(v.tipo_credito)) {
+    opc.add('orden_pago_seguro_calidad');
+    opc.add('solicitud_pago_seguro_calidad');
   }
   return opc;
 }

--- a/lib/dilesa/copiloto-cierre.test.ts
+++ b/lib/dilesa/copiloto-cierre.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { evaluarCierre, type CopilotoInput } from './copiloto-cierre';
-import { rolesOpcionales } from './captura/fase-roles';
+import { requiereSeguroCalidad, rolesOpcionales } from './captura/fase-roles';
 
 const fasesCompletas = Array.from({ length: 17 }, (_, idx) => ({
   pos: idx + 1,
@@ -86,9 +86,12 @@ describe('rolesOpcionales (docs condicionales)', () => {
     expect(opc.has('pagare')).toBe(true);
     expect(opc.has('nota_credito')).toBe(true);
     expect(opc.has('condiciones_financieras')).toBe(false); // Infonavit SÍ lo exige
+    // Infonavit SÍ exige el seguro de calidad (no opcional).
+    expect(opc.has('orden_pago_seguro_calidad')).toBe(false);
+    expect(opc.has('solicitud_pago_seguro_calidad')).toBe(false);
   });
 
-  it('crédito bancario: exime el Anexo B', () => {
+  it('crédito bancario: exime el Anexo B y el seguro de calidad', () => {
     const opc = rolesOpcionales({
       monto_credito_cotitular: 100000,
       monto_credito_directo: 50000,
@@ -99,5 +102,50 @@ describe('rolesOpcionales (docs condicionales)', () => {
     expect(opc.has('constancia_credito_cotitular')).toBe(false);
     expect(opc.has('pagare')).toBe(false);
     expect(opc.has('nota_credito')).toBe(false);
+    // No-Infonavit → seguro de calidad opcional.
+    expect(opc.has('orden_pago_seguro_calidad')).toBe(true);
+    expect(opc.has('solicitud_pago_seguro_calidad')).toBe(true);
+  });
+
+  it('Cofinavit exige el seguro de calidad (cofinanciamiento Infonavit)', () => {
+    const opc = rolesOpcionales({
+      monto_credito_cotitular: null,
+      monto_credito_directo: null,
+      monto_nota_credito: 0,
+      tipo_credito: 'Cofinavit',
+    });
+    expect(opc.has('orden_pago_seguro_calidad')).toBe(false);
+    expect(opc.has('solicitud_pago_seguro_calidad')).toBe(false);
+  });
+
+  it('Contado exime el seguro de calidad', () => {
+    const opc = rolesOpcionales({
+      monto_credito_cotitular: null,
+      monto_credito_directo: null,
+      monto_nota_credito: 0,
+      tipo_credito: 'Contado',
+    });
+    expect(opc.has('orden_pago_seguro_calidad')).toBe(true);
+    expect(opc.has('solicitud_pago_seguro_calidad')).toBe(true);
+  });
+});
+
+describe('requiereSeguroCalidad', () => {
+  it('exige en todos los créditos Infonavit (incluye Cofinavit)', () => {
+    for (const t of [
+      'Infonavit Tradicional',
+      'Infonavit Unamos',
+      'Infonavit Conyugal',
+      'Infonavit/Fovissste',
+      'Cofinavit',
+    ]) {
+      expect(requiereSeguroCalidad(t)).toBe(true);
+    }
+  });
+
+  it('no exige en Fovissste, bancario, contado, IMSS ni cuando falta el dato', () => {
+    for (const t of ['Fovissste Tradicional', 'Hipotecario', 'Contado', 'IMSS', '', null]) {
+      expect(requiereSeguroCalidad(t)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Qué

La **Fase 5 — Avalúo Cerrado** sumaba solo el avalúo comercial. Se agregan **2 documentos del seguro de calidad (RUV)**:

1. **Orden de pago del seguro de calidad** (`orden_pago_seguro_calidad`) — PDF.
2. **Solicitud de pago del seguro de calidad** (`solicitud_pago_seguro_calidad`) — imagen, trae la referencia de la vivienda.

## Obligatoriedad (decisión de Beto)

Obligatorios **solo en créditos Infonavit y Cofinavit** (cofinanciamiento Infonavit + banco). En **Fovissste, bancario, IMSS y contado no aplican** — los slots ni se muestran ni bloquean el cierre.

- Criterio centralizado en `requiereSeguroCalidad(tipo_credito)` → `includes('infonavit') || includes('cofinavit')`.
- `rolesOpcionales` los exime fuera de Infonavit/Cofinavit, así que **ni el cierre de F5 ni el copiloto de Operación Terminada (F17)** los exigen en esas ventas.
- Conteo en prod al abrir: 1,082 ventas Infonavit* + 41 Cofinavit los exigirán; 199 (Fovissste/Hipotecario/Contado/IMSS) no.

## Archivos

- `lib/dilesa/captura/fase-roles.ts` — `FASE_ROLES[5]` + labels + helper `requiereSeguroCalidad` + condicional en `rolesOpcionales`.
- `app/.../capturar/5-avaluo-cerrado/page.tsx` — slots dinámicos por `tipo_credito`; mensaje de error con labels faltantes.
- `lib/dilesa/copiloto-cierre.test.ts` — cobertura del nuevo comportamiento condicional.

## Notas

- **Sin migración de DB**: `erp.adjuntos.rol` es texto libre; el catálogo vive en TS.
- Efecto retroactivo esperado: ventas Infonavit/Cofinavit en curso que aún no lleguen a F17 mostrarán estos 2 docs como pendientes en el expediente hasta subirlos.

## Verificación

Los 6 checks de CI corridos localmente en verde (typecheck, test:coverage 2025 ✓, lint 0 errores, format, initiatives; schema:check no aplica — sin cambios de DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)