### PR TITLE
feat(cxp): tooltip en checkbox bloqueado de selección de pago

### DIFF
--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -878,8 +878,22 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
         const checked = selectedIds.includes(f.id);
         const otroProveedor = !!selProveedorId && f.proveedor_id !== selProveedorId;
         const disabled = !esElegibleProgramar(f) || (!checked && otroProveedor);
+        // Motivo del bloqueo (tooltip), para que Conta sepa qué falta sin adivinar.
+        let motivo: string | undefined;
+        if (disabled && !checked) {
+          if (!f.proveedor_id) motivo = 'Enlaza un proveedor para programar';
+          else if (!f.cuenta_contable_id) motivo = 'Clasifica la cuenta contable para programar';
+          else if (f.porProgramar <= 0) motivo = 'Sin saldo por programar';
+          else if (otroProveedor)
+            motivo = `Selección limitada a ${proveedorLabel(selectedFacturas[0])}`;
+        }
         return (
-          <span onClick={(e) => e.stopPropagation()} className="flex">
+          <span
+            onClick={(e) => e.stopPropagation()}
+            className="flex"
+            title={motivo}
+            aria-label={motivo}
+          >
             <input
               type="checkbox"
               checked={checked}
@@ -893,7 +907,7 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
       },
     };
     return [selCol, ...columnsConPartida];
-  }, [vista, columnsConPartida, selectedIds, selProveedorId, toggleSeleccion]);
+  }, [vista, columnsConPartida, selectedIds, selProveedorId, selectedFacturas, toggleSeleccion]);
 
   // Facturas EN ESPERA del XML: destajos de vivienda aprobados o estimaciones de
   // obra autorizadas, cuya factura nació en borrador. Administración sube aquí el

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -654,15 +654,25 @@ export function CxpPagosModule({
                               const otroProv =
                                 !!selProveedorId && p.proveedor_id !== selProveedorId;
                               const disabled = !elegible || (!checked && otroProv);
+                              // Motivo del bloqueo (tooltip) para que se entienda al instante.
+                              let motivo: string | undefined;
+                              if (disabled && !checked) {
+                                if (!elegible)
+                                  motivo = 'Solo se consolidan pagos programados o aprobados';
+                                else if (otroProv)
+                                  motivo = `Selección limitada a ${selectedPagos[0]?.proveedor_nombre ?? 'un proveedor'}`;
+                              }
                               return (
-                                <input
-                                  type="checkbox"
-                                  checked={checked}
-                                  disabled={disabled}
-                                  onChange={() => togglePagoSel(p)}
-                                  aria-label="Seleccionar pago para consolidar"
-                                  className="h-4 w-4 cursor-pointer accent-foreground disabled:cursor-not-allowed disabled:opacity-30"
-                                />
+                                <span title={motivo} aria-label={motivo} className="flex">
+                                  <input
+                                    type="checkbox"
+                                    checked={checked}
+                                    disabled={disabled}
+                                    onChange={() => togglePagoSel(p)}
+                                    aria-label="Seleccionar pago para consolidar"
+                                    className="h-4 w-4 cursor-pointer accent-foreground disabled:cursor-not-allowed disabled:opacity-30"
+                                  />
+                                </span>
                               );
                             })()}
                           </td>

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -352,6 +352,13 @@ patrón canónico de **ADR-037** (subledger gemelo):
 
 ## Bitácora
 
+- **2026-06-29 — Tooltip en checkbox de selección bloqueado (claridad).**
+  Conta no veía _por qué_ algunas facturas/pagos no se podían seleccionar para
+  agrupar. Se agrega `title`/`aria-label` al checkbox deshabilitado con el motivo:
+  "Clasifica la cuenta contable…", "Enlaza un proveedor…", "Sin saldo por programar"
+  o "Selección limitada a [Proveedor]" (Facturas), y "Solo pagos programados o
+  aprobados" / "Selección limitada a [Proveedor]" (Programación). Solo UI.
+
 - **2026-06-29 — Agrupar pagos · Fase 2 (consolidar pagos ya fragmentados al pagar).**
   Para los pagos sueltos que ya existen del mismo proveedor, en la pestaña
   **Programación** se seleccionan varios (mismo proveedor, programado/aprobado) y


### PR DESCRIPTION
## Contexto

Conta reportó que algunos proveedores "no dejan agrupar" y no aparece el botón de programar. La causa no es un bug: esas facturas/pagos no son elegibles (falta cuenta contable, falta proveedor, o se intenta mezclar proveedores). El problema era de **claridad** — el checkbox bloqueado no decía por qué.

## Cambio (solo UI)

Tooltip (`title` + `aria-label`) en el checkbox deshabilitado con el motivo:

- **Facturas (agrupar al programar):** "Enlaza un proveedor para programar", "Clasifica la cuenta contable para programar", "Sin saldo por programar", o "Selección limitada a [Proveedor]".
- **Programación (consolidar):** "Solo se consolidan pagos programados o aprobados" o "Selección limitada a [Proveedor]".

## Validación
typecheck, lint, format ✓. Sin migración.

Dejo el PR abierto para tu Preview (cambio visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)