### PR TITLE
fix(tareas): derivar depto del responsable en el filtro de tareas

### DIFF
--- a/components/tasks/tasks-filters-bar.tsx
+++ b/components/tasks/tasks-filters-bar.tsx
@@ -94,8 +94,14 @@ export function TasksFiltersBar({
         });
       }
     });
+    // Also surface departments derived from the assigned employees, so tasks
+    // created via the UI (departamento_nombre = null) are still filterable.
+    empleados.forEach((e) => {
+      const d = e.departamento?.trim();
+      if (d) deptos.add(d);
+    });
     return [...deptos].sort().map((d) => ({ id: d, label: d }));
-  }, [tasks, isRich]);
+  }, [tasks, isRich, empleados]);
 
   return (
     <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] p-4">

--- a/components/tasks/tasks-module.tsx
+++ b/components/tasks/tasks-module.tsx
@@ -216,7 +216,9 @@ export function TasksModule({
       const { data: empData } = await supabase
         .schema('erp')
         .from('empleados')
-        .select('id, persona:persona_id(nombre, apellido_paterno)')
+        .select(
+          'id, persona:persona_id(nombre, apellido_paterno), departamento:departamento_id(nombre)'
+        )
         .in('empresa_id', ids)
         .eq('activo', true)
         .is('deleted_at', null);
@@ -224,9 +226,12 @@ export function TasksModule({
       const mapped: Empleado[] = (empData ?? []).map((e: Record<string, unknown>) => {
         const persona = Array.isArray(e.persona) ? e.persona[0] : e.persona;
         const p = (persona ?? null) as { nombre?: string; apellido_paterno?: string } | null;
+        const depto = Array.isArray(e.departamento) ? e.departamento[0] : e.departamento;
+        const d = (depto ?? null) as { nombre?: string } | null;
         return {
           id: e.id as string,
           nombre: [p?.nombre, p?.apellido_paterno].filter(Boolean).join(' '),
+          departamento: d?.nombre ?? null,
         };
       });
       setEmpleados(mapped);
@@ -765,12 +770,15 @@ export function TasksModule({
     if (search) {
       const s = search.toLowerCase();
       if (isRich) {
-        const responsableName = empleadoMap.get(t.asignado_a ?? '')?.nombre?.toLowerCase() ?? '';
+        const responsable = empleadoMap.get(t.asignado_a ?? '');
+        const responsableName = responsable?.nombre?.toLowerCase() ?? '';
+        const responsableDepto = responsable?.departamento?.toLowerCase() ?? '';
         if (
           !t.titulo.toLowerCase().includes(s) &&
           !t.descripcion?.toLowerCase().includes(s) &&
           !t.departamento_nombre?.toLowerCase().includes(s) &&
-          !responsableName.includes(s)
+          !responsableName.includes(s) &&
+          !responsableDepto.includes(s)
         )
           return false;
       } else if (!t.titulo.toLowerCase().includes(s)) {
@@ -789,6 +797,8 @@ export function TasksModule({
         .split(',')
         .map((d) => d.trim())
         .filter(Boolean);
+      const responsableDepto = empleadoMap.get(t.asignado_a ?? '')?.departamento;
+      if (responsableDepto) taskDeptos.push(responsableDepto);
       if (!taskDeptos.includes(filterDepto)) return false;
     }
     return true;

--- a/components/tasks/tasks-shared.tsx
+++ b/components/tasks/tasks-shared.tsx
@@ -50,7 +50,7 @@ export type ErpTask = {
   departamento_nombre?: string | null;
 };
 
-export type Empleado = { id: string; nombre: string };
+export type Empleado = { id: string; nombre: string; departamento?: string | null };
 
 export type TaskUpdateRow = {
   id: string;


### PR DESCRIPTION
## Problema

En Tareas — DILESA, el filtro **Depto** no mostraba una tarea asignada a alguien de "maquinaria" (ej. Gustavo) al filtrar por ese departamento.

## Causa

El filtro comparaba únicamente contra `tasks.departamento_nombre`, columna que **solo** se llenó con el import CSV de Coda. Las tareas creadas desde la UI dejan `departamento_nombre = NULL` — nunca se deriva del departamento del responsable. Por eso no matcheaban.

## Fix

- El módulo ahora carga el departamento del empleado vía `empleados.departamento_id → departamentos.nombre`.
- El **filtro**, el **buscador** y las **opciones del dropdown** consideran el departamento del responsable (`asignado_a`) además del `departamento_nombre` legacy.
- Sin migración de datos: es puramente derivación en cliente.

## Verificación
- `typecheck` ✅ · `lint` (0 errores) ✅ · `format:check` ✅ · `test:coverage` 2248 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)