### PR TITLE
fix(dilesa-ventas): corregir avalúo con la Fase 5 ya cerrada

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
@@ -52,6 +52,7 @@ type VentaCtx = {
   persona_id: string;
   unidad_id: string | null;
   monto_avaluo: number | null;
+  fecha_avaluo_cerrado: string | null;
   valuador_id: string | null;
   tipo_credito: string | null;
 };
@@ -132,7 +133,9 @@ function CapturarFase5Body() {
       const { data: vRow, error: vErr } = await sb
         .schema('dilesa')
         .from('ventas')
-        .select('id, persona_id, unidad_id, monto_avaluo, valuador_id, tipo_credito')
+        .select(
+          'id, persona_id, unidad_id, monto_avaluo, fecha_avaluo_cerrado, valuador_id, tipo_credito'
+        )
         .eq('id', ventaId)
         .is('deleted_at', null)
         .maybeSingle();
@@ -150,6 +153,8 @@ function CapturarFase5Body() {
       const v = vRow as unknown as VentaCtx;
       setVenta(v);
       if (v.monto_avaluo != null) setMontoAvaluo(String(v.monto_avaluo));
+      // En corrección (fase ya cerrada) mostramos la fecha real del cierre, no hoy.
+      if (v.fecha_avaluo_cerrado) setFechaAvaluo(v.fecha_avaluo_cerrado.slice(0, 10));
 
       const [fRes, valRes] = await Promise.all([
         sb
@@ -195,20 +200,52 @@ function CapturarFase5Body() {
     async (e: React.FormEvent) => {
       e.preventDefault();
       if (!venta) return;
-      if (docsFase.faltantes.length > 0) {
-        const faltan = docsFase.faltantes.map((rol) => docsFase.labelDe(rol)).join(', ');
-        toast.add({
-          title: docsFase.faltantes.length === 1 ? 'Falta un documento' : 'Faltan documentos',
-          description: `Sube en el expediente: ${faltan}. Quedan guardados al subirlos.`,
-          type: 'error',
-        });
-        return;
-      }
+
       const monto = Number(montoAvaluo);
       if (!Number.isFinite(monto) || monto <= 0) {
         toast.add({
           title: 'Monto del avalúo inválido',
           description: 'Captura el monto dictaminado por el valuador (mayor a cero).',
+          type: 'error',
+        });
+        return;
+      }
+
+      // ── Modo corrección: la fase ya está cerrada. Solo se ajusta el dato
+      //    financiero (monto/fecha) vía RPC auditada; el PDF corregido ya se
+      //    versionó al subirse. NO se re-marca la fase — el pipeline no cambia.
+      if (yaCerrada) {
+        setSubmitting(true);
+        const { error: rpcErr } = await sb.schema('dilesa').rpc('fn_corregir_avaluo_venta', {
+          p_venta_id: venta.id,
+          p_monto_avaluo: monto,
+          p_fecha_avaluo_cerrado: fechaAvaluo,
+          p_motivo: 'Corrección de avalúo (Fase 5 ya cerrada)',
+        });
+        setSubmitting(false);
+        if (rpcErr) {
+          toast.add({
+            title: 'No se pudo corregir el avalúo',
+            description: getSupabaseErrorMessage(rpcErr, 'Error desconocido.'),
+            type: 'error',
+          });
+          return;
+        }
+        toast.add({
+          title: 'Avalúo corregido',
+          description: 'Monto y fecha actualizados. El pipeline no se modificó.',
+          type: 'success',
+        });
+        router.push(`/dilesa/ventas/${venta.id}`);
+        return;
+      }
+
+      // ── Modo cierre (primera vez): valida el expediente + marcarFase.
+      if (docsFase.faltantes.length > 0) {
+        const faltan = docsFase.faltantes.map((rol) => docsFase.labelDe(rol)).join(', ');
+        toast.add({
+          title: docsFase.faltantes.length === 1 ? 'Falta un documento' : 'Faltan documentos',
+          description: `Sube en el expediente: ${faltan}. Quedan guardados al subirlos.`,
           type: 'error',
         });
         return;
@@ -246,7 +283,7 @@ function CapturarFase5Body() {
       });
       router.push(`/dilesa/ventas/${venta.id}`);
     },
-    [docsFase, fechaAvaluo, montoAvaluo, router, sb, toast, venta]
+    [docsFase, fechaAvaluo, montoAvaluo, router, sb, toast, venta, yaCerrada]
   );
 
   // ── Render ───────────────────────────────────────────────────────
@@ -278,13 +315,7 @@ function CapturarFase5Body() {
         descripcion="Registra el monto dictaminado por la casa valuadora y sube el PDF del avalúo."
       />
 
-      {yaCerrada ? (
-        <Banner
-          tone="success"
-          title="Fase 5 ya está cerrada"
-          body="Esta venta ya pasó por Avalúo Cerrado. La siguiente fase es Dictaminación."
-        />
-      ) : !fase4Cerrada ? (
+      {!yaCerrada && !fase4Cerrada ? (
         <Banner
           tone="warning"
           title="Falta cerrar Fase 4 (Avalúo Solicitado)"
@@ -305,6 +336,14 @@ function CapturarFase5Body() {
         />
       ) : (
         <form onSubmit={onSubmit} className="space-y-6">
+          {yaCerrada ? (
+            <Banner
+              tone="info"
+              title="Fase 5 cerrada — modo corrección"
+              body="Si el avalúo cambió, sube el archivo corregido (se guarda al instante y conserva el anterior) y/o ajusta el monto y la fecha. Esto solo corrige el expediente: no mueve el pipeline ni regresa la venta."
+            />
+          ) : null}
+
           {valuadorNombre ? (
             <div className="rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-4 py-2 text-xs text-[var(--text)]/70">
               <span className="font-medium text-[var(--text)]/80">Casa valuadora:</span>{' '}
@@ -352,7 +391,8 @@ function CapturarFase5Body() {
                 </>
               ) : (
                 <>
-                  <Save className="mr-2 size-4" /> Guardar fase
+                  <Save className="mr-2 size-4" />{' '}
+                  {yaCerrada ? 'Guardar corrección' : 'Guardar fase'}
                 </>
               )}
             </Button>
@@ -395,7 +435,7 @@ function Banner({
   body,
   extra,
 }: {
-  tone: 'success' | 'warning';
+  tone: 'success' | 'warning' | 'info';
   title: string;
   body: React.ReactNode;
   extra?: React.ReactNode;
@@ -403,7 +443,9 @@ function Banner({
   const styles =
     tone === 'success'
       ? 'border-emerald-400/40 bg-emerald-50 text-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-100'
-      : 'border-amber-400/40 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-100';
+      : tone === 'info'
+        ? 'border-sky-400/40 bg-sky-50 text-sky-900 dark:bg-sky-950/30 dark:text-sky-100'
+        : 'border-amber-400/40 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-100';
   return (
     <div className={`rounded-lg border p-4 ${styles}`}>
       <p className="text-sm font-medium">{title}</p>

--- a/supabase/migrations/20260625201752_dilesa_fn_corregir_avaluo_venta.sql
+++ b/supabase/migrations/20260625201752_dilesa_fn_corregir_avaluo_venta.sql
@@ -1,0 +1,102 @@
+-- ╭─ 20260625201752_dilesa_fn_corregir_avaluo_venta ─╮
+-- Permite corregir el avalúo (monto + fecha) de una venta DILESA cuya Fase 5
+-- ya está cerrada, SIN tocar el pipeline (no inserta `venta_fases`, no regresa
+-- la venta). Caso real: el valuador emite un avalúo corregido después de que la
+-- fase cerró; hasta hoy la única vía era "Regresar a fase…" (destructiva).
+--
+-- `monto_avaluo` es un dato financiero. Igual que el descuento (decisión Beto
+-- 2026-06-15, mig 20260616020428), `dilesa.ventas` no pasa por ningún auditor,
+-- así que el cambio va por una RPC SECURITY DEFINER que registra anterior/nuevo
+-- en core.audit_log (autor vía email del JWT) en vez de un UPDATE plano sin
+-- rastro. Gate: admin global O rol en la empresa de la venta (admin nunca
+-- bloqueado — política Beto 2026-06-10). El PDF corregido NO pasa por aquí: se
+-- versiona por su cuenta en `erp.adjuntos` (subida colaborativa con uploaded_by).
+--
+-- Aditiva: 1 función nueva. No cambia datos.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION dilesa.fn_corregir_avaluo_venta(
+  p_venta_id uuid,
+  p_monto_avaluo numeric,
+  p_fecha_avaluo_cerrado date DEFAULT NULL,
+  p_motivo text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, dilesa, core, public
+AS $$
+DECLARE
+  v_empresa_id uuid;
+  v_usuario_id uuid;
+  v_old jsonb;
+  v_new jsonb;
+BEGIN
+  SELECT empresa_id INTO v_empresa_id
+  FROM dilesa.ventas
+  WHERE id = p_venta_id AND deleted_at IS NULL
+  FOR UPDATE;
+
+  IF v_empresa_id IS NULL THEN
+    RAISE EXCEPTION 'Venta % no encontrada o borrada', p_venta_id USING ERRCODE = '22023';
+  END IF;
+
+  -- Gate de empresa (admin nunca bloqueado — política Beto 2026-06-10).
+  IF NOT core.fn_is_admin() AND NOT core.fn_has_empresa(v_empresa_id) THEN
+    RAISE EXCEPTION 'Sin permiso para la empresa de la venta' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_monto_avaluo IS NULL OR p_monto_avaluo <= 0 THEN
+    RAISE EXCEPTION 'El monto del avalúo debe ser mayor a cero' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'monto_avaluo', monto_avaluo,
+    'fecha_avaluo_cerrado', fecha_avaluo_cerrado
+  ) INTO v_old
+  FROM dilesa.ventas
+  WHERE id = p_venta_id;
+
+  UPDATE dilesa.ventas SET
+    monto_avaluo = p_monto_avaluo,
+    fecha_avaluo_cerrado = coalesce(p_fecha_avaluo_cerrado, fecha_avaluo_cerrado),
+    updated_at = now()
+  WHERE id = p_venta_id;
+
+  SELECT jsonb_build_object(
+    'monto_avaluo', monto_avaluo,
+    'fecha_avaluo_cerrado', fecha_avaluo_cerrado
+  ) INTO v_new
+  FROM dilesa.ventas
+  WHERE id = p_venta_id;
+
+  -- Auditoría: solo si cambió algo (patrón fn_venta_auditar_descuentos).
+  IF v_old IS DISTINCT FROM v_new THEN
+    SELECT id INTO v_usuario_id
+    FROM core.usuarios
+    WHERE email = lower(coalesce(auth.jwt() ->> 'email', ''))
+      AND activo = true
+    LIMIT 1;
+
+    INSERT INTO core.audit_log (
+      empresa_id, usuario_id, accion, tabla, registro_id,
+      datos_anteriores, datos_nuevos, created_at
+    ) VALUES (
+      v_empresa_id, v_usuario_id, 'venta_avaluo_corregido', 'dilesa.ventas', p_venta_id,
+      v_old, v_new || jsonb_build_object('motivo', p_motivo), now()
+    );
+  END IF;
+
+  RETURN v_new;
+END;
+$$;
+
+COMMENT ON FUNCTION dilesa.fn_corregir_avaluo_venta(uuid, numeric, date, text) IS
+  'Corrige el avalúo (monto + fecha) de una venta con Fase 5 ya cerrada, sin tocar el pipeline; audita anterior/nuevo en core.audit_log. Gate: admin O rol en la empresa.';
+
+GRANT EXECUTE ON FUNCTION dilesa.fn_corregir_avaluo_venta(uuid, numeric, date, text) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -6392,6 +6392,15 @@ export type Database = {
         Args: { p_pago_id: string }
         Returns: undefined
       }
+      fn_corregir_avaluo_venta: {
+        Args: {
+          p_fecha_avaluo_cerrado?: string
+          p_monto_avaluo: number
+          p_motivo?: string
+          p_venta_id: string
+        }
+        Returns: Json
+      }
       fn_es_vendedor_restringido: { Args: never; Returns: boolean }
       fn_estimaciones_backfill_incremental: {
         Args: never


### PR DESCRIPTION
## Problema

La pantalla de captura de **Fase 5 — Cerrar avalúo** escondía el formulario **completo** cuando la venta ya había pasado la fase 5, mostrando solo el banner "Fase 5 ya está cerrada". No había manera de subir un avalúo corregido ni de ajustar el monto. La única acción disponible era **"Regresar a fase…"**, que es destructiva (borra el pipeline desde la fase destino, libera la unidad y manda correos al cliente).

Caso real: una venta en fase 12/17 (Detonada) cuyo valuador emitió un avalúo corregido.

## Solución

Cuando la fase ya está cerrada, la pantalla entra en **modo corrección** (no destructivo, no toca el pipeline):

- **Re-subir el PDF del avalúo** → se versiona en el expediente (`erp.adjuntos`, subida colaborativa con `uploaded_by`), conservando el anterior. Audit trail intacto.
- **Ajustar monto/fecha** → botón "Guardar corrección" → RPC `dilesa.fn_corregir_avaluo_venta`. **No** re-marca la fase (no duplica `venta_fases`), **no** regresa la venta, **no** manda correos.

`monto_avaluo` es un dato financiero. Igual que el descuento (decisión Beto 2026-06-15, mig `20260616020428`), `dilesa.ventas` no pasa por ningún auditor, así que el cambio va por una **RPC `SECURITY DEFINER`** que registra anterior→nuevo en `core.audit_log` (gate admin/empresa, admin nunca bloqueado) en vez de un UPDATE plano sin rastro.

## Migración

`20260625201752_dilesa_fn_corregir_avaluo_venta.sql` — **ya aplicada a prod** (`psql` + `migration repair --status applied`, ledger en sync). Función nueva y aditiva, cero cambios a datos existentes.

## Impacto de cambiar `monto_avaluo`
Sin triggers ni cascadas. Solo lo leen la revisión PLD de Fase 13 (donde es deseable que refleje el valor correcto; se congela por versión de adjunto) y vistas de resumen. No alimenta cuadratura ni cálculos de crédito automáticos.

## Test plan
- [x] 6 checks de CI locales en verde (typecheck, test:coverage, lint, format:check, initiatives:check, schema:check)
- [ ] Fase 5 ya cerrada → modo corrección visible; re-subir PDF versiona; "Guardar corrección" actualiza monto+fecha sin mover el pipeline
- [ ] Fase 5 sin cerrar → flujo de cierre normal intacto (marcarFase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)