### PR TITLE
feat(dilesa-compras-operacion): Sprint 2a — folio secuencial OC-2026-NNNN

### DIFF
--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -1225,13 +1225,12 @@ function CapturaPrecios({
     const total = totalProveedor(cotizacion, cotProveedorId);
     try {
       if (adjudicaA(cotizacion.tipo) === 'oc') {
-        const folio = `OC-${Date.now().toString(36).toUpperCase()}`;
+        // El folio (OC-{año}-{NNNN}) lo asigna el trigger erp.fn_oc_asignar_folio.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const ocResp = await (sb.schema('erp') as any)
           .from('ordenes_compra')
           .insert({
             empresa_id: empresaId,
-            codigo: folio,
             cotizacion_id: cotizacion.id,
             proveedor_id: prov.proveedorId,
             // Adjudicar = autorizar = emitir en un acto (D2): la OC nace

--- a/components/compras/ordenes-compra-module.tsx
+++ b/components/compras/ordenes-compra-module.tsx
@@ -511,17 +511,17 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
         return;
       }
     } else {
-      folio = `OC-${Date.now().toString(36).toUpperCase()}`;
+      // El folio (OC-{año}-{NNNN}) lo asigna el trigger erp.fn_oc_asignar_folio;
+      // el cliente ya no lo genera, se lee de vuelta para el toast.
       const ocResp = await erp
         .from('ordenes_compra')
         .insert({
           empresa_id: empresaId,
-          codigo: folio,
           proveedor_id: proveedorId || null,
           estado: 'borrador',
           total,
         })
-        .select('id')
+        .select('id, codigo')
         .single();
       if (ocResp.error || !ocResp.data) {
         toast.add({
@@ -533,6 +533,7 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
         return;
       }
       ocId = ocResp.data.id as string;
+      folio = (ocResp.data.codigo as string) ?? ocId;
     }
 
     const detalle = validas.map((l) => ({

--- a/components/compras/requisiciones-module.tsx
+++ b/components/compras/requisiciones-module.tsx
@@ -519,15 +519,14 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
       if (!esDireccion || !puedeGenerarOc(req) || accionId === req.id) return;
       setAccionId(req.id);
       const sb = createSupabaseBrowserClient();
-      const folio = `OC-${Date.now().toString(36).toUpperCase()}`;
       // Partida opcional: gasto suelto genera OC sin partida (no compromete presupuesto).
       const validas = req.lineas.filter((l) => l.cantidad > 0);
+      // El folio (OC-{año}-{NNNN}) lo asigna el trigger erp.fn_oc_asignar_folio.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const ocResp = await (sb.schema('erp') as any)
         .from('ordenes_compra')
         .insert({
           empresa_id: empresaId,
-          codigo: folio,
           requisicion_id: req.id,
           proveedor_id: null,
           // La OC hereda las líneas y su partida pero NO el proveedor (la
@@ -540,7 +539,7 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
           autorizada_at: null,
           total: validas.reduce((acc, l) => acc + l.cantidad * l.precioEstimado, 0),
         })
-        .select('id')
+        .select('id, codigo')
         .single();
       if (ocResp.error || !ocResp.data) {
         setAccionId(null);
@@ -552,6 +551,7 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
         return;
       }
       const ocId = ocResp.data.id as string;
+      const folio = (ocResp.data.codigo as string) ?? ocId;
       const detalle = validas.map((l) => ({
         empresa_id: empresaId,
         orden_compra_id: ocId,

--- a/supabase/migrations/20260624233040_oc_folio_secuencial.sql
+++ b/supabase/migrations/20260624233040_oc_folio_secuencial.sql
@@ -1,0 +1,60 @@
+-- ╭─ 20260624233040_oc_folio_secuencial ─╮
+-- Folio secuencial OC-{año}-{NNNN} para órdenes de compra (DILESA).
+--
+-- Iniciativa `dilesa-compras-operacion` · Sprint 2. Hoy el folio se genera en el
+-- cliente con `Date.now().toString(36)` → "OC-LXY8Z3K": ilegible en un documento
+-- que va al proveedor y al SAT, y no secuencial/auditable. Este trigger asigna un
+-- consecutivo legible por (empresa, año), atómico — mismo patrón probado que el
+-- folio LEV-{año}-{NNNN} de `erp.inventario_levantamientos` (advisory lock por
+-- empresa+año + MAX(consecutivo)+1).
+--
+-- Convive con lo existente sin tocarlo:
+--   - Solo asigna cuando `codigo` viene NULL/''. RDB SIEMPRE manda su propio folio
+--     (`generarFolio('OC')` en su server action) → el trigger lo respeta y NO toca
+--     RDB. DILESA dejará de mandar `codigo` (cliente) → obtiene el secuencial.
+--   - Las OC viejas (`OC-<base36>`) no matchean el patrón `OC-{año}-%`, así que el
+--     consecutivo del año arranca limpio en 0001 sin colisionar.
+--   - El UNIQUE (empresa_id, codigo) ya existente sigue garantizando unicidad.
+--
+-- NO toca montos, estados, permisos ni `erp.v_partida_control`. Solo numeración.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION erp.fn_oc_asignar_folio()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = erp, pg_catalog AS $$
+DECLARE
+  v_year int;
+  v_next int;
+  v_lock_key bigint;
+BEGIN
+  -- Respeta un folio explícito (RDB, imports, backfills): no lo pisa.
+  IF NEW.codigo IS NOT NULL AND NEW.codigo <> '' THEN
+    RETURN NEW;
+  END IF;
+
+  v_year := EXTRACT(YEAR FROM COALESCE(NEW.created_at, now()))::int;
+  -- Advisory lock por (empresa, año) para evitar race en el consecutivo.
+  v_lock_key := ('x' || substr(md5(NEW.empresa_id::text || '-' || v_year::text), 1, 16))::bit(64)::bigint;
+  PERFORM pg_advisory_xact_lock(v_lock_key);
+
+  SELECT COALESCE(MAX(
+           CAST(NULLIF(regexp_replace(codigo, '^OC-' || v_year || '-', ''), '') AS int)
+         ), 0) + 1
+    INTO v_next
+  FROM erp.ordenes_compra
+  WHERE empresa_id = NEW.empresa_id
+    AND codigo LIKE 'OC-' || v_year || '-%';
+
+  NEW.codigo := 'OC-' || v_year || '-' || lpad(v_next::text, 4, '0');
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_oc_folio ON erp.ordenes_compra;
+CREATE TRIGGER trg_oc_folio
+BEFORE INSERT ON erp.ordenes_compra
+FOR EACH ROW EXECUTE FUNCTION erp.fn_oc_asignar_folio();
+
+COMMIT;


### PR DESCRIPTION
Sprint 2a de [`dilesa-compras-operacion`](docs/planning/dilesa-compras-operacion.md): folio legible para la OC, prerequisito del PDF (Sprint 2b). **Migración ya aplicada a prod con OK de Beto** (ledger reconciliado).

## Qué

Las OC de DILESA dejan de generar el folio en cliente (`Date.now()` → `OC-LXY8Z3K`, ilegible en el documento que va al proveedor y al SAT). Un **trigger `BEFORE INSERT`** (`erp.fn_oc_asignar_folio`) asigna **`OC-{año}-{NNNN}`** consecutivo por empresa+año, atómico (advisory lock — mismo patrón probado en prod desde abril para los folios `LEV-` de inventario).

- Los **3 productores de OC** (alta directa, desde requisición, desde adjudicación) omiten `codigo` y leen el que asigna el trigger.
- **Solo numeración**: no toca montos, estados, permisos ni `erp.v_partida_control`.
- **RDB intacto**: siempre manda su propio folio (`generarFolio('OC')`), y el trigger respeta cualquier `codigo` explícito.

## Verificación
- **Dry-run (BEGIN/ROLLBACK) en prod antes de aplicar**: DILESA `codigo` null → `OC-2026-0001` / `OC-2026-0002`; RDB (codigo explícito) → conservado intacto.
- Migración aplicada a prod (MCP) + **ledger reconciliado 1:1** (archivo `20260624233040`, huérfano del MCP revertido).
- ✅ typecheck · lint (0 errores) · format · test:coverage (2026 tests) · initiatives:check · schema:check (la función trigger no aparece en SCHEMA_REF, sin diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)