### PR TITLE
fix(dilesa-descuento-perdonado-motor): descuentoAplicado usa la promo consumida, no el tope del bono [FINANCIERO]

### DIFF
--- a/docs/planning/dilesa-descuento-perdonado-motor.md
+++ b/docs/planning/dilesa-descuento-perdonado-motor.md
@@ -1,0 +1,97 @@
+# Iniciativa — Descuento perdonado fantasma en el motor de cuadratura (DILESA)
+
+**Slug:** `dilesa-descuento-perdonado-motor`
+**Empresas:** DILESA
+**Schemas afectados:** `lib/dilesa/cuadratura.ts` (en el modelo desglosado ADR-045, `descuentoAplicado` pasa a usar la promoción REALMENTE consumida `aportacionPromocion` + sobreprecio capturado, en vez del TOPE del bono `promocionGastos`). Sin migración ni cambio de schema de DB. Consumidores indirectos: `app/api/dilesa/ventas/[id]/revision-pld/route.ts` (calcula `descuentoPerdonado = descuentoAplicado − chequePagado`) y la revisión PLD de la Fase 13.
+**Estado:** in_progress
+**Próximo hito:** Implementar Opción A en `cuadratura.ts` + test que blinda la regla; abrir PR (financiero → OK de Beto antes de mergear). Después: revisar con Michelle los 4 outliers de sobreprecio que el fix no resuelve.
+**Dueño:** Beto
+**Creada:** 2026-06-29
+**Última actualización:** 2026-06-29 (promoción + análisis de impacto con el motor real)
+
+> Detonante: revisando la venta de **ARACELY MARTINEZ VASQUEZ** (M10-L32-LDLE) en la
+> revisión PLD de la Fase 13, Beto vio el warning _"Σ liquidaciones = valor pactado −
+> descuento — … con el descuento perdonado de $1,620.00 se esperaban $938,380.00 …"_
+> y no encontraba ese descuento por ningún lado. Beto: _"creo que algo no está bien"_.
+> El diagnóstico confirmó su instinto: es un bug del motor, no de la captura.
+
+## Problema
+
+En la revisión PLD (Fase 13) el check `Σ liquidaciones = valor pactado − descuento`
+compara las liquidaciones del aviso contra `valor pactado − descuentoPerdonado`,
+donde `descuentoPerdonado = descuentoAplicado − chequePagado`
+([revision-pld/route.ts:360](../../app/api/dilesa/ventas/[id]/revision-pld/route.ts)).
+
+En el **modelo desglosado** (ADR-045), `descuentoAplicado` se calculaba como
+`promocionGastos + sobreprecioGastos`, donde `promocionGastos`
+(`dilesa.ventas.promocion_gastos_monto`) es el **TOPE del bono** del catálogo
+(se guarda al asignar tomando `promocion.monto`), **no** el bono realmente
+consumido. Cuando el bono no se consume completo, la diferencia (tope − usado)
+se cuela como **"descuento perdonado" fantasma** y dispara el warning.
+
+Caso Aracely (M10-L32):
+
+- Tope del bono `promocion_gastos_monto` = 15,000; sobreprecio = 20,000 → `descuentoAplicado` = **35,000**.
+- Bono realmente consumido (`aportacionPromocion`, que el motor YA calcula para la card) = 13,380.
+- Cheque a notaría girado = 33,380.
+- `descuentoPerdonado` = 35,000 − 33,380 = **1,620** ← exactamente el bono NO usado (15,000 − 13,380).
+- El motor ya conocía el número correcto (13,380); simplemente `descuentoAplicado` no lo reusaba.
+
+## Outcome esperado
+
+`descuentoAplicado` (desglose) refleja la promoción **consumida**, no el tope del
+bono. El "descuento perdonado" fantasma desaparece y el warning PLD solo aparece
+cuando hay un descuadre real. El campo `promocion_gastos_monto` se conserva como
+**tope autorizado** (correcto y útil); lo consumido se deriva del motor — no se
+edita dato por dato.
+
+## Alcance
+
+**Sprint 1 — Fix del motor + tests (código).**
+
+- `cuadratura.ts`: en el modelo desglosado, `descuentoAplicado = aportacionPromocion + sobreprecioGastos`
+  (la promo topada a lo consumido vía `partirDescuento`, + el sobreprecio capturado, hecho escriturado).
+  Requiere reordenar: el bloque de cobertura de gastos (que produce `aportacionPromocion`)
+  se calcula ANTES de `descuentoAplicado`. El modelo legacy (sin desglose) queda intacto.
+- Test que blinda la regla: bono parcialmente consumido → `descuentoAplicado` = promo consumida +
+  sobreprecio, perdón = 0; sin regresión en los casos existentes.
+
+**Fuera de alcance v1 (requiere Michelle):** 4 ventas (M11-L7, M3-L16, M8-L10,
+M11-L14) siguen con perdón > 0 tras el fix por **sobreprecio grande** (precio
+inflado para que el crédito absorba gastos altos, con cheque a notaría chico).
+Eso es una pregunta de modelo del sobreprecio, distinta del bug del bono. Se
+revisa por separado.
+
+## Impacto medido (motor real sobre las 109 ventas con desglose)
+
+- 68 ventas cambian `descuentoAplicado`; **0 suben** (el fix nunca infla — `aportacionPromocion ≤ tope`).
+- 45 ventas: perdón fantasma → **$0**. 22 ventas: perdón baja.
+- Σ perdón fantasma eliminado: **−$799K**.
+- Subconjunto PLD (fase ≥ 12, donde corre la revisión): ~10 ventas a perdón 0, incluida Aracely (1,620 → 0).
+- Script de análisis (read-only, no escribe): `scripts/analyze_dilesa_descuento_perdonado.ts`.
+
+## Riesgos
+
+- `descuentoAplicado` también alimenta `excedenteDisponible` y `saldoCliente` (legacy).
+  En modelo desglosado el display usa `operacionCubierta`/`saldoOperacion` (no `saldoCliente`),
+  así que el blast radius queda contenido. **No** afecta la comisión
+  (`baseComision = valorRealVentaDilesa − sobreprecioGastos`, no depende de `descuentoAplicado`).
+- Financiero: aunque no hay migración, cambia números de la operación → **OK de Beto antes de mergear** (no auto-merge).
+
+## Bitácora
+
+- 2026-06-29 — Promoción + diagnóstico + análisis de impacto con el motor real. Script
+  `scripts/analyze_dilesa_descuento_perdonado.ts`. (PR pendiente.)
+
+## Decisiones registradas
+
+- 2026-06-29 — **Opción A (quirúrgica) sobre la alternativa amplia.** El fix usa
+  `aportacionPromocion + sobreprecioGastos` (promo consumida + sobreprecio
+  capturado), no `aportacionPromocion + sobreprecioCobertura` (que se enredaba con
+  el estado de captura de gastos por fase y movía saldos en ambas direcciones —
+  ej. M9-L18 subía 0→101K). Opción A es monótona (nunca infla) y robusta al estado
+  de captura. Razón: el sobreprecio capturado es un hecho escriturado; solo el bono
+  debe toparse a lo consumido. Extiende el modelo de [ADR-045].
+- 2026-06-29 — **No se edita `promocion_gastos_monto`.** El campo es el tope
+  autorizado (correcto); lo consumido se deriva en el motor. Un parche por-venta
+  perdería el tope y habría que rehacerlo ante cualquier cambio de insumos.

--- a/docs/planning/dilesa-descuento-perdonado-motor.md
+++ b/docs/planning/dilesa-descuento-perdonado-motor.md
@@ -4,10 +4,10 @@
 **Empresas:** DILESA
 **Schemas afectados:** `lib/dilesa/cuadratura.ts` (en el modelo desglosado ADR-045, `descuentoAplicado` pasa a usar la promoción REALMENTE consumida `aportacionPromocion` + sobreprecio capturado, en vez del TOPE del bono `promocionGastos`). Sin migración ni cambio de schema de DB. Consumidores indirectos: `app/api/dilesa/ventas/[id]/revision-pld/route.ts` (calcula `descuentoPerdonado = descuentoAplicado − chequePagado`) y la revisión PLD de la Fase 13.
 **Estado:** in_progress
-**Próximo hito:** Implementar Opción A en `cuadratura.ts` + test que blinda la regla; abrir PR (financiero → OK de Beto antes de mergear). Después: revisar con Michelle los 4 outliers de sobreprecio que el fix no resuelve.
+**Próximo hito:** Beto revisa y mergea [#1132](https://github.com/beto-sudo/BSOP/pull/1132) (financiero, sin auto-merge). Después: revisar con Michelle los 4 outliers de sobreprecio que el fix no resuelve.
 **Dueño:** Beto
 **Creada:** 2026-06-29
-**Última actualización:** 2026-06-29 (promoción + análisis de impacto con el motor real)
+**Última actualización:** 2026-06-29 (Sprint 1 en PR [#1132]: fix del motor + tests + script de análisis; 6 checks CI verdes localmente)
 
 > Detonante: revisando la venta de **ARACELY MARTINEZ VASQUEZ** (M10-L32-LDLE) en la
 > revisión PLD de la Fase 13, Beto vio el warning _"Σ liquidaciones = valor pactado −
@@ -81,7 +81,11 @@ revisa por separado.
 ## Bitácora
 
 - 2026-06-29 — Promoción + diagnóstico + análisis de impacto con el motor real. Script
-  `scripts/analyze_dilesa_descuento_perdonado.ts`. (PR pendiente.)
+  `scripts/analyze_dilesa_descuento_perdonado.ts`.
+- 2026-06-29 — Sprint 1 en PR [#1132](https://github.com/beto-sudo/BSOP/pull/1132): fix
+  Opción A en `cuadratura.ts` (reorden + `descuentoAplicado = aportacionPromocion +
+sobreprecioGastos`) + tests (M3-L9 real + Aracely M10-L32 sintético) + script. 6 checks
+  CI verdes localmente. Sin auto-merge (financiero) — espera revisión y merge de Beto.
 
 ## Decisiones registradas
 

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -566,6 +566,10 @@ describe('calcularCuadratura', () => {
       expect(cob.engancheAlPrecio).toBe(156943); // el enganche cubre el saldo del precio
       expect(cob.engancheCliente).toBe(0); // nada del enganche fondea gastos
       expect(cob.aportacionPromocion).toBe(12569.42); // DILESA solo aporta del bono (< 15k)
+      // `dilesa-descuento-perdonado-motor`: descuentoAplicado usa la promo CONSUMIDA
+      // (12,569.42), NO el tope del bono (15,000). Antes daba 15,000 → 2,430.58 de
+      // "descuento perdonado" fantasma en la revisión PLD.
+      expect(c.descuentoAplicado).toBe(12569.42);
       expect(cob.sobreprecioCobertura).toBe(0); // NO se deriva sobreprecio fantasma
       expect(cob.pagareNecesario).toBe(0);
       expect(cob.saldoCobertura).toBe(0); // cuadra
@@ -579,6 +583,39 @@ describe('calcularCuadratura', () => {
       const split = partirDescuento(c.descuentoReal, cob.promocion);
       expect(split.promocion).toBe(13361.42);
       expect(split.sobreprecio).toBe(0);
+    });
+
+    // `dilesa-descuento-perdonado-motor`: bono parcialmente consumido CON sobreprecio
+    // — el caso que disparaba el warning PLD de Aracely (M10-L32). El tope del bono
+    // (15,000) no se consume completo (13,380); con sobreprecio 20,000 el motor daba
+    // descuentoAplicado 35,000 y `descuentoAplicado − cheque` = 1,620 de perdón
+    // fantasma. Con el fix usa la promo consumida → 33,380 = cheque → perdón 0.
+    it('bono parcialmente consumido + sobreprecio: descuentoAplicado = promo consumida, sin perdón fantasma (Aracely M10-L32)', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 940000,
+        montoCreditoTitular: 940000, // el crédito cubre el precio → el enganche fondea gastos
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: null,
+        montoChequeNotaria: 33380, // cheque a notaría girado (Fase 11)
+        gastosEscrituracion: 63380,
+        apoyoInfonavit: 0,
+        precioBase: 920000,
+        incrementoCredito: 0,
+        sobreprecioGastos: 20000, // 920k → 940k escriturado (hecho)
+        promocionGastos: 15000, // TOPE del bono del catálogo
+        depositos: [{ monto: 30000, directoCliente: true, tieneRecibo: false }],
+        proyectoNombre: 'Lomas de los Encinos',
+      });
+      const cob = c.coberturaGastos!;
+      expect(cob.aportacionPromocion).toBe(13380); // bono CONSUMIDO < tope 15,000
+      expect(cob.sobreprecioCobertura).toBe(20000);
+      expect(cob.saldoCobertura).toBe(0); // los gastos cuadran
+      // FIX: promo consumida (13,380) + sobreprecio (20,000) = 33,380, NO el tope
+      // (15,000 + 20,000 = 35,000).
+      expect(c.descuentoAplicado).toBe(33380);
+      expect(c.chequePagado).toBe(33380);
+      // "Descuento perdonado" de la revisión PLD = descuentoAplicado − cheque.
+      expect(c.descuentoAplicado - c.chequePagado).toBe(0); // sin fantasma → sin warning
     });
 
     // Camino "Cobrar" del residual de precio (iniciativa dilesa-saldos-residuales S2):

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -450,40 +450,19 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
   // la migración 20260623155819; antes se revolvían en `productos_adicionales`.
   const sobreprecioGastos = n(i.sobreprecioGastos);
   const productosAdicionales = n(i.productosAdicionales);
-  // Tope a lo autorizado desde el inicio: el saldo solo acredita el descuento
-  // hasta el máximo CONFIABLE (promo de la solicitud). Sin tope confiable
-  // (legacy) se aplica el otorgado completo. El exceso sobre el tope NO reduce
-  // el saldo (queda como pendiente a revisar).
-  const descuentoAplicado = tieneDesglose
-    ? round2(promocionGastos + sobreprecioGastos)
-    : i.descuentoMaximoAutorizado != null
-      ? Math.min(descuentoOtorgadoTotal, Math.max(0, n(i.descuentoMaximoAutorizado)))
-      : descuentoOtorgadoTotal;
   const gastosNetos = n(i.gastosEscrituracion) - n(i.apoyoInfonavit);
-  const excedenteDisponible = montoDisponible - valorEscrituracion + descuentoAplicado;
-  // Con desglose, el cheque a notaría cubre los gastos netos COMPLETOS (las 4
-  // fuentes los fondean; ADR-045). Sin desglose, la fórmula vieja de Coda
-  // (capeada al excedente disponible) — fallback intacto.
-  const chequeNotariaCalculado = tieneDesglose
-    ? round2(gastosNetos)
-    : round2(Math.min(gastosNetos, excedenteDisponible));
 
-  // Cheque a notaría GIRADO (capturado en Fase 11; 0 si aún no se gira). El
-  // saldo efectivo usa este, no el calculado: mide un giro real contra el
-  // descuento, no una sugerencia.
-  const chequePagado = round2(n(i.montoChequeNotaria));
-  // Saldo efectivo: el descuento aplicado cubre el faltante de cobranza y el
-  // cheque girado se fondea de ese descuento (o del excedente). Equivale a
-  // `chequePagado − excedenteDisponible`.
-  const saldoCliente = round2(saldoCobranza - descuentoAplicado + chequePagado);
-  const cubierta = saldoCliente <= TOLERANCIA_SALDO;
-
-  // ADR-045: desglose de las fuentes que cubren el presupuesto notarial COMPLETO.
-  // Solo con desglose poblado. Gastos BRUTOS = subsidio Infonavit + aportación
-  // DILESA (promoción) + enganche + sobreprecio + pagaré → saldo 0. El split del
-  // lado DILESA (lo que cubre tras el enganche y el pagaré) se hace con
-  // `partirDescuento`: promoción (bono autorizado, topado) + sobreprecio (el resto).
-  // Fuente ÚNICA para la card de cuadratura y el mini-resumen (no recalcular).
+  // ADR-045 + iniciativa `dilesa-descuento-perdonado-motor`: el desglose de las
+  // fuentes que cubren el presupuesto notarial COMPLETO se calcula ANTES del
+  // `descuentoAplicado`, porque en el modelo desglosado ese descuento debe usar la
+  // promoción REALMENTE consumida (`aportacionPromocion`, topada a lo necesario vía
+  // `partirDescuento`) y NO el TOPE del bono — si no, el bono no usado se cuela como
+  // "descuento perdonado" fantasma en la revisión PLD (`descuentoAplicado − cheque`).
+  // Solo con desglose poblado. Gastos BRUTOS = subsidio Infonavit + aportación DILESA
+  // (promoción) + enganche + sobreprecio + pagaré → saldo 0. El split del lado DILESA
+  // (lo que cubre tras el enganche y el pagaré) es `partirDescuento`: promoción (bono
+  // autorizado, topado) + sobreprecio (el resto). Fuente ÚNICA para la card de
+  // cuadratura y el mini-resumen (no recalcular).
   const gastosNetosR = round2(gastosNetos);
   const gastosBrutosR = round2(n(i.gastosEscrituracion));
   // El enganche del cliente cubre PRIMERO el saldo del precio (lo que el crédito
@@ -525,6 +504,39 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
     promocionGastos,
     sobreprecioGastos
   );
+
+  // Descuento que reduce el saldo. Con desglose (ADR-045 + `dilesa-descuento-
+  // perdonado-motor`): promoción CONSUMIDA (`aportacionPromocion`, ya topada al bono
+  // autorizado por `partirDescuento`) + sobreprecio CAPTURADO (hecho escriturado, lo
+  // absorbe el crédito). Antes se usaba el TOPE del bono (`promocionGastos`), que
+  // sobre-estimaba el descuento cuando el bono no se consumía completo y dejaba un
+  // "descuento perdonado" fantasma (`descuentoAplicado − cheque`) en la Fase 13
+  // (ej. Aracely M10-L32: tope 15,000 vs consumido 13,380 → 1,620 fantasma). Como
+  // `aportacionPromocion ≤ promocionGastos`, el fix nunca infla el descuento. Sin
+  // desglose (ventas cerradas/legacy) → modelo viejo: `descuento_total` topado al
+  // máximo autorizado. Fallback que NO altera nada histórico.
+  const descuentoAplicado = tieneDesglose
+    ? round2(aportacionPromocion + sobreprecioGastos)
+    : i.descuentoMaximoAutorizado != null
+      ? Math.min(descuentoOtorgadoTotal, Math.max(0, n(i.descuentoMaximoAutorizado)))
+      : descuentoOtorgadoTotal;
+  const excedenteDisponible = montoDisponible - valorEscrituracion + descuentoAplicado;
+  // Con desglose, el cheque a notaría cubre los gastos netos COMPLETOS (las 4
+  // fuentes los fondean; ADR-045). Sin desglose, la fórmula vieja de Coda
+  // (capeada al excedente disponible) — fallback intacto.
+  const chequeNotariaCalculado = tieneDesglose
+    ? round2(gastosNetos)
+    : round2(Math.min(gastosNetos, excedenteDisponible));
+
+  // Cheque a notaría GIRADO (capturado en Fase 11; 0 si aún no se gira). El
+  // saldo efectivo usa este, no el calculado: mide un giro real contra el
+  // descuento, no una sugerencia.
+  const chequePagado = round2(n(i.montoChequeNotaria));
+  // Saldo efectivo: el descuento aplicado cubre el faltante de cobranza y el
+  // cheque girado se fondea de ese descuento (o del excedente). Equivale a
+  // `chequePagado − excedenteDisponible`.
+  const saldoCliente = round2(saldoCobranza - descuentoAplicado + chequePagado);
+  const cubierta = saldoCliente <= TOLERANCIA_SALDO;
   const saldoCobertura = round2(
     gastosBrutosR -
       n(i.apoyoInfonavit) -

--- a/scripts/analyze_dilesa_descuento_perdonado.ts
+++ b/scripts/analyze_dilesa_descuento_perdonado.ts
@@ -1,0 +1,216 @@
+/**
+ * analyze_dilesa_descuento_perdonado.ts  (READ-ONLY, no escribe nada)
+ *
+ * Mide el impacto del bug del "descuento perdonado" en el motor de cuadratura
+ * DILESA. Hoy `descuentoAplicado` (cuadratura.ts) usa el TOPE del bono
+ * (`promocion_gastos_monto`) + sobreprecio, en vez de la promo REALMENTE
+ * aplicada (`aportacionPromocion + sobreprecioCobertura`, que el motor ya
+ * calcula = `faltanteGastosDilesa`). Cuando el bono no se consume completo, la
+ * diferencia se cuela como "descuento perdonado" fantasma → warning en la
+ * revisión PLD (Σ liquidaciones = valor pactado − descuento).
+ *
+ * Corre el MOTOR REAL sobre todas las ventas con desglose y reporta, por venta,
+ * el `descuentoAplicado` actual vs el corregido, el perdón actual vs corregido,
+ * y el delta de `saldoCliente`. No escribe en DB.
+ *
+ *   npx tsx --env-file=/Users/Beto/BSOP/.env.local \
+ *     scripts/analyze_dilesa_descuento_perdonado.ts
+ *
+ * Env: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+import { cargarCuadraturaVenta } from '../lib/dilesa/cuadratura-server';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Faltan NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY (usa --env-file).');
+}
+
+const round2 = (v: number): number => Math.round((v + Number.EPSILON) * 100) / 100;
+const money = (v: number): string =>
+  v.toLocaleString('es-MX', { style: 'currency', currency: 'MXN' });
+
+type Fila = {
+  id: string;
+  unidad: string;
+  estado: string | null;
+  fase: number | null;
+  valorEscrituracion: number;
+  aplicadoActual: number;
+  aplicadoFix: number;
+  cheque: number;
+  perdonadoActual: number;
+  perdonadoFix: number;
+  saldoClienteActual: number;
+  saldoClienteFix: number;
+  descuentoReal: number;
+};
+
+async function main() {
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+
+  // Universo: ventas vivas con desglose poblado (el modelo afectado).
+  const { data: ventas, error } = await sb
+    .schema('dilesa')
+    .from('ventas')
+    .select(
+      'id, estado, fase_posicion, valor_escrituracion, promocion_gastos_monto, precio_base, unidad_id'
+    )
+    .is('deleted_at', null)
+    .or('promocion_gastos_monto.not.is.null,precio_base.not.is.null');
+  if (error) throw error;
+  const universo = ventas ?? [];
+
+  // Clave de unidad (manzana-lote) para el reporte.
+  const unidadIds = [...new Set(universo.map((v) => v.unidad_id).filter(Boolean))] as string[];
+  const claves = new Map<string, string>();
+  for (let i = 0; i < unidadIds.length; i += 200) {
+    const chunk = unidadIds.slice(i, i + 200);
+    const { data: us } = await sb
+      .schema('dilesa')
+      .from('unidades')
+      .select('id, manzana, numero_lote')
+      .in('id', chunk);
+    for (const u of (us ?? []) as { id: string; manzana: string; numero_lote: string }[]) {
+      claves.set(u.id, `M${u.manzana}-L${u.numero_lote}`);
+    }
+  }
+
+  const filas: Fila[] = [];
+  let saltadas = 0;
+  for (const v of universo) {
+    const cuad = await cargarCuadraturaVenta(sb, v.id);
+    if (!cuad || !cuad.tieneDesglose) {
+      saltadas++;
+      continue;
+    }
+    const cheque = cuad.chequePagado;
+    const aplicadoActual = round2(cuad.descuentoAplicado);
+    const cg = cuad.coberturaGastos;
+    // Fix QUIRÚRGICO (Opción A): solo topa la PROMO al bono consumido
+    // (`aportacionPromocion`); conserva el sobreprecio CAPTURADO (hecho
+    // escriturado, robusto al estado de captura de gastos). Nunca sube el
+    // descuento por encima del actual.
+    const aplicadoFix = round2((cg?.aportacionPromocion ?? 0) + (cg?.sobreprecio ?? 0));
+    const perdonadoActual = Math.max(0, round2(aplicadoActual - cheque));
+    const perdonadoFix = Math.max(0, round2(aplicadoFix - cheque));
+    const saldoClienteFix = round2(cuad.saldoCobranza - aplicadoFix + cheque);
+    filas.push({
+      id: v.id,
+      unidad: claves.get(v.unidad_id as string) ?? '—',
+      estado: v.estado,
+      fase: v.fase_posicion,
+      valorEscrituracion: round2(cuad.saldoCobranza + cuad.montoDisponible),
+      aplicadoActual,
+      aplicadoFix,
+      cheque,
+      perdonadoActual,
+      perdonadoFix,
+      saldoClienteActual: round2(cuad.saldoCliente),
+      saldoClienteFix,
+      descuentoReal: round2(cuad.descuentoReal),
+    });
+  }
+
+  const cambian = filas.filter((f) => Math.abs(f.aplicadoActual - f.aplicadoFix) > 0.01);
+  const perdonFantasma = filas.filter((f) => f.perdonadoActual > 0.01 && f.perdonadoFix <= 0.01);
+  const perdonBaja = cambian.filter((f) => f.perdonadoFix < f.perdonadoActual - 0.01);
+
+  const sumaPerdonActual = round2(filas.reduce((s, f) => s + f.perdonadoActual, 0));
+  const sumaPerdonFix = round2(filas.reduce((s, f) => s + f.perdonadoFix, 0));
+
+  const subió = filas.filter((f) => f.aplicadoFix > f.aplicadoActual + 0.01);
+  // Subconjunto que de verdad dispara el warning PLD: la revisión corre en
+  // fase ≥ 13 (facturación). Ahí es donde el perdón fantasma importa.
+  const pld = filas.filter((f) => (f.fase ?? 0) >= 13);
+  const pldCambian = pld.filter((f) => f.perdonadoActual - f.perdonadoFix > 0.01);
+
+  console.log('\n══════════ IMPACTO: descuento perdonado fantasma (motor cuadratura) ══════════\n');
+  console.log(
+    'Fix evaluado: Opción A (topar promo al bono consumido; sobreprecio capturado intacto)\n'
+  );
+  console.log(`Universo con desglose evaluado:        ${filas.length}`);
+  console.log(`Saltadas (sin desglose efectivo):      ${saltadas}`);
+  console.log(`Ventas que CAMBIAN descuentoAplicado:  ${cambian.length}`);
+  console.log(`  · perdón pasa a CERO:                ${perdonFantasma.length}`);
+  console.log(
+    `  · perdón BAJA (no a cero):           ${perdonBaja.length - perdonFantasma.length}`
+  );
+  console.log(`  · descuentoAplicado SUBE (no debe):  ${subió.length}`);
+  console.log(`Σ perdón ACTUAL:                       ${money(sumaPerdonActual)}`);
+  console.log(`Σ perdón CORREGIDO:                    ${money(sumaPerdonFix)}`);
+  console.log(
+    `Σ perdón fantasma eliminado:           ${money(round2(sumaPerdonActual - sumaPerdonFix))}`
+  );
+  console.log(`\n── Subconjunto PLD (fase ≥ 13, donde corre la revisión) ──`);
+  console.log(`Ventas en fase ≥ 13:                   ${pld.length}`);
+  console.log(`  · con perdón fantasma que baja:      ${pldCambian.length}`);
+  console.log(
+    `  · de esas, perdón a CERO:            ${pld.filter((f) => f.perdonadoActual > 0.01 && f.perdonadoFix <= 0.01).length}`
+  );
+
+  const orden = [...cambian].sort(
+    (a, b) => b.perdonadoActual - b.perdonadoFix - (a.perdonadoActual - a.perdonadoFix)
+  );
+  console.log('\n── Ventas afectadas (orden por delta de perdón) ──\n');
+  console.log(
+    'unidad'.padEnd(12),
+    'estado'.padEnd(12),
+    'fase'.padStart(4),
+    'aplicadoAct'.padStart(13),
+    'aplicadoFix'.padStart(13),
+    'cheque'.padStart(12),
+    'perdonAct'.padStart(11),
+    'perdonFix'.padStart(11),
+    'ΔsaldoCli'.padStart(11)
+  );
+  for (const f of orden) {
+    console.log(
+      f.unidad.padEnd(12),
+      (f.estado ?? '—').padEnd(12),
+      String(f.fase ?? '—').padStart(4),
+      money(f.aplicadoActual).padStart(13),
+      money(f.aplicadoFix).padStart(13),
+      money(f.cheque).padStart(12),
+      money(f.perdonadoActual).padStart(11),
+      money(f.perdonadoFix).padStart(11),
+      money(round2(f.saldoClienteFix - f.saldoClienteActual)).padStart(11)
+    );
+  }
+
+  // CSV completo para revisión (en el tmp del SO; portable).
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const csvPath = path.join(os.tmpdir(), 'descuento_perdonado_impacto.csv');
+  const header =
+    'id,unidad,estado,fase,valor_escrituracion,aplicado_actual,aplicado_fix,cheque,perdon_actual,perdon_fix,saldo_cli_actual,saldo_cli_fix,descuento_real\n';
+  const rows = filas
+    .map((f) =>
+      [
+        f.id,
+        f.unidad,
+        f.estado ?? '',
+        f.fase ?? '',
+        f.valorEscrituracion,
+        f.aplicadoActual,
+        f.aplicadoFix,
+        f.cheque,
+        f.perdonadoActual,
+        f.perdonadoFix,
+        f.saldoClienteActual,
+        f.saldoClienteFix,
+        f.descuentoReal,
+      ].join(',')
+    )
+    .join('\n');
+  const fs = await import('node:fs/promises');
+  await fs.writeFile(csvPath, header + rows + '\n');
+  console.log(`\nCSV completo: ${csvPath}\n`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Qué y por qué

Detonante: en la revisión PLD (Fase 13) de **ARACELY MARTINEZ VASQUEZ** (M10-L32-LDLE) aparecía el warning _"Σ liquidaciones = valor pactado − descuento … con el descuento perdonado de \$1,620.00 …"_ y ese descuento no existía por ningún lado.

**Causa (bug del motor, no de captura):** en el modelo desglosado (ADR-045), `lib/dilesa/cuadratura.ts` calculaba `descuentoAplicado = promocionGastos (TOPE del bono) + sobreprecio`. Cuando el bono no se consume completo, el sobrante (tope − usado) se cuela como **"descuento perdonado" fantasma** (`descuentoAplicado − cheque`) y dispara el warning.

Aracely: tope 15,000 vs bono consumido 13,380 → 1,620 fantasma. El motor **ya calculaba** el consumido (`aportacionPromocion`, para la card); solo no lo reusaba.

## Fix (Opción A, quirúrgico)

`descuentoAplicado = aportacionPromocion (promo consumida, ya topada al bono vía partirDescuento) + sobreprecio capturado`. Reordena el bloque de cobertura de gastos para calcularlo antes. Como `aportacionPromocion ≤ tope`, **nunca infla** el descuento. El modelo legacy (sin desglose) queda intacto.

## Impacto (motor real sobre 109 ventas con desglose)

- 68 ventas cambian `descuentoAplicado`; **0 suben**.
- 45 perdón fantasma → **\$0**; 22 bajan. Σ fantasma eliminado: **−\$799K**.
- Subconjunto PLD (fase ≥ 12): ~10 a perdón 0, incl. Aracely (1,620 → 0).
- **No afecta la comisión** (`base = valor real − sobreprecio`, no depende de `descuentoAplicado`).

## Fuera de alcance (requiere Michelle)

4 ventas (M11-L7, M3-L16, M8-L10, M11-L14) siguen con perdón > 0 por **sobreprecio grande** (precio inflado, cheque chico) — es otro fenómeno, no el bug del bono.

## Pruebas

- `lib/dilesa/cuadratura.test.ts`: caso real M3-L9 (12,569.42, antes 15,000) + caso sintético Aracely M10-L32 (33,380, perdón 0). 84 tests verdes.
- 6 checks CI verdes localmente (typecheck, coverage 2151, lint, format, initiatives:validate). Sin migración.
- Script de análisis read-only: `scripts/analyze_dilesa_descuento_perdonado.ts`.

⚠️ **FINANCIERO** — cambia números de la operación. Sin auto-merge: para tu revisión y merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)