### PR TITLE
feat(cxp): Contabilidad programa, Dirección autoriza y registra el pago [FINANCIERO]

### DIFF
--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -45,7 +45,7 @@ import {
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
 import { CancelarConMotivoDialog } from '@/components/shared/cancelar-con-motivo-dialog';
-import { usePermissions, useEffectiveUser } from '@/components/providers';
+import { usePermissions } from '@/components/providers';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -1079,7 +1079,6 @@ function FacturaDrawer({
   onProgramado: () => void;
 }) {
   const { permissions } = usePermissions();
-  const { data: effectiveUser } = useEffectiveUser();
   const feedback = useActionFeedback();
   const [programarOpen, setProgramarOpen] = useState(false);
   const [mostrarCancelar, setMostrarCancelar] = useState(false);
@@ -1209,13 +1208,12 @@ function FacturaDrawer({
     factura != null &&
     (factura.estado_cxp === 'borrador' || factura.estado_cxp === 'por_pagar');
 
-  // Programar pago (= autoriza, S1 corte 2). Espejo en cliente del gate server
-  // de cxp_pago_aprobar (core.fn_is_admin() OR rol Dirección en la empresa).
-  // Solo aparece si la factura tiene monto por programar y hay proveedor enlazado.
-  const esDireccion =
-    permissions.isAdmin || (effectiveUser?.direccionEmpresaIds ?? []).includes(empresaId);
+  // Programar pago — lo hace Contabilidad (cualquiera con acceso al módulo; el
+  // gate de pantalla ya lo da <RequireAccess>). Programar solo deja el pago en
+  // 'programado'; quien AUTORIZA y registra el pago es Dirección, en la pestaña
+  // Programación (decisión 2026-06-29). Aparece si la factura tiene monto por
+  // programar y hay proveedor enlazado.
   const puedeProgramar =
-    esDireccion &&
     factura != null &&
     (factura.estado_cxp === 'por_pagar' || factura.estado_cxp === 'parcial') &&
     factura.porProgramar > 0;
@@ -1342,8 +1340,9 @@ function FacturaDrawer({
               </dl>
             </section>
 
-            {/* Programar pago (= autoriza, solo Dirección). Pone la acción en la
-                misma pantalla donde se clasifica partida/cuenta (pipeline S1). */}
+            {/* Programar pago — Contabilidad (mismo lugar donde clasifica
+                partida/cuenta). Deja el pago en 'programado'; la autorización y
+                el registro del pago son de Dirección, en la pestaña Programación. */}
             {puedeProgramar && (
               <>
                 <Separator />
@@ -1365,8 +1364,8 @@ function FacturaDrawer({
                         </Button>
                       </div>
                       <p className="text-[11px] text-muted-foreground">
-                        Programar autoriza el pago (rol Dirección). Luego se ejecuta y se sube el
-                        comprobante en la pestaña Programación.
+                        Queda programado. Dirección lo autoriza y registra el pago (con comprobante)
+                        en la pestaña Programación.
                       </p>
                     </>
                   ) : (
@@ -2248,10 +2247,10 @@ function RecibirXmlDialog({
   );
 }
 
-// ── Dialog: programar (= autorizar) el pago de UNA factura desde el drawer ──────
-// Pipeline S1 corte 2: la pantalla Facturas absorbe la acción de programar.
-// "Programar = autoriza" → tras crear el pago (programado) se aprueba de
-// inmediato; el gate real lo impone el RPC server-side (admin O rol Dirección).
+// ── Dialog: programar el pago de UNA factura desde el drawer ───────────────────
+// La pantalla Facturas (Contabilidad) crea el pago en 'programado'. La
+// autorización y el registro del pago los hace Dirección en la pestaña
+// Programación (decisión 2026-06-29) — aquí NO se autoriza.
 
 function ProgramarFacturaDialog({
   factura,
@@ -2298,7 +2297,9 @@ function ProgramarFacturaDialog({
     setSubmitting(true);
     setError(null);
     const sb = createSupabaseBrowserClient();
-    // 1) Programar: crea el cxp_pago en estado 'programado' + la aplicación.
+    // Programar deja el cxp_pago en 'programado' + la aplicación. La autorización
+    // y el registro del pago son de Dirección, en la pestaña Programación
+    // (decisión 2026-06-29). Aquí NO se autoriza.
     const { data: pagoId, error: progErr } = await sb.schema('erp').rpc('cxp_pago_programar', {
       p_empresa_id: empresaId,
       p_proveedor_id: factura.proveedor_id,
@@ -2307,27 +2308,13 @@ function ProgramarFacturaDialog({
       p_fecha_programada: fecha || undefined,
       p_cuenta_bancaria_id: cuentaId || undefined,
     });
+    setSubmitting(false);
     if (progErr || !pagoId) {
       setError(getSupabaseErrorMessage(progErr, 'No se pudo programar el pago.'));
-      setSubmitting(false);
       return;
     }
-    // 2) Programar = autoriza: aprobar de inmediato. El RPC valida Dirección/admin.
-    const { error: aprErr } = await sb
-      .schema('erp')
-      .rpc('cxp_pago_aprobar', { p_pago_id: pagoId as string });
-    setSubmitting(false);
-    if (aprErr) {
-      // Quedó programado pero no autorizado (no debería pasar: el botón ya gatea
-      // Dirección). Avisar sin bloquear — el pago existe y puede aprobarse aparte.
-      feedback.error(getSupabaseErrorMessage(aprErr, 'Se programó, pero no se pudo autorizar.'), {
-        title: 'Programado · falta autorizar',
-      });
-      onDone();
-      return;
-    }
-    feedback.success('Pago programado y autorizado', {
-      description: 'Pasa a la pestaña Programación para ejecutarlo y subir el comprobante.',
+    feedback.success('Pago programado', {
+      description: 'Dirección lo autoriza y registra el pago en la pestaña Programación.',
     });
     onDone();
   };
@@ -2343,8 +2330,8 @@ function ProgramarFacturaDialog({
         <DialogHeader>
           <DialogTitle>Programar pago</DialogTitle>
           <DialogDescription>
-            {proveedorLabel(factura)} · {formatCurrency(factura.porProgramar)}. Al programar, el
-            pago queda autorizado (rol Dirección); no sale dinero hasta ejecutarlo.
+            {proveedorLabel(factura)} · {formatCurrency(factura.porProgramar)}. Queda programado;
+            Dirección lo autoriza y registra el pago en la pestaña Programación.
           </DialogDescription>
         </DialogHeader>
 
@@ -2395,7 +2382,7 @@ function ProgramarFacturaDialog({
             Cancelar
           </Button>
           <Button onClick={() => void handleSubmit()} disabled={submitting}>
-            {submitting ? 'Programando…' : 'Programar y autorizar'}
+            {submitting ? 'Programando…' : 'Programar pago'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -1211,8 +1211,9 @@ function FacturaDrawer({
   // Programar pago — lo hace Contabilidad (cualquiera con acceso al módulo; el
   // gate de pantalla ya lo da <RequireAccess>). Programar solo deja el pago en
   // 'programado'; quien AUTORIZA y registra el pago es Dirección, en la pestaña
-  // Programación (decisión 2026-06-29). Aparece si la factura tiene monto por
-  // programar y hay proveedor enlazado.
+  // Programación (decisión 2026-06-29). La sección aparece si la factura tiene
+  // monto por programar; dentro, el botón exige proveedor enlazado Y cuenta
+  // contable clasificada (no se programa sin clasificar el egreso).
   const puedeProgramar =
     factura != null &&
     (factura.estado_cxp === 'por_pagar' || factura.estado_cxp === 'parcial') &&
@@ -1350,7 +1351,15 @@ function FacturaDrawer({
                   <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                     Programar pago
                   </div>
-                  {factura.proveedor_id ? (
+                  {!factura.proveedor_id ? (
+                    <p className="text-muted-foreground">
+                      Enlaza un proveedor a la factura antes de programar el pago.
+                    </p>
+                  ) : !factura.cuenta_contable_id ? (
+                    <p className="text-muted-foreground">
+                      Clasifica la cuenta contable de la factura antes de programar el pago.
+                    </p>
+                  ) : (
                     <>
                       <div className="flex items-center justify-between gap-2">
                         <span className="text-muted-foreground">
@@ -1368,10 +1377,6 @@ function FacturaDrawer({
                         en la pestaña Programación.
                       </p>
                     </>
-                  ) : (
-                    <p className="text-muted-foreground">
-                      Enlaza un proveedor a la factura antes de programar el pago.
-                    </p>
                   )}
                 </section>
               </>

--- a/components/cxp/cxp-pagos-module.test.ts
+++ b/components/cxp/cxp-pagos-module.test.ts
@@ -141,3 +141,71 @@ describe('armarControlPorPartida (CxP · drawer del pago)', () => {
     expect(cards.map((c) => c.partida_id)).toEqual(['muro']);
   });
 });
+
+// ── filtrarPagosPorHorizonte (pestaña Programación) ───────────────────────────
+
+import { filtrarPagosPorHorizonte } from './cxp-pagos-module';
+
+const HOY = '2026-06-29';
+const POR_FECHA = [
+  { id: 'vencido', fecha_programada: '2026-06-20' }, // pasado
+  { id: 'hoy', fecha_programada: '2026-06-29' }, // hoy
+  { id: 'en5', fecha_programada: '2026-07-04' }, // +5 días
+  { id: 'en12', fecha_programada: '2026-07-11' }, // +12 días
+  { id: 'en25', fecha_programada: '2026-07-24' }, // +25 días
+  { id: 'lejos', fecha_programada: '2026-09-01' }, // > mes
+  { id: 'sinfecha', fecha_programada: null }, // siempre visible
+];
+
+describe('filtrarPagosPorHorizonte (CxP · Programación)', () => {
+  it("'hoy_vencidos' (default) = vencidos + hoy + los sin fecha", () => {
+    expect(filtrarPagosPorHorizonte(POR_FECHA, 'hoy_vencidos', HOY).map((p) => p.id)).toEqual([
+      'vencido',
+      'hoy',
+      'sinfecha',
+    ]);
+  });
+
+  it("'semana' incluye hasta +7 días (acumulativo con lo vencido)", () => {
+    expect(filtrarPagosPorHorizonte(POR_FECHA, 'semana', HOY).map((p) => p.id)).toEqual([
+      'vencido',
+      'hoy',
+      'en5',
+      'sinfecha',
+    ]);
+  });
+
+  it("'quincena' incluye hasta +15 días", () => {
+    expect(filtrarPagosPorHorizonte(POR_FECHA, 'quincena', HOY).map((p) => p.id)).toEqual([
+      'vencido',
+      'hoy',
+      'en5',
+      'en12',
+      'sinfecha',
+    ]);
+  });
+
+  it("'mes' incluye hasta +30 días", () => {
+    expect(filtrarPagosPorHorizonte(POR_FECHA, 'mes', HOY).map((p) => p.id)).toEqual([
+      'vencido',
+      'hoy',
+      'en5',
+      'en12',
+      'en25',
+      'sinfecha',
+    ]);
+  });
+
+  it("'todos' (y cadena vacía) no filtra por fecha", () => {
+    expect(filtrarPagosPorHorizonte(POR_FECHA, 'todos', HOY)).toHaveLength(POR_FECHA.length);
+    expect(filtrarPagosPorHorizonte(POR_FECHA, '', HOY)).toHaveLength(POR_FECHA.length);
+  });
+
+  it('los pagos sin fecha programada nunca se esconden', () => {
+    for (const h of ['hoy_vencidos', 'semana', 'quincena', 'mes']) {
+      expect(filtrarPagosPorHorizonte(POR_FECHA, h, HOY).some((p) => p.id === 'sinfecha')).toBe(
+        true
+      );
+    }
+  });
+});

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -59,7 +59,7 @@ import { useActionFeedback } from '@/hooks/use-action-feedback';
 import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { formatCurrency } from '@/lib/format';
-import { FileAttachments } from '@/components/file-attachments';
+import { FileAttachments, useAdjuntos } from '@/components/file-attachments';
 import type { EmpresaSlug } from '@/lib/empresa-branding';
 import { HiloGastoSection } from '@/components/gasto/hilo-gasto-stepper';
 import { useFocusDrilldown } from '@/hooks/use-focus-drilldown';
@@ -1092,6 +1092,17 @@ function AutorizarYPagarDialog({
   const [referencia, setReferencia] = useState(pago.referencia ?? '');
   const [submitting, setSubmitting] = useState(false);
 
+  // Espejo del gate server (cxp_pago_autorizar_y_pagar): no se puede registrar el
+  // pago sin fecha y sin comprobante cargado. `entidad_tipo='cxp_pago'` (singular)
+  // es como FileAttachments guarda los adjuntos de 'cxp_pagos'.
+  const { adjuntos, refresh } = useAdjuntos({
+    empresaId,
+    entidadTipo: 'cxp_pago',
+    entidadId: pago.id,
+  });
+  const tieneComprobante = adjuntos.some((a) => a.rol === 'comprobante');
+  const puedeRegistrar = !!fecha && tieneComprobante && !submitting;
+
   const handleSubmit = async () => {
     setSubmitting(true);
     const sb = createSupabaseBrowserClient();
@@ -1158,7 +1169,7 @@ function AutorizarYPagarDialog({
           </div>
           <div className="space-y-1.5">
             <span className="text-xs text-muted-foreground">
-              Comprobante (imagen o PDF de la transferencia)
+              Comprobante (imagen o PDF de la transferencia) — obligatorio
             </span>
             <FileAttachments
               empresaId={empresaId}
@@ -1167,15 +1178,24 @@ function AutorizarYPagarDialog({
               entidadId={pago.id}
               roles={COMPROBANTE_ROLES}
               variant="flat"
+              onChange={() => void refresh()}
             />
           </div>
+
+          {!puedeRegistrar && !submitting && (
+            <p className="text-[11px] text-amber-600">
+              {!fecha
+                ? 'Indica la fecha de pago para continuar.'
+                : 'Sube el comprobante del pago para continuar.'}
+            </p>
+          )}
         </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={submitting}>
             Cancelar
           </Button>
-          <Button onClick={() => void handleSubmit()} disabled={submitting}>
+          <Button onClick={() => void handleSubmit()} disabled={!puedeRegistrar}>
             {submitting ? 'Registrando…' : 'Autorizar y registrar'}
           </Button>
         </DialogFooter>

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -8,18 +8,19 @@
  * Acciones por pago según su estado, todas cableadas a las RPCs que ya
  * validan server-side (ADR-037):
  *
- *   - Aprobar (programado → aprobado): `cxp_pago_aprobar`. El RPC gatea
- *     rol "Dirección"; si el caller no lo es, se muestra el error del RPC
- *     con un toast claro. El botón NO se esconde por rol en cliente —
- *     defensa: manda el RPC.
- *   - Marcar pagado (aprobado → pagado): dialog con fecha + referencia +
- *     comprobante (imagen/PDF de la transferencia, `<FileAttachments>`
- *     sobre `erp.adjuntos`), `cxp_pago_marcar_pagado`. **Confirmación
+ *   - Autorizar y registrar pago (programado|aprobado → pagado): un solo paso
+ *     (decisión 2026-06-29) — Contabilidad programa en la pestaña Facturas y
+ *     **Dirección** autoriza+registra aquí. Dialog con fecha + referencia +
+ *     comprobante (imagen/PDF, `<FileAttachments>` sobre `erp.adjuntos`),
+ *     `cxp_pago_autorizar_y_pagar`. El RPC gatea rol "Dirección"; el botón NO
+ *     se esconde por rol en cliente — defensa: manda el RPC. **Confirmación
  *     fuerte** (egreso real).
  *   - Cancelar (si no pagado): `cxp_pago_cancelar` con motivo.
  *
  * Filtro default `'pendientes'` = programados + aprobados: lo vivo que aún
- * no se ejecuta nunca sale de la vista hasta estar pagado.
+ * no se ejecuta nunca sale de la vista hasta estar pagado. La pestaña
+ * Programación añade un filtro por **horizonte de vencimiento** (default
+ * "hoy + vencidos"; presets semana/15 días/mes/todos).
  *
  * El drawer de detalle muestra las facturas aplicadas
  * (`cxp_pago_aplicaciones` → `facturas`), montos, quién aprobó/pagó, los
@@ -35,12 +36,11 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { CheckCircle2, RefreshCw, Wallet, XCircle } from 'lucide-react';
+import { RefreshCw, Wallet, XCircle } from 'lucide-react';
 
 import { ModuleFilters, ModuleContent, ErrorBanner } from '@/components/module-page';
 import { DesktopOnlyNotice } from '@/components/responsive';
 import { DetailDrawer, DetailDrawerContent } from '@/components/detail-page';
-import { ConfirmDialog } from '@/components/shared/confirm-dialog';
 import { CancelarConMotivoDialog } from '@/components/shared/cancelar-con-motivo-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -278,6 +278,47 @@ export function filtrarPagosPorEstado<T extends { estado: EstadoPago }>(
   return pagos.filter((p) => p.estado === estado);
 }
 
+// ── Filtro por horizonte de vencimiento (pestaña Programación) ────────────────
+// Cada preset es acumulativo "vence dentro de N días" e INCLUYE lo vencido
+// (fecha ≤ hoy). Default 'hoy_vencidos' = solo lo que toca hoy o ya se pasó; el
+// resto se esconde hasta cambiar el filtro. Los pagos SIN fecha programada
+// siempre se muestran (necesitan atención, no deben desaparecer).
+const HORIZONTE_DIAS: Record<string, number> = {
+  hoy_vencidos: 0,
+  semana: 7,
+  quincena: 15,
+  mes: 30,
+};
+
+export const HORIZONTE_OPTIONS = [
+  { value: 'hoy_vencidos', label: 'Hoy + vencidos' },
+  { value: 'semana', label: 'Próxima semana' },
+  { value: 'quincena', label: 'Próximos 15 días' },
+  { value: 'mes', label: 'Próximo mes' },
+  { value: 'todos', label: 'Todos' },
+];
+
+/** Suma `dias` a una fecha ISO `YYYY-MM-DD` sin arrastre de zona horaria. */
+function sumarDiasISO(iso: string, dias: number): string {
+  const [y, m, d] = iso.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + dias);
+  return dt.toISOString().slice(0, 10);
+}
+
+export function filtrarPagosPorHorizonte<T extends { fecha_programada: string | null }>(
+  pagos: T[],
+  horizonte: string,
+  hoyISO: string
+): T[] {
+  if (!horizonte || horizonte === 'todos') return pagos;
+  const dias = HORIZONTE_DIAS[horizonte];
+  if (dias == null) return pagos;
+  const limite = sumarDiasISO(hoyISO, dias);
+  // Sin fecha → siempre visible; con fecha → vence en/antes del límite.
+  return pagos.filter((p) => !p.fecha_programada || p.fecha_programada <= limite);
+}
+
 // ── Módulo ─────────────────────────────────────────────────────────────────────
 
 export function CxpPagosModule({
@@ -290,6 +331,16 @@ export function CxpPagosModule({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [estado, setEstado] = useState(estadoInicial);
+
+  // La pestaña Programación (estadoInicial='pendientes') trae el filtro por
+  // horizonte de vencimiento, con default "hoy + vencidos". La de Pagos (histórico)
+  // no lo necesita.
+  const esProgramacion = estadoInicial === 'pendientes';
+  const [horizonte, setHorizonte] = useState(esProgramacion ? 'hoy_vencidos' : 'todos');
+  const hoyISO = useMemo(
+    () => new Intl.DateTimeFormat('en-CA', { timeZone: TZ }).format(new Date()),
+    []
+  );
 
   const [selected, setSelected] = useState<Pago | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -304,8 +355,7 @@ export function CxpPagosModule({
     }
   );
 
-  // Acción pendiente: aprobar / cancelar (confirm) o marcar pagado (dialog).
-  const [aprobarPago, setAprobarPago] = useState<Pago | null>(null);
+  // Acción pendiente: cancelar (confirm) o autorizar+registrar pago (dialog).
   const [cancelarPago, setCancelarPago] = useState<Pago | null>(null);
   const [pagarPago, setPagarPago] = useState<Pago | null>(null);
 
@@ -403,7 +453,10 @@ export function CxpPagosModule({
     void fetchPagos();
   }, [fetchPagos]);
 
-  const filtered = useMemo(() => filtrarPagosPorEstado(pagos, estado), [pagos, estado]);
+  const filtered = useMemo(() => {
+    const porEstado = filtrarPagosPorEstado(pagos, estado);
+    return esProgramacion ? filtrarPagosPorHorizonte(porEstado, horizonte, hoyISO) : porEstado;
+  }, [pagos, estado, esProgramacion, horizonte, hoyISO]);
 
   const openDetail = useCallback((p: Pago) => {
     setSelected(p);
@@ -411,23 +464,6 @@ export function CxpPagosModule({
   }, []);
 
   // ── Acciones ───────────────────────────────────────────────────────────────
-
-  const doAprobar = useCallback(
-    async (pago: Pago) => {
-      const sb = createSupabaseBrowserClient();
-      const { error } = await sb.schema('erp').rpc('cxp_pago_aprobar', { p_pago_id: pago.id });
-      if (error) {
-        // El RPC valida Dirección server-side; muestra su error elegante.
-        feedback.error(getSupabaseErrorMessage(error, 'No se pudo aprobar el pago.'), {
-          title: 'No se pudo aprobar',
-        });
-        throw error; // mantiene el ConfirmDialog abierto
-      }
-      feedback.success('Pago aprobado');
-      void fetchPagos();
-    },
-    [feedback, fetchPagos]
-  );
 
   const doCancelar = useCallback(
     async (pago: Pago, motivo: string) => {
@@ -466,6 +502,17 @@ export function CxpPagosModule({
             className="w-48"
           />
 
+          {esProgramacion && (
+            <Combobox
+              value={horizonte}
+              onChange={(v) => setHorizonte(v ?? 'todos')}
+              options={HORIZONTE_OPTIONS}
+              placeholder="Horizonte"
+              size="sm"
+              className="w-44"
+            />
+          )}
+
           <Button
             variant="outline"
             size="icon"
@@ -486,7 +533,7 @@ export function CxpPagosModule({
               <Wallet className="mx-auto h-8 w-8 text-muted-foreground" />
               <p className="mt-2 font-medium">Sin pagos en este estado</p>
               <p className="mt-1 text-sm text-muted-foreground">
-                Programa pagos desde la pestaña «Programación».
+                Programa pagos desde la pestaña «Facturas».
               </p>
             </div>
           ) : (
@@ -545,25 +592,14 @@ export function CxpPagosModule({
                           onClick={(e) => e.stopPropagation()}
                         >
                           <div className="flex items-center justify-end gap-1.5">
-                            {p.estado === 'programado' && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="h-7 gap-1 px-2 text-xs"
-                                onClick={() => setAprobarPago(p)}
-                              >
-                                <CheckCircle2 className="h-3.5 w-3.5" />
-                                Aprobar
-                              </Button>
-                            )}
-                            {p.estado === 'aprobado' && (
+                            {(p.estado === 'programado' || p.estado === 'aprobado') && (
                               <Button
                                 size="sm"
                                 className="h-7 gap-1 px-2 text-xs"
                                 onClick={() => setPagarPago(p)}
                               >
                                 <Wallet className="h-3.5 w-3.5" />
-                                Marcar pagado
+                                Autorizar y registrar
                               </Button>
                             )}
                             {p.estado !== 'pagado' &&
@@ -597,11 +633,7 @@ export function CxpPagosModule({
         empresa={empresa}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
-        onAprobar={(p) => {
-          setDrawerOpen(false);
-          setAprobarPago(p);
-        }}
-        onMarcarPagado={(p) => {
+        onAutorizarPagar={(p) => {
           setDrawerOpen(false);
           setPagarPago(p);
         }}
@@ -609,28 +641,6 @@ export function CxpPagosModule({
           setDrawerOpen(false);
           setCancelarPago(p);
         }}
-      />
-
-      {/* Aprobar — confirmación (el RPC valida Dirección). */}
-      <ConfirmDialog
-        open={!!aprobarPago}
-        onOpenChange={(v) => !v && setAprobarPago(null)}
-        onConfirm={async () => {
-          if (aprobarPago) await doAprobar(aprobarPago);
-        }}
-        title="¿Aprobar este pago?"
-        description={
-          aprobarPago ? (
-            <>
-              Vas a aprobar el pago de{' '}
-              <strong>{aprobarPago.proveedor_nombre ?? '(sin proveedor)'}</strong> por{' '}
-              <strong>{formatCurrency(aprobarPago.monto_total)}</strong>. Solo Dirección puede
-              aprobar pagos; si no tienes ese rol, la acción será rechazada.
-            </>
-          ) : null
-        }
-        confirmLabel="Aprobar"
-        confirmVariant="default"
       />
 
       {/* Cancelar — confirmación con motivo (audit trail, p2p-cancelaciones D1).
@@ -646,9 +656,11 @@ export function CxpPagosModule({
         />
       )}
 
-      {/* Marcar pagado — egreso real, confirmación fuerte con fecha + referencia. */}
+      {/* Autorizar y registrar pago — Dirección. Egreso real: confirmación fuerte
+          con fecha + referencia + comprobante. Aprueba (si venía programado) y
+          marca pagado en un paso (RPC cxp_pago_autorizar_y_pagar). */}
       {pagarPago && (
-        <MarcarPagadoDialog
+        <AutorizarYPagarDialog
           key={pagarPago.id}
           pago={pagarPago}
           empresaId={empresaId}
@@ -672,8 +684,7 @@ function PagoDrawer({
   empresa,
   open,
   onClose,
-  onAprobar,
-  onMarcarPagado,
+  onAutorizarPagar,
   onCancelar,
 }: {
   pago: Pago | null;
@@ -681,8 +692,7 @@ function PagoDrawer({
   empresa: EmpresaSlug;
   open: boolean;
   onClose: () => void;
-  onAprobar: (pago: Pago) => void;
-  onMarcarPagado: (pago: Pago) => void;
+  onAutorizarPagar: (pago: Pago) => void;
   onCancelar: (pago: Pago) => void;
 }) {
   const [aplicaciones, setAplicaciones] = useState<FacturaAplicada[]>([]);
@@ -832,16 +842,10 @@ function PagoDrawer({
       footer={
         conAcciones ? (
           <div className="flex flex-wrap items-center gap-2">
-            {pago.estado === 'programado' ? (
-              <Button variant="outline" className="gap-1.5" onClick={() => onAprobar(pago)}>
-                <CheckCircle2 className="h-4 w-4" />
-                Aprobar
-              </Button>
-            ) : null}
-            {pago.estado === 'aprobado' ? (
-              <Button className="gap-1.5" onClick={() => onMarcarPagado(pago)}>
+            {pago.estado === 'programado' || pago.estado === 'aprobado' ? (
+              <Button className="gap-1.5" onClick={() => onAutorizarPagar(pago)}>
                 <Wallet className="h-4 w-4" />
-                Marcar pagado
+                Autorizar y registrar pago
               </Button>
             ) : null}
             {puedeCancelar ? (
@@ -1069,7 +1073,7 @@ function Field({ label, value, mono = false }: { label: string; value: string; m
 
 // ── Dialog: marcar pagado (egreso real) ────────────────────────────────────────
 
-function MarcarPagadoDialog({
+function AutorizarYPagarDialog({
   pago,
   empresaId,
   empresa,
@@ -1091,19 +1095,21 @@ function MarcarPagadoDialog({
   const handleSubmit = async () => {
     setSubmitting(true);
     const sb = createSupabaseBrowserClient();
-    const { error } = await sb.schema('erp').rpc('cxp_pago_marcar_pagado', {
+    // Aprueba (si venía 'programado') y marca pagado en un paso. El RPC valida
+    // rol Dirección server-side.
+    const { error } = await sb.schema('erp').rpc('cxp_pago_autorizar_y_pagar', {
       p_pago_id: pago.id,
       p_fecha_pago: fecha || undefined,
       p_referencia: referencia || undefined,
     });
     setSubmitting(false);
     if (error) {
-      feedback.error(getSupabaseErrorMessage(error, 'No se pudo marcar como pagado.'), {
-        title: 'No se pudo marcar pagado',
+      feedback.error(getSupabaseErrorMessage(error, 'No se pudo autorizar y registrar el pago.'), {
+        title: 'No se pudo registrar el pago',
       });
       return;
     }
-    feedback.success('Pago marcado como pagado', {
+    feedback.success('Pago autorizado y registrado', {
       description: pago.cuenta_nombre
         ? 'Se emitió el movimiento bancario (egreso) en la cuenta.'
         : 'Sin cuenta bancaria: no se emitió movimiento. Concílialo manualmente.',
@@ -1115,14 +1121,15 @@ function MarcarPagadoDialog({
     <Dialog open onOpenChange={(v) => !v && !submitting && onClose()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Marcar pago como pagado</DialogTitle>
+          <DialogTitle>Autorizar y registrar pago</DialogTitle>
           <DialogDescription>
-            Confirma el egreso de <strong>{formatCurrency(pago.monto_total)}</strong> a{' '}
+            Autoriza y registra el egreso de <strong>{formatCurrency(pago.monto_total)}</strong> a{' '}
             <strong>{pago.proveedor_nombre ?? '(sin proveedor)'}</strong>.{' '}
             {pago.cuenta_nombre
               ? `Se emitirá un cargo en «${pago.cuenta_nombre}».`
               : 'Este pago no tiene cuenta bancaria: no se emitirá movimiento.'}{' '}
-            Esta acción registra dinero saliendo y no es reversible automáticamente.
+            Solo Dirección puede hacerlo. Registra dinero saliendo y no es reversible
+            automáticamente.
           </DialogDescription>
         </DialogHeader>
 
@@ -1169,7 +1176,7 @@ function MarcarPagadoDialog({
             Cancelar
           </Button>
           <Button onClick={() => void handleSubmit()} disabled={submitting}>
-            {submitting ? 'Registrando…' : 'Confirmar pago'}
+            {submitting ? 'Registrando…' : 'Autorizar y registrar'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -371,6 +371,9 @@ patrón canónico de **ADR-037** (subledger gemelo):
     próxima semana / próximos 15 días / próximo mes / todos (acumulativos; los
     pagos sin fecha programada siempre visibles). Helper puro
     `filtrarPagosPorHorizonte` + tests.
+  - **Programar exige cuenta contable:** el botón "Programar pago" (pestaña
+    Facturas) solo se habilita si la factura tiene proveedor enlazado **y** cuenta
+    contable clasificada — no se programa un egreso sin clasificar.
   - Migración `20260629182508`. Aplica a prod al mergear con label `finanzas-ok`.
 
 - **2026-06-29 — Fix: facturas sin botón "Programar pago" (proveedor sin enlazar).**

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -7,7 +7,7 @@
 **Próximo hito:** Sprint 5 — conciliación de `cxp_pagos` contra el estado de cuenta. CxP ya hace su parte (emite los movimientos bancarios); el casamiento movimiento↔banco es **v1 de `conciliacion-bancaria`** (hermana, hoy desbloqueada porque CxP ya emite). Decidir con Beto si esa iniciativa lo absorbe o se hace un puente mínimo acá. Sprints 6 y 7 **cerrados**.
 **Dueño:** Beto
 **Creada:** 2026-04-28
-**Última actualización:** 2026-06-29 (fix: facturas de egreso sin proveedor enlazado no mostraban "Programar pago" — match emisor→proveedor del importador no filtraba por empresa; agregado scoping + trigger DB de auto-enlace + backfill, migración `20260629174922`)
+**Última actualización:** 2026-06-29 (nuevo reparto de deberes de pago: Contabilidad programa, Dirección autoriza+registra en un paso; "programar" sin gate, "autorizar+registrar" gateado a Dirección + filtro de horizonte en Programación, migración `20260629182508`)
 
 ## Problema
 
@@ -233,6 +233,23 @@ Revisión contra prod (2026-06-28): los dos entregables que faltaban resultaron
 
 ## Decisiones registradas
 
+### 2026-06-29 — Contabilidad programa, Dirección autoriza+registra (separación de deberes)
+
+Reunión Michelle + Administración. El control de pagos se reparte así:
+**Contabilidad** programa los pagos (y los carga al banco), **Dirección** los
+autoriza y registra en BSOP. Implicaciones de diseño:
+
+- "Programar" deja de ser un acto de Dirección → cualquier usuario con acceso al
+  módulo puede programar (queda en `programado`, sin autorizar).
+- La autorización y el registro del pago se fusionan en **un solo paso** para
+  Dirección (`cxp_pago_autorizar_y_pagar`): por decisión de Michelle, ella
+  autoriza y registra de un jalón; se sellan ambos timestamps de auditoría
+  (`aprobado_*` y `pagado_*`). El estado `aprobado` intermedio queda como legacy
+  (pagos viejos) pero el flujo nuevo no lo expone como paso separado.
+- `marcar_pagado` se blinda con gate Dirección (antes libre) por si se invoca por
+  otra vía. Política uniforme para todas las empresas (gate por rol Dirección por
+  empresa, no por código empresa-específico).
+
 ### 2026-06-29 — El enlace factura→proveedor se resuelve por RFC scoped a empresa (+ trigger DB)
 
 El match emisor→proveedor **siempre** debe filtrar por `empresa_id`: un mismo RFC
@@ -334,6 +351,27 @@ patrón canónico de **ADR-037** (subledger gemelo):
   reusan CxC y CxP (convención `shared-modules-refactor`, ADR-011).
 
 ## Bitácora
+
+- **2026-06-29 — Nuevo reparto de responsabilidades de pago (reunión Michelle + Admin).**
+  Se separa "programar" de "autorizar": **Contabilidad** carga facturas, clasifica
+  partida/cuenta y **programa** los pagos (y los carga al banco ellos mismos);
+  **Dirección (Michelle)** **autoriza y registra** el pago en BSOP. Antes
+  "programar = autoriza" (gate Dirección en Facturas) y "marcar pagado" era libre
+  — se invirtió.
+  - **Facturas tab:** "Programar pago" deja de exigir rol Dirección (lo gatea el
+    acceso al módulo) y ya **no auto-aprueba** — el pago queda en `programado`.
+  - **Programación tab:** una sola acción **"Autorizar y registrar pago"** para
+    pagos `programado`/`aprobado` (RPC nueva `cxp_pago_autorizar_y_pagar`: aprueba
+    si venía programado + marca pagado, atómico, gate Dirección). Se retiró el
+    botón "Aprobar" separado.
+  - **Gate:** `cxp_pago_marcar_pagado` ahora exige Dirección (antes libre);
+    `cxp_pago_aprobar` se mantiene. Aplica a **todas las empresas** (gate por rol
+    Dirección por empresa).
+  - **Filtro de horizonte** en Programación: default **"Hoy + vencidos"**; presets
+    próxima semana / próximos 15 días / próximo mes / todos (acumulativos; los
+    pagos sin fecha programada siempre visibles). Helper puro
+    `filtrarPagosPorHorizonte` + tests.
+  - Migración `20260629182508`. Aplica a prod al mergear con label `finanzas-ok`.
 
 - **2026-06-29 — Fix: facturas sin botón "Programar pago" (proveedor sin enlazar).**
   Beto reportó facturas de egreso en DILESA donde no aparecía el botón. Causa raíz:

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -374,6 +374,10 @@ patrón canónico de **ADR-037** (subledger gemelo):
   - **Programar exige cuenta contable:** el botón "Programar pago" (pestaña
     Facturas) solo se habilita si la factura tiene proveedor enlazado **y** cuenta
     contable clasificada — no se programa un egreso sin clasificar.
+  - **Autorizar y registrar exige fecha + comprobante:** el botón se deshabilita
+    hasta que haya fecha de pago y comprobante cargado; reforzado server-side en
+    `cxp_pago_autorizar_y_pagar` (RAISE si falta fecha o no existe adjunto
+    `rol='comprobante'`) — no se registra un egreso sin fecha ni evidencia.
   - Migración `20260629182508`. Aplica a prod al mergear con label `finanzas-ok`.
 
 - **2026-06-29 — Fix: facturas sin botón "Programar pago" (proveedor sin enlazar).**

--- a/supabase/migrations/20260629182508_cxp_pago_gate_autorizar_registrar.sql
+++ b/supabase/migrations/20260629182508_cxp_pago_gate_autorizar_registrar.sql
@@ -13,6 +13,7 @@
 -- Esta migración:
 --   1. `cxp_pago_autorizar_y_pagar` — RPC nueva: en un paso aprueba (si venía
 --      'programado') y marca pagado. Gate Dirección. Es la acción de Michelle.
+--      Exige además fecha de pago y comprobante cargado (erp.adjuntos).
 --   2. `cxp_pago_marcar_pagado` — se le agrega el gate Dirección (defensa: ya no
 --      debe poder ejecutarla Contabilidad).
 --   3. `cxp_pago_aprobar` se mantiene con su gate Dirección (sin cambios).
@@ -47,6 +48,18 @@ BEGIN
   END IF;
   IF NOT (core.fn_is_admin() OR core.fn_user_has_role('Dirección', v.empresa_id)) THEN
     RAISE EXCEPTION 'Solo admin o un usuario con rol Dirección puede autorizar y registrar pagos';
+  END IF;
+  -- Exige fecha de pago y comprobante cargado (control financiero: no se registra
+  -- un egreso sin fecha ni evidencia). El comprobante vive en erp.adjuntos.
+  IF p_fecha_pago IS NULL THEN
+    RAISE EXCEPTION 'La fecha de pago es obligatoria';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM erp.adjuntos
+    WHERE entidad_tipo = 'cxp_pago' AND entidad_id = p_pago_id
+      AND rol = 'comprobante' AND sustituido_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Sube el comprobante del pago antes de autorizar y registrarlo';
   END IF;
 
   UPDATE erp.cxp_pagos

--- a/supabase/migrations/20260629182508_cxp_pago_gate_autorizar_registrar.sql
+++ b/supabase/migrations/20260629182508_cxp_pago_gate_autorizar_registrar.sql
@@ -1,0 +1,141 @@
+-- CxP — nuevo reparto de responsabilidades de pago (iniciativa `cxp`).
+--
+-- Decisión operativa (reunión Michelle + Administración, 2026-06-29):
+--   • Contabilidad: carga facturas, clasifica partida/cuenta y **programa** los
+--     pagos (los cargan ellos mismos en el banco). → "programar" deja de exigir
+--     rol Dirección (el gate de pantalla lo da el acceso al módulo).
+--   • Dirección (Michelle): **autoriza y registra** el pago en BSOP. → la
+--     ejecución (marcar pagado) pasa a exigir rol Dirección.
+--
+-- Antes, "programar = autoriza" (un paso de Dirección en la pestaña Facturas) y
+-- "marcar pagado" era libre. Se invierte: programar libre, ejecutar gateado.
+--
+-- Esta migración:
+--   1. `cxp_pago_autorizar_y_pagar` — RPC nueva: en un paso aprueba (si venía
+--      'programado') y marca pagado. Gate Dirección. Es la acción de Michelle.
+--   2. `cxp_pago_marcar_pagado` — se le agrega el gate Dirección (defensa: ya no
+--      debe poder ejecutarla Contabilidad).
+--   3. `cxp_pago_aprobar` se mantiene con su gate Dirección (sin cambios).
+--
+-- Aplica a TODAS las empresas: el gate es por rol Dirección en cada empresa.
+
+BEGIN;
+
+-- ── 1. RPC combinada: autorizar (aprobar) + registrar pago (marcar pagado) ────
+-- Acepta un pago en 'programado' (lo aprueba en el camino) o 'aprobado' (legacy
+-- del flujo anterior). Atómica: o queda pagado o no cambia nada.
+CREATE OR REPLACE FUNCTION erp.cxp_pago_autorizar_y_pagar(
+  p_pago_id uuid,
+  p_fecha_pago date DEFAULT CURRENT_DATE,
+  p_referencia text DEFAULT NULL::text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'erp', 'public'
+AS $function$
+DECLARE
+  v erp.cxp_pagos%ROWTYPE;
+BEGIN
+  SELECT * INTO v FROM erp.cxp_pagos
+   WHERE id = p_pago_id AND deleted_at IS NULL FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Pago % no existe o está cancelado', p_pago_id;
+  END IF;
+  IF v.estado NOT IN ('programado', 'aprobado') THEN
+    RAISE EXCEPTION 'El pago debe estar programado o aprobado para autorizarse y pagarse (estado actual: %)', v.estado;
+  END IF;
+  IF NOT (core.fn_is_admin() OR core.fn_user_has_role('Dirección', v.empresa_id)) THEN
+    RAISE EXCEPTION 'Solo admin o un usuario con rol Dirección puede autorizar y registrar pagos';
+  END IF;
+
+  UPDATE erp.cxp_pagos
+     SET estado = 'pagado',
+         -- Si venía 'programado', sella también la autorización en este paso.
+         aprobado_por = COALESCE(aprobado_por, auth.uid()),
+         aprobado_at  = COALESCE(aprobado_at, now()),
+         fecha_pago = p_fecha_pago,
+         referencia = COALESCE(p_referencia, referencia),
+         pagado_por = auth.uid(),
+         pagado_at = now(),
+         updated_at = now()
+   WHERE id = p_pago_id;
+
+  -- Gancho de tesorería (ADR-037 D4). Solo si se conoce la cuenta.
+  IF v.cuenta_bancaria_id IS NOT NULL THEN
+    INSERT INTO erp.movimientos_bancarios (
+      empresa_id, cuenta_id, tipo, monto, fecha, descripcion, referencia,
+      referencia_tipo, referencia_id, conciliado
+    ) VALUES (
+      v.empresa_id, v.cuenta_bancaria_id, 'cargo', v.monto_total, p_fecha_pago,
+      'Pago CxP', COALESCE(p_referencia, v.referencia), 'cxp_pago', p_pago_id, false
+    );
+  END IF;
+
+  INSERT INTO core.audit_log (empresa_id, usuario_id, accion, tabla, registro_id, datos_nuevos)
+  VALUES (v.empresa_id, auth.uid(), 'cxp_pago_autorizado_y_pagado', 'erp.cxp_pagos', p_pago_id,
+    jsonb_build_object('fecha_pago', p_fecha_pago, 'referencia', p_referencia,
+      'monto', v.monto_total, 'cuenta_bancaria_id', v.cuenta_bancaria_id,
+      'estado_previo', v.estado));
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION erp.cxp_pago_autorizar_y_pagar(uuid, date, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION erp.cxp_pago_autorizar_y_pagar(uuid, date, text) FROM anon;
+GRANT EXECUTE ON FUNCTION erp.cxp_pago_autorizar_y_pagar(uuid, date, text) TO authenticated, service_role;
+
+-- ── 2. Gate Dirección en marcar_pagado (antes era libre) ─────────────────────
+-- Redefinida desde la versión viva en prod + el chequeo de rol. Mantiene el
+-- gancho de tesorería y el audit intactos.
+CREATE OR REPLACE FUNCTION erp.cxp_pago_marcar_pagado(
+  p_pago_id uuid,
+  p_fecha_pago date DEFAULT CURRENT_DATE,
+  p_referencia text DEFAULT NULL::text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'erp', 'public'
+AS $function$
+DECLARE
+  v erp.cxp_pagos%ROWTYPE;
+BEGIN
+  SELECT * INTO v FROM erp.cxp_pagos
+   WHERE id = p_pago_id AND deleted_at IS NULL FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Pago % no existe o está cancelado', p_pago_id;
+  END IF;
+  IF v.estado <> 'aprobado' THEN
+    RAISE EXCEPTION 'El pago debe estar aprobado antes de marcarse pagado (estado actual: %)', v.estado;
+  END IF;
+  IF NOT (core.fn_is_admin() OR core.fn_user_has_role('Dirección', v.empresa_id)) THEN
+    RAISE EXCEPTION 'Solo admin o un usuario con rol Dirección puede registrar el pago';
+  END IF;
+
+  UPDATE erp.cxp_pagos
+     SET estado = 'pagado',
+         fecha_pago = p_fecha_pago,
+         referencia = COALESCE(p_referencia, referencia),
+         pagado_por = auth.uid(),
+         pagado_at = now(),
+         updated_at = now()
+   WHERE id = p_pago_id;
+
+  IF v.cuenta_bancaria_id IS NOT NULL THEN
+    INSERT INTO erp.movimientos_bancarios (
+      empresa_id, cuenta_id, tipo, monto, fecha, descripcion, referencia,
+      referencia_tipo, referencia_id, conciliado
+    ) VALUES (
+      v.empresa_id, v.cuenta_bancaria_id, 'cargo', v.monto_total, p_fecha_pago,
+      'Pago CxP', COALESCE(p_referencia, v.referencia), 'cxp_pago', p_pago_id, false
+    );
+  END IF;
+
+  INSERT INTO core.audit_log (empresa_id, usuario_id, accion, tabla, registro_id, datos_nuevos)
+  VALUES (v.empresa_id, auth.uid(), 'cxp_pago_pagado', 'erp.cxp_pagos', p_pago_id,
+    jsonb_build_object('fecha_pago', p_fecha_pago, 'referencia', p_referencia,
+      'monto', v.monto_total, 'cuenta_bancaria_id', v.cuenta_bancaria_id));
+END;
+$function$;
+
+COMMIT;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -13284,6 +13284,14 @@ export type Database = {
         Returns: string
       }
       cxp_pago_aprobar: { Args: { p_pago_id: string }; Returns: undefined }
+      cxp_pago_autorizar_y_pagar: {
+        Args: {
+          p_fecha_pago?: string
+          p_pago_id: string
+          p_referencia?: string
+        }
+        Returns: undefined
+      }
       cxp_pago_cancelar: {
         Args: { p_motivo?: string; p_pago_id: string }
         Returns: undefined


### PR DESCRIPTION
## Contexto

Decisión de la reunión de Michelle + el equipo de Administración (2026-06-29): se separan responsabilidades en el ciclo de pago de CxP.

- **Contabilidad**: carga facturas, clasifica partida/cuenta contable, **programa** los pagos y los carga ellos mismos en el sistema bancario.
- **Dirección (Michelle)**: **autoriza y registra** el pago en BSOP.

Antes el gate de Dirección estaba en "Programar pago" (programar = autoriza); ahora se invierte.

## Cambios

**Pestaña Facturas**
- "Programar pago" deja de exigir rol Dirección — lo gatea el acceso al módulo (Contabilidad). Ya **no auto-aprueba**: el pago queda en `programado`.

**Pestaña Programación**
- Una sola acción **"Autorizar y registrar pago"** para pagos `programado`/`aprobado`, vía RPC nueva `erp.cxp_pago_autorizar_y_pagar` (aprueba si venía programado **+** marca pagado, atómico, con fecha + referencia + comprobante). Gate Dirección. Se retira el botón "Aprobar" separado.
- **Filtro de horizonte de vencimiento**, default **"Hoy + vencidos"**; presets: próxima semana, próximos 15 días, próximo mes, todos. Acumulativos (cada uno incluye lo vencido); los pagos **sin fecha programada siempre se muestran**. Helper puro `filtrarPagosPorHorizonte` + 6 tests.

**Gates (migración `20260629182508`)**
- `cxp_pago_autorizar_y_pagar` (nueva): gate Dirección.
- `cxp_pago_marcar_pagado`: se blinda con gate Dirección (antes era libre).
- `cxp_pago_aprobar`: sin cambios (sigue Dirección).
- Aplica a **todas las empresas** (gate por rol Dirección en cada empresa).

## Validación
- Shadow: `programar` deja `programado` (sin auto-aprobar) ✓; `autorizar_y_pagar` bloquea sin rol Dirección ✓.
- typecheck, lint (0 errores), format, initiatives:validate ✓
- Suite completa: **2156 tests passed** (171 files), incl. 6 nuevos del filtro de horizonte.
- `types/supabase.ts` regenerado desde shadow (solo +8 líneas: el RPC nuevo).

## ⚠️ Migración financiera
Toca RPCs de `erp.cxp_pagos`. Requiere label **`finanzas-ok`** para que `db-push-on-merge` la aplique al mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)