### PR TITLE
fix(arrendamiento): dropdowns usables (personas + caras)

### DIFF
--- a/components/dilesa/arrendamiento-capture-dialog.tsx
+++ b/components/dilesa/arrendamiento-capture-dialog.tsx
@@ -26,6 +26,12 @@ import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
  */
 
 type Persona = { id: string; nombre: string };
+type RawPersona = {
+  id: string;
+  nombre: string;
+  apellido_paterno: string | null;
+  apellido_materno: string | null;
+};
 type ActivoRentable = { id: string; nombre: string; tipo: string };
 
 type LineaForm = {
@@ -77,7 +83,17 @@ export function ArrendamientoCaptureDialog({
   const cargarCatalogos = useCallback(async () => {
     const sb = createSupabaseBrowserClient();
     const [{ data: per }, { data: dest }] = await Promise.all([
-      sb.schema('erp').from('personas').select('id, nombre').order('nombre'),
+      sb
+        .schema('erp')
+        .from('personas')
+        // Solo personas de esta empresa y activas; nombre completo (con
+        // apellidos) — antes traía las ~1900 de todas las empresas, solo `nombre`.
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .eq('empresa_id', empresaId)
+        .eq('activo', true)
+        .is('deleted_at', null)
+        .order('apellido_paterno', { nullsFirst: false })
+        .order('nombre'),
       sb.schema('dilesa').from('portafolio_destinos').select('id').eq('cuenta_renta', true),
     ]);
     const destinoIds = (dest ?? []).map((d) => (d as { id: string }).id);
@@ -89,14 +105,18 @@ export function ArrendamientoCaptureDialog({
         .select('id, nombre, tipo')
         .eq('empresa_id', empresaId)
         .in('destino_id', destinoIds)
+        // Excluye el espectacular/unipolar PADRE: se renta por cara (tipo='cara',
+        // activo hijo). El dropdown muestra las caras + el resto de hojas rentables.
+        .not('tipo', 'in', '(espectacular,unipolar)')
         .is('deleted_at', null)
         .order('nombre');
       act = (activosData ?? []) as ActivoRentable[];
     }
-    return {
-      personas: (per ?? []) as Persona[],
-      activos: act,
-    };
+    const personas: Persona[] = ((per ?? []) as RawPersona[]).map((p) => ({
+      id: p.id,
+      nombre: [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' '),
+    }));
+    return { personas, activos: act };
   }, [empresaId]);
 
   useEffect(() => {

--- a/supabase/migrations/20260628014634_dilesa_promover_caras_espectacular.sql
+++ b/supabase/migrations/20260628014634_dilesa_promover_caras_espectacular.sql
@@ -1,0 +1,68 @@
+-- ╭──────────────────────────────────────────────────────────────────╮
+-- │  20260628014634_dilesa_promover_caras_espectacular                  │
+-- │                                                                    │
+-- │  Iniciativa `arrendamiento` — fix S1e. Promueve cada cara de los    │
+-- │  espectaculares/unipolares (hoy en activo_espectacular.caras_detalle │
+-- │  jsonb: Flujo/Contraflujo) a un activo HIJO (tipo='cara',           │
+-- │  activo_padre_id), heredando el destino rentable del padre. Así el  │
+-- │  form de arrendamiento puede elegir la cara (no el espectacular     │
+-- │  completo). Ver ADR-052 + S1a (que creó tipo 'cara' + activo_cara). │
+-- │                                                                    │
+-- │  Idempotente (NOT EXISTS por nombre) y robusta a Preview (si no hay  │
+-- │  espectaculares, 0 filas). Data-only: no cambia schema. NO toca      │
+-- │  dinero ni permisos.                                                │
+-- ╰──────────────────────────────────────────────────────────────────╯
+
+BEGIN;
+
+-- 1. Master: un activo hijo tipo='cara' por cada elemento de caras_detalle,
+--    heredando empresa/estado/destino/geo del espectacular padre.
+INSERT INTO dilesa.activos (
+  empresa_id, tipo, nombre, estado, activo_padre_id, destino_id,
+  municipio, estado_geo, direccion_referencia, latitud, longitud
+)
+SELECT
+  a.empresa_id, 'cara',
+  a.nombre || ' — ' || COALESCE(c.elem->>'cara', 'Cara') ||
+    CASE WHEN NULLIF(c.elem->>'alias', '') IS NOT NULL THEN ' (' || (c.elem->>'alias') || ')' ELSE '' END,
+  a.estado, a.id, a.destino_id,
+  a.municipio, a.estado_geo, a.direccion_referencia, a.latitud, a.longitud
+FROM dilesa.activos a
+JOIN dilesa.activo_espectacular ae ON ae.activo_id = a.id
+CROSS JOIN LATERAL jsonb_array_elements(ae.caras_detalle) AS c(elem)
+WHERE a.tipo IN ('espectacular', 'unipolar')
+  AND a.deleted_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM dilesa.activos h
+    WHERE h.activo_padre_id = a.id
+      AND h.tipo = 'cara'
+      AND h.deleted_at IS NULL
+      AND h.nombre = a.nombre || ' — ' || COALESCE(c.elem->>'cara', 'Cara') ||
+        CASE WHEN NULLIF(c.elem->>'alias', '') IS NOT NULL THEN ' (' || (c.elem->>'alias') || ')' ELSE '' END
+  );
+
+-- 2. Satélite activo_cara: metadata física de cada cara (orientación,
+--    iluminación, scoring) tomada de caras_detalle. Match por el nombre del
+--    hijo (que incluye cara + alias). Idempotente.
+INSERT INTO dilesa.activo_cara (
+  activo_id, empresa_id, orientacion, iluminado, scoring, notas
+)
+SELECT
+  h.id, h.empresa_id,
+  c.elem->>'cara',
+  COALESCE((c.elem->>'iluminado')::boolean, false),
+  NULLIF(c.elem->'scoring'->>'puntos', '')::numeric,
+  NULLIF(c.elem->>'alias', '')
+FROM dilesa.activos h
+JOIN dilesa.activos a ON a.id = h.activo_padre_id
+JOIN dilesa.activo_espectacular ae ON ae.activo_id = a.id
+CROSS JOIN LATERAL jsonb_array_elements(ae.caras_detalle) AS c(elem)
+WHERE h.tipo = 'cara'
+  AND h.deleted_at IS NULL
+  AND h.nombre = a.nombre || ' — ' || COALESCE(c.elem->>'cara', 'Cara') ||
+    CASE WHEN NULLIF(c.elem->>'alias', '') IS NOT NULL THEN ' (' || (c.elem->>'alias') || ')' ELSE '' END
+  AND NOT EXISTS (SELECT 1 FROM dilesa.activo_cara ac WHERE ac.activo_id = h.id);
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
Dos arreglos al form de alta (S1e), reportados al probarlo:

**1. Arrendatario** — el dropdown traía las ~1900 personas de **todas** las empresas con solo `nombre` (de ahí "repetidos" y "sin apellidos"). Ahora: filtra **empresa DILESA + activo**, muestra **nombre completo** (nombre + apellidos), ordenado por apellido.

**2. Caras de espectacular** — solo aparecía el padre. Migración data-only promueve las **52 caras** (Flujo/Contraflujo, con su alias) de los 26 espectaculares/unipolares a **activos hijos** (`tipo='cara'`, heredan el destino rentable). El dropdown ahora muestra las caras y **excluye el espectacular padre** (se renta por cara). Idempotente + robusta a Preview; **no-financiera** (catálogo de activos, sin dinero/permisos).

Dry-run contra prod: 52 caras, nombres claros (ej. "Espectacular #1 — … — Flujo (Entrada Acuña)"). Suite 2134/2134, typecheck/lint/format OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)