### PR TITLE
fix(dilesa-ventas): unifica slug de rutas API ([ventaId]→[id]) que rompía next dev

### DIFF
--- a/app/api/dilesa/ventas/[id]/cerrar-fase13/route.test.ts
+++ b/app/api/dilesa/ventas/[id]/cerrar-fase13/route.test.ts
@@ -99,7 +99,7 @@ function post(body?: Record<string, unknown>) {
       body: JSON.stringify(body ?? {}),
       headers: { 'Content-Type': 'application/json' },
     }),
-    { params: Promise.resolve({ ventaId: VENTA_ID }) }
+    { params: Promise.resolve({ id: VENTA_ID }) }
   );
 }
 
@@ -137,7 +137,7 @@ beforeEach(() => {
 
 // ── Tests ──────────────────────────────────────────────────────────────
 
-describe('POST /api/dilesa/ventas/[ventaId]/cerrar-fase13', () => {
+describe('POST /api/dilesa/ventas/[id]/cerrar-fase13', () => {
   it('cierra con revisión vigente en verde: inserta la fase y audita fase13_cerrada', async () => {
     const res = await post({ valorRealSnapshot: 897378 });
     expect(res.status).toBe(200);

--- a/app/api/dilesa/ventas/[id]/cerrar-fase13/route.ts
+++ b/app/api/dilesa/ventas/[id]/cerrar-fase13/route.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * POST /api/dilesa/ventas/[ventaId]/cerrar-fase13 — cierre de la Fase 13
+ * POST /api/dilesa/ventas/[id]/cerrar-fase13 — cierre de la Fase 13
  * con gate de revisión (iniciativa `dilesa-ventas-captura-colaborativa`,
  * Sprint 3). El cierre dejó de ser client-side: el gate se valida AQUÍ.
  *
@@ -39,7 +39,7 @@ import { leerCfdiMetadata } from '@/lib/dilesa/captura/cfdi-validacion';
 import { cargarCuadraturaVenta } from '@/lib/dilesa/cuadratura-server';
 import { requiereNotaCredito } from '@/lib/dilesa/captura/pld-revision';
 
-type Params = { params: Promise<{ ventaId: string }> };
+type Params = { params: Promise<{ id: string }> };
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const FASE = 13;
@@ -48,7 +48,7 @@ const money = (n: number) =>
   new Intl.NumberFormat('es-MX', { style: 'currency', currency: 'MXN' }).format(n);
 
 export async function POST(req: NextRequest, { params }: Params) {
-  const { ventaId } = await params;
+  const { id: ventaId } = await params;
   if (!UUID_RE.test(ventaId)) {
     return NextResponse.json({ ok: false, error: 'Venta inválida.' }, { status: 400 });
   }

--- a/app/api/dilesa/ventas/[id]/docs/route.test.ts
+++ b/app/api/dilesa/ventas/[id]/docs/route.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 /**
- * Tests para `GET /api/dilesa/ventas/[ventaId]/docs` (Sprint 1 de
+ * Tests para `GET /api/dilesa/ventas/[id]/docs` (Sprint 1 de
  * `dilesa-ventas-captura-colaborativa`).
  *
  * El endpoint existe porque `core.usuarios` es RLS self-only: el "subido
@@ -68,7 +68,7 @@ function req(ventaId: string, roles?: string) {
   const url = `http://localhost/api/dilesa/ventas/${ventaId}/docs${
     roles != null ? `?roles=${encodeURIComponent(roles)}` : ''
   }`;
-  return GET(new NextRequest(url), { params: Promise.resolve({ ventaId }) });
+  return GET(new NextRequest(url), { params: Promise.resolve({ id: ventaId }) });
 }
 
 beforeEach(() => {
@@ -82,7 +82,7 @@ beforeEach(() => {
 
 // ── Tests ──────────────────────────────────────────────────────────────
 
-describe('GET /api/dilesa/ventas/[ventaId]/docs', () => {
+describe('GET /api/dilesa/ventas/[id]/docs', () => {
   it('400 con ventaId que no es uuid', async () => {
     const res = await req('no-es-uuid', 'factura');
     expect(res.status).toBe(400);

--- a/app/api/dilesa/ventas/[id]/docs/route.ts
+++ b/app/api/dilesa/ventas/[id]/docs/route.ts
@@ -1,5 +1,5 @@
 /**
- * GET /api/dilesa/ventas/[ventaId]/docs?roles=factura,nota_credito,aviso_pld
+ * GET /api/dilesa/ventas/[id]/docs?roles=factura,nota_credito,aviso_pld
  *
  * Documentos del expediente de una venta (erp.adjuntos, entidad_tipo='venta')
  * para los roles pedidos, con `subidoPorNombre` resuelto server-side —
@@ -18,13 +18,13 @@ import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import type { DocFase } from '@/lib/dilesa/captura/docs-fase';
 
-type Params = { params: Promise<{ ventaId: string }> };
+type Params = { params: Promise<{ id: string }> };
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ROL_RE = /^[a-z0-9_]+$/;
 
 export async function GET(req: NextRequest, { params }: Params) {
-  const { ventaId } = await params;
+  const { id: ventaId } = await params;
   if (!UUID_RE.test(ventaId)) {
     return NextResponse.json({ ok: false, error: 'Venta inválida.' }, { status: 400 });
   }

--- a/app/api/dilesa/ventas/[id]/revision-pld/route.ts
+++ b/app/api/dilesa/ventas/[id]/revision-pld/route.ts
@@ -61,7 +61,7 @@ import {
 export const runtime = 'nodejs';
 export const maxDuration = 300;
 
-type Params = { params: Promise<{ ventaId: string }> };
+type Params = { params: Promise<{ id: string }> };
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const FASE = 13;
@@ -237,7 +237,7 @@ function revisionDto(r: RevisionRow, ejecutadoPorNombre: string | null, vigente:
 }
 
 export async function GET(_req: NextRequest, { params }: Params) {
-  const { ventaId } = await params;
+  const { id: ventaId } = await params;
   const auth = await autorizar(ventaId);
   if (!auth.ok) return auth.res;
 
@@ -260,7 +260,7 @@ export async function GET(_req: NextRequest, { params }: Params) {
 }
 
 export async function POST(_req: NextRequest, { params }: Params) {
-  const { ventaId } = await params;
+  const { id: ventaId } = await params;
   const auth = await autorizar(ventaId);
   if (!auth.ok) return auth.res;
   const { admin, userId } = auth;

--- a/lib/ai/registry.ts
+++ b/lib/ai/registry.ts
@@ -132,7 +132,7 @@ export const AI_USOS = {
     envVar: 'ANTHROPIC_API_KEY',
     criticidad: 'alta',
     descripcion: 'Extrae el Informe de Avisos PLD para el cruce determinista contra el expediente.',
-    archivo: 'app/api/dilesa/ventas/[ventaId]/revision-pld/route.ts',
+    archivo: 'app/api/dilesa/ventas/[id]/revision-pld/route.ts',
   },
   'dilesa-pld-acuse': {
     label: 'Revisión PLD — Acuse de envío (Fase 13)',
@@ -143,7 +143,7 @@ export const AI_USOS = {
     envVar: 'ANTHROPIC_API_KEY',
     criticidad: 'alta',
     descripcion: 'Extrae el Acuse de envío PLD que cierra el ciclo (presentado ante el SPPLD).',
-    archivo: 'app/api/dilesa/ventas/[ventaId]/revision-pld/route.ts',
+    archivo: 'app/api/dilesa/ventas/[id]/revision-pld/route.ts',
   },
   'sanren-recibo-extraccion': {
     label: 'Extracción de recibos de servicios (SANREN)',

--- a/lib/dilesa/captura/docs-fase.ts
+++ b/lib/dilesa/captura/docs-fase.ts
@@ -12,7 +12,7 @@
  * "Cambiar" NO borra: inserta una versión nueva y conserva la anterior
  * (audit trail). El vigente por rol es el adjunto más reciente.
  *
- * La lectura va por `GET /api/dilesa/ventas/[ventaId]/docs` porque
+ * La lectura va por `GET /api/dilesa/ventas/[id]/docs` porque
  * `core.usuarios` es RLS self-only: el "subido por" de terceros solo se
  * resuelve server-side con el admin client.
  */


### PR DESCRIPTION
## Qué

Unifica el slug de las rutas API de ventas DILESA: `[ventaId]` → `[id]`. Dos slugs distintos para el mismo path (`app/api/dilesa/ventas/[id]` y `[ventaId]`) hacían que **Turbopack `next dev` no arrancara** (`You cannot use different slug names for the same dynamic path`).

## Por qué pasó ~10 días desapercibido

El **build de producción tolera la colisión** (todos los deploys `READY`), así que prod nunca se vio afectada y ambos conjuntos de rutas responden. Se trabaja con Preview deploys, no con `next dev` local, así que nadie topó el crash. Lo destapó el primer arranque de un smoke E2E local.

## El cambio (mecánico, URLs intactas)

- `git mv` de `cerrar-fase13`, `docs`, `revision-pld` de `[ventaId]/` → `[id]/` (junto a `notify-*`, `pdf`, `encuesta`).
- En los 3 handlers, solo la **key del slug**: `const { id: ventaId } = await params` — variable interna y lógica idénticas.
- **Las URLs públicas no cambian** (el cliente llama por valor de UUID, no por nombre de slug) → cero impacto en el front ni en el ciclo de F13.
- Actualiza 3 referencias textuales stale (metadata del registro de IA + un comentario).

## Verificación

- `next dev` arranca ✓ (antes crasheaba al boot)
- Tests de las rutas movidas: 18/18 ✓
- Suite completo: 2077/2077 ✓ · typecheck limpio · lint/format ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)