### PR TITLE
feat(dilesa-ventas): movimiento del día en Fases + back-link a la fase de origen

### DIFF
--- a/app/dilesa/ventas/fases/page.tsx
+++ b/app/dilesa/ventas/fases/page.tsx
@@ -15,12 +15,19 @@
  * esa fase (definida por `dilesa.ventas.fase_actual` denormalizado).
  *
  * Click en una card filtra hacia la lista de ventas en esa fase
- * (`/dilesa/ventas?fase=<nombre>`) — la lista del tab Ventas no consume
- * el query param hoy pero la URL queda como deep link futuro; mientras
- * tanto manda al usuario al tab Ventas con scroll natural a la lista.
+ * (`/dilesa/ventas?fase=<nombre>`) — el tab Ventas consume el query param
+ * y abre la lista ya filtrada por esa fase.
+ *
+ * Cada card muestra dos cifras: `Ventas activas` (cuántas están "en" la
+ * fase ahora, vía `dilesa.ventas.fase_actual`) y `Movimiento del día`
+ * (cuántas ENTRARON a la fase hoy, contando filas de `dilesa.venta_fases`
+ * con `fecha` = hoy local de Matamoros — una venta que avanza 3 fases en
+ * un día suma +1 en cada una). La misma cifra alimenta el correo al Consejo.
  *
  * Filtros: proyecto, vendedor, mes. Filtran las ventas que se cuentan
- * en cada fase. Los catálogos (las 17 fases) se cargan desde
+ * en cada fase. El chip `Movimiento del día` respeta proyecto/vendedor
+ * pero NO el filtro de mes (que es de creación de la venta, ortogonal a
+ * "hoy"). Los catálogos (las 17 fases) se cargan desde
  * `dilesa.venta_fase_catalogo` (single source of truth — viene del Coda
  * original).
  *
@@ -40,6 +47,7 @@ import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { useUrlFilters } from '@/hooks/use-url-filters';
 import { deriveFasesKpis } from '@/lib/dilesa/kpis/fases';
 import { proximaFase } from '@/lib/dilesa/fases';
+import { fechaISOMatamoros } from '@/lib/fecha-mx';
 
 type Fase = {
   posicion: number;
@@ -63,6 +71,14 @@ type Unidad = {
   proyecto_id: string | null;
 };
 
+// Una fila de `dilesa.venta_fases` registrada con `fecha` = hoy: la venta entró
+// a `posicion` hoy. Cada avance es su propia fila, así que una venta que sube 3
+// fases en un día aporta a 3 posiciones distintas.
+type MovimientoFase = {
+  venta_id: string;
+  posicion: number | null;
+};
+
 const DEFAULT_FILTERS = {
   proyecto: '',
   vendedor: '',
@@ -84,6 +100,7 @@ function VentasFasesBody() {
 
   const [fases, setFases] = useState<Fase[]>([]);
   const [ventas, setVentas] = useState<Venta[]>([]);
+  const [movimientosHoy, setMovimientosHoy] = useState<MovimientoFase[]>([]);
   const [unidadProyecto, setUnidadProyecto] = useState<Map<string, string>>(new Map());
   const [proyectos, setProyectos] = useState<Array<{ id: string; nombre: string }>>([]);
   const [loading, setLoading] = useState(true);
@@ -94,7 +111,12 @@ function VentasFasesBody() {
     setError(null);
     const sb = createSupabaseBrowserClient();
 
-    const [fasesRes, ventasRes, unidadesRes, prjRes] = await Promise.all([
+    // "Hoy" = fecha calendario local de Matamoros (DST real). El campo
+    // `venta_fases.fecha` es un `date` capturado localmente, así que comparamos
+    // contra la misma fecha local — no contra el día UTC.
+    const hoyISO = fechaISOMatamoros(new Date());
+
+    const [fasesRes, ventasRes, movHoyRes, unidadesRes, prjRes] = await Promise.all([
       sb
         .schema('dilesa')
         .from('venta_fase_catalogo')
@@ -112,6 +134,13 @@ function VentasFasesBody() {
         .is('deleted_at', null),
       sb
         .schema('dilesa')
+        .from('venta_fases')
+        .select('venta_id, posicion')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null)
+        .eq('fecha', hoyISO),
+      sb
+        .schema('dilesa')
         .from('unidades')
         .select('id, proyecto_id')
         .eq('empresa_id', DILESA_EMPRESA_ID)
@@ -125,7 +154,8 @@ function VentasFasesBody() {
         .order('nombre', { ascending: true }),
     ]);
 
-    const firstErr = fasesRes.error ?? ventasRes.error ?? unidadesRes.error ?? prjRes.error;
+    const firstErr =
+      fasesRes.error ?? ventasRes.error ?? movHoyRes.error ?? unidadesRes.error ?? prjRes.error;
     if (firstErr) {
       setError(getSupabaseErrorMessage(firstErr, 'No se pudieron cargar las fases.'));
       setLoading(false);
@@ -134,6 +164,7 @@ function VentasFasesBody() {
 
     setFases((fasesRes.data ?? []) as Fase[]);
     setVentas((ventasRes.data ?? []) as Venta[]);
+    setMovimientosHoy((movHoyRes.data ?? []) as MovimientoFase[]);
     const m = new Map<string, string>();
     for (const u of (unidadesRes.data ?? []) as Unidad[]) {
       if (u.proyecto_id) m.set(u.id, u.proyecto_id);
@@ -194,6 +225,39 @@ function VentasFasesBody() {
   const totalActivas = useMemo(
     () => [...conteoPorFase.values()].reduce((s, n) => s + n, 0),
     [conteoPorFase]
+  );
+
+  // Ventas que pasan proyecto+vendedor (NO mes — el mes filtra por creación de
+  // la venta, ortogonal al movimiento de "hoy"). Acota el conteo del día para
+  // que cuadre con el chip "Ventas activas" cuando hay un proyecto/vendedor
+  // seleccionado.
+  const ventaIdsScope = useMemo(() => {
+    const set = new Set<string>();
+    for (const v of ventas) {
+      if (filters.proyecto) {
+        if (!v.unidad_id || unidadProyecto.get(v.unidad_id) !== filters.proyecto) continue;
+      }
+      if (filters.vendedor && v.vendedor !== filters.vendedor) continue;
+      set.add(v.id);
+    }
+    return set;
+  }, [ventas, filters.proyecto, filters.vendedor, unidadProyecto]);
+
+  // Movimiento del día por posición: filas de `venta_fases` con fecha = hoy,
+  // contadas por posición (cada avance cuenta), acotadas al scope de filtros.
+  const movHoyPorPosicion = useMemo(() => {
+    const m = new Map<number, number>();
+    for (const mov of movimientosHoy) {
+      if (mov.posicion == null) continue;
+      if (!ventaIdsScope.has(mov.venta_id)) continue;
+      m.set(mov.posicion, (m.get(mov.posicion) ?? 0) + 1);
+    }
+    return m;
+  }, [movimientosHoy, ventaIdsScope]);
+
+  const totalMovHoy = useMemo(
+    () => [...movHoyPorPosicion.values()].reduce((s, n) => s + n, 0),
+    [movHoyPorPosicion]
   );
 
   // KPIs sobre el dataset filtrado — ADR-034. Deriva del mismo array
@@ -299,13 +363,17 @@ function VentasFasesBody() {
         </button>
         <span className="ml-auto text-sm text-[var(--text)]/60">
           {totalActivas} ventas activas en pipeline
+          {totalMovHoy > 0 ? (
+            <span className="text-emerald-500"> · {totalMovHoy} movimiento(s) hoy</span>
+          ) : null}
         </span>
       </div>
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
         {fases.map((f) => {
           const cuenta = conteoPorFase.get(f.nombre) ?? 0;
-          return <FaseCard key={f.posicion} fase={f} cuenta={cuenta} />;
+          const movHoy = movHoyPorPosicion.get(f.posicion) ?? 0;
+          return <FaseCard key={f.posicion} fase={f} cuenta={cuenta} movHoy={movHoy} />;
         })}
       </div>
 
@@ -319,7 +387,7 @@ function VentasFasesBody() {
   );
 }
 
-function FaseCard({ fase, cuenta }: { fase: Fase; cuenta: number }) {
+function FaseCard({ fase, cuenta, movHoy }: { fase: Fase; cuenta: number; movHoy: number }) {
   const href = `/dilesa/ventas?fase=${encodeURIComponent(fase.nombre)}`;
   // "Lo que sigue por hacer" para las ventas en esta fase = la acción
   // (infinitivo) de la fase SIGUIENTE (posición + 1). null en la 17 (el final).
@@ -355,6 +423,15 @@ function FaseCard({ fase, cuenta }: { fase: Fase; cuenta: number }) {
         </span>
         <Badge tone={cuenta > 0 ? 'info' : 'neutral'}>{cuenta}</Badge>
       </div>
+      {movHoy > 0 ? (
+        <div
+          className="mt-1 flex items-baseline justify-between"
+          title="Movimiento del día — ventas que entraron a esta fase hoy"
+        >
+          <span className="text-[10px] uppercase tracking-wide text-[var(--text)]/40">Hoy</span>
+          <Badge tone="success">+{movHoy}</Badge>
+        </div>
+      ) : null}
     </Link>
   );
 }

--- a/components/dilesa/venta-detalle/ui.tsx
+++ b/components/dilesa/venta-detalle/ui.tsx
@@ -9,9 +9,9 @@
  * `dilesa-ventas-expediente-tabs`).
  */
 
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { ArrowLeft, Download, ExternalLink, FileText, Mail } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -29,13 +29,41 @@ import { formatearVencimiento, type HoldSnapshot } from '@/lib/dilesa/hold-cola'
 import { regresarAFase, desasignarVenta } from '@/app/dilesa/ventas/[id]/actions';
 import type { Adjunto } from './types';
 
+/**
+ * Back-link del expediente. Context-aware: si llegaste desde una fase
+ * (`/dilesa/ventas?fase=<X>` → fila → venta), regresa a la lista YA filtrada por
+ * esa fase ("Volver a Fase: X"); si no, vuelve al listado completo.
+ *
+ * El origen (`?fase=`) se captura UNA vez con `useState` lazy. El shell que
+ * monta este link vive en el layout `[id]`, que NO se re-monta al cambiar de tab
+ * (Operación↔Pipeline↔…) — así el origen sobrevive aunque los Links de tab
+ * borren el query. Se reinicia al navegar a otra venta (el layout sí re-monta).
+ */
 export function BackLink() {
   return (
+    <Suspense fallback={<BackLinkView origenFase={null} />}>
+      <BackLinkInner />
+    </Suspense>
+  );
+}
+
+function BackLinkInner() {
+  const searchParams = useSearchParams();
+  const [origenFase] = useState(() => searchParams.get('fase'));
+  return <BackLinkView origenFase={origenFase} />;
+}
+
+function BackLinkView({ origenFase }: { origenFase: string | null }) {
+  const href = origenFase
+    ? `/dilesa/ventas?fase=${encodeURIComponent(origenFase)}`
+    : '/dilesa/ventas';
+  return (
     <Link
-      href="/dilesa/ventas"
+      href={href}
       className="inline-flex items-center gap-1.5 text-sm text-[var(--text)]/60 hover:text-[var(--text)]"
     >
-      <ArrowLeft className="size-4" /> Volver a ventas
+      <ArrowLeft className="size-4" />{' '}
+      {origenFase ? `Volver a Fase: ${origenFase}` : 'Volver a ventas'}
     </Link>
   );
 }

--- a/components/dilesa/ventas-module.tsx
+++ b/components/dilesa/ventas-module.tsx
@@ -450,7 +450,10 @@ export function VentasModule({ empresaId }: { empresaId: string }) {
   ];
 
   const onRowClick = (v: VentaListaRow) => {
-    router.push(`/dilesa/ventas/${v.id}`);
+    // Si estás viendo la lista filtrada por una fase, propaga esa fase al
+    // detalle (`?fase=`) para que su back-link regrese aquí, a la misma fase.
+    const qs = faseFiltro ? `?fase=${encodeURIComponent(faseFiltro)}` : '';
+    router.push(`/dilesa/ventas/${v.id}${qs}`);
   };
 
   return (

--- a/lib/dilesa/resumen-consejo-email.test.ts
+++ b/lib/dilesa/resumen-consejo-email.test.ts
@@ -193,17 +193,22 @@ describe('renderResumenConsejoHtml — 4 secciones', () => {
     expect(html).toContain('Utilidad potencial total en inventario');
   });
 
-  it('renderiza el pipeline vivo y la línea de histórico aparte', () => {
+  it('renderiza el pipeline vivo (con movimiento del día) y la línea de histórico aparte', () => {
     const html = renderResumenConsejoHtml(
       {
         ...EMPTY,
-        tuberiaViva: [{ fase: 'Formalizada', clientes: 20, valor: 22000000 }],
+        tuberiaViva: [
+          { fase: 'Formalizada', clientes: 20, valor: 22000000, hoy: 3 },
+          { fase: 'Escriturada', clientes: 8, valor: 12000000, hoy: 0 },
+        ],
         tuberiaHistorico: { clientes: 1093, valor: 1060000000 },
       },
       { fechaTitulo: 'x' }
     );
     expect(html).toContain('Pipeline de Ventas (vivo)');
     expect(html).toContain('Formalizada');
+    expect(html).toContain('Movimiento del día');
+    expect(html).toContain('+3'); // entradas de hoy a Formalizada
     expect(html).toContain('Histórico acumulado: 1,093 operaciones');
   });
 
@@ -262,7 +267,7 @@ describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
     ]);
     // Solo la fase con clientes vivos; las fases en 0 se filtran del funnel.
     // `valor_escrituracion` tiene precedencia sobre `precio_asignacion` (el 9999 se ignora).
-    expect(viva).toEqual([{ fase: 'Asignada', clientes: 2, valor: 1500 }]);
+    expect(viva).toEqual([{ fase: 'Asignada', clientes: 2, valor: 1500, hoy: 0 }]);
     expect(historico).toEqual({ clientes: 2, valor: 3000 });
   });
 
@@ -282,7 +287,7 @@ describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
       },
     ]);
     // 800 (fallback a precio_asignacion) + 1200 (valor_escrituracion gana) = 2000.
-    expect(viva).toEqual([{ fase: 'Asignada', clientes: 2, valor: 2000 }]);
+    expect(viva).toEqual([{ fase: 'Asignada', clientes: 2, valor: 2000, hoy: 0 }]);
   });
 
   it('junta en "Sin fase asignada" las activas con fase NULL o fuera de catálogo', () => {
@@ -295,7 +300,12 @@ describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
         precio_asignacion: null,
       },
     ]);
-    expect(viva[viva.length - 1]).toEqual({ fase: 'Sin fase asignada', clientes: 2, valor: 700 });
+    expect(viva[viva.length - 1]).toEqual({
+      fase: 'Sin fase asignada',
+      clientes: 2,
+      valor: 700,
+      hoy: 0,
+    });
   });
 
   it('excluye desasignadas/expiradas: no entran ni al funnel ni al histórico', () => {
@@ -315,6 +325,28 @@ describe('armarTuberiaSplit — pipeline vivo vs histórico', () => {
     ]);
     expect(viva).toEqual([]);
     expect(historico).toEqual({ clientes: 0, valor: 0 });
+  });
+
+  it('anota el movimiento del día por posición de fase', () => {
+    const movHoy = new Map<number, number>([
+      [2, 3], // 3 ventas entraron a Asignada (pos 2) hoy
+      [1, 1], // 1 entró a Asignación Solicitada (pos 1) — sin clientes vivos, no aparece
+    ]);
+    const { viva } = armarTuberiaSplit(
+      CAT,
+      [
+        {
+          estado: 'activa',
+          fase_actual: 'Asignada',
+          valor_escrituracion: 1000,
+          precio_asignacion: null,
+        },
+      ],
+      movHoy
+    );
+    // El movimiento se anota en la fila por posición; pos 1 no tiene clientes
+    // vivos, así que su movimiento no aparece en el funnel (lo muestra el módulo Fases).
+    expect(viva).toEqual([{ fase: 'Asignada', clientes: 1, valor: 1000, hoy: 3 }]);
   });
 });
 

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -17,6 +17,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { KpisDelDia } from './resumen-consejo-kpis';
+import { fechaISOMatamoros } from '@/lib/fecha-mx';
 
 // ── Tipos por sección ───────────────────────────────────────────────────────
 
@@ -53,6 +54,8 @@ export type TuberiaRow = {
   fase: string;
   clientes: number;
   valor: number;
+  /** Ventas que ENTRARON a esta fase hoy (movimiento del día). */
+  hoy: number;
 };
 
 export type VentaTuberiaInput = {
@@ -70,10 +73,17 @@ export type VentaTuberiaInput = {
  * asignada" para las activas con fase NULL o con grafía fuera de catálogo (así
  * la tubería nunca pierde clientes en silencio). Las desasignadas/expiradas no
  * cuentan: son ventas caídas.
+ *
+ * `movHoyPorPos` = movimiento del día por posición de fase (filas de
+ * `venta_fases` con fecha = hoy). Se anota en cada fila viva. Nota: el funnel
+ * solo lista fases con clientes vivos, así que un movimiento a una fase que ya
+ * quedó en cero vivos (entró y avanzó el mismo día) no aparece aquí — el módulo
+ * Fases sí lo muestra (lista las 17 siempre).
  */
 export function armarTuberiaSplit(
   fasesCat: { nombre: string; posicion: number }[],
-  ventas: VentaTuberiaInput[]
+  ventas: VentaTuberiaInput[],
+  movHoyPorPos: ReadonlyMap<number, number> = new Map()
 ): { viva: TuberiaRow[]; historico: { clientes: number; valor: number } } {
   const orden = [...fasesCat].sort((a, b) => a.posicion - b.posicion);
   const conocidas = new Set(orden.map((f) => f.nombre));
@@ -107,12 +117,18 @@ export function armarTuberiaSplit(
       fase: f.nombre,
       clientes: porFase.get(f.nombre)?.clientes ?? 0,
       valor: porFase.get(f.nombre)?.valor ?? 0,
+      hoy: movHoyPorPos.get(f.posicion) ?? 0,
     }))
     // Solo fases con clientes vivos — el funnel muestra dónde están las ventas,
     // no las 17 etapas en cero.
     .filter((r) => r.clientes > 0);
   if (sinFase.clientes > 0) {
-    viva.push({ fase: 'Sin fase asignada', clientes: sinFase.clientes, valor: sinFase.valor });
+    viva.push({
+      fase: 'Sin fase asignada',
+      clientes: sinFase.clientes,
+      valor: sinFase.valor,
+      hoy: 0,
+    });
   }
   return { viva, historico };
 }
@@ -613,8 +629,14 @@ function renderTuberiaViva(rows: TuberiaRow[]): string {
       { label: 'Fase' },
       { label: 'Clientes', align: 'right' },
       { label: 'Valor de escrituración', align: 'right' },
+      { label: 'Movimiento del día', align: 'right' },
     ],
-    rows.map((r) => [r.fase, fmtInt(r.clientes), fmtMoney(r.valor)])
+    rows.map((r) => [
+      r.fase,
+      fmtInt(r.clientes),
+      fmtMoney(r.valor),
+      r.hoy > 0 ? `+${fmtInt(r.hoy)}` : '—',
+    ])
   );
 }
 
@@ -879,6 +901,10 @@ export async function fetchResumenConsejoData(
   const inicioMes = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
     .toISOString()
     .slice(0, 10);
+  // "Hoy" = fecha calendario local de Matamoros (el correo sale a las 20:00
+  // locales, ya con el día consumido). `venta_fases.fecha` es un `date` local,
+  // así que comparamos contra la misma fecha local — no contra el día UTC.
+  const hoyISO = fechaISOMatamoros(now);
   // Ventana de absorción: 3 meses móviles hasta hoy.
   const inicio3m = new Date(
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - ABSORCION_VENTANA_MESES, now.getUTCDate())
@@ -898,6 +924,7 @@ export async function fetchResumenConsejoData(
     contratistaRes,
     saldosRes,
     asign3mRes,
+    movHoyRes,
   ] = await Promise.all([
     dilesa.from('proyectos').select('id,nombre').eq('empresa_id', empresaId).is('deleted_at', null),
     dilesa.from('v_proyecto_avances').select('*').eq('empresa_id', empresaId),
@@ -932,6 +959,12 @@ export async function fetchResumenConsejoData(
       .is('deleted_at', null)
       .eq('posicion', 2)
       .gte('fecha', inicio3m),
+    dilesa
+      .from('venta_fases')
+      .select('posicion')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .eq('fecha', hoyISO),
   ]);
 
   const proyNombre = new Map<string, string>(
@@ -970,10 +1003,18 @@ export async function fetchResumenConsejoData(
     protoNombre
   );
 
+  // Movimiento del día por posición: filas de `venta_fases` con fecha = hoy.
+  const movHoyPorPos = new Map<number, number>();
+  for (const r of (movHoyRes.data ?? []) as { posicion: number | null }[]) {
+    if (r.posicion == null) continue;
+    movHoyPorPos.set(r.posicion, (movHoyPorPos.get(r.posicion) ?? 0) + 1);
+  }
+
   // Tubería: pipeline vivo (activas por fase) + línea de histórico (terminadas).
   const { viva: tuberiaViva, historico: tuberiaHistorico } = armarTuberiaSplit(
     (fasesCatRes.data ?? []) as { nombre: string; posicion: number }[],
-    (ventasRes.data ?? []) as VentaTuberiaInput[]
+    (ventasRes.data ?? []) as VentaTuberiaInput[],
+    movHoyPorPos
   );
 
   // Asignaciones/escrituras del mes: por venta_fases del mes, agrupadas por prototipo.

--- a/lib/fecha-mx.test.ts
+++ b/lib/fecha-mx.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { fechaISOMatamoros } from './fecha-mx';
+
+describe('fechaISOMatamoros', () => {
+  it('invierno (CST, UTC-6): a las 20:00 locales el día UTC ya avanzó, pero la fecha local es la de hoy', () => {
+    // 2026-01-15 02:30 UTC = 2026-01-14 20:30 en Matamoros (CST).
+    expect(fechaISOMatamoros(new Date('2026-01-15T02:30:00Z'))).toBe('2026-01-14');
+  });
+
+  it('verano (CDT, UTC-5): mismo cruce de medianoche con el offset de verano', () => {
+    // 2026-07-15 01:30 UTC = 2026-07-14 20:30 en Matamoros (CDT).
+    expect(fechaISOMatamoros(new Date('2026-07-15T01:30:00Z'))).toBe('2026-07-14');
+  });
+
+  it('media tarde resuelve al día correcto en verano', () => {
+    // 2026-06-26 18:00 UTC = 2026-06-26 13:00 en Matamoros (CDT, UTC-5).
+    expect(fechaISOMatamoros(new Date('2026-06-26T18:00:00Z'))).toBe('2026-06-26');
+  });
+
+  it('justo antes de medianoche local (invierno) cae en el día correcto', () => {
+    // 2026-02-10 05:30 UTC = 2026-02-09 23:30 en Matamoros (CST, UTC-6).
+    expect(fechaISOMatamoros(new Date('2026-02-10T05:30:00Z'))).toBe('2026-02-09');
+  });
+});

--- a/lib/fecha-mx.ts
+++ b/lib/fecha-mx.ts
@@ -1,0 +1,23 @@
+/**
+ * Fecha calendario (YYYY-MM-DD) en horario local de Matamoros, con DST real.
+ *
+ * Matamoros es zona fronteriza y SÍ observa horario de verano (CDT, UTC-5) e
+ * invierno (CST, UTC-6) siguiendo a EE.UU.; por eso no usamos un offset fijo —
+ * `Intl` resuelve el offset correcto según la fecha. El locale `en-CA` formatea
+ * la fecha como `YYYY-MM-DD`, justo el shape que comparamos contra columnas
+ * `date` capturadas localmente (p.ej. la fecha de entrada a una fase en
+ * `dilesa.venta_fases`).
+ *
+ * Es el complemento de `relojMatamoros` (que da hora/día de semana): este da la
+ * fecha calendario. Crítico cerca de medianoche local — a las 20:00 de Matamoros
+ * el `Date` en UTC ya es el día siguiente, así que un `toISOString().slice(0,10)`
+ * daría "mañana". Cf. memoria `reference_vercel_cron_dst_matamoros`.
+ */
+export function fechaISOMatamoros(d: Date): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Matamoros',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d);
+}


### PR DESCRIPTION
Dos mejoras al módulo de **Fases** (DILESA), pedidas por Beto.

## 1. Movimiento del día
Cada card de fase suma un chip **"Hoy +N"** con cuántas ventas *entraron* a esa fase hoy. Se cuenta de `dilesa.venta_fases` (una fila por fase alcanzada, con su `fecha`), agrupando por `posicion` con `fecha = hoy` (fecha local de Matamoros, DST real). Como cada avance es su propia fila, una venta que sube 3 fases en un día suma +1 en cada una.

- Respeta los filtros de **proyecto/vendedor** (cuadra con "Ventas activas"); ignora el de **mes** (que es de creación de la venta, ortogonal a "hoy").
- La barra superior muestra el total: `… · N movimiento(s) hoy`.
- La **misma cifra** alimenta una columna nueva **"Movimiento del día"** en la tabla *Pipeline de Ventas (vivo)* del correo al Consejo (sale 20:00 de Matamoros, con el día ya consumido → "hoy" tiene sentido).

## 2. Back-link contextual a la fase
Hoy el botón del expediente es un *"Volver a ventas"* fijo. Ahora, si llegas a una venta **desde una fase** (`/dilesa/ventas?fase=X` → fila → venta), el botón dice **"Volver a Fase: X"** y regresa a la lista ya filtrada por esa fase. Si no vienes de una fase, queda igual.

El origen (`?fase=`) se captura una vez con `useState` lazy y **sobrevive a los cambios de tab** del expediente (Operación↔Pipeline↔…) porque el layout `[id]` no se re-monta; se reinicia al cambiar de venta.

## Archivos
- `lib/fecha-mx.ts` (+test) — fecha calendario local de Matamoros con DST real (complementa `relojMatamoros`).
- `app/dilesa/ventas/fases/page.tsx` — query de movimiento del día + chip + total.
- `lib/dilesa/resumen-consejo-email.ts` (+test) — columna "Movimiento del día" en el pipeline vivo.
- `components/dilesa/venta-detalle/ui.tsx` — `BackLink` context-aware.
- `components/dilesa/ventas-module.tsx` — propaga `?fase=` al abrir la venta.

## Verificación local (6 checks de CI)
typecheck ✓ · test:coverage ✓ (2104 tests) · lint ✓ · format:check ✓ · initiatives:check ✓ · schema:check N/A (sin cambios de DB/migraciones/SCHEMA_REF/types).

**Sin auto-merge** — hay UI visible (cards del módulo Fases + back-link). Revisa el Vercel Preview y mergea cuando te cuadre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)