### PR TITLE
fix(dilesa-cuadratura): mini-resumen muestra el saldo del precio post-enganche

### DIFF
--- a/components/dilesa/cuadratura-panel.tsx
+++ b/components/dilesa/cuadratura-panel.tsx
@@ -50,9 +50,9 @@ export function CuadraturaPanel({
   const cob = c.coberturaGastos;
   // Saldo del precio que el enganche pagado aún no cubre. Si el cliente no lo
   // completa antes de escriturar, lo absorbe el bono de DILESA (entra al descuento).
-  const saldoPrecioPorCubrir = cob
-    ? Math.round(((c.saldoPrecioEscrituracion ?? 0) - cob.engancheAlPrecio) * 100) / 100
-    : 0;
+  // Fuente única en el motor (`cuadratura.ts`) — no recalcular aquí (lo mismo que
+  // muestra el mini-resumen de la cabecera).
+  const saldoPrecioPorCubrir = c.saldoPrecioPorCubrir ?? 0;
   return (
     <div className="space-y-5">
       {c.posibleDobleConteo ? (

--- a/components/dilesa/operacion-resumen.tsx
+++ b/components/dilesa/operacion-resumen.tsx
@@ -119,20 +119,24 @@ export function OperacionResumen({
           <Cifra label="Depósitos directos" value={money(cuadratura.depositosDirectoCliente)} />
           {cuadratura.tieneDesglose ? (
             // Modelo desglosado (ADR-045): dos coberturas separadas — el precio lo
-            // cubre el crédito; los gastos notariales los cubre el presupuesto
-            // (subsidio + DILESA + enganche + sobreprecio + pagaré). Ambos leen de
-            // la misma `cuadratura`; el pagaré real va en su columna de arriba. NO
-            // se muestra el saldoCliente crudo (mezclaba precio + descuento → −74,651).
+            // cubre el crédito (+ enganche); los gastos notariales los cubre el
+            // presupuesto (subsidio + DILESA + enganche + sobreprecio + pagaré).
+            // Ambos leen de la misma `cuadratura`; el pagaré real va en su columna
+            // de arriba. "Precio" = `saldoPrecioPorCubrir` (saldo del precio −
+            // enganche pagado), el MISMO "Saldo por cubrir" del panel — no el
+            // `saldoPrecioEscrituracion` crudo (ignoraba el enganche → en Infonavit
+            // mostraba 158,551 cuando el panel ya mostraba 1) ni el `saldoCliente`
+            // crudo (mezclaba precio + descuento → −74,651).
             <div className="ml-auto flex items-stretch gap-x-6">
               <Cifra
                 label="Precio"
                 value={
-                  (cuadratura.saldoPrecioEscrituracion ?? 0) <= 0
-                    ? 'Cubierto ✓'
-                    : money(cuadratura.saldoPrecioEscrituracion)
+                  (cuadratura.saldoPrecioPorCubrir ?? 0) > 0.5
+                    ? money(cuadratura.saldoPrecioPorCubrir)
+                    : 'Cubierto ✓'
                 }
                 strong
-                tone={(cuadratura.saldoPrecioEscrituracion ?? 0) <= 0 ? 'ok' : 'warn'}
+                tone={(cuadratura.saldoPrecioPorCubrir ?? 0) > 0.5 ? 'warn' : 'ok'}
               />
               <Cifra
                 label="Gastos notariales"

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -429,6 +429,7 @@ describe('calcularCuadratura', () => {
       // Saldo del precio (lo que header/panel muestran, NO el saldoCliente): el
       // crédito cubre el precio al 100%. El saldo de gastos = pagaré (9,387).
       expect(c.saldoPrecioEscrituracion).toBe(0);
+      expect(c.saldoPrecioPorCubrir).toBe(0); // crédito cubre el precio → nada por cubrir
     });
 
     it('desglosa el presupuesto notarial completo y cuadra en 0 — MAYRA', () => {
@@ -517,6 +518,7 @@ describe('calcularCuadratura', () => {
       expect(cob.pagareNecesario).toBe(0);
       expect(cob.saldoCobertura).toBe(0); // cuadra
       expect(c.saldoPrecioEscrituracion).toBe(157735); // crédito no cubre; lo cubre el enganche
+      expect(c.saldoPrecioPorCubrir).toBe(792); // 157,735 − 156,943 enganche (lo que ve el cliente)
       // Descuento real = 13,361.42 < 15,000 → todo bono (promoción), sin sobreprecio.
       // El "$17,953 de sobreprecio fantasma" del reporte original venía solo de los
       // gastos inflados (62,161); con los gastos correctos del Anexo B (42,569.42) se va.
@@ -524,6 +526,31 @@ describe('calcularCuadratura', () => {
       const split = partirDescuento(c.descuentoReal, cob.promocion);
       expect(split.promocion).toBe(13361.42);
       expect(split.sobreprecio).toBe(0);
+    });
+
+    // Regresión (caso Ruben M3-L17-LDLE, reportado 2026-06-25): la cabecera mostraba
+    // `saldoPrecioEscrituracion` crudo (158,551) mientras el panel ya restaba el
+    // enganche y mostraba 1. `saldoPrecioPorCubrir` unifica ambos: crédito 761,449 +
+    // enganche 158,550 cubren el precio salvo 1 peso de redondeo (lo absorbe el bono).
+    // (Los gastos no afectan este derivado: depende solo de precio − crédito − enganche.)
+    it('Ruben (M3-L17): saldoPrecioPorCubrir resta el enganche pagado del saldo del precio', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 920000,
+        montoCreditoTitular: 761449,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: 0,
+        montoChequeNotaria: null,
+        gastosEscrituracion: 42569.42,
+        apoyoInfonavit: 30000,
+        precioBase: 920000,
+        sobreprecioGastos: 0,
+        promocionGastos: 14209,
+        depositos: [{ monto: 158550, directoCliente: true, tieneRecibo: false }],
+        proyectoNombre: 'Lomas de los Encinos',
+      });
+      expect(c.saldoPrecioEscrituracion).toBe(158551); // crudo (lo que mostraba la cabecera)
+      expect(c.coberturaGastos?.engancheAlPrecio).toBe(158550); // enganche aplicado al precio
+      expect(c.saldoPrecioPorCubrir).toBe(1); // ← lo que el panel ya mostraba ("Saldo por cubrir")
     });
 
     // Infonavit con enganche MAYOR que el saldo del precio: el excedente sí fondea
@@ -697,6 +724,7 @@ describe('calcularCuadratura', () => {
       const c = mayra({ promocionGastos: null, precioBase: null, incrementoCredito: null });
       expect(c.formacionPrecio).toBe(null);
       expect(c.saldoPrecioEscrituracion).toBe(null); // legacy usa saldoCliente, no este
+      expect(c.saldoPrecioPorCubrir).toBe(null); // sin desglose, no aplica
       // Con la fórmula vieja: depósitos 35,000 − cheque calc + CD.
       expect(c.valorRealVentaDilesa).not.toBe(954419);
     });

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -290,6 +290,17 @@ export type Cuadratura = {
    */
   saldoPrecioEscrituracion: number | null;
   /**
+   * Saldo del precio que el enganche pagado del cliente AÚN no cubre:
+   * `saldoPrecioEscrituracion` − `coberturaGastos.engancheAlPrecio`. Es el "Saldo
+   * por cubrir" que ve el cliente (≈ 0 cuando crédito + enganche alcanzan el
+   * precio; un residual de centavos lo absorbe el bono de DILESA al escriturar).
+   * Fuente ÚNICA del panel y del mini-resumen — antes el panel lo calculaba inline
+   * y el mini-resumen mostraba `saldoPrecioEscrituracion` crudo (sin restar el
+   * enganche), divergiendo en Infonavit (crédito < precio: cabecera 158,551 vs
+   * panel 1). `null` en legacy/cerradas.
+   */
+  saldoPrecioPorCubrir: number | null;
+  /**
    * Desglose de facturación (ADR-045), solo con desglose. Factura de venta
    * (escrituración) + factura de enganche = total facturado; − NC = neto (=
    * escritura). `null` en legacy/cerradas.
@@ -523,6 +534,15 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   const saldoPrecioEscrituracion = tieneDesglose
     ? round2(valorEscrituracion - creditoInstitucion)
     : null;
+  // Saldo del precio que el enganche pagado aún no cubre (= "Saldo por cubrir"
+  // del panel y la cifra "Precio" del mini-resumen): el crédito cubre el precio
+  // primero, el enganche aplica al resto, y lo que quede es el pendiente real del
+  // cliente. Fuente ÚNICA — antes el panel lo calculaba inline y el mini-resumen
+  // mostraba el saldo crudo (sin restar el enganche), por eso divergían en
+  // Infonavit (crédito < precio). `engancheAlPrecio` ya está topado al saldo.
+  const saldoPrecioPorCubrir = tieneDesglose
+    ? round2((saldoPrecioEscrituracion ?? 0) - engancheAlPrecio)
+    : null;
 
   // Cobertura model-aware de TODA la operación — fuente ÚNICA para el copiloto de
   // cierre y otros gates. NO el `saldoCliente`/`cubierta` legacy, que en ventas
@@ -651,6 +671,7 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     coberturaGastos,
     formacionPrecio,
     saldoPrecioEscrituracion,
+    saldoPrecioPorCubrir,
     desgloseFacturacion,
     posibleDobleConteo,
   };


### PR DESCRIPTION
## Problema

En el Expediente de Operación de una venta DILESA, el **mini-resumen** de la cabecera y la pestaña **Cuadratura** mostraban dos números distintos para el saldo del precio. Reportado por Beto en el cliente **Ruben (M3-L17-LDLE)**, Infonavit Tradicional:

- **Cabecera → "Precio": $158,551** (en naranja)
- **Cuadratura → "Saldo por cubrir": $1.00**

## Causa

Ambas vistas leen del mismo motor (`lib/dilesa/cuadratura.ts`), pero:

- La **Cuadratura** restaba el enganche ya pagado: `saldo del precio ($158,551) − enganche ($158,550) = $1`.
- El **mini-resumen** mostraba `saldoPrecioEscrituracion` **crudo** (`valor escritura − crédito`), **sin restar el enganche**.

El cálculo "saldo por cubrir = saldo del precio − enganche al precio" vivía **inline solo en el panel**, así que la cabecera tomó el valor crudo. Rompía el principio de fuente única del motor.

**Alcance:** afecta a toda venta donde el crédito institución < precio y el enganche cubre la diferencia → típico **Infonavit Tradicional**. En FOVISSSTE/IMSS el crédito cubre el precio completo y ambos ya mostraban "Cubierto ✓".

## Fix

Se mueve el cálculo al motor como `saldoPrecioPorCubrir` (= `saldoPrecioEscrituracion − engancheAlPrecio`), **fuente única** que consumen el panel y el mini-resumen. La cabecera ahora muestra **$1.00** / "Cubierto ✓", consistente con la Cuadratura.

Es cambio **de presentación**: no toca dinero, comisiones, CxC ni datos.

## Tests

- Aserciones de `saldoPrecioPorCubrir` en los casos existentes: MAYRA (0, FOVISSSTE) y Juan Antonio (792, Infonavit).
- Regresión dedicada al caso **Ruben** ($1 de redondeo).
- Suite completa verde (2048 tests) + typecheck + lint + format + schema:check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)