### PR TITLE
feat(dilesa-autoguardado-captura): autoguardado fases 3 y 5 (Sprint 2)

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
@@ -34,6 +34,10 @@ import {
   useDocsFaseColaborativos,
   type SlotColaborativo,
 } from '@/components/dilesa/captura/docs-fase-colaborativos';
+import {
+  IndicadorAutoguardado,
+  useAutoguardadoCampos,
+} from '@/components/dilesa/captura/autoguardado-campos';
 
 const SLOTS_FASE: SlotColaborativo[] = [
   {
@@ -79,6 +83,10 @@ function CapturarFase3Body() {
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
 
   const [descuentoTotal, setDescuentoTotal] = useState<string>('');
+  // Autoguardado (ADR-051): firma del descuento persistido (arranca = lo cargado).
+  // Solo el descuento autoguarda — la fecha del contrato va a venta_fases.notas al
+  // avanzar (sin columna en dilesa.ventas), así que no tiene destino directo.
+  const [descuentoGuardado, setDescuentoGuardado] = useState<string>('');
   const [fechaContrato, setFechaContrato] = useState<string>(new Date().toISOString().slice(0, 10));
   const docsFase = useDocsFaseColaborativos(ventaId, SLOTS_FASE);
 
@@ -115,7 +123,10 @@ function CapturarFase3Body() {
       }
       const v = vRow as unknown as VentaCtx;
       setVenta(v);
-      if (v.descuento_total != null) setDescuentoTotal(String(v.descuento_total));
+      if (v.descuento_total != null) {
+        setDescuentoTotal(String(v.descuento_total));
+        setDescuentoGuardado(String(v.descuento_total));
+      }
 
       // Enforcement: Fase 2 cerrada + Fase 3 no cerrada.
       const { data: fRows } = await sb
@@ -137,6 +148,32 @@ function CapturarFase3Body() {
       activo = false;
     };
   }, [ventaId, sb]);
+
+  // ── Autoguardado del descuento (ADR-051, vía RPC auditada D3) ────
+  // El descuento persiste al cambiarlo, por la MISMA RPC que el cierre
+  // (`fn_actualizar_descuentos_venta`) — registra cada cambio en el audit_log,
+  // no salta el rastro. La fecha del contrato NO autoguarda (va a notas al avanzar).
+  const auto = useAutoguardadoCampos({
+    clave: descuentoTotal,
+    claveGuardada: descuentoGuardado,
+    habilitado: !!venta && !yaCerrada,
+    guardar: async () => {
+      if (!venta) return { ok: false };
+      const descuento = descuentoTotal.trim() ? Number(descuentoTotal) : 0;
+      const { error: descErr } = await sb.schema('dilesa').rpc('fn_actualizar_descuentos_venta', {
+        p_venta_id: venta.id,
+        p_descuento_total: descuento,
+        p_motivo: 'Autoguardado en Formalizada (Fase 3)',
+      });
+      if (descErr)
+        return {
+          ok: false,
+          error: getSupabaseErrorMessage(descErr, 'No se pudo guardar el descuento.'),
+        };
+      setDescuentoGuardado(descuentoTotal);
+      return { ok: true };
+    },
+  });
 
   // ── Submit ─────────────────────────────────────────────────────────
   const onSubmit = useCallback(
@@ -290,7 +327,10 @@ function CapturarFase3Body() {
         <form onSubmit={onSubmit} className="space-y-6">
           <DocsFaseSection state={docsFase} />
 
-          <Section title="Campos requeridos">
+          <Section
+            title="Campos requeridos"
+            accion={<IndicadorAutoguardado estado={auto.estado} error={auto.error} />}
+          >
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Field label="Precio de asignación">
                 <div className="flex h-9 items-center rounded-md border border-[var(--border)] bg-[var(--bg)]/30 px-3 text-sm font-medium tabular-nums text-[var(--text)]">
@@ -345,12 +385,23 @@ function CapturarFase3Body() {
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  accion,
+  children,
+}: {
+  title: string;
+  accion?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
-      <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
-        {title}
-      </h2>
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {accion}
+      </div>
       {children}
     </section>
   );

--- a/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
@@ -45,6 +45,10 @@ import {
   useDocsFaseColaborativos,
   type SlotColaborativo,
 } from '@/components/dilesa/captura/docs-fase-colaborativos';
+import {
+  IndicadorAutoguardado,
+  useAutoguardadoCampos,
+} from '@/components/dilesa/captura/autoguardado-campos';
 import { requiereSeguroCalidad } from '@/lib/dilesa/captura/fase-roles';
 
 type VentaCtx = {
@@ -116,6 +120,11 @@ function CapturarFase5Body() {
   const docsFase = useDocsFaseColaborativos(ventaId, slotsF5);
   const [montoAvaluo, setMontoAvaluo] = useState<string>('');
   const [fechaAvaluo, setFechaAvaluo] = useState<string>(new Date().toISOString().slice(0, 10));
+  // Autoguardado (ADR-051): firma de lo último persistido (arranca = lo cargado).
+  const [guardado, setGuardado] = useState<{ monto: string; fecha: string }>({
+    monto: '',
+    fecha: new Date().toISOString().slice(0, 10),
+  });
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -152,9 +161,14 @@ function CapturarFase5Body() {
       }
       const v = vRow as unknown as VentaCtx;
       setVenta(v);
-      if (v.monto_avaluo != null) setMontoAvaluo(String(v.monto_avaluo));
+      const montoCargado = v.monto_avaluo != null ? String(v.monto_avaluo) : '';
       // En corrección (fase ya cerrada) mostramos la fecha real del cierre, no hoy.
-      if (v.fecha_avaluo_cerrado) setFechaAvaluo(v.fecha_avaluo_cerrado.slice(0, 10));
+      const fechaCargada = v.fecha_avaluo_cerrado
+        ? v.fecha_avaluo_cerrado.slice(0, 10)
+        : new Date().toISOString().slice(0, 10);
+      if (v.monto_avaluo != null) setMontoAvaluo(montoCargado);
+      if (v.fecha_avaluo_cerrado) setFechaAvaluo(fechaCargada);
+      setGuardado({ monto: montoCargado, fecha: fechaCargada });
 
       const [fRes, valRes] = await Promise.all([
         sb
@@ -194,6 +208,30 @@ function CapturarFase5Body() {
       activo = false;
     };
   }, [ventaId, sb]);
+
+  // ── Autoguardado (ADR-051) ──────────────────────────────────────
+  // Monto + fecha del avalúo persisten al cambiarlos (UPDATE directo, igual que el
+  // cierre vía marcarFase). Solo PRE-cierre: en corrección (fase ya cerrada) la
+  // escritura va por la RPC auditada `fn_corregir_avaluo_venta` con su propio botón.
+  const auto = useAutoguardadoCampos({
+    clave: JSON.stringify({ monto: montoAvaluo, fecha: fechaAvaluo }),
+    claveGuardada: JSON.stringify(guardado),
+    habilitado: !!venta && !yaCerrada,
+    guardar: async () => {
+      if (!venta) return { ok: false };
+      const { error: upErr } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .update({
+          monto_avaluo: montoAvaluo.trim() ? Number(montoAvaluo) : null,
+          fecha_avaluo_cerrado: fechaAvaluo || null,
+        })
+        .eq('id', venta.id);
+      if (upErr) return { ok: false, error: getSupabaseErrorMessage(upErr, 'No se pudo guardar.') };
+      setGuardado({ monto: montoAvaluo, fecha: fechaAvaluo });
+      return { ok: true };
+    },
+  });
 
   // ── Submit ───────────────────────────────────────────────────────
   const onSubmit = useCallback(
@@ -353,7 +391,12 @@ function CapturarFase5Body() {
 
           <DocsFaseSection state={docsFase} titulo="Documentos" />
 
-          <Section title="Datos del avalúo">
+          <Section
+            title="Datos del avalúo"
+            accion={
+              yaCerrada ? null : <IndicadorAutoguardado estado={auto.estado} error={auto.error} />
+            }
+          >
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Field label="Monto del avalúo *">
                 <Input
@@ -403,12 +446,23 @@ function CapturarFase5Body() {
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  accion,
+  children,
+}: {
+  title: string;
+  accion?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
-      <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
-        {title}
-      </h2>
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {accion}
+      </div>
       {children}
     </section>
   );


### PR DESCRIPTION
## Sprint 2 — fases con RPC auditada / financieras

Continúa `dilesa-autoguardado-captura` ([ADR-051](docs/adr/051_autoguardado_campos_captura_fase.md)).

- **Fase 3 (Formalizada)** — el **descuento** autoguarda al cambiarlo, por la **misma RPC auditada** que el cierre (`fn_actualizar_descuentos_venta`): registra cada cambio en el `audit_log`, no salta el rastro (ADR-051 D3). La **fecha del contrato no autoguarda** — va a `venta_fases.notas` al avanzar, sin columna en `dilesa.ventas`.
- **Fase 5 (Avalúo Cerrado)** — **monto + fecha del avalúo** autoguardan (UPDATE directo pre-cierre, igual que el cierre vía `marcarFase`). En **corrección post-cierre** se mantiene la RPC auditada `fn_corregir_avaluo_venta` con su botón (el autoguardado solo aplica `!yaCerrada`).

**Nota financiera:** el autoguardado del descuento genera una entrada de `audit_log` por cada pausa de tecleo — el cambio queda auditado (deseable), apenas más verboso. Las cifras siguen pasando por su RPC/UPDATE existente; no se cambió la lógica de escritura, solo el momento.

**Sin cambios de schema.** typecheck · lint · format · 2104 tests — verdes. El smoke Playwright de captura (mergeado en #1078) ya cubre estas páginas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)