### PR TITLE
feat(derivados-sin-drift): Sprint 2 — INITIATIVES fuera del PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,14 @@ jobs:
       - name: Prettier — check
         run: npm run format:check
 
-      # Verifica que docs/strategy/INITIATIVES.md (tabla Activas) sigue en sync
-      # con los headers de docs/planning/*.md. Si alguien editó la tabla a mano,
-      # o promovió/cambió el estado de una iniciativa sin correr el generador,
-      # este step falla y pide correr `npm run initiatives:gen`. No necesita
-      # secrets — solo lee archivos del repo. Iniciativa cross-session-coordination.
-      - name: Initiatives index — drift check
-        run: npm run initiatives:check
+      # Valida los HEADERS de docs/planning/*.md (slug == archivo, y que cada
+      # iniciativa activa tenga nombre/Empresas/Schemas/Próximo hito/Última
+      # actualización). NO compara la tabla `## Activas` de INITIATIVES.md: esa
+      # se regenera en `main` post-merge (initiatives-regen.yml), no en las
+      # ramas — así INITIATIVES.md deja de ser hotspot de conflictos entre
+      # sesiones (iniciativa derivados-sin-drift, Sprint 2). Solo lee archivos.
+      - name: Initiatives headers — validate
+        run: npm run initiatives:validate
 
       # El drift de SCHEMA_REF se valida en el workflow `schema-check.yml`
       # (iniciativa derivados-sin-drift): regenera contra una shadow DB

--- a/.github/workflows/initiatives-regen.yml
+++ b/.github/workflows/initiatives-regen.yml
@@ -1,0 +1,70 @@
+name: Initiatives Index Regen
+
+# Regenera la tabla `## Activas` de docs/strategy/INITIATIVES.md desde los
+# headers de docs/planning/*.md, en `main` post-merge (iniciativa
+# `derivados-sin-drift`, Sprint 2).
+#
+# Por qué: la tabla es un DERIVADO. Antes las ramas la regeneraban y commiteaban
+# (`initiatives:check`), volviéndola un hotspot de conflictos de merge entre
+# sesiones paralelas. Ahora las ramas solo editan el header de su planning doc
+# (el check de PR es `initiatives:validate`, que valida headers sin tocar la
+# tabla) y ESTE workflow la regenera en `main`. Las ramas dejan de chocar.
+#
+# Hace commit directo a `main` con `[skip ci]`. Si branch protection bloquea el
+# push del bot, lo deja en ::warning:: con la config necesaria (no falla rojo).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/planning/**'
+      - 'scripts/gen-initiatives.ts'
+      - 'scripts/lib/initiatives.ts'
+  workflow_dispatch:
+
+concurrency:
+  group: initiatives-regen
+  cancel-in-progress: false
+
+jobs:
+  regen:
+    name: Regenerar tabla Activas en main
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Regenerar la tabla Activas
+        run: npm run initiatives:gen
+
+      - name: Commitear si la tabla cambió
+        run: |
+          if git diff --quiet -- docs/strategy/INITIATIVES.md; then
+            echo "Tabla Activas ya al día — nada que commitear."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/strategy/INITIATIVES.md
+          git commit -m "chore(initiatives): regenera la tabla Activas desde los headers [skip ci]"
+          if git push; then
+            echo "✓ Tabla Activas actualizada en main."
+          else
+            echo "::warning::No pude pushear la tabla regenerada a main (branch protection)."
+            echo "Para habilitar el auto-regen: agregá 'github-actions[bot]' a la bypass list"
+            echo "de la regla de protección de main, o configurá un PAT. Mientras tanto, la"
+            echo "tabla se puede regenerar local con 'npm run initiatives:gen' (es solo cosmética)."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,15 +146,19 @@ al arrancar (no hay candado global):
   timestamp mayor que toda migración existente, local **y en los PRs abiertos de
   otras sesiones** (las ve vía `gh`). Residual: dos sesiones en el mismo segundo
   antes de abrir su PR → **abre tu PR pronto**.
-- **Regla 1 — la tabla `## Activas` se auto-genera; NO la edites a mano.** Editá
-  solo el header de tu planning doc (`Estado`/`Próximo hito`/`Última
-actualización`), corré `npm run initiatives:gen`, y commiteá el `INITIATIVES.md`
-  regenerado junto con tu cambio. La región entre `<!-- initiatives:activas:start
--->` y `<!-- …:end -->` la sobrescribe el generador. Toda iniciativa activa
-  debe tener `**Próximo hito:**` o `initiatives:check` falla en CI. La sección
-  `## Done` y el resto del archivo se mantienen a mano. Promover = crear el
-  planning doc con header completo + correr el generador (ya no se agrega fila a
-  mano).
+- **Regla 1 — la tabla `## Activas` se regenera en `main`, NO en tu rama**
+  (modelo `derivados-sin-drift` S2). Editá **solo el header** de tu planning doc
+  (`Estado`/`Próximo hito`/`Última actualización`). **No corras `initiatives:gen`
+  ni commitees la tabla de `INITIATIVES.md` en tu rama** — la regenera el workflow
+  `initiatives-regen.yml` post-merge. El check de PR es **`initiatives:validate`**:
+  valida los headers (slug == archivo; toda activa con `**Próximo hito:**` /
+  `**Empresas:**` / `**Schemas afectados:**` / `**Última actualización:**`) **sin
+  comparar la tabla** — por eso `INITIATIVES.md` ya no choca entre sesiones.
+  Promover = crear el planning doc con header completo (la fila aparece al
+  regenerar en main). **`## Done`** sí se edita a mano en tu PR al cerrar una
+  iniciativa (es append-only, sección distinta de la tabla; rara vez choca). Si
+  querés ver la tabla al día localmente, `npm run initiatives:gen` (no la
+  commitees).
 - **Regla 2 — rebase preventivo** antes de cada `git push` que toca
   `docs/strategy/*` o migraciones: `git fetch origin && git rebase origin/main`.
   Si conflictúa la tabla `## Activas` (auto-generada), **no la resuelvas a mano**:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "schema:check": "npm run schema:ref && git diff --exit-code -I '^  Last regenerated: ' supabase/SCHEMA_REF.md",
     "initiatives:gen": "npx tsx scripts/gen-initiatives.ts",
     "initiatives:check": "npm run initiatives:gen && git diff --exit-code docs/strategy/INITIATIVES.md",
+    "initiatives:validate": "npx tsx scripts/validate-initiatives.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/validate-initiatives.ts
+++ b/scripts/validate-initiatives.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env npx tsx
+/**
+ * Valida los HEADERS de `docs/planning/*.md` sin regenerar ni comparar la tabla
+ * `## Activas` de INITIATIVES.md (iniciativa `derivados-sin-drift`, Sprint 2).
+ *
+ * Reemplaza a `initiatives:check` en el job `quality` de CI. Motivación: el
+ * `initiatives:check` viejo exigía que la tabla regenerada estuviera commiteada
+ * en la rama (`initiatives:gen && git diff --exit-code`), lo que volvía a
+ * `INITIATIVES.md` un hotspot de conflictos de merge entre sesiones (cada una
+ * regeneraba la tabla completa). Ahora la tabla se regenera en `main` post-merge
+ * (`.github/workflows/initiatives-regen.yml`) y las ramas ya NO la tocan — solo
+ * editan el header de su propio planning doc. Este validador asegura que esos
+ * headers estén bien formados, sin tocar la tabla.
+ *
+ * Falla (exit 1) si:
+ *   - una iniciativa activa (proposed/planned/in_progress/blocked) no tiene los
+ *     campos requeridos en su header (nombre, Empresas, Schemas afectados,
+ *     Próximo hito, Última actualización), o
+ *   - el `**Slug:**` del header no coincide con el nombre de archivo.
+ *
+ * Uso:  npm run initiatives:validate
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { isActive, parsePlanningDoc, toInitiative } from './lib/initiatives';
+
+const PLANNING_DIR = path.join(process.cwd(), 'docs', 'planning');
+
+function main(): void {
+  const files = readdirSync(PLANNING_DIR)
+    .filter((f) => f.endsWith('.md'))
+    .sort();
+
+  const errors: string[] = [];
+  let activos = 0;
+
+  for (const file of files) {
+    const slug = file.replace(/\.md$/, '');
+    const content = readFileSync(path.join(PLANNING_DIR, file), 'utf8');
+    const doc = parsePlanningDoc(content, slug);
+
+    // Cross-check: el `**Slug:**` del header debe coincidir con el archivo.
+    const declared = content.match(/^\*\*Slug:\*\*\s*`?([a-z0-9-]+)`?/m)?.[1];
+    if (declared && declared !== slug) {
+      errors.push(
+        `${file}: el **Slug:** del header ("${declared}") no coincide con el nombre de archivo ("${slug}").`
+      );
+    }
+
+    // Solo las iniciativas ACTIVAS necesitan header completo (aparecen en la
+    // tabla). Las `done` y demás pueden tener headers más ligeros.
+    if (isActive(doc.estado)) {
+      activos++;
+      try {
+        toInitiative(doc); // tira un error claro con el campo faltante
+      } catch (e) {
+        errors.push(e instanceof Error ? e.message : String(e));
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('✖ Validación de headers de planning docs falló:\n');
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error(
+      '\nCorregí los headers de tus docs/planning/*.md. La tabla `## Activas` de ' +
+        'INITIATIVES.md se regenera en `main` (workflow initiatives-regen.yml), NO en tu rama.'
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ Headers de planning docs OK (${activos} iniciativas activas). ` +
+      'La tabla Activas se regenera en main post-merge — no la edites a mano en tu rama.'
+  );
+}
+
+main();


### PR DESCRIPTION
**Sprint 2** de `derivados-sin-drift`: que `INITIATIVES.md` deje de chocar entre sesiones.

La tabla `## Activas` es un derivado que antes las ramas regeneraban+commiteaban (`initiatives:check`) → conflictos de merge constantes en celdas-párrafo. Ahora:
- El check de PR es **`initiatives:validate`**: valida los headers de `docs/planning/*.md` (slug == archivo, toda activa con Próximo hito/Empresas/Schemas/Última actualización) **sin comparar la tabla**.
- La tabla se regenera en `main` post-merge (**`initiatives-regen.yml`**).
- Las ramas solo editan el header de su planning doc → **cero conflictos en la tabla**.

**Acción opcional para activar el auto-regen de la tabla:** agregá `github-actions[bot]` a la bypass list de la branch protection de `main` (o configurá un PAT). Sin eso, `initiatives-regen.yml` deja un `::warning::` y la tabla se regenera local con `npm run initiatives:gen` (es cosmética, no bloquea nada).

Parte de la iniciativa que arregla los choques diarios de SCHEMA_REF/INITIATIVES. Sprint 3 (db push al merge) va aparte, sin auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)