### PR TITLE
feat(notificaciones): centralizar solicitud de avalúo + dictamen (S5b.1)

### DIFF
--- a/app/api/dilesa/ventas/[id]/notify-solicitud-avaluo/route.ts
+++ b/app/api/dilesa/ventas/[id]/notify-solicitud-avaluo/route.ts
@@ -25,6 +25,11 @@ import { sendAvaluoSolicitudEmail, type AvaluoSolicitudContext } from '@/lib/dil
 import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
 import { signAvaluoToken } from '@/lib/dilesa/avaluo-token';
 import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
+import {
+  getDefinitionBySlug,
+  overridesFromDefinition,
+  writeNotificationLog,
+} from '@/lib/notifications';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -232,7 +237,46 @@ export async function POST(_req: NextRequest, ctx: { params: Promise<{ id: strin
     vendedorTelefono: gerente?.telefono ?? null,
   };
 
-  const res = await sendAvaluoSolicitudEmail(emailCtx);
+  // Catálogo de notificaciones (slug `dilesa_avaluo_solicitud`). FAIL-OPEN a los
+  // defaults hardcoded de la lib si el catálogo no responde.
+  const ref = `${proyectoNombre} · ${unidad?.identificador ?? ''}`.trim();
+  const def = await getDefinitionBySlug(admin, 'dilesa_avaluo_solicitud', venta.empresa_id);
+  const { killed, definitionId, overrides } = overridesFromDefinition(def, {
+    ref,
+    proyecto: proyectoNombre,
+    unidad: unidad?.identificador ?? '',
+  });
+
+  if (killed) {
+    await writeNotificationLog(admin, {
+      definitionId,
+      empresaId: venta.empresa_id,
+      status: 'skipped',
+      recipients: { to: [] },
+      subject: overrides.subject ?? null,
+      triggeredByUserId: user.id,
+      context: { venta_id: venta.id },
+    });
+    return NextResponse.json({
+      ok: false,
+      skipped: true,
+      error: 'La solicitud de avalúo está desactivada en /settings/notificaciones.',
+    });
+  }
+
+  const res = await sendAvaluoSolicitudEmail(emailCtx, overrides);
+
+  await writeNotificationLog(admin, {
+    definitionId,
+    empresaId: venta.empresa_id,
+    status: res.ok ? 'sent' : 'failed',
+    recipients: { to: res.sentTo },
+    subject: overrides.subject ?? `Solicitud de avalúo — ${ref}`,
+    errorMessage: res.ok ? null : (res.error ?? 'send failed'),
+    triggeredByUserId: user.id,
+    context: { venta_id: venta.id },
+  });
+
   if (!res.ok) {
     return NextResponse.json({
       ok: false,

--- a/app/api/dilesa/ventas/[id]/notify-solicitud-dictamen/route.ts
+++ b/app/api/dilesa/ventas/[id]/notify-solicitud-dictamen/route.ts
@@ -25,6 +25,11 @@ import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
 import { signDictamenToken } from '@/lib/dilesa/dictamen-token';
 import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
 import { getNotaria } from '@/lib/dilesa/notarios';
+import {
+  getDefinitionBySlug,
+  overridesFromDefinition,
+  writeNotificationLog,
+} from '@/lib/notifications';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -214,7 +219,46 @@ export async function POST(_req: NextRequest, ctx: { params: Promise<{ id: strin
     vendedorEmail: contactoEmail,
   };
 
-  const res = await sendDictamenSolicitudEmail(emailCtx);
+  // Catálogo de notificaciones (slug `dilesa_dictamen_solicitud`). FAIL-OPEN a
+  // los defaults hardcoded de la lib si el catálogo no responde.
+  const ref = `${proyectoNombre} · ${unidad?.identificador ?? ''}`.trim();
+  const def = await getDefinitionBySlug(admin, 'dilesa_dictamen_solicitud', venta.empresa_id);
+  const { killed, definitionId, overrides } = overridesFromDefinition(def, {
+    ref,
+    proyecto: proyectoNombre,
+    unidad: unidad?.identificador ?? '',
+  });
+
+  if (killed) {
+    await writeNotificationLog(admin, {
+      definitionId,
+      empresaId: venta.empresa_id,
+      status: 'skipped',
+      recipients: { to: [] },
+      subject: overrides.subject ?? null,
+      triggeredByUserId: user.id,
+      context: { venta_id: venta.id },
+    });
+    return NextResponse.json({
+      ok: false,
+      skipped: true,
+      error: 'La solicitud de dictaminación está desactivada en /settings/notificaciones.',
+    });
+  }
+
+  const res = await sendDictamenSolicitudEmail(emailCtx, overrides);
+
+  await writeNotificationLog(admin, {
+    definitionId,
+    empresaId: venta.empresa_id,
+    status: res.ok ? 'sent' : 'failed',
+    recipients: { to: res.sentTo },
+    subject: overrides.subject ?? `Solicitud de dictaminación notarial — ${ref}`,
+    errorMessage: res.ok ? null : (res.error ?? 'send failed'),
+    triggeredByUserId: user.id,
+    context: { venta_id: venta.id },
+  });
+
   if (!res.ok) {
     return NextResponse.json({
       ok: false,

--- a/docs/planning/notificaciones-catalogo.md
+++ b/docs/planning/notificaciones-catalogo.md
@@ -6,8 +6,8 @@
 **Estado:** in_progress
 **Dueño:** Beto
 **Creada:** 2026-05-26
-**Próximo hito:** S5b — centralizar los 4 correos de ventas (hold, avalúo, dictamen, encuesta). S6 (#1153) y S5a (orden de compra + briefing) ya en prod / PR abierto.
-**Última actualización:** 2026-06-30 (S5a: seed orden de compra + briefing al catálogo)
+**Próximo hito:** S5b.1 (avalúo + dictamen) PR abierto — requiere label `finanzas-ok` (falso positivo por "avalúo"). Sigue S5b.2 (hold + encuesta). S6/#1153 y S5a en prod.
+**Última actualización:** 2026-07-01 (S5b.1: seed + wiring avalúo/dictamen + helper overrides)
 
 ## Problema
 
@@ -286,8 +286,14 @@ Y faltaba el correo de alta/baja de personal que Coda mandaba al comité.
   - **S5a (PR abierto)** — lote de bajo riesgo: `dilesa_orden_compra` (solo
     seed, ya lee el catálogo) + `daily_briefing` (seed + reconexión del cron,
     interno a Beto). Migración `20260630235504` (solo INSERT, sin DDL).
-  - **S5b (sigue)** — los 4 de ventas a clientes/proveedores: `hold`,
-    `avaluo`, `dictamen`, `encuesta`. Fail-open al comportamiento actual.
+  - **S5b.1 (PR abierto)** — `dilesa_avaluo_solicitud` + `dilesa_dictamen_solicitud`
+    (Fases 4 y 7). Helper compartido `lib/notifications/overrides.ts`
+    (`overridesFromDefinition` + `dedupEmails`) para no repetir el boilerplate
+    del catálogo en cada route; libs con param `overrides?` (fail-open). Trip del
+    finanzas-gate por la palabra "avalúo" (falso positivo, solo seed) → requiere
+    label `finanzas-ok`.
+  - **S5b.2 (sigue)** — `hold` (creado/por vencer, multi-caller) + `encuesta`
+    post-venta (cron + manual).
 - **S7 (opcional)** — mostrar el schedule del cron en la UI (read-only desde
   `trigger_config.schedule_human`).
 

--- a/lib/dilesa/avaluo-emails.ts
+++ b/lib/dilesa/avaluo-emails.ts
@@ -17,6 +17,7 @@
 
 import { renderEmailLayout, renderSeccionDatos, escapeHtml } from './email-layout';
 import type { EmpresaBranding } from './email-branding';
+import { dedupEmails, type NotificationOverrides } from '../notifications/overrides';
 
 /**
  * `From` para Resend — mismo dominio verificado que el resto de los
@@ -70,7 +71,10 @@ interface SendResult {
  * operación principal (mismo patrón que hold-emails) — sólo loguea a
  * console.warn.
  */
-export async function sendAvaluoSolicitudEmail(ctx: AvaluoSolicitudContext): Promise<SendResult> {
+export async function sendAvaluoSolicitudEmail(
+  ctx: AvaluoSolicitudContext,
+  overrides?: NotificationOverrides
+): Promise<SendResult> {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
     console.warn('[avaluo-emails] RESEND_API_KEY missing — skipping');
@@ -82,14 +86,21 @@ export async function sendAvaluoSolicitudEmail(ctx: AvaluoSolicitudContext): Pro
     return { ok: false, sentTo: [], error: 'sin email del valuador' };
   }
 
-  // Copia al gerente de ventas para que tenga trazabilidad de qué se mandó.
-  const recipients: string[] = [ctx.valuadorEmail];
-  const ccs: string[] = [];
-  if (ctx.vendedorEmail && ctx.vendedorEmail !== ctx.valuadorEmail) {
-    ccs.push(ctx.vendedorEmail);
-  }
+  // Recipientes dinámicos (valuador + cc al gerente de ventas) + los fijos del
+  // catálogo (overrides.extra*). Sin overrides = comportamiento de siempre.
+  const recipients = dedupEmails([ctx.valuadorEmail, ...(overrides?.extraTo ?? [])]);
+  const ccs = dedupEmails([
+    ctx.vendedorEmail && ctx.vendedorEmail !== ctx.valuadorEmail ? ctx.vendedorEmail : null,
+    ...(overrides?.extraCc ?? []),
+  ]).filter((c) => !recipients.some((r) => r.toLowerCase() === c.toLowerCase()));
+  const bccs = dedupEmails(overrides?.extraBcc ?? []).filter(
+    (b) =>
+      !recipients.some((r) => r.toLowerCase() === b.toLowerCase()) &&
+      !ccs.some((c) => c.toLowerCase() === b.toLowerCase())
+  );
 
-  const { subject, html } = renderTemplate(ctx);
+  const { subject: computedSubject, html } = renderTemplate(ctx);
+  const subject = overrides?.subject ?? computedSubject;
 
   const resp = await fetch('https://api.resend.com/emails', {
     method: 'POST',
@@ -98,9 +109,11 @@ export async function sendAvaluoSolicitudEmail(ctx: AvaluoSolicitudContext): Pro
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: RESEND_FROM,
+      from: overrides?.from ?? RESEND_FROM,
       to: recipients,
       cc: ccs.length > 0 ? ccs : undefined,
+      bcc: bccs.length > 0 ? bccs : undefined,
+      reply_to: overrides?.replyTo ?? undefined,
       subject,
       html,
     }),
@@ -110,7 +123,7 @@ export async function sendAvaluoSolicitudEmail(ctx: AvaluoSolicitudContext): Pro
     console.warn(`[avaluo-emails] resend ${resp.status}: ${errText.slice(0, 400)}`);
     return { ok: false, sentTo: recipients, error: `resend ${resp.status}` };
   }
-  return { ok: true, sentTo: [...recipients, ...ccs] };
+  return { ok: true, sentTo: [...recipients, ...ccs, ...bccs] };
 }
 
 function fechaTextoMx(): string {

--- a/lib/dilesa/dictamen-emails.ts
+++ b/lib/dilesa/dictamen-emails.ts
@@ -19,6 +19,7 @@
 
 import { renderEmailLayout, renderSeccionDatos, escapeHtml } from './email-layout';
 import type { EmpresaBranding } from './email-branding';
+import { dedupEmails, type NotificationOverrides } from '../notifications/overrides';
 
 const RESEND_FROM = 'DILESA <noreply@bsop.io>';
 
@@ -63,7 +64,8 @@ interface SendResult {
 }
 
 export async function sendDictamenSolicitudEmail(
-  ctx: DictamenSolicitudContext
+  ctx: DictamenSolicitudContext,
+  overrides?: NotificationOverrides
 ): Promise<SendResult> {
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
@@ -75,13 +77,21 @@ export async function sendDictamenSolicitudEmail(
     return { ok: false, sentTo: [], error: 'sin email del notario' };
   }
 
-  const recipients: string[] = [ctx.notarioEmail];
-  const ccs: string[] = [];
-  if (ctx.vendedorEmail && ctx.vendedorEmail !== ctx.notarioEmail) {
-    ccs.push(ctx.vendedorEmail);
-  }
+  // Recipientes dinámicos (notario + cc al gerente de ventas) + los fijos del
+  // catálogo (overrides.extra*). Sin overrides = comportamiento de siempre.
+  const recipients = dedupEmails([ctx.notarioEmail, ...(overrides?.extraTo ?? [])]);
+  const ccs = dedupEmails([
+    ctx.vendedorEmail && ctx.vendedorEmail !== ctx.notarioEmail ? ctx.vendedorEmail : null,
+    ...(overrides?.extraCc ?? []),
+  ]).filter((c) => !recipients.some((r) => r.toLowerCase() === c.toLowerCase()));
+  const bccs = dedupEmails(overrides?.extraBcc ?? []).filter(
+    (b) =>
+      !recipients.some((r) => r.toLowerCase() === b.toLowerCase()) &&
+      !ccs.some((c) => c.toLowerCase() === b.toLowerCase())
+  );
 
-  const { subject, html } = renderTemplate(ctx);
+  const { subject: computedSubject, html } = renderTemplate(ctx);
+  const subject = overrides?.subject ?? computedSubject;
 
   const resp = await fetch('https://api.resend.com/emails', {
     method: 'POST',
@@ -90,9 +100,11 @@ export async function sendDictamenSolicitudEmail(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      from: RESEND_FROM,
+      from: overrides?.from ?? RESEND_FROM,
       to: recipients,
       cc: ccs.length > 0 ? ccs : undefined,
+      bcc: bccs.length > 0 ? bccs : undefined,
+      reply_to: overrides?.replyTo ?? undefined,
       subject,
       html,
     }),
@@ -102,7 +114,7 @@ export async function sendDictamenSolicitudEmail(
     console.warn(`[dictamen-emails] resend ${resp.status}: ${errText.slice(0, 400)}`);
     return { ok: false, sentTo: recipients, error: `resend ${resp.status}` };
   }
-  return { ok: true, sentTo: [...recipients, ...ccs] };
+  return { ok: true, sentTo: [...recipients, ...ccs, ...bccs] };
 }
 
 function fechaTextoMx(): string {

--- a/lib/notifications/index.ts
+++ b/lib/notifications/index.ts
@@ -18,3 +18,10 @@ export {
   type LogRecipients,
   type WriteLogInput,
 } from './log';
+
+export {
+  overridesFromDefinition,
+  dedupEmails,
+  type NotificationOverrides,
+  type ResolvedOverrides,
+} from './overrides';

--- a/lib/notifications/overrides.test.ts
+++ b/lib/notifications/overrides.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { overridesFromDefinition, dedupEmails } from './overrides';
+import type { NotificationDefinition } from './registry';
+
+function def(overrides: Partial<NotificationDefinition> = {}): NotificationDefinition {
+  return {
+    id: 'def1',
+    slug: 'dilesa_avaluo_solicitud',
+    empresa_id: null,
+    nombre: 'Avalúo',
+    descripcion: null,
+    trigger_type: 'manual',
+    trigger_config: {},
+    from_email: 'noreply@bsop.io',
+    from_name: 'DILESA',
+    reply_to: 'ventas@dilesa.mx',
+    recipients_extra: [
+      { email: 'bcc@dilesa.mx', type: 'bcc' },
+      { email: 'audit@dilesa.mx', type: 'always' },
+    ],
+    subject_template: 'Solicitud de avalúo — {proyecto}',
+    activo: true,
+    created_at: '',
+    updated_at: '',
+    updated_by: null,
+    ...overrides,
+  };
+}
+
+describe('overridesFromDefinition', () => {
+  it('def null → overrides vacío, sin kill', () => {
+    const r = overridesFromDefinition(null, { proyecto: 'X' });
+    expect(r.killed).toBe(false);
+    expect(r.definitionId).toBeNull();
+    expect(r.overrides).toEqual({});
+  });
+
+  it('def activa → compone from, subject renderizado, recipientes por tipo', () => {
+    const r = overridesFromDefinition(def(), { proyecto: 'Los Encinos' });
+    expect(r.killed).toBe(false);
+    expect(r.definitionId).toBe('def1');
+    expect(r.overrides.from).toBe('DILESA <noreply@bsop.io>');
+    expect(r.overrides.replyTo).toBe('ventas@dilesa.mx');
+    expect(r.overrides.subject).toBe('Solicitud de avalúo — Los Encinos');
+    expect(r.overrides.extraTo).toEqual(['audit@dilesa.mx']);
+    expect(r.overrides.extraBcc).toEqual(['bcc@dilesa.mx']);
+  });
+
+  it('from sin from_name → solo el email', () => {
+    const r = overridesFromDefinition(def({ from_name: null }), {});
+    expect(r.overrides.from).toBe('noreply@bsop.io');
+  });
+
+  it('activo=false → killed', () => {
+    const r = overridesFromDefinition(def({ activo: false }), {});
+    expect(r.killed).toBe(true);
+    expect(r.definitionId).toBe('def1');
+  });
+});
+
+describe('dedupEmails', () => {
+  it('quita duplicados case-insensitive y vacíos', () => {
+    expect(dedupEmails(['A@x.com', 'a@x.com', null, ' ', 'b@x.com'])).toEqual([
+      'A@x.com',
+      'b@x.com',
+    ]);
+  });
+});

--- a/lib/notifications/overrides.ts
+++ b/lib/notifications/overrides.ts
@@ -1,0 +1,82 @@
+/**
+ * overrides.ts — traduce una definición del catálogo a "overrides" que un
+ * handler de email aplica sobre sus defaults hardcoded.
+ *
+ * Fase 2 de `notificaciones-catalogo` (S5). Los handlers viejos (avaluo,
+ * dictamen, hold, encuesta) hacían el fetch a Resend con from/subject
+ * hardcoded. Para reconectarlos al catálogo SIN duplicar el boilerplate en
+ * cada route, el route:
+ *   1. lee la definición con `getDefinitionBySlug`,
+ *   2. la pasa por `overridesFromDefinition`,
+ *   3. si `killed` → loguea skipped y no manda,
+ *   4. si no → pasa `overrides` al `send*Email(ctx, overrides)` de la lib.
+ *
+ * FAIL-OPEN: si no hay definición (catálogo caído o slug sin sembrar),
+ * `overrides` sale vacío y la lib usa sus defaults de siempre.
+ */
+
+import type { NotificationDefinition } from './registry';
+import { renderSubject, splitRecipientsExtra } from './registry';
+
+/** Overrides que un handler aplica sobre sus defaults. Todo opcional. */
+export interface NotificationOverrides {
+  /** "Nombre <email>" ya compuesto. */
+  from?: string;
+  replyTo?: string | null;
+  /** Recipientes fijos del catálogo (se SUMAN a los dinámicos del handler). */
+  extraTo?: string[];
+  extraCc?: string[];
+  extraBcc?: string[];
+  /** Subject ya renderizado (reemplaza el que computa la lib). */
+  subject?: string;
+}
+
+export interface ResolvedOverrides {
+  /** Kill switch: la definición existe y está `activo=false`. */
+  killed: boolean;
+  /** ID de la definición usada (para el log). NULL si no hay. */
+  definitionId: string | null;
+  overrides: NotificationOverrides;
+}
+
+/**
+ * Convierte una `NotificationDefinition` (o null) en overrides + el subject
+ * renderizado con `subjectVars`. Si `def` es null → overrides vacío (la lib
+ * usa sus defaults). No tira nunca.
+ */
+export function overridesFromDefinition(
+  def: NotificationDefinition | null,
+  subjectVars: Record<string, string | number> = {}
+): ResolvedOverrides {
+  if (!def) {
+    return { killed: false, definitionId: null, overrides: {} };
+  }
+  const extras = splitRecipientsExtra(def.recipients_extra);
+  return {
+    killed: !def.activo,
+    definitionId: def.id,
+    overrides: {
+      from: def.from_name ? `${def.from_name} <${def.from_email}>` : def.from_email,
+      replyTo: def.reply_to,
+      extraTo: extras.to,
+      extraCc: extras.cc,
+      extraBcc: extras.bcc,
+      subject: renderSubject(def.subject_template, subjectVars),
+    },
+  };
+}
+
+/** Dedup case-insensitive preservando orden y el casing del primero. */
+export function dedupEmails(emails: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const e of emails) {
+    const v = e?.trim();
+    if (!v) continue;
+    const k = v.toLowerCase();
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(v);
+  }
+  return out;
+}

--- a/supabase/migrations/20260701000455_notif_seed_avaluo_dictamen.sql
+++ b/supabase/migrations/20260701000455_notif_seed_avaluo_dictamen.sql
@@ -1,0 +1,70 @@
+-- ╭─ 20260701000455_notif_seed_avaluo_dictamen ─╮
+-- S5b (Fase 2 de `notificaciones-catalogo`) — centraliza 2 correos de ventas
+-- que ya se mandan pero no estaban en el catálogo:
+--
+--   1. `dilesa_avaluo_solicitud` — al cerrar Fase 4, mail a la casa valuadora.
+--   2. `dilesa_dictamen_solicitud` — al cerrar Fase 7, mail a la notaría.
+--
+-- Con el seed aparecen en /settings/notificaciones (kill switch + from/asunto +
+-- recipientes extra editables). Los handlers se reconectan al catálogo en el
+-- mismo PR (routes notify-solicitud-avaluo / -dictamen), FAIL-OPEN a los
+-- defaults hardcoded de las libs. El destinatario principal sigue siendo
+-- dinámico (valuador / notario); recipients_extra son copias fijas opcionales.
+--
+-- Global (empresa_id NULL): son correos DILESA y los handlers leen el slug con
+-- venta.empresa_id (fallback a global). Aditiva pura, idempotente (NOT EXISTS).
+-- Valores sembrados = los hardcoded de hoy.
+
+BEGIN;
+
+-- ── dilesa_avaluo_solicitud (global) ─────────────────────────────────────
+INSERT INTO core.notification_definitions
+  (slug, empresa_id, nombre, descripcion, trigger_type, trigger_config,
+   from_email, from_name, reply_to, recipients_extra, subject_template, activo)
+SELECT
+  'dilesa_avaluo_solicitud',
+  NULL,
+  'Solicitud de avalúo al valuador (DILESA)',
+  'Al cerrar la Fase 4 se manda a la casa valuadora los datos del inmueble y '
+  'del comprador + un magic link para subir el dictamen sin login. Cc al gerente '
+  'de ventas. Destinatario principal = email del valuador (dinámico).',
+  'manual',
+  '{"ui_location": "/dilesa/ventas/[id] — captura Fase 4 (solicitud de avalúo)", "button_label": "Solicitud de avalúo"}'::jsonb,
+  'noreply@bsop.io',
+  'DILESA',
+  NULL,
+  '[]'::jsonb,
+  'Solicitud de avalúo — {proyecto} · {unidad}',
+  true
+WHERE NOT EXISTS (
+  SELECT 1 FROM core.notification_definitions
+  WHERE slug = 'dilesa_avaluo_solicitud' AND empresa_id IS NULL
+);
+
+-- ── dilesa_dictamen_solicitud (global) ───────────────────────────────────
+INSERT INTO core.notification_definitions
+  (slug, empresa_id, nombre, descripcion, trigger_type, trigger_config,
+   from_email, from_name, reply_to, recipients_extra, subject_template, activo)
+SELECT
+  'dilesa_dictamen_solicitud',
+  NULL,
+  'Solicitud de dictaminación notarial (DILESA)',
+  'Al cerrar la Fase 7 se manda a la notaría los datos del cliente, inmueble y '
+  'crédito + un magic link para subir la Carta de Instrucción sin login. Cc al '
+  'gerente de ventas. Destinatario principal = email del notario (dinámico).',
+  'manual',
+  '{"ui_location": "/dilesa/ventas/[id] — captura Fase 7 (solicitud de dictamen)", "button_label": "Solicitud de dictaminación"}'::jsonb,
+  'noreply@bsop.io',
+  'DILESA',
+  NULL,
+  '[]'::jsonb,
+  'Solicitud de dictaminación notarial — {proyecto} · {unidad}',
+  true
+WHERE NOT EXISTS (
+  SELECT 1 FROM core.notification_definitions
+  WHERE slug = 'dilesa_dictamen_solicitud' AND empresa_id IS NULL
+);
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
**S5b.1** de la Fase 2 de `notificaciones-catalogo`. Reconecta al catálogo dos correos de ventas que se mandaban con from/asunto hardcoded.

## Qué entra
- **`dilesa_avaluo_solicitud`** (Fase 4 → valuador) y **`dilesa_dictamen_solicitud`** (Fase 7 → notaría): ahora aparecen en `/settings/notificaciones` con kill switch, from/asunto y recipientes extra editables, y traza en `notification_log`.
- Helper compartido **`lib/notifications/overrides.ts`** (`overridesFromDefinition` + `dedupEmails`, con test) — evita repetir el boilerplate del catálogo en cada route; lo reusaré en S5b.2 (hold, encuesta).
- Libs `avaluo-emails` / `dictamen-emails`: param opcional `overrides?`. **FAIL-OPEN**: sin definición usan sus defaults de siempre (mismo from, mismo asunto, mismo destinatario dinámico valuador/notario).

## Riesgo
- Migración `20260701000455`: **solo INSERT, sin DDL**. Idempotente. Valores sembrados = los hardcoded de hoy → cero cambio de comportamiento salvo que edites el catálogo.
- El destinatario principal (valuador/notario) sigue siendo dinámico; `recipients_extra` son copias fijas opcionales (hoy vacías).

## ⚠️ Finanzas-gate: falso positivo
El clasificador marca la migración como financiera por la palabra **"avalúo"** (regex de términos de dinero). **No mueve dinero ni permisos** — solo siembra 2 filas en `core.notification_definitions`. Requiere tu label `finanzas-ok` para mergear.

## Sigue (S5b.2)
`hold` (creado/por vencer, multi-caller) + `encuesta` post-venta (cron + manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)