### PR TITLE
fix(cxp): no duplicar las facturas en espera en la tabla principal

### DIFF
--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -695,6 +695,11 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
 
   const filtered = useMemo(() => {
     return facturas.filter((f) => {
+      // Las facturas en espera del destajo (borrador + estimacion_id) viven en
+      // su panel dedicado de arriba; no las dupliques en la tabla principal —
+      // salvo que se filtre explícito por "Borrador". Reaparecen como filas
+      // normales en cuanto reciben su XML (→ por pagar).
+      if (f.estado_cxp === 'borrador' && f.estimacion_id && estado !== 'borrador') return false;
       if (estado && f.estado_cxp !== estado) return false;
       if (!search) return true;
       const q = search.toLowerCase();


### PR DESCRIPTION
Las facturas **en espera del destajo** (borrador + `estimacion_id`) ya se muestran en el panel ámbar "Facturas en espera del XML". Aparecían **también** como filas en la tabla principal de abajo → se veían como duplicadas (mismo monto, Sin UUID, Borrador).

Este cambio las **oculta de la tabla principal** por default. Reaparecen si filtras explícito por estado "Borrador", y como fila normal en cuanto reciben su XML (→ por pagar). Cero cambio de datos — es solo el filtro de la vista.

UI visible → sin auto-merge, revisa el Vercel Preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)