### PR TITLE
feat(cxp): agrupar pagos por proveedor — Fases 1 y 2 [FINANCIERO]

### DIFF
--- a/components/cxp/cxp-facturas-module.test.ts
+++ b/components/cxp/cxp-facturas-module.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { esElegibleProgramar } from './cxp-facturas-module';
+
+// Builder mínimo: solo los campos que mira la regla de elegibilidad.
+type Arg = Parameters<typeof esElegibleProgramar>[0];
+const f = (over: Partial<Arg>): Arg =>
+  ({
+    estado_cxp: 'por_pagar',
+    porProgramar: 100,
+    proveedor_id: 'prov-1',
+    cuenta_contable_id: 'cta-1',
+    ...over,
+  }) as Arg;
+
+describe('esElegibleProgramar (selección para pago agrupado)', () => {
+  it('elegible: por_pagar (o parcial) con saldo, proveedor y cuenta contable', () => {
+    expect(esElegibleProgramar(f({}))).toBe(true);
+    expect(esElegibleProgramar(f({ estado_cxp: 'parcial' }))).toBe(true);
+  });
+
+  it('no elegible sin saldo por programar', () => {
+    expect(esElegibleProgramar(f({ porProgramar: 0 }))).toBe(false);
+  });
+
+  it('no elegible sin proveedor enlazado', () => {
+    expect(esElegibleProgramar(f({ proveedor_id: null }))).toBe(false);
+  });
+
+  it('no elegible sin cuenta contable clasificada', () => {
+    expect(esElegibleProgramar(f({ cuenta_contable_id: null }))).toBe(false);
+  });
+
+  it('no elegible en estados que no son por_pagar/parcial', () => {
+    for (const estado of ['borrador', 'pagada', 'cancelada'] as const) {
+      expect(esElegibleProgramar(f({ estado_cxp: estado }))).toBe(false);
+    }
+  });
+});

--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -389,6 +389,20 @@ const columns: Column<Factura>[] = [
   },
 ];
 
+/**
+ * Una factura es elegible para programar (sola o en grupo) si tiene saldo por
+ * programar, proveedor enlazado y cuenta contable clasificada — mismas
+ * condiciones que el botón individual del drawer.
+ */
+export function esElegibleProgramar(f: Factura): boolean {
+  return (
+    (f.estado_cxp === 'por_pagar' || f.estado_cxp === 'parcial') &&
+    f.porProgramar > 0 &&
+    !!f.proveedor_id &&
+    !!f.cuenta_contable_id
+  );
+}
+
 // ── Módulo ─────────────────────────────────────────────────────────────────────
 
 export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps) {
@@ -402,6 +416,11 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
 
   const [selected, setSelected] = useState<Factura | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // Selección múltiple para programar un PAGO que cubre varias facturas del mismo
+  // proveedor (Fase 1 de agrupación de pagos). Solo en la vista "Por programar".
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [bulkProgramarOpen, setBulkProgramarOpen] = useState(false);
 
   // Drill-down (?focus=<factura_id>) desde el hilo del gasto de otros módulos.
   useFocusDrilldown(
@@ -823,6 +842,59 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
     });
   }, [facturas, search, estado, vista]);
 
+  // ── Selección múltiple (programar un pago por varias facturas) ──────────────
+  const selectedFacturas = useMemo(
+    () => facturas.filter((f) => selectedIds.includes(f.id)),
+    [facturas, selectedIds]
+  );
+  // Proveedor "ancla" de la selección: un pago = una transferencia a un solo
+  // proveedor, así que mientras haya selección los demás proveedores se bloquean.
+  const selProveedorId = selectedFacturas[0]?.proveedor_id ?? null;
+  const selTotal = selectedFacturas.reduce((s, f) => s + f.porProgramar, 0);
+
+  const toggleSeleccion = useCallback((f: Factura) => {
+    setSelectedIds((prev) =>
+      prev.includes(f.id) ? prev.filter((id) => id !== f.id) : [...prev, f.id]
+    );
+  }, []);
+  const limpiarSeleccion = useCallback(() => setSelectedIds([]), []);
+
+  // La selección solo vive en la vista "Por programar"; al cambiar de vista o
+  // buscar, se limpia para no arrastrar facturas que ya no se ven.
+  useEffect(() => {
+    if (vista !== 'por_programar') setSelectedIds([]);
+  }, [vista]);
+
+  // Columna de selección (checkbox) al frente, solo en "Por programar". Bloquea
+  // las no elegibles y las de otro proveedor mientras haya selección activa.
+  const columnsConSeleccion = useMemo<Column<Factura>[]>(() => {
+    if (vista !== 'por_programar') return columnsConPartida;
+    const selCol: Column<Factura> = {
+      key: '_sel',
+      label: '',
+      sortable: false,
+      width: 'w-8',
+      render: (f) => {
+        const checked = selectedIds.includes(f.id);
+        const otroProveedor = !!selProveedorId && f.proveedor_id !== selProveedorId;
+        const disabled = !esElegibleProgramar(f) || (!checked && otroProveedor);
+        return (
+          <span onClick={(e) => e.stopPropagation()} className="flex">
+            <input
+              type="checkbox"
+              checked={checked}
+              disabled={disabled}
+              onChange={() => toggleSeleccion(f)}
+              aria-label="Seleccionar factura para pago agrupado"
+              className="h-4 w-4 cursor-pointer accent-foreground disabled:cursor-not-allowed disabled:opacity-30"
+            />
+          </span>
+        );
+      },
+    };
+    return [selCol, ...columnsConPartida];
+  }, [vista, columnsConPartida, selectedIds, selProveedorId, toggleSeleccion]);
+
   // Facturas EN ESPERA del XML: destajos de vivienda aprobados o estimaciones de
   // obra autorizadas, cuya factura nació en borrador. Administración sube aquí el
   // XML del contratista (sin teclear folio). Iniciativas dilesa-estimaciones-cxp
@@ -954,10 +1026,32 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
 
         {error && <ErrorBanner error={error} onRetry={() => void fetchFacturas()} />}
 
+        {vista === 'por_programar' && selectedFacturas.length > 0 && (
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-primary/40 bg-primary/5 px-4 py-2.5">
+            <div className="text-sm">
+              <span className="font-semibold">{selectedFacturas.length}</span> factura
+              {selectedFacturas.length !== 1 ? 's' : ''} de{' '}
+              <span className="font-medium">{proveedorLabel(selectedFacturas[0])}</span> ·{' '}
+              <span className="font-semibold tabular-nums text-amber-600">
+                {formatCurrency(selTotal)}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={limpiarSeleccion}>
+                Limpiar
+              </Button>
+              <Button size="sm" className="gap-2" onClick={() => setBulkProgramarOpen(true)}>
+                <CalendarClock className="h-3.5 w-3.5" />
+                Programar pago
+              </Button>
+            </div>
+          </div>
+        )}
+
         <ModuleContent>
           <DataTable<Factura>
             data={filtered}
-            columns={columnsConPartida}
+            columns={columnsConSeleccion}
             rowKey="id"
             loading={loading}
             onRowClick={openDetail}
@@ -1007,6 +1101,20 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
           void fetchFacturas();
         }}
       />
+
+      {/* Programar un pago que cubre varias facturas del mismo proveedor (Fase 1). */}
+      {bulkProgramarOpen && selectedFacturas.length > 0 && (
+        <ProgramarFacturaDialog
+          facturas={selectedFacturas}
+          empresaId={empresaId}
+          onClose={() => setBulkProgramarOpen(false)}
+          onDone={() => {
+            setBulkProgramarOpen(false);
+            limpiarSeleccion();
+            void fetchFacturas();
+          }}
+        />
+      )}
 
       <UploadXmlDialog
         empresa={empresa}
@@ -1783,7 +1891,7 @@ function FacturaDrawer({
 
       {programarOpen && factura && (
         <ProgramarFacturaDialog
-          factura={factura}
+          facturas={[factura]}
           empresaId={empresaId}
           onClose={() => setProgramarOpen(false)}
           onDone={() => {
@@ -2258,12 +2366,13 @@ function RecibirXmlDialog({
 // Programación (decisión 2026-06-29) — aquí NO se autoriza.
 
 function ProgramarFacturaDialog({
-  factura,
+  facturas,
   empresaId,
   onClose,
   onDone,
 }: {
-  factura: Factura;
+  /** 1..N facturas del MISMO proveedor a cubrir con un solo pago. */
+  facturas: Factura[];
   empresaId: string;
   onClose: () => void;
   onDone: () => void;
@@ -2277,6 +2386,10 @@ function ProgramarFacturaDialog({
   const [fecha, setFecha] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const proveedorId = facturas[0]?.proveedor_id ?? null;
+  const total = facturas.reduce((s, f) => s + f.porProgramar, 0);
+  const esGrupo = facturas.length > 1;
 
   useEffect(() => {
     let activo = true;
@@ -2298,17 +2411,20 @@ function ProgramarFacturaDialog({
   }, [empresaId]);
 
   const handleSubmit = async () => {
-    if (!factura.proveedor_id) return;
+    if (!proveedorId || facturas.length === 0) return;
     setSubmitting(true);
     setError(null);
     const sb = createSupabaseBrowserClient();
-    // Programar deja el cxp_pago en 'programado' + la aplicación. La autorización
-    // y el registro del pago son de Dirección, en la pestaña Programación
-    // (decisión 2026-06-29). Aquí NO se autoriza.
+    // Un solo cxp_pago cubre las N facturas (la RPC recibe N aplicaciones).
+    // Programar deja el pago en 'programado'; la autorización y el registro los
+    // hace Dirección en la pestaña Programación (decisión 2026-06-29).
     const { data: pagoId, error: progErr } = await sb.schema('erp').rpc('cxp_pago_programar', {
       p_empresa_id: empresaId,
-      p_proveedor_id: factura.proveedor_id,
-      p_aplicaciones: [{ factura_id: factura.id, monto: factura.porProgramar }] as unknown as Json,
+      p_proveedor_id: proveedorId,
+      p_aplicaciones: facturas.map((f) => ({
+        factura_id: f.id,
+        monto: f.porProgramar,
+      })) as unknown as Json,
       p_metodo_pago: metodo || undefined,
       p_fecha_programada: fecha || undefined,
       p_cuenta_bancaria_id: cuentaId || undefined,
@@ -2318,9 +2434,12 @@ function ProgramarFacturaDialog({
       setError(getSupabaseErrorMessage(progErr, 'No se pudo programar el pago.'));
       return;
     }
-    feedback.success('Pago programado', {
-      description: 'Dirección lo autoriza y registra el pago en la pestaña Programación.',
-    });
+    feedback.success(
+      esGrupo ? `Pago programado · ${facturas.length} facturas` : 'Pago programado',
+      {
+        description: 'Dirección lo autoriza y registra el pago en la pestaña Programación.',
+      }
+    );
     onDone();
   };
 
@@ -2335,12 +2454,28 @@ function ProgramarFacturaDialog({
         <DialogHeader>
           <DialogTitle>Programar pago</DialogTitle>
           <DialogDescription>
-            {proveedorLabel(factura)} · {formatCurrency(factura.porProgramar)}. Queda programado;
-            Dirección lo autoriza y registra el pago en la pestaña Programación.
+            {esGrupo
+              ? `${facturas.length} facturas de ${proveedorLabel(facturas[0])} · ${formatCurrency(total)}`
+              : `${proveedorLabel(facturas[0])} · ${formatCurrency(total)}`}
+            . Un solo pago las cubre. Queda programado; Dirección lo autoriza y registra en la
+            pestaña Programación.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3">
+          {esGrupo && (
+            <ul className="max-h-40 space-y-1 overflow-y-auto rounded-lg border bg-muted/30 p-2 text-xs">
+              {facturas.map((f) => (
+                <li key={f.id} className="flex items-center justify-between gap-2">
+                  <span className="truncate text-muted-foreground">
+                    {f.uuid_sat ? `${f.uuid_sat.slice(0, 8)}…` : 'Sin folio'} ·{' '}
+                    {formatDate(f.fecha_pago_programada ?? f.fecha_vencimiento)}
+                  </span>
+                  <span className="tabular-nums">{formatCurrency(f.porProgramar)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
           <div className="grid grid-cols-2 gap-3">
             <label className="space-y-1 text-sm">
               <span className="text-xs text-muted-foreground">Método de pago</span>

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -15,6 +15,10 @@
  *     `cxp_pago_autorizar_y_pagar`. El RPC gatea rol "Dirección"; el botón NO
  *     se esconde por rol en cliente — defensa: manda el RPC. **Confirmación
  *     fuerte** (egreso real).
+ *   - Pagar juntos (Fase 2): selección múltiple de pagos del mismo proveedor →
+ *     `cxp_pago_consolidar` los funde en uno (mueve aplicaciones, saldo-neutral)
+ *     y abre el diálogo de pago sobre el sobreviviente — una transferencia, un
+ *     comprobante. Solo en la pestaña Programación.
  *   - Cancelar (si no pagado): `cxp_pago_cancelar` con motivo.
  *
  * Filtro default `'pendientes'` = programados + aprobados: lo vivo que aún
@@ -359,6 +363,12 @@ export function CxpPagosModule({
   const [cancelarPago, setCancelarPago] = useState<Pago | null>(null);
   const [pagarPago, setPagarPago] = useState<Pago | null>(null);
 
+  // Selección múltiple para CONSOLIDAR varios pagos del mismo proveedor en uno
+  // (Fase 2). Solo en la pestaña Programación. `pendingPayId` abre el diálogo de
+  // pago sobre el sobreviviente apenas se refresca la lista tras consolidar.
+  const [selectedPagoIds, setSelectedPagoIds] = useState<string[]>([]);
+  const [pendingPayId, setPendingPayId] = useState<string | null>(null);
+
   const fetchPagos = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -463,6 +473,36 @@ export function CxpPagosModule({
     setDrawerOpen(true);
   }, []);
 
+  // ── Selección múltiple para consolidar (Fase 2) ─────────────────────────────
+  const selectedPagos = useMemo(
+    () => pagos.filter((p) => selectedPagoIds.includes(p.id)),
+    [pagos, selectedPagoIds]
+  );
+  const selProveedorId = selectedPagos[0]?.proveedor_id ?? null;
+  const selTotal = selectedPagos.reduce((s, p) => s + p.monto_total, 0);
+  const togglePagoSel = useCallback((p: Pago) => {
+    setSelectedPagoIds((prev) =>
+      prev.includes(p.id) ? prev.filter((id) => id !== p.id) : [...prev, p.id]
+    );
+  }, []);
+  const limpiarPagoSel = useCallback(() => setSelectedPagoIds([]), []);
+
+  // La selección se limpia al cambiar de filtro/horizonte (la lista cambia).
+  useEffect(() => {
+    setSelectedPagoIds([]);
+  }, [estado, horizonte]);
+
+  // Tras consolidar, abre el diálogo de pago sobre el sobreviviente cuando la
+  // lista refrescada ya lo contiene.
+  useEffect(() => {
+    if (!pendingPayId) return;
+    const p = pagos.find((x) => x.id === pendingPayId);
+    if (p) {
+      setPagarPago(p);
+      setPendingPayId(null);
+    }
+  }, [pendingPayId, pagos]);
+
   // ── Acciones ───────────────────────────────────────────────────────────────
 
   const doCancelar = useCallback(
@@ -482,6 +522,28 @@ export function CxpPagosModule({
     },
     [feedback, fetchPagos]
   );
+
+  // Consolida los pagos seleccionados (mismo proveedor) en uno y abre el diálogo
+  // para autorizarlo y registrarlo con un solo comprobante.
+  const doConsolidarYPagar = useCallback(async () => {
+    if (selectedPagoIds.length < 2) return;
+    const sb = createSupabaseBrowserClient();
+    const { data: survivorId, error } = await sb
+      .schema('erp')
+      .rpc('cxp_pago_consolidar', { p_pago_ids: selectedPagoIds });
+    if (error || !survivorId) {
+      feedback.error(getSupabaseErrorMessage(error, 'No se pudieron consolidar los pagos.'), {
+        title: 'No se pudo consolidar',
+      });
+      return;
+    }
+    feedback.success(`${selectedPagoIds.length} pagos consolidados en uno`, {
+      description: 'Autorízalo y regístralo con un solo comprobante.',
+    });
+    setSelectedPagoIds([]);
+    await fetchPagos();
+    setPendingPayId(survivorId as string);
+  }, [selectedPagoIds, feedback, fetchPagos]);
 
   return (
     <>
@@ -525,6 +587,30 @@ export function CxpPagosModule({
 
         {error && <ErrorBanner error={error} onRetry={() => void fetchPagos()} />}
 
+        {esProgramacion && selectedPagos.length >= 2 && (
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-primary/40 bg-primary/5 px-4 py-2.5">
+            <div className="text-sm">
+              <span className="font-semibold">{selectedPagos.length}</span> pagos de{' '}
+              <span className="font-medium">
+                {selectedPagos[0].proveedor_nombre ?? '(sin proveedor)'}
+              </span>{' '}
+              ·{' '}
+              <span className="font-semibold tabular-nums text-amber-600">
+                {formatCurrency(selTotal)}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={limpiarPagoSel}>
+                Limpiar
+              </Button>
+              <Button size="sm" className="gap-2" onClick={() => void doConsolidarYPagar()}>
+                <Wallet className="h-3.5 w-3.5" />
+                Pagar juntos
+              </Button>
+            </div>
+          </div>
+        )}
+
         <ModuleContent>
           {loading ? (
             <p className="px-4 py-6 text-sm text-muted-foreground sm:px-6">Cargando…</p>
@@ -541,6 +627,7 @@ export function CxpPagosModule({
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    {esProgramacion && <th className="w-8 py-2 pl-3 pr-0" />}
                     <th className="py-2 pl-3 pr-2 font-medium">Proveedor</th>
                     <th className="py-2 pr-2 font-medium">Estado</th>
                     <th className="py-2 pr-2 font-medium">Método</th>
@@ -559,6 +646,27 @@ export function CxpPagosModule({
                         className="cursor-pointer border-b last:border-0 hover:bg-muted/40"
                         onClick={() => openDetail(p)}
                       >
+                        {esProgramacion && (
+                          <td className="py-2 pl-3 pr-0" onClick={(e) => e.stopPropagation()}>
+                            {(() => {
+                              const checked = selectedPagoIds.includes(p.id);
+                              const elegible = p.estado === 'programado' || p.estado === 'aprobado';
+                              const otroProv =
+                                !!selProveedorId && p.proveedor_id !== selProveedorId;
+                              const disabled = !elegible || (!checked && otroProv);
+                              return (
+                                <input
+                                  type="checkbox"
+                                  checked={checked}
+                                  disabled={disabled}
+                                  onChange={() => togglePagoSel(p)}
+                                  aria-label="Seleccionar pago para consolidar"
+                                  className="h-4 w-4 cursor-pointer accent-foreground disabled:cursor-not-allowed disabled:opacity-30"
+                                />
+                              );
+                            })()}
+                          </td>
+                        )}
                         <td className="py-2 pl-3 pr-2">
                           <div className="truncate font-medium">
                             {p.proveedor_nombre ?? '(sin proveedor)'}

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -352,6 +352,18 @@ patrón canónico de **ADR-037** (subledger gemelo):
 
 ## Bitácora
 
+- **2026-06-29 — Agrupar pagos · Fase 2 (consolidar pagos ya fragmentados al pagar).**
+  Para los pagos sueltos que ya existen del mismo proveedor, en la pestaña
+  **Programación** se seleccionan varios (mismo proveedor, programado/aprobado) y
+  "Pagar juntos" los **consolida en uno** vía RPC nueva `cxp_pago_consolidar`
+  (migración `20260629191202`): elige el más antiguo como sobreviviente, mueve a él
+  las aplicaciones de los demás (sumando si coinciden en factura, por el UNIQUE
+  (pago_id,factura_id)), recalcula su `monto_total` y cancela los demás. Es
+  **saldo-neutral** (el conjunto de aplicaciones vivas no cambia, solo se reagrupa)
+  y no hay triggers en `cxp_pagos`/aplicaciones que reviertan. Tras consolidar se
+  abre el diálogo de "Autorizar y registrar" sobre el sobreviviente → una
+  transferencia, un comprobante, un movimiento bancario. Gate Dirección.
+
 - **2026-06-29 — Agrupar facturas en un solo pago · Fase 1 (consolidar al programar).**
   Varias facturas del mismo proveedor que vencen el mismo día generaban N pagos
   sueltos. La RPC `cxp_pago_programar` ya soporta N aplicaciones; lo que faltaba

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -352,6 +352,18 @@ patrón canónico de **ADR-037** (subledger gemelo):
 
 ## Bitácora
 
+- **2026-06-29 — Agrupar facturas en un solo pago · Fase 1 (consolidar al programar).**
+  Varias facturas del mismo proveedor que vencen el mismo día generaban N pagos
+  sueltos. La RPC `cxp_pago_programar` ya soporta N aplicaciones; lo que faltaba
+  era la UI. En la pestaña **Facturas**, vista "Por programar": multi-selección
+  (checkbox por fila) **restringida al mismo proveedor** (se bloquean los demás
+  mientras hay selección) y solo facturas elegibles (`esElegibleProgramar`:
+  saldo + proveedor + cuenta contable). Una barra muestra "N facturas de
+  [Proveedor] · $Total" → un diálogo → **un** `cxp_pago` que las cubre. El diálogo
+  `ProgramarFacturaDialog` se generalizó a `facturas: Factura[]` (lo reusa el botón
+  individual del drawer con `[factura]`). Sin migración (solo UI). Fase 2 (pagar
+  juntos pagos ya fragmentados, en Programación) viene en PR aparte.
+
 - **2026-06-29 — Nuevo reparto de responsabilidades de pago (reunión Michelle + Admin).**
   Se separa "programar" de "autorizar": **Contabilidad** carga facturas, clasifica
   partida/cuenta y **programa** los pagos (y los carga al banco ellos mismos);

--- a/supabase/migrations/20260629191202_cxp_pago_consolidar.sql
+++ b/supabase/migrations/20260629191202_cxp_pago_consolidar.sql
@@ -1,0 +1,109 @@
+-- CxP — consolidar varios pagos del mismo proveedor en uno (iniciativa `cxp`).
+--
+-- Fase 2 de la agrupación de pagos: cuando ya existen varios `cxp_pagos` sueltos
+-- del mismo proveedor (programado/aprobado), Dirección los consolida en UNO para
+-- pagarlos con una sola transferencia (un comprobante, un movimiento bancario,
+-- vía `cxp_pago_autorizar_y_pagar`).
+--
+-- Cómo: se elige el pago más antiguo como "sobreviviente", se mueven a él las
+-- aplicaciones de los demás (sumando si coinciden en la misma factura, por el
+-- UNIQUE (pago_id, factura_id)), se recalcula su `monto_total` y los demás quedan
+-- 'cancelado' (ya sin aplicaciones). Es SALDO-NEUTRAL: el conjunto de
+-- aplicaciones en pagos vivos no cambia (solo se reagrupa), así que el comprometido
+-- y el saldo por factura quedan idénticos.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION erp.cxp_pago_consolidar(p_pago_ids uuid[])
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'erp', 'public'
+AS $function$
+DECLARE
+  v_survivor uuid;
+  v_empresa uuid;
+  v_n_empresas int;
+  v_n_proveedores int;
+  v_n_invalidos int;
+  v_total numeric(14, 2);
+BEGIN
+  IF p_pago_ids IS NULL OR array_length(p_pago_ids, 1) IS NULL OR array_length(p_pago_ids, 1) < 2 THEN
+    RAISE EXCEPTION 'Selecciona al menos 2 pagos para consolidar';
+  END IF;
+
+  -- Bloquea las filas involucradas.
+  PERFORM 1 FROM erp.cxp_pagos WHERE id = ANY(p_pago_ids) FOR UPDATE;
+
+  -- Todos deben existir, estar vivos y en estado consolidable.
+  SELECT count(*) INTO v_n_invalidos
+  FROM unnest(p_pago_ids) AS x(id)
+  LEFT JOIN erp.cxp_pagos p ON p.id = x.id
+  WHERE p.id IS NULL OR p.deleted_at IS NOT NULL OR p.estado NOT IN ('programado', 'aprobado');
+  IF v_n_invalidos > 0 THEN
+    RAISE EXCEPTION 'Todos los pagos deben existir y estar programados o aprobados (sin cancelar ni pagar)';
+  END IF;
+
+  -- Mismo empresa y mismo proveedor (una transferencia = un beneficiario).
+  SELECT count(DISTINCT empresa_id), count(DISTINCT proveedor_id)
+    INTO v_n_empresas, v_n_proveedores
+  FROM erp.cxp_pagos WHERE id = ANY(p_pago_ids);
+  IF v_n_empresas <> 1 THEN
+    RAISE EXCEPTION 'Los pagos son de empresas distintas';
+  END IF;
+  SELECT empresa_id INTO v_empresa FROM erp.cxp_pagos WHERE id = ANY(p_pago_ids) LIMIT 1;
+  IF v_n_proveedores <> 1 THEN
+    RAISE EXCEPTION 'Solo se pueden consolidar pagos del mismo proveedor';
+  END IF;
+
+  -- Gate Dirección (igual que autorizar/pagar).
+  IF NOT (core.fn_is_admin() OR core.fn_user_has_role('Dirección', v_empresa)) THEN
+    RAISE EXCEPTION 'Solo admin o un usuario con rol Dirección puede consolidar pagos';
+  END IF;
+
+  -- Sobreviviente = el más antiguo.
+  SELECT id INTO v_survivor
+  FROM erp.cxp_pagos WHERE id = ANY(p_pago_ids)
+  ORDER BY created_at ASC, id ASC
+  LIMIT 1;
+
+  -- Mueve las aplicaciones de los demás al sobreviviente, sumando si la misma
+  -- factura ya está aplicada en él (respeta el UNIQUE (pago_id, factura_id)).
+  INSERT INTO erp.cxp_pago_aplicaciones (empresa_id, pago_id, factura_id, monto_aplicado)
+  SELECT empresa_id, v_survivor, factura_id, SUM(monto_aplicado)
+  FROM erp.cxp_pago_aplicaciones
+  WHERE pago_id = ANY(p_pago_ids) AND pago_id <> v_survivor
+  GROUP BY empresa_id, factura_id
+  ON CONFLICT (pago_id, factura_id)
+  DO UPDATE SET monto_aplicado = erp.cxp_pago_aplicaciones.monto_aplicado + EXCLUDED.monto_aplicado;
+
+  DELETE FROM erp.cxp_pago_aplicaciones
+  WHERE pago_id = ANY(p_pago_ids) AND pago_id <> v_survivor;
+
+  -- Recalcula el total del sobreviviente desde sus aplicaciones.
+  SELECT COALESCE(SUM(monto_aplicado), 0) INTO v_total
+  FROM erp.cxp_pago_aplicaciones WHERE pago_id = v_survivor;
+  UPDATE erp.cxp_pagos SET monto_total = v_total, updated_at = now() WHERE id = v_survivor;
+
+  -- Los demás quedan cancelados (ya sin aplicaciones; no revierten nada).
+  UPDATE erp.cxp_pagos
+     SET estado = 'cancelado',
+         notas = trim(both ' ·' from COALESCE(notas, '') || ' · consolidado en pago ' || v_survivor),
+         updated_at = now()
+   WHERE id = ANY(p_pago_ids) AND id <> v_survivor;
+
+  INSERT INTO core.audit_log (empresa_id, usuario_id, accion, tabla, registro_id, datos_nuevos)
+  VALUES (v_empresa, auth.uid(), 'cxp_pago_consolidado', 'erp.cxp_pagos', v_survivor,
+    jsonb_build_object('pago_ids', to_jsonb(p_pago_ids), 'monto_total', v_total));
+
+  RETURN v_survivor;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION erp.cxp_pago_consolidar(uuid[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION erp.cxp_pago_consolidar(uuid[]) FROM anon;
+GRANT EXECUTE ON FUNCTION erp.cxp_pago_consolidar(uuid[]) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -13296,6 +13296,7 @@ export type Database = {
         Args: { p_motivo?: string; p_pago_id: string }
         Returns: undefined
       }
+      cxp_pago_consolidar: { Args: { p_pago_ids: string[] }; Returns: string }
       cxp_pago_desde_estimacion: {
         Args: {
           p_cuenta_bancaria_id?: string


### PR DESCRIPTION
## Contexto

Beto: varias facturas del mismo proveedor que vencen el mismo día se pagan con **una sola transferencia**, pero la UI obligaba a programar/pagar una por una. La RPC `cxp_pago_programar` ya soporta N aplicaciones — el resto era UI + una pieza de consolidación.

Dos frentes (decidido "ambas"):

## Fase 1 — Consolidar al programar (pestaña Facturas) · sin migración
- Vista "Por programar": checkbox por fila para multi-selección, **restringida al mismo proveedor** (los demás se bloquean) y solo facturas **elegibles** (saldo + proveedor + cuenta contable, `esElegibleProgramar`).
- Barra: *"N facturas de [Proveedor] · $Total"* → **un** `cxp_pago` que las cubre.
- `ProgramarFacturaDialog` generalizado a `facturas: Factura[]` (el botón individual del drawer lo reusa con `[factura]`).

## Fase 2 — Pagar juntos lo ya fragmentado (pestaña Programación) · con migración
- Multi-selección de pagos del mismo proveedor (programado/aprobado) → **"Pagar juntos"** → `cxp_pago_consolidar` los **funde en uno** (mueve aplicaciones, suma duplicados por el UNIQUE pago_id+factura_id, recalcula `monto_total`, cancela los demás) y abre el diálogo de "Autorizar y registrar" sobre el sobreviviente.
- Resultado: **una transferencia, un comprobante, un movimiento bancario**. La consolidación es **saldo-neutral** (solo reagrupa aplicaciones vivas; sin triggers que reviertan). Gate Dirección.

## Validación
- Shadow: consolida 2 facturas distintas (total sumado), suma duplicados de la misma factura, y el gate Dirección bloquea sin rol.
- typecheck, lint, format ✓; suite completa **2162 tests** verde.
- `types/supabase.ts` regenerado desde shadow (+1 línea: `cxp_pago_consolidar`).

## ⚠️ Migración financiera
`supabase/migrations/20260629191202_cxp_pago_consolidar.sql` agrega la RPC de consolidación. Requiere label **`finanzas-ok`** para aplicarse al mergear. (La Fase 1 es UI; la Fase 2 trae la migración.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)