### PR TITLE
fix(dilesa-pld): elimina falsos warnings PLD (sobreprecio capturado + enganche a gastos)

### DIFF
--- a/app/api/dilesa/ventas/[id]/revision-pld/route.ts
+++ b/app/api/dilesa/ventas/[id]/revision-pld/route.ts
@@ -356,8 +356,14 @@ export async function POST(_req: NextRequest, { params }: Params) {
       Number(a.monto_total ?? 0)
     ),
     // Descuento perdonado (no cobrado): el hueco legítimo entre liquidaciones y
-    // valor pactado. El cheque a notaría girado NO perdona (entró y salió).
+    // valor pactado. El cheque a notaría girado NO perdona (entró y salió). Con el
+    // desglose corregido (`dilesa-descuento-perdonado-motor`) `descuentoAplicado` ==
+    // descuento real, así que el sobreprecio que NO perdona ya no infla este hueco.
     descuentoPerdonado: Math.max(0, (cuad?.descuentoAplicado ?? 0) - (cuad?.chequePagado ?? 0)),
+    // Enganche del cliente que fondea gastos notariales (no el precio): se netea de
+    // los depósitos registrados para comparar contra las liquidaciones del aviso
+    // sobre la misma base (el dinero que liquidó el precio del inmueble).
+    engancheAGastos: cuad?.coberturaGastos?.engancheCliente ?? 0,
   };
 
   // ── PDFs del ciclo ───────────────────────────────────────────────

--- a/lib/dilesa/captura/pld-revision.test.ts
+++ b/lib/dilesa/captura/pld-revision.test.ts
@@ -69,6 +69,8 @@ function expediente(partial: Partial<ExpedientePld> = {}): ExpedientePld {
     // Descuento $15,000 (gastos escrituración), $13,378 girados a notaría →
     // $1,622 perdonados = el hueco exacto entre liquidaciones y pactado.
     descuentoPerdonado: 1622,
+    // Enganche íntegro al precio (los depósitos == liquidaciones del aviso).
+    engancheAGastos: 0,
     ...partial,
   };
 }
@@ -121,6 +123,40 @@ describe('cruzarPldConExpediente — caso real cuadrado', () => {
 
   it('veredicto: verde (el caso real cuadra con el descuento)', () => {
     expect(veredictoDe(checks)).toBe('verde');
+  });
+});
+
+describe('cruzarPldConExpediente — liq_vs_depositos netea el enganche a gastos', () => {
+  // Caso Christopher M3-L16: el aviso declara liquidaciones del PRECIO ($1,021,000,
+  // solo el crédito); los depósitos registrados incluyen el enganche de $15,640 que
+  // fondea GASTOS notariales, no el precio. Netear ese enganche cuadra el check.
+  const ext = () =>
+    extraccion({
+      valorPactado: 1021000,
+      liquidaciones: [{ fecha: '2026-06-01', monto: 1021000 }],
+    });
+  const exp = (partial: Partial<ExpedientePld> = {}) =>
+    expediente({
+      valorEscrituracion: 1021000,
+      depositos: [1021000, 15640], // crédito + enganche
+      descuentoPerdonado: 0,
+      engancheAGastos: 15640,
+      ...partial,
+    });
+
+  it('pasa: depósitos ($1,036,640) − enganche a gastos ($15,640) = liquidaciones', () => {
+    const c = porClave(cruzarPldConExpediente(ext(), exp()), 'liq_vs_depositos');
+    expect(c?.ok).toBe(true);
+  });
+
+  it('sin netear (enganche a gastos = 0) el mismo caso marcaría warning', () => {
+    const c = porClave(
+      cruzarPldConExpediente(ext(), exp({ engancheAGastos: 0 })),
+      'liq_vs_depositos'
+    );
+    expect(c?.ok).toBe(false);
+    expect(c?.severidad).toBe('warning');
+    expect(c?.detalle).toContain('1,036,640');
   });
 });
 

--- a/lib/dilesa/captura/pld-revision.ts
+++ b/lib/dilesa/captura/pld-revision.ts
@@ -103,6 +103,15 @@ export type ExpedientePld = {
   /** Montos de los depósitos registrados (erp.cxc_pagos de la venta). */
   depositos: number[];
   /**
+   * Enganche del cliente aplicado a GASTOS notariales (no al precio), del motor
+   * de cuadratura (`coberturaGastos.engancheCliente`). El aviso PLD declara las
+   * liquidaciones del PRECIO (= valor de escrituración), pero los depósitos
+   * registrados incluyen este enganche que fondea los gastos, no el precio. Sin
+   * netearlo, toda venta con enganche-a-gastos marca un falso descuadre por este
+   * monto. 0 cuando el enganche va íntegro al precio (o no hay enganche).
+   */
+  engancheAGastos: number;
+  /**
    * Descuento "perdonado" (no cobrado) = descuento aplicado − cheque a notaría
    * girado, ≥ 0 (del motor de cuadratura). Las liquidaciones del aviso quedan
    * por debajo del valor pactado EXACTAMENTE en este monto — es el descuento
@@ -360,15 +369,24 @@ export function cruzarPldConExpediente(ext: ExtraccionPld, exp: ExpedientePld): 
             : `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el valor pactado es ${money(ext.valorPactado)} (diferencia ${money(totalLiquidaciones - ext.valorPactado)}).`
         )
   );
+  // Las liquidaciones del aviso son las del PRECIO (= valor de escrituración); los
+  // depósitos registrados incluyen el enganche que fondea GASTOS notariales, no el
+  // precio. Se netea ese enganche-a-gastos para comparar sobre la misma base (el
+  // dinero que liquidó el inmueble), si no toda venta con enganche marca un falso
+  // descuadre por su monto.
   const totalDepositos = exp.depositos.reduce((s, m) => s + (m || 0), 0);
+  const engancheAGastos = Math.max(0, exp.engancheAGastos);
+  const depositosAlPrecio = totalDepositos - engancheAGastos;
   checks.push(
-    montosIguales(totalLiquidaciones, totalDepositos, 1)
-      ? ok('liq_vs_depositos', 'Σ liquidaciones = depósitos registrados', 'warning')
+    montosIguales(totalLiquidaciones, depositosAlPrecio, 1)
+      ? ok('liq_vs_depositos', 'Σ liquidaciones = depósitos al precio', 'warning')
       : falla(
           'liq_vs_depositos',
-          'Σ liquidaciones = depósitos registrados',
+          'Σ liquidaciones = depósitos al precio',
           'warning',
-          `Las liquidaciones suman ${money(totalLiquidaciones)}; los depósitos registrados en la venta suman ${money(totalDepositos)}.`
+          engancheAGastos > 0
+            ? `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; los depósitos al precio suman ${money(depositosAlPrecio)} (depósitos registrados ${money(totalDepositos)} − enganche a gastos ${money(engancheAGastos)}). Diferencia ${money(totalLiquidaciones - depositosAlPrecio)}.`
+            : `Las liquidaciones suman ${money(totalLiquidaciones)}; los depósitos registrados en la venta suman ${money(totalDepositos)}.`
         )
   );
 

--- a/lib/dilesa/cuadratura.test.ts
+++ b/lib/dilesa/cuadratura.test.ts
@@ -618,6 +618,43 @@ describe('calcularCuadratura', () => {
       expect(c.descuentoAplicado - c.chequePagado).toBe(0); // sin fantasma → sin warning
     });
 
+    // `dilesa-descuento-perdonado-motor`: sobreprecio capturado >> el que cubre los
+    // gastos — el caso que disparaba el warning PLD de Christopher (M3-L16). El precio
+    // se subió 101,000 (920k → 1,021k) pero solo 15,000 de ese sobreprecio cubre los
+    // gastos (el resto es venta real que DILESA conserva). El motor sumaba el CAPTURADO
+    // (101,000) a descuentoAplicado → `descuentoAplicado − cheque` = 70,360 de perdón
+    // fantasma. Con el efectivo (sobreprecioCobertura 15,000) → descuentoAplicado =
+    // 15,000 = descuentoReal, sin fantasma.
+    it('sobreprecio capturado >> el que cubre gastos: descuentoAplicado usa el efectivo, sin perdón fantasma (Christopher M3-L16)', () => {
+      const c = calcularCuadratura({
+        valorEscrituracion: 1021000,
+        montoCreditoTitular: 1021000, // crédito cubre el precio → el enganche fondea gastos
+        montoCreditoCotitular: 0,
+        montoCreditoDirecto: null,
+        montoChequeNotaria: 30640, // cheque a notaría girado (Fase 11)
+        gastosEscrituracion: 60640,
+        apoyoInfonavit: 30000,
+        precioBase: 920000,
+        incrementoCredito: 0,
+        sobreprecioGastos: 101000, // 920k → 1,021k escriturado (hecho); solo 15k cubre gastos
+        promocionGastos: 0, // sin bono
+        depositos: [{ monto: 15640, directoCliente: true, tieneRecibo: true }],
+        proyectoNombre: 'Lomas de los Encinos',
+      });
+      const cob = c.coberturaGastos!;
+      expect(cob.aportacionPromocion).toBe(0); // sin bono
+      expect(cob.sobreprecioCobertura).toBe(15000); // efectivo: lo que cubre los gastos
+      expect(cob.saldoCobertura).toBe(0); // los gastos cuadran
+      // FIX: el efectivo (15,000), NO el capturado (101,000).
+      expect(c.descuentoAplicado).toBe(15000);
+      expect(c.descuentoReal).toBe(15000); // descuentoAplicado == descuentoReal
+      expect(c.chequePagado).toBe(30640);
+      // "Descuento perdonado" de la revisión PLD = descuentoAplicado − cheque.
+      expect(Math.max(0, c.descuentoAplicado - c.chequePagado)).toBe(0); // sin fantasma → sin warning
+      // El saldoCliente legacy (no mostrado en desglose) también queda sano.
+      expect(c.saldoCliente).toBe(0); // antes: −86,000
+    });
+
     // Camino "Cobrar" del residual de precio (iniciativa dilesa-saldos-residuales S2):
     // el cliente firma un pagaré por los $792. El pagaré NO sobre-fondea los gastos
     // (ya cuadran): se asigna al PRECIO, sube el Valor Real y baja la NC en $792.
@@ -748,11 +785,13 @@ describe('calcularCuadratura', () => {
       expect(c.comisionVendedor).toBe(8995.39); // (909,539 − 10,000) × 1%
     });
 
-    it('operacionCubierta es model-aware: cubierta aunque el saldoCliente legacy sea fantasma — Arizpe', () => {
-      // El crédito cubre el precio (909,000) y las fuentes cubren los gastos. El
-      // `saldoCliente` legacy = cheque 18,313 − descuento 15,000 = 3,313 (fantasma,
-      // NO deuda) y marca `cubierta=false`; `operacionCubierta` corrige a true y el
-      // copiloto/gates lo leen. saldoOperacion = 0 (nada pendiente).
+    it('operacionCubierta es model-aware y el saldoCliente legacy ya no es fantasma — Arizpe', () => {
+      // El crédito cubre el precio (909,000) y las fuentes cubren los gastos.
+      // `dilesa-descuento-perdonado-motor`: con `descuentoAplicado` usando el
+      // sobreprecio EFECTIVO (15,000 promo + 3,313 sobreprecio = 18,313 = cheque), el
+      // `saldoCliente` legacy queda en 0 (antes daba 3,313 fantasma usando el descuento
+      // sin el sobreprecio). `operacionCubierta` sigue siendo la fuente canónica para
+      // copiloto/gates. saldoOperacion = 0 (nada pendiente).
       const c = calcularCuadratura({
         valorEscrituracion: 909000,
         montoCreditoTitular: 909000,
@@ -767,8 +806,9 @@ describe('calcularCuadratura', () => {
         promocionGastos: 15000,
         depositos: [],
       });
-      expect(c.saldoCliente).toBe(3313); // legacy fantasma
-      expect(c.cubierta).toBe(false); // legacy, equivocado para desglose
+      expect(c.descuentoAplicado).toBe(18313); // promo 15,000 + sobreprecio efectivo 3,313
+      expect(c.saldoCliente).toBe(0); // ya no fantasma (antes 3,313)
+      expect(c.cubierta).toBe(true); // legacy ya coincide con operacionCubierta
       expect(c.operacionCubierta).toBe(true); // ← model-aware: SÍ cubierta
       expect(c.saldoOperacion).toBe(0); // nada pendiente
     });

--- a/lib/dilesa/cuadratura.ts
+++ b/lib/dilesa/cuadratura.ts
@@ -507,16 +507,22 @@ export function calcularCuadratura(i: CuadraturaInput): Cuadratura {
 
   // Descuento que reduce el saldo. Con desglose (ADR-045 + `dilesa-descuento-
   // perdonado-motor`): promoción CONSUMIDA (`aportacionPromocion`, ya topada al bono
-  // autorizado por `partirDescuento`) + sobreprecio CAPTURADO (hecho escriturado, lo
-  // absorbe el crédito). Antes se usaba el TOPE del bono (`promocionGastos`), que
-  // sobre-estimaba el descuento cuando el bono no se consumía completo y dejaba un
-  // "descuento perdonado" fantasma (`descuentoAplicado − cheque`) en la Fase 13
-  // (ej. Aracely M10-L32: tope 15,000 vs consumido 13,380 → 1,620 fantasma). Como
-  // `aportacionPromocion ≤ promocionGastos`, el fix nunca infla el descuento. Sin
-  // desglose (ventas cerradas/legacy) → modelo viejo: `descuento_total` topado al
-  // máximo autorizado. Fallback que NO altera nada histórico.
+  // autorizado por `partirDescuento`) + sobreprecio que CUBRE el presupuesto
+  // (`sobreprecioCobertura`, el efectivo — ya topado al faltante por `partirDescuento`).
+  // Antes se usaban el TOPE del bono (`promocionGastos`) y el sobreprecio CAPTURADO
+  // (`sobreprecioGastos`), ambos sin topar: sobre-estimaban el descuento cuando el bono
+  // no se consumía completo o el precio se subía MÁS de lo que cubre los gastos, y
+  // dejaban un "descuento perdonado" fantasma (`descuentoAplicado − cheque`) en la
+  // Fase 13. Casos reales: Aracely M10-L32 (tope bono 15,000 vs consumido 13,380 →
+  // 1,620 fantasma, ya corregido el lado promo) y Christopher M3-L16 (sobreprecio
+  // capturado 101,000 vs efectivo 15,000 → 70,360 fantasma, corregido aquí el lado
+  // sobreprecio). Con el efectivo, `descuentoAplicado` == `descuentoReal` y el fix
+  // nunca infla el descuento (`aportacionPromocion ≤ promocionGastos`,
+  // `sobreprecioCobertura ≤ sobreprecioGastos`). Sin desglose (ventas cerradas/legacy)
+  // → modelo viejo: `descuento_total` topado al máximo autorizado. Fallback que NO
+  // altera nada histórico.
   const descuentoAplicado = tieneDesglose
-    ? round2(aportacionPromocion + sobreprecioGastos)
+    ? round2(aportacionPromocion + sobreprecioCobertura)
     : i.descuentoMaximoAutorizado != null
       ? Math.min(descuentoOtorgadoTotal, Math.max(0, n(i.descuentoMaximoAutorizado)))
       : descuentoOtorgadoTotal;


### PR DESCRIPTION
## Problema

La Revisión PLD (Fase 13) marcaba **«Con advertencias — requiere Dirección»** en ventas correctas y cuadradas. Dos falsos positivos en ventas con desglose:

### 1. `Σ liquidaciones = valor pactado − descuento`
El motor de cuadratura calculaba `descuentoAplicado` sumando el **sobreprecio CAPTURADO** (el salto total del precio, p.ej. $101,000) en vez del **sobreprecio EFECTIVO** que cubre los gastos ($15,000). Eso inflaba el «descuento perdonado» (`descuentoAplicado − cheque`) y producía un descuadre fantasma de **$70,360** (caso Christopher M3-L16).

Es exactamente la **misma clase de bug ya corregida del lado promoción** (usar lo consumido, no el tope) — solo faltaba aplicarlo al sobreprecio. Fix de 1 línea: `sobreprecioGastos` → `sobreprecioCobertura` (ambos ya topados por `partirDescuento`).

Con esto `descuentoAplicado == descuentoReal` y el `saldoCliente` legacy deja de ser fantasma. **No cambia ningún valor visible de la cuadratura desglosada**: `descuentoAplicado`/`saldoCliente` solo se renderizan en la rama legacy (`!tieneDesglose`); en ventas desglosadas ese campo solo lo consume la Revisión PLD.

### 2. `Σ liquidaciones = depósitos registrados`
Comparaba las liquidaciones del aviso (que son del **precio** = valor de escrituración) contra los depósitos crudos de `cxc_pagos`, que incluyen el **enganche que fondea gastos notariales**, no el precio. Diferencia = el enganche ($15,640). Se netea ese enganche-a-gastos (`coberturaGastos.engancheCliente`) para comparar sobre la misma base. Sin esto, **toda venta con enganche** marcaba un falso descuadre.

## Cambios
- `lib/dilesa/cuadratura.ts` — `descuentoAplicado` usa el sobreprecio efectivo.
- `lib/dilesa/captura/pld-revision.ts` — check `liq_vs_depositos` netea `engancheAGastos`; nuevo campo en `ExpedientePld`.
- `app/api/dilesa/ventas/[id]/revision-pld/route.ts` — alimenta `engancheAGastos` desde la cuadratura.
- Tests: caso Christopher (descuentoAplicado $15,000, sin fantasma) + neteo en pld-revision; Arizpe actualizado (saldoCliente $3,313 → $0).

## Verificación
- 2204 tests verdes (typecheck, lint, format, coverage OK).
- Sin migraciones ni cambios de DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)