### PR TITLE
feat(arrendamiento): S1e — form de alta de contrato

### DIFF
--- a/app/dilesa/arrendamiento/actions.ts
+++ b/app/dilesa/arrendamiento/actions.ts
@@ -1,0 +1,92 @@
+'use server';
+
+/**
+ * Server actions del módulo Arrendamiento (DILESA). Iniciativa `arrendamiento`
+ * · Sprint 1e. El alta llama la RPC atómica `erp.arrendamiento_alta` (S1c). El
+ * gate (admin global o Dirección DILESA) se aplica aquí; la UI solo muestra el
+ * botón a esos roles.
+ */
+
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { revalidatePath } from 'next/cache';
+
+import { getEffectiveUser } from '@/lib/auth/effective-user';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import type { Database, Json } from '@/types/supabase';
+
+type Result = { ok: true; id: string } | { ok: false; error: string };
+
+async function getActionClient() {
+  const cookieStore = await cookies();
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll() {},
+      },
+    }
+  );
+}
+
+async function puedeAdministrar(
+  supabase: Awaited<ReturnType<typeof getActionClient>>
+): Promise<boolean> {
+  const eu = await getEffectiveUser(supabase);
+  if (!eu) return false;
+  return eu.isAdmin === true || (eu.direccionEmpresaIds ?? []).includes(DILESA_EMPRESA_ID);
+}
+
+export type ArrendamientoLineaInput = {
+  activo_id: string;
+  tipo_operacion_fiscal?: string;
+  renta_subtotal: number;
+  regimen_iva?: string;
+  iva_tasa_pct?: number;
+  vigencia_inicio?: string | null;
+  vigencia_fin?: string | null;
+  estado?: string;
+};
+
+/**
+ * Alta de un contrato de arrendamiento (master + líneas + periodo inicial) vía
+ * la RPC atómica. Devuelve el id creado para que el caller navegue/refresque.
+ */
+export async function crearArrendamiento(
+  master: Record<string, unknown>,
+  lineas: ArrendamientoLineaInput[]
+): Promise<Result> {
+  if (!String(master.arrendatario_persona_id ?? '').trim()) {
+    return { ok: false, error: 'El arrendatario es obligatorio.' };
+  }
+  if (!lineas.length) {
+    return { ok: false, error: 'Agrega al menos un espacio rentado.' };
+  }
+  for (const l of lineas) {
+    if (!l.activo_id) return { ok: false, error: 'Cada espacio necesita un activo.' };
+    if (!(l.renta_subtotal > 0))
+      return { ok: false, error: 'La renta de cada espacio debe ser mayor a 0.' };
+  }
+
+  const supabase = await getActionClient();
+  if (!(await puedeAdministrar(supabase))) {
+    return { ok: false, error: 'Solo Dirección o un administrador puede dar de alta contratos.' };
+  }
+
+  const { data, error } = await supabase.schema('erp').rpc('arrendamiento_alta', {
+    p_empresa_id: DILESA_EMPRESA_ID,
+    p_master: master as unknown as Json,
+    p_lineas: lineas as unknown as Json,
+  });
+  if (error) {
+    return { ok: false, error: getSupabaseErrorMessage(error, 'No se pudo crear el contrato.') };
+  }
+
+  revalidatePath('/dilesa/arrendamiento');
+  return { ok: true, id: data as string };
+}

--- a/components/dilesa/arrendamiento-capture-dialog.tsx
+++ b/components/dilesa/arrendamiento-capture-dialog.tsx
@@ -1,0 +1,340 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { FieldLabel } from '@/components/ui/field-label';
+import { Input } from '@/components/ui/input';
+import {
+  crearArrendamiento,
+  type ArrendamientoLineaInput,
+} from '@/app/dilesa/arrendamiento/actions';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+
+/**
+ * Alta de contrato de arrendamiento (Sprint 1e). Cabecera + líneas dinámicas
+ * (1 contrato : N espacios). Envía a la RPC atómica vía la server action; las
+ * invariantes (cuenta_renta, anti-doble-booking) las valida la RPC.
+ */
+
+type Persona = { id: string; nombre: string };
+type ActivoRentable = { id: string; nombre: string; tipo: string };
+
+type LineaForm = {
+  activo_id: string;
+  tipo_operacion_fiscal: string;
+  renta_subtotal: string;
+  regimen_iva: string;
+  vigencia_inicio: string;
+  vigencia_fin: string;
+};
+
+const NUEVA_LINEA: LineaForm = {
+  activo_id: '',
+  tipo_operacion_fiscal: 'arrendamiento_inmueble',
+  renta_subtotal: '',
+  regimen_iva: 'tasa_8',
+  vigencia_inicio: '',
+  vigencia_fin: '',
+};
+
+const selectCls =
+  'w-full rounded-md border bg-transparent px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring';
+
+export function ArrendamientoCaptureDialog({
+  empresaId,
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  empresaId: string;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onCreated: () => void;
+}) {
+  const [personas, setPersonas] = useState<Persona[]>([]);
+  const [activos, setActivos] = useState<ActivoRentable[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Cabecera
+  const [arrendatario, setArrendatario] = useState('');
+  const [tipoPlazo, setTipoPlazo] = useState('plazo');
+  const [fechaInicio, setFechaInicio] = useState('');
+  const [fechaFin, setFechaFin] = useState('');
+  const [diaCorte, setDiaCorte] = useState('1');
+  const [depositoMeses, setDepositoMeses] = useState('1');
+  const [lineas, setLineas] = useState<LineaForm[]>([{ ...NUEVA_LINEA }]);
+
+  const cargarCatalogos = useCallback(async () => {
+    const sb = createSupabaseBrowserClient();
+    const [{ data: per }, { data: dest }] = await Promise.all([
+      sb.schema('erp').from('personas').select('id, nombre').order('nombre'),
+      sb.schema('dilesa').from('portafolio_destinos').select('id').eq('cuenta_renta', true),
+    ]);
+    const destinoIds = (dest ?? []).map((d) => (d as { id: string }).id);
+    let act: ActivoRentable[] = [];
+    if (destinoIds.length) {
+      const { data: activosData } = await sb
+        .schema('dilesa')
+        .from('activos')
+        .select('id, nombre, tipo')
+        .eq('empresa_id', empresaId)
+        .in('destino_id', destinoIds)
+        .is('deleted_at', null)
+        .order('nombre');
+      act = (activosData ?? []) as ActivoRentable[];
+    }
+    return {
+      personas: (per ?? []) as Persona[],
+      activos: act,
+    };
+  }, [empresaId]);
+
+  useEffect(() => {
+    if (!open) return;
+    let activo = true;
+    void cargarCatalogos().then((res) => {
+      if (!activo) return;
+      setPersonas(res.personas);
+      setActivos(res.activos);
+    });
+    return () => {
+      activo = false;
+    };
+  }, [open, cargarCatalogos]);
+
+  function actualizarLinea(i: number, patch: Partial<LineaForm>) {
+    setLineas((prev) => prev.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
+  }
+
+  async function guardar() {
+    setSaving(true);
+    setError(null);
+    const master = {
+      arrendatario_persona_id: arrendatario,
+      tipo_plazo: tipoPlazo,
+      fecha_inicio: fechaInicio || null,
+      fecha_fin: fechaFin || null,
+      dia_corte: diaCorte ? Number(diaCorte) : null,
+      deposito_meses: depositoMeses ? Number(depositoMeses) : 1,
+      estado: 'borrador',
+    };
+    const lineasInput: ArrendamientoLineaInput[] = lineas.map((l) => ({
+      activo_id: l.activo_id,
+      tipo_operacion_fiscal: l.tipo_operacion_fiscal,
+      renta_subtotal: Number(l.renta_subtotal || 0),
+      regimen_iva: l.regimen_iva,
+      iva_tasa_pct: l.regimen_iva === 'tasa_16' ? 16 : l.regimen_iva === 'exento' ? 0 : 8,
+      vigencia_inicio: l.vigencia_inicio || fechaInicio || null,
+      vigencia_fin: l.vigencia_fin || fechaFin || null,
+      estado: 'borrador',
+    }));
+    const res = await crearArrendamiento(master, lineasInput);
+    setSaving(false);
+    if (!res.ok) {
+      setError(res.error);
+      return;
+    }
+    // Reset + cerrar + refrescar la lista.
+    setArrendatario('');
+    setFechaInicio('');
+    setFechaFin('');
+    setLineas([{ ...NUEVA_LINEA }]);
+    onOpenChange(false);
+    onCreated();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Nuevo contrato de arrendamiento</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Cabecera */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="col-span-2">
+              <FieldLabel htmlFor="arr-arrendatario" required>
+                Arrendatario
+              </FieldLabel>
+              <select
+                id="arr-arrendatario"
+                className={selectCls}
+                value={arrendatario}
+                onChange={(e) => setArrendatario(e.target.value)}
+              >
+                <option value="">Selecciona…</option>
+                {personas.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.nombre}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <FieldLabel htmlFor="arr-plazo">Tipo</FieldLabel>
+              <select
+                id="arr-plazo"
+                className={selectCls}
+                value={tipoPlazo}
+                onChange={(e) => setTipoPlazo(e.target.value)}
+              >
+                <option value="plazo">Contrato a plazo</option>
+                <option value="campana">Campaña corta</option>
+              </select>
+            </div>
+            <div>
+              <FieldLabel htmlFor="arr-corte">Día de corte</FieldLabel>
+              <Input
+                id="arr-corte"
+                type="number"
+                min={1}
+                max={28}
+                value={diaCorte}
+                onChange={(e) => setDiaCorte(e.target.value)}
+              />
+            </div>
+            <div>
+              <FieldLabel htmlFor="arr-inicio">Inicio</FieldLabel>
+              <Input
+                id="arr-inicio"
+                type="date"
+                value={fechaInicio}
+                onChange={(e) => setFechaInicio(e.target.value)}
+              />
+            </div>
+            <div>
+              <FieldLabel htmlFor="arr-fin">Fin (vacío = indefinido)</FieldLabel>
+              <Input
+                id="arr-fin"
+                type="date"
+                value={fechaFin}
+                onChange={(e) => setFechaFin(e.target.value)}
+              />
+            </div>
+            <div>
+              <FieldLabel htmlFor="arr-deposito">Depósito (meses)</FieldLabel>
+              <Input
+                id="arr-deposito"
+                type="number"
+                min={0}
+                step="0.5"
+                value={depositoMeses}
+                onChange={(e) => setDepositoMeses(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {/* Líneas */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <FieldLabel>Espacios rentados</FieldLabel>
+              <button
+                type="button"
+                onClick={() => setLineas((p) => [...p, { ...NUEVA_LINEA }])}
+                className="inline-flex items-center gap-1 text-xs text-sky-600 hover:underline"
+              >
+                <Plus className="size-3.5" /> Agregar espacio
+              </button>
+            </div>
+            {lineas.map((l, i) => (
+              <div key={i} className="space-y-2 rounded-md border p-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-muted-foreground">Espacio {i + 1}</span>
+                  {lineas.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setLineas((p) => p.filter((_, idx) => idx !== i))}
+                      className="text-muted-foreground hover:text-rose-600"
+                      aria-label="Quitar espacio"
+                    >
+                      <Trash2 className="size-4" />
+                    </button>
+                  )}
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="col-span-2">
+                    <FieldLabel required>Activo</FieldLabel>
+                    <select
+                      className={selectCls}
+                      value={l.activo_id}
+                      onChange={(e) => actualizarLinea(i, { activo_id: e.target.value })}
+                    >
+                      <option value="">Selecciona un activo rentable…</option>
+                      {activos.map((a) => (
+                        <option key={a.id} value={a.id}>
+                          {a.nombre} ({a.tipo})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <FieldLabel required>Renta mensual (subtotal)</FieldLabel>
+                    <Input
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      value={l.renta_subtotal}
+                      onChange={(e) => actualizarLinea(i, { renta_subtotal: e.target.value })}
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel>Régimen IVA</FieldLabel>
+                    <select
+                      className={selectCls}
+                      value={l.regimen_iva}
+                      onChange={(e) => actualizarLinea(i, { regimen_iva: e.target.value })}
+                    >
+                      <option value="tasa_8">IVA 8% (frontera)</option>
+                      <option value="tasa_16">IVA 16%</option>
+                      <option value="exento">Exento (habitacional)</option>
+                    </select>
+                  </div>
+                  <div className="col-span-2">
+                    <FieldLabel>Operación fiscal</FieldLabel>
+                    <select
+                      className={selectCls}
+                      value={l.tipo_operacion_fiscal}
+                      onChange={(e) =>
+                        actualizarLinea(i, { tipo_operacion_fiscal: e.target.value })
+                      }
+                    >
+                      <option value="arrendamiento_inmueble">Arrendamiento de inmueble</option>
+                      <option value="espacio_publicitario">Espacio publicitario</option>
+                      <option value="servicio_publicidad">Servicio de publicidad</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {error && (
+            <div className="rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-600">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancelar
+          </Button>
+          <Button onClick={() => void guardar()} disabled={saving || !arrendatario}>
+            {saving ? 'Guardando…' : 'Crear contrato'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dilesa/arrendamiento-module.tsx
+++ b/components/dilesa/arrendamiento-module.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { FileText, RefreshCw } from 'lucide-react';
+import { FileText, Plus, RefreshCw } from 'lucide-react';
 
 import { ModuleKpiStrip, type ModuleKpi } from '@/components/module-page';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+
+import { ArrendamientoCaptureDialog } from './arrendamiento-capture-dialog';
 
 /**
  * Módulo Arrendamiento (DILESA) — lista de contratos + KPIs. Iniciativa
@@ -59,6 +61,7 @@ export function ArrendamientoModule({ empresaId }: { empresaId: string }) {
   const [nombres, setNombres] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   // fetchData RETORNA el resultado (no setea estado). El setState vive en
   // aplicar(), llamado dentro del .then — así el efecto no dispara setState de
@@ -140,16 +143,25 @@ export function ArrendamientoModule({ empresaId }: { empresaId: string }) {
             Contratos de renta de activos del portafolio.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => {
-            setLoading(true);
-            void fetchData().then(aplicar);
-          }}
-          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
-        >
-          <RefreshCw className="size-4" /> Actualizar
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setLoading(true);
+              void fetchData().then(aplicar);
+            }}
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            <RefreshCw className="size-4" /> Actualizar
+          </button>
+          <button
+            type="button"
+            onClick={() => setDialogOpen(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            <Plus className="size-4" /> Nuevo contrato
+          </button>
+        </div>
       </div>
 
       <ModuleKpiStrip stats={kpis} />
@@ -209,6 +221,13 @@ export function ArrendamientoModule({ empresaId }: { empresaId: string }) {
           </table>
         </div>
       )}
+
+      <ArrendamientoCaptureDialog
+        empresaId={empresaId}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onCreated={() => void fetchData().then(aplicar)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
**Sprint 1e** de [`arrendamiento`](docs/planning/arrendamiento.md) — **no-financiero** (UI pura, sin migración → auto-merge). **Cierra S1.**

- Dialog de captura de contrato: cabecera (arrendatario, plazo, fechas, día de corte, depósito) + **líneas dinámicas** (activo rentable + renta + régimen IVA + operación fiscal); agregar/quitar espacios.
- `app/dilesa/arrendamiento/actions.ts`: server action `crearArrendamiento` → RPC `erp.arrendamiento_alta`, con **gate de rol** (Dirección/admin), igual que el alta de activos.
- Botón **"Nuevo contrato"** en el módulo; carga activos rentables (destino `cuenta_renta`) + personas. La lista se refresca al crear.

Las invariantes (cuenta_renta, anti-doble-booking) las valida la RPC server-side. Suite completa **2134/2134** verde; typecheck/lint/format OK.

Con esto el módulo Arrendamiento queda **capturable de punta a punta** — listo para cargar los contratos reales el lunes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)