### PR TITLE
fix(rdb-inventario): RLS set-membership destraba el tab Stock (timeout)

### DIFF
--- a/app/rdb/inventario/page.tsx
+++ b/app/rdb/inventario/page.tsx
@@ -36,6 +36,7 @@ import { printStockList } from '@/components/inventario/print-stock-list';
 import { type StockItem } from '@/components/inventario/types';
 import { computeStockStats } from '@/components/inventario/utils';
 import { formatCurrency } from '@/lib/format';
+import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 
 const FILTER_DEFAULTS = {
   search: '',
@@ -183,7 +184,9 @@ function InventarioStockBody() {
       if (error) throw error;
       setItems((data ?? []) as StockItem[]);
     } catch (e: unknown) {
-      setErrorStock(e instanceof Error ? e.message : 'Error al cargar inventario');
+      // PostgrestError no es instanceof Error → usar el helper para no perder
+      // el mensaje real (p.ej. timeout, permission denied).
+      setErrorStock(getSupabaseErrorMessage(e, 'Error al cargar inventario'));
     } finally {
       setLoadingStock(false);
     }
@@ -202,7 +205,7 @@ function InventarioStockBody() {
       if (error) throw error;
       setItems((data ?? []) as StockItem[]);
     } catch (e: unknown) {
-      setErrorStock(e instanceof Error ? e.message : 'Error al cargar inventario histórico');
+      setErrorStock(getSupabaseErrorMessage(e, 'Error al cargar inventario histórico'));
     } finally {
       setLoadingStock(false);
     }

--- a/supabase/migrations/20260630203657_erp_inventario_rls_set_membership.sql
+++ b/supabase/migrations/20260630203657_erp_inventario_rls_set_membership.sql
@@ -1,0 +1,62 @@
+-- ╭─ 20260630203657_erp_inventario_rls_set_membership ─╮
+-- Perf RLS: las políticas SELECT de las tablas erp que alimentan
+-- `rdb.v_inventario_stock` (vista security_invoker) usaban
+-- `core.fn_has_empresa(empresa_id)` — función con argumento de COLUMNA, que
+-- Postgres evalúa POR FILA aunque sea STABLE. La vista agrega DOS veces
+-- `erp.movimientos_inventario` (~40k filas y creciendo a diario con ventas
+-- Waitry) → ~2× 1.5s en llamadas a la función (cada una hace 2 JOINs contra
+-- core.usuarios) → ~3s con caché caliente y >8s en frío, pasando el
+-- statement_timeout de 8s del rol `authenticated` → "canceling statement due
+-- to statement timeout". El error real se traga en la UI y aparece como
+-- "Error al cargar inventario" en el tab Stock de RDB.
+--
+-- Fix: set-membership. `empresa_id IN (SELECT core.fn_current_empresa_ids())`
+-- evalúa el subquery UNA sola vez (InitPlan), no por fila. Medición directa
+-- del mismo scan: 1,560ms → 14ms (~110×). Autorización IDÉNTICA:
+-- fn_current_empresa_ids() corre el mismo join con los mismos filtros
+-- (u.activo + ue.activo) que fn_has_empresa, y el override de admin
+-- (fn_is_admin) se preserva. ALTER POLICY conserva rol, cmd (SELECT) y
+-- permissive; solo reemplaza el predicado USING. Mismo fix que
+-- 20260624180340_estimacion_tareas_rls_set_membership.
+--
+-- Alcance: las 4 tablas que toca la vista. La crítica es
+-- movimientos_inventario (los dos scans de ~40k filas); las otras tres se
+-- escanean por índice (pocas filas) pero comparten el anti-patrón, así que se
+-- alinean por consistencia y para que no degraden al crecer.
+--
+-- Nota: el anti-patrón fn_has_empresa-por-fila vive en ~334 políticas (erp,
+-- dilesa, core). Solo causa timeout cuando una query barre muchas filas. Un
+-- barrido global es iniciativa aparte (RLS financiera de todo el DB).
+
+BEGIN;
+
+ALTER POLICY erp_movimientos_inventario_select ON erp.movimientos_inventario
+  USING (
+    empresa_id IN (SELECT core.fn_current_empresa_ids())
+    OR core.fn_is_admin()
+  );
+
+ALTER POLICY erp_productos_select ON erp.productos
+  USING (
+    empresa_id IN (SELECT core.fn_current_empresa_ids())
+    OR core.fn_is_admin()
+  );
+
+ALTER POLICY erp_inventario_select ON erp.inventario
+  USING (
+    empresa_id IN (SELECT core.fn_current_empresa_ids())
+    OR core.fn_is_admin()
+  );
+
+ALTER POLICY erp_productos_precios_select ON erp.productos_precios
+  USING (
+    empresa_id IN (SELECT core.fn_current_empresa_ids())
+    OR core.fn_is_admin()
+  );
+
+-- Higiene: la vista es de módulo logueado. Estaba expuesta a `anon`, pero sus
+-- tablas base no, así que un request sin token recibía un 42501 confuso
+-- ("permission denied for table productos") en vez de un resultado limpio.
+REVOKE SELECT ON rdb.v_inventario_stock FROM anon;
+
+COMMIT;


### PR DESCRIPTION
## Problema

El tab **Stock** de Inventario RDB mostraba **"Error al cargar inventario"**.

Causa raíz: la vista `rdb.v_inventario_stock` (security_invoker) agrega **dos veces** `erp.movimientos_inventario` (~40k filas, crece a diario con ventas Waitry). La RLS de esa tabla evaluaba `core.fn_has_empresa(empresa_id)` **por fila** (cada llamada hace 2 JOINs contra `core.usuarios`) → ~3s con caché caliente, **>8s en frío** → pasa el `statement_timeout` de 8s del rol `authenticated` → `canceling statement due to statement timeout`. El error real se tragaba en la UI (`PostgrestError` no es `instanceof Error`) y salía como mensaje genérico.

## Fix

1. **RLS set-membership** en las 4 tablas `erp` que alimentan la vista (`movimientos_inventario` ← la crítica, + `productos`, `inventario`, `productos_precios`): `fn_has_empresa(empresa_id)` → `empresa_id IN (SELECT core.fn_current_empresa_ids())`. Semántica y aislamiento **idénticos** (mismas funciones, mismos filtros `u.activo`/`ue.activo`, override admin preservado). El subquery se evalúa **una vez** (InitPlan).
2. **Surfacing del error** en `app/rdb/inventario/page.tsx`: usar `getSupabaseErrorMessage` para no volver a tragar el mensaje real.
3. **Higiene**: `REVOKE SELECT` de la vista a `anon` (módulo logueado; evitaba un `42501` confuso).

## Medición (mismo scan, solo cambia el predicado)

| Predicado | Tiempo | Buffers |
|---|---|---|
| `fn_has_empresa(empresa_id)` por fila (actual) | 1,560 ms | 40,038 |
| `empresa_id IN (SELECT fn_current_empresa_ids())` (fix) | 14 ms | 806 |

~110× por scan. Mismo patrón que `20260624180340_estimacion_tareas_rls_set_membership`.

## Nota (fuera de alcance)

El anti-patrón `fn_has_empresa`-por-fila vive en ~334 políticas (erp/dilesa/core). Solo causa timeout cuando una query barre muchas filas. Barrido global = iniciativa aparte.

## Checks
typecheck ✓ · lint ✓ (0 errores) · format:check ✓ · test:coverage ✓ (2210) · migración = `ALTER POLICY`+`REVOKE` (no afecta SCHEMA_REF/types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)