### PR TITLE
fix(fechas-tz): S1+S2 — «hoy» local de Matamoros en todo el repo + lint guard

### DIFF
--- a/app/api/dilesa/encuesta/[token]/route.ts
+++ b/app/api/dilesa/encuesta/[token]/route.ts
@@ -15,6 +15,7 @@ import { verifyEncuestaToken } from '@/lib/dilesa/encuesta-token';
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { nombreFase } from '@/lib/dilesa/fases';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const FASE_POSICION = 16;
 const FASE_NOMBRE = nombreFase(FASE_POSICION);
@@ -94,7 +95,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ token: 
       .insert({
         empresa_id: DILESA_EMPRESA_ID,
         venta_id: ventaId,
-        programada_para: new Date().toISOString().slice(0, 10),
+        programada_para: hoyISOMatamoros(),
         ...respuestas,
       });
     if (insErr) {
@@ -113,18 +114,15 @@ export async function POST(req: Request, { params }: { params: Promise<{ token: 
     .maybeSingle();
 
   if (!fase16) {
-    await admin
-      .schema('dilesa')
-      .from('venta_fases')
-      .insert({
-        empresa_id: DILESA_EMPRESA_ID,
-        venta_id: ventaId,
-        fase: FASE_NOMBRE,
-        posicion: FASE_POSICION,
-        fecha: new Date().toISOString().slice(0, 10),
-        registrado_por: null,
-        notas: 'Encuesta respondida por el cliente (magic link).',
-      });
+    await admin.schema('dilesa').from('venta_fases').insert({
+      empresa_id: DILESA_EMPRESA_ID,
+      venta_id: ventaId,
+      fase: FASE_NOMBRE,
+      posicion: FASE_POSICION,
+      fecha: hoyISOMatamoros(),
+      registrado_por: null,
+      notas: 'Encuesta respondida por el cliente (magic link).',
+    });
 
     // Sync del caché fase_actual/posicion — solo avanza, nunca retrocede.
     const { data: venta } = await admin

--- a/app/api/dilesa/valuador/avaluo/[token]/route.ts
+++ b/app/api/dilesa/valuador/avaluo/[token]/route.ts
@@ -32,6 +32,7 @@ import { verifyAvaluoToken } from '@/lib/dilesa/avaluo-token';
 import { buildAdjuntoPath } from '@/lib/storage/path';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { nombreFase } from '@/lib/dilesa/fases';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -223,7 +224,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ token: str
       venta_id: ventaId,
       fase: nombreFase(5),
       posicion: 5,
-      fecha: new Date().toISOString().slice(0, 10),
+      fecha: hoyISOMatamoros(),
       registrado_por: null,
       notas,
     });

--- a/app/api/dilesa/ventas/[id]/cerrar-fase13/route.ts
+++ b/app/api/dilesa/ventas/[id]/cerrar-fase13/route.ts
@@ -38,6 +38,7 @@ import { checkDireccionEmpresa } from '@/lib/auth/direccion-gate';
 import { leerCfdiMetadata } from '@/lib/dilesa/captura/cfdi-validacion';
 import { cargarCuadraturaVenta } from '@/lib/dilesa/cuadratura-server';
 import { requiereNotaCredito } from '@/lib/dilesa/captura/pld-revision';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -306,7 +307,7 @@ export async function POST(req: NextRequest, { params }: Params) {
       venta_id: ventaId,
       fase: nombreFase(FASE),
       posicion: FASE,
-      fecha: new Date().toISOString().slice(0, 10),
+      fecha: hoyISOMatamoros(),
       registrado_por: user.id,
       notas: cierreConOverride ? `Cierre autorizado por Dirección: ${motivoOverride}` : null,
     })

--- a/app/api/dilesa/ventas/[id]/encuesta/enviar/route.ts
+++ b/app/api/dilesa/ventas/[id]/encuesta/enviar/route.ts
@@ -14,6 +14,7 @@ import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { signEncuestaToken } from '@/lib/dilesa/encuesta-token';
 import { sendEncuestaEmail } from '@/lib/dilesa/encuesta-emails';
 import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -109,18 +110,15 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
         })
         .eq('id', enc.id);
     } else {
-      await admin
-        .schema('dilesa')
-        .from('venta_encuestas')
-        .insert({
-          empresa_id: venta.empresa_id,
-          venta_id: id,
-          programada_para: new Date().toISOString().slice(0, 10),
-          estado: 'enviada',
-          canal: 'email',
-          intentos: 1,
-          ultimo_envio_at: new Date().toISOString(),
-        });
+      await admin.schema('dilesa').from('venta_encuestas').insert({
+        empresa_id: venta.empresa_id,
+        venta_id: id,
+        programada_para: hoyISOMatamoros(),
+        estado: 'enviada',
+        canal: 'email',
+        intentos: 1,
+        ultimo_envio_at: new Date().toISOString(),
+      });
     }
   }
 

--- a/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
+++ b/app/api/dilesa/ventas/[id]/pdf/[tipo]/route.tsx
@@ -47,6 +47,7 @@ import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import { formatMontoEnLetras } from '@/lib/format/numero-a-letras';
 import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
 import { getNotaria } from '@/lib/dilesa/notarios';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const TIPOS = [
   'solicitud-asignacion',
@@ -590,7 +591,7 @@ export async function GET(
         : ordinarioSnapshot > 0
           ? Math.round(ordinarioSnapshot * 3 * 100) / 100
           : null;
-    const fechaSuscripcion = cd.cd_fecha_suscripcion ?? new Date().toISOString().slice(0, 10);
+    const fechaSuscripcion = cd.cd_fecha_suscripcion ?? hoyISOMatamoros();
 
     // Desglose de interés ordinario por parcialidad (mismo motor que la
     // preview de la fase 10 — lib/dilesa/pagare-interes.ts).

--- a/app/dilesa/construccion/[id]/page.tsx
+++ b/app/dilesa/construccion/[id]/page.tsx
@@ -47,6 +47,7 @@ import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { RecepcionObraDrawer } from '@/components/dilesa/recepcion-obra-drawer';
 import { HITO_RECEPCION_LABEL } from '@/lib/dilesa/recepcion-checklist';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type Construccion = {
   id: string;
@@ -514,7 +515,7 @@ function DetailInner() {
     if (!obra || !currentUser || palomeoInFlight) return;
     setPalomeoInFlight(plantillaId);
     const sb = createSupabaseBrowserClient();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = hoyISOMatamoros();
     const { data: insRow, error } = await sb
       .schema('dilesa')
       .from('construccion_tareas_terminadas')
@@ -973,7 +974,7 @@ function DetailInner() {
                 size="sm"
                 variant="outline"
                 onClick={() => {
-                  setFechaProgInput(new Date().toISOString().slice(0, 10));
+                  setFechaProgInput(hoyISOMatamoros());
                   setProgramarOpen(true);
                 }}
               >

--- a/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
+++ b/app/dilesa/construccion/contratos/nuevo-obra/page.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/lib/dilesa/proyectos-selector';
 import { buildPartidaIndex, type PartidaGrupo } from '@/lib/compras/partidas';
 import { OBJETOS_COMUNES } from '@/lib/dilesa/objetos-obra';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type Contratista = {
   id: string;
@@ -89,7 +90,7 @@ function NuevoContratoObraBody() {
   const [proyectoId, setProyectoId] = useState('');
   const [partidaId, setPartidaId] = useState('');
   const [tipo, setTipo] = useState<string>('urbanizacion');
-  const [fechaContrato, setFechaContrato] = useState(new Date().toISOString().slice(0, 10));
+  const [fechaContrato, setFechaContrato] = useState(hoyISOMatamoros());
   const [valorTotal, setValorTotal] = useState('');
   // Defaults: anticipo y fianza en 0 (los locales no llevan; se capturan si aplican),
   // retención en 5 (el fondo de garantía estándar — la garantía real cuando no hay fianza).
@@ -281,7 +282,7 @@ function NuevoContratoObraBody() {
 
   const codigoSugerido = useMemo(() => {
     if (!contratistaSel) return '';
-    const year = (fechaContrato || new Date().toISOString().slice(0, 10)).slice(0, 4);
+    const year = (fechaContrato || hoyISOMatamoros()).slice(0, 4);
     const abrev = contratistaSel.abreviacion ?? 'CONTR';
     const seq = (seqByContratista.get(contratistaId) ?? 0) + 1;
     return `${year}/${seq}-DIE-${abrev}-${TIPO_ABREV[tipo] ?? 'OBRA'}#${seq}`;

--- a/app/dilesa/construccion/contratos/nuevo/page.tsx
+++ b/app/dilesa/construccion/contratos/nuevo/page.tsx
@@ -51,6 +51,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type Contratista = {
   id: string;
@@ -129,7 +130,7 @@ function NuevoContratoForm() {
   const [contratistaId, setContratistaId] = useState<string>('');
   const [proyectoId, setProyectoId] = useState<string>('');
   const [precioMoM2, setPrecioMoM2] = useState<string>('');
-  const [fechaContrato, setFechaContrato] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [fechaContrato, setFechaContrato] = useState<string>(hoyISOMatamoros());
   const [fianzasUrl, setFianzasUrl] = useState<string>('');
   const [codigoOverride, setCodigoOverride] = useState<string>('');
   const [notas, setNotas] = useState<string>('');
@@ -140,7 +141,7 @@ function NuevoContratoForm() {
       key: makeRowKey(),
       unidadId: '',
       productoId: '',
-      fechaArranque: new Date().toISOString().slice(0, 10),
+      fechaArranque: hoyISOMatamoros(),
     },
   ]);
 
@@ -368,7 +369,7 @@ function NuevoContratoForm() {
 
   const codigoSugerido = useMemo(() => {
     if (!contratistaSel) return '';
-    const year = (fechaContrato || new Date().toISOString().slice(0, 10)).slice(0, 4);
+    const year = (fechaContrato || hoyISOMatamoros()).slice(0, 4);
     const abrev = contratistaSel.abreviacion ?? 'CONTR';
     const seq = (seqByContratista.get(contratistaId) ?? 0) + 1;
     return `${year}/${seq}-DIE-${abrev}-CONTRATO#${seq}`;
@@ -416,7 +417,7 @@ function NuevoContratoForm() {
         key: makeRowKey(),
         unidadId: '',
         productoId: '',
-        fechaArranque: fechaContrato || new Date().toISOString().slice(0, 10),
+        fechaArranque: fechaContrato || hoyISOMatamoros(),
       },
     ]);
   }

--- a/app/dilesa/construccion/estimaciones/nueva/page.tsx
+++ b/app/dilesa/construccion/estimaciones/nueva/page.tsx
@@ -40,6 +40,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type ContratistaOpt = {
   id: string;
@@ -85,9 +86,7 @@ function NuevaEstimacionForm() {
 
   // ── Form ────────────────────────────────────────────────────────────
   const [contratistaId, setContratistaId] = useState<string>('');
-  const [fechaCierre, setFechaCierre] = useState<string>(() =>
-    new Date().toISOString().slice(0, 10)
-  );
+  const [fechaCierre, setFechaCierre] = useState<string>(() => hoyISOMatamoros());
   const [retencionPct, setRetencionPct] = useState<string>('5');
 
   // ── Preview ─────────────────────────────────────────────────────────

--- a/app/dilesa/notario/dictamen/[token]/form.tsx
+++ b/app/dilesa/notario/dictamen/[token]/form.tsx
@@ -16,13 +16,14 @@
 
 import { CheckCircle2, Loader2, Save, Upload, XCircle } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 interface Props {
   token: string;
 }
 
 export function DictamenUploadForm({ token }: Props) {
-  const [fecha, setFecha] = useState(new Date().toISOString().slice(0, 10));
+  const [fecha, setFecha] = useState(hoyISOMatamoros());
   const [comentarios, setComentarios] = useState('');
   const [archivo, setArchivo] = useState<File | null>(null);
   const [archivoCondiciones, setArchivoCondiciones] = useState<File | null>(null);

--- a/app/dilesa/proyectos/anteproyectos/actions.ts
+++ b/app/dilesa/proyectos/anteproyectos/actions.ts
@@ -45,6 +45,7 @@ import {
 } from '@/components/dilesa/analisis-financiero-types';
 import { checkDireccionEmpresa } from '@/lib/auth/direccion-gate';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type Result = { ok: true; tareasCreadas: number } | { ok: false; error: string };
 
@@ -170,7 +171,7 @@ export async function updateTareaEstado(
   const supabase = await makeServerClient();
   const patch: { estado: TareaEstado; fecha_completada?: string | null } = { estado };
   if (estado === 'completada') {
-    patch.fecha_completada = new Date().toISOString().slice(0, 10);
+    patch.fecha_completada = hoyISOMatamoros();
   } else {
     // Si el operador desmarca, limpia la fecha (consistente con `vendida`/
     // `entregada` de unidades — el ciclo puede revertir).
@@ -207,7 +208,7 @@ export async function marcarTareasHistorico(proyectoId: string): Promise<SimpleR
   const { error } = await supabase
     .schema('dilesa')
     .from('proyecto_tareas')
-    .update({ estado: 'completada', fecha_completada: new Date().toISOString().slice(0, 10) })
+    .update({ estado: 'completada', fecha_completada: hoyISOMatamoros() })
     .eq('proyecto_id', proyectoId)
     .is('deleted_at', null)
     .in('estado', ['pendiente', 'en_curso', 'bloqueada']);

--- a/app/dilesa/ruv/actions.ts
+++ b/app/dilesa/ruv/actions.ts
@@ -16,6 +16,7 @@ import { createSupabaseServerClient } from '@/lib/supabase-server';
 import { assertNotInPreview } from '@/lib/auth/preview-guard';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export type ActionResult = { ok: true } | { ok: false; error: string };
 
@@ -184,7 +185,7 @@ export async function marcarDocumento(input: MarcarDocumentoInput): Promise<Acti
     updated_at: new Date().toISOString(),
   };
   if (input.estado === 'cargado') {
-    patch.fecha_carga = dateOrNull(input.fechaCarga) ?? new Date().toISOString().slice(0, 10);
+    patch.fecha_carga = dateOrNull(input.fechaCarga) ?? hoyISOMatamoros();
     if (input.archivoUrl !== undefined) patch.archivo_url = input.archivoUrl;
   } else {
     // Volver a pendiente limpia la fecha (el archivo se conserva por si fue error).

--- a/app/dilesa/valuador/avaluo/[token]/form.tsx
+++ b/app/dilesa/valuador/avaluo/[token]/form.tsx
@@ -13,6 +13,7 @@
 
 import { CheckCircle2, Loader2, Save, Upload, XCircle } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 interface Props {
   token: string;
@@ -20,7 +21,7 @@ interface Props {
 
 export function AvaluoUploadForm({ token }: Props) {
   const [monto, setMonto] = useState('');
-  const [fecha, setFecha] = useState(new Date().toISOString().slice(0, 10));
+  const [fecha, setFecha] = useState(hoyISOMatamoros());
   const [comentarios, setComentarios] = useState('');
   const [archivo, setArchivo] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);

--- a/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
@@ -46,6 +46,7 @@ import {
   IndicadorAutoguardado,
   useAutoguardadoCampos,
 } from '@/components/dilesa/captura/autoguardado-campos';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const SLOTS_FASE: SlotColaborativo[] = [
   { rol: 'imagen_detonacion', label: 'Comprobante de transferencia/depósito', requerido: true },
@@ -93,13 +94,11 @@ function CapturarFase12Body() {
   const [fase11Cerrada, setFase11Cerrada] = useState<boolean | null>(null);
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
 
-  const [fechaDetonacion, setFechaDetonacion] = useState<string>(
-    new Date().toISOString().slice(0, 10)
-  );
+  const [fechaDetonacion, setFechaDetonacion] = useState<string>(hoyISOMatamoros());
   const [montoDetonado, setMontoDetonado] = useState<string>('');
   // Autoguardado (ADR-051): firma de lo persistido (arranca = lo cargado).
   const [guardado, setGuardado] = useState<{ fecha: string; monto: string }>({
-    fecha: new Date().toISOString().slice(0, 10),
+    fecha: hoyISOMatamoros(),
     monto: '',
   });
   const docsFase = useDocsFaseColaborativos(ventaId, SLOTS_FASE);
@@ -140,7 +139,7 @@ function CapturarFase12Body() {
       if (v.fecha_detonacion) setFechaDetonacion(v.fecha_detonacion);
       if (v.monto_detonado != null) setMontoDetonado(String(v.monto_detonado));
       setGuardado({
-        fecha: v.fecha_detonacion ?? new Date().toISOString().slice(0, 10),
+        fecha: v.fecha_detonacion ?? hoyISOMatamoros(),
         monto: v.monto_detonado != null ? String(v.monto_detonado) : '',
       });
 

--- a/app/dilesa/ventas/[id]/capturar/16-conformidad/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/16-conformidad/page.tsx
@@ -30,6 +30,7 @@ import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
 import { marcarFase } from '@/lib/dilesa/captura/marcar-fase';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type VentaCtx = {
   id: string;
@@ -225,7 +226,7 @@ function CapturarFase16Body() {
             .insert({
               empresa_id: DILESA_EMPRESA_ID,
               venta_id: venta.id,
-              programada_para: new Date().toISOString().slice(0, 10),
+              programada_para: hoyISOMatamoros(),
               ...respuestas,
             });
       if (encErr) {
@@ -279,15 +280,12 @@ function CapturarFase16Body() {
         .update({ estado: 'sin_respuesta' })
         .eq('id', encuesta.id);
     } else {
-      await sb
-        .schema('dilesa')
-        .from('venta_encuestas')
-        .insert({
-          empresa_id: DILESA_EMPRESA_ID,
-          venta_id: venta.id,
-          programada_para: new Date().toISOString().slice(0, 10),
-          estado: 'sin_respuesta',
-        });
+      await sb.schema('dilesa').from('venta_encuestas').insert({
+        empresa_id: DILESA_EMPRESA_ID,
+        venta_id: venta.id,
+        programada_para: hoyISOMatamoros(),
+        estado: 'sin_respuesta',
+      });
     }
     const result = await marcarFase(sb, {
       ventaId: venta.id,

--- a/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/3-formalizada/page.tsx
@@ -38,6 +38,7 @@ import {
   IndicadorAutoguardado,
   useAutoguardadoCampos,
 } from '@/components/dilesa/captura/autoguardado-campos';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const SLOTS_FASE: SlotColaborativo[] = [
   {
@@ -87,7 +88,7 @@ function CapturarFase3Body() {
   // Solo el descuento autoguarda — la fecha del contrato va a venta_fases.notas al
   // avanzar (sin columna en dilesa.ventas), así que no tiene destino directo.
   const [descuentoGuardado, setDescuentoGuardado] = useState<string>('');
-  const [fechaContrato, setFechaContrato] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [fechaContrato, setFechaContrato] = useState<string>(hoyISOMatamoros());
   const docsFase = useDocsFaseColaborativos(ventaId, SLOTS_FASE);
 
   const [loading, setLoading] = useState(true);
@@ -243,10 +244,7 @@ function CapturarFase3Body() {
           // descuento_total se persiste por la RPC auditada (arriba), no aquí.
           // fecha del contrato — se guarda en venta_fases.fecha vía el override más abajo
         },
-        notas:
-          fechaContrato !== new Date().toISOString().slice(0, 10)
-            ? `Fecha del contrato: ${fechaContrato}`
-            : null,
+        notas: fechaContrato !== hoyISOMatamoros() ? `Fecha del contrato: ${fechaContrato}` : null,
         registradoPor: userId,
       });
 

--- a/app/dilesa/ventas/[id]/capturar/4-solicitud-avaluo/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/4-solicitud-avaluo/page.tsx
@@ -35,6 +35,7 @@ import {
   IndicadorAutoguardado,
   useAutoguardadoCampos,
 } from '@/components/dilesa/captura/autoguardado-campos';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type VentaCtx = {
   id: string;
@@ -74,13 +75,11 @@ function CapturarFase4Body() {
 
   const [valuadores, setValuadores] = useState<Valuador[]>([]);
   const [valuadorId, setValuadorId] = useState<string>('');
-  const [fechaSolicitud, setFechaSolicitud] = useState<string>(
-    new Date().toISOString().slice(0, 10)
-  );
+  const [fechaSolicitud, setFechaSolicitud] = useState<string>(hoyISOMatamoros());
   // Autoguardado (ADR-051): firma de lo último persistido (arranca = lo cargado).
   const [guardado, setGuardado] = useState<{ valuadorId: string; fecha: string }>({
     valuadorId: '',
-    fecha: new Date().toISOString().slice(0, 10),
+    fecha: hoyISOMatamoros(),
   });
 
   const [loading, setLoading] = useState(true);
@@ -121,7 +120,7 @@ function CapturarFase4Body() {
       // Firma persistida inicial = lo cargado (no autoguarda hasta que el usuario cambie).
       setGuardado({
         valuadorId: v.valuador_id ?? '',
-        fecha: v.fecha_solicitud_avaluo ?? new Date().toISOString().slice(0, 10),
+        fecha: v.fecha_solicitud_avaluo ?? hoyISOMatamoros(),
       });
 
       // Fases cerradas y catálogo de valuadores en paralelo.

--- a/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/5-avaluo-cerrado/page.tsx
@@ -50,6 +50,7 @@ import {
   useAutoguardadoCampos,
 } from '@/components/dilesa/captura/autoguardado-campos';
 import { requiereSeguroCalidad } from '@/lib/dilesa/captura/fase-roles';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type VentaCtx = {
   id: string;
@@ -119,11 +120,11 @@ function CapturarFase5Body() {
   }, [venta?.tipo_credito]);
   const docsFase = useDocsFaseColaborativos(ventaId, slotsF5);
   const [montoAvaluo, setMontoAvaluo] = useState<string>('');
-  const [fechaAvaluo, setFechaAvaluo] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [fechaAvaluo, setFechaAvaluo] = useState<string>(hoyISOMatamoros());
   // Autoguardado (ADR-051): firma de lo último persistido (arranca = lo cargado).
   const [guardado, setGuardado] = useState<{ monto: string; fecha: string }>({
     monto: '',
-    fecha: new Date().toISOString().slice(0, 10),
+    fecha: hoyISOMatamoros(),
   });
 
   const [loading, setLoading] = useState(true);
@@ -165,7 +166,7 @@ function CapturarFase5Body() {
       // En corrección (fase ya cerrada) mostramos la fecha real del cierre, no hoy.
       const fechaCargada = v.fecha_avaluo_cerrado
         ? v.fecha_avaluo_cerrado.slice(0, 10)
-        : new Date().toISOString().slice(0, 10);
+        : hoyISOMatamoros();
       if (v.monto_avaluo != null) setMontoAvaluo(montoCargado);
       if (v.fecha_avaluo_cerrado) setFechaAvaluo(fechaCargada);
       setGuardado({ monto: montoCargado, fecha: fechaCargada });

--- a/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/6-inscrita/page.tsx
@@ -48,6 +48,7 @@ import {
   IndicadorAutoguardado,
   useAutoguardadoCampos,
 } from '@/components/dilesa/captura/autoguardado-campos';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type VentaCtx = {
   id: string;
@@ -98,9 +99,7 @@ function CapturarFase6Body() {
   // Número de crédito + institución (lo trae la constancia del banco).
   const [creditoTitularRef, setCreditoTitularRef] = useState<string>('');
   const [creditoCotitularRef, setCreditoCotitularRef] = useState<string>('');
-  const [fechaInscripcion, setFechaInscripcion] = useState<string>(
-    new Date().toISOString().slice(0, 10)
-  );
+  const [fechaInscripcion, setFechaInscripcion] = useState<string>(hoyISOMatamoros());
   // Autoguardado (ADR-051): firma de los campos de crédito persistidos (arranca =
   // lo cargado). La fecha de inscripción NO autoguarda (va a venta_fases.notas).
   const [guardado, setGuardado] = useState({ montoTit: '', montoCo: '', refTit: '', refCo: '' });
@@ -286,7 +285,7 @@ function CapturarFase6Body() {
           credito_cotitular_ref: creditoCotitularRef.trim() || null,
         },
         notas:
-          fechaInscripcion !== new Date().toISOString().slice(0, 10)
+          fechaInscripcion !== hoyISOMatamoros()
             ? `Fecha de inscripción: ${fechaInscripcion}`
             : null,
         registradoPor: userId,

--- a/app/dilesa/ventas/[id]/capturar/7-solicitud-dictamen/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/7-solicitud-dictamen/page.tsx
@@ -37,6 +37,7 @@ import {
   IndicadorAutoguardado,
   useAutoguardadoCampos,
 } from '@/components/dilesa/captura/autoguardado-campos';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type VentaCtx = {
   id: string;
@@ -68,13 +69,11 @@ function CapturarFase7Body() {
 
   const [notarios, setNotarios] = useState<Notaria[]>([]);
   const [notarioId, setNotarioId] = useState<string>('');
-  const [fechaSolicitud, setFechaSolicitud] = useState<string>(
-    new Date().toISOString().slice(0, 10)
-  );
+  const [fechaSolicitud, setFechaSolicitud] = useState<string>(hoyISOMatamoros());
   // Autoguardado (ADR-051): firma de lo último persistido (arranca = lo cargado).
   const [guardado, setGuardado] = useState<{ notarioId: string; fecha: string }>({
     notarioId: '',
-    fecha: new Date().toISOString().slice(0, 10),
+    fecha: hoyISOMatamoros(),
   });
 
   const [loading, setLoading] = useState(true);
@@ -114,7 +113,7 @@ function CapturarFase7Body() {
       if (v.fecha_solicitud_dictamen) setFechaSolicitud(v.fecha_solicitud_dictamen);
       setGuardado({
         notarioId: v.notario_id ?? '',
-        fecha: v.fecha_solicitud_dictamen ?? new Date().toISOString().slice(0, 10),
+        fecha: v.fecha_solicitud_dictamen ?? hoyISOMatamoros(),
       });
 
       const [fRes, notarias] = await Promise.all([

--- a/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/8-dictaminada/page.tsx
@@ -78,6 +78,7 @@ import {
   IndicadorAutoguardado,
   useAutoguardadoCampos,
 } from '@/components/dilesa/captura/autoguardado-campos';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 // Pagaré firmado (decisión Beto 2026-06-24): el documento se recaba en la
 // dictaminación (no en la firma). Mismo adjunto (rol `pagare`) que reconoce la
@@ -265,7 +266,7 @@ function CapturarFase8Body() {
   const [fase7Cerrada, setFase7Cerrada] = useState<boolean | null>(null);
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
 
-  const [fechaDictamen, setFechaDictamen] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [fechaDictamen, setFechaDictamen] = useState<string>(hoyISOMatamoros());
   // Confirmar/editar (acarrean de Fase 6) + capturar gastos de escrituración.
   const [montoTitular, setMontoTitular] = useState<string>('');
   const [montoCotitular, setMontoCotitular] = useState<string>('');

--- a/app/dilesa/ventas/[id]/capturar/9-validacion-patronal/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/9-validacion-patronal/page.tsx
@@ -41,6 +41,7 @@ import {
   IndicadorAutoguardado,
   useAutoguardadoCampos,
 } from '@/components/dilesa/captura/autoguardado-campos';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const SLOTS_FASE: SlotColaborativo[] = [
   {
@@ -76,12 +77,10 @@ function CapturarFase9Body() {
   const [fase8Cerrada, setFase8Cerrada] = useState<boolean | null>(null);
   const [yaCerrada, setYaCerrada] = useState<boolean>(false);
 
-  const [fechaValidacion, setFechaValidacion] = useState<string>(
-    new Date().toISOString().slice(0, 10)
-  );
+  const [fechaValidacion, setFechaValidacion] = useState<string>(hoyISOMatamoros());
   // Autoguardado (ADR-051): firma de lo último persistido. Arranca = lo cargado, así
   // que no autoguarda hasta que el usuario cambie la fecha (ni el default "hoy").
-  const [fechaGuardada, setFechaGuardada] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [fechaGuardada, setFechaGuardada] = useState<string>(hoyISOMatamoros());
   const docsFase = useDocsFaseColaborativos(ventaId, SLOTS_FASE);
 
   const [loading, setLoading] = useState(true);

--- a/app/dilesa/ventas/[id]/estado-cuenta/page.tsx
+++ b/app/dilesa/ventas/[id]/estado-cuenta/page.tsx
@@ -28,6 +28,7 @@ import {
   fuenteTone,
   estadoTone,
 } from '@/components/dilesa/venta-detalle/types';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export default function VentaEstadoCuentaPage() {
   return (
@@ -376,7 +377,7 @@ function EstadoCuentaBody() {
               saldo: saldoPendiente,
               saldoFavor,
             }}
-            fechaCorteISO={new Date().toISOString().slice(0, 10)}
+            fechaCorteISO={hoyISOMatamoros()}
           />
         </DetailDrawerContent>
       </DetailDrawer>

--- a/app/dilesa/ventas/nueva/page.tsx
+++ b/app/dilesa/ventas/nueva/page.tsx
@@ -46,6 +46,7 @@ import {
   buildPersonaKycPayload,
   type PersonaKycSnapshot,
 } from '@/lib/dilesa/kyc-persona';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type UnidadDisponible = {
   id: string;
@@ -925,7 +926,7 @@ function NuevaSolicitudForm() {
           posicion: 1,
           // fecha (date) = hoy; created_at (timestamptz) = now() vía default.
           // Para FIFO en Fase 2 se ordena por created_at, que conserva la hora.
-          fecha: new Date().toISOString().slice(0, 10),
+          fecha: hoyISOMatamoros(),
           registrado_por: user?.id ?? null,
         });
       if (fErr) {

--- a/app/rdb/inventario/page.tsx
+++ b/app/rdb/inventario/page.tsx
@@ -37,6 +37,7 @@ import { type StockItem } from '@/components/inventario/types';
 import { computeStockStats } from '@/components/inventario/utils';
 import { formatCurrency } from '@/lib/format';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const FILTER_DEFAULTS = {
   search: '',
@@ -389,7 +390,7 @@ function InventarioStockBody() {
             <input
               type="date"
               aria-label="Fecha de corte del inventario"
-              max={new Date().toISOString().split('T')[0]}
+              max={hoyISOMatamoros()}
               value={fechaCorte}
               onChange={(e) => setFilter('fechaCorte', e.target.value)}
               className="rounded-md border border-input bg-transparent px-3 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/components/compras/cotizaciones-module.tsx
+++ b/components/compras/cotizaciones-module.tsx
@@ -77,6 +77,7 @@ import {
   type DateRange,
 } from '@/components/filters/date-range-filter';
 import { downloadCsv, toCsv } from '@/lib/export/csv';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const ESTADO_TONE: Record<CotizacionEstado, BadgeTone> = {
   abierta: 'info',
@@ -561,7 +562,7 @@ export function CotizacionesModule({ empresaId }: { empresaId: string }) {
       `${r.proveedores.filter((p) => p.estado !== 'invitado').length}/${r.proveedores.length}`,
       r.fechaLimite ?? '',
     ]);
-    downloadCsv(`cotizaciones-${new Date().toISOString().slice(0, 10)}`, toCsv(headers, filas));
+    downloadCsv(`cotizaciones-${hoyISOMatamoros()}`, toCsv(headers, filas));
   }, [filtrados]);
 
   const columns: Column<CotizacionRow>[] = [

--- a/components/compras/ordenes-compra-module.tsx
+++ b/components/compras/ordenes-compra-module.tsx
@@ -79,6 +79,7 @@ import {
   type DateRange,
 } from '@/components/filters/date-range-filter';
 import { downloadCsv, toCsv } from '@/lib/export/csv';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const SIN = '__sin__';
 /** Valor del selector para ver/crear órdenes de gasto suelto (sin proyecto/partida). */
@@ -773,7 +774,7 @@ export function OrdenesCompraModule({ empresaId }: { empresaId: string }) {
       ocTotal(r),
       r.fecha ?? '',
     ]);
-    downloadCsv(`ordenes-compra-${new Date().toISOString().slice(0, 10)}`, toCsv(headers, filas));
+    downloadCsv(`ordenes-compra-${hoyISOMatamoros()}`, toCsv(headers, filas));
   }, [filtrados]);
 
   const columns: Column<OcRow>[] = [

--- a/components/compras/recepciones-module.tsx
+++ b/components/compras/recepciones-module.tsx
@@ -45,6 +45,7 @@ import {
   type DateRange,
 } from '@/components/filters/date-range-filter';
 import { downloadCsv, toCsv } from '@/lib/export/csv';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const ESTADO_TONE: Record<string, BadgeTone> = { enviada: 'info', parcial: 'warning' };
 const ESTADO_LABEL: Record<string, string> = { enviada: 'Enviada', parcial: 'Parcial' };
@@ -361,10 +362,7 @@ export function RecepcionesModule({ empresaId }: { empresaId: string }) {
       r.lineas.filter((l) => lineaPendiente(l) > 0).length,
       r.fecha ?? '',
     ]);
-    downloadCsv(
-      `recepciones-pendientes-${new Date().toISOString().slice(0, 10)}`,
-      toCsv(headers, filas)
-    );
+    downloadCsv(`recepciones-pendientes-${hoyISOMatamoros()}`, toCsv(headers, filas));
   }, [filtrados]);
 
   const columns: Column<OcRow>[] = [

--- a/components/compras/requisiciones-module.tsx
+++ b/components/compras/requisiciones-module.tsx
@@ -72,6 +72,7 @@ import {
   type DateRange,
 } from '@/components/filters/date-range-filter';
 import { downloadCsv, toCsv } from '@/lib/export/csv';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const SIN = '__sin__';
 /** Valor del selector para capturar una requisición libre (gasto suelto sin proyecto). */
@@ -739,7 +740,7 @@ export function RequisicionesModule({ empresaId }: { empresaId: string }) {
       reqTotal(r),
       r.fecha ?? '',
     ]);
-    downloadCsv(`requisiciones-${new Date().toISOString().slice(0, 10)}`, toCsv(headers, filas));
+    downloadCsv(`requisiciones-${hoyISOMatamoros()}`, toCsv(headers, filas));
   }, [filtrados]);
 
   const columns: Column<ReqRow>[] = [

--- a/components/cxp/cxp-pagos-module.tsx
+++ b/components/cxp/cxp-pagos-module.tsx
@@ -67,6 +67,7 @@ import { FileAttachments, useAdjuntos } from '@/components/file-attachments';
 import type { EmpresaSlug } from '@/lib/empresa-branding';
 import { HiloGastoSection } from '@/components/gasto/hilo-gasto-stepper';
 import { useFocusDrilldown } from '@/hooks/use-focus-drilldown';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const TZ = 'America/Matamoros';
 
@@ -1206,7 +1207,7 @@ function AutorizarYPagarDialog({
   onDone: () => void;
 }) {
   const feedback = useActionFeedback();
-  const [fecha, setFecha] = useState(() => new Date().toISOString().slice(0, 10));
+  const [fecha, setFecha] = useState(() => hoyISOMatamoros());
   const [referencia, setReferencia] = useState(pago.referencia ?? '');
   const [submitting, setSubmitting] = useState(false);
 

--- a/components/dilesa/captura/credito-directo-captura.tsx
+++ b/components/dilesa/captura/credito-directo-captura.tsx
@@ -27,6 +27,7 @@ import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { desglosarPagare } from '@/lib/dilesa/pagare-interes';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export type PlanPagoJson = { num?: number; fecha?: string; monto?: number };
 type PlanRow = { fecha: string; monto: string };
@@ -48,7 +49,7 @@ const moneyFmt = new Intl.NumberFormat('es-MX', {
 });
 const money = (n: number | null | undefined): string =>
   n == null ? '—' : moneyFmt.format(Number(n));
-const hoy = () => new Date().toISOString().slice(0, 10);
+const hoy = () => hoyISOMatamoros();
 
 export function CreditoDirectoCaptura({
   ventaId,

--- a/components/dilesa/obra-contrato-detalle.tsx
+++ b/components/dilesa/obra-contrato-detalle.tsx
@@ -51,6 +51,7 @@ import {
   type FacturaCuenta,
   type ObraEstimacionEstado,
 } from '@/lib/dilesa/contratos-estado-cuenta';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export type ObraEstimacion = {
   id: string;
@@ -141,7 +142,7 @@ export function ObraContratoDetalle({
   // form inline
   const [open, setOpen] = useState(false);
   const [etiqueta, setEtiqueta] = useState('');
-  const [fecha, setFecha] = useState(new Date().toISOString().slice(0, 10));
+  const [fecha, setFecha] = useState(hoyISOMatamoros());
   const [factura, setFactura] = useState('');
   const [monto, setMonto] = useState('');
   const [esAnticipo, setEsAnticipo] = useState(false);
@@ -386,7 +387,7 @@ export function ObraContratoDetalle({
 
   function resetForm() {
     setEtiqueta('');
-    setFecha(new Date().toISOString().slice(0, 10));
+    setFecha(hoyISOMatamoros());
     setFactura('');
     setMonto('');
     setEsAnticipo(false);
@@ -958,7 +959,7 @@ function FacturaDelContrato({
   const sb = useMemo(() => createSupabaseBrowserClient(), []);
   const [open, setOpen] = useState(false);
   const [total, setTotal] = useState('');
-  const [fechaEmision, setFechaEmision] = useState(new Date().toISOString().slice(0, 10));
+  const [fechaEmision, setFechaEmision] = useState(hoyISOMatamoros());
   const [facturaRef, setFacturaRef] = useState('');
   const [condicionesDias, setCondicionesDias] = useState('');
   const [submitting, setSubmitting] = useState(false);

--- a/components/dilesa/proyecto-checklist.tsx
+++ b/components/dilesa/proyecto-checklist.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/app/dilesa/proyectos/anteproyectos/actions';
 import { TareasChecklist, type PasoRow } from './tareas-checklist';
 import type { EmpresaSlug } from '@/lib/storage';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export type ProyectoTarea = {
   id: string;
@@ -260,7 +261,7 @@ export function ProyectoChecklist({
 
   const handlePopulate = useCallback(() => {
     setPopulateError(null);
-    const fecha = fechaArranque ?? new Date().toISOString().slice(0, 10);
+    const fecha = fechaArranque ?? hoyISOMatamoros();
     startTransition(async () => {
       const r = await populatePlantilla(proyectoId, fecha);
       if (!r.ok) {

--- a/components/dilesa/recepcion-obra-drawer.tsx
+++ b/components/dilesa/recepcion-obra-drawer.tsx
@@ -32,6 +32,7 @@ import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { getAdjuntoProxyUrl } from '@/lib/adjuntos';
 import { buildAdjuntoPath, type AdjuntoEntidad } from '@/lib/storage/path';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type EstadoRecepcion = 'programada' | 'con_observaciones' | 'recibida' | 'rechazada';
 
@@ -55,7 +56,7 @@ export type RecepcionObraDrawerProps = {
 };
 
 function hoyISO() {
-  return new Date().toISOString().slice(0, 10);
+  return hoyISOMatamoros();
 }
 
 /** Sube un archivo a Storage + registra el adjunto en erp.adjuntos. */

--- a/components/dilesa/reportes/calificacion-por-fase-view.tsx
+++ b/components/dilesa/reportes/calificacion-por-fase-view.tsx
@@ -34,6 +34,7 @@ import {
   type FaseCalificacionRaw,
 } from '@/lib/dilesa/reportes/calificacion-por-fase';
 import { ReporteShell } from './reporte-shell';
+import { fechaISOMatamoros } from '@/lib/fecha-mx';
 
 const REPORTE = getReporte('calificacion-por-fase')!;
 const VOLVER_HREF = '/dilesa/ventas/reportes';
@@ -53,7 +54,7 @@ const DEFAULT_FILTERS = { periodo: 'trimestre' };
 const RESPONSABLE_LABEL = { interna: 'interna', tercero: 'tercero', mixta: 'mixta' } as const;
 
 function fechaISO(msEpoch: number): string {
-  return new Date(msEpoch).toISOString().slice(0, 10);
+  return fechaISOMatamoros(new Date(msEpoch));
 }
 
 export function CalificacionPorFaseView() {

--- a/components/dilesa/tareas-checklist.tsx
+++ b/components/dilesa/tareas-checklist.tsx
@@ -34,6 +34,7 @@ import {
   sumMontosPasos,
 } from './tarea-pasos';
 import type { EmpresaSlug } from '@/lib/storage';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const moneyFmt = new Intl.NumberFormat('es-MX', {
   style: 'currency',
@@ -299,7 +300,7 @@ function TareaRowCompact({
       const prev = tarea.estado;
       onPatch(tarea.id, {
         estado: next,
-        fecha_completada: next === 'completada' ? new Date().toISOString().slice(0, 10) : null,
+        fecha_completada: next === 'completada' ? hoyISOMatamoros() : null,
       });
       startTransition(async () => {
         const r = await updateTareaEstado(tarea.id, next);

--- a/components/health/activity-section.tsx
+++ b/components/health/activity-section.tsx
@@ -9,6 +9,7 @@ import { buildDeltaHelper, filterRecentRows, groupDailySum } from './helpers';
 import { TONES } from './tones';
 import { TrendCard } from './trend-card';
 import type { ChartConfig, ToneKey } from './types';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type Subkey =
   | 'steps'
@@ -121,7 +122,7 @@ export function ActivitySection({
 
   // Rings are pinned to "today" so they represent the live close-your-rings
   // state. The rest of the section shows aggregates for the selected range.
-  const todayKey = new Date().toISOString().slice(0, 10);
+  const todayKey = hoyISOMatamoros();
   const todayFrom = (series: { date: string; value: number }[]) =>
     series.find((point) => point.date === todayKey)?.value ?? 0;
   const todayActiveEnergy = todayFrom(activeEnergySeries);

--- a/components/playtomic/header-section.tsx
+++ b/components/playtomic/header-section.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Combobox } from '@/components/ui/combobox';
 import { CalendarRange, RefreshCw } from 'lucide-react';
 import type { BookingFilters, RangeKey, SportFilter } from './types';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const RANGE_OPTIONS = [
   ['7d', '7 días'],
@@ -44,7 +45,7 @@ export function HeaderSection({
   onRefresh: () => void;
 }) {
   const showCustom = range === 'custom';
-  const todayIso = new Date().toISOString().slice(0, 10);
+  const todayIso = hoyISOMatamoros();
 
   return (
     <section className="rounded-3xl border border-[var(--border)] bg-[var(--panel)] p-6">

--- a/components/rh/contrato-printable.tsx
+++ b/components/rh/contrato-printable.tsx
@@ -25,6 +25,7 @@
 
 import { composeFullName } from '@/lib/name-case';
 import { formatMoneda } from '@/lib/hr/calcular-finiquito';
+import { hoyISOMatamoros, sumarDiasISO } from '@/lib/fecha-mx';
 
 export interface ContratoEmpleado {
   // Persona
@@ -134,7 +135,7 @@ export function ContratoPrintable({
   /** Fecha de fin (para contratos por tiempo determinado; default = 30 días después del inicio). */
   vigenciaFin?: string;
 }) {
-  const fechaHoy = fechaContrato ?? new Date().toISOString().split('T')[0];
+  const fechaHoy = fechaContrato ?? hoyISOMatamoros();
   const nombreCompleto = composeFullName(
     empleado.nombre,
     empleado.apellido_paterno,
@@ -148,13 +149,7 @@ export function ContratoPrintable({
 
   const inicio = vigenciaInicio ?? empleado.fecha_ingreso ?? fechaHoy;
   // Por default, contratos de DILESA son de 1 mes (30 días).
-  const fin =
-    vigenciaFin ??
-    (() => {
-      const d = new Date(inicio);
-      d.setDate(d.getDate() + 30);
-      return d.toISOString().split('T')[0];
-    })();
+  const fin = vigenciaFin ?? sumarDiasISO(inicio, 30);
 
   const sueldoDiarioTexto =
     empleado.sueldo_diario != null

--- a/components/rh/empleado-alta-wizard.tsx
+++ b/components/rh/empleado-alta-wizard.tsx
@@ -62,6 +62,7 @@ import { useToast } from '@/components/ui/toast';
 import { composeFullName, titleCase } from '@/lib/name-case';
 import { createSupabaseERPClient } from '@/lib/supabase-browser';
 import { buildAdjuntoPath, slugifyFilename, type EmpresaSlug } from '@/lib/storage';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type Departamento = { id: string; nombre: string };
 type Puesto = { id: string; nombre: string };
@@ -258,7 +259,7 @@ const DEFAULT_VALUES: WizardValues = {
   departamento_id: '',
   puesto_id: '',
   numero_empleado: '',
-  fecha_ingreso: new Date().toISOString().slice(0, 10),
+  fecha_ingreso: hoyISOMatamoros(),
   tipo_contrato: 'prueba',
   periodo_prueba_dias: '30',
   periodo_prueba_numero: '1',
@@ -472,7 +473,7 @@ export function EmpleadoAltaWizard({
             sueldo_mensual: Number(values.sueldo_mensual),
             sueldo_diario: values.sueldo_diario ? Number(values.sueldo_diario) : null,
             sdi: values.sdi ? Number(values.sdi) : null,
-            fecha_inicio: values.fecha_ingreso || new Date().toISOString().slice(0, 10),
+            fecha_inicio: values.fecha_ingreso || hoyISOMatamoros(),
             vigente: true,
             frecuencia_pago: 'quincenal',
           });

--- a/components/rh/empleado-detail-module.tsx
+++ b/components/rh/empleado-detail-module.tsx
@@ -56,6 +56,7 @@ import {
   FileSignature,
   Send,
 } from 'lucide-react';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 type Persona = {
   id: string;
@@ -532,7 +533,7 @@ function EmpleadoDetailInner({ empresaSlug }: EmpleadoDetailModuleProps) {
 
   const [showBajaDialog, setShowBajaDialog] = useState(false);
   const [motivoBaja, setMotivoBaja] = useState('');
-  const [fechaBaja, setFechaBaja] = useState(new Date().toISOString().split('T')[0]);
+  const [fechaBaja, setFechaBaja] = useState(hoyISOMatamoros());
   const [givingBaja, setGivingBaja] = useState(false);
   const [testingAviso, setTestingAviso] = useState(false);
 
@@ -770,7 +771,7 @@ function EmpleadoDetailInner({ empresaSlug }: EmpleadoDetailModuleProps) {
       .from('empleados')
       .update({
         activo: false,
-        fecha_baja: fechaBaja || new Date().toISOString().split('T')[0],
+        fecha_baja: fechaBaja || hoyISOMatamoros(),
         motivo_baja: motivoBaja.trim() || null,
       })
       .eq('id', empleado.id);

--- a/components/rh/empleado-finiquito-module.tsx
+++ b/components/rh/empleado-finiquito-module.tsx
@@ -46,6 +46,7 @@ import {
   type ZonaSalarioMinimo,
 } from '@/lib/hr/salario-minimo-zona';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 const FORMA_PAGO_LABELS: Record<FormaPagoFiniquito, string> = {
   efectivo: 'Efectivo',
@@ -169,7 +170,7 @@ function Inner({ empresaSlug }: EmpleadoFiniquitoModuleProps) {
     setFechaIngreso(fi ?? '');
     setFechaBajaGuardada(fb);
     setMotivoBajaGuardado((emp as any).motivo_baja ?? null);
-    setFechaBaja(fb ?? new Date().toISOString().split('T')[0]);
+    setFechaBaja(fb ?? hoyISOMatamoros());
 
     const sueldoD =
       (comp as any)?.sueldo_diario ??
@@ -226,7 +227,7 @@ function Inner({ empresaSlug }: EmpleadoFiniquitoModuleProps) {
         empleado_id: id,
         empresa_id: empresaId,
         fecha_baja: calculo.fechaBaja,
-        fecha_convenio: new Date().toISOString().split('T')[0],
+        fecha_convenio: hoyISOMatamoros(),
         causa: calculo.causa,
         motivo_detalle: motivoDetalle || motivoBajaGuardado || null,
         fecha_ingreso: calculo.fechaIngreso,

--- a/components/rh/finiquito-printable.tsx
+++ b/components/rh/finiquito-printable.tsx
@@ -20,6 +20,7 @@ import {
   type FiniquitoCalculado,
 } from '@/lib/hr/calcular-finiquito';
 import type { ContratoPatron } from './contrato-printable';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export interface FiniquitoEmpleadoData {
   nombre: string;
@@ -68,7 +69,7 @@ export function FiniquitoPrintable({
   /** Nº de cheque o referencia de transferencia. NULL si forma=efectivo o no se capturó. */
   referenciaPago?: string | null;
 }) {
-  const fechaHoy = fechaConvenio ?? new Date().toISOString().split('T')[0];
+  const fechaHoy = fechaConvenio ?? hoyISOMatamoros();
   const nombreCompleto = composeFullName(
     empleado.nombre,
     empleado.apellido_paterno,

--- a/docs/planning/fechas-tz.md
+++ b/docs/planning/fechas-tz.md
@@ -2,9 +2,9 @@
 
 **Slug:** `fechas-tz`
 **Empresas:** Todas (DILESA, ANSA, COAGAN, RDB, SANREN)
-**Schemas afectados:** Sin migración de schema en S0. El barrido (S1-S3) toca código TS en `app/**` y `lib/**` (61 archivos con `new Date().toISOString().slice(0, 10)`); S3 audita datos en `dilesa.venta_fases.fecha`, `dilesa.ruv (fecha_carga)`, `dilesa.anteproyectos (fecha_completada)` y defaults `CURRENT_DATE` en funciones de `erp` (CxP `p_fecha_emision`).
+**Schemas afectados:** Sin migración de schema en S0-S2. El barrido S1 tocó código TS en `app/**`, `lib/**` y `components/**` (61 ocurrencias en 39 archivos con `new Date().toISOString().slice(0, 10)`); S3 audita datos en `dilesa.venta_fases.fecha`, `dilesa.ruv (fecha_carga)`, `dilesa.anteproyectos (fecha_completada)` y defaults `CURRENT_DATE` en funciones de `erp` (CxP `p_fecha_emision`, `inventario_levantamientos.fecha_programada`).
 **Estado:** in_progress
-**Próximo hito:** S1 — migrar server actions y formularios de captura a `fechaISOMatamoros()`
+**Próximo hito:** S3 — auditoría read-only de fechas +1 en datos históricos (correcciones solo con OK de Beto)
 **Dueño:** Beto
 **Creada:** 2026-07-01
 **Última actualización:** 2026-07-01
@@ -103,10 +103,38 @@ documenta en S4, no se reescribe.
 
 ## Bitácora
 
+- **2026-07-01 — Análisis de impacto en flujos externos (pedido de Beto antes
+  de S1): Waitry/Playtomic NO se tocan.** (a) El webhook de Waitry
+  (`supabase/functions/waitry-webhook`) y el trigger
+  `rdb.process_waitry_inbound` convierten los timestamps del payload (vienen
+  con `{date, timezone: America/Argentina/Buenos_Aires}`) a `timestamptz` UTC
+  correctamente — fix de abril 2026 (`20260410000000_rdb_fix_timestamp_timezone`).
+  Almacenan instantes, no fechas calendario. (b) Los pedidos se asignan al
+  **corte abierto** (`corte_id` por estado, no por fecha) y `fecha_operativa`
+  viene del corte — el día operativo de RDB no depende de matemática de fechas.
+  (c) Playtomic: el CSV se interpreta deliberadamente en UTC-6 fijo
+  (`parsePlaytomicDate`, así exporta Playtomic Manager) y el edge function
+  `playtomic-sync` compensa el DST del API — ambos documentados y correctos.
+  (d) Las 31 conversiones `AT TIME ZONE` en vistas SQL usan
+  `America/Matamoros`. Residual para S4: tensión teórica de 1 hora (23:00-24:00
+  locales en verano) entre cortes Matamoros-DST y datos Playtomic UTC-6 fijo —
+  documentar, no corregir. Ninguna de las 61 ocurrencias de S1 está en rutas de
+  ingesta externa.
+- **2026-07-01 — S1+S2.** Las 61 ocurrencias de
+  `new Date().toISOString().slice(0, 10)` (39 archivos) migradas a
+  `hoyISOMatamoros()` (helper nuevo en `lib/fecha-mx.ts`). Incluye los
+  server-side críticos: `lib/dilesa/captura/marcar-fase.ts` (escribe
+  `venta_fases.fecha`), `ruv/actions.ts` (`fecha_carga`),
+  `anteproyectos/actions.ts` (`fecha_completada`), `cerrar-fase13`, encuestas
+  (`programada_para`). Los timestamps UTC legítimos (`updated_at`,
+  `synced_at`, ventanas de sync) quedaron intactos. Guard de lint
+  `no-restricted-syntax` en `eslint.config.mjs` contra
+  `new Date().toISOString().slice(...)/.split('T')` en `app/**`, `lib/**`,
+  `components/**` (tests excluidos); smoke-test verificado.
 - **2026-07-01 — Análisis profundo + S0.** Barrido exhaustivo del repo
   (helpers, 61 archivos con "hoy UTC", crons, SQL, inconsistencia
   DST-real/offset-fijo). Causa raíz del acumulado en cero confirmada en
   `resumen-consejo-email.ts:901` (mes UTC). Hotfix aplicado: `inicioMes` →
   `inicioMesMatamoros()`, `inicio3m` sobre fecha local, `fechaTituloCST` con
   TZ real. Tests de regresión con el instante del incidente
-  (2026-07-01T01:00:00Z). PR pendiente de número al abrir.
+  (2026-07-01T01:00:00Z). PR [#1165](https://github.com/beto-sudo/BSOP/pull/1165), mergeado 2026-07-01.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,31 @@ const eslintConfig = [
   ...nextCoreWebVitals,
   ...nextTypeScript,
   prettier,
+  {
+    // Guard fechas-tz: "hoy" NUNCA se deriva de toISOString() — es UTC (también
+    // en el navegador) y a partir de las 18:00/19:00 de Matamoros ya es "mañana".
+    // Usar hoyISOMatamoros()/fechaISOMatamoros()/inicioMesMatamoros() de
+    // lib/fecha-mx.ts. Los tests quedan fuera (usan instantes fijos a propósito).
+    files: ['app/**/*.{ts,tsx}', 'lib/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.property.name='slice'][callee.object.callee.property.name='toISOString'][callee.object.callee.object.type='NewExpression'][callee.object.callee.object.callee.name='Date']",
+          message:
+            'new Date().toISOString().slice(...) recorta el calendario UTC ("hoy" se vuelve "mañana" después de las ~18:00 locales). Usa hoyISOMatamoros()/fechaISOMatamoros()/inicioMesMatamoros() de @/lib/fecha-mx.',
+        },
+        {
+          selector:
+            "CallExpression[callee.property.name='split'][callee.object.callee.property.name='toISOString'][callee.object.callee.object.type='NewExpression'][callee.object.callee.object.callee.name='Date']",
+          message:
+            "new Date().toISOString().split('T')[0] es el día UTC, no el local. Usa hoyISOMatamoros() de @/lib/fecha-mx.",
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/lib/briefing/health.ts
+++ b/lib/briefing/health.ts
@@ -14,6 +14,7 @@
 
 import { getSupabaseAdminClient } from '@/lib/supabase-admin';
 import type { HealthMetricRow } from '@/lib/health';
+import { fechaISOMatamoros } from '@/lib/fecha-mx';
 import {
   groupDailyAverage,
   groupDailySleep,
@@ -69,7 +70,7 @@ function latestDate(rows: HealthMetricRow[]): string | null {
 }
 
 function isoNDaysAgo(days: number): string {
-  return new Date(Date.now() - days * 86_400_000).toISOString().slice(0, 10);
+  return fechaISOMatamoros(new Date(Date.now() - days * 86_400_000));
 }
 
 /**

--- a/lib/dilesa/captura/marcar-fase.ts
+++ b/lib/dilesa/captura/marcar-fase.ts
@@ -25,6 +25,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { buildAdjuntoPath } from '@/lib/storage/path';
 import { DILESA_EMPRESA_ID } from '@/lib/empresa-constants';
 import { FASES_VENTA, nombreFase, type FaseSlug } from '@/lib/dilesa/fases';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export type DocCaptura = {
   /** Rol del adjunto (ej. 'contrato_promesa', 'aviso_pld', 'factura'). */
@@ -168,7 +169,7 @@ export async function marcarFase(
       venta_id: ventaId,
       fase: nombreFase(faseposicion),
       posicion: faseposicion,
-      fecha: new Date().toISOString().slice(0, 10),
+      fecha: hoyISOMatamoros(),
       registrado_por: registradoPor,
       notas: notas ?? null,
     })

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -17,7 +17,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { KpisDelDia } from './resumen-consejo-kpis';
-import { fechaISOMatamoros, inicioMesMatamoros } from '@/lib/fecha-mx';
+import { fechaISOMatamoros, inicioMesMatamoros, restarMesesISO } from '@/lib/fecha-mx';
 
 // ── Tipos por sección ───────────────────────────────────────────────────────
 
@@ -891,12 +891,8 @@ export async function fetchResumenConsejoData(
   // `venta_fases.fecha` es un `date` local, así que comparamos fecha local.
   const inicioMes = inicioMesMatamoros(now);
   const hoyISO = fechaISOMatamoros(now);
-  // Ventana de absorción: 3 meses móviles hasta hoy (aritmética de calendario
-  // sobre los componentes de la fecha local; Date.UTC solo resuelve el rollover).
-  const [hoyY, hoyM, hoyD] = hoyISO.split('-').map(Number);
-  const inicio3m = new Date(Date.UTC(hoyY, hoyM - 1 - ABSORCION_VENTANA_MESES, hoyD))
-    .toISOString()
-    .slice(0, 10);
+  // Ventana de absorción: 3 meses móviles hasta hoy (sobre la fecha local).
+  const inicio3m = restarMesesISO(hoyISO, ABSORCION_VENTANA_MESES);
 
   const [
     proyectosRes,

--- a/lib/documentos/naming.ts
+++ b/lib/documentos/naming.ts
@@ -16,6 +16,8 @@
  * devuelve null — el caller debe usar un placeholder y refinar después.
  */
 
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
+
 const TIPO_TO_SHORT: Record<string, string> = {
   Escritura: 'Escritura',
   Contrato: 'Contrato',
@@ -97,7 +99,7 @@ export function buildStandardFilename(titulo: string, ext = 'pdf'): string {
  */
 export function placeholderTitulo(empresaSlug: string | null | undefined): string {
   const slug = (empresaSlug ?? '').toUpperCase().replace(/[^A-Z0-9]/g, '');
-  const date = new Date().toISOString().slice(0, 10);
+  const date = hoyISOMatamoros();
   return slug ? `${slug}-${date}-Documento por procesar` : `Documento por procesar — ${date}`;
 }
 

--- a/lib/fecha-mx.test.ts
+++ b/lib/fecha-mx.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { fechaISOMatamoros, inicioMesMatamoros } from './fecha-mx';
+import {
+  fechaISOMatamoros,
+  hoyISOMatamoros,
+  inicioMesMatamoros,
+  restarMesesISO,
+  sumarDiasISO,
+} from './fecha-mx';
 
 describe('fechaISOMatamoros', () => {
   it('invierno (CST, UTC-6): a las 20:00 locales el día UTC ya avanzó, pero la fecha local es la de hoy', () => {
@@ -37,5 +43,35 @@ describe('inicioMesMatamoros', () => {
 
   it('media tarde a mitad de mes → primer día del mes local', () => {
     expect(inicioMesMatamoros(new Date('2026-06-15T18:00:00Z'))).toBe('2026-06-01');
+  });
+});
+
+describe('hoyISOMatamoros', () => {
+  it('coincide con fechaISOMatamoros(ahora)', () => {
+    expect(hoyISOMatamoros()).toBe(fechaISOMatamoros(new Date()));
+  });
+});
+
+describe('sumarDiasISO', () => {
+  it('suma días con rollover de mes y año', () => {
+    expect(sumarDiasISO('2026-06-15', 30)).toBe('2026-07-15');
+    expect(sumarDiasISO('2026-12-20', 15)).toBe('2027-01-04');
+    expect(sumarDiasISO('2026-02-28', 1)).toBe('2026-03-01');
+  });
+
+  it('es aritmética pura: no depende de TZ ni de la hora', () => {
+    expect(sumarDiasISO('2026-07-01', 0)).toBe('2026-07-01');
+  });
+});
+
+describe('restarMesesISO', () => {
+  it('resta meses con rollover de año', () => {
+    expect(restarMesesISO('2026-06-30', 3)).toBe('2026-03-30');
+    expect(restarMesesISO('2026-01-15', 3)).toBe('2025-10-15');
+  });
+
+  it('día 31 hacia mes corto rueda al mes siguiente (comportamiento Date.UTC)', () => {
+    // 31 de mayo − 1 mes → "31 de abril" no existe → 1 de mayo.
+    expect(restarMesesISO('2026-05-31', 1)).toBe('2026-05-01');
   });
 });

--- a/lib/fecha-mx.ts
+++ b/lib/fecha-mx.ts
@@ -31,3 +31,39 @@ export function fechaISOMatamoros(d: Date): string {
 export function inicioMesMatamoros(d: Date = new Date()): string {
   return `${fechaISOMatamoros(d).slice(0, 7)}-01`;
 }
+
+/**
+ * "Hoy" (`YYYY-MM-DD`) en horario de Matamoros. Reemplazo directo del
+ * antipatrón `new Date().toISOString().slice(0, 10)` — que devuelve el día
+ * UTC (también en el navegador) y a partir de las 18:00/19:00 locales ya es
+ * "mañana". Default canónico para capturas de fecha y nombres de archivo.
+ * Guard de lint: `no-restricted-syntax` en `eslint.config.mjs` (iniciativa
+ * fechas-tz).
+ */
+export function hoyISOMatamoros(): string {
+  return fechaISOMatamoros(new Date());
+}
+
+/** Formatea componentes UTC de un Date como `YYYY-MM-DD` (sin toISOString). */
+function isoDeUTC(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+}
+
+/**
+ * Suma días de calendario a una fecha `YYYY-MM-DD` (aritmética pura, sin TZ:
+ * el string se interpreta y se re-formatea en UTC, así que no hay corrimiento).
+ */
+export function sumarDiasISO(fechaISO: string, dias: number): string {
+  const [y, m, d] = fechaISO.split('-').map(Number);
+  return isoDeUTC(new Date(Date.UTC(y, m - 1, d + dias)));
+}
+
+/**
+ * Resta meses de calendario a una fecha `YYYY-MM-DD` (aritmética pura, sin
+ * TZ). `Date.UTC` resuelve el rollover (ej. 2026-01-15 − 3m → 2025-10-15).
+ */
+export function restarMesesISO(fechaISO: string, meses: number): string {
+  const [y, m, d] = fechaISO.split('-').map(Number);
+  return isoDeUTC(new Date(Date.UTC(y, m - 1 - meses, d)));
+}


### PR DESCRIPTION
## S1 — Migración del antipatrón "hoy UTC"

`new Date().toISOString().slice(0, 10)` devuelve el día **UTC** (también en el navegador): después de las ~18:00/19:00 de Matamoros, "hoy" era "mañana". Migradas las 61 ocurrencias (39 archivos) + 9 variantes `.split('T')[0]` que cachó el lint guard, a `hoyISOMatamoros()`.

**Server-side críticos incluidos** (escribían fecha +1 sin ojo humano de noche):
- `lib/dilesa/captura/marcar-fase.ts` → `venta_fases.fecha` (de aquí derivan KPIs, escrituras del mes y el resumen al consejo)
- `app/dilesa/ruv/actions.ts` → `fecha_carga` · `anteproyectos/actions.ts` → `fecha_completada`
- `cerrar-fase13`, envío de encuestas (`programada_para`), avalúo por token, PDF fallback
- Módulos RH (fecha de baja/convenio/contrato) y defaults de formularios de captura

Helpers nuevos en `lib/fecha-mx.ts` con tests: `hoyISOMatamoros()`, `sumarDiasISO()`, `restarMesesISO()` (aritmética de calendario sin `toISOString`).

## S2 — Lint guard

`no-restricted-syntax` en `eslint.config.mjs` prohíbe `new Date().toISOString().slice(...)/.split('T')` en `app/**`, `lib/**`, `components/**` (tests excluidos). Smoke-test verificado; ya en este PR cachó 9 ocurrencias que el grep no vio.

## Análisis de impacto en flujos externos (pedido de Beto)

**Waitry/Playtomic NO se tocan y no hay riesgo:**
- El webhook (`supabase/functions/waitry-webhook`) y el trigger `rdb.process_waitry_inbound` convierten los timestamps del payload (`{date, timezone: Buenos_Aires}`) a `timestamptz` UTC correctamente (fix de abril, mig `20260410000000`). Almacenan **instantes**, no fechas calendario.
- Los pedidos se asignan al **corte abierto** (`corte_id` por estado) y `fecha_operativa` viene del corte — el día operativo de RDB no depende de matemática de fechas.
- Playtomic: `parsePlaytomicDate` interpreta el CSV en UTC-6 **fijo** (deliberado, así exporta Playtomic Manager); el edge function `playtomic-sync` compensa DST. Correctos ambos.
- Residual documentado para S4: tensión teórica de 1h (23:00-24:00 locales en verano) entre vistas con `America/Matamoros` y datos Playtomic UTC-6 fijo.
- Ninguna de las ocurrencias migradas está en rutas de ingesta externa; los timestamps UTC legítimos (`updated_at`, `synced_at`, ventanas de sync) quedaron intactos.

## Verificación

- `typecheck` / `lint` (0 errores) / `format:check` / `initiatives:validate` ✅
- `test:coverage`: 182 files, 2,285 tests ✅
- Sin migraciones ni cambios de schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)