### PR TITLE
docs(dilesa-descuento-perdonado-motor): cierre de Sprint 1 en bitácora

### DIFF
--- a/docs/planning/dilesa-descuento-perdonado-motor.md
+++ b/docs/planning/dilesa-descuento-perdonado-motor.md
@@ -4,10 +4,10 @@
 **Empresas:** DILESA
 **Schemas afectados:** `lib/dilesa/cuadratura.ts` (en el modelo desglosado ADR-045, `descuentoAplicado` pasa a usar la promoción REALMENTE consumida `aportacionPromocion` + sobreprecio capturado, en vez del TOPE del bono `promocionGastos`). Sin migración ni cambio de schema de DB. Consumidores indirectos: `app/api/dilesa/ventas/[id]/revision-pld/route.ts` (calcula `descuentoPerdonado = descuentoAplicado − chequePagado`) y la revisión PLD de la Fase 13.
 **Estado:** in_progress
-**Próximo hito:** Beto revisa y mergea [#1132](https://github.com/beto-sudo/BSOP/pull/1132) (financiero, sin auto-merge). Después: revisar con Michelle los 4 outliers de sobreprecio que el fix no resuelve.
+**Próximo hito:** Revisar con Michelle los 4 outliers de sobreprecio que el fix no resuelve (M11-L7, M3-L16, M8-L10, M11-L14) — definir si ese residual es perdón legítimo antes de tocar la lógica de sobreprecio.
 **Dueño:** Beto
 **Creada:** 2026-06-29
-**Última actualización:** 2026-06-29 (Sprint 1 en PR [#1132]: fix del motor + tests + script de análisis; 6 checks CI verdes localmente)
+**Última actualización:** 2026-06-29 (Sprint 1 mergeado [#1132] — fix en prod; pendiente: outliers de sobreprecio con Michelle)
 
 > Detonante: revisando la venta de **ARACELY MARTINEZ VASQUEZ** (M10-L32-LDLE) en la
 > revisión PLD de la Fase 13, Beto vio el warning _"Σ liquidaciones = valor pactado −
@@ -85,7 +85,10 @@ revisa por separado.
 - 2026-06-29 — Sprint 1 en PR [#1132](https://github.com/beto-sudo/BSOP/pull/1132): fix
   Opción A en `cuadratura.ts` (reorden + `descuentoAplicado = aportacionPromocion +
 sobreprecioGastos`) + tests (M3-L9 real + Aracely M10-L32 sintético) + script. 6 checks
-  CI verdes localmente. Sin auto-merge (financiero) — espera revisión y merge de Beto.
+  CI verdes localmente.
+- 2026-06-29 — **[#1132] MERGEADO** (commit `18ef559`). Sin migración → no hubo
+  `db-push-on-merge`; el fix entra a prod con el deploy de Vercel. Aracely M10-L32 deja de
+  marcar el warning (perdón 0). Queda abierto el frente de los 4 outliers de sobreprecio.
 
 ## Decisiones registradas
 


### PR DESCRIPTION
Registra en el planning doc que [#1132](https://github.com/beto-sudo/BSOP/pull/1132) mergeó (commit 18ef559) y actualiza el Próximo hito al frente de outliers de sobreprecio (Michelle). Solo docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)