### PR TITLE
feat(arrendamiento): S1d — módulo RBAC + página

### DIFF
--- a/app/dilesa/arrendamiento/page.tsx
+++ b/app/dilesa/arrendamiento/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { ArrendamientoModule } from '@/components/dilesa/arrendamiento-module';
+import { RequireAccess } from '@/components/require-access';
+import { DesktopOnlyNotice } from '@/components/responsive';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+
+/**
+ * @module Arrendamiento (DILESA)
+ * @responsive desktop-only
+ */
+export default function Page() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.arrendamiento">
+      <DesktopOnlyNotice module="Arrendamiento" />
+      <div className="hidden sm:block">
+        <ArrendamientoModule empresaId={DILESA_EMPRESA_ID} />
+      </div>
+    </RequireAccess>
+  );
+}

--- a/components/app-shell/nav-config.ts
+++ b/components/app-shell/nav-config.ts
@@ -101,6 +101,7 @@ export const NAV_ITEMS: NavItem[] = [
         label: 'Inmobiliario',
         children: [
           { label: 'Portafolio', href: '/dilesa/portafolio' },
+          { label: 'Arrendamiento', href: '/dilesa/arrendamiento' },
           { label: 'Proyectos', href: '/dilesa/proyectos' },
           // Ventas ahora es un hub con 5 tabs (Ventas / Inventario / Fases /
           // Clientes / Vendedores) — el sidebar muestra solo la entry del

--- a/components/dilesa/arrendamiento-module.tsx
+++ b/components/dilesa/arrendamiento-module.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FileText, RefreshCw } from 'lucide-react';
+
+import { ModuleKpiStrip, type ModuleKpi } from '@/components/module-page';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+/**
+ * Módulo Arrendamiento (DILESA) — lista de contratos + KPIs. Iniciativa
+ * `arrendamiento` · Sprint 1d. v1 mínimo: lista read-only de contratos y su
+ * estado; el alta (form sobre la RPC erp.arrendamiento_alta) llega en S1e.
+ */
+
+type ArrendamientoRow = {
+  id: string;
+  folio: string | null;
+  arrendatario_persona_id: string;
+  tipo_plazo: string;
+  fecha_inicio: string | null;
+  fecha_fin: string | null;
+  estado: string;
+};
+
+type FetchResult = {
+  rows: ArrendamientoRow[];
+  nombres: Record<string, string>;
+  error: string | null;
+};
+
+const ESTADO_LABEL: Record<string, string> = {
+  borrador: 'Borrador',
+  vigente: 'Vigente',
+  por_vencer: 'Por vencer',
+  renovado: 'Renovado',
+  terminado: 'Terminado',
+  rescindido: 'Rescindido',
+};
+
+const ESTADO_CLASS: Record<string, string> = {
+  borrador: 'bg-muted text-muted-foreground',
+  vigente: 'bg-emerald-500/15 text-emerald-600',
+  por_vencer: 'bg-amber-500/15 text-amber-600',
+  renovado: 'bg-sky-500/15 text-sky-600',
+  terminado: 'bg-muted text-muted-foreground',
+  rescindido: 'bg-rose-500/15 text-rose-600',
+};
+
+function fmtFecha(d: string | null): string {
+  if (!d) return '—';
+  // Las fechas vienen YYYY-MM-DD (date); parsear sin TZ para no correr el día.
+  const [y, m, day] = d.slice(0, 10).split('-');
+  return `${day}/${m}/${y}`;
+}
+
+export function ArrendamientoModule({ empresaId }: { empresaId: string }) {
+  const [rows, setRows] = useState<ArrendamientoRow[]>([]);
+  const [nombres, setNombres] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // fetchData RETORNA el resultado (no setea estado). El setState vive en
+  // aplicar(), llamado dentro del .then — así el efecto no dispara setState de
+  // forma síncrona (evita el cascade de renders que marca el linter). Patrón de
+  // contabilidad-catalogo-module.
+  const fetchData = useCallback(async (): Promise<FetchResult> => {
+    const sb = createSupabaseBrowserClient();
+    const { data, error: e } = await sb
+      .schema('erp')
+      .from('arrendamientos')
+      .select('id, folio, arrendatario_persona_id, tipo_plazo, fecha_inicio, fecha_fin, estado')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .order('created_at', { ascending: false });
+    if (e) {
+      return {
+        rows: [],
+        nombres: {},
+        error: getSupabaseErrorMessage(e, 'No se pudieron cargar los contratos.'),
+      };
+    }
+    const list = (data ?? []) as ArrendamientoRow[];
+
+    // Nombres de arrendatario (FK a erp.personas, mismo schema). Segunda query
+    // por consistencia con el patrón cross-schema del repo.
+    const ids = [...new Set(list.map((r) => r.arrendatario_persona_id).filter(Boolean))];
+    const map: Record<string, string> = {};
+    if (ids.length) {
+      const { data: personas } = await sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre')
+        .in('id', ids);
+      for (const p of (personas ?? []) as { id: string; nombre: string | null }[]) {
+        map[p.id] = p.nombre ?? '—';
+      }
+    }
+    return { rows: list, nombres: map, error: null };
+  }, [empresaId]);
+
+  const aplicar = useCallback((res: FetchResult) => {
+    setRows(res.rows);
+    setNombres(res.nombres);
+    setError(res.error);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    let activo = true;
+    void fetchData().then((res) => {
+      if (activo) aplicar(res);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [fetchData, aplicar]);
+
+  const kpis = useMemo<ModuleKpi[]>(() => {
+    const by = (estado: string) => rows.filter((r) => r.estado === estado).length;
+    return [
+      { key: 'vigentes', label: 'Vigentes', value: by('vigente') },
+      {
+        key: 'por_vencer',
+        label: 'Por vencer',
+        value: by('por_vencer'),
+        valueClassName: 'text-amber-600',
+      },
+      { key: 'borrador', label: 'Borradores', value: by('borrador') },
+      { key: 'total', label: 'Total de contratos', value: rows.length },
+    ];
+  }, [rows]);
+
+  return (
+    <div className="space-y-4 p-4 sm:p-6">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h1 className="text-xl font-semibold">Arrendamiento</h1>
+          <p className="text-sm text-muted-foreground">
+            Contratos de renta de activos del portafolio.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setLoading(true);
+            void fetchData().then(aplicar);
+          }}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+        >
+          <RefreshCw className="size-4" /> Actualizar
+        </button>
+      </div>
+
+      <ModuleKpiStrip stats={kpis} />
+
+      {error && (
+        <div className="rounded-md border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-600">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">Cargando contratos…</div>
+      ) : rows.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed py-16 text-center">
+          <FileText className="size-8 text-muted-foreground" />
+          <p className="text-sm font-medium">Aún no hay contratos de arrendamiento</p>
+          <p className="max-w-sm text-xs text-muted-foreground">
+            El alta de contratos (con sus líneas y la renta inicial) llega en el siguiente sprint.
+            El modelo y la cobranza ya están en producción.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-left text-xs uppercase text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 font-medium">Folio</th>
+                <th className="px-3 py-2 font-medium">Arrendatario</th>
+                <th className="px-3 py-2 font-medium">Plazo</th>
+                <th className="px-3 py-2 font-medium">Vigencia</th>
+                <th className="px-3 py-2 font-medium">Estado</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-b last:border-0 hover:bg-muted/30">
+                  <td className="px-3 py-2 font-mono text-xs">{r.folio ?? '—'}</td>
+                  <td className="px-3 py-2">{nombres[r.arrendatario_persona_id] ?? '…'}</td>
+                  <td className="px-3 py-2 capitalize">
+                    {r.tipo_plazo === 'campana' ? 'Campaña' : 'Plazo'}
+                  </td>
+                  <td className="px-3 py-2 text-xs">
+                    {fmtFecha(r.fecha_inicio)} → {fmtFecha(r.fecha_fin)}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+                        ESTADO_CLASS[r.estado] ?? 'bg-muted text-muted-foreground'
+                      }`}
+                    >
+                      {ESTADO_LABEL[r.estado] ?? r.estado}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/permissions-deps.ts
+++ b/lib/permissions-deps.ts
@@ -100,6 +100,8 @@ export const MODULE_DEPS: Record<string, readonly string[]> = {
   'dilesa.atencion_clientes': [],
   // Contabilidad — catálogo de cuentas, standalone read-only (sin dependencias).
   'dilesa.contabilidad': [],
+  // Arrendamiento — módulo standalone (lee activos/personas; sin dependencias de otro módulo).
+  'dilesa.arrendamiento': [],
   'dilesa.portafolio': [],
   // Hub Portafolio (ADR-030): tabs Inventario / Evaluación.
   'dilesa.portafolio.inventario': [],

--- a/lib/permissions.test.ts
+++ b/lib/permissions.test.ts
@@ -323,6 +323,8 @@ const EXPECTED_DB_MODULE_SLUGS = new Set<string>([
   'dilesa.cobranza',
   'dilesa.cobranza.pagos',
   'dilesa.cobranza.aging',
+  // Arrendamiento — módulo simple (iniciativa `arrendamiento` S1d).
+  'dilesa.arrendamiento',
   // CxP (Cuentas por Pagar) — hub con 5 tabs (ADR-030). El padre `dilesa.cxp`
   // queda como umbrella; cada tab tiene su sub-slug. Migración base
   // 20260602010000_modulos_dilesa_cxp.sql; programacion/pagos (Sprint 4) en

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -81,6 +81,8 @@ export const ROUTE_TO_MODULE: Record<string, string> = {
   // del primer tab (`.pagos`). ADR-030 SS2.
   '/dilesa/cobranza': 'dilesa.cobranza.pagos',
   '/dilesa/cobranza/aging': 'dilesa.cobranza.aging',
+  // Arrendamiento — módulo simple (iniciativa `arrendamiento` S1d).
+  '/dilesa/arrendamiento': 'dilesa.arrendamiento',
   // Saldos Bancos — hub con 2 tabs (iniciativa `conciliacion-bancaria` v0,
   // ADR-030). El padre `dilesa.saldos-bancos` queda como umbrella; la URL
   // default mapea al sub-slug del primer tab (`.saldos`).

--- a/supabase/migrations/20260627222645_modulos_dilesa_arrendamiento.sql
+++ b/supabase/migrations/20260627222645_modulos_dilesa_arrendamiento.sql
@@ -1,0 +1,34 @@
+-- ╭─ 20260627222645_modulos_dilesa_arrendamiento ─╮
+-- Iniciativa `arrendamiento` · Sprint 1d — RBAC del módulo (ADR-014).
+--
+-- Registra el módulo UI `dilesa.arrendamiento` en core.modulos + backfill
+-- defensivo de core.permisos_rol (por cada rol de DILESA × el módulo,
+-- lectura+escritura) para que el page no se esconda a los no-admin
+-- (canAccessModulo → false sin el backfill). Módulo simple (sin sub-slugs):
+-- migrará a hub con tabs cuando se sumen Ocupación/Cobranza/Rentabilidad.
+--
+-- Aditiva. Patrón de 20260521225606_modulos_dilesa_portafolio.
+
+BEGIN;
+
+INSERT INTO core.modulos (slug, nombre, descripcion, empresa_id, seccion)
+SELECT 'dilesa.arrendamiento', 'Arrendamiento',
+  'Contratos de arrendamiento de activos del portafolio (renta, cobranza, ocupación)',
+  e.id, 'operaciones'
+FROM core.empresas e
+WHERE e.slug = 'dilesa'
+ON CONFLICT (empresa_id, slug) DO NOTHING;
+
+-- Backfill defensivo de permisos (idempotente).
+INSERT INTO core.permisos_rol (rol_id, modulo_id, acceso_lectura, acceso_escritura)
+SELECT r.id, m.id, true, true
+FROM core.roles r
+JOIN core.empresas e ON e.id = r.empresa_id
+JOIN core.modulos m ON m.empresa_id = r.empresa_id
+WHERE e.slug = 'dilesa'
+  AND m.slug = 'dilesa.arrendamiento'
+ON CONFLICT (rol_id, modulo_id) DO NOTHING;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
**Sprint 1d** de [`arrendamiento`](docs/planning/arrendamiento.md) — **no-financiero** (solo `core.modulos`/`permisos_rol`, sin GRANT ni dinero → auto-merge).

- Migración: registra `dilesa.arrendamiento` en `core.modulos` (sección operaciones) + **backfill defensivo** de permisos para los 7 roles DILESA.
- RBAC en los 3 lugares: `NAV_ITEMS` (sidebar, sección Inmobiliario), `ROUTE_TO_MODULE`, `EXPECTED_DB_MODULE_SLUGS`. Test de sync **42/42**.
- Página `/dilesa/arrendamiento`: módulo cliente con KPIs (vigentes / por vencer / borradores / total) + lista de contratos con estado, y estado vacío amigable. El form de alta (sobre `erp.arrendamiento_alta`) es S1e.

Módulo simple por ahora (migrará a hub con tabs cuando se sumen Ocupación/Cobranza/Rentabilidad). Validado: db reset limpio (módulo + 7 permisos), typecheck/lint/format/permissions verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)