### PR TITLE
feat(derivados-sin-drift): Sprint 3 — db push al merge + gate financiero D5 [revisar antes de mergear]

### DIFF
--- a/.github/workflows/db-push-on-merge.yml
+++ b/.github/workflows/db-push-on-merge.yml
@@ -1,0 +1,60 @@
+name: DB Push on Merge
+
+# Raíz de proceso de la iniciativa `derivados-sin-drift` (Sprint 3). Aplica las
+# migraciones a prod AL MERGEAR a `main`, vía `supabase db push` — NUNCA antes de
+# mergear, NUNCA por MCP. Así:
+#   - prod no se adelanta a `main` (muere el drift de SCHEMA_REF que rompía PRs),
+#   - `db push` registra con el timestamp del archivo → el ledger no deriva
+#     (muere el baile de `migration repair`),
+#   - el gate financiero D5 es el MERGE: no-financieras se auto-mergean (y se
+#     aplican solas aquí); financieras las mergea Dirección a mano tras el
+#     `financial-migration-guard` (el merge es la confirmación explícita).
+#
+# Si `db push` falla (out-of-order, SQL inválido que el schema-check no atrapó),
+# main quedó mergeado pero prod atrás → falla ruidoso para re-correr/arreglar.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+  workflow_dispatch:
+
+concurrency:
+  group: db-push-main
+  cancel-in-progress: false
+
+jobs:
+  db-push:
+    name: supabase db push a prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Aplicar migraciones pendientes a prod
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          if [ -z "$SUPABASE_DB_URL" ]; then
+            echo "::error::SUPABASE_DB_URL no configurado — no puedo aplicar a prod."
+            exit 1
+          fi
+          echo "Migraciones pendientes según el ledger de prod:"
+          supabase migration list --db-url "$SUPABASE_DB_URL" 2>&1 | tail -20 || true
+          echo "── db push ──"
+          if supabase db push --db-url "$SUPABASE_DB_URL"; then
+            echo "✓ Migraciones aplicadas a prod. Ledger registrado con el timestamp del archivo."
+          else
+            echo "::error::supabase db push FALLÓ. Prod puede haber quedado atrás de main."
+            echo "Revisar el log (out-of-order / SQL / drift de ledger) y re-correr este workflow"
+            echo "(workflow_dispatch) o aplicar manualmente. NO uses MCP (genera huérfanas)."
+            exit 1
+          fi

--- a/.github/workflows/financial-migration-guard.yml
+++ b/.github/workflows/financial-migration-guard.yml
@@ -1,0 +1,75 @@
+name: Financial Migration Guard
+
+# Gate D5 de la iniciativa `derivados-sin-drift` (Sprint 3). Con el modelo nuevo
+# las migraciones se aplican a prod AL MERGEAR (db-push-on-merge.yml). El control
+# financiero de Beto exige que nada que mueva dinero/permisos se aplique sin su
+# confirmación → las migraciones FINANCIERAS no se auto-mergean: las revisa y
+# mergea Dirección a mano (el merge ES la confirmación).
+#
+# Este check clasifica las migraciones nuevas del PR. Si alguna es financiera y
+# el PR NO tiene el label `finanzas-ok`, FALLA → el auto-merge no procede y el PR
+# queda esperando a Dirección. Dirección revisa, agrega el label `finanzas-ok`
+# (el check re-corre y pasa) y mergea. Migraciones no-financieras pasan directo.
+#
+# Required-safe: solo corre en PRs que tocan supabase/migrations/**; los demás ni
+# lo ven. Si se hace required en branch protection, no cuelga PRs sin migración.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'supabase/migrations/**'
+
+concurrency:
+  group: fin-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Gate de migraciones financieras
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit
+
+      - name: Clasificar migraciones nuevas
+        id: classify
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          NEW=$(git diff --name-only --diff-filter=AM "$BASE" HEAD \
+            | grep -E '^supabase/migrations/.*\.sql$' || true)
+          if [ -z "$NEW" ]; then
+            echo "Sin migraciones nuevas en el PR."
+            echo "financial=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Migraciones nuevas:"; echo "$NEW" | sed 's/^/  /'
+          if npx tsx scripts/classify-financial-migration.ts $NEW; then
+            echo "financial=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "financial=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate financiero (bloquea auto-merge sin aprobación de Dirección)
+        if: steps.classify.outputs.financial == 'true'
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'finanzas-ok') }}" = "true" ]; then
+            echo "✓ Migración financiera con label 'finanzas-ok' — Dirección la aprobó."
+          else
+            echo "::error::Este PR trae una migración FINANCIERA (mueve dinero o permisos)."
+            echo "No se auto-mergea: la revisa y mergea Dirección a mano (el merge la aplica a prod)."
+            echo "Para aprobar: Dirección agrega el label 'finanzas-ok' al PR → este check pasa."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,15 @@ db:regen` (regenera `SCHEMA_REF.md` + `types/supabase.ts` desde las migraciones;
 
 > Norma 2026-06-17 (Beto): cortar de raíz el drift del historial de migraciones.
 
+> **⚠️ MODELO CAMBIADO (`derivados-sin-drift` S3).** El flujo normal ya **no** es
+> aplicar-por-MCP-y-reconciliar. Las migraciones se aplican a prod **al mergear**,
+> automáticamente, vía `db-push-on-merge.yml` (`supabase db push`) — **nunca por
+> MCP ni antes de mergear** (ver `supabase/GOVERNANCE.md` §4 + gate financiero D5:
+> financieras las mergea Dirección a mano con el label `finanzas-ok`). En operación
+> normal **no toques el ledger**: `db push` lo registra con el timestamp del
+> archivo. Lo de abajo aplica SOLO al **hotfix de emergencia por `psql` directo**
+> (raro) — ahí sí reconciliá el ledger en la misma sesión.
+
 `apply_migration` (MCP) / `execute_sql` / `psql` registran la migración en
 `supabase_migrations.schema_migrations` con el **timestamp de aplicación**, NO
 con el timestamp del nombre del archivo (`db:new`). El `name` sí se conserva.

--- a/docs/planning/derivados-sin-drift.md
+++ b/docs/planning/derivados-sin-drift.md
@@ -4,10 +4,10 @@
 **Empresas:** todas (infraestructura del repo / proceso de DB)
 **Schemas afectados:** ninguno de aplicación. Toca el **proceso** de migraciones y el tooling/CI: `package.json`, `scripts/gen-schema-ref.ts`, `scripts/gen-initiatives.ts`, `.github/workflows/{ci,db-types,drift-check}.yml` (+ workflows nuevos), `supabase/GOVERNANCE.md`, `CLAUDE.md`, `docs/strategy/INITIATIVES.md`, `supabase/SCHEMA_REF.md`, `types/supabase.ts`.
 **Estado:** in_progress
-**Próximo hito:** Sprint 1 construido (modelo nuevo): workflow `schema-check.yml` valida `SCHEMA_REF` contra una shadow DB (no prod) + `types` desde shadow + retiro del `schema:check` viejo del job `quality`. En verificación: el `schema-check` del PR del S1 confirma shadow == prod (las 3 sesiones serializadas). Sigue: Sprint 2 (INITIATIVES fuera del PR) + Sprint 3 (db push al merge con gate financiero D5) + agregar `schema-check` a required en branch protection.
+**Próximo hito:** S0/S0.5/S1/S2 en main (#1093, #1095, #1096). **Beto revisa y mergea el Sprint 3 ([#1097](https://github.com/beto-sudo/BSOP/pull/1097), sin auto-merge)**: el clasificador financiero + el cambio de hábito (migraciones se aplican al merge). Tras mergear, config de Beto (admin): crear label `finanzas-ok` + agregar `Gate de migraciones financieras` a required en branch protection (como se hizo con `schema-check` del S1). Con eso → iniciativa **done**.
 **Dueño:** Beto
 **Creada:** 2026-06-26
-**Última actualización:** 2026-06-27 (S0 + S0.5 cerrados — reconciliación en main vía #1093; Sprint 1 construido — modelo `SCHEMA_REF`/`types` desde shadow)
+**Última actualización:** 2026-06-27 (S1 + S2 mergeados a main; S3 en PR #1097 para revisión de Beto; OrbStack local reparado)
 
 ## Problema
 
@@ -187,3 +187,28 @@ NOT EXISTS ... REFERENCES/DEFAULT` (no reproducible). `SCHEMA_REF`/`types`
   las 3. Pendiente para cerrar la iniciativa: Sprint 2 (INITIATIVES fuera del PR),
   Sprint 3 (db push al merge con gate D5), y agregar `schema-check` a required en
   branch protection.
+- **2026-06-27** — **S1 mergeado** (#1095) + `schema-check` agregado a required en
+  branch protection (vía API, OK de Beto). El `schema-check` shadow del PR confirmó
+  shadow == prod (solo difería en comentarios; el `SCHEMA_REF`/`types` commiteado se
+  regeneró desde la shadow para reflejar las migraciones, no prod).
+- **2026-06-27** — **S2 mergeado** (#1096): `initiatives:validate` (valida headers)
+  reemplaza a `initiatives:check` en el job `quality`; la tabla `## Activas` se
+  regenera en `main` post-merge (`initiatives-regen.yml`); las ramas dejan de
+  tocarla → fin de los conflictos de merge en INITIATIVES. `CLAUDE.md` Regla 1
+  reescrita. (initiatives-regen requiere que Beto agregue `github-actions[bot]` a la
+  bypass list de branch protection para el commit directo; mientras, deja warning.)
+- **2026-06-27** — **S3 construido, en PR #1097 (SIN auto-merge — espera revisión de
+  Beto, toca aplicación a prod + control financiero).** `db-push-on-merge.yml` aplica
+  las migraciones a prod **al mergear** (`supabase db push`, nunca antes/MCP) → prod
+  no se adelanta a `main`, ledger no deriva. Gate D5: `financial-migration-guard` +
+  `classify-financial-migration.ts` bloquean el auto-merge de migraciones financieras
+  (clasificador heurístico amplio, probado) → las mergea Dirección con label
+  `finanzas-ok`. `GOVERNANCE.md` §4 + `CLAUDE.md` reescritos. Trabajo autónomo nocturno
+  (Beto durmiendo): S2 auto-mergeado por bajo riesgo; S3 dejado en PR por tocar
+  finanzas/prod.
+- **2026-06-27** — **OrbStack reparado** (fuera de la iniciativa, pero lo destapó el
+  S1): el `supabase start` del S1 dejó el overlayfs de containerd corrupto (snapshot
+  240 huérfano) tras un timeout de VM. `docker system prune -af` (solo borró imágenes
+  de Supabase re-descargables; 0 datos) lo limpió. `supabase start` + `npm run db:regen`
+  verificados local: reproducen el `SCHEMA_REF`/`types` exactos (242 tablas). Flujo
+  local del modelo nuevo funcionando en la máquina de Beto.

--- a/scripts/classify-financial-migration.ts
+++ b/scripts/classify-financial-migration.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env npx tsx
+/**
+ * Clasifica si una migración SQL toca "superficie financiera" — para el gate D5
+ * de la iniciativa `derivados-sin-drift` (Sprint 3, "db push al merge").
+ *
+ * Regla de Beto (control financiero): nada que mueva dinero o permisos se aplica
+ * a prod sin su confirmación explícita. Con el modelo nuevo las migraciones se
+ * aplican a prod AL MERGEAR (workflow `db-push-on-merge.yml`), así que el gate
+ * vive en el merge: las migraciones financieras NO llevan auto-merge — las
+ * revisa y mergea Dirección a mano (el merge ES la confirmación). El workflow
+ * `financial-migration-guard.yml` usa este clasificador para bloquear el
+ * auto-merge de PRs con migraciones financieras hasta que Dirección apruebe.
+ *
+ * Uso:  npx tsx scripts/classify-financial-migration.ts <a.sql> [<b.sql> ...]
+ *
+ * Imprime los archivos financieros (con el patrón que los marcó) y sale con
+ * código 1 si AL MENOS uno es financiero; 0 si ninguno. La heurística es
+ * DELIBERADAMENTE amplia: preferimos falsos positivos (Dirección revisa de más)
+ * a falsos negativos (una migración financiera auto-aplicada a prod sin gate).
+ */
+import { readFileSync } from 'node:fs';
+
+interface Pattern {
+  re: RegExp;
+  label: string;
+}
+
+const PATTERNS: Pattern[] = [
+  { re: /\bGRANT\b|\bREVOKE\b/i, label: 'GRANT/REVOKE (cambia permisos)' },
+  { re: /SECURITY\s+DEFINER/i, label: 'función SECURITY DEFINER (privilegiada)' },
+  {
+    re: /\berp\.(facturas|gastos|cxc_\w+|cxp_\w+|pagos|movimientos_bancarios|ordenes_compra|estados_cuenta|conciliaci\w+|presupuesto\w*)/i,
+    label: 'tabla financiera de erp.*',
+  },
+  {
+    re: /\bdilesa\.(ventas|estimaciones|obra_estimaciones|contratos\w*)/i,
+    label: 'tabla dilesa.* de montos/contratos',
+  },
+  {
+    re: /\b(comisi[oó]n|finiquito|anticipo|retenci[oó]n|sobreprecio|enganche|pagar[ée]|abono|aval[uú]o)\w*/i,
+    label: 'término de dinero',
+  },
+  { re: /\bpld\b|aviso[_\s]?pld|lavado/i, label: 'PLD / antilavado' },
+  {
+    re: /fn_\w*(pago|factura|cxc|cxp|comision|precio|cuadratura|avaluo|abono|presupuesto)\w*/i,
+    label: 'RPC financiera fn_*',
+  },
+];
+
+function classify(path: string): string[] {
+  let sql: string;
+  try {
+    sql = readFileSync(path, 'utf8');
+  } catch {
+    return [];
+  }
+  return PATTERNS.filter((p) => p.re.test(sql)).map((p) => p.label);
+}
+
+function main(): void {
+  const files = process.argv.slice(2).filter((f) => f.endsWith('.sql'));
+  const financial: { file: string; reasons: string[] }[] = [];
+  for (const f of files) {
+    const reasons = classify(f);
+    if (reasons.length) financial.push({ file: f, reasons });
+  }
+
+  if (financial.length === 0) {
+    console.log('✓ Ninguna migración nueva toca superficie financiera.');
+    process.exit(0);
+  }
+
+  console.log('⚠️  Migración(es) FINANCIERA(s) detectada(s):');
+  for (const { file, reasons } of financial) {
+    console.log(`  - ${file}`);
+    for (const r of reasons) console.log(`      · ${r}`);
+  }
+  process.exit(1);
+}
+
+main();

--- a/supabase/GOVERNANCE.md
+++ b/supabase/GOVERNANCE.md
@@ -97,54 +97,51 @@ reproduce desde cero → aplicá §1.
 Sin Docker local podés dejar que CI valide, pero **para regenerar los derivados
 necesitás Docker** — en el modelo nuevo ya no hay atajo contra prod.
 
-## §4 — Aplicar migrations: `db push`, no MCP
+## §4 — Aplicar migrations: AL MERGEAR (db push automático), no antes, no MCP
 
-**Regla dura:** las migrations se aplican vía `supabase db push` desde local
-o desde GH Action. **Nunca** vía `mcp__supabase__apply_migration` excepto
-emergencia.
+**Regla dura (modelo `derivados-sin-drift` S3):** las migraciones se aplican a
+prod **al mergear el PR a `main`**, automáticamente, vía el workflow
+`db-push-on-merge.yml` (`supabase db push`). **No** se aplican antes de mergear,
+**ni** por `mcp__supabase__apply_migration`, **ni** con `psql`/`db push` manual a
+prod. Una sola vía. Así prod nunca se adelanta a `main` (muere el drift de
+SCHEMA_REF que rompía PRs ajenos) y el ledger no deriva (`db push` registra con
+el timestamp del archivo; muere el baile de `migration repair`).
 
-### Por qué
+### Gate financiero (D5) — el gate es el MERGE
 
-`apply_migration` y `psql` directo no respetan el `version` del filename:
-registran la entry en `supabase_migrations.schema_migrations` con un timestamp
-generado al momento del apply. Resultado: el `version` en DB diverge del
-prefijo del filename y el Supabase CLI emite el warning
-`Applied out-of-order migrations: [...]` en cada `supabase db push` siguiente
-— ensucia el output del drift-check en cada PR de DB.
-
-`config.toml` debe tener `project_id`, `[db].major_version` y `[api].schemas`
-completos (ya está en este repo, ver el archivo). Si falta algo, `db push`
-no arranca sin flags y la gente se va al MCP por default — ahí empieza el
-drift.
+- **No-financieras** → auto-merge → al mergear, `db-push-on-merge.yml` las aplica.
+- **Financieras** (mueven dinero o permisos) → el check `financial-migration-guard`
+  las detecta y **bloquea el auto-merge**; las revisa y mergea **Dirección a mano**,
+  agregando el label `finanzas-ok` al PR. Ese merge ES la confirmación explícita
+  que exige el control financiero. Al mergear, se aplican igual vía el workflow.
 
 ### Procedimiento normal
 
-1. Editar archivo en `supabase/migrations/<timestamp>_<name>.sql`. El
-   `<timestamp>` debe ser estrictamente mayor al último aplicado en prod.
-   Para forzar el ordenamiento usá `date -u +%Y%m%d%H%M%S`.
-2. `supabase db push` (CLI valida sintaxis y aplica).
-3. `npm run schema:ref` (regenera `SCHEMA_REF.md`).
-4. Commit + PR.
+1. Crear el archivo con `npm run db:new "<slug>"` (timestamp anti-colisión).
+2. Regenerar los derivados **desde la shadow** (no prod): `supabase start &&
+npm run db:regen` (ver §3). Commitear `SCHEMA_REF.md` + `types/supabase.ts`.
+3. Abrir el PR. CI valida: `schema-check` (shadow) + `financial-migration-guard`.
+4. Mergear — no-financiera: auto-merge; financiera: Dirección con label `finanzas-ok`.
+5. `db-push-on-merge.yml` aplica a prod **al mergear**. NO hagas `db push` manual.
 
-### Procedimiento de emergencia (apply directo en prod sin push)
+### Por qué NO aplicar antes de mergear ni por MCP
 
-Solo si hay un fix urgente que no puede esperar al ciclo de PR:
+`apply_migration`/`psql` directo registran en `schema_migrations` con el timestamp
+del APPLY (≠ el del filename) → el `version` en DB diverge del archivo, `db push`
+emite `Applied out-of-order migrations` y termina rompiéndose para todas las
+sesiones. Aplicar antes de mergear adelanta prod a `main` → rompía el schema-check
+de PRs ajenos. El modelo nuevo elimina ambos males con una sola vía de aplicación
+(post-merge, `db push`, timestamp del archivo).
 
-1. Aplicar via MCP `apply_migration` o `psql` directo a prod.
-2. **Inmediatamente después**, identificar la `version` que registró
-   Supabase:
-   ```sql
-   SELECT version FROM supabase_migrations.schema_migrations
-   WHERE name = '<name>' ORDER BY version DESC LIMIT 1;
-   ```
-3. Crear/renombrar el archivo en `supabase/migrations/` con esa `version`
-   exacta como prefijo del filename. El SQL en disco debe matchear lo que
-   se aplicó (no la versión "limpia" que hubieras querido aplicar).
-4. Commit + PR para sincronizar el repo.
+### Procedimiento de emergencia (hotfix sin esperar al PR)
 
-Si saltás el paso 3, el siguiente PR de DB va a tener divergencia
-filename↔version, el drift-check va a flaggear, y el cleanup posterior
-es ~10x más caro que documentarlo bien al momento.
+Solo si un fix no puede esperar el ciclo de PR/merge:
+
+1. Aplicar vía `psql` directo a prod (preferido sobre MCP: no auto-registra huérfano).
+2. Crear el archivo en `supabase/migrations/` con un timestamp ≥ al último aplicado;
+   el SQL debe matchear lo aplicado.
+3. Abrir PR. Al mergear, `db-push-on-merge` re-aplica como no-op (ya está) y deja el
+   archivo registrado. Verificar `supabase migration list` 1:1 después.
 
 ### Bootstrap files (whitelist permanente)
 


### PR DESCRIPTION
**Sprint 3** de `derivados-sin-drift`: la raíz de proceso. **No auto-mergeado a propósito** — activa la aplicación automática de migraciones a prod + el gate financiero, requiere tu OK.

## Qué hace
- **`db-push-on-merge.yml`** — al mergear a `main` un PR con migración, corre `supabase db push` y la aplica a prod. **Nunca antes de mergear, nunca por MCP.** Prod deja de adelantarse a `main` (muere el drift de SCHEMA_REF que rompía PRs ajenos) y el ledger no deriva (registra con el timestamp del archivo → adiós `migration repair`).
- **`financial-migration-guard.yml` + `classify-financial-migration.ts`** — el gate D5. Clasifica las migraciones nuevas; si alguna es **financiera** (GRANT/REVOKE, `erp.*`/`dilesa.*` de dinero, SECURITY DEFINER, PLD), **bloquea el auto-merge** → la revisás y mergeás vos, agregando el label `finanzas-ok`. Ese merge es tu confirmación explícita. No-financieras pasan directo.
- **`GOVERNANCE.md` §4 + `CLAUDE.md`** reescritos al modelo nuevo.

## Antes de mergear, revisá
1. **El clasificador** (`scripts/classify-financial-migration.ts`) — ¿los patrones cubren tu noción de "financiero"? Probado: marca `dilesa_obra_estimacion_cxp_espera` (✓ GRANT+SECURITY DEFINER+erp+dilesa+dinero) y deja pasar `drop_legacy_rdb` (✓).
2. **El cambio de hábito**: tras mergear esto, la **próxima migración de cualquier sesión** se aplica a prod **al mergear** (no antes). El Preview Branch te sigue dando una DB efímera para probar antes del merge.

## Tras mergear (config tuya, necesita admin)
1. Crear el label **`finanzas-ok`** en el repo (o se crea al primer uso).
2. Agregar **`Gate de migraciones financieras`** a los required checks de `main` para que el gate sea bloqueante (igual que hicimos con el schema-check del S1).
3. El secret `SUPABASE_DB_URL` ya está ✓.

## Transición
Prod == main y el ledger 1:1 (lo dejamos así en el S0.5), así que el primer `db push` post-merge no tendrá pendientes hasta la próxima migración real. Cierra la iniciativa: ya no se choca con SCHEMA_REF ni INITIATIVES, y prod no se adelanta a main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)