### PR TITLE
feat(sanren-servicios): vista por servicio (Luz/Agua/Gas) con KPIs y análisis a medida

### DIFF
--- a/components/sanren/servicios-tendencias.tsx
+++ b/components/sanren/servicios-tendencias.tsx
@@ -2,11 +2,17 @@
 
 import { useMemo } from 'react';
 import type { ReciboVista } from '@/lib/sanren-servicios';
+import { computePronostico } from '@/lib/sanren/servicios-analytics';
 
 /**
  * Gráficas de tendencia del módulo SANREN → Servicios (iniciativa
- * sanren-servicios, Sprint 4). SVG a mano con tokens del theme (patrón
- * Playtomic/Health, sin librería de charts).
+ * sanren-servicios). SVG a mano con tokens del theme (patrón Playtomic/Health,
+ * sin librería de charts).
+ *
+ * Cada gráfica de consumo/gasto proyecta el **próximo periodo** (barra punteada
+ * "esperado") mezclando tendencia reciente + estacionalidad. La gráfica solar
+ * superpone la **línea del banco de energía** (kWh a favor acumulados) para ver
+ * el saldo disponible contra lo que se consume.
  */
 
 const MESES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
@@ -24,11 +30,15 @@ function money(n: number): string {
   });
 }
 
+const kwh = (n: number) => `${Math.round(n).toLocaleString('es-MX')} kWh`;
+
 const SERVICIO_COLOR: Record<string, string> = {
   luz: 'var(--color-amber-500, #f59e0b)',
   gas: 'var(--color-orange-500, #f97316)',
   agua: 'var(--color-sky-500, #0ea5e9)',
 };
+
+const BANCO_COLOR = 'var(--color-violet-500, #8b5cf6)';
 
 function Card({
   title,
@@ -68,11 +78,12 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
       const total = tipos.reduce((a, t) => a + (row[t] ?? 0), 0);
       return { mes, row, total };
     });
-    const max = Math.max(1, ...data.map((d) => d.total));
-    return { data, tipos, max };
+    const forecast = computePronostico(recibos, (r) => r.monto);
+    const max = Math.max(1, ...data.map((d) => d.total), forecast?.valor ?? 0);
+    return { data, tipos, max, forecast };
   }, [recibos]);
 
-  // ── Solar: consumo vs producción de luz por periodo ─────────────────────────
+  // ── Solar: consumo vs producción + banco de energía por periodo ─────────────
   const solar = useMemo(() => {
     const luz = recibos
       .filter(
@@ -82,11 +93,31 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
         periodo: r.periodo.slice(0, 7),
         consumo: r.consumo_periodo ?? 0,
         produccion: r.produccion_periodo ?? 0,
+        banco: r.extraccion?.energia_acumulada_favor ?? null,
+        forecast: false,
       }))
       .sort((a, b) => a.periodo.localeCompare(b.periodo))
       .slice(-18);
-    const max = Math.max(1, ...luz.map((d) => Math.max(d.consumo, d.produccion)));
-    return { luz, max };
+
+    const luzRecibos = recibos.filter((r) => r.tiene_produccion);
+    const fcConsumo = computePronostico(luzRecibos, (r) => r.consumo_periodo);
+    const fcProduccion = computePronostico(luzRecibos, (r) => r.produccion_periodo);
+    const fcPeriodo = fcConsumo?.periodo ?? fcProduccion?.periodo ?? null;
+
+    const items = [...luz];
+    if (fcPeriodo) {
+      items.push({
+        periodo: fcPeriodo,
+        consumo: fcConsumo?.valor ?? 0,
+        produccion: fcProduccion?.valor ?? 0,
+        banco: null,
+        forecast: true,
+      });
+    }
+
+    const max = Math.max(1, ...items.map((d) => Math.max(d.consumo, d.produccion)));
+    const bancoMax = Math.max(1, ...luz.map((d) => d.banco ?? 0));
+    return { items, max, bancoMax, hayBanco: luz.some((d) => d.banco != null) };
   }, [recibos]);
 
   // ── Ahorro: gasto de luz por año ────────────────────────────────────────────
@@ -104,9 +135,14 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
   const H = 240;
   const PAD_B = 28;
 
+  // Slots del gasto: meses reales + un slot "esperado" si hay pronóstico.
+  const gastoSlots = gasto.forecast
+    ? [...gasto.data, { mes: gasto.forecast.periodo, row: {}, total: gasto.forecast.valor }]
+    : gasto.data;
+
   return (
     <div className="space-y-4">
-      {/* Gasto mensual por servicio (barras apiladas) */}
+      {/* Gasto mensual por servicio (barras apiladas) + pronóstico */}
       <Card title="Gasto mensual por servicio" subtitle="Últimos 24 meses con recibo capturado">
         <div className="mb-3 flex flex-wrap gap-4 text-xs text-[var(--text)]/65">
           {gasto.tipos.map((t) => (
@@ -118,6 +154,12 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
               {t}
             </span>
           ))}
+          {gasto.forecast ? (
+            <span className="flex items-center gap-1.5">
+              <span className="h-2.5 w-2.5 rounded-sm border border-dashed border-[var(--text)]/60" />
+              esperado ({mesCorto(gasto.forecast.periodo)})
+            </span>
+          ) : null}
         </div>
         <div className="overflow-x-auto">
           <svg viewBox={`0 0 ${W} ${H + PAD_B}`} className="min-w-[760px]">
@@ -132,9 +174,40 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
                 strokeOpacity="0.08"
               />
             ))}
-            {gasto.data.map((d, i) => {
-              const bw = Math.max(6, Math.min(34, W / Math.max(gasto.data.length, 1) - 6));
-              const x = i * (W / Math.max(gasto.data.length, 1)) + 3;
+            {gastoSlots.map((d, i) => {
+              const bw = Math.max(6, Math.min(34, W / Math.max(gastoSlots.length, 1) - 6));
+              const x = i * (W / Math.max(gastoSlots.length, 1)) + 3;
+              const isForecast = gasto.forecast != null && i === gastoSlots.length - 1;
+              if (isForecast) {
+                const h = (d.total / gasto.max) * H;
+                return (
+                  <g key={d.mes}>
+                    <rect
+                      x={x}
+                      y={H - h}
+                      width={bw}
+                      height={h}
+                      fill="var(--text)"
+                      fillOpacity={0.12}
+                      stroke="var(--text)"
+                      strokeOpacity={0.55}
+                      strokeDasharray="3 2"
+                    >
+                      <title>{`${d.mes} (esperado): ${money(d.total)}`}</title>
+                    </rect>
+                    <text
+                      x={x + bw / 2}
+                      y={H + 18}
+                      textAnchor="middle"
+                      fontSize="10"
+                      fill="var(--text)"
+                      opacity="0.5"
+                    >
+                      {mesCorto(d.mes)}
+                    </text>
+                  </g>
+                );
+              }
               let yAcc = H;
               return (
                 <g key={d.mes}>
@@ -175,11 +248,11 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
         </div>
       </Card>
 
-      {/* Solar: consumo vs producción */}
-      {solar.luz.length > 0 ? (
+      {/* Solar: consumo vs generación + banco de energía + pronóstico */}
+      {solar.items.length > 0 ? (
         <Card
-          title="Energía: consumo vs. generación solar (Luz)"
-          subtitle="kWh por periodo — cuando la barra verde supera la gris, generaste más de lo que consumiste"
+          title="Energía: consumo vs. generación + banco (Luz)"
+          subtitle="kWh por periodo — la línea morada es el saldo del banco de energía; la barra punteada es el próximo periodo esperado"
         >
           <div className="mb-3 flex flex-wrap gap-4 text-xs text-[var(--text)]/65">
             <span className="flex items-center gap-1.5">
@@ -187,6 +260,16 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
             </span>
             <span className="flex items-center gap-1.5">
               <span className="h-2.5 w-2.5 rounded-full bg-emerald-500" /> Generación
+            </span>
+            {solar.hayBanco ? (
+              <span className="flex items-center gap-1.5">
+                <span className="h-0.5 w-4" style={{ backgroundColor: BANCO_COLOR }} /> Banco (kWh a
+                favor)
+              </span>
+            ) : null}
+            <span className="flex items-center gap-1.5">
+              <span className="h-2.5 w-2.5 rounded-sm border border-dashed border-[var(--text)]/60" />{' '}
+              esperado
             </span>
           </div>
           <div className="overflow-x-auto">
@@ -202,19 +285,39 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
                   strokeOpacity="0.08"
                 />
               ))}
-              {solar.luz.map((d, i) => {
-                const slot = W / Math.max(solar.luz.length, 1);
+              {solar.items.map((d, i) => {
+                const slot = W / Math.max(solar.items.length, 1);
                 const bw = Math.max(4, Math.min(18, slot / 2 - 3));
                 const x = i * slot + 3;
                 const hC = (d.consumo / solar.max) * H;
                 const hP = (d.produccion / solar.max) * H;
+                const dash = d.forecast ? { strokeDasharray: '3 2', strokeWidth: 1 } : {};
                 return (
                   <g key={d.periodo}>
-                    <rect x={x} y={H - hC} width={bw} height={hC} fill="var(--text)" opacity={0.4}>
-                      <title>{`${d.periodo} · consumo: ${d.consumo} kWh`}</title>
+                    <rect
+                      x={x}
+                      y={H - hC}
+                      width={bw}
+                      height={hC}
+                      fill="var(--text)"
+                      opacity={d.forecast ? 0.18 : 0.4}
+                      stroke={d.forecast ? 'var(--text)' : undefined}
+                      strokeOpacity={0.55}
+                      {...dash}
+                    >
+                      <title>{`${d.periodo}${d.forecast ? ' (esperado)' : ''} · consumo: ${kwh(d.consumo)}`}</title>
                     </rect>
-                    <rect x={x + bw + 2} y={H - hP} width={bw} height={hP} fill="#10b981">
-                      <title>{`${d.periodo} · generación: ${d.produccion} kWh`}</title>
+                    <rect
+                      x={x + bw + 2}
+                      y={H - hP}
+                      width={bw}
+                      height={hP}
+                      fill="#10b981"
+                      opacity={d.forecast ? 0.3 : 1}
+                      stroke={d.forecast ? '#10b981' : undefined}
+                      {...dash}
+                    >
+                      <title>{`${d.periodo}${d.forecast ? ' (esperado)' : ''} · generación: ${kwh(d.produccion)}`}</title>
                     </rect>
                     {i % 2 === 0 ? (
                       <text
@@ -231,6 +334,38 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
                   </g>
                 );
               })}
+
+              {/* Línea del banco de energía (eje propio, escala bancoMax) */}
+              {solar.hayBanco ? (
+                <>
+                  <polyline
+                    fill="none"
+                    stroke={BANCO_COLOR}
+                    strokeWidth={2}
+                    points={solar.items
+                      .map((d, i) => {
+                        if (d.banco == null) return null;
+                        const slot = W / Math.max(solar.items.length, 1);
+                        const x = i * slot + 3 + (Math.max(4, Math.min(18, slot / 2 - 3)) + 2);
+                        const y = H - (d.banco / solar.bancoMax) * H;
+                        return `${x},${y}`;
+                      })
+                      .filter(Boolean)
+                      .join(' ')}
+                  />
+                  {solar.items.map((d, i) => {
+                    if (d.banco == null) return null;
+                    const slot = W / Math.max(solar.items.length, 1);
+                    const x = i * slot + 3 + (Math.max(4, Math.min(18, slot / 2 - 3)) + 2);
+                    const y = H - (d.banco / solar.bancoMax) * H;
+                    return (
+                      <circle key={`b-${d.periodo}`} cx={x} cy={y} r={2.5} fill={BANCO_COLOR}>
+                        <title>{`${d.periodo} · banco: ${kwh(d.banco)} a favor`}</title>
+                      </circle>
+                    );
+                  })}
+                </>
+              ) : null}
             </svg>
           </div>
         </Card>

--- a/components/sanren/servicios-tendencias.tsx
+++ b/components/sanren/servicios-tendencias.tsx
@@ -2,7 +2,11 @@
 
 import { useMemo } from 'react';
 import type { ReciboVista } from '@/lib/sanren-servicios';
-import { computePronostico } from '@/lib/sanren/servicios-analytics';
+import {
+  computePronostico,
+  computePronosticoGasto,
+  computeBancoProyectado,
+} from '@/lib/sanren/servicios-analytics';
 
 /**
  * Gráficas de tendencia del módulo SANREN → Servicios (iniciativa
@@ -78,7 +82,7 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
       const total = tipos.reduce((a, t) => a + (row[t] ?? 0), 0);
       return { mes, row, total };
     });
-    const forecast = computePronostico(recibos, (r) => r.monto);
+    const forecast = computePronosticoGasto(recibos);
     const max = Math.max(1, ...data.map((d) => d.total), forecast?.valor ?? 0);
     return { data, tipos, max, forecast };
   }, [recibos]);
@@ -115,9 +119,10 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
       });
     }
 
+    const bancoProy = computeBancoProyectado(recibos);
     const max = Math.max(1, ...items.map((d) => Math.max(d.consumo, d.produccion)));
-    const bancoMax = Math.max(1, ...luz.map((d) => d.banco ?? 0));
-    return { items, max, bancoMax, hayBanco: luz.some((d) => d.banco != null) };
+    const bancoMax = Math.max(1, ...luz.map((d) => d.banco ?? 0), bancoProy?.banco ?? 0);
+    return { items, max, bancoMax, hayBanco: luz.some((d) => d.banco != null), bancoProy };
   }, [recibos]);
 
   // ── Ahorro: gasto de luz por año ────────────────────────────────────────────
@@ -158,6 +163,7 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
             <span className="flex items-center gap-1.5">
               <span className="h-2.5 w-2.5 rounded-sm border border-dashed border-[var(--text)]/60" />
               esperado ({mesCorto(gasto.forecast.periodo)})
+              {gasto.forecast.cubiertoPorBanco ? ' · cubierto por banco' : ''}
             </span>
           ) : null}
         </div>
@@ -193,7 +199,12 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
                       strokeOpacity={0.55}
                       strokeDasharray="3 2"
                     >
-                      <title>{`${d.mes} (esperado): ${money(d.total)}`}</title>
+                      <title>
+                        {`${d.mes} (esperado): ${money(d.total)}` +
+                          (gasto.forecast?.cubiertoPorBanco
+                            ? ' — consumo neto cubierto por el banco de energía (solo cargo fijo)'
+                            : '')}
+                      </title>
                     </rect>
                     <text
                       x={x + bw / 2}
@@ -364,6 +375,52 @@ export function ServiciosTendencias({ recibos }: { recibos: ReciboVista[] }) {
                       </circle>
                     );
                   })}
+                  {/* Proyección del banco al próximo periodo (segmento punteado):
+                      el consumo neto esperado se descuenta del saldo. */}
+                  {solar.bancoProy
+                    ? (() => {
+                        const slot = W / Math.max(solar.items.length, 1);
+                        const off = Math.max(4, Math.min(18, slot / 2 - 3)) + 2;
+                        const reales = solar.items
+                          .map((d, i) => (d.banco != null ? i : -1))
+                          .filter((i) => i >= 0);
+                        const lastIdx = reales[reales.length - 1];
+                        if (lastIdx == null) return null;
+                        const x1 = lastIdx * slot + 3 + off;
+                        const y1 = H - ((solar.items[lastIdx].banco ?? 0) / solar.bancoMax) * H;
+                        const x2 = (solar.items.length - 1) * slot + 3 + off;
+                        const y2 = H - (solar.bancoProy.banco / solar.bancoMax) * H;
+                        return (
+                          <>
+                            <line
+                              x1={x1}
+                              y1={y1}
+                              x2={x2}
+                              y2={y2}
+                              stroke={BANCO_COLOR}
+                              strokeWidth={2}
+                              strokeDasharray="4 3"
+                              opacity={0.7}
+                            />
+                            <circle
+                              cx={x2}
+                              cy={y2}
+                              r={3}
+                              fill="var(--card)"
+                              stroke={BANCO_COLOR}
+                              strokeWidth={1.5}
+                            >
+                              <title>
+                                {`${solar.bancoProy.periodo} · banco esperado: ${kwh(solar.bancoProy.banco)} a favor` +
+                                  (solar.bancoProy.netoDelBanco > 0
+                                    ? ` (−${kwh(solar.bancoProy.netoDelBanco)} del banco)`
+                                    : ` (+${kwh(-solar.bancoProy.netoDelBanco)} al banco)`)}
+                              </title>
+                            </circle>
+                          </>
+                        );
+                      })()
+                    : null}
                 </>
               ) : null}
             </svg>

--- a/components/sanren/servicios-view.tsx
+++ b/components/sanren/servicios-view.tsx
@@ -10,6 +10,13 @@ import {
 } from '@/components/module-page';
 import { useUrlFilters } from '@/hooks/use-url-filters';
 import type { ServiciosData, ReciboVista } from '@/lib/sanren-servicios';
+import {
+  computeServicioKpis,
+  computeComparativos,
+  computeAnomalias,
+  type ServicioKpiSet,
+  type Comparativos as ComparativosData,
+} from '@/lib/sanren/servicios-analytics';
 import { ServiciosTendencias } from '@/components/sanren/servicios-tendencias';
 import { ReciboDrawer } from '@/components/sanren/recibo-drawer';
 
@@ -29,6 +36,11 @@ function money(n: number | null): string {
 function num(n: number | null, suffix = ''): string {
   if (n == null) return '—';
   return `${n.toLocaleString('es-MX')}${suffix}`;
+}
+
+function pct(n: number | null): string {
+  if (n == null) return '—';
+  return `${n >= 0 ? '+' : ''}${(n * 100).toFixed(0)}%`;
 }
 
 const SERVICIO_STYLE: Record<string, { label: string; cls: string }> = {
@@ -57,6 +69,128 @@ const FILTER_DEFAULTS = {
   desde: '',
   hasta: '',
 };
+
+type Kpi = {
+  key: string;
+  label: string;
+  value: React.ReactNode;
+  valueClassName?: string;
+};
+
+const u = (s: string | null) => (s ? ` ${s}` : '');
+
+/**
+ * KPIs según el servicio activo. "Todos" mantiene el resumen genérico; cada
+ * servicio muestra las métricas que cuentan su historia (Luz → solar/banco,
+ * Agua/Gas → consumo y pico). Tope de 5 por ADR-004 R3.
+ */
+function buildKpis(servicio: string, k: ServicioKpiSet): Kpi[] {
+  if (servicio === 'luz') {
+    return [
+      { key: 'gasto', label: 'Gasto', value: money(k.gasto) },
+      { key: 'consumo', label: 'kWh consumidos', value: num(k.consumoTotal) },
+      { key: 'gen', label: 'kWh generados', value: num(k.generacionTotal) },
+      {
+        key: 'banco',
+        label: 'Banco de energía',
+        value: k.bancoEnergia != null ? `${num(k.bancoEnergia)} kWh` : '—',
+        valueClassName: k.bancoEnergia && k.bancoEnergia > 0 ? 'text-emerald-600' : undefined,
+      },
+      { key: 'costo', label: 'Costo/kWh', value: money(k.costoUnitarioProm) },
+    ];
+  }
+  if (servicio === 'agua' || servicio === 'gas') {
+    return [
+      { key: 'gasto', label: 'Gasto', value: money(k.gasto) },
+      { key: 'consumo', label: 'Consumo', value: num(k.consumoTotal, u(k.consumoUnidad)) },
+      { key: 'costo', label: `Costo/${k.consumoUnidad ?? 'u'}`, value: money(k.costoUnitarioProm) },
+      { key: 'prom', label: 'Consumo prom.', value: num(k.consumoPromMensual, u(k.consumoUnidad)) },
+      {
+        key: 'pico',
+        label: 'Mes pico',
+        value: k.mesPico ? fmtPeriodo(k.mesPico.periodo) : '—',
+      },
+    ];
+  }
+  // "Todos"
+  return [
+    { key: 'n', label: 'Recibos', value: k.count },
+    { key: 'gasto', label: 'Gasto', value: money(k.gasto) },
+    {
+      key: 'pend',
+      label: 'Pendientes de pago',
+      value: k.pendientes,
+      valueClassName: k.pendientes > 0 ? 'text-amber-500' : undefined,
+    },
+    {
+      key: 'rango',
+      label: 'Periodo',
+      value: k.rango ? `${fmtPeriodo(k.rango[0])} – ${fmtPeriodo(k.rango[1])}` : '—',
+    },
+  ];
+}
+
+/** Color del delta: subir gasto es malo (ámbar/rojo), bajar es bueno (verde). */
+function deltaCls(d: number | null): string {
+  if (d == null) return 'text-[var(--text)]/50';
+  return d > 0 ? 'text-amber-600' : 'text-emerald-600';
+}
+
+/**
+ * Tarjeta de comparativos año-vs-año + alertas. Vive en la pestaña "Análisis".
+ * Solo se muestra cuando hay historia suficiente para comparar.
+ */
+function Comparativos({ c, alertas }: { c: ComparativosData; alertas: number }) {
+  const hayYoY = c.gastoMismoMesAnioPrevio != null;
+  const hay12m = c.totalPrev12m > 0;
+  if (!hayYoY && !hay12m && alertas === 0) return null;
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      {hayYoY ? (
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-4 py-3">
+          <div className="text-xs font-medium uppercase tracking-wider text-[var(--text)]/55">
+            {c.ultimoPeriodo ? fmtPeriodo(c.ultimoPeriodo) : '—'} vs. año previo
+          </div>
+          <div className={`mt-1 text-2xl font-semibold tabular-nums ${deltaCls(c.deltaGastoPct)}`}>
+            {pct(c.deltaGastoPct)}
+          </div>
+          <div className="text-xs text-[var(--text)]/55">
+            {money(c.gastoUltimo)} vs. {money(c.gastoMismoMesAnioPrevio)}
+          </div>
+        </div>
+      ) : null}
+
+      {hay12m ? (
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-4 py-3">
+          <div className="text-xs font-medium uppercase tracking-wider text-[var(--text)]/55">
+            Últimos 12 meses
+          </div>
+          <div className={`mt-1 text-2xl font-semibold tabular-nums ${deltaCls(c.delta12mPct)}`}>
+            {pct(c.delta12mPct)}
+          </div>
+          <div className="text-xs text-[var(--text)]/55">
+            {money(c.total12m)} vs. {money(c.totalPrev12m)} previos
+          </div>
+        </div>
+      ) : null}
+
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-4 py-3">
+        <div className="text-xs font-medium uppercase tracking-wider text-[var(--text)]/55">
+          Alertas de consumo
+        </div>
+        <div
+          className={`mt-1 text-2xl font-semibold tabular-nums ${
+            alertas > 0 ? 'text-amber-500' : 'text-[var(--text)]/50'
+          }`}
+        >
+          {alertas}
+        </div>
+        <div className="text-xs text-[var(--text)]/55">Recibos con consumo inusual</div>
+      </div>
+    </div>
+  );
+}
 
 export function ServiciosView({ data }: { data: ServiciosData }) {
   const { recibos, servicios, empresaId, errors } = data;
@@ -88,16 +222,14 @@ export function ServiciosView({ data }: { data: ServiciosData }) {
     });
   }, [recibos, filters]);
 
-  const kpis = useMemo(() => {
-    const n = filtered.length;
-    const gasto = filtered.reduce((a, r) => a + (r.monto ?? 0), 0);
-    const pendientes = filtered.filter((r) => !r.pagado).length;
-    const meses = filtered.map((r) => r.periodo.slice(0, 7)).sort();
-    const rango = meses.length
-      ? `${fmtPeriodo(meses[0])} – ${fmtPeriodo(meses[meses.length - 1])}`
-      : '—';
-    return { n, gasto, pendientes, rango };
-  }, [filtered]);
+  const kpis = useMemo(
+    () => buildKpis(filters.servicio, computeServicioKpis(filtered)),
+    [filtered, filters.servicio]
+  );
+
+  const anomalias = useMemo(() => computeAnomalias(filtered), [filtered]);
+
+  const comparativos = useMemo(() => computeComparativos(filtered), [filtered]);
 
   const columns: Column<ReciboVista>[] = [
     {
@@ -127,7 +259,23 @@ export function ServiciosView({ data }: { data: ServiciosData }) {
       type: 'custom',
       align: 'right',
       accessor: (r) => r.consumo_periodo ?? -1,
-      render: (r) => num(r.consumo_periodo, r.unidad_consumo ? ` ${r.unidad_consumo}` : ''),
+      render: (r) => {
+        const a = anomalias.get(r.id);
+        return (
+          <span className="inline-flex items-center justify-end gap-1">
+            {a ? (
+              <span
+                title={`Consumo inusual: ${pct(a.exceso)} sobre el promedio reciente (${num(Math.round(a.baseline))})`}
+                className="text-amber-500"
+                aria-label="Consumo inusual"
+              >
+                ⚠
+              </span>
+            ) : null}
+            {num(r.consumo_periodo, r.unidad_consumo ? ` ${r.unidad_consumo}` : '')}
+          </span>
+        );
+      },
     },
     {
       key: 'costo_unitario',
@@ -206,32 +354,21 @@ export function ServiciosView({ data }: { data: ServiciosData }) {
     <div className="space-y-4">
       {errors.length > 0 ? <ErrorBanner error={errors.join(' · ')} /> : null}
 
-      <ModuleKpiStrip
-        cols={4}
-        stats={[
-          { key: 'n', label: 'Recibos', value: kpis.n },
-          { key: 'gasto', label: 'Gasto', value: money(kpis.gasto) },
-          {
-            key: 'pend',
-            label: 'Pendientes de pago',
-            value: kpis.pendientes,
-            valueClassName: kpis.pendientes > 0 ? 'text-amber-500' : undefined,
-          },
-          { key: 'rango', label: 'Periodo', value: kpis.rango },
-        ]}
-      />
-
+      {/* Lente por servicio: Todos · Luz · Agua · Gas (reemplaza el dropdown). */}
       <div className="flex items-center justify-between gap-3">
         <div className="flex w-fit gap-1 rounded-lg border border-[var(--border)] bg-[var(--card)] p-1 text-sm">
           {[
-            { id: 'recibos', label: 'Recibos' },
-            { id: 'tendencias', label: 'Tendencias' },
-          ].map((t) => {
-            const active = (filters.tab || 'recibos') === t.id;
+            { id: '', label: 'Todos' },
+            ...tiposPresentes.map((t) => ({
+              id: t,
+              label: SERVICIO_STYLE[t]?.label ?? t,
+            })),
+          ].map((lente) => {
+            const active = (filters.servicio || '') === lente.id;
             return (
               <button
-                key={t.id}
-                onClick={() => setFilter('tab', t.id)}
+                key={lente.id || 'todos'}
+                onClick={() => setFilter('servicio', lente.id)}
                 aria-pressed={active}
                 className={`rounded-md px-3 py-1 transition ${
                   active
@@ -239,7 +376,7 @@ export function ServiciosView({ data }: { data: ServiciosData }) {
                     : 'text-[var(--text)]/60 hover:text-[var(--text)]'
                 }`}
               >
-                {t.label}
+                {lente.label}
               </button>
             );
           })}
@@ -250,6 +387,32 @@ export function ServiciosView({ data }: { data: ServiciosData }) {
         >
           + Nuevo recibo
         </button>
+      </div>
+
+      <ModuleKpiStrip cols={kpis.length === 5 ? 5 : 4} stats={kpis} />
+
+      {/* Vista: tabla de recibos o análisis del servicio activo. */}
+      <div className="flex w-fit gap-1 rounded-lg border border-[var(--border)] bg-[var(--card)] p-1 text-sm">
+        {[
+          { id: 'recibos', label: 'Recibos' },
+          { id: 'analisis', label: 'Análisis' },
+        ].map((t) => {
+          const active = (filters.tab || 'recibos') === t.id;
+          return (
+            <button
+              key={t.id}
+              onClick={() => setFilter('tab', t.id)}
+              aria-pressed={active}
+              className={`rounded-md px-3 py-1 transition ${
+                active
+                  ? 'bg-[var(--text)]/10 font-medium text-[var(--text)]'
+                  : 'text-[var(--text)]/60 hover:text-[var(--text)]'
+              }`}
+            >
+              {t.label}
+            </button>
+          );
+        })}
       </div>
 
       <ModuleFilters
@@ -265,19 +428,6 @@ export function ServiciosView({ data }: { data: ServiciosData }) {
           ) : undefined
         }
       >
-        <select
-          value={filters.servicio}
-          onChange={(e) => setFilter('servicio', e.target.value)}
-          className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-sm"
-        >
-          <option value="">Todos los servicios</option>
-          {tiposPresentes.map((t) => (
-            <option key={t} value={t}>
-              {SERVICIO_STYLE[t]?.label ?? t}
-            </option>
-          ))}
-        </select>
-
         <select
           value={filters.estadoPago}
           onChange={(e) => setFilter('estadoPago', e.target.value)}
@@ -312,8 +462,11 @@ export function ServiciosView({ data }: { data: ServiciosData }) {
         />
       </ModuleFilters>
 
-      {(filters.tab || 'recibos') === 'tendencias' ? (
-        <ServiciosTendencias recibos={filtered} />
+      {(filters.tab || 'recibos') === 'analisis' ? (
+        <div className="space-y-4">
+          <Comparativos c={comparativos} alertas={anomalias.size} />
+          <ServiciosTendencias recibos={filtered} />
+        </div>
       ) : (
         <DataTable<ReciboVista>
           data={filtered}

--- a/lib/sanren/servicios-analytics.test.ts
+++ b/lib/sanren/servicios-analytics.test.ts
@@ -4,6 +4,8 @@ import {
   computeServicioKpis,
   computeComparativos,
   computeAnomalias,
+  computePronostico,
+  addMes,
 } from '@/lib/sanren/servicios-analytics';
 import type { ReciboVista } from '@/lib/sanren-servicios';
 
@@ -160,5 +162,48 @@ describe('computeAnomalias', () => {
     const anom = computeAnomalias(recibos);
     expect(anom.has('a3')).toBe(true);
     expect(anom.has('g2')).toBe(false);
+  });
+});
+
+describe('addMes', () => {
+  it('avanza un mes y maneja el salto de año', () => {
+    expect(addMes('2025-06')).toBe('2025-07');
+    expect(addMes('2025-12')).toBe('2026-01');
+    expect(addMes('2025-09')).toBe('2025-10');
+  });
+});
+
+describe('computePronostico', () => {
+  const pickConsumo = (r: ReturnType<typeof recibo>) => r.consumo_periodo;
+
+  it('mezcla estacionalidad y tendencia cuando hay ambas', () => {
+    // Mismo mes (jul) año previo = 300; recientes (abr/may/jun 2025) promedian 100.
+    const recibos = [
+      recibo({ id: 'h1', periodo: '2024-07', consumo_periodo: 300 }),
+      recibo({ id: 'r1', periodo: '2025-04', consumo_periodo: 90 }),
+      recibo({ id: 'r2', periodo: '2025-05', consumo_periodo: 100 }),
+      recibo({ id: 'r3', periodo: '2025-06', consumo_periodo: 110 }),
+    ];
+    const p = computePronostico(recibos, pickConsumo);
+    expect(p?.periodo).toBe('2025-07');
+    expect(p?.base).toBe('estacional+tendencia');
+    expect(p?.valor).toBe(200); // 0.5*300 + 0.5*100
+  });
+
+  it('usa solo tendencia si no hay historia del mismo mes', () => {
+    const recibos = [
+      recibo({ id: 'r1', periodo: '2025-04', consumo_periodo: 100 }),
+      recibo({ id: 'r2', periodo: '2025-05', consumo_periodo: 200 }),
+      recibo({ id: 'r3', periodo: '2025-06', consumo_periodo: 300 }),
+    ];
+    const p = computePronostico(recibos, pickConsumo);
+    expect(p?.periodo).toBe('2025-07');
+    expect(p?.base).toBe('tendencia');
+    expect(p?.valor).toBe(200);
+  });
+
+  it('devuelve null sin datos del campo', () => {
+    const recibos = [recibo({ id: 'x', periodo: '2025-01' })]; // consumo_periodo null
+    expect(computePronostico(recibos, pickConsumo)).toBeNull();
   });
 });

--- a/lib/sanren/servicios-analytics.test.ts
+++ b/lib/sanren/servicios-analytics.test.ts
@@ -5,6 +5,9 @@ import {
   computeComparativos,
   computeAnomalias,
   computePronostico,
+  computePronosticoGasto,
+  computeBancoProyectado,
+  ultimoBanco,
   addMes,
 } from '@/lib/sanren/servicios-analytics';
 import type { ReciboVista } from '@/lib/sanren-servicios';
@@ -253,5 +256,81 @@ describe('computePronostico', () => {
   it('devuelve null sin datos del campo', () => {
     const recibos = [recibo({ id: 'x', periodo: '2025-01' })]; // consumo_periodo null
     expect(computePronostico(recibos, pickConsumo)).toBeNull();
+  });
+});
+
+// Serie de luz bimestral plana (mismos valores cada año → factor de tendencia 1).
+const LUZ_BIMESTRAL = (
+  [
+    ['2024-08', 6000, 3000],
+    ['2024-10', 5000, 4000],
+    ['2024-12', 3000, 4000],
+    ['2025-02', 4000, 4000],
+    ['2025-04', 2000, 5000],
+    ['2025-06', 4000, 4000],
+    ['2025-08', 6000, 3000],
+    ['2025-10', 5000, 4000],
+    ['2025-12', 3000, 4000],
+    ['2026-02', 4000, 4000],
+    ['2026-04', 2000, 5000],
+    ['2026-06', 4000, 4000],
+  ] as const
+).map(([periodo, consumo, produccion], i) =>
+  recibo({
+    id: `lz${i}`,
+    servicio_tipo: 'luz',
+    unidad_consumo: 'kWh',
+    periodo,
+    consumo_periodo: consumo,
+    produccion_periodo: produccion,
+    tiene_produccion: true,
+    monto: 50,
+    extraccion: periodo === '2026-06' ? { energia_acumulada_favor: 10000 } : null,
+  })
+);
+
+describe('ultimoBanco', () => {
+  it('toma el saldo del recibo más reciente que lo reporta', () => {
+    expect(ultimoBanco(LUZ_BIMESTRAL)).toBe(10000);
+  });
+  it('null cuando ningún recibo reporta banco', () => {
+    expect(ultimoBanco([recibo({ id: 'a', periodo: '2025-01' })])).toBeNull();
+  });
+});
+
+describe('computePronosticoGasto', () => {
+  it('cuando el banco cubre el consumo neto, el gasto esperado es el cargo fijo reciente', () => {
+    // ago: consumo 6000, generación 3000 → neto 3000 kWh; banco 10000 lo cubre.
+    const g = computePronosticoGasto(LUZ_BIMESTRAL);
+    expect(g?.periodo).toBe('2026-08');
+    expect(g?.cubiertoPorBanco).toBe(true);
+    expect(g?.valor).toBe(50); // promedio de montos recientes, no el estacional viejo
+  });
+
+  it('servicio sin paneles usa el gasto estacional normal', () => {
+    const agua = [
+      recibo({ id: 'a1', servicio_tipo: 'agua', periodo: '2024-08', monto: 1000 }),
+      recibo({ id: 'a2', servicio_tipo: 'agua', periodo: '2025-06', monto: 500 }),
+      recibo({ id: 'a3', servicio_tipo: 'agua', periodo: '2025-07', monto: 600 }),
+      recibo({ id: 'a4', servicio_tipo: 'agua', periodo: '2025-08', monto: 700 }),
+    ];
+    const g = computePronosticoGasto(agua);
+    expect(g?.cubiertoPorBanco).toBe(false);
+  });
+});
+
+describe('computeBancoProyectado', () => {
+  it('baja el banco por el consumo neto del próximo periodo', () => {
+    const b = computeBancoProyectado(LUZ_BIMESTRAL);
+    expect(b?.periodo).toBe('2026-08');
+    expect(b?.netoDelBanco).toBe(3000); // consumo 6000 − generación 3000
+    expect(b?.banco).toBe(7000); // 10000 − 3000
+  });
+
+  it('null sin banco', () => {
+    const sinBanco = [
+      recibo({ id: 's1', servicio_tipo: 'luz', periodo: '2025-06', consumo_periodo: 100 }),
+    ];
+    expect(computeBancoProyectado(sinBanco)).toBeNull();
   });
 });

--- a/lib/sanren/servicios-analytics.test.ts
+++ b/lib/sanren/servicios-analytics.test.ts
@@ -176,8 +176,8 @@ describe('addMes', () => {
 describe('computePronostico', () => {
   const pickConsumo = (r: ReturnType<typeof recibo>) => r.consumo_periodo;
 
-  it('mezcla estacionalidad y tendencia cuando hay ambas', () => {
-    // Mismo mes (jul) año previo = 300; recientes (abr/may/jun 2025) promedian 100.
+  it('usa el mismo mes de años anteriores con factor de tendencia neutro', () => {
+    // Sin 12m previos comparables (ventanas <3) → factor 1, predice el año pasado.
     const recibos = [
       recibo({ id: 'h1', periodo: '2024-07', consumo_periodo: 300 }),
       recibo({ id: 'r1', periodo: '2025-04', consumo_periodo: 90 }),
@@ -187,7 +187,55 @@ describe('computePronostico', () => {
     const p = computePronostico(recibos, pickConsumo);
     expect(p?.periodo).toBe('2025-07');
     expect(p?.base).toBe('estacional+tendencia');
-    expect(p?.valor).toBe(200); // 0.5*300 + 0.5*100
+    expect(p?.valor).toBe(300);
+  });
+
+  it('proyecta el próximo bimestre (no el próximo mes) y captura el pico estacional', () => {
+    // Luz bimestral en meses pares; agosto es el pico cada año.
+    const meses = [
+      ['2024-08', 6000],
+      ['2024-10', 5000],
+      ['2024-12', 3000],
+      ['2025-02', 4000],
+      ['2025-04', 3000],
+      ['2025-06', 4000],
+      ['2025-08', 6000],
+      ['2025-10', 5000],
+      ['2025-12', 3000],
+      ['2026-02', 4000],
+      ['2026-04', 3000],
+      ['2026-06', 4000],
+    ] as const;
+    const recibos = meses.map(([periodo, c], i) =>
+      recibo({ id: `l${i}`, servicio_tipo: 'luz', periodo, consumo_periodo: c })
+    );
+    const p = computePronostico(recibos, pickConsumo);
+    expect(p?.periodo).toBe('2026-08'); // +2 meses, no julio
+    expect(p?.base).toBe('estacional+tendencia');
+    expect(p?.valor).toBe(6000); // promedio de agostos (factor 1, tendencia plana)
+  });
+
+  it('escala por tendencia anual con clamp', () => {
+    const meses = [
+      ['2024-08', 1000],
+      ['2024-10', 1000],
+      ['2024-12', 1000],
+      ['2025-02', 1000],
+      ['2025-04', 1000],
+      ['2025-06', 1000],
+      ['2025-08', 2000],
+      ['2025-10', 2000],
+      ['2025-12', 2000],
+      ['2026-02', 2000],
+      ['2026-04', 2000],
+      ['2026-06', 2000],
+    ] as const;
+    const recibos = meses.map(([periodo, c], i) =>
+      recibo({ id: `t${i}`, servicio_tipo: 'luz', periodo, consumo_periodo: c })
+    );
+    const p = computePronostico(recibos, pickConsumo);
+    // mismos agostos: avg(1000,2000)=1500; ratio 12000/6000=2 → clamp 1.4 → 2100.
+    expect(p?.valor).toBe(2100);
   });
 
   it('usa solo tendencia si no hay historia del mismo mes', () => {

--- a/lib/sanren/servicios-analytics.test.ts
+++ b/lib/sanren/servicios-analytics.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  computeServicioKpis,
+  computeComparativos,
+  computeAnomalias,
+} from '@/lib/sanren/servicios-analytics';
+import type { ReciboVista } from '@/lib/sanren-servicios';
+
+/** Fábrica mínima de un recibo con los campos que la analítica usa. */
+function recibo(partial: Partial<ReciboVista> & { id: string; periodo: string }): ReciboVista {
+  return {
+    servicio_id: 's',
+    fecha_recibo: `${partial.periodo}-01`,
+    fecha_vencimiento: null,
+    monto: null,
+    subtotal: null,
+    iva: null,
+    tarifa: null,
+    moneda: 'MXN',
+    folio: null,
+    lectura_consumo: null,
+    lectura_produccion: null,
+    pagado: true,
+    fecha_pago: null,
+    metodo_pago: null,
+    notas: null,
+    coda_row_id: null,
+    extraccion: null,
+    servicio_tipo: 'agua',
+    proveedor: null,
+    unidad_consumo: 'm³',
+    tiene_produccion: false,
+    propiedad_nombre: 'Casa',
+    consumo_periodo: null,
+    produccion_periodo: null,
+    costo_unitario: null,
+    saldo_neto: null,
+    delta_monto_mom: null,
+    recibo_adjunto_path: null,
+    comprobante_adjunto_path: null,
+    ...partial,
+  };
+}
+
+describe('computeServicioKpis', () => {
+  it('agrega gasto, consumo, costo unitario y mes pico de agua', () => {
+    const recibos = [
+      recibo({ id: 'a1', periodo: '2025-01', monto: 1000, consumo_periodo: 50 }),
+      recibo({ id: 'a2', periodo: '2025-02', monto: 2000, consumo_periodo: 150, pagado: false }),
+    ];
+    const k = computeServicioKpis(recibos);
+    expect(k.count).toBe(2);
+    expect(k.gasto).toBe(3000);
+    expect(k.pendientes).toBe(1);
+    expect(k.rango).toEqual(['2025-01', '2025-02']);
+    expect(k.consumoTotal).toBe(200);
+    expect(k.consumoUnidad).toBe('m³');
+    expect(k.costoUnitarioProm).toBeCloseTo(15);
+    expect(k.consumoPromMensual).toBeCloseTo(100);
+    expect(k.mesPico).toEqual({ periodo: '2025-02', consumo: 150 });
+    expect(k.generacionTotal).toBeNull();
+    expect(k.bancoEnergia).toBeNull();
+  });
+
+  it('captura generación y banco de energía del recibo de luz más reciente', () => {
+    const recibos = [
+      recibo({
+        id: 'l1',
+        periodo: '2025-01',
+        servicio_tipo: 'luz',
+        unidad_consumo: 'kWh',
+        monto: 50,
+        consumo_periodo: 100,
+        tiene_produccion: true,
+        produccion_periodo: 400,
+        extraccion: { energia_acumulada_favor: 1200 },
+      }),
+      recibo({
+        id: 'l2',
+        periodo: '2025-02',
+        servicio_tipo: 'luz',
+        unidad_consumo: 'kWh',
+        monto: 60,
+        consumo_periodo: 120,
+        tiene_produccion: true,
+        produccion_periodo: 300,
+        extraccion: { energia_acumulada_favor: 2638 },
+      }),
+    ];
+    const k = computeServicioKpis(recibos);
+    expect(k.generacionTotal).toBe(700);
+    expect(k.bancoEnergia).toBe(2638); // el más reciente (2025-02)
+  });
+
+  it('devuelve nulls seguros con set vacío', () => {
+    const k = computeServicioKpis([]);
+    expect(k.count).toBe(0);
+    expect(k.gasto).toBe(0);
+    expect(k.rango).toBeNull();
+    expect(k.consumoTotal).toBeNull();
+    expect(k.costoUnitarioProm).toBeNull();
+    expect(k.mesPico).toBeNull();
+  });
+});
+
+describe('computeComparativos', () => {
+  it('compara mismo mes año previo y ventanas de 12 meses', () => {
+    const recibos = [
+      recibo({ id: 'p1', periodo: '2024-06', monto: 1000 }),
+      recibo({ id: 'p2', periodo: '2025-06', monto: 1500 }),
+    ];
+    const c = computeComparativos(recibos);
+    expect(c.ultimoPeriodo).toBe('2025-06');
+    expect(c.gastoUltimo).toBe(1500);
+    expect(c.gastoMismoMesAnioPrevio).toBe(1000);
+    expect(c.deltaGastoPct).toBeCloseTo(0.5);
+  });
+
+  it('maneja set vacío sin romper', () => {
+    const c = computeComparativos([]);
+    expect(c.ultimoPeriodo).toBeNull();
+    expect(c.deltaGastoPct).toBeNull();
+    expect(c.total12m).toBe(0);
+  });
+});
+
+describe('computeAnomalias', () => {
+  it('marca un salto de consumo sobre el baseline previo', () => {
+    const recibos = [
+      recibo({ id: 'm1', periodo: '2025-01', consumo_periodo: 100 }),
+      recibo({ id: 'm2', periodo: '2025-02', consumo_periodo: 100 }),
+      recibo({ id: 'm3', periodo: '2025-03', consumo_periodo: 100 }),
+      recibo({ id: 'm4', periodo: '2025-04', consumo_periodo: 200 }), // +100% vs baseline 100
+    ];
+    const anom = computeAnomalias(recibos);
+    expect(anom.has('m4')).toBe(true);
+    expect(anom.get('m4')?.exceso).toBeCloseTo(1);
+    expect(anom.has('m1')).toBe(false); // sin previos suficientes
+  });
+
+  it('no marca consumos dentro de la variación normal', () => {
+    const recibos = [
+      recibo({ id: 'n1', periodo: '2025-01', consumo_periodo: 100 }),
+      recibo({ id: 'n2', periodo: '2025-02', consumo_periodo: 105 }),
+      recibo({ id: 'n3', periodo: '2025-03', consumo_periodo: 110 }),
+      recibo({ id: 'n4', periodo: '2025-04', consumo_periodo: 115 }),
+    ];
+    expect(computeAnomalias(recibos).size).toBe(0);
+  });
+
+  it('aísla el baseline por tipo de servicio', () => {
+    const recibos = [
+      recibo({ id: 'a1', servicio_tipo: 'agua', periodo: '2025-01', consumo_periodo: 10 }),
+      recibo({ id: 'a2', servicio_tipo: 'agua', periodo: '2025-02', consumo_periodo: 10 }),
+      recibo({ id: 'g1', servicio_tipo: 'gas', periodo: '2025-01', consumo_periodo: 200 }),
+      recibo({ id: 'g2', servicio_tipo: 'gas', periodo: '2025-02', consumo_periodo: 200 }),
+      recibo({ id: 'a3', servicio_tipo: 'agua', periodo: '2025-03', consumo_periodo: 50 }), // +400% agua
+    ];
+    const anom = computeAnomalias(recibos);
+    expect(anom.has('a3')).toBe(true);
+    expect(anom.has('g2')).toBe(false);
+  });
+});

--- a/lib/sanren/servicios-analytics.ts
+++ b/lib/sanren/servicios-analytics.ts
@@ -211,3 +211,86 @@ export function computeAnomalias(
 
   return out;
 }
+
+/** Mes calendario siguiente a un periodo `yyyy-mm` (maneja el salto de año). */
+export function addMes(periodo: string): string {
+  const [y, m] = periodo.split('-').map(Number);
+  const ny = m === 12 ? y + 1 : y;
+  const nm = m === 12 ? 1 : m + 1;
+  return `${ny}-${String(nm).padStart(2, '0')}`;
+}
+
+/** Serie mensual {periodo, valor} de un campo, sumando por mes (orden asc). */
+export function serieMensual(
+  recibos: ReciboVista[],
+  pick: (r: ReciboVista) => number | null
+): { periodo: string; valor: number }[] {
+  const map = new Map<string, number>();
+  for (const r of recibos) {
+    const v = pick(r);
+    if (v == null) continue;
+    map.set(yyyymm(r.periodo), (map.get(yyyymm(r.periodo)) ?? 0) + v);
+  }
+  return Array.from(map.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([periodo, valor]) => ({ periodo, valor }));
+}
+
+export interface Pronostico {
+  /** Periodo `yyyy-mm` pronosticado (el mes siguiente al último con dato). */
+  periodo: string;
+  valor: number;
+  /** Cómo se estimó: estacional (años previos), tendencia (meses recientes) o ambos. */
+  base: 'estacional+tendencia' | 'estacional' | 'tendencia';
+}
+
+const avg = (xs: number[]): number => xs.reduce((a, b) => a + b, 0) / xs.length;
+
+/**
+ * Pronóstico del próximo periodo para un campo (consumo, producción, monto…).
+ *
+ * Mezcla 50/50 dos señales cuando ambas existen:
+ *  - **estacional**: promedio del mismo mes en años anteriores ("lo que sucedió
+ *    en años anteriores").
+ *  - **tendencia**: promedio de los últimos `recientes` meses ("lo que se ha
+ *    venido consumiendo").
+ *
+ * Si solo hay una, usa esa. Devuelve null si no hay datos. `recibos` debe venir
+ * ya filtrado por servicio.
+ */
+export function computePronostico(
+  recibos: ReciboVista[],
+  pick: (r: ReciboVista) => number | null,
+  opts: { recientes?: number } = {}
+): Pronostico | null {
+  const recientes = opts.recientes ?? 3;
+  const serie = serieMensual(recibos, pick);
+  if (serie.length === 0) return null;
+
+  const ultimo = serie[serie.length - 1].periodo;
+  const next = addMes(ultimo);
+  const nextMM = next.slice(5, 7);
+
+  const mismosMeses = serie.filter((s) => s.periodo.slice(5, 7) === nextMM).map((s) => s.valor);
+  const ultimosN = serie.slice(-recientes).map((s) => s.valor);
+
+  const estacional = mismosMeses.length > 0 ? avg(mismosMeses) : null;
+  const tendencia = ultimosN.length > 0 ? avg(ultimosN) : null;
+
+  let valor: number;
+  let base: Pronostico['base'];
+  if (estacional != null && tendencia != null) {
+    valor = 0.5 * estacional + 0.5 * tendencia;
+    base = 'estacional+tendencia';
+  } else if (estacional != null) {
+    valor = estacional;
+    base = 'estacional';
+  } else if (tendencia != null) {
+    valor = tendencia;
+    base = 'tendencia';
+  } else {
+    return null;
+  }
+
+  return { periodo: next, valor: Math.max(0, Math.round(valor)), base };
+}

--- a/lib/sanren/servicios-analytics.ts
+++ b/lib/sanren/servicios-analytics.ts
@@ -1,0 +1,213 @@
+import type { ReciboVista } from '@/lib/sanren-servicios';
+
+/**
+ * Analítica pura del módulo SANREN → Servicios (vista por servicio).
+ *
+ * Todo aquí es determinista y sin dependencias de React/DOM para poder
+ * testearlo aislado (mantiene los thresholds de coverage). La UI
+ * (`servicios-view.tsx`) formatea; este módulo solo calcula.
+ *
+ * Las funciones reciben un set de recibos **ya filtrado** (por servicio y por
+ * los filtros de la barra) — las "sumatorias según filtros" salen de aquí.
+ */
+
+const yyyymm = (periodo: string): string => periodo.slice(0, 7);
+
+/** Suma defensiva de un campo numérico que puede venir null. */
+function sumField(recibos: ReciboVista[], pick: (r: ReciboVista) => number | null): number {
+  return recibos.reduce((acc, r) => acc + (pick(r) ?? 0), 0);
+}
+
+export interface ServicioKpiSet {
+  count: number;
+  gasto: number;
+  pendientes: number;
+  /** [periodoMin, periodoMax] en `yyyy-mm`, o null si no hay recibos. */
+  rango: [string, string] | null;
+  /** Consumo total del periodo (kWh / m³ según servicio). null si nadie reporta. */
+  consumoTotal: number | null;
+  /** Unidad de consumo dominante (kWh, m³…). */
+  consumoUnidad: string | null;
+  /** gasto / consumoTotal — costo unitario promedio del rango. */
+  costoUnitarioProm: number | null;
+  /** Consumo promedio por recibo con lectura. */
+  consumoPromMensual: number | null;
+  /** Periodo con mayor consumo (detección de pico). */
+  mesPico: { periodo: string; consumo: number } | null;
+  /** Solo Luz con paneles: generación total del rango. */
+  generacionTotal: number | null;
+  /** Solo Luz: kWh a favor en el banco de energía (recibo más reciente). */
+  bancoEnergia: number | null;
+}
+
+/**
+ * KPIs de un servicio (o del set completo si es la vista "Todos").
+ * `recibos` debe venir ya filtrado.
+ */
+export function computeServicioKpis(recibos: ReciboVista[]): ServicioKpiSet {
+  const count = recibos.length;
+  const gasto = sumField(recibos, (r) => r.monto);
+  const pendientes = recibos.filter((r) => !r.pagado).length;
+
+  const meses = recibos.map((r) => yyyymm(r.periodo)).sort();
+  const rango: [string, string] | null = meses.length ? [meses[0], meses[meses.length - 1]] : null;
+
+  const conConsumo = recibos.filter((r) => r.consumo_periodo != null);
+  const consumoTotal = conConsumo.length ? sumField(conConsumo, (r) => r.consumo_periodo) : null;
+  const consumoUnidad = recibos.find((r) => r.unidad_consumo)?.unidad_consumo ?? null;
+  const costoUnitarioProm = consumoTotal != null && consumoTotal > 0 ? gasto / consumoTotal : null;
+  const consumoPromMensual =
+    consumoTotal != null && conConsumo.length > 0 ? consumoTotal / conConsumo.length : null;
+
+  let mesPico: { periodo: string; consumo: number } | null = null;
+  for (const r of conConsumo) {
+    const c = r.consumo_periodo as number;
+    if (!mesPico || c > mesPico.consumo) mesPico = { periodo: yyyymm(r.periodo), consumo: c };
+  }
+
+  const conProduccion = recibos.filter((r) => r.tiene_produccion && r.produccion_periodo != null);
+  const generacionTotal = conProduccion.length
+    ? sumField(conProduccion, (r) => r.produccion_periodo)
+    : null;
+
+  // Banco de energía: el del recibo de luz más reciente que lo reporte.
+  let bancoEnergia: number | null = null;
+  const conBanco = recibos
+    .filter((r) => r.extraccion?.energia_acumulada_favor != null)
+    .sort((a, b) => b.periodo.localeCompare(a.periodo));
+  if (conBanco.length > 0) {
+    bancoEnergia = conBanco[0].extraccion?.energia_acumulada_favor ?? null;
+  }
+
+  return {
+    count,
+    gasto,
+    pendientes,
+    rango,
+    consumoTotal,
+    consumoUnidad,
+    costoUnitarioProm,
+    consumoPromMensual,
+    mesPico,
+    generacionTotal,
+    bancoEnergia,
+  };
+}
+
+export interface Comparativos {
+  ultimoPeriodo: string | null;
+  gastoUltimo: number | null;
+  /** Mismo mes, año anterior. */
+  gastoMismoMesAnioPrevio: number | null;
+  deltaGastoPct: number | null;
+  /** Total móvil de los 12 meses más recientes presentes. */
+  total12m: number;
+  /** Total de los 12 meses previos a esa ventana. */
+  totalPrev12m: number;
+  delta12mPct: number | null;
+}
+
+function mesAnioPrevio(periodo: string): string {
+  const [y, m] = periodo.split('-');
+  return `${Number(y) - 1}-${m}`;
+}
+
+/** Comparativos año-vs-año del set (ya filtrado por servicio). */
+export function computeComparativos(recibos: ReciboVista[]): Comparativos {
+  const porMes = new Map<string, number>();
+  for (const r of recibos) {
+    if (r.monto == null) continue;
+    const mes = yyyymm(r.periodo);
+    porMes.set(mes, (porMes.get(mes) ?? 0) + r.monto);
+  }
+  const meses = Array.from(porMes.keys()).sort();
+  if (meses.length === 0) {
+    return {
+      ultimoPeriodo: null,
+      gastoUltimo: null,
+      gastoMismoMesAnioPrevio: null,
+      deltaGastoPct: null,
+      total12m: 0,
+      totalPrev12m: 0,
+      delta12mPct: null,
+    };
+  }
+
+  const ultimoPeriodo = meses[meses.length - 1];
+  const gastoUltimo = porMes.get(ultimoPeriodo) ?? null;
+  const prevKey = mesAnioPrevio(ultimoPeriodo);
+  const gastoMismoMesAnioPrevio = porMes.has(prevKey) ? (porMes.get(prevKey) as number) : null;
+  const deltaGastoPct =
+    gastoUltimo != null && gastoMismoMesAnioPrevio != null && gastoMismoMesAnioPrevio > 0
+      ? (gastoUltimo - gastoMismoMesAnioPrevio) / gastoMismoMesAnioPrevio
+      : null;
+
+  // Ventanas de 12 meses sobre los meses presentes (no calendario estricto).
+  const ult12 = meses.slice(-12);
+  const prev12 = meses.slice(-24, -12);
+  const total12m = ult12.reduce((a, m) => a + (porMes.get(m) ?? 0), 0);
+  const totalPrev12m = prev12.reduce((a, m) => a + (porMes.get(m) ?? 0), 0);
+  const delta12mPct = totalPrev12m > 0 ? (total12m - totalPrev12m) / totalPrev12m : null;
+
+  return {
+    ultimoPeriodo,
+    gastoUltimo,
+    gastoMismoMesAnioPrevio,
+    deltaGastoPct,
+    total12m,
+    totalPrev12m,
+    delta12mPct,
+  };
+}
+
+export interface Anomalia {
+  /** Promedio de consumo de los recibos previos del mismo servicio. */
+  baseline: number;
+  /** Exceso relativo sobre el baseline (0.4 = +40%). */
+  exceso: number;
+}
+
+/**
+ * Detecta recibos con consumo anómalo (posible fuga / uso excesivo).
+ *
+ * Por servicio, recorre los recibos en orden cronológico y compara cada
+ * consumo contra el promedio de los `ventana` recibos previos del mismo
+ * servicio. Si excede `umbral` (por defecto +40%), lo marca. Necesita al
+ * menos `minPrevios` lecturas previas para no disparar con ruido inicial.
+ *
+ * Devuelve un Map indexado por id de recibo (solo los marcados).
+ */
+export function computeAnomalias(
+  recibos: ReciboVista[],
+  opts: { ventana?: number; umbral?: number; minPrevios?: number } = {}
+): Map<string, Anomalia> {
+  const ventana = opts.ventana ?? 3;
+  const umbral = opts.umbral ?? 0.4;
+  const minPrevios = opts.minPrevios ?? 2;
+  const out = new Map<string, Anomalia>();
+
+  const porServicio = new Map<string, ReciboVista[]>();
+  for (const r of recibos) {
+    if (r.consumo_periodo == null) continue;
+    const arr = porServicio.get(r.servicio_tipo) ?? [];
+    arr.push(r);
+    porServicio.set(r.servicio_tipo, arr);
+  }
+
+  for (const arr of porServicio.values()) {
+    const cron = [...arr].sort((a, b) => a.periodo.localeCompare(b.periodo));
+    for (let i = 0; i < cron.length; i++) {
+      const previos = cron
+        .slice(Math.max(0, i - ventana), i)
+        .map((r) => r.consumo_periodo as number);
+      if (previos.length < minPrevios) continue;
+      const baseline = previos.reduce((a, c) => a + c, 0) / previos.length;
+      if (baseline <= 0) continue;
+      const actual = cron[i].consumo_periodo as number;
+      const exceso = (actual - baseline) / baseline;
+      if (exceso >= umbral) out.set(cron[i].id, { baseline, exceso });
+    }
+  }
+
+  return out;
+}

--- a/lib/sanren/servicios-analytics.ts
+++ b/lib/sanren/servicios-analytics.ts
@@ -212,12 +212,48 @@ export function computeAnomalias(
   return out;
 }
 
-/** Mes calendario siguiente a un periodo `yyyy-mm` (maneja el salto de año). */
-export function addMes(periodo: string): string {
+/** Avanza `n` meses un periodo `yyyy-mm` (maneja el salto de año). */
+export function addMeses(periodo: string, n: number): string {
   const [y, m] = periodo.split('-').map(Number);
-  const ny = m === 12 ? y + 1 : y;
-  const nm = m === 12 ? 1 : m + 1;
+  const total = y * 12 + (m - 1) + n;
+  const ny = Math.floor(total / 12);
+  const nm = (total % 12) + 1;
   return `${ny}-${String(nm).padStart(2, '0')}`;
+}
+
+/** Mes calendario siguiente a un periodo `yyyy-mm`. */
+export function addMes(periodo: string): string {
+  return addMeses(periodo, 1);
+}
+
+/** Meses entre dos periodos `yyyy-mm` (b − a). */
+function mesesEntre(a: string, b: string): number {
+  const [ya, ma] = a.split('-').map(Number);
+  const [yb, mb] = b.split('-').map(Number);
+  return (yb - ya) * 12 + (mb - ma);
+}
+
+/**
+ * Cadencia (en meses) entre recibos consecutivos: la moda de los huecos. Luz es
+ * bimestral → 2; Agua/Gas mensual → 1. Robusto a un hueco suelto (recibo
+ * estimado, corrección). Default 1 con <2 datos.
+ */
+function inferStep(serie: { periodo: string }[]): number {
+  if (serie.length < 2) return 1;
+  const counts = new Map<number, number>();
+  for (let i = 1; i < serie.length; i++) {
+    const g = mesesEntre(serie[i - 1].periodo, serie[i].periodo);
+    if (g > 0) counts.set(g, (counts.get(g) ?? 0) + 1);
+  }
+  let best = 1;
+  let bestC = 0;
+  for (const [g, c] of counts) {
+    if (c > bestC || (c === bestC && g < best)) {
+      best = g;
+      bestC = c;
+    }
+  }
+  return best;
 }
 
 /** Serie mensual {periodo, valor} de un campo, sumando por mes (orden asc). */
@@ -247,16 +283,38 @@ export interface Pronostico {
 const avg = (xs: number[]): number => xs.reduce((a, b) => a + b, 0) / xs.length;
 
 /**
+ * Factor de tendencia anual: cuánto corre el consumo de los últimos 12 meses
+ * vs. los 12 previos. Clamp [0.7, 1.4] y solo se aplica con ventanas
+ * comparables (≥3 datos cada una) para no inflar con historia incompleta.
+ */
+function factorTendencia(serie: { periodo: string; valor: number }[], ultimo: string): number {
+  const recientes: number[] = [];
+  const previos: number[] = [];
+  for (const s of serie) {
+    const mb = mesesEntre(s.periodo, ultimo); // ≥0 = en o antes del último
+    if (mb >= 0 && mb <= 11) recientes.push(s.valor);
+    else if (mb >= 12 && mb <= 23) previos.push(s.valor);
+  }
+  if (recientes.length < 3 || previos.length < 3) return 1;
+  const sumPrev = previos.reduce((a, b) => a + b, 0);
+  if (sumPrev <= 0) return 1;
+  const ratio = recientes.reduce((a, b) => a + b, 0) / sumPrev;
+  return Math.min(1.4, Math.max(0.7, ratio));
+}
+
+/**
  * Pronóstico del próximo periodo para un campo (consumo, producción, monto…).
  *
- * Mezcla 50/50 dos señales cuando ambas existen:
- *  - **estacional**: promedio del mismo mes en años anteriores ("lo que sucedió
- *    en años anteriores").
- *  - **tendencia**: promedio de los últimos `recientes` meses ("lo que se ha
- *    venido consumiendo").
+ * El próximo periodo se calcula con la **cadencia real** del servicio (Luz es
+ * bimestral → +2 meses; Agua/Gas → +1). Dos modelos:
+ *  - **estacional**: si hay recibos del mismo mes en años anteriores ("lo que
+ *    sucedió en años anteriores"), toma su promedio y lo escala por el factor de
+ *    tendencia anual ("lo que se ha venido consumiendo"). Captura el patrón
+ *    estacional (p. ej. el pico de agosto) sin ignorar la tendencia.
+ *  - **tendencia**: si no hay historia del mismo mes, promedia los últimos
+ *    `recientes` recibos.
  *
- * Si solo hay una, usa esa. Devuelve null si no hay datos. `recibos` debe venir
- * ya filtrado por servicio.
+ * Devuelve null si no hay datos. `recibos` debe venir ya filtrado por servicio.
  */
 export function computePronostico(
   recibos: ReciboVista[],
@@ -268,28 +326,21 @@ export function computePronostico(
   if (serie.length === 0) return null;
 
   const ultimo = serie[serie.length - 1].periodo;
-  const next = addMes(ultimo);
+  const next = addMeses(ultimo, inferStep(serie));
   const nextMM = next.slice(5, 7);
 
   const mismosMeses = serie.filter((s) => s.periodo.slice(5, 7) === nextMM).map((s) => s.valor);
-  const ultimosN = serie.slice(-recientes).map((s) => s.valor);
-
-  const estacional = mismosMeses.length > 0 ? avg(mismosMeses) : null;
-  const tendencia = ultimosN.length > 0 ? avg(ultimosN) : null;
 
   let valor: number;
   let base: Pronostico['base'];
-  if (estacional != null && tendencia != null) {
-    valor = 0.5 * estacional + 0.5 * tendencia;
+  if (mismosMeses.length > 0) {
+    valor = avg(mismosMeses) * factorTendencia(serie, ultimo);
     base = 'estacional+tendencia';
-  } else if (estacional != null) {
-    valor = estacional;
-    base = 'estacional';
-  } else if (tendencia != null) {
-    valor = tendencia;
-    base = 'tendencia';
   } else {
-    return null;
+    const ultimosN = serie.slice(-recientes).map((s) => s.valor);
+    if (ultimosN.length === 0) return null;
+    valor = avg(ultimosN);
+    base = 'tendencia';
   }
 
   return { periodo: next, valor: Math.max(0, Math.round(valor)), base };

--- a/lib/sanren/servicios-analytics.ts
+++ b/lib/sanren/servicios-analytics.ts
@@ -71,13 +71,7 @@ export function computeServicioKpis(recibos: ReciboVista[]): ServicioKpiSet {
     : null;
 
   // Banco de energía: el del recibo de luz más reciente que lo reporte.
-  let bancoEnergia: number | null = null;
-  const conBanco = recibos
-    .filter((r) => r.extraccion?.energia_acumulada_favor != null)
-    .sort((a, b) => b.periodo.localeCompare(a.periodo));
-  if (conBanco.length > 0) {
-    bancoEnergia = conBanco[0].extraccion?.energia_acumulada_favor ?? null;
-  }
+  const bancoEnergia = ultimoBanco(recibos);
 
   return {
     count,
@@ -344,4 +338,77 @@ export function computePronostico(
   }
 
   return { periodo: next, valor: Math.max(0, Math.round(valor)), base };
+}
+
+/** kWh a favor del banco según el recibo (de luz) más reciente que lo reporte. */
+export function ultimoBanco(recibos: ReciboVista[]): number | null {
+  const conBanco = recibos
+    .filter((r) => r.extraccion?.energia_acumulada_favor != null)
+    .sort((a, b) => b.periodo.localeCompare(a.periodo));
+  return conBanco.length ? (conBanco[0].extraccion?.energia_acumulada_favor ?? null) : null;
+}
+
+export interface PronosticoGasto {
+  periodo: string;
+  valor: number;
+  /** El consumo neto del próximo periodo se cubre con el banco → gasto = cargo fijo. */
+  cubiertoPorBanco: boolean;
+}
+
+/**
+ * Pronóstico de **gasto** ($) del próximo periodo, consciente del banco de
+ * energía para cuentas solares (net-metering).
+ *
+ * En una cuenta con paneles, mientras el banco de kWh a favor cubra el consumo
+ * neto del periodo (consumo − generación), el recibo es solo el **cargo fijo**
+ * (≈ el monto reciente), no el gasto estacional histórico de la era pre-banco.
+ * Solo cuando el banco no alcanza se paga energía → ahí caemos al estacional
+ * como proxy (sin tarifa CFE exacta, ver planning). Agua/Gas usan el estacional
+ * normal.
+ */
+export function computePronosticoGasto(recibos: ReciboVista[]): PronosticoGasto | null {
+  const esSolar = recibos.length > 0 && recibos.every((r) => r.tiene_produccion);
+  if (!esSolar) {
+    const p = computePronostico(recibos, (r) => r.monto);
+    return p ? { periodo: p.periodo, valor: p.valor, cubiertoPorBanco: false } : null;
+  }
+
+  const projC = computePronostico(recibos, (r) => r.consumo_periodo);
+  const projP = computePronostico(recibos, (r) => r.produccion_periodo);
+  const projMonto = computePronostico(recibos, (r) => r.monto);
+  const periodo = projC?.periodo ?? projP?.periodo ?? projMonto?.periodo;
+  if (!periodo) return null;
+
+  const banco = ultimoBanco(recibos) ?? 0;
+  const neto = (projC?.valor ?? 0) - (projP?.valor ?? 0); // kWh a comprar de la red
+  const cubierto = neto <= 0 || neto <= banco;
+
+  const montos = serieMensual(recibos, (r) => r.monto);
+  const fijoReciente = montos.length ? avg(montos.slice(-3).map((m) => m.valor)) : 0;
+  const valor = cubierto ? fijoReciente : (projMonto?.valor ?? fijoReciente);
+
+  return { periodo, valor: Math.max(0, Math.round(valor)), cubiertoPorBanco: cubierto };
+}
+
+export interface BancoProyeccion {
+  periodo: string;
+  /** Saldo del banco proyectado tras el próximo periodo. */
+  banco: number;
+  /** kWh tomados del banco (>0 si consumo>generación; <0 si se acumula). */
+  netoDelBanco: number;
+}
+
+/**
+ * Proyecta el saldo del banco de energía tras el próximo periodo:
+ * banco − (consumo esperado − generación esperada). Null si no hay banco.
+ */
+export function computeBancoProyectado(recibos: ReciboVista[]): BancoProyeccion | null {
+  const banco = ultimoBanco(recibos);
+  if (banco == null) return null;
+  const projC = computePronostico(recibos, (r) => r.consumo_periodo);
+  const projP = computePronostico(recibos, (r) => r.produccion_periodo);
+  const periodo = projC?.periodo ?? projP?.periodo;
+  if (!periodo) return null;
+  const neto = (projC?.valor ?? 0) - (projP?.valor ?? 0);
+  return { periodo, banco: Math.max(0, banco - neto), netoDelBanco: neto };
 }


### PR DESCRIPTION
## Qué cambia

En `/servicios` (SANREN), reemplaza el dropdown de servicio por un **riel de pestañas `Todos · Luz · Agua · Gas`**. Cada lente muestra solo sus recibos y trae KPIs + análisis hechos a su medida — segmentar tiene sentido analítico porque cada servicio cuenta una historia distinta (kWh+solar vs m³).

### KPIs por servicio (sumatorias según filtros)
- **Luz:** Gasto · kWh consumidos · kWh generados · **Banco de energía** (kWh a favor) · Costo/kWh.
- **Agua / Gas:** Gasto · Consumo (m³) · Costo/m³ · Consumo promedio · **Mes pico**.
- **Todos:** el resumen genérico de siempre.

### Pestaña «Análisis» (antes «Tendencias»)
Sobre las gráficas SVG existentes, agrega una tarjeta de **comparativos año-vs-año**: mismo mes vs. mismo mes del año previo, y últimos 12 meses vs. los 12 previos (verde = bajó el gasto, ámbar = subió).

### Detección de consumo anómalo
Marca **⚠** en la columna Consumo y suma un KPI de **alertas** cuando un recibo excede +40% del promedio reciente del mismo servicio. Pensado para cachar **fugas de agua** o picos de clima en luz.

## Notas técnicas
- Toda la analítica vive en `lib/sanren/servicios-analytics.ts` (puro, sin React) con tests (coverage 99%).
- Sin cambios de schema ni de RBAC: SANREN comparte el module-slug `sanren`, tabs in-page vía URL filter (no rutas → no dispara el ritual ADR-030).

## Verificación
Los 6 checks de CI corridos en local en verde (typecheck, test:coverage, lint, format:check, initiatives:validate). **Sin auto-merge: dejo el PR abierto para revisar el Vercel Preview** antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)