### PR TITLE
fix(rdb-inventario): corregir tipo default de levantamiento ('fisico' → 'total')

### DIFF
--- a/app/rdb/inventario/levantamientos/actions.ts
+++ b/app/rdb/inventario/levantamientos/actions.ts
@@ -44,7 +44,7 @@ export async function crearLevantamiento(
       notas: input.notas?.trim() || null,
       tolerancia_pct_override: input.tolerancia_pct_override ?? null,
       tolerancia_monto_override: input.tolerancia_monto_override ?? null,
-      tipo: input.tipo ?? 'fisico',
+      tipo: input.tipo ?? 'total',
       created_by: session.user.id,
     })
     .select('id, folio')

--- a/app/rdb/inventario/levantamientos/types.ts
+++ b/app/rdb/inventario/levantamientos/types.ts
@@ -10,8 +10,8 @@ export type CrearLevantamientoInput = {
   notas?: string;
   tolerancia_pct_override?: number | null;
   tolerancia_monto_override?: number | null;
-  /** 'fisico' (default) — el schema permite otros tipos a futuro. */
-  tipo?: string;
+  /** 'total' (default) | 'parcial' | 'spot' — debe coincidir con el CHECK de erp.inventario_levantamientos. */
+  tipo?: 'total' | 'parcial' | 'spot';
 };
 
 export type FirmarPasoInput = {


### PR DESCRIPTION
## Problema

Pablo (RDB) no podía crear un levantamiento de inventario: al presionar **Iniciar captura ahora** salía `new row for relation "inventario_levantamientos" violates check constraint "inventario_levantamientos_tipo_check"`.

## Causa

`crearLevantamiento` insertaba `tipo: input.tipo ?? 'fisico'`, pero la UI nunca envía `tipo`, así que caía a `'fisico'` — valor ausente del CHECK de la tabla, que solo acepta `('total','parcial','spot')` (default `'total'`). Nunca coincidió con el schema.

## Fix

- `actions.ts`: default `'fisico'` → `'total'` (levantamiento completo, que es lo que hace la UI).
- `types.ts`: `tipo` tipado como `'total' | 'parcial' | 'spot'` para que TS atrape el drift a futuro.

Code-only, sin cambios de DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)