### PR TITLE
feat(cxc): limpieza de saldos a favor de Coda + cierre v1 [FINANCIERO]

### DIFF
--- a/docs/planning/cxc.md
+++ b/docs/planning/cxc.md
@@ -4,10 +4,10 @@
 **Empresas:** todas (golden: DILESA; rollout RDB/COAGAN/ANSA en sub-iniciativas posteriores)
 **Schemas afectados:** `erp` (nuevas `cxc_cargos`, `cxc_pagos`, `cxc_pago_aplicaciones`; extiende `movimientos_bancarios` con referencia polimórfica), `dilesa` (originación `fn_generar_plan_pagos`; absorbe `venta_pagos`), `core` (helper de roles)
 **Estado:** in_progress
-**Próximo hito:** Contabilidad registra los 2 abonos de la venta Ahumada (con XML y comprobante c/u — ya con FIFO sin fuente, saldan ambos cargos y los comprobantes caen al expediente). Luego: limpieza de ~$2.0M en saldos a favor históricos (185 ventas — requiere regla + OK de Beto), Sprint 4 (recordatorios de vencimiento) + Sprint 5 (retiro del módulo Coda "Depositos Clientes")
+**Próximo hito:** Aplicar la migración de limpieza de saldos a favor (`20260628190355`, requiere `finanzas-ok` de Beto) + retiro del módulo Coda "Depositos Clientes" → cierre v1. Sprint 4 (recordatorios de vencimiento + forecast) **descopeado** a follow-up proposed (`dilesa-cobranza-recordatorios`).
 **Dueño:** Beto
 **Creada:** 2026-06-01
-**Última actualización:** 2026-06-17 (auto-generación del plan de pagos en el ciclo de vida de la venta: trigger en `dilesa.ventas` que genera el plan al alistarse — fase 2-11 + valor>0 + sin plan previo, create-once, fail-open — + backfill de 6 ventas vivas. Elimina el paso manual que dejó flotar el abono de Arizpe Luna)
+**Última actualización:** 2026-06-28 (cierre v1: Ahumada ✅ resuelto en prod; migración de limpieza de los $2.0M de saldos a favor de Coda — 186 pagos / 185 ventas / $2,015,311.81, todas terminada, corregidas a $0 como artefacto de captura; Sprint 4 descopeado a follow-up)
 
 ## Problema
 
@@ -211,6 +211,30 @@ cxc_cargos.saldo = precio − Σ aplicaciones`, y la suma de buckets de
 
 ## Decisiones registradas
 
+### 2026-06-28 — Cierre v1: limpieza de saldos a favor de Coda como artefacto + descope de Sprint 4
+
+Beto en chat, tras la radiografía de prod (read-only):
+
+- **Ahumada ya está resuelto** — Contabilidad registró los 2 abonos; ambos
+  cargos liquidados, saldo $0 (enganche $9,200 + disposición Infonavit
+  $930,800). El pendiente operativo del "Próximo hito" desaparece.
+- **Saldos a favor = artefacto de captura de Coda, se corrigen (todo).**
+  Radiografía 2026-06-28: **186 pagos / 185 ventas / $2,015,311.81** de saldo
+  a favor, **todas `terminada`**, **todas de origen Coda** ($1.94M institución
+  - $73.6K cliente). Ninguna es cartera viva. Regla aprobada: reducir cada
+    abono de Coda a lo realmente aplicado (saldo a favor → $0). NO mueve dinero
+    (no es CFDI ni movimiento bancario): corrige el monto sobre-capturado del
+    depósito. Mismo espíritu que el LIQ-HIST. Migración `20260628190355`
+    data-only, self-verificante, idempotente, con rastro en `core.audit_log` +
+    `notas`. Se aplica con `finanzas-ok` de Beto.
+- **EXCLUIDOS del barrido masivo**: 3 pagos nativos BSOP ($64,341.01, incl.
+  Nancy Villarreal $33,076) → conciliación individual; LIQ-HIST sintéticos
+  (sin saldo a favor); cualquier venta no-terminada.
+- **Sprint 4 (recordatorios de vencimiento + forecast) se descopa** a una
+  sub-iniciativa follow-up `proposed` (`dilesa-cobranza-recordatorios`). CxC
+  v1 cierra con: schema + UI + módulo Cobranza + aging + printables (Sprints
+  1-3, en prod) + limpieza de datos + retiro de Coda.
+
 ### 2026-06-12 — El XML del recibo manda; F12 manual solo Dirección; FIFO sin fuente es canon
 
 Del caso Ahumada Castillo (F12 cerrada a mano sin abono en CxC) y la
@@ -329,6 +353,30 @@ reubicados cuya fase "Entregada" venía heredada del lote en Coda.
   queda `proposed` hasta que CxC+CxP emitan movimientos.
 
 ## Bitácora
+
+### 2026-06-28 — Cierre v1: Ahumada resuelto + limpieza de $2.0M de saldos a favor + descope Sprint 4
+
+Sesión de destrabe pedida por Beto ("no sé qué falta, ayúdame a cerrarla").
+Radiografía de prod (read-only) que actualiza el diagnóstico viejo del doc:
+
+- **Ahumada — ✅ resuelto.** La venta (JESUS SANTIAGO AHUMADA **Carrillo**, el
+  doc decía "Castillo" por error) está detonada (10-jun, $940,000) y en
+  "Preparada para Entrega"; sus 2 cargos liquidados, saldo $0. Contabilidad
+  ya registró los abonos. Pendiente cerrado.
+- **Saldos a favor — caracterizados y migración lista (sin aplicar).** Medición
+  actual: **188 ventas / $2,079,652.82** total. Desglose: $1.94M institución +
+  $73.6K cliente de **origen Coda** en ventas **terminada** (artefacto), +
+  $64.3K en **3 pagos nativos BSOP** (revisión individual, excluidos). Se
+  descartó la hipótesis "doble enganche" del doc (0 casos donde favor =
+  enganche). Migración `20260628190355_cxc_limpieza_saldos_favor_coda.sql`:
+  congela el set 186 pagos / 185 ventas / $2,015,311.81, lo verifica contra lo
+  aprobado y reduce cada abono a lo aplicado; rastro en `core.audit_log` +
+  `notas`. Sin tocar aplicaciones/cargos → ningún trigger de saldo se dispara;
+  el de comprobante (`AFTER UPDATE OF comprobante_adjunto_id`) tampoco.
+  **Construida en este PR; se aplica con `finanzas-ok` de Beto** (crea/edita
+  datos financieros).
+- **Sprint 4 descopeado** a follow-up `proposed`; v1 cierra tras aplicar la
+  migración + retirar Coda. Ver Decisiones registradas 2026-06-28.
 
 ### 2026-06-17 — Auto-generación del plan de pagos en el ciclo de vida de la venta
 

--- a/docs/planning/dilesa-cobranza-recordatorios.md
+++ b/docs/planning/dilesa-cobranza-recordatorios.md
@@ -1,0 +1,46 @@
+# Iniciativa — Recordatorios de vencimiento + forecast de cobranza (DILESA)
+
+**Slug:** `dilesa-cobranza-recordatorios`
+**Empresas:** DILESA
+**Schemas afectados:** `core.notificaciones` (catálogo de recordatorios de cobranza), lectura de `erp.cxc_cargos` (vencidos, `fuente_esperada='cliente'`); sin DDL nuevo previsto más allá del catálogo.
+**Estado:** proposed
+**Próximo hito:** Que Beto la promueva (decisión suya). Es el Sprint 4 descopeado de [`cxc`](cxc.md).
+**Dueño:** Beto
+**Creada:** 2026-06-28
+**Última actualización:** 2026-06-28 (propuesta — descope de CxC v1 Sprint 4)
+
+## Problema
+
+CxC v1 (ver [`cxc`](cxc.md)) entregó schema, captura, módulo Cobranza, aging
+por buckets y printables. Lo que NO entró: la **cobranza activa proactiva** —
+hoy el aging muestra los vencidos pero nadie avisa al cliente ni hay visión de
+lo que entra a futuro. Se descopeó de v1 para cerrar la iniciativa madre sin
+arrastrarla.
+
+## Outcome esperado
+
+- **Recordatorios de vencimiento por email**, **solo `fuente='cliente'`** (a
+  institución no se le cobra; es solo visibilidad del adeudo). Branding por
+  empresa vía `lib/juntas/email.ts`. Catálogo en `core.notificaciones`.
+- **Forecast de cobranza**: lo que entra por fecha (el inverso del calendario
+  de pagos de CxP). Bandeja/vista en `/dilesa/cobranza`.
+- **Confirmar emisión de `movimientos_bancarios`** al cobrar (gancho con
+  [`conciliacion-bancaria`](conciliacion-bancaria.md)).
+
+## Alcance (borrador, a refinar al promover)
+
+- [ ] Catálogo `core.notificaciones` para recordatorios de cobranza + plantilla
+      de email con branding por empresa.
+- [ ] Cron / disparador de recordatorios sobre cargos vencidos `fuente='cliente'`.
+- [ ] Forecast de cobranza por fecha en el módulo Cobranza.
+- [ ] Verificación del gancho de movimiento bancario al cobrar.
+
+## Fuera de alcance
+
+- Cobranza a instituciones (INFONAVIT/FOVISSSTE): solo visibilidad, como en v1.
+- Interés moratorio (sigue diferido a V2 de CxC).
+
+## Notas
+
+Descopeada de `cxc` el 2026-06-28 (decisión de Beto: cerrar CxC v1 ya). Vive
+como `proposed` hasta que Beto la promueva.

--- a/supabase/migrations/20260628190355_cxc_limpieza_saldos_favor_coda.sql
+++ b/supabase/migrations/20260628190355_cxc_limpieza_saldos_favor_coda.sql
@@ -1,0 +1,135 @@
+-- Limpieza de saldos a favor heredados de Coda en CxC (data-only).
+--
+-- Contexto: el import de "Depositos Clientes" de Coda trajo depósitos
+-- capturados por ENCIMA de lo que el cargo de la venta realmente necesitaba
+-- (Infonavit/Fovissste dispone exactamente el crédito, no sobrepaga; el
+-- excedente es ruido de captura de Coda). El backfill FIFO los dejó como
+-- "saldo a favor" en el estado de cuenta / aging, pese a que el adeudo ya
+-- está 100% liquidado y la venta cerrada.
+--
+-- Radiografía a prod 2026-06-28 (read-only, congelada para esta migración):
+--   186 pagos / 185 ventas / $2,015,311.81 de saldo a favor, TODAS en
+--   estado='terminada', TODAS de origen Coda (coda_row_id IS NOT NULL):
+--     · institución: $1,941,717.40 (179 ventas) — artefacto claro.
+--     · cliente:        $73,594.41   (6 ventas).
+--   Ninguna es cartera en proceso. Mismo espíritu que el LIQ-HIST aprobado
+--   (20260611032126): limpiar el ruido histórico de Coda, no tocar lo vivo.
+--
+-- EXCLUIDOS a propósito (NO entran en esta limpieza masiva):
+--   · 3 pagos nativos BSOP ($64,341.01, incl. Nancy Villarreal $33,076) —
+--     captura reciente en BSOP, van a conciliación individual.
+--   · pagos sintéticos LIQ-HIST (aplicados 1:1, sin saldo a favor).
+--   · cualquier venta no 'terminada' (cartera viva).
+--
+-- Regla aprobada por Beto en chat (2026-06-28): "Corregir como artefacto
+-- (todo)" — reducir cada abono de Coda a lo realmente aplicado, de modo que
+-- el saldo a favor quede en $0. NO se mueve dinero (no es CFDI ni movimiento
+-- bancario): se corrige el monto sobre-capturado del depósito. El monto
+-- original queda en core.audit_log y en notas para trazabilidad/reversión.
+--
+-- Mecánica: por cada pago del set, monto_total := Σ aplicaciones. No toca
+-- cxc_pago_aplicaciones ni cxc_cargos → ningún trigger de saldo se dispara
+-- (el cargo ya está liquidado por sus aplicaciones, que no cambian). El
+-- trigger trg_comprobante_cxc_actualizado es AFTER UPDATE OF
+-- comprobante_adjunto_id → no se dispara (solo tocamos monto_total/notas).
+--
+-- Self-verificante (aborta con rollback si el set no cuadra con lo aprobado),
+-- idempotente (re-corrida encuentra set vacío → no-op) y no-op en Supabase
+-- Preview (sin datos). Timestamp con `npm run db:new` (anti-colisión).
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_pagos bigint;
+  v_ventas bigint;
+  v_sobrepago numeric;
+  v_actualizados bigint := 0;
+  v_residual bigint;
+BEGIN
+  -- ── Set objetivo congelado: saldo a favor de Coda en ventas terminada ──
+  CREATE TEMP TABLE tmp_limpieza ON COMMIT DROP AS
+  SELECT pg.id AS pago_id,
+         pg.empresa_id,
+         pg.origen_id AS venta_id,
+         pg.fuente,
+         pg.monto_total AS monto_original,
+         COALESCE((SELECT SUM(a.monto_aplicado)
+                   FROM erp.cxc_pago_aplicaciones a
+                   WHERE a.pago_id = pg.id), 0) AS aplicado
+  FROM erp.cxc_pagos pg
+  JOIN dilesa.ventas v ON v.id = pg.origen_id
+  WHERE pg.deleted_at IS NULL
+    AND pg.origen_tipo = 'venta_dilesa'
+    AND pg.coda_row_id IS NOT NULL
+    AND pg.referencia IS DISTINCT FROM 'LIQ-HIST'
+    AND v.estado = 'terminada';
+
+  -- Solo los que tienen saldo a favor real (monto > aplicado).
+  DELETE FROM tmp_limpieza WHERE (monto_original - aplicado) <= 0.01;
+
+  SELECT count(*), count(DISTINCT venta_id), coalesce(sum(monto_original - aplicado), 0)
+  INTO v_pagos, v_ventas, v_sobrepago
+  FROM tmp_limpieza;
+
+  -- Preview vacío o limpieza ya aplicada: no-op silencioso.
+  IF v_pagos = 0 THEN
+    RAISE NOTICE 'cxc_limpieza_saldos_favor: sin saldos a favor de Coda en ventas terminada — no-op.';
+    RETURN;
+  END IF;
+
+  -- ── Verificación contra el set aprobado (prod 2026-06-28) ──────────────
+  IF v_pagos <> 186 OR v_ventas <> 185 OR abs(v_sobrepago - 2015311.81) > 1 THEN
+    RAISE EXCEPTION 'Set a limpiar no cuadra con lo aprobado: % pagos / % ventas / $% (esperado 186 / 185 / 2015311.81). Abortando (rollback).',
+      v_pagos, v_ventas, v_sobrepago;
+  END IF;
+
+  -- ── 1. Rastro en core.audit_log (monto anterior → nuevo) ───────────────
+  INSERT INTO core.audit_log (empresa_id, usuario_id, accion, tabla, registro_id, datos_anteriores, datos_nuevos)
+  SELECT t.empresa_id, NULL, 'cxc_limpieza_saldo_favor', 'cxc_pagos', t.pago_id,
+         jsonb_build_object('monto_total', t.monto_original, 'fuente', t.fuente, 'saldo_a_favor', round(t.monto_original - t.aplicado, 2)),
+         jsonb_build_object('monto_total', t.aplicado, 'motivo', 'sobre-captura Coda en venta terminada — aprobado por Beto 2026-06-28')
+  FROM tmp_limpieza t;
+
+  -- ── 2. Reducir el abono a lo realmente aplicado (saldo a favor → 0) ────
+  WITH upd AS (
+    UPDATE erp.cxc_pagos p
+    SET monto_total = t.aplicado,
+        notas = coalesce(p.notas || E'\n', '')
+          || 'Saldo a favor limpiado 2026-06-28: depósito Coda sobre-capturado en venta terminada (monto original $'
+          || to_char(t.monto_original, 'FM999G999G990D00') || ', aplicado $'
+          || to_char(t.aplicado, 'FM999G999G990D00') || '). No es movimiento de dinero — corrección de captura. Aprobado por Beto en chat.',
+        updated_at = now()
+    FROM tmp_limpieza t
+    WHERE p.id = t.pago_id
+    RETURNING p.id
+  )
+  SELECT count(*) INTO v_actualizados FROM upd;
+
+  -- ── Verificación final: 0 saldos a favor de Coda/terminada restantes ───
+  SELECT count(*) INTO v_residual
+  FROM erp.cxc_pagos pg
+  JOIN dilesa.ventas v ON v.id = pg.origen_id
+  WHERE pg.deleted_at IS NULL
+    AND pg.origen_tipo = 'venta_dilesa'
+    AND pg.coda_row_id IS NOT NULL
+    AND pg.referencia IS DISTINCT FROM 'LIQ-HIST'
+    AND v.estado = 'terminada'
+    AND (pg.monto_total - COALESCE((SELECT SUM(a.monto_aplicado)
+         FROM erp.cxc_pago_aplicaciones a WHERE a.pago_id = pg.id), 0)) > 0.01;
+
+  IF v_residual > 0 THEN
+    RAISE EXCEPTION 'Quedaron % pagos Coda/terminada con saldo a favor tras la limpieza. Abortando (rollback).', v_residual;
+  END IF;
+
+  IF v_actualizados <> v_pagos THEN
+    RAISE EXCEPTION 'Actualizados (%) != set objetivo (%). Abortando (rollback).', v_actualizados, v_pagos;
+  END IF;
+
+  RAISE NOTICE 'cxc_limpieza_saldos_favor OK: % pagos en % ventas, $% de saldo a favor de Coda corregido a $0 (sin movimiento de dinero).',
+    v_pagos, v_ventas, v_sobrepago;
+END $$;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Qué cierra

Destraba y cierra **CxC v1**. Dos frentes del "Próximo hito" estaban abiertos; ambos resueltos aquí:

### 1. Ahumada — ✅ ya estaba resuelto en prod
Contabilidad registró los 2 abonos. Venta detonada (10-jun, $940,000), en "Preparada para Entrega", ambos cargos liquidados (enganche $9,200 + disposición Infonavit $930,800), **saldo $0**. (El doc decía "Castillo"; el apellido materno real es Carrillo.)

### 2. Saldos a favor — migración de limpieza (sin aplicar)
Radiografía a prod 2026-06-28:

| Frente | Ventas | Monto | Fase | Trato |
|---|---|---|---|---|
| Institución (Coda) | 179 | $1,941,717.40 | terminada | **limpiar** |
| Cliente (Coda) | 6 | $73,594.41 | terminada | **limpiar** |
| Nativos BSOP (incl. Nancy Villarreal $33K) | 3 | $64,341.01 | recientes | excluidos (conciliación individual) |

`20260628190355_cxc_limpieza_saldos_favor_coda.sql` — **data-only**:
- Set congelado **186 pagos / 185 ventas / $2,015,311.81**, verificado contra lo aprobado (aborta si no cuadra).
- Reduce cada abono de Coda a lo realmente aplicado → saldo a favor a **$0**. **No mueve dinero** (no es CFDI ni movimiento bancario): corrige sobre-captura de Coda.
- Rastro en `core.audit_log` (monto anterior→nuevo) + `notas`. Self-verificante, idempotente, no-op en Preview.
- No toca aplicaciones/cargos → ningún trigger de saldo se dispara; el de comprobante (`AFTER UPDATE OF comprobante_adjunto_id`) tampoco.

### 3. Sprint 4 descopeado
Recordatorios + forecast → follow-up `proposed` `dilesa-cobranza-recordatorios`.

## Aplicación
**Financiero — NO auto-merge.** Tras tu **"dale"** pongo el label `finanzas-ok` y mergeo; `db-push-on-merge` aplica la migración a prod. Riesgo: bajo — data-only, reversible vía audit_log, solo toca ventas cerradas.

## Checks locales
typecheck ✅ · format:check ✅ · initiatives:validate ✅ · lint ✅ (0 errores). schema:check lo corre CI en shadow (la migración es no-op en shadow vacío).

🤖 Generated with [Claude Code](https://claude.com/claude-code)