### PR TITLE
feat(cxp): pipeline Sprint 2 — Programación ejecuta el pago, Pagos = histórico

### DIFF
--- a/app/dilesa/cxp/pagos/page.tsx
+++ b/app/dilesa/cxp/pagos/page.tsx
@@ -3,11 +3,12 @@
 /**
  * CxP · Pagos (DILESA) — wrapper delgado del módulo compartido (ADR-011, SM1).
  *
- * Toda la lógica vive en <CxpPagosModule> (components/cxp/). Este page solo
- * gatea con <RequireAccess> y pasa la identidad de la empresa.
+ * Pipeline S2: última etapa, los pagos **ya ejecutados** (histórico). Reusa
+ * <CxpPagosModule> con estado inicial 'pagado'. La ejecución (marcar pagado +
+ * comprobante) vive en la pestaña "Programación".
  *
  * @module CxP — Pagos (DILESA)
- * @responsive desktop-only — aprobación/pago administrativo en escritorio.
+ * @responsive desktop-only — consulta administrativa en escritorio.
  */
 
 import { RequireAccess } from '@/components/require-access';
@@ -17,7 +18,7 @@ import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 export default function CxpPagosPage() {
   return (
     <RequireAccess empresa="dilesa" modulo="dilesa.cxp.pagos">
-      <CxpPagosModule empresaId={DILESA_EMPRESA_ID} empresa="dilesa" />
+      <CxpPagosModule empresaId={DILESA_EMPRESA_ID} empresa="dilesa" estadoInicial="pagado" />
     </RequireAccess>
   );
 }

--- a/app/dilesa/cxp/programacion/page.tsx
+++ b/app/dilesa/cxp/programacion/page.tsx
@@ -3,23 +3,23 @@
 /**
  * CxP · Programación (DILESA) — wrapper delgado del módulo compartido (ADR-011, SM1).
  *
- * Toda la lógica vive en <CxpProgramacionModule> (components/cxp/). Este page
- * solo gatea con <RequireAccess> y pasa la identidad de la empresa. Se separa
- * el cuerpo del gate porque el módulo usa useSearchParams (vía useUrlFilters):
- * <RequireAccess> retorna null mientras carga y provee el boundary de Suspense.
+ * Pipeline S2: esta pestaña muestra los pagos **por ejecutar**
+ * (programado/aprobado) y permite marcar pagado + subir comprobante; al pagarse
+ * pasan solos a la pestaña "Pagos". Reusa <CxpPagosModule> con estado inicial
+ * 'pendientes'. (Programar el pago ahora vive en la pestaña Facturas — S1.)
  *
  * @module CxP — Programación (DILESA)
- * @responsive desktop-only — programación administrativa en escritorio.
+ * @responsive desktop-only — ejecución de pagos administrativa en escritorio.
  */
 
 import { RequireAccess } from '@/components/require-access';
-import { CxpProgramacionModule } from '@/components/cxp/cxp-programacion-module';
+import { CxpPagosModule } from '@/components/cxp/cxp-pagos-module';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 
 export default function CxpProgramacionPage() {
   return (
     <RequireAccess empresa="dilesa" modulo="dilesa.cxp.programacion">
-      <CxpProgramacionModule empresaId={DILESA_EMPRESA_ID} empresa="dilesa" />
+      <CxpPagosModule empresaId={DILESA_EMPRESA_ID} empresa="dilesa" estadoInicial="pendientes" />
     </RequireAccess>
   );
 }

--- a/app/rdb/cxp/pagos/page.tsx
+++ b/app/rdb/cxp/pagos/page.tsx
@@ -3,11 +3,12 @@
 /**
  * CxP · Pagos (RDB) — wrapper delgado del módulo compartido (ADR-011, SM1).
  *
- * Toda la lógica vive en <CxpPagosModule> (components/cxp/). Este page solo
- * gatea con <RequireAccess> y pasa la identidad de la empresa.
+ * Pipeline S2: última etapa, los pagos **ya ejecutados** (histórico). Reusa
+ * <CxpPagosModule> con estado inicial 'pagado'. La ejecución (marcar pagado +
+ * comprobante) vive en la pestaña "Programación".
  *
  * @module CxP — Pagos (RDB)
- * @responsive desktop-only — aprobación/pago administrativo en escritorio.
+ * @responsive desktop-only — consulta administrativa en escritorio.
  */
 
 import { RequireAccess } from '@/components/require-access';
@@ -17,7 +18,7 @@ import { RDB_EMPRESA_ID } from '@/lib/empresa-constants';
 export default function CxpPagosPage() {
   return (
     <RequireAccess empresa="rdb" modulo="rdb.cxp.pagos">
-      <CxpPagosModule empresaId={RDB_EMPRESA_ID} empresa="rdb" />
+      <CxpPagosModule empresaId={RDB_EMPRESA_ID} empresa="rdb" estadoInicial="pagado" />
     </RequireAccess>
   );
 }

--- a/app/rdb/cxp/programacion/page.tsx
+++ b/app/rdb/cxp/programacion/page.tsx
@@ -3,23 +3,23 @@
 /**
  * CxP · Programación (RDB) — wrapper delgado del módulo compartido (ADR-011, SM1).
  *
- * Toda la lógica vive en <CxpProgramacionModule> (components/cxp/). Este page
- * solo gatea con <RequireAccess> y pasa la identidad de la empresa. Se separa
- * el cuerpo del gate porque el módulo usa useSearchParams (vía useUrlFilters):
- * <RequireAccess> retorna null mientras carga y provee el boundary de Suspense.
+ * Pipeline S2: esta pestaña muestra los pagos **por ejecutar**
+ * (programado/aprobado) y permite marcar pagado + subir comprobante; al pagarse
+ * pasan solos a la pestaña "Pagos". Reusa <CxpPagosModule> con estado inicial
+ * 'pendientes'. (Programar el pago ahora vive en la pestaña Facturas — S1.)
  *
  * @module CxP — Programación (RDB)
- * @responsive desktop-only — programación administrativa en escritorio.
+ * @responsive desktop-only — ejecución de pagos administrativa en escritorio.
  */
 
 import { RequireAccess } from '@/components/require-access';
-import { CxpProgramacionModule } from '@/components/cxp/cxp-programacion-module';
+import { CxpPagosModule } from '@/components/cxp/cxp-pagos-module';
 import { RDB_EMPRESA_ID } from '@/lib/empresa-constants';
 
 export default function CxpProgramacionPage() {
   return (
     <RequireAccess empresa="rdb" modulo="rdb.cxp.programacion">
-      <CxpProgramacionModule empresaId={RDB_EMPRESA_ID} empresa="rdb" />
+      <CxpPagosModule empresaId={RDB_EMPRESA_ID} empresa="rdb" estadoInicial="pendientes" />
     </RequireAccess>
   );
 }

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -71,6 +71,12 @@ export type CxpPagosModuleProps = {
   empresaId: string;
   /** Slug de la empresa para armar links del hilo del gasto (dilesa, rdb, …). */
   empresa: EmpresaSlug;
+  /**
+   * Filtro de estado inicial (pipeline S2). 'pendientes' (default) = pagos por
+   * ejecutar (pestaña Programación: marcar pagado + comprobante); 'pagado' =
+   * histórico (pestaña Pagos). El usuario puede cambiarlo con el filtro.
+   */
+  estadoInicial?: string;
 };
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -274,12 +280,16 @@ export function filtrarPagosPorEstado<T extends { estado: EstadoPago }>(
 
 // ── Módulo ─────────────────────────────────────────────────────────────────────
 
-export function CxpPagosModule({ empresaId, empresa }: CxpPagosModuleProps) {
+export function CxpPagosModule({
+  empresaId,
+  empresa,
+  estadoInicial = 'pendientes',
+}: CxpPagosModuleProps) {
   const feedback = useActionFeedback();
   const [pagos, setPagos] = useState<Pago[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [estado, setEstado] = useState('pendientes');
+  const [estado, setEstado] = useState(estadoInicial);
 
   const [selected, setSelected] = useState<Pago | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);


### PR DESCRIPTION
Cierra el rediseño del flujo CxP en 3 etapas (iniciativa `cxp`, Sprint 7). Las 3 pestañas quedan como el pipeline que pediste:

| Pestaña | Muestra | Acción |
|---|---|---|
| **Facturas** | por programar (+ en espera) | clasificar partida/cuenta · **programar = autoriza** (Dirección) — *S1* |
| **Programación** | pagos **por ejecutar** (programado/aprobado) | **marcar pagado + subir comprobante** → pasa solo a Pagos |
| **Pagos** | **pagadas** (histórico) | consulta |

## Cómo
Ambas etapas nuevas reusan `<CxpPagosModule>` (que ya hacía marcar-pagado + comprobante + control por partida) parametrizado con un prop **`estadoInicial`**:
- Programación → `estadoInicial="pendientes"` (programado + aprobado).
- Pagos → `estadoInicial="pagado"`.

El usuario puede cambiar el filtro de estado dentro de cada pestaña; el default define la etapa. "Al pagarse pasa sola a Pagos" sale del filtro (un pago `pagado` deja de aparecer en Programación).

## Notas
- **Programar en lote** (varias facturas → un pago por proveedor) ya no se ofrece: programar vive en Facturas (S1, individual por factura). `cxp-programacion-module` queda sin renderizar (solo provee el helper `pendientesDeProgramar` + su test). Si quieres recuperar el lote, lo re-exponemos.
- El **label** de la pestaña sigue siendo "Programación" (el slug RBAC es `…cxp.programacion`). Si prefieres "Por pagar" o "Ejecutar pagos", lo cambio — es solo cosmético.

## Verificación
typecheck · lint · format · **test:coverage (2099 tests)** · initiatives:check · schema:check — verdes en local.

**UI visible** → sin auto-merge; revisa el Vercel Preview (navega Programación → Pagos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)