### PR TITLE
fix(rdb-inventario): guardar codigo/nombre null al buscar en captura de levantamiento

### DIFF
--- a/app/rdb/inventario/levantamientos/[id]/capturar/page.tsx
+++ b/app/rdb/inventario/levantamientos/[id]/capturar/page.tsx
@@ -150,7 +150,8 @@ function CapturarInner() {
     return lineas
       .filter(
         (l) =>
-          l.producto_nombre.toLowerCase().includes(q) || l.producto_codigo.toLowerCase().includes(q)
+          (l.producto_nombre ?? '').toLowerCase().includes(q) ||
+          (l.producto_codigo ?? '').toLowerCase().includes(q)
       )
       .slice(0, 25);
   }, [lineas, search]);
@@ -179,7 +180,7 @@ function CapturarInner() {
     e.preventDefault();
     const q = search.trim().toLowerCase();
     if (!q) return;
-    const exactCode = lineas.find((l) => l.producto_codigo.toLowerCase() === q);
+    const exactCode = lineas.find((l) => (l.producto_codigo ?? '').toLowerCase() === q);
     if (exactCode) {
       seleccionar(exactCode.producto_id);
       return;

--- a/app/rdb/inventario/levantamientos/types.ts
+++ b/app/rdb/inventario/levantamientos/types.ts
@@ -31,7 +31,8 @@ export type FirmarPasoData = {
 export type LineaParaCapturar = {
   linea_id: string;
   producto_id: string;
-  producto_codigo: string;
+  /** erp.productos.codigo es nullable — guardar antes de `.toLowerCase()` u otras ops de string. */
+  producto_codigo: string | null;
   producto_nombre: string;
   unidad: string;
   categoria: string | null;
@@ -44,7 +45,8 @@ export type LineaParaCapturar = {
 export type LineaParaRevisar = {
   linea_id: string;
   producto_id: string;
-  producto_codigo: string;
+  /** erp.productos.codigo es nullable — guardar antes de `.toLowerCase()` u otras ops de string. */
+  producto_codigo: string | null;
   producto_nombre: string;
   unidad: string;
   categoria: string | null;


### PR DESCRIPTION
## Problema

Tras iniciar la captura de un levantamiento, al escribir/escanear en el buscador salía `Error en RDB — Cannot read properties of null (reading 'toLowerCase')`.

## Causa

`fn_get_lineas_para_capturar` devuelve `producto_codigo` (y `producto_nombre`) desde `erp.productos`, donde **`codigo` es nullable** (la vista Waitry incluso filtra `codigo IS NOT NULL AND codigo <> ''`). El buscador de la pantalla de captura llamaba `.toLowerCase()` directo sobre esos campos → crash cuando una línea sembrada tenía código null. El tipo TS mentía (`producto_codigo: string`), ocultando el caso.

## Fix

- `[id]/capturar/page.tsx`: guard `?? ''` en el filtro fuzzy y en el match exacto del scanner.
- `types.ts`: `producto_codigo` → `string | null` para que TS atrape estos usos a futuro. Los renders JSX ya toleran null.

Code-only, sin cambios de DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)