### PR TITLE
fix(cxc): soft-delete de 3 pagos fantasma en limpieza de saldos a favor [FINANCIERO]

### DIFF
--- a/docs/planning/cxc.md
+++ b/docs/planning/cxc.md
@@ -377,6 +377,14 @@ Radiografía de prod (read-only) que actualiza el diagnóstico viejo del doc:
   datos financieros).
 - **Sprint 4 descopeado** a follow-up `proposed`; v1 cierra tras aplicar la
   migración + retirar Coda. Ver Decisiones registradas 2026-06-28.
+- **Fix de aplicación (mismo día):** el primer `db push` (#1124) abortó por
+  `cxc_pagos_monto_total_check` (`monto_total > 0`): 3 de los 186 pagos son
+  **fantasma** (aplicaron $0, monto = puro saldo a favor, $34,757.10) y no
+  pueden ir a `monto_total = 0`. La transacción hizo rollback completo —
+  **prod quedó intacta** (0 filas de audit, 186 saldos a favor vivos). La
+  migración se corrigió para partir el set: **183 parciales** → reduce a lo
+  aplicado; **3 fantasma** → soft-delete (sin aplicaciones huérfanas ni
+  movimiento bancario). Reaplicada vía nuevo PR + `finanzas-ok`.
 
 ### 2026-06-17 — Auto-generación del plan de pagos en el ciclo de vida de la venta
 

--- a/supabase/migrations/20260628190355_cxc_limpieza_saldos_favor_coda.sql
+++ b/supabase/migrations/20260628190355_cxc_limpieza_saldos_favor_coda.sql
@@ -15,6 +15,15 @@
 --   Ninguna es cartera en proceso. Mismo espíritu que el LIQ-HIST aprobado
 --   (20260611032126): limpiar el ruido histórico de Coda, no tocar lo vivo.
 --
+-- Dos tratamientos según cuánto del depósito sí aplicó a un cargo:
+--   · PARCIAL (183 pagos, aplicó > 0): reducir monto_total a lo aplicado →
+--     saldo a favor a $0, conservando el abono real que sí liquidó cargos.
+--   · FANTASMA (3 pagos, aplicó = 0, $34,757.10): el depósito no liquidó
+--     ningún cargo (no había disposición que cubrir). monto_total no puede
+--     ir a $0 (CHECK monto_total > 0) y el abono no representa nada → se
+--     SOFT-DELETE. No tienen aplicaciones (no quedan huérfanas) ni
+--     movimiento bancario (import Coda sin cuenta).
+--
 -- EXCLUIDOS a propósito (NO entran en esta limpieza masiva):
 --   · 3 pagos nativos BSOP ($64,341.01, incl. Nancy Villarreal $33,076) —
 --     captura reciente en BSOP, van a conciliación individual.
@@ -22,16 +31,9 @@
 --   · cualquier venta no 'terminada' (cartera viva).
 --
 -- Regla aprobada por Beto en chat (2026-06-28): "Corregir como artefacto
--- (todo)" — reducir cada abono de Coda a lo realmente aplicado, de modo que
--- el saldo a favor quede en $0. NO se mueve dinero (no es CFDI ni movimiento
--- bancario): se corrige el monto sobre-capturado del depósito. El monto
--- original queda en core.audit_log y en notas para trazabilidad/reversión.
---
--- Mecánica: por cada pago del set, monto_total := Σ aplicaciones. No toca
--- cxc_pago_aplicaciones ni cxc_cargos → ningún trigger de saldo se dispara
--- (el cargo ya está liquidado por sus aplicaciones, que no cambian). El
--- trigger trg_comprobante_cxc_actualizado es AFTER UPDATE OF
--- comprobante_adjunto_id → no se dispara (solo tocamos monto_total/notas).
+-- (todo)" — el saldo a favor de Coda queda en $0. NO se mueve dinero (no es
+-- CFDI ni movimiento bancario): se corrige el monto sobre-capturado del
+-- depósito. El monto original queda en core.audit_log y en notas.
 --
 -- Self-verificante (aborta con rollback si el set no cuadra con lo aprobado),
 -- idempotente (re-corrida encuentra set vacío → no-op) y no-op en Supabase
@@ -44,8 +46,10 @@ DECLARE
   v_pagos bigint;
   v_ventas bigint;
   v_sobrepago numeric;
-  v_actualizados bigint := 0;
+  v_reducidos bigint := 0;
+  v_borrados bigint := 0;
   v_residual bigint;
+  v_huerfanas bigint;
 BEGIN
   -- ── Set objetivo congelado: saldo a favor de Coda en ventas terminada ──
   CREATE TEMP TABLE tmp_limpieza ON COMMIT DROP AS
@@ -84,14 +88,19 @@ BEGIN
       v_pagos, v_ventas, v_sobrepago;
   END IF;
 
-  -- ── 1. Rastro en core.audit_log (monto anterior → nuevo) ───────────────
+  -- ── 1. Rastro en core.audit_log (monto anterior → acción) ──────────────
   INSERT INTO core.audit_log (empresa_id, usuario_id, accion, tabla, registro_id, datos_anteriores, datos_nuevos)
   SELECT t.empresa_id, NULL, 'cxc_limpieza_saldo_favor', 'cxc_pagos', t.pago_id,
          jsonb_build_object('monto_total', t.monto_original, 'fuente', t.fuente, 'saldo_a_favor', round(t.monto_original - t.aplicado, 2)),
-         jsonb_build_object('monto_total', t.aplicado, 'motivo', 'sobre-captura Coda en venta terminada — aprobado por Beto 2026-06-28')
+         CASE
+           WHEN t.aplicado > 0.01 THEN
+             jsonb_build_object('accion', 'reduce', 'monto_total', t.aplicado, 'motivo', 'sobre-captura Coda en venta terminada — aprobado por Beto 2026-06-28')
+           ELSE
+             jsonb_build_object('accion', 'soft_delete', 'motivo', 'depósito Coda fantasma (no aplicó a ningún cargo) en venta terminada — aprobado por Beto 2026-06-28')
+         END
   FROM tmp_limpieza t;
 
-  -- ── 2. Reducir el abono a lo realmente aplicado (saldo a favor → 0) ────
+  -- ── 2a. PARCIAL: reducir el abono a lo aplicado (saldo a favor → 0) ────
   WITH upd AS (
     UPDATE erp.cxc_pagos p
     SET monto_total = t.aplicado,
@@ -101,10 +110,36 @@ BEGIN
           || to_char(t.aplicado, 'FM999G999G990D00') || '). No es movimiento de dinero — corrección de captura. Aprobado por Beto en chat.',
         updated_at = now()
     FROM tmp_limpieza t
-    WHERE p.id = t.pago_id
+    WHERE p.id = t.pago_id AND t.aplicado > 0.01
     RETURNING p.id
   )
-  SELECT count(*) INTO v_actualizados FROM upd;
+  SELECT count(*) INTO v_reducidos FROM upd;
+
+  -- ── 2b. FANTASMA: soft-delete (monto_total no puede ir a $0) ───────────
+  WITH del AS (
+    UPDATE erp.cxc_pagos p
+    SET deleted_at = now(),
+        notas = coalesce(p.notas || E'\n', '')
+          || 'Depósito Coda fantasma eliminado 2026-06-28: $'
+          || to_char(t.monto_original, 'FM999G999G990D00')
+          || ' que no aplicó a ningún cargo en venta terminada (saldo a favor artefacto). No es movimiento de dinero. Aprobado por Beto en chat.',
+        updated_at = now()
+    FROM tmp_limpieza t
+    WHERE p.id = t.pago_id AND t.aplicado <= 0.01
+    RETURNING p.id
+  )
+  SELECT count(*) INTO v_borrados FROM del;
+
+  -- ── Verificación: ninguna aplicación viva cuelga de un pago soft-deleted
+  SELECT count(*) INTO v_huerfanas
+  FROM erp.cxc_pago_aplicaciones a
+  JOIN erp.cxc_pagos p ON p.id = a.pago_id
+  JOIN tmp_limpieza t ON t.pago_id = p.id
+  WHERE p.deleted_at IS NOT NULL;
+
+  IF v_huerfanas > 0 THEN
+    RAISE EXCEPTION '% aplicaciones quedaron colgando de pagos soft-deleted. Abortando (rollback).', v_huerfanas;
+  END IF;
 
   -- ── Verificación final: 0 saldos a favor de Coda/terminada restantes ───
   SELECT count(*) INTO v_residual
@@ -122,12 +157,13 @@ BEGIN
     RAISE EXCEPTION 'Quedaron % pagos Coda/terminada con saldo a favor tras la limpieza. Abortando (rollback).', v_residual;
   END IF;
 
-  IF v_actualizados <> v_pagos THEN
-    RAISE EXCEPTION 'Actualizados (%) != set objetivo (%). Abortando (rollback).', v_actualizados, v_pagos;
+  IF (v_reducidos + v_borrados) <> v_pagos THEN
+    RAISE EXCEPTION 'Procesados (% reduce + % soft-delete = %) != set objetivo (%). Abortando (rollback).',
+      v_reducidos, v_borrados, v_reducidos + v_borrados, v_pagos;
   END IF;
 
-  RAISE NOTICE 'cxc_limpieza_saldos_favor OK: % pagos en % ventas, $% de saldo a favor de Coda corregido a $0 (sin movimiento de dinero).',
-    v_pagos, v_ventas, v_sobrepago;
+  RAISE NOTICE 'cxc_limpieza_saldos_favor OK: % pagos / % ventas, $% de saldo a favor de Coda a $0 (% reducidos + % fantasma eliminados; sin movimiento de dinero).',
+    v_pagos, v_ventas, v_sobrepago, v_reducidos, v_borrados;
 END $$;
 
 NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Por qué

El `db push` de [#1124](https://github.com/beto-sudo/BSOP/pull/1124) abortó al aplicar la limpieza: `cxc_pagos_monto_total_check` (`monto_total > 0`). 3 de los 186 pagos del set aplicaron **$0** (son saldo a favor puro, $34,757.10) → reducir su `monto_total` a 0 viola el CHECK. **La transacción hizo rollback completo: prod quedó intacta** (verificado: 0 filas de audit, 186 saldos a favor vivos).

## Fix

Parte el set en dos tratamientos:
- **183 parciales** (aplicaron > 0): reduce `monto_total` a lo aplicado → saldo a favor $0 (igual que antes).
- **3 fantasma** (aplicaron 0): **soft-delete** (`deleted_at`), con nota. No tienen aplicaciones (sin huérfanas) ni movimiento bancario (import Coda sin cuenta).

Asserts intactos (set congelado 186/185/$2,015,311.81) + verificación `reduce + soft-delete = 186` + check de aplicaciones huérfanas. Self-verificante, idempotente, no-op en Preview.

> El archivo de migración `20260628190355` no entró al ledger de prod (db push falló), así que editarlo y re-aplicar es limpio.

## Aplicación
**Financiero — NO auto-merge.** Tras tu OK pongo `finanzas-ok` y mergeo → `db-push-on-merge` re-aplica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)