### PR TITLE
docs(fechas-tz): S4a — ADR-054 convención de timezone + cron encuestas a TZ real

### DIFF
--- a/app/api/cron/dilesa-encuestas/route.ts
+++ b/app/api/cron/dilesa-encuestas/route.ts
@@ -27,6 +27,7 @@ import {
 } from '@/lib/dilesa/encuesta-emails';
 import { loadEmpresaBranding } from '@/lib/dilesa/email-branding';
 import { loadGerenteVentas } from '@/lib/dilesa/gerente-ventas';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 
 export const maxDuration = 120;
 
@@ -48,13 +49,10 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'admin client no disponible' }, { status: 500 });
   }
 
-  // Hoy en hora de Piedras Negras (CST fijo) — el ciclo es por días locales.
-  const hoy = new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'Etc/GMT+6',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(new Date());
+  // Hoy en hora local (America/Matamoros, DST real — ADR-054). El cron corre a
+  // las 16:00 UTC (~10:00 locales), lejos de medianoche, así que el cambio de
+  // Etc/GMT+6 fijo a TZ real no altera ningún ciclo; es consistencia de convención.
+  const hoy = hoyISOMatamoros();
 
   const { data: pendientes, error: qErr } = await admin
     .schema('dilesa')

--- a/docs/adr/054_timezone_convencion.md
+++ b/docs/adr/054_timezone_convencion.md
@@ -1,0 +1,73 @@
+# ADR-054 — Convención de timezone: "hoy" es Matamoros, no UTC
+
+- **Estado:** aceptado
+- **Fecha:** 2026-07-01
+- **Iniciativa:** `fechas-tz`
+- **Detonante:** el 30-jun-2026 a las 20:00 (CDT) el resumen al consejo salió
+  con las ventas acumuladas del mes en cero — el corte de mes se calculaba con
+  el calendario UTC, que a esa hora ya iba en julio ([#1165]). El barrido
+  encontró 70 ocurrencias del mismo antipatrón ([#1166]).
+
+## Contexto
+
+La operación vive en `America/Matamoros` (frontera: CST UTC-6 en invierno,
+CDT UTC-5 en verano, siguiendo el DST de EE.UU.). Los servidores (Vercel) y
+Postgres (Supabase) corren en UTC. Entre las ~18:00/19:00 locales y la
+medianoche, **el día/mes UTC ya es el siguiente** — exactamente la franja de
+más captura y de los reportes nocturnos.
+
+`Date.prototype.toISOString()` devuelve UTC **también en el navegador**: un
+default de formulario `new Date().toISOString().slice(0, 10)` muestra "mañana"
+a un operador capturando de noche, sin importar la TZ de su máquina.
+
+## Decisión
+
+1. **Fecha calendario de negocio = `America/Matamoros` (DST real).**
+   - **TypeScript:** helpers de [`lib/fecha-mx.ts`](../../lib/fecha-mx.ts):
+     `hoyISOMatamoros()` ("hoy"), `fechaISOMatamoros(d)` (instante → fecha
+     local), `inicioMesMatamoros(d)` (corte de mes), `sumarDiasISO` /
+     `restarMesesISO` (aritmética de calendario pura sobre strings
+     `YYYY-MM-DD`, sin pasar por `toISOString`).
+   - **SQL:** `(ts AT TIME ZONE 'America/Matamoros')::date` para derivar fecha
+     local de un `timestamptz`. **No usar `CURRENT_DATE`** como "hoy" de
+     negocio en defaults/funciones — es el día UTC.
+2. **Instantes = `timestamptz` UTC, siempre.** `created_at`, `updated_at`,
+   `synced_at`, ventanas de sync, tokens: `new Date().toISOString()` completo
+   es correcto y NO está restringido. La regla es sobre el **recorte a
+   calendario**, no sobre ISO strings.
+3. **Offset fijo `Etc/GMT+6` SOLO donde el dominio lo define** (excepciones
+   documentadas, no default):
+   - **Playtomic (RDB):** Playtomic Manager exporta el CSV en UTC-6 fijo y el
+     club opera así (`parsePlaytomicDate`, `playtomic-sync`).
+   - **Hold-cola DILESA:** plazos operativos en UTC-6 estable para que un hold
+     no cambie de vencimiento al cruzar DST (razonado en
+     `lib/dilesa/hold-cola.ts`).
+   - Residual conocido: 1 hora de tensión (23:00-24:00 locales en verano)
+     entre datos Playtomic UTC-6 fijo y vistas SQL con `America/Matamoros`.
+     Aceptado; el corte operativo de RDB lo da el **corte de caja abierto**,
+     no la fecha calendario.
+4. **Crons Vercel** (UTC, sin DST): patrón **dos-horas-UTC candidatas + guard
+   de hora local** (`relojMatamoros`), como `dilesa-resumen-consejo` y
+   `daily-briefing`. Un cron que corre lejos de medianoche local (p.ej.
+   encuestas a las ~10:00) no necesita doble hora, pero sí deriva "hoy" con
+   `hoyISOMatamoros()`.
+5. **Enforcement:** guard `no-restricted-syntax` en `eslint.config.mjs`
+   prohíbe `new Date().toISOString().slice(...)/.split('T')` en `app/**`,
+   `lib/**`, `components/**` (tests excluidos).
+
+## Consecuencias
+
+- El "hoy" de un formulario y el "hoy" de un cron nocturno coinciden con el
+  calendario del operador, todo el año.
+- Ingesta externa intacta: Waitry entrega `{date, timezone}` y el trigger
+  `rdb.process_waitry_inbound` lo convierte a UTC — instantes, no fechas.
+- Los defaults `DEFAULT CURRENT_DATE` existentes en columnas `date` de `erp` /
+  `dilesa.construccion` quedan como deuda registrada en la iniciativa
+  `fechas-tz` (S4b): migrarlos a
+  `(now() AT TIME ZONE 'America/Matamoros')::date` toca tablas financieras →
+  gate `finanzas-ok`.
+- Display client-side (`toLocaleDateString` sin `timeZone`) se corrige
+  oportunista; no es parte del guard.
+
+[#1165]: https://github.com/beto-sudo/BSOP/pull/1165
+[#1166]: https://github.com/beto-sudo/BSOP/pull/1166

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -359,6 +359,7 @@ Ver [reglas SS1-SS7 en ADR-030](../adr/030_submodule_permissions.md).
 | Manual de usuario in-app           | [ADR-043](../adr/043_manual_usuario_in_app.md)        | markdown versionado + `<HelpButton>` contextual + PDF on-demand (M1-M8)              |
 | Capa única de acceso a IA          | [ADR-046](../adr/046_capa_unica_acceso_ia.md)         | `lib/ai` único entry point + registry + drift-guard (registro-ia)                    |
 | Reportes (preset + vista + PDF)    | [ADR-047](../adr/047_reportes_preset_vista_pdf.md)    | registry + `<ReporteCatalogo>`/`<ReporteShell>` + hub-índice + PDF (dilesa-reportes) |
+| Timezone: "hoy" = Matamoros        | [ADR-054](../adr/054_timezone_convencion.md)          | `lib/fecha-mx.ts` (`hoyISOMatamoros`) + lint guard; `Etc/GMT+6` solo Playtomic/holds |
 
 ### Data / DB
 

--- a/docs/planning/fechas-tz.md
+++ b/docs/planning/fechas-tz.md
@@ -4,7 +4,7 @@
 **Empresas:** Todas (DILESA, ANSA, COAGAN, RDB, SANREN)
 **Schemas afectados:** Sin migración de schema en S0-S2. El barrido S1 tocó código TS en `app/**`, `lib/**` y `components/**` (61 ocurrencias en 39 archivos con `new Date().toISOString().slice(0, 10)`); S3 audita datos en `dilesa.venta_fases.fecha`, `dilesa.ruv (fecha_carga)`, `dilesa.anteproyectos (fecha_completada)` y defaults `CURRENT_DATE` en funciones de `erp` (CxP `p_fecha_emision`, `inventario_levantamientos.fecha_programada`).
 **Estado:** in_progress
-**Próximo hito:** S3 — auditoría read-only de fechas +1 en datos históricos (correcciones solo con OK de Beto)
+**Próximo hito:** OK de Beto para (a) UPDATE de las 11 fechas +1 en `venta_fases` y (b) migración S4b de defaults `CURRENT_DATE` (gate finanzas-ok)
 **Dueño:** Beto
 **Creada:** 2026-07-01
 **Última actualización:** 2026-07-01
@@ -102,6 +102,30 @@ documenta en S4, no se reescribe.
   exportado para no tocar el cron en el hotfix.
 
 ## Bitácora
+
+- **2026-07-01 — S3 (auditoría read-only, prod).** Detector: `fecha = día UTC
+del created_at` donde `día UTC ≠ día local de Matamoros`. Resultados:
+  - `dilesa.venta_fases`: **1,104 filas**, de las cuales **1,093 son el sellado
+    masivo del cutover Coda** (11-jun, fase 17, un minuto, `registrado_por`
+    null — fecha sintética de sellado grabada 06-12 en vez de 06-11; NO
+    contaminan el resumen al consejo, que filtra `posicion in (2, 11)`) y
+    **11 son capturas reales nocturnas** con fecha +1 (fases 1/5/9/10/16,
+    19-jun a 30-jun), incluida una fase 5 del 30-jun grabada **2026-07-01**
+    (cruza el corte de mes). IDs y detalle en la sesión; corrección propuesta:
+    `UPDATE ... SET fecha = (created_at AT TIME ZONE 'America/Matamoros')::date`
+    sobre los IDs listados — **pendiente OK de Beto**.
+  - `dilesa.ruv_frente_documentos` y `dilesa.proyecto_tareas`: 0 filas.
+  - `dilesa.venta_encuestas`: 8 filas con `programada_para` +1 (11-jun, mismo
+    bulk); ciclo ya consumido → sin acción.
+- **2026-07-01 — S4a.** ADR-054 (convención: fecha de negocio =
+  `America/Matamoros`; instantes = timestamptz UTC; `Etc/GMT+6` solo
+  Playtomic/hold-cola documentados; crons = dos-horas-UTC + guard). Cron
+  `dilesa-encuestas` migrado de `Etc/GMT+6` a `hoyISOMatamoros()` (corre
+  ~10:00 locales — cero cambio de comportamiento, consistencia). Índice en
+  ARCHITECTURE.md §5. S4b (defaults `CURRENT_DATE` → fecha local en ~13
+  columnas `date` de `erp`/`dilesa.construccion`) queda propuesto —
+  migración toca tablas financieras, gate finanzas-ok, **pendiente OK de
+  Beto**.
 
 - **2026-07-01 — Análisis de impacto en flujos externos (pedido de Beto antes
   de S1): Waitry/Playtomic NO se tocan.** (a) El webhook de Waitry


### PR DESCRIPTION
## ADR-054 — Convención de timezone

- **Fecha calendario de negocio = `America/Matamoros`** (DST real): `hoyISOMatamoros()`/`fechaISOMatamoros()`/`inicioMesMatamoros()` en TS, `AT TIME ZONE 'America/Matamoros'` en SQL. `CURRENT_DATE` prohibido como "hoy" de negocio.
- **Instantes = `timestamptz` UTC siempre** (`created_at`, `synced_at`, etc.) — la restricción es sobre el recorte a calendario, no sobre ISO completo.
- **`Etc/GMT+6` fijo SOLO como excepción documentada de dominio**: Playtomic (el Manager exporta -6 fijo, así opera el club) y hold-cola (plazos estables ante DST). Residual conocido de 1h (23:00-24:00 verano) documentado.
- **Crons Vercel**: patrón dos-horas-UTC + guard `relojMatamoros` (resumen-consejo, daily-briefing).

## Cambio de código

`app/api/cron/dilesa-encuestas`: `Etc/GMT+6` → `hoyISOMatamoros()`. El cron corre a las 16:00 UTC (~10:00 locales), lejos de medianoche: **cero cambio de comportamiento**, consistencia con la convención.

## Bitácora (S3 read-only, sin cambios de datos en este PR)

Auditoría en prod documentada en el planning doc: 11 capturas nocturnas reales con fecha +1 en `venta_fases` (una cruza el corte de mes: 30-jun grabada 1-jul) + 1,093 filas del sellado Coda (sintéticas, no contaminan reportes — el conteo filtra `posicion in (2,11)`). Correcciones y migración S4b de defaults `CURRENT_DATE` esperan OK de Beto — **este PR no toca datos ni schema**.

## Verificación

- `typecheck` / `lint` (0 errores) / `format:check` / `initiatives:validate` ✅
- `test:coverage`: 182 files, 2,287 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)