### PR TITLE
fix(dilesa-cuadratura): el split bono/sobreprecio respeta el sobreprecio capturado

### DIFF
--- a/components/dilesa/cuadratura-ajustes.tsx
+++ b/components/dilesa/cuadratura-ajustes.tsx
@@ -96,10 +96,11 @@ export function CuadraturaAjustes({
   //    No se captura aquí; se deriva. ──
   if (tieneDesglose) {
     const descuentoTotal = Math.round(descuentoReal * 100) / 100;
-    // Parte el descuento real en promoción (bono autorizado, topado) + sobreprecio
-    // (el resto). Mismo helper que la card de cobertura del presupuesto notarial.
+    // Parte el descuento real en sobreprecio (piso = el capturado, que sube el
+    // precio para que el crédito absorba gastos) + promoción (bono autorizado, el
+    // residual). Mismo helper que la card de cobertura del presupuesto notarial.
     const { promocion: descuentoPorPromocion, sobreprecio: descuentoPorSobreprecio } =
-      partirDescuento(descuentoReal, descuentoPromocion);
+      partirDescuento(descuentoReal, descuentoPromocion, sobreprecioCapturado);
     // Cuánto del sobreprecio aún no está formalizado como productos adicionales
     // (precio inflado) → pendiente de capturar como Máxima Aportación.
     const sobreprecioPorCapturar =

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -620,6 +620,48 @@ describe('calcularCuadratura', () => {
       expect(c.coberturaGastos?.pagareNecesario).toBe(9387);
     });
 
+    // Raquel (M3-L6-LDLE, Infonavit Tradicional): venta legacy a la que se subió la
+    // escrituración 920,000 → 930,000 con un sobreprecio de 10,000 (margen del crédito
+    // para absorber gastos). Con el dato corregido (precio_base 920k + sobreprecio 10k),
+    // el split de cobertura respeta el sobreprecio capturado: sobreprecio 10,000 + bono
+    // 10,461 — NO el bono-primero (15,000 + sobreprecio 5,461). El descuento real, el
+    // valor real y el saldo NO cambian: solo se reparte distinto el mismo total.
+    it('Raquel (M3-L6): el sobreprecio capturado manda el split, no el bono-primero', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 930000,
+        montoCreditoTitular: 930000,
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: null,
+        montoChequeNotaria: null,
+        gastosEscrituracion: 50461,
+        apoyoInfonavit: 30000,
+        precioBase: 920000,
+        incrementoCredito: 0,
+        sobreprecioGastos: 10000,
+        promocionGastos: 15000,
+        depositos: [],
+        proyectoNombre: 'Lomas de los Encinos',
+      });
+      const cob = c.coberturaGastos!;
+      // Formación del precio: base 920k + sobreprecio 10k = escrituración 930k.
+      expect(c.formacionPrecio?.precioBase).toBe(920000);
+      expect(c.formacionPrecio?.sobreprecioGastos).toBe(10000);
+      expect(c.formacionPrecio?.valorEscrituracion).toBe(930000);
+      // Cobertura del presupuesto notarial: el sobreprecio capturado (10k) manda; el
+      // bono es el residual (10,461). El subsidio Infonavit (30k) aparte. Cuadra en 0.
+      expect(cob.gastosBrutos).toBe(50461);
+      expect(cob.apoyoInfonavit).toBe(30000);
+      expect(cob.aportacionPromocion).toBe(10461);
+      expect(cob.sobreprecioCobertura).toBe(10000);
+      expect(cob.pagareNecesario).toBe(0); // 20,461 − 15,000 − 0 − 10,000 < 0 → 0
+      expect(cob.saldoCobertura).toBe(0);
+      // Invariantes que NO cambian con el split: descuento real (= a pagar notaría),
+      // valor real y comisión sobre el valor real menos el sobreprecio (no comisiona).
+      expect(c.descuentoReal).toBe(20461);
+      expect(c.valorRealVentaDilesa).toBe(909539);
+      expect(c.comisionVendedor).toBe(8995.39); // (909,539 − 10,000) × 1%
+    });
+
     it('operacionCubierta es model-aware: cubierta aunque el saldoCliente legacy sea fantasma — Arizpe', () => {
       // El crédito cubre el precio (909,000) y las fuentes cubren los gastos. El
       // `saldoCliente` legacy = cheque 18,313 − descuento 15,000 = 3,313 (fantasma,
@@ -827,5 +869,33 @@ describe('partirDescuento', () => {
 
   it('conserva centavos (escritura − valor real puede no ser entero)', () => {
     expect(partirDescuento(18313.29, 15000)).toEqual({ promocion: 15000, sobreprecio: 3313.29 });
+  });
+
+  // El sobreprecio CAPTURADO es piso del split: cuando se subió el precio para que
+  // el crédito absorbiera gastos, ese monto es sobreprecio aunque el bono no se
+  // haya agotado. Caso Raquel (M3-L6): descuento real 20,461, bono 15,000,
+  // sobreprecio capturado 10,000 → sobreprecio 10,000 (no 5,461) + bono 10,461.
+  it('el sobreprecio capturado es piso del split (Raquel M3-L6)', () => {
+    expect(partirDescuento(20461, 15000, 10000)).toEqual({ promocion: 10461, sobreprecio: 10000 });
+  });
+
+  it('piso ≤ residual no cambia nada (idéntico a 2 args)', () => {
+    // Residual sobre el bono = 18,313 − 15,000 = 3,313; un piso menor no manda.
+    expect(partirDescuento(18313, 15000, 3000)).toEqual({ promocion: 15000, sobreprecio: 3313 });
+    expect(partirDescuento(18313, 15000, 0)).toEqual({ promocion: 15000, sobreprecio: 3313 });
+    // MAYRA: el piso capturado coincide con el residual.
+    expect(partirDescuento(39651, 15000, 24651)).toEqual({ promocion: 15000, sobreprecio: 24651 });
+  });
+
+  it('el piso nunca inventa bono por encima del autorizado', () => {
+    // Sin piso, residual 5,461 + bono 15,000; con piso 10,000 el bono BAJA a 10,461
+    // (nunca sube de 15,000). El sobreprecio capturado solo puede mover bono→sobreprecio.
+    expect(partirDescuento(20461, 15000)).toEqual({ promocion: 15000, sobreprecio: 5461 });
+    expect(partirDescuento(20461, 15000, 10000).promocion).toBeLessThanOrEqual(15000);
+  });
+
+  it('el piso se topa al total (no genera bono negativo)', () => {
+    // Sobreprecio capturado mayor que el descuento real → todo sobreprecio, bono 0.
+    expect(partirDescuento(20461, 15000, 25000)).toEqual({ promocion: 0, sobreprecio: 20461 });
   });
 });

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -382,19 +382,32 @@ export function topeDescuentoAutorizado(
 /**
  * Parte el descuento real (= Escrituración − Valor Real, columna "Descuento" de
  * Michelle) en sus dos orígenes, para las cards de la cuadratura:
- *  - `promocion`: el bono autorizado del catálogo, usado hasta el total (topado
- *    al máximo autorizado).
- *  - `sobreprecio`: el resto, que DILESA concede subiendo el precio (pendiente de
- *    formalizar como Máxima Aportación en la solicitud).
- * Con descuento ≥ 0 se cumple `promocion + sobreprecio = descuentoReal`.
+ *  - `sobreprecio`: lo que DILESA concede subiendo el precio para que el crédito
+ *    absorba los gastos (NO le cuesta a DILESA; lo paga el crédito).
+ *  - `promocion`: el bono autorizado del catálogo (SÍ le cuesta a DILESA); el
+ *    residual tras el sobreprecio.
+ *
+ * El `sobreprecioCapturado` (`dilesa.ventas.sobreprecio_gastos_escrituracion`) es
+ * un HECHO escriturado y actúa como PISO del sobreprecio: si se subió el precio
+ * 10,000, esos 10,000 son sobreprecio aunque el bono no se haya agotado. Sin
+ * sobreprecio capturado (0/undefined) se cae al residual sobre la promoción
+ * topada — comportamiento idéntico al previo (el bono se quema primero). El piso
+ * NO puede inventar bono por encima del autorizado: `sobreprecio ≥ total − promo`
+ * garantiza `promocion ≤ promocionAutorizada`. Con `total ≥ 0` se mantiene
+ * `promocion + sobreprecio = total` (el sobreprecio se topa a `total`).
  */
 export function partirDescuento(
   descuentoReal: number,
-  promocionAutorizada: number | null | undefined
+  promocionAutorizada: number | null | undefined,
+  sobreprecioCapturado?: number | null | undefined
 ): { promocion: number; sobreprecio: number } {
   const total = round2(descuentoReal);
-  const promocion = total <= 0 ? 0 : round2(Math.min(total, n(promocionAutorizada)));
-  const sobreprecio = round2(Math.max(0, total - promocion));
+  if (total <= 0) return { promocion: 0, sobreprecio: 0 };
+  const residualSobrePromo = Math.max(0, total - n(promocionAutorizada));
+  const sobreprecio = round2(
+    Math.min(total, Math.max(n(sobreprecioCapturado), residualSobrePromo))
+  );
+  const promocion = round2(total - sobreprecio);
   return { promocion, sobreprecio };
 }
 
@@ -497,9 +510,15 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   // precio) y la parte del pagaré que SÍ fondea gastos, partido en promoción
   // (topada al bono) + sobreprecio (el resto).
   const faltanteGastosDilesa = round2(gastosNetosR - engancheAGastos - pagareAGastos);
+  // El sobreprecio CAPTURADO es piso del split: si se subió el precio para que el
+  // crédito absorbiera gastos, ese monto es sobreprecio (no bono), aunque la
+  // promoción no se haya agotado. Sin él, residual sobre la promo topada (igual
+  // que antes). No cambia el total (promo + sobreprecio = faltante) ⇒ saldoCobertura
+  // intacto; solo reparte distinto bono↔sobreprecio en la card.
   const { promocion: aportacionPromocion, sobreprecio: sobreprecioCobertura } = partirDescuento(
     faltanteGastosDilesa,
-    promocionGastos
+    promocionGastos,
+    sobreprecioGastos
   );
   const saldoCobertura = round2(
     gastosBrutosR -


### PR DESCRIPTION
## Contexto

Detonante: la venta de **Raquel Anahí Vivanco Camarillo** (M3-L6-LDLE, Infonavit Tradicional, fase 9). Es legacy de Coda: nació con asignación = escrituración = 920,000 y después se subió la escrituración a **930,000** para aprovechar el crédito Infonavit (930k), pero **el sobreprecio de 10,000 nunca se capturó**. El desglose había puesto `precio_base = escrituración` (930k) y `sobreprecio = 0`.

## Cambio de código (este PR)

`partirDescuento` partía el descuento real con **bono-primero** (promoción hasta el tope, sobreprecio = residual), **ignorando el `sobreprecio_gastos_escrituracion` capturado**. Resultado: la card "Formación del precio" mostraba el sobreprecio capturado (10k) pero "Descuento de la operación" y "Cobertura del presupuesto notarial" mostraban 5,461 (= 20,461 − 15,000 bono). Incoherente.

Ahora el **sobreprecio capturado es PISO del split** y el bono es el residual:
- `sobreprecio = min(total, max(sobreprecioCapturado, total − promoAutorizada))`
- `promocion = total − sobreprecio`

Topado por construcción al máximo autorizado (`sobreprecio ≥ total − promo ⇒ promo ≤ promoAutorizada`). Mantiene **`promoción + sobreprecio = total`**, así que **saldo, NC, valor real y comisión quedan intactos** — solo cambia la etiqueta bono↔sobreprecio en las dos cards. Cableado en las dos llamadas (motor `coberturaGastos` + card `cuadratura-ajustes`).

## Verificación adversarial

23 ventas activas con sobreprecio capturado:
- **8 corrigen su split** (sobrestimaban el bono: mostraban 15,000 cuando DILESA realmente puso 0–13k; el resto lo cubría el sobreprecio capturado, que es lo que la iniciativa buscaba).
- **15 sin cambio.**
- **0 rompen el cuadre** (`saldoCobertura` se preserva por el invariante).
- **0 generan bono negativo** (los topes `min`/`max` lo garantizan).

5 tests nuevos (caso Raquel + bordes del piso). 51 tests del motor verdes; 2081 del repo.

## Data-fix aplicado a prod (autorizado por Beto, fuera de este PR)

`dilesa.ventas` de Raquel (`bf422386-…`):
| Campo | Antes | Ahora |
|---|---|---|
| `precio_base` | 930,000 | **920,000** |
| `sobreprecio_gastos_escrituracion` | 0 | **10,000** |

Cadena: 920k base + 10k sobreprecio = 930k escrituración. Registrado en `core.audit_log` (`correccion_desglose_precio`) + nota en la venta. No es migración (UPDATE de datos).

## Resultado esperado (revisar en preview)
- Formación del precio: 920k + sobreprecio 10k = 930k
- Descuento de la operación: bono **10,461** + sobreprecio **10,000** = 20,461
- Cobertura del presupuesto notarial: 50,461 − 30,000 Infonavit − 10,461 bono − 10,000 sobreprecio = 0 ✓

> ⚠️ Financiero visible — sin auto-merge para que lo revises en el Vercel Preview (abre Raquel M3-L6 → pestaña Cuadratura).

🤖 Generated with [Claude Code](https://claude.com/claude-code)