### PR TITLE
feat(dilesa-ventas): chip de color para "Sigue" + responsables Dictaminada/Firmas

### DIFF
--- a/app/dilesa/ventas/fases/page.tsx
+++ b/app/dilesa/ventas/fases/page.tsx
@@ -344,8 +344,9 @@ function FaseCard({ fase, cuenta }: { fase: Fase; cuenta: number }) {
         </div>
       ) : null}
       {sig ? (
-        <div className="mt-1 text-[11px] text-[var(--text)]/50">
-          Sigue: <span className="font-medium text-[var(--text)]/70">{sig.accion}</span>
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <span className="text-[10px] uppercase tracking-wide text-[var(--text)]/40">Sigue</span>
+          <Badge tone="accent">{sig.accion}</Badge>
         </div>
       ) : null}
       <div className="mt-3 flex items-baseline justify-between">

--- a/supabase/migrations/20260624220154_dilesa_fase_catalogo_responsables.sql
+++ b/supabase/migrations/20260624220154_dilesa_fase_catalogo_responsables.sql
@@ -1,0 +1,24 @@
+-- ╭─ 20260624220154_dilesa_fase_catalogo_responsables ─╮
+-- Ajusta el "responsable" (etiqueta de display `rol`) de dos fases del catálogo
+-- de ventas DILESA (decisión Beto 2026-06-24):
+--   · Fase 8  Dictaminada       → Comité            (antes Gerencia de Ventas)
+--   · Fase 10 Firmas Programadas → Gerencia de Ventas (antes Gerencia General)
+-- `rol` es solo etiqueta de la pestaña Fases ("Resp.: …"); NO es el RBAC (eso
+-- vive en los sub-slugs faseNN_*). Idempotente y scopeado a 'dilesa'.
+
+BEGIN;
+
+UPDATE dilesa.venta_fase_catalogo c
+SET rol = m.rol
+FROM (
+  VALUES
+    (8, 'Comité'),
+    (10, 'Gerencia de Ventas')
+) AS m(posicion, rol)
+WHERE c.posicion = m.posicion
+  AND c.empresa_id = (SELECT id FROM core.empresas WHERE slug = 'dilesa')
+  AND c.rol IS DISTINCT FROM m.rol;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
Dos cosas:

**1. Chip de color en la pestaña Fases.** "Lo que sigue" pasa de texto plano a un **chip violeta** (`Badge` tone accent), distinto del azul del conteo, para identificar de un vistazo qué sigue por hacer.

**2. Responsables (etiqueta `Resp.:` del catálogo).**
- Fase 8 **Dictaminada**: Gerencia de Ventas → **Comité**
- Fase 10 **Firmas Programadas**: Gerencia General → **Gerencia de Ventas**

`rol` es solo etiqueta de display de la pestaña Fases — NO es el RBAC (eso vive en los sub-slugs `faseNN_*`), así que no cambia permisos. Migración `20260624220154` idempotente, por posición.

typecheck · 2021 tests · lint · format ✓. ⚠️ Migración solo-datos: la aplico con db push coordinada con el merge.