### PR TITLE
feat(dilesa-estimaciones-cxp): S4 — carga única de XML con auto-match a destajos

### DIFF
--- a/app/api/[empresa]/cxp/facturas/upload-xml/route.test.ts
+++ b/app/api/[empresa]/cxp/facturas/upload-xml/route.test.ts
@@ -23,6 +23,15 @@ type Script = {
   personaByRfc?: Record<string, { id: string }>;
   rpcResult?: { data: string | null; error: { message: string } | null };
   auditInsertError?: { message: string } | null;
+  /** Facturas en espera (placeholders de destajo) para el auto-match (S4). */
+  placeholders?: {
+    id: string;
+    proveedor_id: string | null;
+    total: number;
+    estimacion_id: string;
+  }[];
+  /** dilesa.estimaciones para resolver el código del destajo. */
+  estimaciones?: { id: string; codigo: string }[];
 };
 
 type Calls = {
@@ -41,10 +50,25 @@ function buildAdminMock(): any {
         from(tableName: string) {
           const key = `${schemaName}.${tableName}`;
           const filters: Record<string, unknown> = {};
+          let usedNot = false; // marca la query de placeholders (fetchDestajoPlaceholders)
           const builder: any = {
             select: () => builder,
             eq(col: string, val: unknown) {
               filters[col] = val;
+              return builder;
+            },
+            // fetchDestajoPlaceholders (S4): cadena .not().is() awaiteada directo.
+            // El mock devuelve vacío (sin placeholders) → carga normal, como antes.
+            not(col: string, _op: string, val: unknown) {
+              filters[col] = val;
+              usedNot = true;
+              return builder;
+            },
+            is(col: string, val: unknown) {
+              filters[col] = val;
+              return builder;
+            },
+            in() {
               return builder;
             },
             insert(rows: unknown) {
@@ -80,12 +104,16 @@ function buildAdminMock(): any {
                 };
               return { data: null, error: null };
             },
-            // Update chain awaiteado directo (facturas.update().eq()).
+            // Awaiteado directo: update().eq() (data null), la query de
+            // placeholders (erp.facturas + .not) y el lookup de estimaciones.
             then(
-              onFulfilled: (r: { data: null; error: null }) => unknown,
+              onFulfilled: (r: { data: unknown; error: null }) => unknown,
               onRejected?: (reason: unknown) => unknown
             ) {
-              return Promise.resolve({ data: null, error: null }).then(onFulfilled, onRejected);
+              let data: unknown = null;
+              if (key === 'erp.facturas' && usedNot) data = script.placeholders ?? [];
+              else if (key === 'dilesa.estimaciones') data = script.estimaciones ?? [];
+              return Promise.resolve({ data, error: null }).then(onFulfilled, onRejected);
             },
           };
           return builder;
@@ -286,5 +314,66 @@ describe('POST /api/[empresa]/cxp/facturas/upload-xml', () => {
     } finally {
       errSpy.mockRestore();
     }
+  });
+
+  // ── Auto-match destajo → CxP (S4) ──────────────────────────────────────
+
+  function makeReqRaw(fields: {
+    analyze?: boolean;
+    decisiones?: Record<string, string>;
+  }): NextRequest {
+    const fd = new FormData();
+    if (fields.analyze) fd.append('analyze', '1');
+    if (fields.decisiones) fd.append('decisiones', JSON.stringify(fields.decisiones));
+    fd.append('file', new File([XML_OK], 'a.xml', { type: 'application/xml' }));
+    return new NextRequest(new URL('http://localhost/api/dilesa/cxp/facturas/upload-xml'), {
+      method: 'POST',
+      body: fd,
+      headers: { 'user-agent': 'vitest-agent' },
+    });
+  }
+
+  it('analyze → sugiere asociar al destajo en espera del contratista (neto ≥ CFDI)', async () => {
+    script.placeholders = [
+      { id: 'ph-1', proveedor_id: 'prov-1', total: 1200, estimacion_id: 'est-1' },
+    ];
+    script.estimaciones = [{ id: 'est-1', codigo: 'EST-2026-W26-AAA-001' }];
+    const res = await POST(makeReqRaw({ analyze: true }), params);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    const a = body.analisis[0];
+    expect(a.ok).toBe(true);
+    expect(a.candidatos).toHaveLength(1);
+    // CFDI total 1160, neto 1200 → Δ materiales 40.
+    expect(a.candidatos[0]).toMatchObject({ facturaId: 'ph-1', neto: 1200, delta: 40 });
+    expect(a.sugerencia).toBe('ph-1');
+    expect(calls.rpc).toHaveLength(0); // analyze no escribe
+  });
+
+  it('analyze → si el CFDI excede el neto, no es candidato (sugiere normal)', async () => {
+    // neto 1000 < CFDI 1160 → fuera (la factura nunca debe ser mayor).
+    script.placeholders = [
+      { id: 'ph-1', proveedor_id: 'prov-1', total: 1000, estimacion_id: 'est-1' },
+    ];
+    script.estimaciones = [{ id: 'est-1', codigo: 'EST-2026-W26-AAA-001' }];
+    const res = await POST(makeReqRaw({ analyze: true }), params);
+    const body = await res.json();
+    expect(body.analisis[0].candidatos).toHaveLength(0);
+    expect(body.analisis[0].sugerencia).toBe('normal');
+  });
+
+  it('commit con decisiones → asocia el CFDI al destajo (recibir_cfdi, no alta)', async () => {
+    script.placeholders = [
+      { id: 'ph-1', proveedor_id: 'prov-1', total: 1200, estimacion_id: 'est-1' },
+    ];
+    script.estimaciones = [{ id: 'est-1', codigo: 'EST-2026-W26-AAA-001' }];
+    const res = await POST(makeReqRaw({ decisiones: { 'a.xml': 'ph-1' } }), params);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, exitosos: 1 });
+    expect(calls.rpc).toHaveLength(1);
+    expect(calls.rpc[0].fn).toBe('cxp_factura_recibir_cfdi');
+    expect(calls.rpc[0].args.p_factura_id).toBe('ph-1');
   });
 });

--- a/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
+++ b/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
@@ -14,6 +14,17 @@
  *      `auth.uid()` es NULL).
  *   6. Sube el XML a storage (`adjuntos`) + registra `erp.adjuntos` + `xml_url`.
  *
+ * Auto-match destajo → CxP (S4, iniciativa dilesa-estimaciones-cxp): si el
+ * emisor tiene una factura EN ESPERA (placeholder borrador con estimacion_id),
+ * el CFDI se ASOCIA a ella (la promueve a por_pagar) en vez de duplicar.
+ *   - `analyze=1` → devuelve por archivo la sugerencia (destajo o normal) +
+ *     candidatos, SIN escribir. El uploader lo usa para el review.
+ *   - `decisiones` (JSON filename→facturaId|'normal') → el commit asocia o crea
+ *     según lo que confirmó el operador. Sin decisiones → todo se crea normal.
+ *   - `factura_id` → recepción directa sobre una factura en espera (bandeja).
+ *   Regla: la factura del contratista nunca debe ser MAYOR que el neto del
+ *   destajo (puede ser menor por materiales descontados, solo informativo).
+ *
  * Devuelve un resultado por archivo (éxito o error) para no abortar el lote
  * completo por un XML malo. Status: 200 todo cargado, 207 lote parcial,
  * 422 ningún archivo pasó (el body es idéntico en los tres casos).
@@ -55,6 +66,108 @@ type AuditLogInsert = Database['core']['Tables']['audit_log']['Insert'];
 type CxpFacturaAltaArgs = Database['erp']['Functions']['cxp_factura_alta']['Args'] & {
   p_usuario_id?: string;
 };
+
+// ── Auto-match destajo → CxP (S4) ──────────────────────────────────────────
+// Una factura EN ESPERA (placeholder borrador con estimacion_id) por contratista.
+
+type DestajoPlaceholder = {
+  facturaId: string;
+  proveedorId: string | null;
+  neto: number;
+  estimacionId: string;
+  codigo: string | null;
+};
+
+type DestajoCandidato = {
+  facturaId: string;
+  codigo: string | null;
+  neto: number;
+  /** materiales descontados = neto − CFDI (≥ 0, solo informativo). */
+  delta: number;
+};
+
+type AnalisisArchivo = {
+  filename: string;
+  /** parseó + receptor correcto + no duplicada. */
+  ok: boolean;
+  error?: string;
+  proveedorNombre: string | null;
+  emisorRfc?: string;
+  proveedorId?: string | null;
+  total?: number;
+  uuid?: string | null;
+  /** ya existe una factura con ese folio fiscal. */
+  yaCargada?: boolean;
+  candidatos: DestajoCandidato[];
+  /** facturaId del destajo sugerido, o 'normal'. */
+  sugerencia: string;
+};
+
+const NETO_EPS = 1.005; // tolerancia de redondeo para "CFDI ≤ neto".
+
+/** Destajos abiertos cuyo neto ≥ total del CFDI (puede ser menor por materiales), tightest primero. */
+function candidatosParaCfdi(
+  placeholders: DestajoPlaceholder[],
+  proveedorId: string | null,
+  total: number
+): DestajoCandidato[] {
+  if (!proveedorId) return [];
+  return placeholders
+    .filter((p) => p.proveedorId === proveedorId && total <= p.neto * NETO_EPS)
+    .map((p) => ({
+      facturaId: p.facturaId,
+      codigo: p.codigo,
+      neto: p.neto,
+      delta: Math.max(0, p.neto - total),
+    }))
+    .sort((a, b) => a.neto - b.neto);
+}
+
+/** Sugerencia: el destajo de mejor encaje (tightest) si el CFDI no es muy menor; si no, factura normal. */
+function sugerirAccion(candidatos: DestajoCandidato[], total: number): string {
+  const tightest = candidatos[0];
+  if (tightest && total >= tightest.neto * 0.8) return tightest.facturaId;
+  return 'normal';
+}
+
+/** Carga las facturas en espera (placeholders de destajo) de la empresa, con código y neto. */
+async function fetchDestajoPlaceholders(
+  admin: ReturnType<typeof getSupabaseAdminClient>,
+  empresaId: string
+): Promise<DestajoPlaceholder[]> {
+  if (!admin) return [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: facs } = await (admin.schema('erp') as any)
+    .from('facturas')
+    .select('id, proveedor_id, total, estimacion_id')
+    .eq('empresa_id', empresaId)
+    .eq('estado_cxp', 'borrador')
+    .not('estimacion_id', 'is', null)
+    .is('cancelada_at', null);
+  const rows = (facs ?? []) as {
+    id: string;
+    proveedor_id: string | null;
+    total: number | null;
+    estimacion_id: string;
+  }[];
+  const estIds = [...new Set(rows.map((r) => r.estimacion_id))];
+  const codigoPorEst = new Map<string, string>();
+  if (estIds.length > 0) {
+    const { data: ests } = await admin
+      .schema('dilesa')
+      .from('estimaciones')
+      .select('id, codigo')
+      .in('id', estIds);
+    for (const e of ests ?? []) codigoPorEst.set(e.id as string, (e.codigo as string | null) ?? '');
+  }
+  return rows.map((r) => ({
+    facturaId: r.id,
+    proveedorId: r.proveedor_id,
+    neto: Number(r.total ?? 0),
+    estimacionId: r.estimacion_id,
+    codigo: codigoPorEst.get(r.estimacion_id) ?? null,
+  }));
+}
 
 export async function POST(req: NextRequest, { params }: Params) {
   const { empresa: empresaSlug } = await params;
@@ -173,6 +286,19 @@ export async function POST(req: NextRequest, { params }: Params) {
       );
     }
 
+    // Regla del destajo: la factura nunca debe ser MAYOR que el neto (puede ser
+    // menor por materiales descontados). Si excede, es probable error de captura.
+    const netoEsperado = Number(fac.total ?? 0);
+    if (netoEsperado > 0 && cfdi.total > netoEsperado * NETO_EPS) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `La factura ($${cfdi.total.toLocaleString('es-MX')}) excede el neto del destajo ($${netoEsperado.toLocaleString('es-MX')}). La factura del contratista nunca debería ser mayor que el destajo — revisa el XML.`,
+        },
+        { status: 422 }
+      );
+    }
+
     // RPC aún no en types — mismo patrón de cast que el resto de CxP.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { error: rpcErr } = await (admin.schema('erp') as any).rpc('cxp_factura_recibir_cfdi', {
@@ -224,12 +350,13 @@ export async function POST(req: NextRequest, { params }: Params) {
       await admin.schema('erp').from('facturas').update({ xml_url: path }).eq('id', facturaId);
     }
 
-    // Warning (no bloqueante): el total del CFDI difiere del neto autorizado.
+    // Informativo (no bloqueante): el CFDI vino por menos que el neto = materiales
+    // descontados al contratista.
     const esperado = Number(fac.total ?? 0);
-    const dif = Math.abs(cfdi.total - esperado);
+    const deltaMateriales = esperado - cfdi.total;
     const warning =
-      esperado > 0 && dif > Math.max(1, esperado * 0.005)
-        ? `El total del CFDI (${cfdi.total.toLocaleString('es-MX')}) difiere del neto autorizado (${esperado.toLocaleString('es-MX')}). Se tomó el monto del CFDI; revísalo si no esperabas la diferencia.`
+      esperado > 0 && deltaMateriales > Math.max(1, esperado * 0.005)
+        ? `Δ materiales $${deltaMateriales.toLocaleString('es-MX')} (neto del destajo $${esperado.toLocaleString('es-MX')}, facturado $${cfdi.total.toLocaleString('es-MX')}).`
         : null;
 
     await admin
@@ -246,6 +373,77 @@ export async function POST(req: NextRequest, { params }: Params) {
       });
 
     return NextResponse.json({ ok: true, facturaId, uuid: cfdi.uuid, warning }, { status: 200 });
+  }
+
+  // Facturas en espera (placeholders de destajo) para el auto-match (S4).
+  const placeholders = await fetchDestajoPlaceholders(admin, emp.id);
+
+  // ── Modo ANALYZE: por cada XML devuelve la sugerencia (destajo o normal),
+  // sin escribir nada. El uploader lo llama antes del commit para el review.
+  if (form.get('analyze') === '1') {
+    const analisis: AnalisisArchivo[] = [];
+    for (const file of files) {
+      const a: AnalisisArchivo = {
+        filename: file.name,
+        ok: false,
+        proveedorNombre: null,
+        candidatos: [],
+        sugerencia: 'normal',
+      };
+      try {
+        const cfdi = parseCfdiXml(await file.text());
+        a.emisorRfc = cfdi.emisorRfc;
+        a.total = cfdi.total;
+        a.uuid = cfdi.uuid;
+        a.proveedorNombre = cfdi.emisorNombre;
+        if (empresaRfc && cfdi.receptorRfc !== empresaRfc) {
+          a.error = `El CFDI es para el RFC ${cfdi.receptorRfc}, no para ${empresaSlug}.`;
+          analisis.push(a);
+          continue;
+        }
+        if (cfdi.uuid) {
+          const { data: dup } = await admin
+            .schema('erp')
+            .from('facturas')
+            .select('id')
+            .eq('uuid_sat', cfdi.uuid)
+            .maybeSingle();
+          if (dup) {
+            a.yaCargada = true;
+            a.error = `Ya cargada (folio ${cfdi.uuid.slice(0, 8)}…).`;
+            analisis.push(a);
+            continue;
+          }
+        }
+        const { data: prov } = await admin
+          .schema('erp')
+          .from('personas')
+          .select('id')
+          .eq('rfc', cfdi.emisorRfc)
+          .maybeSingle();
+        a.proveedorId = prov?.id ?? null;
+        a.candidatos = candidatosParaCfdi(placeholders, a.proveedorId, cfdi.total);
+        a.sugerencia = sugerirAccion(a.candidatos, cfdi.total);
+        a.ok = true;
+      } catch (e) {
+        a.error =
+          e instanceof CfdiParseError ? e.message : `Error inesperado: ${(e as Error).message}`;
+      }
+      analisis.push(a);
+    }
+    return NextResponse.json({ ok: true, analisis }, { status: 200 });
+  }
+
+  // Decisiones del operador (commit del review): filename → destajo a asociar o 'normal'.
+  // Sin decisiones → todo se crea como factura normal (compat con la carga directa).
+  let decisiones: Record<string, string> = {};
+  const decisionesRaw = form.get('decisiones');
+  if (typeof decisionesRaw === 'string' && decisionesRaw) {
+    try {
+      decisiones = JSON.parse(decisionesRaw) as Record<string, string>;
+    } catch {
+      decisiones = {};
+    }
   }
 
   const results: FacturaResult[] = [];
@@ -321,6 +519,85 @@ export async function POST(req: NextRequest, { params }: Params) {
           results.push(r);
           continue;
         }
+      }
+
+      // ── Decisión del operador: asociar este CFDI a un destajo en espera ──
+      // (en vez de crear factura nueva → evita el duplicado del placeholder).
+      const decision = decisiones[file.name];
+      if (decision && decision !== 'normal') {
+        const targetId = decision;
+        const cand = placeholders.find((p) => p.facturaId === targetId);
+        if (cand && cfdi.total > cand.neto * NETO_EPS) {
+          r.error = `La factura ($${cfdi.total.toLocaleString('es-MX')}) excede el neto del destajo ($${cand.neto.toLocaleString('es-MX')}) — nunca debería ser mayor.`;
+          addRechazo({
+            filename: file.name,
+            motivo: r.error,
+            uuidSat: cfdi.uuid,
+            emisorRfc: cfdi.emisorRfc,
+          });
+          results.push(r);
+          continue;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { error: recErr } = await (admin.schema('erp') as any).rpc(
+          'cxp_factura_recibir_cfdi',
+          {
+            p_factura_id: targetId,
+            p_uuid_sat: cfdi.uuid ?? undefined,
+            p_total: cfdi.total,
+            p_subtotal: cfdi.subtotal,
+            p_iva: cfdi.ivaTrasladado,
+            p_fecha_emision: cfdi.fecha || undefined,
+            p_emisor_rfc: cfdi.emisorRfc,
+            p_emisor_nombre: cfdi.emisorNombre ?? undefined,
+            p_receptor_rfc: cfdi.receptorRfc,
+            p_forma_pago_sat: cfdi.formaPago ?? undefined,
+            p_metodo_pago_sat:
+              cfdi.metodoPago === 'PUE' || cfdi.metodoPago === 'PPD' ? cfdi.metodoPago : undefined,
+            p_uso_cfdi: cfdi.usoCfdi ?? undefined,
+            p_tasa_iva: cfdi.tasaIva ?? undefined,
+            p_retencion_iva: cfdi.retencionIva,
+            p_retencion_isr: cfdi.retencionIsr,
+          }
+        );
+        if (recErr) {
+          r.error = (recErr as { message: string }).message;
+          addRechazo({
+            filename: file.name,
+            motivo: r.error,
+            uuidSat: cfdi.uuid,
+            emisorRfc: cfdi.emisorRfc,
+          });
+          results.push(r);
+          continue;
+        }
+        const pathA = buildAdjuntoPath({
+          empresa: empresaSlug as EmpresaSlug,
+          entidad: 'facturas',
+          entidadId: targetId,
+          filename: file.name,
+        });
+        const bytesA = new Uint8Array(await file.arrayBuffer());
+        const { error: upErrA } = await admin.storage
+          .from('adjuntos')
+          .upload(pathA, bytesA, { contentType: 'application/xml', upsert: false });
+        if (!upErrA) {
+          await admin.schema('erp').from('adjuntos').insert({
+            empresa_id: emp.id,
+            entidad_tipo: 'cxp_factura',
+            entidad_id: targetId,
+            rol: 'xml_cfdi',
+            nombre: file.name,
+            url: pathA,
+            tipo_mime: 'application/xml',
+          });
+          await admin.schema('erp').from('facturas').update({ xml_url: pathA }).eq('id', targetId);
+        }
+        r.ok = true;
+        r.facturaId = targetId;
+        r.uuid = cfdi.uuid;
+        results.push(r);
+        continue;
       }
 
       // Emisor → proveedor (persona por RFC).

--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -1645,6 +1645,18 @@ function MoneyRow({
 
 // ── Dialog: cargar XML (1..N) ──────────────────────────────────────────────────
 
+type AnalisisArchivo = {
+  filename: string;
+  ok: boolean;
+  error?: string;
+  proveedorNombre: string | null;
+  total?: number;
+  uuid?: string | null;
+  yaCargada?: boolean;
+  candidatos: { facturaId: string; codigo: string | null; neto: number; delta: number }[];
+  sugerencia: string;
+};
+
 function UploadXmlDialog({
   empresa,
   open,
@@ -1657,31 +1669,72 @@ function UploadXmlDialog({
   onDone: (exitosos: number) => void;
 }) {
   const [files, setFiles] = useState<File[]>([]);
-  const [submitting, setSubmitting] = useState(false);
+  const [phase, setPhase] = useState<'select' | 'review' | 'results'>('select');
+  const [analisis, setAnalisis] = useState<AnalisisArchivo[]>([]);
+  // filename → facturaId del destajo a asociar, o 'normal'.
+  const [decisiones, setDecisiones] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [topError, setTopError] = useState<string | null>(null);
   const [results, setResults] = useState<
     { filename: string; ok: boolean; error?: string }[] | null
   >(null);
 
-  // Reset al cerrar.
   useEffect(() => {
     if (!open) {
       setFiles([]);
+      setPhase('select');
+      setAnalisis([]);
+      setDecisiones({});
+      setBusy(false);
+      setTopError(null);
       setResults(null);
-      setSubmitting(false);
     }
   }, [open]);
 
-  const handleSubmit = async () => {
-    if (files.length === 0) return;
-    setSubmitting(true);
-    setResults(null);
+  const url = `/api/${empresa}/cxp/facturas/upload-xml`;
+
+  // Paso 1: analizar (sugiere destajo o factura normal por archivo, sin escribir).
+  const handleAnalyze = async (chosen: File[]) => {
+    if (chosen.length === 0) return;
+    setBusy(true);
+    setTopError(null);
     try {
       const fd = new FormData();
-      for (const f of files) fd.append('file', f);
-      const res = await fetch(`/api/${empresa}/cxp/facturas/upload-xml`, {
-        method: 'POST',
-        body: fd,
-      });
+      fd.append('analyze', '1');
+      for (const f of chosen) fd.append('file', f);
+      const res = await fetch(url, { method: 'POST', body: fd });
+      const json = (await res.json()) as {
+        ok: boolean;
+        analisis?: AnalisisArchivo[];
+        error?: string;
+      };
+      if (!res.ok || !json.analisis) {
+        setTopError(json.error ?? 'No se pudo analizar.');
+        return;
+      }
+      setAnalisis(json.analisis);
+      const init: Record<string, string> = {};
+      for (const a of json.analisis) if (a.ok) init[a.filename] = a.sugerencia;
+      setDecisiones(init);
+      setPhase('review');
+    } catch (e) {
+      setTopError((e as Error).message ?? 'Error de red.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Paso 2: confirmar → carga (asocia o crea según las decisiones).
+  const handleCommit = async () => {
+    const okFiles = files.filter((f) => analisis.find((a) => a.filename === f.name)?.ok);
+    if (okFiles.length === 0) return;
+    setBusy(true);
+    setTopError(null);
+    try {
+      const fd = new FormData();
+      for (const f of okFiles) fd.append('file', f);
+      fd.append('decisiones', JSON.stringify(decisiones));
+      const res = await fetch(url, { method: 'POST', body: fd });
       const json = (await res.json()) as {
         ok: boolean;
         exitosos?: number;
@@ -1690,21 +1743,29 @@ function UploadXmlDialog({
       };
       if (!res.ok && !json.results) {
         setResults([{ filename: '(lote)', ok: false, error: json.error ?? 'Error en la carga.' }]);
+        setPhase('results');
         return;
       }
       setResults(json.results ?? []);
+      setPhase('results');
       onDone(json.exitosos ?? 0);
     } catch (e) {
       setResults([
         { filename: '(lote)', ok: false, error: (e as Error).message ?? 'Error de red.' },
       ]);
+      setPhase('results');
     } finally {
-      setSubmitting(false);
+      setBusy(false);
     }
   };
 
-  const exitosos = results?.filter((r) => r.ok).length ?? 0;
   const empresaLabel = empresa.toUpperCase();
+  const procesables = analisis.filter((a) => a.ok);
+  const aDestajo = procesables.filter(
+    (a) => (decisiones[a.filename] ?? 'normal') !== 'normal'
+  ).length;
+  const omitidas = analisis.length - procesables.length;
+  const exitosos = results?.filter((r) => r.ok).length ?? 0;
 
   return (
     <Dialog
@@ -1713,78 +1774,134 @@ function UploadXmlDialog({
         if (!v) onOpenChange(false);
       }}
     >
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Cargar facturas (XML CFDI)</DialogTitle>
           <DialogDescription>
-            Selecciona uno o varios XML de facturas de egreso. Se valida que el receptor sea{' '}
-            {empresaLabel}, se evita duplicar por folio fiscal y se enlaza el proveedor por RFC.
+            Sube uno o varios XML. Se valida que el receptor sea {empresaLabel}, se evita duplicar
+            por folio fiscal, y si el CFDI es de un <strong>destajo en espera</strong> se asocia
+            automáticamente (en vez de duplicar).
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-3">
-          <label className="flex cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed bg-muted/30 px-4 py-6 text-sm text-muted-foreground hover:bg-muted/50">
-            <Upload className="h-4 w-4" />
-            {files.length > 0
-              ? `${files.length} archivo${files.length !== 1 ? 's' : ''} seleccionado${files.length !== 1 ? 's' : ''}`
-              : 'Elegir archivos XML…'}
-            <input
-              type="file"
-              accept=".xml,application/xml,text/xml"
-              multiple
-              className="hidden"
-              onChange={(e) => {
-                setFiles(Array.from(e.target.files ?? []));
-                setResults(null);
-              }}
-            />
-          </label>
+        {topError && <p className="text-sm text-destructive">{topError}</p>}
 
-          {files.length > 0 && !results && (
-            <ul className="max-h-32 space-y-0.5 overflow-y-auto text-xs text-muted-foreground">
-              {files.map((f) => (
-                <li key={f.name} className="truncate font-mono">
-                  {f.name}
+        {/* Paso 1: selección */}
+        {phase === 'select' && (
+          <div className="space-y-3">
+            <label className="flex cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed bg-muted/30 px-4 py-6 text-sm text-muted-foreground hover:bg-muted/50">
+              <Upload className="h-4 w-4" />
+              {busy ? 'Analizando…' : 'Elegir archivos XML…'}
+              <input
+                type="file"
+                accept=".xml,application/xml,text/xml"
+                multiple
+                disabled={busy}
+                className="hidden"
+                onChange={(e) => {
+                  const chosen = Array.from(e.target.files ?? []);
+                  setFiles(chosen);
+                  void handleAnalyze(chosen);
+                }}
+              />
+            </label>
+          </div>
+        )}
+
+        {/* Paso 2: revisar + confirmar */}
+        {phase === 'review' && (
+          <div className="space-y-3">
+            <p className="text-xs text-muted-foreground">
+              {procesables.length} factura{procesables.length !== 1 ? 's' : ''} ·{' '}
+              <span className="text-amber-600">{aDestajo} a destajo</span> ·{' '}
+              {procesables.length - aDestajo} normal
+              {procesables.length - aDestajo !== 1 ? 'es' : ''}
+              {omitidas > 0 ? ` · ${omitidas} omitida${omitidas !== 1 ? 's' : ''}` : ''}
+            </p>
+            <ul className="max-h-80 space-y-1.5 overflow-y-auto">
+              {analisis.map((a) => (
+                <li key={a.filename} className="rounded-md border px-3 py-2 text-sm">
+                  {!a.ok ? (
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate font-mono text-xs text-muted-foreground">
+                        {a.filename}
+                      </span>
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {a.yaCargada ? 'Ya cargada' : (a.error ?? 'omitida')}
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="space-y-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="min-w-0 truncate font-medium">
+                          {a.proveedorNombre ?? a.filename}
+                        </span>
+                        <span className="shrink-0 tabular-nums">
+                          {formatCurrency(a.total ?? 0)}
+                        </span>
+                      </div>
+                      <select
+                        value={decisiones[a.filename] ?? 'normal'}
+                        onChange={(e) =>
+                          setDecisiones((d) => ({ ...d, [a.filename]: e.target.value }))
+                        }
+                        className="h-8 w-full rounded-md border bg-background px-2 text-xs"
+                      >
+                        <option value="normal">Factura normal (sin destajo)</option>
+                        {a.candidatos.map((c) => (
+                          <option key={c.facturaId} value={c.facturaId}>
+                            Destajo {c.codigo ?? '—'} · neto {formatCurrency(c.neto)}
+                            {c.delta > 0 ? ` · Δ materiales ${formatCurrency(c.delta)}` : ''}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
                 </li>
               ))}
             </ul>
-          )}
+          </div>
+        )}
 
-          {results && (
-            <div className="space-y-1.5">
-              <p className="text-sm font-medium">
-                {exitosos} de {results.length} cargada{results.length !== 1 ? 's' : ''}.
-              </p>
-              <ul className="max-h-40 space-y-1 overflow-y-auto text-xs">
-                {results.map((r, i) => (
-                  <li
-                    key={`${r.filename}-${i}`}
-                    className={r.ok ? 'text-emerald-600' : 'text-destructive'}
-                  >
-                    <span className="font-mono">{r.filename}</span>
-                    {r.ok ? ' · OK' : ` · ${r.error ?? 'error'}`}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
+        {/* Paso 3: resultados */}
+        {phase === 'results' && results && (
+          <div className="space-y-1.5">
+            <p className="text-sm font-medium">
+              {exitosos} de {results.length} procesada{results.length !== 1 ? 's' : ''}.
+            </p>
+            <ul className="max-h-60 space-y-1 overflow-y-auto text-xs">
+              {results.map((r, i) => (
+                <li
+                  key={`${r.filename}-${i}`}
+                  className={r.ok ? 'text-emerald-600' : 'text-destructive'}
+                >
+                  <span className="font-mono">{r.filename}</span>
+                  {r.ok ? ' · OK' : ` · ${r.error ?? 'error'}`}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         <DialogFooter>
-          {results ? (
+          {phase === 'results' ? (
             <Button onClick={() => onOpenChange(false)}>Cerrar</Button>
-          ) : (
+          ) : phase === 'review' ? (
             <>
-              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
-                Cancelar
+              <Button variant="outline" onClick={() => setPhase('select')} disabled={busy}>
+                Atrás
               </Button>
               <Button
-                onClick={() => void handleSubmit()}
-                disabled={files.length === 0 || submitting}
+                onClick={() => void handleCommit()}
+                disabled={busy || procesables.length === 0}
               >
-                {submitting ? 'Cargando…' : `Cargar ${files.length || ''}`.trim()}
+                {busy ? 'Cargando…' : `Cargar ${procesables.length || ''}`.trim()}
               </Button>
             </>
+          ) : (
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+              Cancelar
+            </Button>
           )}
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
Resuelve lo que viste: el "Cargar XML" general y el "Subir XML" de cada pendiente no se hablaban. Ahora **una sola puerta de carga, masiva, que detecta y confirma**.

## Flujo
1. **Cargar XML** (1..N archivos) → el sistema **analiza** cada uno.
2. **Revisar**: por archivo, un select pre-seleccionado a la sugerencia:
   - **Factura normal** (proveedores sin destajo, anticipos, obras puntuales), o
   - **Destajo EST-XXX · neto $Y · Δ materiales $Z** (si el contratista tiene un destajo en espera cuyo neto ≥ el CFDI).
3. **Confirmar** → asocia (promueve la factura en espera a *por pagar*) o crea normal. Sin duplicados.

## Regla del destajo (tu definición)
La factura del contratista **nunca debe ser mayor que el neto** (puede ser menor por materiales que se le descuentan). Si excede → se rechaza. El **Δ materiales** es informativo. Cuando hay varios destajos abiertos del mismo contratista, te muestro los candidatos y **tú eliges** (sugiero el de mejor encaje).

## Detalle
- Sin migración (todo route + UI; el Δ se deriva del neto del destajo).
- `cxp_factura_recibir_cfdi` (S2) hace la asociación; `cxp_factura_alta` la creación normal.
- La bandeja "Subir XML" por fila sigue como camino explícito de 1.
- +3 tests del auto-match. CI: typecheck/test:coverage(2076)/lint/format verdes.

UI visible → sin auto-merge, revisa el Vercel Preview (sube unos XML de la semana y mira el review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)