### PR TITLE
fix(dilesa-pld): liquidaciones del aviso validadas por banda [precio, depósitos]

### DIFF
--- a/app/api/dilesa/ventas/[id]/revision-pld/route.ts
+++ b/app/api/dilesa/ventas/[id]/revision-pld/route.ts
@@ -360,10 +360,6 @@ export async function POST(_req: NextRequest, { params }: Params) {
     // desglose corregido (`dilesa-descuento-perdonado-motor`) `descuentoAplicado` ==
     // descuento real, así que el sobreprecio que NO perdona ya no infla este hueco.
     descuentoPerdonado: Math.max(0, (cuad?.descuentoAplicado ?? 0) - (cuad?.chequePagado ?? 0)),
-    // Enganche del cliente que fondea gastos notariales (no el precio): se netea de
-    // los depósitos registrados para comparar contra las liquidaciones del aviso
-    // sobre la misma base (el dinero que liquidó el precio del inmueble).
-    engancheAGastos: cuad?.coberturaGastos?.engancheCliente ?? 0,
   };
 
   // ── PDFs del ciclo ───────────────────────────────────────────────

--- a/lib/dilesa/captura/pld-revision.test.ts
+++ b/lib/dilesa/captura/pld-revision.test.ts
@@ -69,8 +69,6 @@ function expediente(partial: Partial<ExpedientePld> = {}): ExpedientePld {
     // Descuento $15,000 (gastos escrituración), $13,378 girados a notaría →
     // $1,622 perdonados = el hueco exacto entre liquidaciones y pactado.
     descuentoPerdonado: 1622,
-    // Enganche íntegro al precio (los depósitos == liquidaciones del aviso).
-    engancheAGastos: 0,
     ...partial,
   };
 }
@@ -126,37 +124,80 @@ describe('cruzarPldConExpediente — caso real cuadrado', () => {
   });
 });
 
-describe('cruzarPldConExpediente — liq_vs_depositos netea el enganche a gastos', () => {
-  // Caso Christopher M3-L16: el aviso declara liquidaciones del PRECIO ($1,021,000,
-  // solo el crédito); los depósitos registrados incluyen el enganche de $15,640 que
-  // fondea GASTOS notariales, no el precio. Netear ese enganche cuadra el check.
-  const ext = () =>
-    extraccion({
-      valorPactado: 1021000,
-      liquidaciones: [{ fecha: '2026-06-01', monto: 1021000 }],
-    });
-  const exp = (partial: Partial<ExpedientePld> = {}) =>
-    expediente({
-      valorEscrituracion: 1021000,
-      depositos: [1021000, 15640], // crédito + enganche
-      descuentoPerdonado: 0,
-      engancheAGastos: 15640,
-      ...partial,
-    });
+describe('cruzarPldConExpediente — liquidaciones dentro de la banda [precio, depósitos]', () => {
+  // Dos formas válidas de capturar las liquidaciones del aviso; ambas cuadran porque
+  // caen dentro de la banda [precio neto de descuento, total de depósitos recibidos].
+  // El ancho de la banda = el enganche que excede el precio (lo que fondea gastos).
 
-  it('pasa: depósitos ($1,036,640) − enganche a gastos ($15,640) = liquidaciones', () => {
-    const c = porClave(cruzarPldConExpediente(ext(), exp()), 'liq_vs_depositos');
-    expect(c?.ok).toBe(true);
+  it('Christopher M3-L16: reporta SOLO el precio → cae en el piso, pasa', () => {
+    // Aviso = crédito 1,021,000 (sin enganche). Banda [1,021,000, 1,036,640].
+    const checks = cruzarPldConExpediente(
+      extraccion({
+        valorPactado: 1021000,
+        liquidaciones: [{ fecha: '2026-06-01', monto: 1021000 }],
+      }),
+      expediente({
+        valorEscrituracion: 1021000,
+        depositos: [1021000, 15640], // crédito + enganche
+        descuentoPerdonado: 0,
+      })
+    );
+    expect(porClave(checks, 'liq_vs_pactado')?.ok).toBe(true); // ≥ piso 1,021,000
+    expect(porClave(checks, 'liq_vs_depositos')?.ok).toBe(true); // ≤ techo 1,036,640
   });
 
-  it('sin netear (enganche a gastos = 0) el mismo caso marcaría warning', () => {
-    const c = porClave(
-      cruzarPldConExpediente(ext(), exp({ engancheAGastos: 0 })),
-      'liq_vs_depositos'
+  it('Nancy M22-L1: reporta TODOS los depósitos → cae en el techo, pasa', () => {
+    // Aviso = crédito + enganche completo = 1,428,126.01 (incluye enganche a gastos).
+    // Banda [1,392,050, 1,428,127]. Antes (neteo) marcaba descuadre por +36,076.
+    const checks = cruzarPldConExpediente(
+      extraccion({
+        valorPactado: 1392050,
+        liquidaciones: [{ fecha: '2026-06-01', monto: 1428126.01 }],
+      }),
+      expediente({
+        valorEscrituracion: 1392050,
+        depositos: [1331887, 96240], // crédito + enganche (= 1,428,127)
+        descuentoPerdonado: 0,
+      })
     );
+    expect(porClave(checks, 'liq_vs_pactado')?.ok).toBe(true); // ≥ piso 1,392,050
+    expect(porClave(checks, 'liq_vs_depositos')?.ok).toBe(true); // ≤ techo 1,428,127
+  });
+
+  it('sub-declaración (por debajo del piso): liq_vs_pactado en warning', () => {
+    const checks = cruzarPldConExpediente(
+      extraccion({
+        valorPactado: 1392050,
+        liquidaciones: [{ fecha: '2026-06-01', monto: 1000000 }],
+      }),
+      expediente({
+        valorEscrituracion: 1392050,
+        depositos: [1331887, 96240],
+        descuentoPerdonado: 0,
+      })
+    );
+    const c = porClave(checks, 'liq_vs_pactado');
     expect(c?.ok).toBe(false);
     expect(c?.severidad).toBe('warning');
-    expect(c?.detalle).toContain('1,036,640');
+    expect(c?.detalle).toContain('1,392,050');
+  });
+
+  it('declara más dinero del recibido (por arriba del techo): liq_vs_depositos en warning', () => {
+    const checks = cruzarPldConExpediente(
+      extraccion({
+        valorPactado: 1392050,
+        liquidaciones: [{ fecha: '2026-06-01', monto: 1500000 }],
+      }),
+      expediente({
+        valorEscrituracion: 1392050,
+        depositos: [1331887, 96240],
+        descuentoPerdonado: 0,
+      })
+    );
+    const c = porClave(checks, 'liq_vs_depositos');
+    expect(c?.ok).toBe(false);
+    expect(c?.severidad).toBe('warning');
+    expect(c?.detalle).toContain('de más');
   });
 });
 

--- a/lib/dilesa/captura/pld-revision.ts
+++ b/lib/dilesa/captura/pld-revision.ts
@@ -100,17 +100,9 @@ export type ExpedientePld = {
   unidadNumeroOficial: string | null;
   unidadM2Terreno: number | null;
   unidadM2Construccion: number | null;
-  /** Montos de los depósitos registrados (erp.cxc_pagos de la venta). */
+  /** Montos de los depósitos registrados (erp.cxc_pagos de la venta). El techo de
+   *  la banda de liquidaciones del aviso (crédito + enganche = todo lo recibido). */
   depositos: number[];
-  /**
-   * Enganche del cliente aplicado a GASTOS notariales (no al precio), del motor
-   * de cuadratura (`coberturaGastos.engancheCliente`). El aviso PLD declara las
-   * liquidaciones del PRECIO (= valor de escrituración), pero los depósitos
-   * registrados incluyen este enganche que fondea los gastos, no el precio. Sin
-   * netearlo, toda venta con enganche-a-gastos marca un falso descuadre por este
-   * monto. 0 cuando el enganche va íntegro al precio (o no hay enganche).
-   */
-  engancheAGastos: number;
   /**
    * Descuento "perdonado" (no cobrado) = descuento aplicado − cheque a notaría
    * girado, ≥ 0 (del motor de cuadratura). Las liquidaciones del aviso quedan
@@ -350,43 +342,48 @@ export function cruzarPldConExpediente(ext: ExtraccionPld, exp: ExpedientePld): 
         )
   );
 
-  // 8. Liquidaciones vs valor pactado (neto de descuento) y vs depósitos
-  //    registrados (warnings). El valor pactado es el de escrituración; las
-  //    liquidaciones (lo realmente pagado) quedan por debajo en el descuento
-  //    PERDONADO (no cobrado) — ese hueco es legítimo, no un descuadre.
+  // 8. Liquidaciones del aviso dentro de la BANDA esperada (warnings). El oficial
+  //    de cumplimiento captura las liquidaciones de dos formas igualmente válidas:
+  //    solo el PRECIO (el crédito que liquida el inmueble) o el precio MÁS el
+  //    enganche que el cliente aportó (parte del cual fondea gastos notariales). Por
+  //    eso no se exige igualdad exacta sino una banda [piso, techo]:
+  //      - piso  = valor pactado − descuento perdonado (no cobrado): el precio que
+  //                realmente liquidó el inmueble. Por debajo = sub-declaración.
+  //      - techo = total de depósitos recibidos (crédito + enganche): todo el dinero
+  //                que entró. Por arriba = el aviso declara más de lo que se recibió.
+  //    El ancho de la banda = el enganche que excede el precio (lo que fondea gastos)
+  //    — exactamente la ambigüedad legítima de captura. Casos reales: Christopher
+  //    M3-L16 (reportó solo el precio → cae en el piso) y Nancy M22-L1 (reportó todos
+  //    los depósitos → cae en el techo); ambos cuadran.
   const totalLiquidaciones = ext.liquidaciones.reduce((s, l) => s + (l.monto || 0), 0);
   const perdonado = Math.max(0, exp.descuentoPerdonado);
-  const liquidacionesEsperadas = ext.valorPactado - perdonado;
+  const totalDepositos = exp.depositos.reduce((s, m) => s + (m || 0), 0);
+  const piso = ext.valorPactado - perdonado;
+  const techo = Math.max(totalDepositos, piso); // si los depósitos no alcanzan el piso, la banda colapsa al precio
+
+  // Piso: el aviso no declara MENOS que el precio liquidado (neto del perdón).
   checks.push(
-    montosIguales(totalLiquidaciones, liquidacionesEsperadas, 1)
-      ? ok('liq_vs_pactado', 'Σ liquidaciones = valor pactado − descuento', 'warning')
+    totalLiquidaciones >= piso - 1
+      ? ok('liq_vs_pactado', 'Σ liquidaciones ≥ precio (neto de descuento)', 'warning')
       : falla(
           'liq_vs_pactado',
-          'Σ liquidaciones = valor pactado − descuento',
+          'Σ liquidaciones ≥ precio (neto de descuento)',
           'warning',
           perdonado > 0
-            ? `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; con el descuento perdonado de ${money(perdonado)} se esperaban ${money(liquidacionesEsperadas)} (valor pactado ${money(ext.valorPactado)}). Diferencia ${money(totalLiquidaciones - liquidacionesEsperadas)}.`
-            : `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el valor pactado es ${money(ext.valorPactado)} (diferencia ${money(totalLiquidaciones - ext.valorPactado)}).`
+            ? `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el precio neto del descuento perdonado (${money(perdonado)}) es ${money(piso)} (valor pactado ${money(ext.valorPactado)}). Faltan ${money(piso - totalLiquidaciones)}.`
+            : `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el valor pactado es ${money(ext.valorPactado)} (faltan ${money(piso - totalLiquidaciones)}).`
         )
   );
-  // Las liquidaciones del aviso son las del PRECIO (= valor de escrituración); los
-  // depósitos registrados incluyen el enganche que fondea GASTOS notariales, no el
-  // precio. Se netea ese enganche-a-gastos para comparar sobre la misma base (el
-  // dinero que liquidó el inmueble), si no toda venta con enganche marca un falso
-  // descuadre por su monto.
-  const totalDepositos = exp.depositos.reduce((s, m) => s + (m || 0), 0);
-  const engancheAGastos = Math.max(0, exp.engancheAGastos);
-  const depositosAlPrecio = totalDepositos - engancheAGastos;
+
+  // Techo: el aviso no declara MÁS dinero del que efectivamente entró (depósitos).
   checks.push(
-    montosIguales(totalLiquidaciones, depositosAlPrecio, 1)
-      ? ok('liq_vs_depositos', 'Σ liquidaciones = depósitos al precio', 'warning')
+    totalLiquidaciones <= techo + 1
+      ? ok('liq_vs_depositos', 'Σ liquidaciones ≤ depósitos recibidos', 'warning')
       : falla(
           'liq_vs_depositos',
-          'Σ liquidaciones = depósitos al precio',
+          'Σ liquidaciones ≤ depósitos recibidos',
           'warning',
-          engancheAGastos > 0
-            ? `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; los depósitos al precio suman ${money(depositosAlPrecio)} (depósitos registrados ${money(totalDepositos)} − enganche a gastos ${money(engancheAGastos)}). Diferencia ${money(totalLiquidaciones - depositosAlPrecio)}.`
-            : `Las liquidaciones suman ${money(totalLiquidaciones)}; los depósitos registrados en la venta suman ${money(totalDepositos)}.`
+          `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; los depósitos registrados en la venta suman ${money(totalDepositos)} (el aviso declara ${money(totalLiquidaciones - techo)} de más).`
         )
   );
 


### PR DESCRIPTION
## Problema

Caso Nancy M22-L1: aviso PLD correcto pero la Revisión marcaba **«Con advertencias — requiere Dirección»**. Las liquidaciones del aviso suman **$1,428,126** (crédito + enganche completo) contra un precio de **$1,392,050** → los dos checks de liquidaciones tronaban por **+$36,076** (el enganche que fondea gastos).

Es el **patrón opuesto** a Christopher M3-L16 (#1148): ahí el oficial de cumplimiento declaró las liquidaciones = solo el precio; aquí declaró = todos los depósitos. **Ambas capturas son válidas.** El reframe de #1148 (netear el enganche de los depósitos) asumió la primera y rompía la segunda.

## Solución: banda en vez de igualdad

Las liquidaciones del aviso se validan ahora contra un **rango**, no una igualdad exacta:

- **piso** = valor pactado − descuento perdonado → el precio que liquidó el inmueble
- **techo** = total de depósitos recibidos (crédito + enganche) → todo el dinero que entró

El ancho de la banda = el enganche que excede el precio (lo que fondea gastos notariales) — exactamente la ambigüedad legítima de captura del oficial.

| Caso | Liquidaciones aviso | Banda | Resultado |
|---|---|---|---|
| Christopher M3-L16 | $1,021,000 (solo precio) | [1,021,000 – 1,036,640] | piso ✓ |
| Nancy M22-L1 | $1,428,126 (todos los depósitos) | [1,392,050 – 1,428,127] | techo ✓ |

Fuera de banda **sí** hay descuadre real: por debajo del piso = sub-declaración; por arriba del techo = el aviso declara más dinero del que entró. Ambos siguen marcando warning.

## Cambios
- `lib/dilesa/captura/pld-revision.ts` — checks `liq_vs_pactado` (piso) y `liq_vs_depositos` (techo) como banda; se retira el campo `engancheAGastos` (la banda lo absorbe).
- `app/api/dilesa/ventas/[id]/revision-pld/route.ts` — deja de pasar `engancheAGastos`.
- Tests: banda con los 4 escenarios (piso, techo, sub- y sobre-declaración).

## Verificación
- 2210 tests verdes (typecheck, lint, format, coverage OK). Sin migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)