### PR TITLE
feat(dilesa-reportes): reporte de Detonaciones / Depósitos por mes para cierre contable [FINANCIERO]

### DIFF
--- a/app/api/dilesa/reportes/detonaciones/csv/route.ts
+++ b/app/api/dilesa/reportes/detonaciones/csv/route.ts
@@ -1,0 +1,80 @@
+/**
+ * CSV del reporte «Detonaciones / Depósitos» (DILESA · Ventas) — ADR-047.
+ * Fetch server (RLS) + mismos filtros que la vista (motor puro). Una fila por
+ * depósito (ligados + sin ligar), columnas planas para cruzar en Excel.
+ */
+import { NextResponse } from 'next/server';
+import { cargarDepositosServer } from '@/lib/dilesa/reportes/detonaciones-data-server';
+import { construirDetonaciones } from '@/lib/dilesa/reportes/detonaciones';
+import { parseFiltrosDetonaciones } from '@/lib/dilesa/reportes/detonaciones-filtros';
+import { etiquetaFuente, type DepositoReporteRow } from '@/lib/dilesa/reportes/detonaciones-data';
+
+export const runtime = 'nodejs';
+
+/** Escapa un campo CSV (comillas, comas, saltos de línea). */
+function cell(v: string | number | null | undefined): string {
+  if (v === null || v === undefined) return '';
+  const s = String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+const HEADERS = [
+  'Fecha',
+  'Mes',
+  'Origen',
+  'Cliente',
+  'Unidad',
+  'Proyecto',
+  'Tipo de crédito',
+  'Forma de pago',
+  'Referencia',
+  'Cuenta bancaria',
+  'UUID SAT',
+  'Venta detonada',
+  'Monto',
+] as const;
+
+function fila(d: DepositoReporteRow): string {
+  return [
+    d.fecha,
+    d.mes,
+    etiquetaFuente(d.fuente),
+    d.cliente,
+    d.unidadIdentificador ?? '',
+    d.proyectoNombre,
+    d.tipoCredito ?? '',
+    d.formaPago ?? '',
+    d.referencia ?? '',
+    d.cuentaBancaria ?? '',
+    d.uuidSat ?? '',
+    d.ventaDetonada ? 'Sí' : 'No',
+    d.monto.toFixed(2),
+  ]
+    .map(cell)
+    .join(',');
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const filtros = parseFiltrosDetonaciones(url.searchParams);
+
+  const { depositos, error } = await cargarDepositosServer();
+  if (error) {
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  const result = construirDetonaciones(depositos, filtros);
+  const rows = [...result.depositos, ...result.sinLigar];
+
+  // BOM para que Excel respete acentos en UTF-8.
+  const csv = ['﻿' + HEADERS.join(','), ...rows.map(fila)].join('\r\n');
+
+  return new Response(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="detonaciones-depositos.csv"',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/app/api/dilesa/reportes/detonaciones/pdf/route.tsx
+++ b/app/api/dilesa/reportes/detonaciones/pdf/route.tsx
@@ -1,0 +1,49 @@
+/**
+ * PDF del reporte «Detonaciones / Depósitos» (DILESA · Ventas) — ADR-047.
+ * Fetch server (RLS) + mismos filtros que la vista (motor puro) + branding DILESA.
+ */
+import { NextResponse } from 'next/server';
+import { renderToBuffer } from '@react-pdf/renderer';
+import { cargarDepositosServer } from '@/lib/dilesa/reportes/detonaciones-data-server';
+import { construirDetonaciones } from '@/lib/dilesa/reportes/detonaciones';
+import {
+  parseFiltrosDetonaciones,
+  filtrosTextoDetonaciones,
+} from '@/lib/dilesa/reportes/detonaciones-filtros';
+import {
+  ReporteDetonacionesPDF,
+  type DetonacionesPdfMeta,
+} from '@/lib/dilesa/pdf/reporte-detonaciones';
+
+export const runtime = 'nodejs';
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const filtros = parseFiltrosDetonaciones(url.searchParams);
+
+  const { depositos, proyectoNombre, error } = await cargarDepositosServer();
+  if (error) {
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  const result = construirDetonaciones(depositos, filtros);
+
+  const meta: DetonacionesPdfMeta = {
+    fechaTexto: new Date().toLocaleDateString('es-MX', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }),
+    filtrosTexto: filtrosTextoDetonaciones(filtros, proyectoNombre),
+  };
+
+  const buf = await renderToBuffer(<ReporteDetonacionesPDF result={result} meta={meta} />);
+  return new Response(new Uint8Array(buf), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': 'inline; filename="detonaciones-depositos.pdf"',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/app/dilesa/ventas/reportes/detonaciones/page.tsx
+++ b/app/dilesa/ventas/reportes/detonaciones/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+/**
+ * @module Ventas · Reporte Detonaciones / Depósitos (DILESA)
+ * @responsive desktop-only
+ *
+ * Patrón ADR-047 (preset + vista + PDF + CSV). `'use client'` (como
+ * `ventas-periodo/page.tsx`): el cuerpo usa `useUrlFilters` (useSearchParams),
+ * separado en `<DetonacionesView>` bajo Suspense.
+ *
+ * Gate: sub-slug `dilesa.ventas.reportes` (ADR-030 SS5).
+ */
+import { Suspense } from 'react';
+import { RequireAccess } from '@/components/require-access';
+import { Skeleton } from '@/components/ui/skeleton';
+import { DetonacionesView } from '@/components/dilesa/reportes/detonaciones-view';
+
+export default function DetonacionesPage() {
+  return (
+    <RequireAccess empresa="dilesa" modulo="dilesa.ventas.reportes">
+      <Suspense
+        fallback={
+          <div className="p-6">
+            <Skeleton className="h-96 w-full rounded-xl" />
+          </div>
+        }
+      >
+        <DetonacionesView />
+      </Suspense>
+    </RequireAccess>
+  );
+}

--- a/components/dilesa/reportes/detonaciones-view.tsx
+++ b/components/dilesa/reportes/detonaciones-view.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+/**
+ * Vista del reporte «Detonaciones / Depósitos» (DILESA · Ventas) — ADR-047.
+ * Depósitos recibidos en el rango, desglose por mes y por origen (cliente vs
+ * institución), detalle por operación y sección de depósitos sin ligar. Export
+ * PDF + CSV con los filtros aplicados. Datos vía `useDetonacionesReporte`;
+ * cálculo vía el motor puro.
+ */
+import { useMemo } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { ModuleKpiStrip, type ModuleKpi } from '@/components/module-page';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useUrlFilters } from '@/hooks/use-url-filters';
+import { formatCurrency } from '@/lib/format';
+import { getReporte } from '@/lib/dilesa/reportes/registry';
+import {
+  etiquetaFuente,
+  proyectosDepositos,
+  type DepositoReporteRow,
+} from '@/lib/dilesa/reportes/detonaciones-data';
+import { construirDetonaciones } from '@/lib/dilesa/reportes/detonaciones';
+import { useDetonacionesReporte } from './use-detonaciones-reporte';
+import { ReporteShell } from './reporte-shell';
+
+const REPORTE = getReporte('detonaciones')!;
+const VOLVER_HREF = '/dilesa/ventas/reportes';
+const DEFAULT_FILTERS = { desde: '', hasta: '', fuente: '', proyecto: '' };
+
+const inputCls =
+  'h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-2 text-sm text-[var(--text)]';
+
+function FuenteBadge({ row }: { row: DepositoReporteRow }) {
+  const esInst = row.fuente === 'institucion';
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
+        esInst
+          ? 'bg-[var(--accent)]/15 text-[var(--accent)]'
+          : 'bg-[var(--bg)]/60 text-[var(--text)]/60'
+      }`}
+    >
+      {etiquetaFuente(row.fuente)}
+    </span>
+  );
+}
+
+export function DetonacionesView() {
+  const { filters, setFilter, clearAll, activeCount } = useUrlFilters(DEFAULT_FILTERS);
+  const { depositos, loading, error, recargar } = useDetonacionesReporte();
+
+  const result = useMemo(
+    () =>
+      construirDetonaciones(depositos, {
+        desde: filters.desde,
+        hasta: filters.hasta,
+        fuente: filters.fuente as '' | 'cliente' | 'institucion' | 'otro',
+        proyecto: filters.proyecto,
+      }),
+    [depositos, filters]
+  );
+  const proys = useMemo(() => proyectosDepositos(depositos), [depositos]);
+
+  const kpis = useMemo<readonly ModuleKpi[]>(
+    () => [
+      { key: 'depositos', label: 'Depósitos', value: result.totalDepositos },
+      {
+        key: 'monto',
+        label: 'Monto total',
+        value: result.totalMonto === 0 ? '—' : formatCurrency(result.totalMonto, { compact: true }),
+      },
+      {
+        key: 'institucion',
+        label: 'Institución (detonaciones)',
+        value:
+          result.totalInstitucion === 0
+            ? '—'
+            : formatCurrency(result.totalInstitucion, { compact: true }),
+      },
+      {
+        key: 'cliente',
+        label: 'Cliente',
+        value:
+          result.totalCliente === 0 ? '—' : formatCurrency(result.totalCliente, { compact: true }),
+      },
+    ],
+    [result]
+  );
+
+  const queryString = useMemo(() => {
+    const p = new URLSearchParams();
+    if (filters.desde) p.set('desde', filters.desde);
+    if (filters.hasta) p.set('hasta', filters.hasta);
+    if (filters.fuente) p.set('fuente', filters.fuente);
+    if (filters.proyecto) p.set('proyecto', filters.proyecto);
+    return p.toString();
+  }, [filters]);
+
+  const pdfHref = `/api/dilesa/reportes/detonaciones/pdf${queryString ? `?${queryString}` : ''}`;
+  const csvHref = `/api/dilesa/reportes/detonaciones/csv${queryString ? `?${queryString}` : ''}`;
+
+  const filtros = (
+    <>
+      <label className="flex items-center gap-1.5 text-xs text-[var(--text)]/60">
+        Desde
+        <input
+          type="date"
+          value={filters.desde}
+          onChange={(e) => setFilter('desde', e.target.value)}
+          className={inputCls}
+        />
+      </label>
+      <label className="flex items-center gap-1.5 text-xs text-[var(--text)]/60">
+        Hasta
+        <input
+          type="date"
+          value={filters.hasta}
+          onChange={(e) => setFilter('hasta', e.target.value)}
+          className={inputCls}
+        />
+      </label>
+      <select
+        value={filters.fuente}
+        onChange={(e) => setFilter('fuente', e.target.value)}
+        className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+      >
+        <option value="">Todos los orígenes</option>
+        <option value="institucion">Solo institución (detonaciones)</option>
+        <option value="cliente">Solo cliente</option>
+      </select>
+      <select
+        value={filters.proyecto}
+        onChange={(e) => setFilter('proyecto', e.target.value)}
+        className="h-9 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm text-[var(--text)]"
+      >
+        <option value="">Todos los proyectos</option>
+        {proys.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.nombre}
+          </option>
+        ))}
+      </select>
+      {activeCount > 0 ? (
+        <button
+          type="button"
+          onClick={() => clearAll()}
+          className="text-xs text-[var(--text)]/60 underline hover:text-[var(--text)]"
+        >
+          Limpiar filtros
+        </button>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => void recargar()}
+        className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+      >
+        <RefreshCw className="h-3.5 w-3.5" /> Refrescar
+      </button>
+    </>
+  );
+
+  return (
+    <ReporteShell
+      reporte={REPORTE}
+      volverHref={VOLVER_HREF}
+      pdfHref={pdfHref}
+      csvHref={csvHref}
+      filtros={filtros}
+    >
+      <ModuleKpiStrip stats={kpis} cols={4} />
+
+      {error ? (
+        <div className="space-y-3">
+          <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+            {error}
+          </div>
+          <button
+            type="button"
+            onClick={() => void recargar()}
+            className="flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] px-3 text-sm text-[var(--text)]/70 hover:text-[var(--text)]"
+          >
+            <RefreshCw className="h-3.5 w-3.5" /> Reintentar
+          </button>
+        </div>
+      ) : loading ? (
+        <Skeleton className="h-96 w-full rounded-xl" />
+      ) : result.totalDepositos === 0 ? (
+        <div className="rounded-xl border border-dashed border-[var(--border)] p-10 text-center text-sm text-[var(--text)]/50">
+          Sin depósitos en el periodo seleccionado.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {result.porMes.length > 1 ? (
+            <div className="flex flex-wrap gap-2">
+              {result.porMes.map((mm) => (
+                <div
+                  key={mm.mes}
+                  className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-2"
+                >
+                  <div className="text-[11px] uppercase tracking-wide text-[var(--text)]/45">
+                    {mm.mes}
+                  </div>
+                  <div className="text-sm font-semibold text-[var(--text)]">
+                    {mm.depositos} · {formatCurrency(mm.monto, { compact: true })}
+                  </div>
+                  <div className="text-[11px] text-[var(--text)]/50">
+                    Inst. {formatCurrency(mm.montoInstitucion, { compact: true })} · Cli.{' '}
+                    {formatCurrency(mm.montoCliente, { compact: true })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="overflow-x-auto rounded-xl border border-[var(--border)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[var(--border)] bg-[var(--bg)]/40 text-left text-xs uppercase tracking-wide text-[var(--text)]/50">
+                  <th className="px-3 py-2.5 font-medium">Fecha</th>
+                  <th className="px-3 py-2.5 font-medium">Origen</th>
+                  <th className="px-3 py-2.5 font-medium">Cliente</th>
+                  <th className="hidden px-3 py-2.5 font-medium lg:table-cell">
+                    Unidad / proyecto
+                  </th>
+                  <th className="hidden px-3 py-2.5 font-medium xl:table-cell">Tipo crédito</th>
+                  <th className="hidden px-3 py-2.5 font-medium md:table-cell">Forma / ref.</th>
+                  <th className="hidden px-3 py-2.5 font-medium xl:table-cell">Cuenta</th>
+                  <th className="px-3 py-2.5 text-right font-medium">Monto</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.depositos.map((d) => (
+                  <tr
+                    key={d.id}
+                    className="border-b border-[var(--border)]/50 last:border-0 hover:bg-[var(--bg)]/30"
+                  >
+                    <td className="px-3 py-2.5 tabular-nums text-[var(--text)]/70">{d.fecha}</td>
+                    <td className="px-3 py-2.5">
+                      <FuenteBadge row={d} />
+                    </td>
+                    <td className="px-3 py-2.5 font-medium text-[var(--text)]">{d.cliente}</td>
+                    <td className="hidden px-3 py-2.5 text-[var(--text)]/70 lg:table-cell">
+                      {[d.unidadIdentificador, d.proyectoNombre].filter(Boolean).join(' · ') || '—'}
+                    </td>
+                    <td className="hidden px-3 py-2.5 text-[var(--text)]/70 xl:table-cell">
+                      {d.tipoCredito ?? '—'}
+                    </td>
+                    <td className="hidden px-3 py-2.5 text-[var(--text)]/70 md:table-cell">
+                      {[d.formaPago, d.referencia].filter(Boolean).join(' · ') || '—'}
+                    </td>
+                    <td className="hidden px-3 py-2.5 text-[var(--text)]/70 xl:table-cell">
+                      {d.cuentaBancaria ?? '—'}
+                    </td>
+                    <td className="px-3 py-2.5 text-right font-semibold tabular-nums text-[var(--text)]">
+                      {formatCurrency(d.monto)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t-2 border-[var(--accent)]/40 bg-[var(--bg)]/40 font-semibold">
+                  <td className="px-3 py-2.5" colSpan={7}>
+                    Total ({result.totalDepositos}) · Inst.{' '}
+                    {formatCurrency(result.totalInstitucion)} · Cli.{' '}
+                    {formatCurrency(result.totalCliente)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-[var(--accent)]">
+                    {formatCurrency(result.totalMonto)}
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+
+          {result.sinLigar.length > 0 ? (
+            <div className="space-y-2">
+              <h3 className="text-sm font-semibold text-[var(--text)]/70">
+                Depósitos sin ligar a una venta ({result.sinLigar.length})
+              </h3>
+              <p className="text-xs text-[var(--text)]/45">
+                Abonos registrados en Cobranza que aún no se aplican a una venta. Revisar para el
+                cuadre.
+              </p>
+              <div className="overflow-x-auto rounded-xl border border-dashed border-[var(--border)]">
+                <table className="w-full text-sm">
+                  <tbody>
+                    {result.sinLigar.map((d) => (
+                      <tr key={d.id} className="border-b border-[var(--border)]/40 last:border-0">
+                        <td className="px-3 py-2 tabular-nums text-[var(--text)]/70">{d.fecha}</td>
+                        <td className="px-3 py-2">
+                          <FuenteBadge row={d} />
+                        </td>
+                        <td className="px-3 py-2 text-[var(--text)]/60">
+                          {[d.formaPago, d.referencia].filter(Boolean).join(' · ') || '—'}
+                        </td>
+                        <td className="px-3 py-2 text-right font-semibold tabular-nums text-[var(--text)]">
+                          {formatCurrency(d.monto)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </ReporteShell>
+  );
+}

--- a/components/dilesa/reportes/reporte-shell.tsx
+++ b/components/dilesa/reportes/reporte-shell.tsx
@@ -10,13 +10,14 @@
  */
 import { type ReactNode } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Download } from 'lucide-react';
+import { ArrowLeft, Download, Sheet } from 'lucide-react';
 import type { ReporteDef } from '@/lib/dilesa/reportes/tipos';
 
 export function ReporteShell({
   reporte,
   volverHref,
   pdfHref,
+  csvHref,
   filtros,
   children,
 }: {
@@ -25,6 +26,8 @@ export function ReporteShell({
   volverHref: string;
   /** Link de exportación a PDF (con los filtros actuales). Omitir = sin botón. */
   pdfHref?: string;
+  /** Link de exportación a CSV (con los filtros actuales). Omitir = sin botón. */
+  csvHref?: string;
   /** Barra de filtros (selects, date-range…). */
   filtros?: ReactNode;
   children: ReactNode;
@@ -52,17 +55,28 @@ export function ReporteShell({
             <p className="max-w-2xl text-sm text-[var(--text)]/60">{reporte.descripcion}</p>
           </div>
         </div>
-        {pdfHref ? (
-          <a
-            href={pdfHref}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40"
-          >
-            <Download className="h-4 w-4" />
-            Exportar PDF
-          </a>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {csvHref ? (
+            <a
+              href={csvHref}
+              className="inline-flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40"
+            >
+              <Sheet className="h-4 w-4" />
+              Exportar CSV
+            </a>
+          ) : null}
+          {pdfHref ? (
+            <a
+              href={pdfHref}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex h-9 items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 text-sm font-medium text-[var(--text)]/80 hover:bg-[var(--bg)]/40"
+            >
+              <Download className="h-4 w-4" />
+              Exportar PDF
+            </a>
+          ) : null}
+        </div>
       </header>
 
       {filtros ? <div className="flex flex-wrap items-center gap-3">{filtros}</div> : null}

--- a/components/dilesa/reportes/use-detonaciones-reporte.ts
+++ b/components/dilesa/reportes/use-detonaciones-reporte.ts
@@ -1,0 +1,107 @@
+'use client';
+
+/* eslint-disable react-hooks/set-state-in-effect --
+ * Mismo data-sync pattern que el resto de páginas de lectura DILESA
+ * (cf. use-ventas-reporte.ts).
+ */
+
+/**
+ * Hook de datos para el reporte de Detonaciones / Depósitos (ADR-047). Fetch en
+ * el browser (queries con `.eq(empresa_id)` para evitar URLs > 8KB) +
+ * normalización compartida (`normalizarDepositos`), con estado de carga/error y
+ * refetch. Espejo de `use-ventas-reporte` adaptado a `erp.cxc_pagos`.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import {
+  normalizarDepositos,
+  DEPOSITOS_SELECT,
+  VENTAS_DEPOSITO_SELECT,
+  type DepositoRaw,
+  type DepositoReporteRow,
+  type DepositosRawBundle,
+  type VentaDepositoRaw,
+} from '@/lib/dilesa/reportes/detonaciones-data';
+
+export function useDetonacionesReporte() {
+  const [depositos, setDepositos] = useState<DepositoReporteRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const recargar = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const sb = createSupabaseBrowserClient();
+    const [depRes, ventasRes, unidadesRes, prjRes, personasRes, cuentasRes] = await Promise.all([
+      sb
+        .schema('erp')
+        .from('cxc_pagos')
+        .select(DEPOSITOS_SELECT)
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .eq('origen_tipo', 'venta_dilesa')
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('ventas')
+        .select(VENTAS_DEPOSITO_SELECT)
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null),
+      sb
+        .schema('dilesa')
+        .from('unidades')
+        .select('id, identificador, proyecto_id')
+        .eq('empresa_id', DILESA_EMPRESA_ID),
+      sb
+        .schema('dilesa')
+        .from('proyectos')
+        .select('id, nombre')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .is('deleted_at', null),
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .eq('empresa_id', DILESA_EMPRESA_ID)
+        .eq('tipo', 'cliente'),
+      sb
+        .schema('erp')
+        .from('cuentas_bancarias')
+        .select('id, nombre')
+        .eq('empresa_id', DILESA_EMPRESA_ID),
+    ]);
+
+    const firstErr =
+      depRes.error ??
+      ventasRes.error ??
+      unidadesRes.error ??
+      prjRes.error ??
+      personasRes.error ??
+      cuentasRes.error;
+    if (firstErr) {
+      setError(getSupabaseErrorMessage(firstErr, 'No se pudo cargar el reporte.'));
+      setDepositos([]);
+      setLoading(false);
+      return;
+    }
+
+    setDepositos(
+      normalizarDepositos({
+        depositos: (depRes.data ?? []) as DepositoRaw[],
+        ventas: (ventasRes.data ?? []) as VentaDepositoRaw[],
+        unidades: (unidadesRes.data ?? []) as DepositosRawBundle['unidades'],
+        proyectos: (prjRes.data ?? []) as DepositosRawBundle['proyectos'],
+        personas: (personasRes.data ?? []) as DepositosRawBundle['personas'],
+        cuentas: (cuentasRes.data ?? []) as DepositosRawBundle['cuentas'],
+      })
+    );
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void recargar();
+  }, [recargar]);
+
+  return { depositos, loading, error, recargar };
+}

--- a/lib/dilesa/pdf/reporte-detonaciones.tsx
+++ b/lib/dilesa/pdf/reporte-detonaciones.tsx
@@ -1,0 +1,209 @@
+/**
+ * PDF del reporte «Detonaciones / Depósitos» (DILESA · Ventas) — ADR-047.
+ * Recibe el `DetonacionesResult` ya calculado (misma fuente que la pantalla).
+ */
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import { styles, colors } from './styles';
+import { HeaderBand, FooterBand } from './header-footer';
+import { etiquetaFuente } from '@/lib/dilesa/reportes/detonaciones-data';
+import type { DetonacionesResult } from '@/lib/dilesa/reportes/detonaciones';
+
+const moneyFmt = new Intl.NumberFormat('es-MX', {
+  style: 'currency',
+  currency: 'MXN',
+  maximumFractionDigits: 0,
+});
+const m = (n: number) => moneyFmt.format(n);
+
+export type DetonacionesPdfMeta = { fechaTexto: string; filtrosTexto: string };
+
+export function ReporteDetonacionesPDF({
+  result,
+  meta,
+}: {
+  result: DetonacionesResult;
+  meta: DetonacionesPdfMeta;
+}) {
+  return (
+    <Document title="Detonaciones / Depósitos — DILESA">
+      <Page size="LETTER" orientation="landscape" style={styles.page}>
+        <HeaderBand title="DETONACIONES / DEPÓSITOS" fecha={meta.fechaTexto} />
+        <Text style={s.subtitle}>Depósitos recibidos · {meta.filtrosTexto}</Text>
+
+        <View style={s.resumenRow}>
+          <View style={s.resumenCard}>
+            <Text style={s.resumenLabel}>Depósitos</Text>
+            <Text style={s.resumenValue}>{result.totalDepositos}</Text>
+          </View>
+          <View style={s.resumenCard}>
+            <Text style={s.resumenLabel}>Monto total</Text>
+            <Text style={s.resumenValue}>{m(result.totalMonto)}</Text>
+          </View>
+          <View style={s.resumenCard}>
+            <Text style={s.resumenLabel}>Institución (detonaciones)</Text>
+            <Text style={s.resumenValue}>{m(result.totalInstitucion)}</Text>
+          </View>
+          <View style={s.resumenCard}>
+            <Text style={s.resumenLabel}>Cliente</Text>
+            <Text style={s.resumenValue}>{m(result.totalCliente)}</Text>
+          </View>
+        </View>
+
+        {result.porMes.length > 1 ? (
+          <View style={s.porMesWrap}>
+            <Text style={s.blockTitle}>Por mes</Text>
+            {result.porMes.map((mm) => (
+              <View key={mm.mes} style={s.porMesRow} wrap={false}>
+                <Text style={s.porMesMes}>{mm.mes}</Text>
+                <Text style={s.porMesNum}>{mm.depositos} dep.</Text>
+                <Text style={s.porMesSplit}>Inst. {m(mm.montoInstitucion)}</Text>
+                <Text style={s.porMesSplit}>Cli. {m(mm.montoCliente)}</Text>
+                <Text style={s.porMesMonto}>{m(mm.monto)}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        <Text style={s.blockTitle}>Detalle</Text>
+        <View style={s.tableHead}>
+          <Text style={[s.th, s.colFecha]}>Fecha</Text>
+          <Text style={[s.th, s.colFuente]}>Origen</Text>
+          <Text style={[s.th, s.colCliente]}>Cliente</Text>
+          <Text style={[s.th, s.colUnidad]}>Unidad / proyecto</Text>
+          <Text style={[s.th, s.colCredito]}>Tipo crédito</Text>
+          <Text style={[s.th, s.colRef]}>Forma / ref.</Text>
+          <Text style={[s.thNum, s.colMonto]}>Monto</Text>
+        </View>
+        {result.depositos.map((d) => (
+          <View key={d.id} style={s.tr} wrap={false}>
+            <Text style={[s.tdMuted, s.colFecha]}>{d.fecha}</Text>
+            <Text style={[s.td, s.colFuente]}>{etiquetaFuente(d.fuente)}</Text>
+            <Text style={[s.td, s.colCliente]}>{d.cliente}</Text>
+            <Text style={[s.tdMuted, s.colUnidad]}>
+              {[d.unidadIdentificador, d.proyectoNombre].filter(Boolean).join(' · ') || '—'}
+            </Text>
+            <Text style={[s.tdMuted, s.colCredito]}>{d.tipoCredito ?? '—'}</Text>
+            <Text style={[s.tdMuted, s.colRef]}>
+              {[d.formaPago, d.referencia].filter(Boolean).join(' · ') || '—'}
+            </Text>
+            <Text style={[s.tdNum, s.colMonto]}>{m(d.monto)}</Text>
+          </View>
+        ))}
+        <View style={s.trTotal} wrap={false}>
+          <Text style={[s.tdTotal, s.colFecha]}> </Text>
+          <Text style={[s.tdTotal, s.colFuente]}>Total ({result.totalDepositos})</Text>
+          <Text style={[s.tdTotal, s.colCliente]}>Inst. {m(result.totalInstitucion)}</Text>
+          <Text style={[s.tdTotal, s.colUnidad]}>Cli. {m(result.totalCliente)}</Text>
+          <Text style={[s.tdTotal, s.colCredito]}> </Text>
+          <Text style={[s.tdTotal, s.colRef]}> </Text>
+          <Text style={[s.tdTotalNum, s.colMonto]}>{m(result.totalMonto)}</Text>
+        </View>
+
+        {result.sinLigar.length > 0 ? (
+          <View style={s.sinLigarWrap}>
+            <Text style={s.blockTitle}>
+              Depósitos sin ligar a una venta ({result.sinLigar.length})
+            </Text>
+            {result.sinLigar.map((d) => (
+              <View key={d.id} style={s.tr} wrap={false}>
+                <Text style={[s.tdMuted, s.colFecha]}>{d.fecha}</Text>
+                <Text style={[s.td, s.colFuente]}>{etiquetaFuente(d.fuente)}</Text>
+                <Text style={[s.tdMuted, s.colCliente]}>
+                  {[d.formaPago, d.referencia].filter(Boolean).join(' · ') || '—'}
+                </Text>
+                <Text style={[s.tdMuted, s.colUnidad]}> </Text>
+                <Text style={[s.tdMuted, s.colCredito]}> </Text>
+                <Text style={[s.tdMuted, s.colRef]}> </Text>
+                <Text style={[s.tdNum, s.colMonto]}>{m(d.monto)}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        <FooterBand />
+      </Page>
+    </Document>
+  );
+}
+
+const s = StyleSheet.create({
+  subtitle: { fontSize: 9, color: colors.textMuted, marginBottom: 10 },
+  resumenRow: { flexDirection: 'row', marginBottom: 14 },
+  resumenCard: {
+    flex: 1,
+    borderWidth: 0.5,
+    borderColor: colors.border,
+    borderRadius: 3,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    marginRight: 8,
+  },
+  resumenLabel: {
+    fontSize: 7,
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    marginBottom: 3,
+  },
+  resumenValue: { fontSize: 14, fontFamily: 'Helvetica-Bold', color: colors.primary },
+  blockTitle: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    letterSpacing: 0.4,
+    marginTop: 6,
+    marginBottom: 5,
+  },
+  porMesWrap: { marginBottom: 8 },
+  porMesRow: {
+    flexDirection: 'row',
+    paddingVertical: 2.5,
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.borderSoft,
+  },
+  porMesMes: { fontSize: 9, fontFamily: 'Helvetica-Bold', width: '15%' },
+  porMesNum: { fontSize: 9, color: colors.textMuted, width: '15%' },
+  porMesSplit: { fontSize: 9, color: colors.textMuted, width: '25%' },
+  porMesMonto: { fontSize: 9, fontFamily: 'Helvetica-Bold', textAlign: 'right', width: '20%' },
+  tableHead: {
+    flexDirection: 'row',
+    backgroundColor: colors.primary,
+    paddingVertical: 5,
+    paddingHorizontal: 4,
+    borderRadius: 2,
+  },
+  th: { fontSize: 8, fontFamily: 'Helvetica-Bold', color: '#fff', letterSpacing: 0.3 },
+  thNum: { fontSize: 8, fontFamily: 'Helvetica-Bold', color: '#fff', textAlign: 'right' },
+  tr: {
+    flexDirection: 'row',
+    paddingVertical: 3.5,
+    paddingHorizontal: 4,
+    borderBottomWidth: 0.5,
+    borderBottomColor: colors.borderSoft,
+  },
+  td: { fontSize: 9, color: colors.text },
+  tdMuted: { fontSize: 8, color: colors.textMuted },
+  tdNum: { fontSize: 9, fontFamily: 'Helvetica-Bold', color: colors.text, textAlign: 'right' },
+  trTotal: {
+    flexDirection: 'row',
+    paddingVertical: 5,
+    paddingHorizontal: 4,
+    backgroundColor: colors.bgSoft,
+    borderTopWidth: 1,
+    borderTopColor: colors.primary,
+  },
+  tdTotal: { fontSize: 8, fontFamily: 'Helvetica-Bold', color: colors.text },
+  tdTotalNum: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.primary,
+    textAlign: 'right',
+  },
+  sinLigarWrap: { marginTop: 10 },
+  colFecha: { width: '10%' },
+  colFuente: { width: '10%' },
+  colCliente: { width: '24%' },
+  colUnidad: { width: '21%' },
+  colCredito: { width: '14%' },
+  colRef: { width: '11%' },
+  colMonto: { width: '10%' },
+});

--- a/lib/dilesa/reportes/detonaciones-data-server.ts
+++ b/lib/dilesa/reportes/detonaciones-data-server.ts
@@ -1,0 +1,86 @@
+/**
+ * Loader server-side de DEPÓSITOS DILESA para las rutas de PDF/CSV del reporte
+ * de detonaciones (ADR-047). Espejo del fetch del hook del browser, con
+ * `createSupabaseServerClient` (sesión + RLS empresa-scoped) y la misma
+ * normalización pura. Solo lo importan route handlers (server).
+ */
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import {
+  normalizarDepositos,
+  DEPOSITOS_SELECT,
+  VENTAS_DEPOSITO_SELECT,
+  type DepositoRaw,
+  type DepositoReporteRow,
+  type DepositosRawBundle,
+  type VentaDepositoRaw,
+} from './detonaciones-data';
+
+export async function cargarDepositosServer(): Promise<{
+  depositos: DepositoReporteRow[];
+  proyectoNombre: Map<string, string>;
+  error?: string;
+}> {
+  const sb = await createSupabaseServerClient();
+  const [depRes, ventasRes, unidadesRes, prjRes, personasRes, cuentasRes] = await Promise.all([
+    sb
+      .schema('erp')
+      .from('cxc_pagos')
+      .select(DEPOSITOS_SELECT)
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .eq('origen_tipo', 'venta_dilesa')
+      .is('deleted_at', null),
+    sb
+      .schema('dilesa')
+      .from('ventas')
+      .select(VENTAS_DEPOSITO_SELECT)
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .is('deleted_at', null),
+    sb
+      .schema('dilesa')
+      .from('unidades')
+      .select('id, identificador, proyecto_id')
+      .eq('empresa_id', DILESA_EMPRESA_ID),
+    sb
+      .schema('dilesa')
+      .from('proyectos')
+      .select('id, nombre')
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .is('deleted_at', null),
+    sb
+      .schema('erp')
+      .from('personas')
+      .select('id, nombre, apellido_paterno, apellido_materno')
+      .eq('empresa_id', DILESA_EMPRESA_ID)
+      .eq('tipo', 'cliente'),
+    sb
+      .schema('erp')
+      .from('cuentas_bancarias')
+      .select('id, nombre')
+      .eq('empresa_id', DILESA_EMPRESA_ID),
+  ]);
+
+  const firstErr =
+    depRes.error ??
+    ventasRes.error ??
+    unidadesRes.error ??
+    prjRes.error ??
+    personasRes.error ??
+    cuentasRes.error;
+  if (firstErr) {
+    return { depositos: [], proyectoNombre: new Map(), error: firstErr.message };
+  }
+
+  const proyectos = (prjRes.data ?? []) as Array<{ id: string; nombre: string }>;
+  return {
+    depositos: normalizarDepositos({
+      depositos: (depRes.data ?? []) as DepositoRaw[],
+      ventas: (ventasRes.data ?? []) as VentaDepositoRaw[],
+      unidades: (unidadesRes.data ?? []) as DepositosRawBundle['unidades'],
+      proyectos,
+      personas: (personasRes.data ?? []) as DepositosRawBundle['personas'],
+      cuentas: (cuentasRes.data ?? []) as DepositosRawBundle['cuentas'],
+    }),
+    proyectoNombre: new Map(proyectos.map((p) => [p.id, p.nombre])),
+  };
+}

--- a/lib/dilesa/reportes/detonaciones-data.ts
+++ b/lib/dilesa/reportes/detonaciones-data.ts
@@ -1,0 +1,168 @@
+/**
+ * Tipos + normalización de DEPÓSITOS DILESA para el reporte de detonaciones
+ * (ADR-047). Grano: un abono de `erp.cxc_pagos` ligado a una venta DILESA vía
+ * `origen_id` (mismo amarre que `cuadratura-server`). Distingue origen
+ * cliente (enganche/abono) vs institución (liberación de crédito = la
+ * «detonación» de fase 12).
+ *
+ * Módulo PURO (sin Supabase ni React): lo comparten el hook del browser
+ * (`use-detonaciones-reporte`) y el loader server (`detonaciones-data-server`,
+ * rutas PDF/CSV). `normalizarDepositos` deriva el shape una sola vez →
+ * paridad pantalla ↔ PDF ↔ CSV.
+ */
+
+/** Origen del depósito tal como lo guarda `erp.cxc_pagos.fuente`. */
+export type FuenteDeposito = 'cliente' | 'institucion' | 'otro';
+
+/** Depósito normalizado con los campos que consume el reporte. */
+export type DepositoReporteRow = {
+  id: string;
+  /** Fecha del depósito `YYYY-MM-DD`. */
+  fecha: string;
+  /** Mes del depósito `YYYY-MM` (agrupador). */
+  mes: string;
+  monto: number;
+  fuente: FuenteDeposito;
+  /** Forma de pago libre (transferencia, cheque, efectivo…). */
+  formaPago: string | null;
+  /** Referencia/folio del movimiento. */
+  referencia: string | null;
+  /** Nombre de la cuenta bancaria que recibió (null si no asignada). */
+  cuentaBancaria: string | null;
+  /** UUID del CFDI si el abono trae comprobante fiscal. */
+  uuidSat: string | null;
+  /** Venta ligada (null = depósito sin ligar a una venta). */
+  ventaId: string | null;
+  cliente: string;
+  proyectoId: string | null;
+  proyectoNombre: string;
+  unidadIdentificador: string | null;
+  /** Tipo de crédito de la venta = la institución cuando `fuente='institucion'`. */
+  tipoCredito: string | null;
+  faseActual: string | null;
+  estadoVenta: string | null;
+  /** ¿La venta llegó a Detonada (fase ≥ 12)? Contexto contable. */
+  ventaDetonada: boolean;
+};
+
+export type DepositoRaw = {
+  id: string;
+  fecha: string;
+  monto_total: number | null;
+  fuente: string | null;
+  forma_pago: string | null;
+  referencia: string | null;
+  cuenta_bancaria_id: string | null;
+  uuid_sat: string | null;
+  origen_id: string | null;
+};
+
+export type VentaDepositoRaw = {
+  id: string;
+  persona_id: string;
+  unidad_id: string | null;
+  tipo_credito: string | null;
+  fase_actual: string | null;
+  fase_posicion: number | null;
+  estado: string | null;
+};
+
+export type DepositosRawBundle = {
+  depositos: readonly DepositoRaw[];
+  ventas: ReadonlyArray<VentaDepositoRaw>;
+  unidades: ReadonlyArray<{ id: string; identificador: string | null; proyecto_id: string | null }>;
+  proyectos: ReadonlyArray<{ id: string; nombre: string }>;
+  personas: ReadonlyArray<{
+    id: string;
+    nombre: string | null;
+    apellido_paterno: string | null;
+    apellido_materno: string | null;
+  }>;
+  cuentas: ReadonlyArray<{ id: string; nombre: string }>;
+};
+
+/** El SELECT de depósitos que necesita el reporte (mantener en sync con DepositoRaw). */
+export const DEPOSITOS_SELECT =
+  'id, fecha, monto_total, fuente, forma_pago, referencia, cuenta_bancaria_id, uuid_sat, origen_id';
+
+/** El SELECT de ventas para el reporte de depósitos (mantener en sync con VentaDepositoRaw). */
+export const VENTAS_DEPOSITO_SELECT =
+  'id, persona_id, unidad_id, tipo_credito, fase_actual, fase_posicion, estado';
+
+/** Normaliza `cxc_pagos.fuente` (texto libre) al enum del reporte. */
+export function normalizarFuente(f: string | null): FuenteDeposito {
+  if (f === 'cliente') return 'cliente';
+  if (f === 'institucion') return 'institucion';
+  return 'otro';
+}
+
+/** Etiqueta legible de la fuente. */
+export function etiquetaFuente(f: FuenteDeposito): string {
+  if (f === 'cliente') return 'Cliente';
+  if (f === 'institucion') return 'Institución';
+  return 'Otro';
+}
+
+/**
+ * Normaliza el bundle crudo a filas de reporte. Pura: la usan tanto el fetch
+ * del browser como el del server (misma derivación → paridad pantalla/PDF/CSV).
+ */
+export function normalizarDepositos(b: DepositosRawBundle): DepositoReporteRow[] {
+  const ventaMap = new Map(b.ventas.map((v) => [v.id, v]));
+  const unidadMap = new Map(
+    b.unidades.map((u) => [u.id, { identificador: u.identificador, proyectoId: u.proyecto_id }])
+  );
+  const proyectoMap = new Map(b.proyectos.map((p) => [p.id, p.nombre]));
+  const personaMap = new Map(
+    b.personas.map((p) => [
+      p.id,
+      [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' ') ||
+        '(sin nombre)',
+    ])
+  );
+  const cuentaMap = new Map(b.cuentas.map((c) => [c.id, c.nombre]));
+
+  return b.depositos.map((d) => {
+    const venta = d.origen_id ? ventaMap.get(d.origen_id) : undefined;
+    const u = venta?.unidad_id ? unidadMap.get(venta.unidad_id) : null;
+    return {
+      id: d.id,
+      fecha: d.fecha,
+      mes: d.fecha.slice(0, 7),
+      monto: d.monto_total ?? 0,
+      fuente: normalizarFuente(d.fuente),
+      formaPago: d.forma_pago,
+      referencia: d.referencia,
+      cuentaBancaria: d.cuenta_bancaria_id ? (cuentaMap.get(d.cuenta_bancaria_id) ?? null) : null,
+      uuidSat: d.uuid_sat,
+      ventaId: venta?.id ?? null,
+      cliente: venta
+        ? (personaMap.get(venta.persona_id) ?? '(sin comprador)')
+        : '(sin venta ligada)',
+      proyectoId: u?.proyectoId ?? null,
+      proyectoNombre: u?.proyectoId ? (proyectoMap.get(u.proyectoId) ?? '') : '',
+      unidadIdentificador: u?.identificador ?? null,
+      tipoCredito: venta?.tipo_credito ?? null,
+      faseActual: venta?.fase_actual ?? null,
+      estadoVenta: venta?.estado ?? null,
+      ventaDetonada: (venta?.fase_posicion ?? 0) >= 12,
+    };
+  });
+}
+
+/**
+ * Proyectos presentes EN LOS DEPÓSITOS (para el selector de filtro), únicos por
+ * id y ordenados por nombre. Simétrico con `proyectosPresentes` de `ventas-data`:
+ * se deriva del propio dataset para no traer cascarones del catálogo.
+ */
+export function proyectosDepositos(
+  depositos: readonly DepositoReporteRow[]
+): Array<{ id: string; nombre: string }> {
+  const porId = new Map<string, string>();
+  for (const d of depositos) {
+    if (d.proyectoId && d.proyectoNombre) porId.set(d.proyectoId, d.proyectoNombre);
+  }
+  return [...porId.entries()]
+    .map(([id, nombre]) => ({ id, nombre }))
+    .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'));
+}

--- a/lib/dilesa/reportes/detonaciones-filtros.ts
+++ b/lib/dilesa/reportes/detonaciones-filtros.ts
@@ -1,0 +1,42 @@
+/**
+ * Parseo + descripción legible de los filtros del reporte de detonaciones.
+ * Compartido por las rutas de PDF y CSV (server) para no duplicar la lógica.
+ * Puro (sin Supabase ni React).
+ */
+import { etiquetaFuente, normalizarFuente, type FuenteDeposito } from './detonaciones-data';
+import type { FiltrosDetonaciones } from './detonaciones';
+
+/** Lee los filtros desde los query params de la request. */
+export function parseFiltrosDetonaciones(params: URLSearchParams): FiltrosDetonaciones {
+  const fuenteRaw = params.get('fuente') ?? '';
+  const fuente: '' | FuenteDeposito = fuenteRaw === '' ? '' : normalizarFuente(fuenteRaw);
+  return {
+    desde: params.get('desde') ?? '',
+    hasta: params.get('hasta') ?? '',
+    fuente,
+    proyecto: params.get('proyecto') ?? '',
+  };
+}
+
+/** Descripción legible del rango + filtros activos para el encabezado del PDF. */
+export function filtrosTextoDetonaciones(
+  filtros: FiltrosDetonaciones,
+  proyectoNombre: Map<string, string>
+): string {
+  const rango =
+    filtros.desde && filtros.hasta
+      ? `Del ${filtros.desde} al ${filtros.hasta}`
+      : filtros.desde
+        ? `Desde ${filtros.desde}`
+        : filtros.hasta
+          ? `Hasta ${filtros.hasta}`
+          : null;
+  const partes = [
+    rango,
+    filtros.fuente ? `Origen: ${etiquetaFuente(filtros.fuente)}` : null,
+    filtros.proyecto
+      ? `Proyecto: ${proyectoNombre.get(filtros.proyecto) ?? filtros.proyecto}`
+      : null,
+  ].filter(Boolean);
+  return partes.length > 0 ? partes.join(' · ') : 'Todos los depósitos';
+}

--- a/lib/dilesa/reportes/detonaciones.test.ts
+++ b/lib/dilesa/reportes/detonaciones.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { construirDetonaciones } from './detonaciones';
+import {
+  normalizarDepositos,
+  normalizarFuente,
+  etiquetaFuente,
+  proyectosDepositos,
+  type DepositoReporteRow,
+  type DepositosRawBundle,
+} from './detonaciones-data';
+
+function row(overrides: Partial<DepositoReporteRow>): DepositoReporteRow {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    fecha: '2026-06-15',
+    mes: '2026-06',
+    monto: 100,
+    fuente: 'cliente',
+    formaPago: null,
+    referencia: null,
+    cuentaBancaria: null,
+    uuidSat: null,
+    ventaId: 'v1',
+    cliente: 'Cliente X',
+    proyectoId: 'p1',
+    proyectoNombre: 'Proyecto 1',
+    unidadIdentificador: 'A-1',
+    tipoCredito: 'Infonavit',
+    faseActual: 'Detonada',
+    estadoVenta: 'activa',
+    ventaDetonada: true,
+    ...overrides,
+    // mes deriva de fecha si no se pasa explícito
+    ...(overrides.fecha && !overrides.mes ? { mes: overrides.fecha.slice(0, 7) } : {}),
+  };
+}
+
+describe('normalizarFuente / etiquetaFuente', () => {
+  it('mapea cliente / institucion y cae a otro', () => {
+    expect(normalizarFuente('cliente')).toBe('cliente');
+    expect(normalizarFuente('institucion')).toBe('institucion');
+    expect(normalizarFuente('algo')).toBe('otro');
+    expect(normalizarFuente(null)).toBe('otro');
+  });
+  it('etiqueta legible', () => {
+    expect(etiquetaFuente('cliente')).toBe('Cliente');
+    expect(etiquetaFuente('institucion')).toBe('Institución');
+    expect(etiquetaFuente('otro')).toBe('Otro');
+  });
+});
+
+describe('normalizarDepositos', () => {
+  const bundle: DepositosRawBundle = {
+    depositos: [
+      {
+        id: 'd1',
+        fecha: '2026-06-10',
+        monto_total: 500000,
+        fuente: 'institucion',
+        forma_pago: 'transferencia',
+        referencia: 'REF-1',
+        cuenta_bancaria_id: 'c1',
+        uuid_sat: 'UUID-1',
+        origen_id: 'v1',
+      },
+      // depósito sin venta ligada
+      {
+        id: 'd2',
+        fecha: '2026-06-12',
+        monto_total: 30000,
+        fuente: 'cliente',
+        forma_pago: null,
+        referencia: null,
+        cuenta_bancaria_id: null,
+        uuid_sat: null,
+        origen_id: null,
+      },
+    ],
+    ventas: [
+      {
+        id: 'v1',
+        persona_id: 'per1',
+        unidad_id: 'u1',
+        tipo_credito: 'Infonavit',
+        fase_actual: 'Detonada',
+        fase_posicion: 12,
+        estado: 'activa',
+      },
+    ],
+    unidades: [{ id: 'u1', identificador: 'A-1', proyecto_id: 'p1' }],
+    proyectos: [{ id: 'p1', nombre: 'Lomas' }],
+    personas: [
+      { id: 'per1', nombre: 'Juan', apellido_paterno: 'Pérez', apellido_materno: 'Gómez' },
+    ],
+    cuentas: [{ id: 'c1', nombre: 'BBVA Operativa' }],
+  };
+
+  it('liga venta → cliente/unidad/proyecto/cuenta y marca detonada', () => {
+    const rows = normalizarDepositos(bundle);
+    const d1 = rows.find((r) => r.id === 'd1')!;
+    expect(d1.cliente).toBe('Juan Pérez Gómez');
+    expect(d1.unidadIdentificador).toBe('A-1');
+    expect(d1.proyectoNombre).toBe('Lomas');
+    expect(d1.cuentaBancaria).toBe('BBVA Operativa');
+    expect(d1.fuente).toBe('institucion');
+    expect(d1.mes).toBe('2026-06');
+    expect(d1.ventaDetonada).toBe(true);
+  });
+
+  it('depósito sin origen_id queda sin venta ligada', () => {
+    const rows = normalizarDepositos(bundle);
+    const d2 = rows.find((r) => r.id === 'd2')!;
+    expect(d2.ventaId).toBeNull();
+    expect(d2.cliente).toBe('(sin venta ligada)');
+    expect(d2.ventaDetonada).toBe(false);
+  });
+
+  it('proyectosDepositos deriva únicos de los ligados', () => {
+    const rows = normalizarDepositos(bundle);
+    expect(proyectosDepositos(rows)).toEqual([{ id: 'p1', nombre: 'Lomas' }]);
+  });
+});
+
+describe('construirDetonaciones', () => {
+  const rows: DepositoReporteRow[] = [
+    row({ id: 'a', fecha: '2026-05-20', monto: 400000, fuente: 'institucion' }),
+    row({ id: 'b', fecha: '2026-06-05', monto: 30000, fuente: 'cliente' }),
+    row({ id: 'c', fecha: '2026-06-18', monto: 500000, fuente: 'institucion' }),
+    row({ id: 'd', fecha: '2026-06-25', monto: 12000, fuente: 'cliente', ventaId: null }),
+  ];
+
+  it('totales globales y split por origen', () => {
+    const r = construirDetonaciones(rows, { desde: '', hasta: '', fuente: '', proyecto: '' });
+    expect(r.totalDepositos).toBe(4);
+    expect(r.totalMonto).toBe(942000);
+    expect(r.totalInstitucion).toBe(900000);
+    expect(r.totalCliente).toBe(42000);
+    expect(r.detonaciones).toBe(2);
+  });
+
+  it('separa los depósitos sin ligar', () => {
+    const r = construirDetonaciones(rows, { desde: '', hasta: '', fuente: '', proyecto: '' });
+    expect(r.depositos.map((d) => d.id)).toEqual(['c', 'b', 'a']); // ligados, fecha desc
+    expect(r.sinLigar.map((d) => d.id)).toEqual(['d']);
+  });
+
+  it('agrupa por mes con split y orden ascendente', () => {
+    const r = construirDetonaciones(rows, { desde: '', hasta: '', fuente: '', proyecto: '' });
+    expect(r.porMes.map((m) => m.mes)).toEqual(['2026-05', '2026-06']);
+    const jun = r.porMes.find((m) => m.mes === '2026-06')!;
+    expect(jun.depositos).toBe(3); // b, c, d
+    expect(jun.montoInstitucion).toBe(500000);
+    expect(jun.montoCliente).toBe(42000);
+  });
+
+  it('filtra por rango de fechas', () => {
+    const r = construirDetonaciones(rows, {
+      desde: '2026-06-01',
+      hasta: '2026-06-30',
+      fuente: '',
+      proyecto: '',
+    });
+    expect(r.totalDepositos).toBe(3);
+    expect(r.depositos.find((d) => d.id === 'a')).toBeUndefined();
+  });
+
+  it('filtra solo institución (las detonaciones)', () => {
+    const r = construirDetonaciones(rows, {
+      desde: '',
+      hasta: '',
+      fuente: 'institucion',
+      proyecto: '',
+    });
+    expect(r.totalDepositos).toBe(2);
+    expect(r.totalCliente).toBe(0);
+    expect(r.sinLigar).toHaveLength(0);
+  });
+
+  it('al filtrar por proyecto omite los sin ligar', () => {
+    const r = construirDetonaciones(rows, { desde: '', hasta: '', fuente: '', proyecto: 'p1' });
+    expect(r.sinLigar).toHaveLength(0);
+    expect(r.depositos.every((d) => d.proyectoId === 'p1')).toBe(true);
+  });
+});

--- a/lib/dilesa/reportes/detonaciones.ts
+++ b/lib/dilesa/reportes/detonaciones.ts
@@ -1,0 +1,123 @@
+/**
+ * Motor del reporte «Detonaciones / Depósitos» (DILESA · Ventas) — ADR-047.
+ *
+ * Lista los DEPÓSITOS recibidos (cobranza de ventas) cuya fecha cae en el rango,
+ * con desglose por mes y por origen (cliente vs institución). La «detonación»
+ * contable = el abono de institución que libera el crédito y cierra la fase 12;
+ * el reporte la marca como subconjunto `fuente='institucion'`. Pura y testeable;
+ * la comparten la vista, el PDF y el CSV.
+ */
+import type { DepositoReporteRow, FuenteDeposito } from './detonaciones-data';
+
+export type FiltrosDetonaciones = {
+  /** Inicio del rango `YYYY-MM-DD` (vacío = sin límite inferior). */
+  desde: string;
+  /** Fin del rango `YYYY-MM-DD` (vacío = sin límite superior). */
+  hasta: string;
+  /** Origen del depósito: '' = todos. */
+  fuente: '' | FuenteDeposito;
+  proyecto: string;
+};
+
+export const FILTROS_DETONACIONES_VACIOS: FiltrosDetonaciones = {
+  desde: '',
+  hasta: '',
+  fuente: '',
+  proyecto: '',
+};
+
+export type DetonacionMesRow = {
+  mes: string;
+  /** Conteo de depósitos del mes. */
+  depositos: number;
+  monto: number;
+  montoCliente: number;
+  montoInstitucion: number;
+};
+
+export type DetonacionesResult = {
+  /** Depósitos ligados a una venta, en el rango, ordenados por fecha desc. */
+  depositos: DepositoReporteRow[];
+  /** Depósitos sin venta ligada (a vigilar en el cuadre), fecha desc. */
+  sinLigar: DepositoReporteRow[];
+  /** Desglose por mes, ascendente. */
+  porMes: DetonacionMesRow[];
+  totalDepositos: number;
+  totalMonto: number;
+  totalCliente: number;
+  totalInstitucion: number;
+  /** Depósitos de institución (las «detonaciones» propiamente). */
+  detonaciones: number;
+};
+
+function enRango(fecha: string, desde: string, hasta: string): boolean {
+  if (desde && fecha < desde) return false;
+  if (hasta && fecha > hasta) return false;
+  return true;
+}
+
+/** Construye el reporte de depósitos/detonaciones a partir de las filas normalizadas. */
+export function construirDetonaciones(
+  rows: readonly DepositoReporteRow[],
+  filtros: FiltrosDetonaciones
+): DetonacionesResult {
+  // Rango + origen aplican a todo; el filtro de proyecto solo aplica a los
+  // ligados (un depósito sin venta no tiene proyecto y quedaría siempre fuera).
+  const enRangoYFuente = rows.filter(
+    (r) =>
+      enRango(r.fecha, filtros.desde, filtros.hasta) &&
+      (!filtros.fuente || r.fuente === filtros.fuente)
+  );
+
+  const ligados = enRangoYFuente
+    .filter((r) => r.ventaId !== null)
+    .filter((r) => !filtros.proyecto || r.proyectoId === filtros.proyecto)
+    .sort((a, b) => b.fecha.localeCompare(a.fecha) || b.monto - a.monto);
+
+  // Los «sin ligar» se omiten cuando se filtra por proyecto (no tienen uno).
+  const sinLigar = filtros.proyecto
+    ? []
+    : enRangoYFuente
+        .filter((r) => r.ventaId === null)
+        .sort((a, b) => b.fecha.localeCompare(a.fecha) || b.monto - a.monto);
+
+  const todos = [...ligados, ...sinLigar];
+
+  const mesMap = new Map<string, DetonacionMesRow>();
+  for (const d of todos) {
+    const cur =
+      mesMap.get(d.mes) ??
+      ({
+        mes: d.mes,
+        depositos: 0,
+        monto: 0,
+        montoCliente: 0,
+        montoInstitucion: 0,
+      } as DetonacionMesRow);
+    cur.depositos += 1;
+    cur.monto += d.monto;
+    if (d.fuente === 'cliente') cur.montoCliente += d.monto;
+    else if (d.fuente === 'institucion') cur.montoInstitucion += d.monto;
+    mesMap.set(d.mes, cur);
+  }
+  const porMes = [...mesMap.values()].sort((a, b) => a.mes.localeCompare(b.mes));
+
+  const totalMonto = todos.reduce((acc, d) => acc + d.monto, 0);
+  const totalCliente = todos
+    .filter((d) => d.fuente === 'cliente')
+    .reduce((acc, d) => acc + d.monto, 0);
+  const totalInstitucion = todos
+    .filter((d) => d.fuente === 'institucion')
+    .reduce((acc, d) => acc + d.monto, 0);
+
+  return {
+    depositos: ligados,
+    sinLigar,
+    porMes,
+    totalDepositos: todos.length,
+    totalMonto,
+    totalCliente,
+    totalInstitucion,
+    detonaciones: todos.filter((d) => d.fuente === 'institucion').length,
+  };
+}

--- a/lib/dilesa/reportes/registry.ts
+++ b/lib/dilesa/reportes/registry.ts
@@ -10,6 +10,7 @@
  * los siguientes sprints calcando este molde.
  */
 import {
+  Banknote,
   Boxes,
   CalendarClock,
   CalendarRange,
@@ -46,6 +47,17 @@ export const REPORTES: readonly ReporteDef[] = [
     modulo: { slug: MODULO_VENTAS_REPORTES, label: 'Ventas' },
     href: '/dilesa/ventas/reportes/ventas-periodo',
     icon: CalendarRange,
+    tipo: 'modulo',
+    pdf: true,
+  },
+  {
+    id: 'detonaciones',
+    nombre: 'Detonaciones / Depósitos',
+    descripcion:
+      'Depósitos recibidos en el periodo (cobranza de ventas) con desglose por mes y por origen: liberación de crédito de institución (la detonación) vs abono directo del cliente. El insumo del cierre contable, exportable a PDF y CSV.',
+    modulo: { slug: MODULO_VENTAS_REPORTES, label: 'Ventas' },
+    href: '/dilesa/ventas/reportes/detonaciones',
+    icon: Banknote,
     tipo: 'modulo',
     pdf: true,
   },


### PR DESCRIPTION
## Qué

Nuevo reporte **Detonaciones / Depósitos** en el hub de Reportes de Ventas (ADR-047), pensado para que contabilidad tenga claras las detonaciones del mes en el cierre.

Grano: un renglón por **depósito** (`erp.cxc_pagos` ligado a una venta DILESA vía `origen_id`, mismo amarre que `cuadratura-server`), agrupado por **mes** de la fecha del depósito, distinguiendo origen:
- **Institución** = liberación del crédito (INFONAVIT/banco) → la "detonación" de fase 12.
- **Cliente** = enganche / abono directo.

## Columnas
Fecha · Origen · Cliente · Unidad/Proyecto · Tipo de crédito · Forma de pago / Referencia · Cuenta bancaria · UUID SAT · ¿Venta detonada? · Monto. Subtotales por mes con split Institución/Cliente y totales globales.

## Entrega
- **Pantalla**: KPIs + desglose mensual + tabla + sección de **depósitos sin ligar** (abonos en Cobranza aún sin aplicar a una venta — a vigilar en el cuadre).
- **PDF** (`/api/dilesa/reportes/detonaciones/pdf`, @react-pdf landscape) y **CSV** (`/api/dilesa/reportes/detonaciones/csv`, BOM UTF-8 para Excel). Ambos respetan los filtros activos.
- **Filtros**: rango de fechas, origen (todos / solo institución / solo cliente), proyecto.

## Alcance / seguridad
- **Solo lectura.** No toca DB, no hay migración, no toca RBAC — reusa el sub-slug `dilesa.ventas.reportes`.
- Tag `[FINANCIERO]` por presentar montos de cobranza; sin mutaciones ni gate (no aplica `finanzas-ok`).

## Verificación
- 6 checks CI espejo en verde local: typecheck, test:coverage (2162 tests; motor 100% líneas, thresholds OK), lint (0 errores), format:check, initiatives:validate. schema:check N/A (sin DB).

## Nota
Dejo el PR **sin auto-merge** por ser pantalla nueva: revisá el Vercel Preview (`/dilesa/ventas/reportes/detonaciones`) y mergeás vos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)