### PR TITLE
feat(notificaciones): centralizar orden de compra + briefing (S5a)

### DIFF
--- a/app/api/cron/daily-briefing/route.ts
+++ b/app/api/cron/daily-briefing/route.ts
@@ -31,6 +31,13 @@ import { generateBriefingMarkdown } from '@/lib/briefing/build';
 import { mdToEmailHtml } from '@/lib/briefing/markdown';
 import { sendBriefingEmail } from '@/lib/briefing/email';
 import { matamorosFecha } from '@/lib/briefing/fecha';
+import { getSupabaseAdminClient } from '@/lib/supabase-admin';
+import {
+  getDefinitionBySlug,
+  renderSubject,
+  splitRecipientsExtra,
+  writeNotificationLog,
+} from '@/lib/notifications';
 
 // Web search + generación con Opus puede tomar > 60s; damos holgura.
 export const maxDuration = 300;
@@ -87,8 +94,57 @@ export async function GET(req: NextRequest) {
   }
 
   const html = mdToEmailHtml(markdown);
-  const subject = `Daily Briefing — ${fecha.iso} (${fecha.diaSemana})`;
-  const sent = await sendBriefingEmail(resendKey, { html, subject, to: BRIEFING_TO });
+
+  // Catálogo de notificaciones (slug `daily_briefing`, global). FAIL-OPEN: si el
+  // catálogo no responde, se usan los defaults hardcoded. El cron corre con
+  // service role (sin sesión), por eso el admin client.
+  const admin = getSupabaseAdminClient();
+  const def = admin ? await getDefinitionBySlug(admin, 'daily_briefing') : null;
+
+  const subject = renderSubject(def?.subject_template ?? 'Daily Briefing — {fecha} ({dia})', {
+    fecha: fecha.iso,
+    dia: fecha.diaSemana,
+  });
+
+  // Kill switch.
+  if (def && !def.activo) {
+    if (admin) {
+      await writeNotificationLog(admin, {
+        definitionId: def.id,
+        status: 'skipped',
+        recipients: { to: [] },
+        subject,
+        context: { fecha: fecha.iso },
+      });
+    }
+    const skip = { status: 'skipped', reason: 'kill switch (daily_briefing desactivado)' };
+    console.log('[daily-briefing]', JSON.stringify(skip));
+    return NextResponse.json(skip);
+  }
+
+  const extras = def
+    ? splitRecipientsExtra(def.recipients_extra)
+    : { to: [BRIEFING_TO], cc: [], bcc: [] };
+  const to = extras.to[0] ?? BRIEFING_TO;
+  const from = def
+    ? def.from_name
+      ? `${def.from_name} <${def.from_email}>`
+      : def.from_email
+    : undefined;
+
+  const sent = await sendBriefingEmail(resendKey, { html, subject, to, from });
+
+  if (admin) {
+    await writeNotificationLog(admin, {
+      definitionId: def?.id ?? null,
+      status: sent.ok ? 'sent' : 'failed',
+      recipients: { to: [to] },
+      subject,
+      resendId: sent.id ?? null,
+      errorMessage: sent.ok ? null : String(sent.error),
+      context: { fecha: fecha.iso },
+    });
+  }
 
   if (!sent.ok) {
     console.error('[daily-briefing] Resend falló:', sent.error);
@@ -101,7 +157,7 @@ export async function GET(req: NextRequest) {
   const result = {
     status: 'sent',
     resendId: sent.id,
-    to: BRIEFING_TO,
+    to,
     fecha: fecha.iso,
     healthAvailable: health.available,
   };

--- a/docs/planning/notificaciones-catalogo.md
+++ b/docs/planning/notificaciones-catalogo.md
@@ -6,8 +6,8 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-05-26
-**Próximo hito:** S6 alta/baja de empleados al comité (PR abierto); luego S5 centralizar los 6 emails huérfanos (hold, avalúo, dictamen, encuesta, briefing, orden de compra).
-**Última actualización:** 2026-06-30 (reabierta Fase 2 — completar el catálogo + avisos de personal)
+**Próximo hito:** S5b — centralizar los 4 correos de ventas (hold, avalúo, dictamen, encuesta). S6 (#1153) y S5a (orden de compra + briefing) ya en prod / PR abierto.
+**Última actualización:** 2026-06-30 (S5a: seed orden de compra + briefing al catálogo)
 
 ## Problema
 
@@ -271,7 +271,7 @@ no se pueden apagar ni editar, y su traza no liga a una definición:
 
 Y faltaba el correo de alta/baja de personal que Coda mandaba al comité.
 
-- **S6 — Avisos de alta/baja de personal** (esta sesión, PR abierto):
+- **S6 — Avisos de alta/baja de personal** ([#1153](https://github.com/beto-sudo/BSOP/pull/1153), mergeado 2026-06-30; verificado en prod):
   slugs `empleado_alta` / `empleado_baja` **por empresa** (DILESA + RDB →
   `comite@dilesa.mx`, primer uso del override por `empresa_id` del catálogo).
   Migración `20260630230337` (columnas idempotencia `erp.empleados.notif_*_at`
@@ -280,10 +280,14 @@ Y faltaba el correo de alta/baja de personal que Coda mandaba al comité.
     `resend`/`test` (test = [PRUEBA] solo al usuario). Disparo automático
     fire-and-forget en el wizard de alta y en `handleBaja` del detalle + botón
     "Probar aviso" en el expediente. Kill switch + log como el resto.
-- **S5 — Centralizar los 6 huérfanos** (siguiente PR): sembrar + reconectar
-  cada handler al catálogo (mismo refactor que el Sprint 2 original), uno o
-  dos por PR para no arriesgar los correos vivos. La orden de compra solo
-  necesita el seed (ya lee el catálogo con fail-open).
+- **S5 — Centralizar los 6 huérfanos**: sembrar + reconectar cada handler al
+  catálogo (mismo refactor que el Sprint 2 original). Por R1 va en lotes para
+  no arriesgar los correos vivos:
+  - **S5a (PR abierto)** — lote de bajo riesgo: `dilesa_orden_compra` (solo
+    seed, ya lee el catálogo) + `daily_briefing` (seed + reconexión del cron,
+    interno a Beto). Migración `20260630235504` (solo INSERT, sin DDL).
+  - **S5b (sigue)** — los 4 de ventas a clientes/proveedores: `hold`,
+    `avaluo`, `dictamen`, `encuesta`. Fail-open al comportamiento actual.
 - **S7 (opcional)** — mostrar el schedule del cron en la UI (read-only desde
   `trigger_config.schedule_human`).
 

--- a/supabase/migrations/20260630235504_notif_seed_orden_compra_briefing.sql
+++ b/supabase/migrations/20260630235504_notif_seed_orden_compra_briefing.sql
@@ -1,0 +1,71 @@
+-- ╭─ 20260630235504_notif_seed_orden_compra_briefing ─╮
+-- S5 (Fase 2 de `notificaciones-catalogo`) — primer lote de centralización.
+-- Dos correos que el sistema ya manda pero NO estaban registrados en el
+-- catálogo, por lo que no se veían ni se podían apagar/editar en
+-- /settings/notificaciones:
+--
+--   1. `dilesa_orden_compra` — el endpoint POST de la OC YA lee el catálogo con
+--      fail-open (getDefinitionBySlug + kill switch + log), solo le faltaba la
+--      fila. Con esto aparece, se puede apagar y editar from/subject. Global
+--      (el handler busca el slug sin empresa_id). Valores = los hardcoded de hoy.
+--   2. `daily_briefing` — el cron matutino de Beto. La fila lo hace visible +
+--      apagable + editable (from/subject/destinatario); el handler se reconecta
+--      al catálogo en el mismo PR (fail-open a los valores de hoy).
+--
+-- Aditiva pura, idempotente vía WHERE NOT EXISTS (slug global, empresa_id IS
+-- NULL — el UNIQUE no cubre NULL). Sin tocar comportamiento: los handlers caen
+-- a sus defaults hardcoded si el catálogo no responde.
+
+BEGIN;
+
+-- ── dilesa_orden_compra (global) ─────────────────────────────────────────
+INSERT INTO core.notification_definitions
+  (slug, empresa_id, nombre, descripcion, trigger_type, trigger_config,
+   from_email, from_name, reply_to, recipients_extra, subject_template, activo)
+SELECT
+  'dilesa_orden_compra',
+  NULL,
+  'Orden de compra al proveedor (DILESA)',
+  'Envía la orden de compra en PDF al proveedor adjudicado. Se dispara desde el '
+  'detalle de la OC (botón Enviar). El destinatario es el email del proveedor '
+  '(no un recipiente fijo); from/asunto/kill switch editables aquí.',
+  'manual',
+  '{"ui_location": "/dilesa/compras — detalle de la orden de compra", "button_label": "Enviar OC al proveedor"}'::jsonb,
+  'noreply@bsop.io',
+  'DILESA Compras',
+  'compras@dilesa.mx',
+  '[]'::jsonb,
+  'Orden de compra {folio} — DILESA',
+  true
+WHERE NOT EXISTS (
+  SELECT 1 FROM core.notification_definitions
+  WHERE slug = 'dilesa_orden_compra' AND empresa_id IS NULL
+);
+
+-- ── daily_briefing (global) ──────────────────────────────────────────────
+INSERT INTO core.notification_definitions
+  (slug, empresa_id, nombre, descripcion, trigger_type, trigger_config,
+   from_email, from_name, reply_to, recipients_extra, subject_template, activo)
+SELECT
+  'daily_briefing',
+  NULL,
+  'Briefing matutino (Beto)',
+  'Briefing diario que redacta Claude (salud + agenda + correo + FX/noticias) y '
+  'se manda por correo cada mañana ~07:00 hora de Matamoros. Cron en Vercel '
+  '(0 12,13 UTC + guard de hora local). Destinatario, from y asunto editables.',
+  'cron',
+  '{"schedule_cron": "0 12,13 * * *", "schedule_human": "~07:00 Matamoros (guard de hora local, auto-DST)", "defined_in": "vercel.json"}'::jsonb,
+  'briefing@bsop.io',
+  'Daily Briefing',
+  NULL,
+  '[{"email": "beto@anorte.com", "type": "always"}]'::jsonb,
+  'Daily Briefing — {fecha} ({dia})',
+  true
+WHERE NOT EXISTS (
+  SELECT 1 FROM core.notification_definitions
+  WHERE slug = 'daily_briefing' AND empresa_id IS NULL
+);
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
**S5a** de la Fase 2 de `notificaciones-catalogo` — primer lote (bajo riesgo) de la centralización de correos huérfanos detectados en la auditoría.

## Qué entra
- **`dilesa_orden_compra`** (seed): el endpoint POST de la OC **ya** leía el catálogo con fail-open (kill switch + log), solo faltaba la fila. Ahora aparece en `/settings/notificaciones`, se puede **apagar** y editar from/asunto. Sigue mandando al proveedor adjudicado (destinatario dinámico). Valores = los hardcoded de hoy.
- **`daily_briefing`** (seed + wire): el cron matutino ahora lee el catálogo — kill switch, from/asunto/destinatario editables, y queda traza en `notification_log`. **Fail-open**: si el catálogo no responde, usa los defaults de hoy (`briefing@bsop.io` → `beto@anorte.com`).

## Riesgo
- Migración `20260630235504`: **solo INSERT, sin DDL** → no cambia schema (no regen de derivados).
- Idempotente (`WHERE NOT EXISTS`). No financiera.
- Briefing: cambio aditivo con fallback; el subject pasó a template (`Daily Briefing — {fecha} ({dia})`) con las mismas variables.

## Sigue (S5b)
Los 4 correos de ventas a clientes/proveedores: `hold`, `avaluo`, `dictamen`, `encuesta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)