### PR TITLE
fix(cxp): facturas sin proveedor enlazado no mostraban "Programar pago" [FINANCIERO]

### DIFF
--- a/app/api/[empresa]/cxp/facturas/upload-xml/route.test.ts
+++ b/app/api/[empresa]/cxp/facturas/upload-xml/route.test.ts
@@ -64,10 +64,22 @@ function buildAdminMock(): any {
           const key = `${schemaName}.${tableName}`;
           const filters: Record<string, unknown> = {};
           let usedOr = false; // marca la query de placeholders (fetchDestajoPlaceholders)
+          let usedIlike = false; // marca el match de proveedor (matchProveedorId)
           const builder: any = {
             select: () => builder,
             eq(col: string, val: unknown) {
               filters[col] = val;
+              return builder;
+            },
+            ilike(col: string, val: unknown) {
+              filters[col] = val;
+              usedIlike = true;
+              return builder;
+            },
+            order() {
+              return builder;
+            },
+            limit() {
               return builder;
             },
             not(col: string, _op: string, val: unknown) {
@@ -133,7 +145,16 @@ function buildAdminMock(): any {
               else if (key === 'dilesa.estimaciones') data = script.estimaciones ?? [];
               else if (key === 'dilesa.obra_estimaciones') data = script.obraEstimaciones ?? [];
               else if (key === 'dilesa.contratos_construccion') data = script.contratos ?? [];
-              else if (key === 'erp.personas') data = script.placeholderPersonas ?? [];
+              else if (key === 'erp.personas')
+                // matchProveedorId (empresa-scoped, `.ilike` + `.limit(1)`) reusa
+                // el fixture personaByRfc; el otro uso (placeholders, `.in`) trae
+                // las personas de los contratistas.
+                data = usedIlike
+                  ? (() => {
+                      const hit = script.personaByRfc?.[String(filters.rfc)];
+                      return hit ? [hit] : [];
+                    })()
+                  : (script.placeholderPersonas ?? []);
               return Promise.resolve({ data, error: null }).then(onFulfilled, onRejected);
             },
           };

--- a/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
+++ b/app/api/[empresa]/cxp/facturas/upload-xml/route.ts
@@ -85,6 +85,33 @@ type DestajoPlaceholder = {
   codigo: string | null;
 };
 
+/**
+ * Resuelve el proveedor (persona) por RFC del emisor, SCOPED a la empresa. El
+ * scope es clave: un mismo RFC vive como persona en varias empresas del
+ * portafolio (DILESA y RDB comparten HOME DEPOT, IMSS, RIPSA…), así que sin
+ * `empresa_id` el match traía 2 filas y el `.maybeSingle()` reventaba dejando la
+ * factura sin proveedor. `order + limit(1)` además es robusto a duplicados
+ * intra-empresa (no lanza). Espejo de erp.fn_cxp_factura_autolink_proveedor.
+ */
+async function matchProveedorId(
+  admin: NonNullable<ReturnType<typeof getSupabaseAdminClient>>,
+  empresaId: string,
+  emisorRfc: string | null
+): Promise<string | null> {
+  const rfc = (emisorRfc ?? '').trim();
+  if (!rfc) return null;
+  const { data } = await admin
+    .schema('erp')
+    .from('personas')
+    .select('id')
+    .eq('empresa_id', empresaId)
+    .ilike('rfc', rfc)
+    .is('deleted_at', null)
+    .order('created_at', { ascending: true })
+    .limit(1);
+  return data?.[0]?.id ?? null;
+}
+
 /** Normaliza un nombre para comparar: sin acentos, mayúsculas, espacios colapsados. */
 function normNombre(s: string | null | undefined): string {
   if (!s) return '';
@@ -513,13 +540,7 @@ export async function POST(req: NextRequest, { params }: Params) {
             continue;
           }
         }
-        const { data: prov } = await admin
-          .schema('erp')
-          .from('personas')
-          .select('id')
-          .eq('rfc', cfdi.emisorRfc)
-          .maybeSingle();
-        a.proveedorId = prov?.id ?? null;
+        a.proveedorId = await matchProveedorId(admin, emp.id, cfdi.emisorRfc);
         a.candidatos = candidatosParaCfdi(
           placeholders,
           a.proveedorId,
@@ -704,14 +725,8 @@ export async function POST(req: NextRequest, { params }: Params) {
         continue;
       }
 
-      // Emisor → proveedor (persona por RFC).
-      const { data: prov } = await admin
-        .schema('erp')
-        .from('personas')
-        .select('id')
-        .eq('rfc', cfdi.emisorRfc)
-        .maybeSingle();
-      const proveedorId: string | null = prov?.id ?? null;
+      // Emisor → proveedor (persona por RFC, scoped a esta empresa).
+      const proveedorId = await matchProveedorId(admin, emp.id, cfdi.emisorRfc);
 
       // Alta de la factura (RPC SECURITY DEFINER).
       const rpcArgs: CxpFacturaAltaArgs = {

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -7,7 +7,7 @@
 **Próximo hito:** Sprint 5 — conciliación de `cxp_pagos` contra el estado de cuenta. CxP ya hace su parte (emite los movimientos bancarios); el casamiento movimiento↔banco es **v1 de `conciliacion-bancaria`** (hermana, hoy desbloqueada porque CxP ya emite). Decidir con Beto si esa iniciativa lo absorbe o se hace un puente mínimo acá. Sprints 6 y 7 **cerrados**.
 **Dueño:** Beto
 **Creada:** 2026-04-28
-**Última actualización:** 2026-06-28 (higiene + cierre honesto: Sprint 7 confirmado en prod; Sprint 6 cerrado por decisión —gastos vacía=no-op, COAGAN/ANSA diferido sin datos—; código muerto `CxpProgramacionModule` eliminado y bug `cxc_pago_registrar` verificado ya corregido en prod. Único pendiente sustantivo = Sprint 5 conciliación, que es de la hermana `conciliacion-bancaria`)
+**Última actualización:** 2026-06-29 (fix: facturas de egreso sin proveedor enlazado no mostraban "Programar pago" — match emisor→proveedor del importador no filtraba por empresa; agregado scoping + trigger DB de auto-enlace + backfill, migración `20260629174922`)
 
 ## Problema
 
@@ -233,6 +233,19 @@ Revisión contra prod (2026-06-28): los dos entregables que faltaban resultaron
 
 ## Decisiones registradas
 
+### 2026-06-29 — El enlace factura→proveedor se resuelve por RFC scoped a empresa (+ trigger DB)
+
+El match emisor→proveedor **siempre** debe filtrar por `empresa_id`: un mismo RFC
+existe como persona en varias empresas del portafolio, y un match global rompe
+(`maybeSingle` con 2 filas) dejando la factura sin proveedor. Además del fix en el
+importador, el invariante se garantiza a nivel DB con
+`erp.fn_cxp_factura_autolink_proveedor` (trigger BEFORE INSERT/UPDATE): cualquier
+factura de egreso con `proveedor_id` NULL y `emisor_rfc` conocido se auto-enlaza a
+la persona de su empresa. El trigger no pisa enlaces explícitos (solo actúa cuando
+`proveedor_id IS NULL`). Razón: el botón "Programar pago" depende de
+`factura.proveedor_id`; sin proveedor, el operador queda atorado sin recurso (hoy
+no hay UI para enlazar manualmente — pendiente como mejora aparte).
+
 ### 2026-06-26 — Rediseño del flujo de CxP en 3 etapas (pipeline por pestaña)
 
 Beto rediseña la navegación del módulo para que cada pestaña sea una etapa del
@@ -321,6 +334,26 @@ patrón canónico de **ADR-037** (subledger gemelo):
   reusan CxC y CxP (convención `shared-modules-refactor`, ADR-011).
 
 ## Bitácora
+
+- **2026-06-29 — Fix: facturas sin botón "Programar pago" (proveedor sin enlazar).**
+  Beto reportó facturas de egreso en DILESA donde no aparecía el botón. Causa raíz:
+  el importador de XML (`app/api/[empresa]/cxp/facturas/upload-xml/route.ts`)
+  matcheaba el emisor → proveedor con `.eq('rfc', …).maybeSingle()` **sin filtrar
+  por empresa**. Para los RFCs que viven como persona en dos empresas del portafolio
+  (HOME DEPOT, IMSS, RIPSA, GOBIERNO EDO., JORGE AMIN — duplicados en DILESA y RDB),
+  `maybeSingle()` recibía 2 filas → error silencioso → `proveedor_id` NULL → sin
+  proveedor el botón no se muestra (gate `factura.proveedor_id`). 10 de 12 facturas
+  afectadas por esto; las otras 2 (AUTO SERVICIOS DE PIEDRAS NEGRAS, SOPORTE DE
+  SUPERVISIÓN EN CONSTRUCCIÓN) simplemente no tenían proveedor en el catálogo.
+  - **Fix raíz (código):** helper `matchProveedorId` scoped a `empresa_id`, robusto
+    a duplicados intra-empresa (`order created_at + limit(1)`, no lanza). Reemplaza
+    las 2 búsquedas del importador (analyze + commit).
+  - **Backstop DB:** migración `20260629174922_cxp_factura_autolink_proveedor` —
+    trigger `BEFORE INSERT/UPDATE` en `erp.facturas` que auto-enlaza
+    `proveedor_id`+`persona_id` desde el RFC del emisor dentro de la misma empresa
+    cuando viene NULL. Cubre **cualquier** vía de alta, no solo el importador.
+  - **Datos:** la misma migración crea los 2 proveedores faltantes (morales) y
+    backfillea las 12 facturas. Aplica a prod al mergear con label `finanzas-ok`.
 
 - **2026-06-28 — Higiene + cierre honesto de Sprint 6 (diagnóstico contra prod).**
   Beto pidió arrancar pendientes. El diagnóstico contra prod desinfló dos de los

--- a/supabase/migrations/20260629174922_cxp_factura_autolink_proveedor.sql
+++ b/supabase/migrations/20260629174922_cxp_factura_autolink_proveedor.sql
@@ -1,0 +1,106 @@
+-- CxP — auto-enlace de proveedor por RFC del emisor (iniciativa `cxp`).
+--
+-- Problema: facturas de egreso quedaban con `proveedor_id` NULL aunque el
+-- proveedor SÍ existía en el catálogo. El importador de XML matcheaba el emisor
+-- con `.eq('rfc', …).maybeSingle()` SIN filtrar por empresa; para RFCs que viven
+-- como persona en dos empresas del portafolio (p. ej. HOME DEPOT, IMSS, RIPSA en
+-- DILESA *y* en RDB) la consulta devolvía 2 filas → error silencioso → proveedor
+-- NULL → el botón "Programar pago" nunca aparecía (requiere proveedor enlazado).
+--
+-- Esta migración deja un backstop a nivel DB que cubre CUALQUIER vía de alta
+-- (importador, RPC, seeds), más el backfill de las facturas ya afectadas y el
+-- alta de los 2 proveedores que aún no estaban en el catálogo.
+
+BEGIN;
+
+-- ── 1. Función + trigger: auto-enlace por RFC dentro de la misma empresa ──────
+-- Solo actúa cuando falta el proveedor (no pisa un enlace explícito) y hay RFC
+-- de emisor. Determinista ante personas duplicadas intra-empresa: la activa más
+-- antigua. Espejo de la lógica del importador (route upload-xml).
+CREATE OR REPLACE FUNCTION erp.fn_cxp_factura_autolink_proveedor()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_persona_id uuid;
+BEGIN
+  IF NEW.flujo = 'egreso'
+     AND NEW.proveedor_id IS NULL
+     AND NEW.emisor_rfc IS NOT NULL
+     AND btrim(NEW.emisor_rfc) <> ''
+  THEN
+    SELECT p.id INTO v_persona_id
+    FROM erp.personas p
+    WHERE p.empresa_id = NEW.empresa_id
+      AND p.deleted_at IS NULL
+      AND upper(btrim(p.rfc)) = upper(btrim(NEW.emisor_rfc))
+    ORDER BY p.created_at ASC
+    LIMIT 1;
+
+    IF v_persona_id IS NOT NULL THEN
+      NEW.proveedor_id := v_persona_id;
+      -- `persona_id` se mantiene en espejo de `proveedor_id` (consistente con
+      -- erp.cxp_factura_alta, que inserta ambos con el mismo valor).
+      NEW.persona_id := v_persona_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_cxp_factura_autolink_proveedor ON erp.facturas;
+CREATE TRIGGER trg_cxp_factura_autolink_proveedor
+  BEFORE INSERT OR UPDATE OF emisor_rfc, proveedor_id, empresa_id ON erp.facturas
+  FOR EACH ROW
+  EXECUTE FUNCTION erp.fn_cxp_factura_autolink_proveedor();
+
+-- ── 2. Alta de los 2 proveedores faltantes (no existían en ninguna empresa) ──
+-- Personas morales (RFC de 12 caracteres). Idempotente: solo inserta si no hay
+-- ya una persona con ese RFC en DILESA. Robusto a Preview/shadow: si no existe
+-- la empresa 'dilesa' (DB sin datos de prod) el SELECT no produce filas.
+INSERT INTO erp.personas (empresa_id, nombre, rfc, tipo, tipo_persona, activo)
+SELECT e.id, v.nombre, v.rfc, 'general', 'moral', true
+FROM core.empresas e
+CROSS JOIN (
+  VALUES
+    ('AUTO SERVICIOS DE PIEDRAS NEGRAS', 'ASP931118M58'),
+    ('SOPORTE DE SUPERVISION EN CONSTRUCCION', 'SSC090624KW1')
+) AS v(nombre, rfc)
+WHERE e.slug = 'dilesa'
+  AND NOT EXISTS (
+    SELECT 1 FROM erp.personas p
+    WHERE p.empresa_id = e.id
+      AND upper(btrim(p.rfc)) = upper(btrim(v.rfc))
+      AND p.deleted_at IS NULL
+  );
+
+-- ── 3. Backfill: enlazar las facturas de egreso con proveedor NULL cuyo RFC ya
+-- matchea una persona en la misma empresa (incluye las 2 recién creadas). ──────
+UPDATE erp.facturas f
+SET proveedor_id = sub.persona_id,
+    persona_id   = sub.persona_id
+FROM (
+  SELECT f2.id AS factura_id,
+         (
+           SELECT p.id
+           FROM erp.personas p
+           WHERE p.empresa_id = f2.empresa_id
+             AND p.deleted_at IS NULL
+             AND upper(btrim(p.rfc)) = upper(btrim(f2.emisor_rfc))
+           ORDER BY p.created_at ASC
+           LIMIT 1
+         ) AS persona_id
+  FROM erp.facturas f2
+  WHERE f2.flujo = 'egreso'
+    AND f2.proveedor_id IS NULL
+    AND f2.cancelada_at IS NULL
+    AND f2.emisor_rfc IS NOT NULL
+) sub
+WHERE f.id = sub.factura_id
+  AND sub.persona_id IS NOT NULL;
+
+-- Recarga el cache de PostgREST (nueva función + cambios en datos de embeds).
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Problema

Beto reportó facturas de egreso en DILESA (CxP) que **no mostraban el botón "Programar pago"** — solo el texto *"Enlaza un proveedor a la factura…"* — aunque el drawer mostraba el nombre del proveedor (HOME DEPOT, etc.).

El botón depende de `factura.proveedor_id` (liga al catálogo `erp.personas`). El nombre que se ve viene del CFDI (`emisor_nombre`), no del proveedor enlazado — por eso se veía el nombre pero no el botón.

## Causa raíz

El importador de XML (`app/api/[empresa]/cxp/facturas/upload-xml/route.ts`) resolvía emisor→proveedor con `.eq('rfc', cfdi.emisorRfc).maybeSingle()` **sin filtrar por empresa**. Los 5 RFCs afectados existen como persona en **DILESA y en Rincón del Bosque** (portafolio multi-empresa) → `maybeSingle()` recibía 2 filas → error silencioso → `proveedor_id` quedaba `NULL`.

Diagnóstico contra prod: de 57 facturas de egreso, **12 sin `proveedor_id`** — 10 por este bug (el proveedor ya existía en DILESA) y 2 porque el proveedor no estaba en el catálogo.

## Fix

1. **Raíz (código):** helper `matchProveedorId` scoped a `empresa_id`, robusto a duplicados intra-empresa (`order created_at + limit(1)`, no lanza). Reemplaza las 2 búsquedas del importador (analyze + commit).
2. **Backstop DB:** trigger `erp.fn_cxp_factura_autolink_proveedor` (`BEFORE INSERT/UPDATE`) auto-enlaza `proveedor_id`+`persona_id` desde el RFC del emisor dentro de la misma empresa cuando viene `NULL`. Cubre **cualquier** vía de alta, no solo el importador. No pisa enlaces explícitos.
3. **Datos:** la migración crea los 2 proveedores faltantes (morales) + backfillea las 12 facturas.

## Validación
- Migración corre limpia en shadow; trigger verificado (matchea case-insensitive, RFC desconocido queda NULL).
- typecheck, lint (0 errores), format, initiatives:validate ✓
- Suite completa: **2150 tests passed** (171 files), incl. los 11 del route con el mock actualizado.

## ⚠️ Migración financiera
`supabase/migrations/20260629174922_cxp_factura_autolink_proveedor.sql` toca `erp.facturas` (subledger CxP). **No mueve dinero ni saldos** — solo enlaza proveedor. Requiere label **`finanzas-ok`** para que `db-push-on-merge` la aplique al mergear.

## Pendiente aparte (no en este PR)
No hay UI para enlazar/crear un proveedor manualmente desde el drawer cuando el auto-match falla. Con el trigger esto se vuelve raro (solo proveedor 100% nuevo), pero conviene como mejora futura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)