### PR TITLE
fix(dilesa-resumen-consejo): corte de mes en TZ local, no UTC — promueve iniciativa fechas-tz

### DIFF
--- a/docs/planning/fechas-tz.md
+++ b/docs/planning/fechas-tz.md
@@ -1,0 +1,112 @@
+# Iniciativa — Fechas y timezone: erradicar el "hoy UTC" del repo
+
+**Slug:** `fechas-tz`
+**Empresas:** Todas (DILESA, ANSA, COAGAN, RDB, SANREN)
+**Schemas afectados:** Sin migración de schema en S0. El barrido (S1-S3) toca código TS en `app/**` y `lib/**` (61 archivos con `new Date().toISOString().slice(0, 10)`); S3 audita datos en `dilesa.venta_fases.fecha`, `dilesa.ruv (fecha_carga)`, `dilesa.anteproyectos (fecha_completada)` y defaults `CURRENT_DATE` en funciones de `erp` (CxP `p_fecha_emision`).
+**Estado:** in_progress
+**Próximo hito:** S1 — migrar server actions y formularios de captura a `fechaISOMatamoros()`
+**Dueño:** Beto
+**Creada:** 2026-07-01
+**Última actualización:** 2026-07-01
+
+> Detonante: el 30-jun-2026 a las 20:00 (CDT) el resumen diario al consejo de
+> DILESA llegó con las ventas acumuladas del mes en **cero**. A esa hora el
+> reloj UTC ya estaba en 1-jul 01:00: el corte de mes se calculaba con
+> `Date.UTC(getUTCFullYear(), getUTCMonth(), 1)` → `2026-07-01` → el filtro del
+> mes no encontró nada. Beto pidió un análisis profundo de fechas en todo el
+> repo; el barrido encontró que es un patrón sistémico, no un caso aislado.
+
+## Problema
+
+La operación vive en `America/Matamoros` (frontera, DST real: CST UTC-6
+invierno / CDT UTC-5 verano), pero Vercel y Postgres corren en UTC. Entre las
+18:00-19:00 locales y la medianoche, **el día/mes UTC ya es el siguiente**.
+Todo código que derive "hoy" o "el mes actual" de UTC se desfasa un día en esa
+ventana — que es exactamente cuando más se captura (tarde-noche) y cuando
+salen los reportes (8PM).
+
+Los helpers correctos **ya existen** (`lib/fecha-mx.ts`: `fechaISOMatamoros`,
+`inicioMesMatamoros`; `lib/timezone.ts`; `lib/briefing/fecha.ts`), pero la
+adopción es de 3 archivos contra 61 con el antipatrón
+`new Date().toISOString().slice(0, 10)` — que devuelve el día UTC **también en
+el navegador** (`toISOString` siempre es UTC).
+
+## Outcome
+
+Ningún cálculo de "hoy/este mes" en código de negocio deriva de UTC. Un lint
+guard impide que el antipatrón regrese. Los datos históricos con fecha +1 están
+detectados y corregidos (o descartados como irrelevantes).
+
+## Alcance
+
+1. **S0 — Hotfix resumen consejo (este PR).** `inicioMes`/`inicio3m`/
+   `fechaTituloCST` en `lib/dilesa/resumen-consejo-email.ts` → helpers de
+   `fecha-mx.ts`. Tests de regresión con el instante exacto del incidente.
+2. **S1 — Server actions y formularios de captura.** Los ~61 archivos, en dos
+   olas por riesgo: (a) server actions que escriben directo sin ojo humano
+   (`app/dilesa/ruv/actions.ts` `fecha_carga`,
+   `app/dilesa/proyectos/anteproyectos/actions.ts` `fecha_completada`); (b)
+   defaults de formularios de captura de fases
+   (`app/dilesa/ventas/[id]/capturar/*`, `ventas/nueva`, forms de
+   notario/valuador por token) donde el operador puede aceptar un default +1
+   por la noche.
+3. **S2 — Lint guard.** Regla ESLint (`no-restricted-syntax`) que prohíba
+   `new Date().toISOString().slice(0, 10)` / `.slice(0, 7)` y
+   `toLocaleDateString` sin `timeZone` en `app/**` y `lib/**`, apuntando a
+   `fecha-mx.ts`.
+4. **S3 — Auditoría de datos históricos.** Detectar fechas +1 ya grabadas:
+   filas cuya columna `date` = día UTC de un `created_at` entre 00:00-06:00 UTC
+   (ventana donde local ≠ UTC). Tablas: `dilesa.venta_fases`,
+   `ruv.fecha_carga`, `anteproyectos.fecha_completada`. Corrección con OK de
+   Beto (toca datos de fases → deriva KPIs/reportes).
+5. **S4 — Convención DST-real vs offset-fijo.** Decidir y documentar (ADR
+   corto o sección en CLAUDE.md): `America/Matamoros` (DST real) como default;
+   `Etc/GMT+6` fijo solo donde esté razonado (hold-cola lo documenta;
+   Playtomic/RDB es correcto por operación del club). Migrar el cron
+   `dilesa-encuestas` a la convención que se decida. Revisar `CURRENT_DATE`
+   como default en funciones SQL de CxP.
+
+**Fuera de alcance:** display cosmético (`toLocaleDateString` sin `timeZone`
+en componentes client) se arregla oportunista al tocar cada archivo, no como
+barrido dedicado. `calendario-habil.ts` (naive-local, hoy solo client) se
+documenta en S4, no se reescribe.
+
+## Riesgos
+
+- **S3 toca datos financieros/operativos** (`venta_fases` alimenta KPIs,
+  comisiones, reportes al consejo) → cada UPDATE con evidencia y OK explícito.
+- Falsos positivos en S3: una captura legítima de madrugada local (00:00-01:00
+  CST) también cae en la ventana UTC 06:00-07:00 — el detector usa la ventana
+  00:00-06:00 UTC que en local es 18:00-24:00, pero el operador pudo
+  genuinamente querer la fecha siguiente en casos de corrección manual.
+  Revisión caso por caso, no UPDATE masivo.
+- El lint guard (S2) puede tener excepciones legítimas (timestamps UTC
+  intencionales, p.ej. `notif_*_at`) → la regla apunta solo al slice de
+  fecha-calendario, no a `toISOString()` completo.
+
+## Métricas de éxito
+
+- 0 ocurrencias de `new Date().toISOString().slice(0, 10)` en `app/**`/`lib/**`
+  (hoy: 61 archivos).
+- Resumen al consejo del último día de mes con acumulado correcto (verificable
+  el 31-jul-2026).
+- Lint guard activo en CI.
+
+## Decisiones registradas
+
+- **2026-07-01 — El hotfix S0 viaja con la promoción de la iniciativa** en el
+  mismo PR: el fix es chico, urgente (el correo de hoy 8PM ya debe salir bien)
+  y es el caso testigo del problema que la iniciativa ataca.
+- **2026-07-01 — `fechaTituloCST` pasa de offset fijo -6 a TZ real** vía
+  `Intl` con `es-MX` (mismo output, DST correcto). Se conserva el nombre
+  exportado para no tocar el cron en el hotfix.
+
+## Bitácora
+
+- **2026-07-01 — Análisis profundo + S0.** Barrido exhaustivo del repo
+  (helpers, 61 archivos con "hoy UTC", crons, SQL, inconsistencia
+  DST-real/offset-fijo). Causa raíz del acumulado en cero confirmada en
+  `resumen-consejo-email.ts:901` (mes UTC). Hotfix aplicado: `inicioMes` →
+  `inicioMesMatamoros()`, `inicio3m` sobre fecha local, `fechaTituloCST` con
+  TZ real. Tests de regresión con el instante del incidente
+  (2026-07-01T01:00:00Z). PR pendiente de número al abrir.

--- a/lib/dilesa/resumen-consejo-email.test.ts
+++ b/lib/dilesa/resumen-consejo-email.test.ts
@@ -127,9 +127,17 @@ describe('relojMatamoros — envío 8pm local con DST real', () => {
 });
 
 describe('fechaTituloCST', () => {
-  it('aplica el offset CST (UTC-6) al título', () => {
+  it('usa el calendario local de Matamoros', () => {
     expect(fechaTituloCST(new Date('2026-06-07T02:00:00Z'))).toBe('6 de junio de 2026');
     expect(fechaTituloCST(new Date('2026-06-07T18:00:00Z'))).toBe('7 de junio de 2026');
+  });
+
+  it('resuelve el DST real, no un offset fijo -6', () => {
+    // 2026-07-01 05:30 UTC = 2026-07-01 00:30 en Matamoros (CDT, UTC-5); un
+    // offset fijo -6 daría 23:30 del 30 de junio.
+    expect(fechaTituloCST(new Date('2026-07-01T05:30:00Z'))).toBe('1 de julio de 2026');
+    // El instante del incidente del 30-jun-2026 (20:00 locales, mes UTC ya en julio).
+    expect(fechaTituloCST(new Date('2026-07-01T01:00:00Z'))).toBe('30 de junio de 2026');
   });
 });
 

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -17,7 +17,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { KpisDelDia } from './resumen-consejo-kpis';
-import { fechaISOMatamoros } from '@/lib/fecha-mx';
+import { fechaISOMatamoros, inicioMesMatamoros } from '@/lib/fecha-mx';
 
 // ── Tipos por sección ───────────────────────────────────────────────────────
 
@@ -840,27 +840,14 @@ export function renderResumenConsejoHtml(
 
 // ── Fetch ────────────────────────────────────────────────────────────────────
 
-const MONTH_NAMES = [
-  'enero',
-  'febrero',
-  'marzo',
-  'abril',
-  'mayo',
-  'junio',
-  'julio',
-  'agosto',
-  'septiembre',
-  'octubre',
-  'noviembre',
-  'diciembre',
-];
-
-/** Fecha-título en español (ej. "7 de junio de 2026"), TZ America/Matamoros. */
+/** Fecha-título en español (ej. "7 de junio de 2026"), TZ America/Matamoros (DST real). */
 export function fechaTituloCST(now: Date): string {
-  // America/Matamoros = UTC-6 (CST) / UTC-5 (CDT). Aproximación CST fija para el
-  // título; el guard de domingo del cron usa el TZ real.
-  const cst = new Date(now.getTime() - 6 * 3600 * 1000);
-  return `${cst.getUTCDate()} de ${MONTH_NAMES[cst.getUTCMonth()]} de ${cst.getUTCFullYear()}`;
+  return new Intl.DateTimeFormat('es-MX', {
+    timeZone: 'America/Matamoros',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(now);
 }
 
 /** Hora objetivo de envío en horario local de Matamoros (8pm). */
@@ -898,17 +885,16 @@ export async function fetchResumenConsejoData(
 ): Promise<ResumenConsejoData> {
   const dilesa = supabase.schema('dilesa');
   const erp = supabase.schema('erp');
-  const inicioMes = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
-    .toISOString()
-    .slice(0, 10);
-  // "Hoy" = fecha calendario local de Matamoros (el correo sale a las 20:00
-  // locales, ya con el día consumido). `venta_fases.fecha` es un `date` local,
-  // así que comparamos contra la misma fecha local — no contra el día UTC.
+  // "Hoy" y "el mes" = calendario LOCAL de Matamoros. El correo sale a las 20:00
+  // locales, cuando el día/mes UTC ya rodó al siguiente — un corte en UTC vacía
+  // el acumulado del mes en cada cierre (bug del 30-jun-2026: acumulado en cero).
+  // `venta_fases.fecha` es un `date` local, así que comparamos fecha local.
+  const inicioMes = inicioMesMatamoros(now);
   const hoyISO = fechaISOMatamoros(now);
-  // Ventana de absorción: 3 meses móviles hasta hoy.
-  const inicio3m = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - ABSORCION_VENTANA_MESES, now.getUTCDate())
-  )
+  // Ventana de absorción: 3 meses móviles hasta hoy (aritmética de calendario
+  // sobre los componentes de la fecha local; Date.UTC solo resuelve el rollover).
+  const [hoyY, hoyM, hoyD] = hoyISO.split('-').map(Number);
+  const inicio3m = new Date(Date.UTC(hoyY, hoyM - 1 - ABSORCION_VENTANA_MESES, hoyD))
     .toISOString()
     .slice(0, 10);
 

--- a/lib/fecha-mx.test.ts
+++ b/lib/fecha-mx.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { fechaISOMatamoros } from './fecha-mx';
+import { fechaISOMatamoros, inicioMesMatamoros } from './fecha-mx';
 
 describe('fechaISOMatamoros', () => {
   it('invierno (CST, UTC-6): a las 20:00 locales el día UTC ya avanzó, pero la fecha local es la de hoy', () => {
@@ -20,5 +20,22 @@ describe('fechaISOMatamoros', () => {
   it('justo antes de medianoche local (invierno) cae en el día correcto', () => {
     // 2026-02-10 05:30 UTC = 2026-02-09 23:30 en Matamoros (CST, UTC-6).
     expect(fechaISOMatamoros(new Date('2026-02-10T05:30:00Z'))).toBe('2026-02-09');
+  });
+});
+
+describe('inicioMesMatamoros', () => {
+  it('cierre de mes a las 20:00 locales: el mes UTC ya es el siguiente, el local no (bug 30-jun-2026)', () => {
+    // 2026-07-01 01:00 UTC = 2026-06-30 20:00 en Matamoros (CDT) — el instante
+    // exacto en que el resumen al consejo salió con el acumulado del mes en cero.
+    expect(inicioMesMatamoros(new Date('2026-07-01T01:00:00Z'))).toBe('2026-06-01');
+  });
+
+  it('mismo cruce en invierno (CST, UTC-6)', () => {
+    // 2026-02-01 02:00 UTC = 2026-01-31 20:00 en Matamoros (CST).
+    expect(inicioMesMatamoros(new Date('2026-02-01T02:00:00Z'))).toBe('2026-01-01');
+  });
+
+  it('media tarde a mitad de mes → primer día del mes local', () => {
+    expect(inicioMesMatamoros(new Date('2026-06-15T18:00:00Z'))).toBe('2026-06-01');
   });
 });


### PR DESCRIPTION
## Qué pasó

El 30-jun-2026 a las 20:00 (CDT, UTC-5) el resumen diario al consejo de DILESA llegó con las **ventas acumuladas del mes en cero**. A esa hora el reloj UTC ya estaba en 1-jul 01:00: `inicioMes` se calculaba con `Date.UTC(getUTCFullYear(), getUTCMonth(), 1)` → `'2026-07-01'` → el filtro `gte('fecha', inicioMes)` de asignaciones/escrituras del mes no encontró nada.

El bug pegaba **todo el verano**, no solo en fin de mes: cada correo de las 8PM contaba el mes con el corte desfasado un día; el 30-jun fue el caso extremo (mes completo → cero).

## Fix (S0 de `fechas-tz`)

- `inicioMes` → `inicioMesMatamoros()` — helper que **ya existía** en `lib/fecha-mx.ts`, escrito exactamente para esto (el archivo de al lado, `hoyISO`, ya lo hacía bien).
- `inicio3m` (ventana de absorción 3M) → aritmética de calendario sobre la fecha local.
- `fechaTituloCST` → `Intl` con `America/Matamoros` (DST real; antes offset fijo -6).
- Tests de regresión con el instante exacto del incidente (`2026-07-01T01:00:00Z`) en `fecha-mx.test.ts` y `resumen-consejo-email.test.ts`, incluyendo un caso que distingue DST real de offset fijo.

## Promoción de iniciativa

`docs/planning/fechas-tz.md` — el barrido del repo encontró que es patrón sistémico: **61 archivos** con `new Date().toISOString().slice(0, 10)` ("hoy" en UTC, también en browser) contra 3 que usan el helper canónico. Sprints: S1 server actions + formularios de captura, S2 lint guard, S3 auditoría de datos históricos con fecha +1, S4 convención DST-real vs offset-fijo. La fila en `## Activas` la regenera el workflow post-merge.

## Verificación

- `typecheck` / `lint` / `format:check` / `initiatives:validate` ✅
- `test:coverage`: 180 files, 2,254 tests ✅
- Sin migraciones ni cambios de schema.
- El correo de hoy 8PM ya debe salir con el acumulado de julio correcto (día 1 — verificable de inmediato: debe mostrar lo del día, no cero por estar en "agosto").

🤖 Generated with [Claude Code](https://claude.com/claude-code)