### PR TITLE
feat(dilesa-construccion): PDF de tareas pendientes al contratista + envío por correo

### DIFF
--- a/app/api/dilesa/construccion/[id]/pendientes/pdf/route.tsx
+++ b/app/api/dilesa/construccion/[id]/pendientes/pdf/route.tsx
@@ -1,0 +1,416 @@
+/**
+ * GET  /api/dilesa/construccion/[id]/pendientes/pdf  → abre el PDF (imprimir/guardar)
+ * POST /api/dilesa/construccion/[id]/pendientes/pdf  → envía el PDF por email al contratista
+ *
+ * Relación de tareas pendientes de ejecución de una obra, con el valor de
+ * mano de obra de cada tarea + datos de la vivienda y del contrato. Se le
+ * entrega al contratista (a veces lo piden).
+ *
+ * Auth: sesión Supabase. La RLS de `dilesa.construccion` decide si el
+ * usuario puede leer la obra; si no, 404.
+ *
+ * El POST acepta body opcional `{ to?: string; subject?: string }` — por
+ * default usa `erp.personas.email` del contratista y un subject generado.
+ */
+
+import { NextResponse } from 'next/server';
+import { renderToBuffer } from '@react-pdf/renderer';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import {
+  TareasPendientesPDF,
+  type TareasPendientesPdfData,
+} from '@/lib/dilesa/pdf/tareas-pendientes';
+import {
+  getDefinitionBySlug,
+  renderSubject,
+  splitRecipientsExtra,
+  writeNotificationLog,
+} from '@/lib/notifications';
+
+const MESES_ES = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+];
+
+function fmtFechaHoy(): string {
+  const d = new Date();
+  return `${d.getDate()} de ${MESES_ES[d.getMonth()]} de ${d.getFullYear()}`;
+}
+
+/** Construye la data del PDF desde la obra + sus tareas pendientes. */
+async function buildPdfData(
+  sb: Awaited<ReturnType<typeof createSupabaseServerClient>>,
+  construccionId: string
+): Promise<{ data?: TareasPendientesPdfData; contratistaEmail?: string | null; error?: string }> {
+  const { data: obra, error: oErr } = await sb
+    .schema('dilesa')
+    .from('construccion')
+    .select(
+      'id, codigo, unidad_id, producto_id, contratista_id, valor_contrato_mo, mo_ejecutado, avance_pct, m2_construccion'
+    )
+    .eq('id', construccionId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (oErr || !obra) return { error: 'Obra no encontrada' };
+
+  const valorContratoMo = Number(obra.valor_contrato_mo ?? 0);
+  const moEjecutado = Number(obra.mo_ejecutado ?? 0);
+
+  const [uRes, prodRes, persRes, datosRes, etRes, taCatRes, plRes, ttRes, clRes] =
+    await Promise.all([
+      sb
+        .schema('dilesa')
+        .from('unidades')
+        .select('identificador, proyecto_id')
+        .eq('id', obra.unidad_id as string)
+        .maybeSingle(),
+      sb
+        .schema('dilesa')
+        .from('productos')
+        .select('nombre')
+        .eq('id', obra.producto_id as string)
+        .maybeSingle(),
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('nombre, apellido_paterno, apellido_materno, email')
+        .eq('id', obra.contratista_id as string)
+        .maybeSingle(),
+      sb
+        .schema('dilesa')
+        .from('contratistas_datos')
+        .select('abreviacion')
+        .eq('persona_id', obra.contratista_id as string)
+        .is('deleted_at', null)
+        .maybeSingle(),
+      sb.schema('dilesa').from('etapas_construccion').select('id, nombre, orden'),
+      sb.schema('dilesa').from('tareas_construccion').select('id, nombre, hito_recepcion'),
+      sb
+        .schema('dilesa')
+        .from('plantilla_tareas')
+        .select('id, tarea_id, etapa_id, porcentaje_costo')
+        .eq('producto_id', obra.producto_id as string)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('construccion_tareas_terminadas')
+        .select('plantilla_tarea_id')
+        .eq('construccion_id', construccionId)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('contrato_lotes')
+        .select('contrato_id')
+        .eq('construccion_id', construccionId)
+        .is('deleted_at', null),
+    ]);
+
+  // Proyecto del lote.
+  let proyecto: string | null = null;
+  const proyectoId = (uRes.data?.proyecto_id as string | null) ?? null;
+  if (proyectoId) {
+    const { data: prj } = await sb
+      .schema('dilesa')
+      .from('proyectos')
+      .select('nombre')
+      .eq('id', proyectoId)
+      .maybeSingle();
+    proyecto = (prj?.nombre as string | null) ?? null;
+  }
+
+  // Contrato(s) de obra ligados — referencia para el contratista. Solo los
+  // del contratista de esta obra, vigentes.
+  let contratoCodigo: string | null = null;
+  const contratoIds = [...new Set((clRes.data ?? []).map((cl) => cl.contrato_id as string))];
+  if (contratoIds.length) {
+    const { data: ccRows } = await sb
+      .schema('dilesa')
+      .from('contratos_construccion')
+      .select('codigo')
+      .in('id', contratoIds)
+      .eq('contratista_id', obra.contratista_id as string)
+      .is('deleted_at', null)
+      .is('cancelada_at', null);
+    const codigos = [...new Set((ccRows ?? []).map((c) => c.codigo as string).filter(Boolean))];
+    contratoCodigo = codigos.length ? codigos.join(', ') : null;
+  }
+
+  // Catálogos: etapa (orden/nombre) y tarea (nombre/hito).
+  const etapaMap = new Map<string, { nombre: string; orden: number }>();
+  for (const e of etRes.data ?? [])
+    etapaMap.set(e.id as string, {
+      nombre: e.nombre as string,
+      orden: Number(e.orden ?? 0),
+    });
+  const tareaCatMap = new Map<string, { nombre: string; hito: string | null }>();
+  for (const t of taCatRes.data ?? [])
+    tareaCatMap.set(t.id as string, {
+      nombre: t.nombre as string,
+      hito: (t.hito_recepcion as string | null) ?? null,
+    });
+
+  const terminadasSet = new Set((ttRes.data ?? []).map((t) => t.plantilla_tarea_id as string));
+
+  // Tareas pendientes de EJECUCIÓN: de la plantilla del prototipo, las que
+  // no están terminadas y no son hito de recepción (esas las cierra el flujo
+  // de recepción, no es trabajo del contratista). Valor = % × valor MO,
+  // misma fórmula que la pantalla de la obra.
+  const porEtapa = new Map<
+    string,
+    {
+      nombre: string;
+      orden: number;
+      tareas: Array<{ nombre: string; valor: number }>;
+      subtotal: number;
+    }
+  >();
+  for (const p of plRes.data ?? []) {
+    const cat = tareaCatMap.get(p.tarea_id as string);
+    if (cat?.hito) continue;
+    if (terminadasSet.has(p.id as string)) continue;
+    const etapaId = p.etapa_id as string;
+    const et = etapaMap.get(etapaId) ?? { nombre: '(sin etapa)', orden: 999 };
+    const valor = Number(p.porcentaje_costo ?? 0) * valorContratoMo;
+    const grupo = porEtapa.get(etapaId) ?? {
+      nombre: et.nombre,
+      orden: et.orden,
+      tareas: [],
+      subtotal: 0,
+    };
+    grupo.tareas.push({ nombre: cat?.nombre ?? '(tarea desconocida)', valor });
+    grupo.subtotal += valor;
+    porEtapa.set(etapaId, grupo);
+  }
+
+  const etapas = [...porEtapa.values()]
+    .map((g) => ({ ...g, tareas: g.tareas.sort((a, b) => a.nombre.localeCompare(b.nombre)) }))
+    .sort((a, b) => a.orden - b.orden);
+  const totalPendiente = etapas.reduce((s, e) => s + e.subtotal, 0);
+  const totalTareas = etapas.reduce((s, e) => s + e.tareas.length, 0);
+
+  // Identificador legible — mismo armado que la pantalla de la obra:
+  // unidad + sufijo del prototipo (M13-L4 + RMC → M13-L4-RMC).
+  const prototipo = (prodRes.data?.nombre as string | null) ?? null;
+  const unidad = (uRes.data?.identificador as string | null) ?? null;
+  const protoSufijo = prototipo ? prototipo.split('-').pop() : null;
+  const identificador = unidad
+    ? protoSufijo
+      ? `${unidad}-${protoSufijo}`
+      : unidad
+    : (obra.codigo as string);
+
+  const contratistaNombre =
+    [persRes.data?.nombre, persRes.data?.apellido_paterno, persRes.data?.apellido_materno]
+      .filter(Boolean)
+      .join(' ') || '(sin nombre)';
+
+  const data: TareasPendientesPdfData = {
+    obraCodigo: obra.codigo as string,
+    identificador,
+    fechaTexto: fmtFechaHoy(),
+    proyecto,
+    unidad,
+    prototipo,
+    m2Construccion: obra.m2_construccion != null ? Number(obra.m2_construccion) : null,
+    contratista: {
+      nombre: contratistaNombre,
+      abreviacion: (datosRes.data?.abreviacion as string | null) ?? null,
+    },
+    contratoCodigo,
+    avancePct: Number(obra.avance_pct ?? 0),
+    valorContratoMo,
+    moEjecutado,
+    moPorEjecutar: valorContratoMo - moEjecutado,
+    etapas,
+    totalPendiente,
+    totalTareas,
+  };
+
+  return { data, contratistaEmail: (persRes.data?.email as string | null) ?? null };
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const sb = await createSupabaseServerClient();
+  const result = await buildPdfData(sb, id);
+  if (result.error || !result.data) {
+    return NextResponse.json({ error: result.error ?? 'Error' }, { status: 404 });
+  }
+  const buf = await renderToBuffer(<TareasPendientesPDF data={result.data} />);
+  const filename = `pendientes-${result.data.identificador.replace(/[^\w.-]+/g, '_')}.pdf`;
+  return new Response(new Uint8Array(buf), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      // inline: abre en el visor del navegador para imprimir o guardar.
+      'Content-Disposition': `inline; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const body = (await req.json().catch(() => ({}))) as { to?: string; subject?: string };
+
+  const sb = await createSupabaseServerClient();
+  const result = await buildPdfData(sb, id);
+  if (result.error || !result.data) {
+    return NextResponse.json({ error: result.error ?? 'Error' }, { status: 404 });
+  }
+  const data = result.data;
+
+  const to = body.to?.trim() || result.contratistaEmail;
+  if (!to) {
+    return NextResponse.json(
+      {
+        error:
+          'El contratista no tiene email registrado. Indica el destinatario en el campo de correo.',
+      },
+      { status: 400 }
+    );
+  }
+
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!resendKey) {
+    return NextResponse.json({ error: 'RESEND_API_KEY no configurada' }, { status: 500 });
+  }
+
+  // Iniciativa notificaciones-catalogo: config runtime + log post-envío.
+  const def = await getDefinitionBySlug(sb, 'dilesa_tareas_pendientes');
+
+  // Defaults hardcoded como fallback fail-open (si la def no existe aún).
+  let fromAddress = 'DILESA Obra <noreply@bsop.io>';
+  let replyTo: string | null = 'admin@dilesa.mx';
+  let toList = [to];
+  let ccList: string[] = [];
+  let bccList: string[] = [];
+
+  if (def) {
+    if (!def.activo) {
+      await writeNotificationLog(sb, {
+        definitionId: def.id,
+        status: 'skipped',
+        recipients: { to: toList },
+        subject: `dilesa_tareas_pendientes ${data.identificador} — kill switch`,
+        context: { construccionId: id },
+      });
+      return NextResponse.json({ ok: true, skipped: true, reason: 'kill_switch' });
+    }
+    fromAddress = def.from_name ? `${def.from_name} <${def.from_email}>` : def.from_email;
+    replyTo = def.reply_to;
+    const extras = splitRecipientsExtra(def.recipients_extra);
+    toList = [to, ...extras.to];
+    ccList = extras.cc;
+    bccList = extras.bcc;
+  }
+
+  const buf = await renderToBuffer(<TareasPendientesPDF data={data} />);
+  const base64 = buf.toString('base64');
+
+  const subject =
+    body.subject?.trim() ||
+    (def?.subject_template
+      ? renderSubject(def.subject_template, {
+          identificador: data.identificador,
+          contratista: data.contratista.abreviacion ?? data.contratista.nombre,
+        })
+      : `Pendientes de obra ${data.identificador}`);
+
+  const moneyFmt = new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: 'MXN',
+    maximumFractionDigits: 0,
+  });
+
+  const html = `
+<div style="font-family: -apple-system, sans-serif; color: #222; max-width: 600px;">
+  <h2 style="color: #4a5d23;">Pendientes de obra ${data.identificador}</h2>
+  <p>Hola ${data.contratista.abreviacion ?? data.contratista.nombre},</p>
+  <p>
+    Adjuntamos la relación de <strong>tareas pendientes de ejecución</strong> de la obra
+    <strong>${data.identificador}</strong>${data.proyecto ? ` (${data.proyecto})` : ''}.
+    Son <strong>${data.totalTareas} ${data.totalTareas === 1 ? 'tarea' : 'tareas'}</strong>
+    con un valor de mano de obra por ejecutar de
+    <strong style="color: #4a5d23; font-size: 18px;">${moneyFmt.format(data.moPorEjecutar)}</strong>.
+  </p>
+  <p>
+    El detalle por etapa, con el valor de mano de obra de cada tarea, está en el PDF adjunto.
+  </p>
+  <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;" />
+  <p style="color: #888; font-size: 11px;">
+    DILESA · Desarrollo Inmobiliario Los Encinos<br/>
+    dilesa.mx · (878) 791-1818
+  </p>
+</div>`.trim();
+
+  const resendBody: Record<string, unknown> = {
+    from: fromAddress,
+    to: toList,
+    subject,
+    html,
+    attachments: [
+      {
+        filename: `pendientes-${data.identificador.replace(/[^\w.-]+/g, '_')}.pdf`,
+        content: base64,
+      },
+    ],
+  };
+  if (replyTo) resendBody.reply_to = replyTo;
+  if (ccList.length) resendBody.cc = ccList;
+  if (bccList.length) resendBody.bcc = bccList;
+
+  const emailRes = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${resendKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(resendBody),
+  });
+  const resJson = (await emailRes.json()) as { id?: string; message?: string; name?: string };
+
+  if (!emailRes.ok) {
+    console.error('[construccion/pendientes POST] Resend rechazó el envío', {
+      construccionId: id,
+      to,
+      status: emailRes.status,
+      resendError: resJson,
+    });
+    await writeNotificationLog(sb, {
+      definitionId: def?.id ?? null,
+      status: 'failed',
+      recipients: { to: toList, cc: ccList, bcc: bccList },
+      subject,
+      errorMessage: `Resend ${emailRes.status}: ${JSON.stringify(resJson).slice(0, 800)}`,
+      context: { construccionId: id, identificador: data.identificador },
+    });
+    return NextResponse.json(
+      { error: resJson.message ?? 'Error al enviar email', detail: resJson },
+      { status: 500 }
+    );
+  }
+
+  await writeNotificationLog(sb, {
+    definitionId: def?.id ?? null,
+    status: 'sent',
+    recipients: { to: toList, cc: ccList, bcc: bccList },
+    subject,
+    resendId: resJson.id ?? null,
+    context: { construccionId: id, identificador: data.identificador },
+  });
+
+  return NextResponse.json({ ok: true, emailId: resJson.id, sentTo: to });
+}
+
+export const runtime = 'nodejs';

--- a/app/dilesa/construccion/[id]/page.tsx
+++ b/app/dilesa/construccion/[id]/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
- 
-
 /**
  * Detalle completo de una construcción DILESA — 4 secciones:
  *   1. Datos generales — prototipo, contratista, supervisor, fechas

--- a/app/dilesa/construccion/[id]/page.tsx
+++ b/app/dilesa/construccion/[id]/page.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-/* eslint-disable react-hooks/set-state-in-effect --
- * Mismo data-sync pattern que el resto de páginas de detalle (cf.
- * app/dilesa/ventas/[id]/page.tsx).
- */
+ 
 
 /**
  * Detalle completo de una construcción DILESA — 4 secciones:
@@ -33,8 +30,10 @@ import {
   ChevronRight,
   Circle,
   ClipboardCheck,
+  FileDown,
   HardHat,
   Lock,
+  Send,
 } from 'lucide-react';
 import { RequireAccess } from '@/components/require-access';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
@@ -192,6 +191,10 @@ function DetailInner() {
   const [programarOpen, setProgramarOpen] = useState(false);
   const [fechaProgInput, setFechaProgInput] = useState('');
   const [programando, setProgramando] = useState(false);
+  // Envío de la relación de pendientes al contratista (correo).
+  const [enviarOpen, setEnviarOpen] = useState(false);
+  const [enviarEmailInput, setEnviarEmailInput] = useState('');
+  const [enviando, setEnviando] = useState(false);
 
   const [obra, setObra] = useState<Construccion | null>(null);
   const [unidad, setUnidad] = useState<UnidadInfo | null>(null);
@@ -199,6 +202,7 @@ function DetailInner() {
   const [prototipoNombre, setPrototipoNombre] = useState<string | null>(null);
   const [contratistaNombre, setContratistaNombre] = useState<string | null>(null);
   const [contratistaAbrev, setContratistaAbrev] = useState<string | null>(null);
+  const [contratistaEmail, setContratistaEmail] = useState<string | null>(null);
   const [supervisorNombre, setSupervisorNombre] = useState<string | null>(null);
   const [etapas, setEtapas] = useState<Etapa[]>([]);
   const [tareasCat, setTareasCat] = useState<Map<string, Tarea>>(new Map());
@@ -264,7 +268,7 @@ function DetailInner() {
         sb
           .schema('erp')
           .from('personas')
-          .select('nombre, apellido_paterno, apellido_materno')
+          .select('nombre, apellido_paterno, apellido_materno, email')
           .eq('id', obraRow.contratista_id)
           .maybeSingle(),
         sb
@@ -300,6 +304,7 @@ function DetailInner() {
         : null;
       setContratistaNombre(cName);
       setContratistaAbrev((datosRes.data?.abreviacion as string | null) ?? null);
+      setContratistaEmail((contRes.data?.email as string | null) ?? null);
       if (supRes.data) {
         setSupervisorNombre(
           [supRes.data.nombre, supRes.data.apellido_paterno, supRes.data.apellido_materno]
@@ -648,6 +653,56 @@ function DetailInner() {
     setRecepcionOpen(true);
   }
 
+  /** Abre el PDF de tareas pendientes en una pestaña nueva (imprimir/guardar). */
+  function abrirPendientesPdf() {
+    window.open(`/api/dilesa/construccion/${id}/pendientes/pdf`, '_blank', 'noopener,noreferrer');
+  }
+
+  /** Envía la relación de pendientes por correo al contratista (POST). */
+  async function enviarPendientes() {
+    const to = enviarEmailInput.trim();
+    if (!to || !to.includes('@')) {
+      toast.add({ title: 'Indica un correo válido', type: 'error' });
+      return;
+    }
+    setEnviando(true);
+    try {
+      const res = await fetch(`/api/dilesa/construccion/${id}/pendientes/pdf`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to }),
+      });
+      const json = (await res.json()) as { error?: string; skipped?: boolean; sentTo?: string };
+      if (!res.ok) {
+        toast.add({
+          title: 'No se pudo enviar',
+          description: json.error ?? 'Error al enviar el correo.',
+          type: 'error',
+        });
+        return;
+      }
+      if (json.skipped) {
+        toast.add({
+          title: 'Envío desactivado',
+          description: 'El correo de pendientes está apagado en Configuración → Notificaciones.',
+          type: 'info',
+        });
+        setEnviarOpen(false);
+        return;
+      }
+      toast.add({ title: `Enviado a ${json.sentTo ?? to}`, type: 'success' });
+      setEnviarOpen(false);
+    } catch {
+      toast.add({
+        title: 'No se pudo enviar',
+        description: 'Error de red al enviar el correo. Intenta de nuevo.',
+        type: 'error',
+      });
+    } finally {
+      setEnviando(false);
+    }
+  }
+
   const etapasConTareas = useMemo(() => {
     const terminadasByPlantilla = new Map<string, Terminada>();
     for (const t of terminadas) terminadasByPlantilla.set(t.plantilla_tarea_id, t);
@@ -824,6 +879,12 @@ function DetailInner() {
       : unidad.identificador
     : obra.codigo;
 
+  // Botón de pendientes: solo en obras vivas (no terminadas/canceladas) con
+  // tareas de ejecución por hacer — es justo lo que el contratista pide.
+  const ESTADOS_OBRA_TERMINAL = ['terminada', 'dtu', 'seguro_calidad', 'extraida', 'cancelada'];
+  const puedeImprimirPendientes =
+    !ESTADOS_OBRA_TERMINAL.includes(obra.estado) && previas.pendientes > 0;
+
   // Fechas/días de progreso viven en la sección "Cronograma" (más abajo).
   // Aquí solo datos identificadores + hitos post-cierre (DTU/SC/RUV).
   const fichaGeneral: { label: string; value: string }[] = (
@@ -882,6 +943,24 @@ function DetailInner() {
           ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
+          {puedeImprimirPendientes ? (
+            <>
+              <Button size="sm" variant="outline" onClick={abrirPendientesPdf}>
+                <FileDown className="h-4 w-4" /> Pendientes
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setEnviarEmailInput(contratistaEmail ?? '');
+                  setEnviarOpen(true);
+                }}
+                title="Enviar la relación de pendientes al contratista por correo"
+              >
+                <Send className="h-4 w-4" /> Enviar
+              </Button>
+            </>
+          ) : null}
           {puedeRecibirObra ? (
             recepcionEstado === 'recibida' ? (
               <Button size="sm" variant="outline" onClick={() => setRecepcionOpen(true)}>
@@ -1089,6 +1168,50 @@ function DetailInner() {
               </button>
               <Button onClick={() => void programarRecepcion()} disabled={programando}>
                 {programando ? 'Programando…' : 'Programar recepción'}
+              </Button>
+            </div>
+          </div>
+        </DetailDrawerContent>
+      </DetailDrawer>
+
+      <DetailDrawer
+        open={enviarOpen}
+        onOpenChange={setEnviarOpen}
+        size="sm"
+        title="Enviar pendientes al contratista"
+        description={identificadorCompleto}
+      >
+        <DetailDrawerContent>
+          <div className="space-y-4">
+            <p className="text-sm text-[var(--text)]/70">
+              Se enviará por correo la relación de tareas pendientes de ejecución (con el valor de
+              mano de obra de cada una) como PDF adjunto. Revisa el destinatario antes de enviar.
+            </p>
+            <label className="block text-xs font-medium text-[var(--text)]">
+              Correo del contratista
+              <Input
+                type="email"
+                value={enviarEmailInput}
+                onChange={(e) => setEnviarEmailInput(e.target.value)}
+                placeholder="contratista@correo.com"
+                className="mt-1 rounded-xl border-[var(--border)] bg-[var(--panel)] text-[var(--text)]"
+              />
+            </label>
+            {!contratistaEmail ? (
+              <p className="text-xs text-[var(--text)]/50">
+                Este contratista no tiene correo registrado; captúralo aquí para este envío.
+              </p>
+            ) : null}
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <button
+                type="button"
+                onClick={() => setEnviarOpen(false)}
+                className="text-sm text-muted-foreground hover:text-[var(--text)]"
+              >
+                Cancelar
+              </button>
+              <Button onClick={() => void enviarPendientes()} disabled={enviando}>
+                {enviando ? 'Enviando…' : 'Enviar al contratista'}
               </Button>
             </div>
           </div>

--- a/lib/dilesa/pdf/tareas-pendientes.tsx
+++ b/lib/dilesa/pdf/tareas-pendientes.tsx
@@ -1,0 +1,291 @@
+/**
+ * Template PDF: Tareas pendientes de ejecución de una obra (DILESA).
+ *
+ * Documento que se entrega al contratista (a veces lo piden) con la
+ * relación de tareas que aún faltan por ejecutar, el valor de mano de
+ * obra de cada una, los datos de la vivienda y del contrato. Branding
+ * olivo compartido (HeaderBand / FooterBand).
+ *
+ * El valor por tarea = `porcentaje_costo × valor_contrato_mo` — misma
+ * fórmula que la pantalla de la obra (app/dilesa/construccion/[id]) y que
+ * la vista `dilesa.v_construccion_tareas_terminadas_con_mo`. Excluye los
+ * hitos de recepción: no son trabajo de ejecución del contratista (se
+ * cierran por el flujo "Recibir obra").
+ *
+ * Multipágina (`wrap`) — la lista por etapa puede crecer; por eso el PDF
+ * se genera server-side con @react-pdf/renderer (no print del navegador,
+ * que no pagina bajo el app-shell).
+ */
+import { Document, Page, Text, View } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand, Folio } from './header-footer';
+
+export type TareasPendientesPdfData = {
+  obraCodigo: string;
+  /** Identificador legible de la vivienda — ej. "M13-L4-LDS-RMC". */
+  identificador: string;
+  fechaTexto: string;
+  proyecto: string | null;
+  unidad: string | null;
+  prototipo: string | null;
+  m2Construccion: number | null;
+  contratista: { nombre: string; abreviacion: string | null };
+  /** Código(s) del contrato de obra ligado a la vivienda, si lo hay. */
+  contratoCodigo: string | null;
+  avancePct: number;
+  valorContratoMo: number;
+  moEjecutado: number;
+  /** Autoritativo de la obra: valor_contrato_mo − mo_ejecutado. */
+  moPorEjecutar: number;
+  etapas: Array<{
+    nombre: string;
+    orden: number;
+    tareas: Array<{ nombre: string; valor: number }>;
+    subtotal: number;
+  }>;
+  /** Suma de las tareas listadas (lo que el contratista tiene por hacer). */
+  totalPendiente: number;
+  totalTareas: number;
+};
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const m = (n: number) => moneyFmt.format(n);
+
+export function TareasPendientesPDF({ data }: { data: TareasPendientesPdfData }) {
+  const contratistaDisplay = data.contratista.abreviacion
+    ? `${data.contratista.abreviacion} · ${data.contratista.nombre}`
+    : data.contratista.nombre;
+
+  const ficha: Array<[string, string | null]> = [
+    ['Proyecto', data.proyecto],
+    ['Unidad', data.unidad],
+    ['Código de obra', data.obraCodigo],
+    ['Prototipo', data.prototipo],
+    ['m² construcción', data.m2Construccion != null ? `${data.m2Construccion} m²` : null],
+    ['Contratista', contratistaDisplay],
+    ['Contrato', data.contratoCodigo],
+    ['Avance de obra', `${data.avancePct.toFixed(0)}%`],
+  ];
+
+  return (
+    <Document title={`Pendientes ${data.identificador}`}>
+      <Page size="LETTER" style={styles.page} wrap>
+        <HeaderBand title="PENDIENTES DE EJECUCIÓN" fecha={data.fechaTexto} />
+        <Folio value={data.identificador} />
+
+        {/* Datos de la vivienda + contrato */}
+        <Text style={sectionTitle}>DATOS DE LA OBRA</Text>
+        <View style={fichaWrap}>
+          {ficha
+            .filter((r): r is [string, string] => r[1] != null && r[1] !== '')
+            .map(([label, value]) => (
+              <View key={label} style={fichaRow}>
+                <Text style={fichaLabel}>{label}</Text>
+                <Text style={fichaValue}>{value}</Text>
+              </View>
+            ))}
+        </View>
+
+        {/* Resumen de mano de obra */}
+        <View style={resumenWrap} wrap={false}>
+          <View style={resumenRow}>
+            <Text style={resumenLabel}>Valor contrato MO</Text>
+            <Text style={resumenMonto}>{m(data.valorContratoMo)}</Text>
+          </View>
+          <View style={resumenRow}>
+            <Text style={resumenLabel}>MO ejecutado</Text>
+            <Text style={resumenMonto}>{m(data.moEjecutado)}</Text>
+          </View>
+          <View style={[resumenRow, resumenRowTotal]}>
+            <Text style={resumenLabelTotal}>MO POR EJECUTAR</Text>
+            <Text style={resumenMontoTotal}>{m(data.moPorEjecutar)}</Text>
+          </View>
+        </View>
+
+        {/* Tareas pendientes por etapa */}
+        <Text style={sectionTitle}>
+          TAREAS PENDIENTES DE EJECUCIÓN ({data.totalTareas}
+          {data.totalTareas === 1 ? ' tarea' : ' tareas'})
+        </Text>
+
+        {data.etapas.length === 0 ? (
+          <Text style={vacioText}>
+            No hay tareas de construcción pendientes. La obra está lista para recepción.
+          </Text>
+        ) : (
+          <>
+            <View style={tablaHeader} fixed>
+              <Text style={[tablaCellNombre, tablaHeaderText]}>Tarea</Text>
+              <Text style={[tablaCellMonto, tablaHeaderText]}>Valor MO</Text>
+            </View>
+            {data.etapas.map((et) => (
+              <View key={`${et.orden}-${et.nombre}`} style={etapaWrap} wrap={false}>
+                <View style={etapaHeader}>
+                  <Text style={etapaHeaderNombre}>
+                    {et.orden}. {et.nombre}
+                  </Text>
+                  <Text style={etapaHeaderSubtotal}>{m(et.subtotal)}</Text>
+                </View>
+                {et.tareas.map((t, idx) => (
+                  <View key={idx} style={tablaRow}>
+                    <Text style={tablaCellNombre}>{t.nombre}</Text>
+                    <Text style={tablaCellMonto}>{m(t.valor)}</Text>
+                  </View>
+                ))}
+              </View>
+            ))}
+            <View style={totalWrap} wrap={false}>
+              <Text style={totalLabel}>TOTAL TAREAS PENDIENTES</Text>
+              <Text style={totalMonto}>{m(data.totalPendiente)}</Text>
+            </View>
+          </>
+        )}
+
+        <Text style={notaText}>
+          Relación de mano de obra pendiente de ejecución. Los montos corresponden al valor de mano
+          de obra de cada tarea según el contrato de obra; no incluyen material. El avance y los
+          montos se calculan al momento de generar este documento.
+        </Text>
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+// ── Estilos locales (los compartidos vienen de ./styles) ──────────────────
+const sectionTitle = {
+  fontSize: 11,
+  fontFamily: 'Helvetica-Bold' as const,
+  marginTop: 12,
+  marginBottom: 6,
+  color: colors.primary,
+  borderBottom: `1pt solid ${colors.primary}`,
+  paddingBottom: 2,
+};
+
+const fichaWrap = { marginBottom: 6 };
+const fichaRow = { flexDirection: 'row' as const, marginVertical: 1.5 };
+const fichaLabel = {
+  width: 130,
+  fontSize: 9,
+  color: colors.textMuted,
+  textTransform: 'uppercase' as const,
+};
+const fichaValue = { flex: 1, fontSize: 10, color: colors.text };
+
+const resumenWrap = {
+  marginTop: 10,
+  marginLeft: 'auto' as const,
+  width: 280,
+  padding: 8,
+  border: `0.5pt solid ${colors.border}`,
+  borderRadius: 3,
+};
+const resumenRow = {
+  flexDirection: 'row' as const,
+  justifyContent: 'space-between' as const,
+  marginVertical: 2,
+};
+const resumenRowTotal = {
+  borderTop: `0.5pt solid ${colors.primary}`,
+  paddingTop: 6,
+  marginTop: 4,
+};
+const resumenLabel = { fontSize: 9, color: colors.textMuted };
+const resumenMonto = { fontSize: 10, color: colors.text, textAlign: 'right' as const };
+const resumenLabelTotal = {
+  fontSize: 10,
+  fontFamily: 'Helvetica-Bold' as const,
+  color: colors.primary,
+};
+const resumenMontoTotal = {
+  fontSize: 12,
+  fontFamily: 'Helvetica-Bold' as const,
+  color: colors.primary,
+  textAlign: 'right' as const,
+};
+
+const tablaHeader = {
+  flexDirection: 'row' as const,
+  borderBottom: `0.5pt solid ${colors.border}`,
+  paddingVertical: 2,
+};
+const tablaHeaderText = {
+  fontSize: 8,
+  color: colors.textMuted,
+  textTransform: 'uppercase' as const,
+};
+const tablaRow = {
+  flexDirection: 'row' as const,
+  paddingVertical: 1.5,
+  borderBottom: `0.25pt solid ${colors.borderSoft}`,
+};
+const tablaCellNombre = { flex: 1, fontSize: 9, color: colors.text, paddingRight: 8 };
+const tablaCellMonto = {
+  width: 90,
+  fontSize: 9,
+  color: colors.text,
+  textAlign: 'right' as const,
+};
+
+const etapaWrap = { marginBottom: 8 };
+const etapaHeader = {
+  flexDirection: 'row' as const,
+  backgroundColor: colors.bgSoft,
+  paddingVertical: 3,
+  paddingHorizontal: 4,
+  alignItems: 'center' as const,
+  marginTop: 4,
+};
+const etapaHeaderNombre = {
+  flex: 1,
+  fontSize: 9.5,
+  fontFamily: 'Helvetica-Bold' as const,
+  color: colors.text,
+};
+const etapaHeaderSubtotal = {
+  width: 90,
+  fontSize: 9,
+  fontFamily: 'Helvetica-Bold' as const,
+  textAlign: 'right' as const,
+  color: colors.text,
+};
+
+const totalWrap = {
+  flexDirection: 'row' as const,
+  justifyContent: 'flex-end' as const,
+  alignItems: 'center' as const,
+  marginTop: 8,
+  paddingTop: 6,
+  borderTop: `1pt solid ${colors.primary}`,
+};
+const totalLabel = {
+  fontSize: 10,
+  fontFamily: 'Helvetica-Bold' as const,
+  color: colors.primary,
+  marginRight: 12,
+};
+const totalMonto = {
+  width: 90,
+  fontSize: 12,
+  fontFamily: 'Helvetica-Bold' as const,
+  color: colors.primary,
+  textAlign: 'right' as const,
+};
+
+const vacioText = {
+  fontSize: 10,
+  color: colors.textMuted,
+  marginTop: 4,
+};
+const notaText = {
+  fontSize: 7.5,
+  color: colors.textMuted,
+  marginTop: 16,
+  lineHeight: 1.35,
+};

--- a/supabase/migrations/20260625000107_dilesa_notif_tareas_pendientes.sql
+++ b/supabase/migrations/20260625000107_dilesa_notif_tareas_pendientes.sql
@@ -1,0 +1,44 @@
+-- ╭─ 20260625000107_dilesa_notif_tareas_pendientes ─╮
+-- Definición de notificación para el correo de "Tareas pendientes de
+-- ejecución" que se le envía al contratista desde el detalle de la obra
+-- (app/dilesa/construccion/[id] → botón "Pendientes"). Slug
+-- `dilesa_tareas_pendientes`, global — from/reply-to/subject/destinatarios
+-- extra editables runtime en /settings/notificaciones + kill switch.
+--
+-- El handler (app/api/dilesa/construccion/[id]/pendientes/pdf POST) es
+-- FAIL-OPEN: si esta fila no existe usa defaults hardcoded, así que el
+-- envío funciona aunque la migración aún no se aplique a prod. Esta fila
+-- solo lo hace gobernable (config sin deploy + traza en notification_log).
+--
+-- Pure DML (INSERT) — no toca schema, robusto a Preview branches:
+-- idempotente vía WHERE NOT EXISTS (el UNIQUE (slug, empresa_id) no
+-- protege duplicados cuando empresa_id es NULL) y sin FK a datos de prod.
+
+BEGIN;
+
+INSERT INTO core.notification_definitions
+  (slug, empresa_id, nombre, descripcion, trigger_type, trigger_config,
+   from_email, from_name, reply_to, recipients_extra, subject_template, activo)
+SELECT
+  'dilesa_tareas_pendientes',
+  NULL,
+  'Tareas pendientes al contratista (DILESA)',
+  'Email al contratista con la relación de tareas pendientes de ejecución '
+  'de una obra (valor de mano de obra por tarea + datos de la vivienda y el '
+  'contrato), como adjunto PDF. Se dispara manualmente desde el detalle de '
+  'la obra cuando el contratista lo pide. Excluye los hitos de recepción.',
+  'manual',
+  '{"ui_location": "/dilesa/construccion/[id] (detalle de obra)", "button_label": "Pendientes → Enviar al contratista"}'::jsonb,
+  'noreply@bsop.io',
+  'DILESA Obra',
+  'admin@dilesa.mx',
+  '[]'::jsonb,
+  'Pendientes de obra {identificador} · {contratista}',
+  true
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM core.notification_definitions
+  WHERE slug = 'dilesa_tareas_pendientes' AND empresa_id IS NULL
+);
+
+COMMIT;


### PR DESCRIPTION
## Qué hace

En el detalle de una **obra en progreso** aparece un botón **Pendientes** que abre un PDF imprimible con:

- **Datos de la vivienda y el contrato**: proyecto, unidad, código de obra, prototipo, m², contratista, contrato ligado, avance.
- **Resumen de mano de obra**: valor contrato MO · MO ejecutado · **MO por ejecutar**.
- **Tareas pendientes de ejecución agrupadas por etapa**, con el **valor de MO de cada tarea** y subtotal por etapa. Total = MO por ejecutar.

Es justo lo que los contratistas a veces piden. Un segundo botón **Enviar** lo manda por correo al contratista con el PDF adjunto (confirmando el destinatario antes de enviar).

## Decisiones

- **Valor por tarea = `porcentaje_costo × valor_contrato_mo`** — la misma fórmula que ya muestra la pantalla de la obra ([page.tsx](app/dilesa/construccion/%5Bid%5D/page.tsx)), así el PDF cuadra con lo que ves. (No usa la vista de estimaciones que divide entre 100 — ese es otro flujo de pago.)
- **Excluye los hitos de recepción**: no son trabajo de ejecución del contratista (se cierran por "Recibir obra").
- **Botón visible solo en obras vivas** (no terminadas/DTU/canceladas) **con pendientes**.
- **Template react-pdf** con branding olivo (reusa `HeaderBand`/`FooterBand` de `lib/dilesa/pdf`), multipágina — patrón correcto para listas largas (no `window.print`).
- **Envío fail-open**: usa el catálogo de notificaciones (slug `dilesa_tareas_pendientes`) + traza en `notification_log`; si la migración no está aplicada, cae a defaults hardcoded y funciona igual.

## Migración

`20260625000107_dilesa_notif_tareas_pendientes.sql` — solo inserta la definición del correo en `core.notification_definitions` (config runtime + kill switch en Configuración → Notificaciones). **DML idempotente**, no toca schema. El feature funciona aunque no se aplique; aplicarla solo la hace gobernable sin deploy.

## Cómo probar (Vercel Preview)

1. Abre una obra **en progreso** en `/dilesa/construccion` → entra al detalle.
2. Click en **Pendientes** → se abre el PDF (imprimir/guardar).
3. Click en **Enviar** → confirma el correo del contratista → envía.

## Checks

Los 6 de CI en verde local: typecheck · lint · format · test:coverage · initiatives:check · schema:check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)