### PR TITLE
feat(dilesa-autoguardado-captura): autoguardado fases 6 y 12 (Sprint 3a)

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
@@ -42,6 +42,10 @@ import {
   useDocsFaseColaborativos,
   type SlotColaborativo,
 } from '@/components/dilesa/captura/docs-fase-colaborativos';
+import {
+  IndicadorAutoguardado,
+  useAutoguardadoCampos,
+} from '@/components/dilesa/captura/autoguardado-campos';
 
 const SLOTS_FASE: SlotColaborativo[] = [
   { rol: 'imagen_detonacion', label: 'Comprobante de transferencia/depósito', requerido: true },
@@ -93,6 +97,11 @@ function CapturarFase12Body() {
     new Date().toISOString().slice(0, 10)
   );
   const [montoDetonado, setMontoDetonado] = useState<string>('');
+  // Autoguardado (ADR-051): firma de lo persistido (arranca = lo cargado).
+  const [guardado, setGuardado] = useState<{ fecha: string; monto: string }>({
+    fecha: new Date().toISOString().slice(0, 10),
+    monto: '',
+  });
   const docsFase = useDocsFaseColaborativos(ventaId, SLOTS_FASE);
 
   const [loading, setLoading] = useState(true);
@@ -130,6 +139,10 @@ function CapturarFase12Body() {
       setVenta(v);
       if (v.fecha_detonacion) setFechaDetonacion(v.fecha_detonacion);
       if (v.monto_detonado != null) setMontoDetonado(String(v.monto_detonado));
+      setGuardado({
+        fecha: v.fecha_detonacion ?? new Date().toISOString().slice(0, 10),
+        monto: v.monto_detonado != null ? String(v.monto_detonado) : '',
+      });
 
       const { data: fRows } = await sb
         .schema('dilesa')
@@ -150,6 +163,29 @@ function CapturarFase12Body() {
       activo = false;
     };
   }, [ventaId, sb]);
+
+  // ── Autoguardado (ADR-051) ──────────────────────────────────────
+  // Fecha + monto de detonación persisten al cambiarlos. SOLO Dirección (el form
+  // de captura manual solo se le muestra a Dirección; el resto ve la guía de cobranza).
+  const auto = useAutoguardadoCampos({
+    clave: JSON.stringify({ fecha: fechaDetonacion, monto: montoDetonado }),
+    claveGuardada: JSON.stringify(guardado),
+    habilitado: !!venta && !yaCerrada && esDireccion,
+    guardar: async () => {
+      if (!venta) return { ok: false };
+      const { error: upErr } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .update({
+          fecha_detonacion: fechaDetonacion || null,
+          monto_detonado: montoDetonado.trim() ? Number(montoDetonado) : null,
+        })
+        .eq('id', venta.id);
+      if (upErr) return { ok: false, error: getSupabaseErrorMessage(upErr, 'No se pudo guardar.') };
+      setGuardado({ fecha: fechaDetonacion, monto: montoDetonado });
+      return { ok: true };
+    },
+  });
 
   // ── Submit ───────────────────────────────────────────────────────
   const onSubmit = useCallback(
@@ -300,7 +336,10 @@ function CapturarFase12Body() {
 
           <DocsFaseSection state={docsFase} titulo="Comprobante del depósito" />
 
-          <Section title="Datos de la detonación">
+          <Section
+            title="Datos de la detonación"
+            accion={<IndicadorAutoguardado estado={auto.estado} error={auto.error} />}
+          >
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Field label="Fecha de detonación *">
                 <Input
@@ -379,12 +418,23 @@ function GuiaCobranza({ ventaId }: { ventaId: string }) {
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  accion,
+  children,
+}: {
+  title: string;
+  accion?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
-      <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
-        {title}
-      </h2>
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {accion}
+      </div>
       {children}
     </section>
   );

--- a/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
@@ -44,6 +44,10 @@ import {
   useDocsFaseColaborativos,
   type SlotColaborativo,
 } from '@/components/dilesa/captura/docs-fase-colaborativos';
+import {
+  IndicadorAutoguardado,
+  useAutoguardadoCampos,
+} from '@/components/dilesa/captura/autoguardado-campos';
 
 type VentaCtx = {
   id: string;
@@ -97,6 +101,9 @@ function CapturarFase6Body() {
   const [fechaInscripcion, setFechaInscripcion] = useState<string>(
     new Date().toISOString().slice(0, 10)
   );
+  // Autoguardado (ADR-051): firma de los campos de crédito persistidos (arranca =
+  // lo cargado). La fecha de inscripción NO autoguarda (va a venta_fases.notas).
+  const [guardado, setGuardado] = useState({ montoTit: '', montoCo: '', refTit: '', refCo: '' });
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -141,6 +148,12 @@ function CapturarFase6Body() {
       }
       if (v.credito_titular_ref) setCreditoTitularRef(v.credito_titular_ref);
       if (v.credito_cotitular_ref) setCreditoCotitularRef(v.credito_cotitular_ref);
+      setGuardado({
+        montoTit: v.monto_credito_titular != null ? String(v.monto_credito_titular) : '',
+        montoCo: v.monto_credito_cotitular != null ? String(v.monto_credito_cotitular) : '',
+        refTit: v.credito_titular_ref ?? '',
+        refCo: v.credito_cotitular_ref ?? '',
+      });
 
       const { data: fRows } = await sb
         .schema('dilesa')
@@ -187,6 +200,41 @@ function CapturarFase6Body() {
     [requiereTitular, requiereCotitular]
   );
   const docsFase = useDocsFaseColaborativos(ventaId, slotsConstancias);
+
+  // ── Autoguardado (ADR-051) ──────────────────────────────────────
+  // Montos y referencias de crédito persisten al cambiarlos (UPDATE directo). La
+  // fecha de inscripción no autoguarda (va a venta_fases.notas al avanzar).
+  const auto = useAutoguardadoCampos({
+    clave: JSON.stringify({
+      montoTit: montoTitular,
+      montoCo: montoCotitular,
+      refTit: creditoTitularRef,
+      refCo: creditoCotitularRef,
+    }),
+    claveGuardada: JSON.stringify(guardado),
+    habilitado: !!venta && !yaCerrada,
+    guardar: async () => {
+      if (!venta) return { ok: false };
+      const { error: upErr } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .update({
+          monto_credito_titular: montoTitular.trim() ? Number(montoTitular) : null,
+          monto_credito_cotitular: montoCotitular.trim() ? Number(montoCotitular) : null,
+          credito_titular_ref: creditoTitularRef.trim() || null,
+          credito_cotitular_ref: creditoCotitularRef.trim() || null,
+        })
+        .eq('id', venta.id);
+      if (upErr) return { ok: false, error: getSupabaseErrorMessage(upErr, 'No se pudo guardar.') };
+      setGuardado({
+        montoTit: montoTitular,
+        montoCo: montoCotitular,
+        refTit: creditoTitularRef,
+        refCo: creditoCotitularRef,
+      });
+      return { ok: true };
+    },
+  });
 
   // ── Submit ───────────────────────────────────────────────────────
   const onSubmit = useCallback(
@@ -341,7 +389,10 @@ function CapturarFase6Body() {
             <DocsFaseSection state={docsFase} titulo="Constancias de crédito" />
           )}
 
-          <Section title="Montos aprobados por el banco">
+          <Section
+            title="Montos aprobados por el banco"
+            accion={<IndicadorAutoguardado estado={auto.estado} error={auto.error} />}
+          >
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Field label={`Monto Crédito Titular${sinCredito ? '' : ' *'}`}>
                 <Input
@@ -420,12 +471,23 @@ function CapturarFase6Body() {
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  accion,
+  children,
+}: {
+  title: string;
+  accion?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <section className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
-      <h2 className="mb-3 text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
-        {title}
-      </h2>
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--text)]/60">
+          {title}
+        </h2>
+        {accion}
+      </div>
       {children}
     </section>
   );


### PR DESCRIPTION
Continúa `dilesa-autoguardado-captura` (ADR-051).

- **Fase 6 (Inscrita)** — montos + referencias de crédito (titular/co-titular) autoguardan al cambiarlos (UPDATE directo). La fecha de inscripción no autoguarda (va a `venta_fases.notas` al avanzar).
- **Fase 12 (Detonada)** — fecha + monto de detonación autoguardan, **solo para Dirección** (el form de captura manual solo se le muestra a Dirección; el resto ve la guía de cobranza). El autoguardado hereda ese gate.

Falta del rollout: fase **16** (encuesta → `venta_encuestas`) y fase **8** (la delicada: Gerencia autoguarda los datos del dictamen, Dirección cierra) en el PR final + consolidación del planning.

Sin cambios de schema. typecheck · lint · format · tests verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)