### PR TITLE
fix(cxp): doble-programación legible + copy reparto de deberes [FINANCIERO]

### DIFF
--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -1495,8 +1495,8 @@ function FacturaDrawer({
                         </Button>
                       </div>
                       <p className="text-[11px] text-muted-foreground">
-                        Queda programado. Dirección lo autoriza y registra el pago (con comprobante)
-                        en la pestaña Programación.
+                        Aquí solo lo programas. La autorización y el registro del pago (con
+                        comprobante) los hace Dirección en la pestaña Programación.
                       </p>
                     </>
                   )}
@@ -2445,13 +2445,31 @@ function ProgramarFacturaDialog({
     });
     setSubmitting(false);
     if (progErr || !pagoId) {
+      // La RPC valida contra lo ya comprometido (pagos vivos). Si rechaza por
+      // "excede lo disponible / ya comprometido", la(s) factura(s) YA tienen un
+      // pago que las cubre: doble envío o vista desactualizada (el primer intento
+      // sí pasó del lado servidor). No es error del operador — mensaje claro +
+      // refrescar para que la factura salga de la bandeja "Por programar".
+      const yaComprometido = /excede lo disponible por programar|ya comprometido/i.test(
+        progErr?.message ?? ''
+      );
+      if (yaComprometido) {
+        feedback.info(esGrupo ? 'Ya estaban programadas' : 'Ya estaba programada', {
+          description: esGrupo
+            ? 'Una o más de estas facturas ya tienen un pago programado que las cubre. Actualicé la vista.'
+            : 'Esta factura ya tiene un pago programado que la cubre. Actualicé la vista.',
+        });
+        onDone();
+        return;
+      }
       setError(getSupabaseErrorMessage(progErr, 'No se pudo programar el pago.'));
       return;
     }
     feedback.success(
       esGrupo ? `Pago programado · ${facturas.length} facturas` : 'Pago programado',
       {
-        description: 'Dirección lo autoriza y registra el pago en la pestaña Programación.',
+        description:
+          'La autorización y el registro del pago los hace Dirección en la pestaña Programación.',
       }
     );
     onDone();
@@ -2471,8 +2489,8 @@ function ProgramarFacturaDialog({
             {esGrupo
               ? `${facturas.length} facturas de ${proveedorLabel(facturas[0])} · ${formatCurrency(total)}`
               : `${proveedorLabel(facturas[0])} · ${formatCurrency(total)}`}
-            . Un solo pago las cubre. Queda programado; Dirección lo autoriza y registra en la
-            pestaña Programación.
+            . Un solo pago las cubre. Aquí solo lo programas; la autorización y el registro del pago
+            los hace Dirección en la pestaña Programación.
           </DialogDescription>
         </DialogHeader>
 

--- a/docs/planning/cxp.md
+++ b/docs/planning/cxp.md
@@ -352,6 +352,16 @@ patrón canónico de **ADR-037** (subledger gemelo):
 
 ## Bitácora
 
+- **2026-06-29 — Doble-programación: error legible + copy del reparto de deberes.**
+  Maribel veía un error rojo crudo (UUID de factura + montos) al "Programar pago":
+  su 1er intento sí creó el pago (servidor OK), pero la vista del drawer no reflejó
+  el comprometido y reofreció el botón → el 2º intento lo rechaza la RPC ("excede lo
+  disponible / ya comprometido"). Fix: `ProgramarFacturaDialog` detecta ese caso y
+  muestra "Ya estaba programada" + refresca/cierra (la factura sale de la bandeja),
+  en vez del error técnico. Además se reescribió el copy (diálogo, hint del drawer,
+  toast) para no implicar que Dirección programa: "Aquí solo lo programas; la
+  autorización y el registro los hace Dirección en la pestaña Programación". Solo UI.
+
 - **2026-06-29 — Tooltip en checkbox de selección bloqueado (claridad).**
   Conta no veía _por qué_ algunas facturas/pagos no se podían seleccionar para
   agrupar. Se agrega `title`/`aria-label` al checkbox deshabilitado con el motivo:


### PR DESCRIPTION
## Qué pasaba

Maribel (Contabilidad) veía un **error rojo crudo** al programar el pago de CFE ($4,710.92):

> El monto (4710.92) excede lo disponible por programar de la factura 4724c5e8-… (total 4710.92, ya comprometido en otros pagos 4710.92)

### Diagnóstico (verificado en prod)
- La factura **ya tenía un pago programado** por el monto completo, creado hoy 21:01 por **la propia Maribel**, fecha 10-jul — la misma fecha que muestra su diálogo.
- O sea: **su primer intento sí funcionó** (servidor OK). El error es de un **segundo intento** que la RPC `cxp_pago_programar` rechaza correctamente como duplicado. En la BD hay **un solo pago**, no dos. Nada que corregir en los datos.
- Por qué reintentó: el drawer usa un snapshot (`selected`) y/o el primer envío no cerró limpio del lado cliente, así que la UI siguió ofreciendo "Programar pago" sobre una factura que ya estaba cubierta.

## Cambios (solo UI/copy, sin DB)

1. **Error legible + auto-sanado.** `ProgramarFacturaDialog` detecta el rechazo "excede lo disponible / ya comprometido" y muestra **"Ya estaba programada"** + refresca/cierra (la factura sale de la bandeja), en lugar del UUID + montos crudos.
2. **Copy del reparto de deberes.** Se reescribe el texto del diálogo, el hint del drawer y el toast para **no implicar que Dirección programa**:
   > Aquí solo lo programas; la autorización y el registro del pago los hace Dirección en la pestaña Programación.

## Verificación
- ✅ typecheck · lint · format:check (repo completo) · vitest (20 tests cxp)
- Sin migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)