### PR TITLE
fix(dilesa-pld): el piso de liquidaciones resta el residual de precio absorbido por DILESA (NC)

### DIFF
--- a/app/api/dilesa/ventas/[id]/revision-pld/route.ts
+++ b/app/api/dilesa/ventas/[id]/revision-pld/route.ts
@@ -282,7 +282,7 @@ export async function POST(_req: NextRequest, { params }: Params) {
     .schema('dilesa')
     .from('ventas')
     .select(
-      'id, empresa_id, persona_id, unidad_id, notario_id, valor_escrituracion, monto_avaluo, numero_escritura, fecha_escritura'
+      'id, empresa_id, persona_id, unidad_id, notario_id, valor_escrituracion, monto_avaluo, numero_escritura, fecha_escritura, saldo_residual_resolucion'
     )
     .eq('id', ventaId)
     .is('deleted_at', null)
@@ -300,6 +300,7 @@ export async function POST(_req: NextRequest, { params }: Params) {
     monto_avaluo: number | null;
     numero_escritura: string | null;
     fecha_escritura: string | null;
+    saldo_residual_resolucion: 'cobrar' | 'absorber' | null;
   };
 
   const [{ data: empresa }, { data: persona }, { data: unidad }, notaria, { data: abonos }, cuad] =
@@ -360,6 +361,13 @@ export async function POST(_req: NextRequest, { params }: Params) {
     // desglose corregido (`dilesa-descuento-perdonado-motor`) `descuentoAplicado` ==
     // descuento real, así que el sobreprecio que NO perdona ya no infla este hueco.
     descuentoPerdonado: Math.max(0, (cuad?.descuentoAplicado ?? 0) - (cuad?.chequePagado ?? 0)),
+    // Residual del PRECIO que DILESA absorbe con NC (crédito + enganche < valor de
+    // escrituración y Dirección lo resolvió como `absorber` en la dictaminación). Ese
+    // monto no entra como liquidación — baja el piso de la banda. Si el residual se
+    // `cobrar` (pagaré) el cliente sí lo paga → no se resta. `saldoPrecioPorCubrir` es
+    // el residual antes de la resolución; solo cuenta cuando se absorbe.
+    saldoPrecioAbsorbidoDilesa:
+      venta.saldo_residual_resolucion === 'absorber' ? (cuad?.saldoPrecioPorCubrir ?? 0) : 0,
   };
 
   // ── PDFs del ciclo ───────────────────────────────────────────────

--- a/lib/dilesa/captura/pld-revision.test.ts
+++ b/lib/dilesa/captura/pld-revision.test.ts
@@ -69,6 +69,9 @@ function expediente(partial: Partial<ExpedientePld> = {}): ExpedientePld {
     // Descuento $15,000 (gastos escrituración), $13,378 girados a notaría →
     // $1,622 perdonados = el hueco exacto entre liquidaciones y pactado.
     descuentoPerdonado: 1622,
+    // Sin residual de precio absorbido por default (el crédito + enganche cubren el
+    // precio). El caso Julio Cesar lo sobreescribe abajo.
+    saldoPrecioAbsorbidoDilesa: 0,
     ...partial,
   };
 }
@@ -162,6 +165,48 @@ describe('cruzarPldConExpediente — liquidaciones dentro de la banda [precio, d
     );
     expect(porClave(checks, 'liq_vs_pactado')?.ok).toBe(true); // ≥ piso 1,392,050
     expect(porClave(checks, 'liq_vs_depositos')?.ok).toBe(true); // ≤ techo 1,428,127
+  });
+
+  it('Julio Cesar M11-L4: DILESA absorbe el residual del precio con NC → baja el piso, pasa', () => {
+    // Crédito 903,360 + enganche 21,951 = 925,311 (todo lo recibido) < valor de
+    // escrituración 930,000. DILESA absorbe el residual 4,689.28 con una nota de
+    // crédito (resolucion='absorber'). El aviso reporta las liquidaciones recibidas.
+    // Sin restar el absorbido el piso era 930,000 → falso descuadre de 4,689.28.
+    const checks = cruzarPldConExpediente(
+      extraccion({
+        valorPactado: 930000,
+        liquidaciones: [{ fecha: '2026-06-01', monto: 925310.72 }],
+      }),
+      expediente({
+        valorEscrituracion: 930000,
+        depositos: [903360, 21951], // crédito + enganche = 925,311 (techo)
+        descuentoPerdonado: 0,
+        saldoPrecioAbsorbidoDilesa: 4689.28,
+      })
+    );
+    expect(porClave(checks, 'liq_vs_pactado')?.ok).toBe(true); // ≥ piso 925,310.72
+    expect(porClave(checks, 'liq_vs_depositos')?.ok).toBe(true); // ≤ techo 925,311
+  });
+
+  it('residual de precio SIN absorber (cobrar/null): el piso NO baja → warning', () => {
+    // Mismo hueco, pero el residual NO se absorbe (p.ej. resolucion='cobrar' o sin
+    // resolver) → saldoPrecioAbsorbidoDilesa=0. El piso sigue en 930,000: el aviso
+    // debe reportar también lo que el cliente pagará (pagaré) o resolverse.
+    const checks = cruzarPldConExpediente(
+      extraccion({
+        valorPactado: 930000,
+        liquidaciones: [{ fecha: '2026-06-01', monto: 925310.72 }],
+      }),
+      expediente({
+        valorEscrituracion: 930000,
+        depositos: [903360, 21951],
+        descuentoPerdonado: 0,
+        saldoPrecioAbsorbidoDilesa: 0,
+      })
+    );
+    const c = porClave(checks, 'liq_vs_pactado');
+    expect(c?.ok).toBe(false);
+    expect(c?.detalle).toContain('930,000');
   });
 
   it('sub-declaración (por debajo del piso): liq_vs_pactado en warning', () => {

--- a/lib/dilesa/captura/pld-revision.ts
+++ b/lib/dilesa/captura/pld-revision.ts
@@ -109,9 +109,22 @@ export type ExpedientePld = {
    * por debajo del valor pactado EXACTAMENTE en este monto — es el descuento
    * que no entró como pago (el cheque a notaría sí entró y luego salió). Sin
    * esto, una operación con descuento marca un falso descuadre por el monto del
-   * descuento perdonado. 0 cuando no hay descuento.
+   * descuento perdonado. 0 cuando no hay descuento. Es el hueco del lado GASTOS.
    */
   descuentoPerdonado: number;
+  /**
+   * Saldo del PRECIO que DILESA absorbe con una nota de crédito (`saldoPrecio-
+   * PorCubrir` de la cuadratura cuando Dirección lo resuelve como `absorber` en
+   * la dictaminación). Cuando el crédito + enganche no alcanzan el valor de
+   * escrituración y DILESA come la diferencia (NC autorizada por Dirección), esa
+   * diferencia NUNCA entra como liquidación — el aviso reporta solo lo que se
+   * recibió (crédito + enganche). Sin restarlo, el piso de liquidaciones marca un
+   * falso descuadre por el monto de la NC. Es el hueco del lado PRECIO, distinto
+   * de `descuentoPerdonado` (gastos); no se doble-cuentan. 0 cuando el precio se
+   * cubre completo o el residual se resuelve como `cobrar` (pagaré: el cliente sí
+   * lo paga). Ver [[reference_dilesa_pld_liquidaciones_banda]].
+   */
+  saldoPrecioAbsorbidoDilesa: number;
 };
 
 // ── Normalización ───────────────────────────────────────────────────────
@@ -347,21 +360,34 @@ export function cruzarPldConExpediente(ext: ExtraccionPld, exp: ExpedientePld): 
   //    solo el PRECIO (el crédito que liquida el inmueble) o el precio MÁS el
   //    enganche que el cliente aportó (parte del cual fondea gastos notariales). Por
   //    eso no se exige igualdad exacta sino una banda [piso, techo]:
-  //      - piso  = valor pactado − descuento perdonado (no cobrado): el precio que
-  //                realmente liquidó el inmueble. Por debajo = sub-declaración.
+  //      - piso  = valor pactado − descuento perdonado (gastos) − saldo del precio
+  //                absorbido por DILESA vía NC (precio): el precio que REALMENTE
+  //                liquidó el inmueble, neto de lo que DILESA no cobra. Por debajo
+  //                = sub-declaración.
   //      - techo = total de depósitos recibidos (crédito + enganche): todo el dinero
   //                que entró. Por arriba = el aviso declara más de lo que se recibió.
   //    El ancho de la banda = el enganche que excede el precio (lo que fondea gastos)
   //    — exactamente la ambigüedad legítima de captura. Casos reales: Christopher
   //    M3-L16 (reportó solo el precio → cae en el piso) y Nancy M22-L1 (reportó todos
-  //    los depósitos → cae en el techo); ambos cuadran.
+  //    los depósitos → cae en el techo); ambos cuadran. Julio Cesar M11-L4: el crédito
+  //    + enganche NO alcanzan el valor de escrituración y DILESA absorbe el residual
+  //    ($4,689) con una NC → sin restarlo el piso marcaba un falso descuadre (#1160+).
   const totalLiquidaciones = ext.liquidaciones.reduce((s, l) => s + (l.monto || 0), 0);
   const perdonado = Math.max(0, exp.descuentoPerdonado);
+  const absorbidoPrecio = Math.max(0, exp.saldoPrecioAbsorbidoDilesa);
   const totalDepositos = exp.depositos.reduce((s, m) => s + (m || 0), 0);
-  const piso = ext.valorPactado - perdonado;
+  const piso = ext.valorPactado - perdonado - absorbidoPrecio;
   const techo = Math.max(totalDepositos, piso); // si los depósitos no alcanzan el piso, la banda colapsa al precio
 
-  // Piso: el aviso no declara MENOS que el precio liquidado (neto del perdón).
+  // Piso: el aviso no declara MENOS que el precio liquidado (neto de lo que DILESA
+  // no cobra: descuento perdonado del lado gastos + residual del precio absorbido
+  // con nota de crédito).
+  const deducciones: string[] = [];
+  if (perdonado > 0) deducciones.push(`descuento perdonado ${money(perdonado)}`);
+  if (absorbidoPrecio > 0)
+    deducciones.push(
+      `saldo del precio absorbido por DILESA (nota de crédito) ${money(absorbidoPrecio)}`
+    );
   checks.push(
     totalLiquidaciones >= piso - 1
       ? ok('liq_vs_pactado', 'Σ liquidaciones ≥ precio (neto de descuento)', 'warning')
@@ -369,8 +395,8 @@ export function cruzarPldConExpediente(ext: ExtraccionPld, exp: ExpedientePld): 
           'liq_vs_pactado',
           'Σ liquidaciones ≥ precio (neto de descuento)',
           'warning',
-          perdonado > 0
-            ? `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el precio neto del descuento perdonado (${money(perdonado)}) es ${money(piso)} (valor pactado ${money(ext.valorPactado)}). Faltan ${money(piso - totalLiquidaciones)}.`
+          deducciones.length > 0
+            ? `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el precio neto (valor pactado ${money(ext.valorPactado)} − ${deducciones.join(' − ')}) es ${money(piso)}. Faltan ${money(piso - totalLiquidaciones)}.`
             : `Las liquidaciones del aviso suman ${money(totalLiquidaciones)}; el valor pactado es ${money(ext.valorPactado)} (faltan ${money(piso - totalLiquidaciones)}).`
         )
   );


### PR DESCRIPTION
## Qué

El check `liq_vs_pactado` del Aviso PLD (Fase 13, modelo de banda `[piso, techo]` #1150) daba un **falso warning** cuando DILESA absorbe parte del precio con una nota de crédito.

## Por qué

El piso solo restaba el descuento perdonado del lado **gastos** (`descuentoAplicado − cheque`). No contemplaba el otro tipo de "dinero que DILESA no cobra": el **residual del precio** que se absorbe con NC (`saldoPrecioPorCubrir`, cuando Dirección lo resuelve como `absorber`).

**Caso Julio Cesar M11-L4-LDLE:**
- Valor escrituración: **$930,000**
- Crédito ($903,360) + enganche ($21,951) = **$925,310.72** (todo lo recibido = las liquidaciones del aviso)
- DILESA absorbe el residual **$4,689.28** con nota de crédito (`resolucion='absorber'`, confirmado por la card "Cobertura del precio" y los checks de facturación en verde)

El piso quedaba en $930,000 → *"Σ liquidaciones ≥ precio — faltan $4,689.28"*.

## El fix

- `ExpedientePld` gana `saldoPrecioAbsorbidoDilesa`: el residual de precio que DILESA absorbe con NC.
- La ruta `revision-pld` lo alimenta desde `cuad.saldoPrecioPorCubrir` **solo cuando** `saldo_residual_resolucion === 'absorber'` (si es `cobrar`/pagaré, el cliente sí lo paga → no se resta).
- El piso: `valorPactado − perdonado − saldoPrecioAbsorbidoDilesa`. Es el hueco del lado **precio**, distinto de `descuentoPerdonado` (gastos); no se doble-cuentan.

## Verificación

- Typecheck, lint, format ✓
- 2 tests nuevos (caso Julio Cesar pasa; residual sin absorber sigue en warning) — **2250 tests verdes**
- Sin migración (lógica TS pura)

🤖 Generated with [Claude Code](https://claude.com/claude-code)