### PR TITLE
fix(dilesa-estimaciones-cxp): auto-match de destajo robusto a personas duplicadas

### DIFF
--- a/app/api/[empresa]/cxp/facturas/upload-xml/route.test.ts
+++ b/app/api/[empresa]/cxp/facturas/upload-xml/route.test.ts
@@ -32,6 +32,14 @@ type Script = {
   }[];
   /** dilesa.estimaciones para resolver el código del destajo. */
   estimaciones?: { id: string; codigo: string }[];
+  /** erp.personas de los contratistas de los placeholders (RFC + nombre). */
+  placeholderPersonas?: {
+    id: string;
+    rfc: string | null;
+    nombre: string | null;
+    apellido_paterno: string | null;
+    apellido_materno: string | null;
+  }[];
 };
 
 type Calls = {
@@ -113,6 +121,7 @@ function buildAdminMock(): any {
               let data: unknown = null;
               if (key === 'erp.facturas' && usedNot) data = script.placeholders ?? [];
               else if (key === 'dilesa.estimaciones') data = script.estimaciones ?? [];
+              else if (key === 'erp.personas') data = script.placeholderPersonas ?? [];
               return Promise.resolve({ data, error: null }).then(onFulfilled, onRejected);
             },
           };
@@ -173,6 +182,19 @@ const XML_OTRO_RECEPTOR = XML_OK.replace('DIE030904866', 'XXX010101XX1').replace
   '88888888-8888-8888-8888-888888888888'
 );
 const XML_MALO = 'esto no es un CFDI';
+
+// Destajo del caso "persona duplicada": el emisor (con RFC) matchea una persona
+// distinta a la del placeholder (sin RFC), pero el nombre coincide. Total 1100.
+const XML_DESTAJO_NOMBRE = `<?xml version="1.0" encoding="UTF-8"?>
+<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4" xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital"
+  Version="4.0" Serie="A" Folio="77" Fecha="2026-06-20T10:30:00"
+  SubTotal="1100.00" Total="1100.00" Moneda="MXN" FormaPago="03" MetodoPago="PUE" TipoDeComprobante="I">
+  <cfdi:Emisor Rfc="SAMD8409154U7" Nombre="DAVID EDUARDO SALAZAR MORALES" RegimenFiscal="612"/>
+  <cfdi:Receptor Rfc="DIE030904866" Nombre="DESARROLLO INMOBILIARIO" UsoCFDI="G03"/>
+  <cfdi:Complemento>
+    <tfd:TimbreFiscalDigital Version="1.1" UUID="11112222-3333-4444-5555-666677778888" FechaTimbrado="2026-06-20T10:31:00"/>
+  </cfdi:Complemento>
+</cfdi:Comprobante>`;
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -321,11 +343,18 @@ describe('POST /api/[empresa]/cxp/facturas/upload-xml', () => {
   function makeReqRaw(fields: {
     analyze?: boolean;
     decisiones?: Record<string, string>;
+    xml?: string;
+    filename?: string;
   }): NextRequest {
     const fd = new FormData();
     if (fields.analyze) fd.append('analyze', '1');
     if (fields.decisiones) fd.append('decisiones', JSON.stringify(fields.decisiones));
-    fd.append('file', new File([XML_OK], 'a.xml', { type: 'application/xml' }));
+    fd.append(
+      'file',
+      new File([fields.xml ?? XML_OK], fields.filename ?? 'a.xml', {
+        type: 'application/xml',
+      })
+    );
     return new NextRequest(new URL('http://localhost/api/dilesa/cxp/facturas/upload-xml'), {
       method: 'POST',
       body: fd,
@@ -361,6 +390,36 @@ describe('POST /api/[empresa]/cxp/facturas/upload-xml', () => {
     const body = await res.json();
     expect(body.analisis[0].candidatos).toHaveLength(0);
     expect(body.analisis[0].sugerencia).toBe('normal');
+  });
+
+  it('analyze → reconoce el destajo por nombre aunque la persona del destajo no tenga RFC (duplicado)', async () => {
+    // El placeholder cuelga de una persona SIN RFC; el emisor del CFDI matchea
+    // OTRA persona (con RFC). Mismo humano → debe ofrecerse el destajo igual.
+    script.placeholders = [
+      { id: 'ph-david', proveedor_id: 'prov-destajo', total: 1200, estimacion_id: 'est-david' },
+    ];
+    script.estimaciones = [{ id: 'est-david', codigo: 'EST-2026-W26-SALA-001' }];
+    script.placeholderPersonas = [
+      {
+        id: 'prov-destajo',
+        rfc: null,
+        nombre: 'DAVID EDUARDO',
+        apellido_paterno: 'SALAZAR',
+        apellido_materno: 'MORALES',
+      },
+    ];
+    script.personaByRfc = { SAMD8409154U7: { id: 'persona-con-rfc' } };
+    const res = await POST(
+      makeReqRaw({ analyze: true, xml: XML_DESTAJO_NOMBRE, filename: 'david.xml' }),
+      params
+    );
+    expect(res.status).toBe(200);
+    const a = (await res.json()).analisis[0];
+    expect(a.ok).toBe(true);
+    expect(a.proveedorId).toBe('persona-con-rfc'); // distinto al del destajo
+    expect(a.candidatos).toHaveLength(1);
+    expect(a.candidatos[0]).toMatchObject({ facturaId: 'ph-david', neto: 1200, delta: 100 });
+    expect(a.sugerencia).toBe('ph-david');
   });
 
   it('commit con decisiones → asocia el CFDI al destajo (recibir_cfdi, no alta)', async () => {

--- a/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
+++ b/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
@@ -73,10 +73,25 @@ type CxpFacturaAltaArgs = Database['erp']['Functions']['cxp_factura_alta']['Args
 type DestajoPlaceholder = {
   facturaId: string;
   proveedorId: string | null;
+  /** RFC del contratista del destajo (puede faltar si la persona no lo tiene). */
+  proveedorRfc: string | null;
+  /** Nombre del contratista del destajo, para el fallback por nombre. */
+  proveedorNombre: string | null;
   neto: number;
   estimacionId: string;
   codigo: string | null;
 };
+
+/** Normaliza un nombre para comparar: sin acentos, mayúsculas, espacios colapsados. */
+function normNombre(s: string | null | undefined): string {
+  if (!s) return '';
+  return s
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toUpperCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
 type DestajoCandidato = {
   facturaId: string;
@@ -105,15 +120,31 @@ type AnalisisArchivo = {
 
 const NETO_EPS = 1.005; // tolerancia de redondeo para "CFDI ≤ neto".
 
-/** Destajos abiertos cuyo neto ≥ total del CFDI (puede ser menor por materiales), tightest primero. */
+/**
+ * Destajos abiertos cuyo neto ≥ total del CFDI (puede ser menor por materiales),
+ * tightest primero. El contratista se reconoce por `proveedor_id`, por RFC, o
+ * por nombre normalizado — esto último rescata el caso de personas duplicadas
+ * (el destajo se capturó con una persona sin RFC y el CFDI matchea otra con RFC,
+ * mismo humano). El operador confirma en el review, así que el match por nombre
+ * es seguro.
+ */
 function candidatosParaCfdi(
   placeholders: DestajoPlaceholder[],
   proveedorId: string | null,
+  emisorRfc: string | null,
+  emisorNombre: string | null,
   total: number
 ): DestajoCandidato[] {
-  if (!proveedorId) return [];
+  const rfc = emisorRfc ? emisorRfc.toUpperCase().trim() : null;
+  const nom = normNombre(emisorNombre);
   return placeholders
-    .filter((p) => p.proveedorId === proveedorId && total <= p.neto * NETO_EPS)
+    .filter((p) => {
+      if (total > p.neto * NETO_EPS) return false;
+      const mismoProveedor = !!proveedorId && p.proveedorId === proveedorId;
+      const mismoRfc = !!rfc && !!p.proveedorRfc && p.proveedorRfc.toUpperCase().trim() === rfc;
+      const mismoNombre = !!nom && normNombre(p.proveedorNombre) === nom;
+      return mismoProveedor || mismoRfc || mismoNombre;
+    })
     .map((p) => ({
       facturaId: p.facturaId,
       codigo: p.codigo,
@@ -160,9 +191,30 @@ async function fetchDestajoPlaceholders(
       .in('id', estIds);
     for (const e of ests ?? []) codigoPorEst.set(e.id as string, (e.codigo as string | null) ?? '');
   }
+
+  // RFC + nombre del contratista de cada placeholder, para reconocerlo aunque la
+  // persona-id difiera de la que matchea el CFDI (personas duplicadas con/sin RFC).
+  const provIds = [...new Set(rows.map((r) => r.proveedor_id).filter((x): x is string => !!x))];
+  const persona = new Map<string, { rfc: string | null; nombre: string }>();
+  if (provIds.length > 0) {
+    const { data: pers } = await admin
+      .schema('erp')
+      .from('personas')
+      .select('id, rfc, nombre, apellido_paterno, apellido_materno')
+      .in('id', provIds);
+    for (const p of pers ?? []) {
+      persona.set(p.id as string, {
+        rfc: (p.rfc as string | null) ?? null,
+        nombre: [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' '),
+      });
+    }
+  }
+
   return rows.map((r) => ({
     facturaId: r.id,
     proveedorId: r.proveedor_id,
+    proveedorRfc: r.proveedor_id ? (persona.get(r.proveedor_id)?.rfc ?? null) : null,
+    proveedorNombre: r.proveedor_id ? (persona.get(r.proveedor_id)?.nombre ?? null) : null,
     neto: Number(r.total ?? 0),
     estimacionId: r.estimacion_id,
     codigo: codigoPorEst.get(r.estimacion_id) ?? null,
@@ -422,7 +474,13 @@ export async function POST(req: NextRequest, { params }: Params) {
           .eq('rfc', cfdi.emisorRfc)
           .maybeSingle();
         a.proveedorId = prov?.id ?? null;
-        a.candidatos = candidatosParaCfdi(placeholders, a.proveedorId, cfdi.total);
+        a.candidatos = candidatosParaCfdi(
+          placeholders,
+          a.proveedorId,
+          cfdi.emisorRfc,
+          cfdi.emisorNombre,
+          cfdi.total
+        );
         a.sugerencia = sugerirAccion(a.candidatos, cfdi.total);
         a.ok = true;
       } catch (e) {


### PR DESCRIPTION
## El bug

Facturas de destajo que ya tenían su XML cargado seguían apareciendo en **"Facturas en espera del XML"**, y al reintentar la subida decía "ya cargada".

**Causa raíz:** el auto-match destajo→CxP reconocía al contratista solo por `proveedor_id` exacto. Cuando el destajo se capturó con una persona **sin RFC** y el CFDI matchea otra persona **con RFC** (mismo humano, registro duplicado en `erp.personas`), no encontraba el placeholder en espera → creaba una factura normal duplicada y dejaba el placeholder huérfano.

## El fix (código)

`candidatosParaCfdi` ahora reconoce al contratista por **`proveedor_id`, RFC, o nombre normalizado** (sin acentos/mayúsculas). `fetchDestajoPlaceholders` trae RFC + nombre de cada placeholder. El operador confirma el destajo en el paso de revisión, así que el match por nombre no es automático ni riesgoso.

## Dato ya reconciliado en prod

Caso real **David Salazar, destajo EST-2026-W26** (con OK de Beto, audit trail):
- Placeholder duplicado huérfano → cancelado (libera el slot del destajo).
- Factura real con XML (FEB2F56C, $22,156.80) → ligada al destajo; la estimación quedó **'facturada'**.
- Bandeja "en espera" de DILESA: **0**.

Quedan **4 contratistas** con el mismo patrón de persona duplicada en el catálogo (con/sin RFC); este fix de código evita que el síntoma se repita. La consolidación de esos registros de persona es una limpieza de catálogo aparte.

## Verificación

6 checks de CI verdes en local — typecheck, lint, format, **test:coverage (2084 tests, branches 83.88% > 82)**, initiatives:check. `schema:check` N/A (no toca schema; la reparación fue de datos). Test nuevo cubre el caso "persona duplicada sin RFC, mismo nombre → sí se ofrece el destajo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)