### PR TITLE
docs(db): flujo de aprobación de migraciones financieras (CC ejecuta tras OK verbal)

### DIFF
--- a/.github/workflows/financial-migration-guard.yml
+++ b/.github/workflows/financial-migration-guard.yml
@@ -82,7 +82,8 @@ jobs:
             echo "✓ Migración financiera con label 'finanzas-ok' — Dirección la aprobó."
           else
             echo "::error::Este PR trae una migración FINANCIERA (mueve dinero o permisos)."
-            echo "No se auto-mergea: la revisa y mergea Dirección a mano (el merge la aplica a prod)."
-            echo "Para aprobar: Dirección agrega el label 'finanzas-ok' al PR → este check pasa."
+            echo "No se auto-mergea. Flujo: CC avisa a Beto en el chat con el resumen + riesgos;"
+            echo "tras su OK explícito ('dale'), CC pone el label 'finanzas-ok' y mergea (este check"
+            echo "pasa y db-push-on-merge la aplica a prod). Sin ese OK no se aplica."
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,8 @@ db:regen` (regenera `SCHEMA_REF.md` + `types/supabase.ts` desde las migraciones;
 > aplicar-por-MCP-y-reconciliar. Las migraciones se aplican a prod **al mergear**,
 > automáticamente, vía `db-push-on-merge.yml` (`supabase db push`) — **nunca por
 > MCP ni antes de mergear** (ver `supabase/GOVERNANCE.md` §4 + gate financiero D5:
-> financieras las mergea Dirección a mano con el label `finanzas-ok`). En operación
+> en financieras CC avisa a Beto en el chat con resumen+riesgos y, tras su **"dale"**,
+> CC pone el label `finanzas-ok` y mergea — nunca sin ese OK). En operación
 > normal **no toques el ledger**: `db push` lo registra con el timestamp del
 > archivo. Lo de abajo aplica SOLO al **hotfix de emergencia por `psql` directo**
 > (raro) — ahí sí reconciliá el ledger en la misma sesión.

--- a/supabase/GOVERNANCE.md
+++ b/supabase/GOVERNANCE.md
@@ -107,13 +107,21 @@ prod. Una sola vía. Así prod nunca se adelanta a `main` (muere el drift de
 SCHEMA_REF que rompía PRs ajenos) y el ledger no deriva (`db push` registra con
 el timestamp del archivo; muere el baile de `migration repair`).
 
-### Gate financiero (D5) — el gate es el MERGE
+### Gate financiero (D5) — confirmación explícita de Dirección en el chat
 
 - **No-financieras** → auto-merge → al mergear, `db-push-on-merge.yml` las aplica.
+  CC hace todo de punta a punta; Beto no interviene ni tiene que acordarse de nada.
 - **Financieras** (mueven dinero o permisos) → el check `financial-migration-guard`
-  las detecta y **bloquea el auto-merge**; las revisa y mergea **Dirección a mano**,
-  agregando el label `finanzas-ok` al PR. Ese merge ES la confirmación explícita
-  que exige el control financiero. Al mergear, se aplican igual vía el workflow.
+  las detecta y **bloquea el auto-merge**. Flujo (norma Beto 2026-06-27):
+  1. CC corre el clasificador al crear la migración; si es financiera, **avisa a Beto
+     en el chat** con el resumen + riesgos (no espera a que él se acuerde).
+  2. Beto da el **OK verbal explícito** para ESA migración ("dale").
+  3. Recién entonces CC pone el label `finanzas-ok` y mergea (lo que la aplica a prod).
+
+  **CC NUNCA pone `finanzas-ok` sin el "dale" de Beto para esa migración específica.**
+  El "dale" en el chat es la confirmación explícita que exige el control financiero; el
+  bloqueo técnico (sin label no hay auto-merge) es la red de seguridad que evita que una
+  financiera se cuele a prod sin pasar por ese OK.
 
 ### Procedimiento normal
 


### PR DESCRIPTION
Norma Beto (2026-06-27): para migraciones **financieras**, CC no espera a que Beto se acuerde ni lo manda a GitHub. Flujo:

1. CC corre el clasificador al crear la migración; si es financiera, **avisa a Beto en el chat** con resumen + riesgos.
2. Beto da el **OK verbal** ("dale").
3. CC pone el label `finanzas-ok` y mergea → `db-push-on-merge` la aplica.

**CC nunca pone el label sin ese OK.** El bloqueo técnico del `financial-migration-guard` sigue como red de seguridad (sin label no hay auto-merge). Las **no-financieras** las hace CC de punta a punta, sin intervención de Beto.

Codificado en `GOVERNANCE.md §4` + `CLAUDE.md` + el mensaje del guard, para que toda sesión lo siga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)