### PR TITLE
feat(rdb-inventario): agrega onza fluida (oz) al catálogo de unidades

### DIFF
--- a/lib/unidades.test.ts
+++ b/lib/unidades.test.ts
@@ -62,6 +62,15 @@ describe('factorUniversal', () => {
     expect(factorUniversal(' Gramo ', 'KILO')).toBe(0.001);
   });
 
+  it('convierte onza fluida ↔ mililitro', () => {
+    expect(factorUniversal('onza', 'mililitro')).toBeCloseTo(29.5735, 4);
+    expect(factorUniversal('mililitro', 'onza')).toBeCloseTo(1 / 29.5735, 10);
+  });
+
+  it('null entre onza (volumen) y gramo (masa)', () => {
+    expect(factorUniversal('onza', 'gramo')).toBeNull();
+  });
+
   it('null entre dimensiones distintas (masa vs volumen)', () => {
     expect(factorUniversal('gramo', 'litro')).toBeNull();
   });
@@ -96,6 +105,14 @@ describe('factorRecetaAStock', () => {
   it('presentación: agua 2 L (2000 ml), receta en ml → 1/2000', () => {
     const agua = { unidad: 'pieza', unidadBase: 'mililitro', contenido: 2000 };
     expect(factorRecetaAStock('mililitro', agua)).toBeCloseTo(0.0005, 10);
+  });
+
+  it('receta en onza contra botella con contenido en ml (1 oz = 29.5735 ml)', () => {
+    const tequila = { unidad: 'pieza', unidadBase: 'mililitro', contenido: 980 };
+    const f = factorRecetaAStock('onza', tequila);
+    expect(f).toBeCloseTo(29.5735 / 980, 10);
+    // un trago de 1.5 oz descuenta ~0.045 botella
+    expect(1.5 * (f as number)).toBeCloseTo(0.045265, 5);
   });
 
   it('receta en unidad distinta a unidad_base pero misma dimensión (litro vs ml base)', () => {

--- a/lib/unidades.ts
+++ b/lib/unidades.ts
@@ -19,6 +19,7 @@ export const UNIDADES: UnidadOption[] = [
   { value: 'gramo', label: 'Gramo (g)' },
   { value: 'litro', label: 'Litro (L)' },
   { value: 'mililitro', label: 'Mililitro (ml)' },
+  { value: 'onza', label: 'Onza fluida (oz)' },
   { value: 'caja', label: 'Caja' },
   { value: 'paquete', label: 'Paquete' },
   { value: 'bolsa', label: 'Bolsa' },
@@ -56,6 +57,7 @@ type DimUnidad = 'V' | 'M'; // Volumen | Masa
 const PESO_POR_UNIDAD: Record<string, { dim: DimUnidad; peso: number }> = {
   mililitro: { dim: 'V', peso: 1 },
   litro: { dim: 'V', peso: 1000 },
+  onza: { dim: 'V', peso: 29.5735 }, // onza fluida US
   galon: { dim: 'V', peso: 3785.412 },
   gramo: { dim: 'M', peso: 1 },
   kilo: { dim: 'M', peso: 1000 },

--- a/supabase/migrations/20260625172555_agregar_onza_a_fn_factor_universal.sql
+++ b/supabase/migrations/20260625172555_agregar_onza_a_fn_factor_universal.sql
@@ -1,0 +1,32 @@
+-- ╭─ 20260625172555_agregar_onza_a_fn_factor_universal ─╮
+-- Agrega la onza fluida (US, 29.5735 ml) al conversor universal de unidades, para
+-- que las recetas medidas en onzas (medida típica de licor en el bar) descuenten
+-- la fracción correcta de la presentación.
+--
+-- Espejo en TS: lib/unidades.ts (PESO_POR_UNIDAD). Mantener ambos en sync.
+-- Reescrito desde la versión viva en prod (pg_get_functiondef, 2026-06-25),
+-- único cambio: la fila ('onza', 'V', 29.5735).
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION erp.fn_factor_universal(p_de text, p_a text)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $fn$
+  WITH u(nombre, dim, peso) AS (
+    VALUES
+      ('mililitro', 'V', 1::numeric),
+      ('litro',     'V', 1000),
+      ('onza',      'V', 29.5735),
+      ('galon',     'V', 3785.412),
+      ('gramo',     'M', 1),
+      ('kilo',      'M', 1000)
+  )
+  SELECT CASE WHEN d.dim = a.dim THEN d.peso / a.peso END
+  FROM u d, u a
+  WHERE d.nombre = lower(btrim(p_de))
+    AND a.nombre = lower(btrim(p_a));
+$fn$;
+
+COMMIT;


### PR DESCRIPTION
A pedido de Beto. Agrega **Onza fluida (oz)** = 29.5735 ml (US) como unidad de medida.

- `lib/unidades.ts`: opción en el dropdown (`UNIDADES`) + factor en el conversor (`PESO_POR_UNIDAD`), como volumen.
- `erp.fn_factor_universal`: misma fila en SQL (migración reescrita desde la versión viva) — para que las recetas en onza **descuenten** la fracción correcta de la botella, no solo aparezcan en el menú.
- 3 unit tests (oz↔ml, oz vs gramo = null, receta en oz contra botella).

Aplicada a prod + ledger reconciliado. Es onza **fluida** (líquidos); si se necesita onza de peso o un jigger de 30 ml exactos, es un ajuste de una línea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)