### PR TITLE
feat(ci): gate financiero D5 a dos niveles + norma "migración primero, UI después"

### DIFF
--- a/.github/workflows/financial-migration-guard.yml
+++ b/.github/workflows/financial-migration-guard.yml
@@ -2,15 +2,22 @@ name: Financial Migration Guard
 
 # Gate D5 de la iniciativa `derivados-sin-drift` (Sprint 3). Con el modelo nuevo
 # las migraciones se aplican a prod AL MERGEAR (db-push-on-merge.yml). El control
-# financiero de Beto exige que nada que mueva dinero/permisos se aplique sin su
-# confirmación → las migraciones FINANCIERAS no se auto-mergean: las revisa y
-# mergea Dirección a mano (el merge ES la confirmación).
+# financiero de Beto exige que nada que MUEVA dinero o ABRA permisos se aplique
+# sin su confirmación → esas migraciones (nivel block) no se auto-mergean: espera
+# el "dale" de Beto + label `finanzas-ok`. El DDL aditivo sobre superficie
+# financiera (nivel notify) auto-mergea con aviso en el chat.
 #
 # Este check clasifica las migraciones nuevas del PR y publica el commit-status
-# `finanzas-gate` (required en branch protection):
+# `finanzas-gate` (required en branch protection). DOS NIVELES (2026-07-01 —
+# antes todo lo financiero bloqueaba y el volumen de aprobaciones triviales
+# convertía el gate en teatro):
 #   - PR sin migración financiera ............... success (no bloquea)
-#   - financiera CON label `finanzas-ok` ........ success (Dirección aprobó)
-#   - financiera SIN label ...................... pending (bloquea el auto-merge)
+#   - financiera ADITIVA (notify: DDL nuevo) .... success (auto-merge; CC avisa
+#                                                  en el chat, sin esperar OK)
+#   - financiera de RIESGO (block: DML/backfill
+#     de montos/destructivo/permisos) CON label
+#     `finanzas-ok` ............................. success (Dirección aprobó)
+#   - de RIESGO SIN label ....................... pending (bloquea el auto-merge)
 #
 # BLOQUEO SILENCIOSO (norma 2026-06-27): el job SIEMPRE termina en success, así
 # que GitHub no manda el correo "workflow run failed". El freno del auto-merge lo
@@ -77,16 +84,22 @@ jobs:
         if: steps.detect.outputs.has == 'true'
         run: npm ci --prefer-offline --no-audit
 
+      # Exit codes del clasificador: 0=none, 2=notify (aditiva), 3=block.
+      # Cualquier otro código (crash, tsx roto) se mapea a block — fail-closed.
       - name: Clasificar migraciones nuevas
         id: classify
         if: steps.detect.outputs.has == 'true'
         run: |
           NEW=$(cat /tmp/new_migrations.txt)
-          if npx tsx scripts/classify-financial-migration.ts $NEW; then
-            echo "financial=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "financial=true" >> "$GITHUB_OUTPUT"
-          fi
+          set +e
+          npx tsx scripts/classify-financial-migration.ts $NEW
+          RC=$?
+          set -e
+          case "$RC" in
+            0) echo "level=none"   >> "$GITHUB_OUTPUT" ;;
+            2) echo "level=notify" >> "$GITHUB_OUTPUT" ;;
+            *) echo "level=block"  >> "$GITHUB_OUTPUT" ;;
+          esac
 
       # Publica el status `finanzas-gate`. Siempre corre (incluso si un paso
       # previo falló) para no dejar el required check colgado, y el job no falla:
@@ -97,20 +110,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.pull_request.head.sha }}
           HAS: ${{ steps.detect.outputs.has }}
-          FINANCIAL: ${{ steps.classify.outputs.financial }}
+          LEVEL: ${{ steps.classify.outputs.level }}
           LABELED: ${{ contains(github.event.pull_request.labels.*.name, 'finanzas-ok') }}
         run: |
           STATE=success
           DESC="Sin migración financiera — OK"
-          # Fail-closed: financiera (true) O clasificación incompleta (vacío) con
+          # Fail-closed: nivel block O clasificación incompleta (vacío) con
           # migraciones presentes ⇒ exigir aprobación.
-          if [ "$HAS" = "true" ] && [ "$FINANCIAL" != "false" ]; then
-            if [ "$LABELED" = "true" ]; then
-              STATE=success
-              DESC="Migración financiera aprobada por Dirección (finanzas-ok)"
+          if [ "$HAS" = "true" ] && [ "$LEVEL" != "none" ]; then
+            if [ "$LEVEL" = "notify" ]; then
+              DESC="Financiera aditiva — auto-merge con aviso en chat (sin bloqueo)"
+            elif [ "$LABELED" = "true" ]; then
+              DESC="Migración financiera de riesgo aprobada por Dirección (finanzas-ok)"
             else
               STATE=pending
-              DESC="Migración financiera: espera label finanzas-ok de Dirección"
+              DESC="Financiera de riesgo (DML/destructivo/permisos): espera finanzas-ok"
             fi
           fi
           echo "finanzas-gate → $STATE — $DESC"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,16 @@ db:regen` (regenera `SCHEMA_REF.md` + `types/supabase.ts` desde las migraciones;
   migraciones son la fuente de verdad del schema; el `schema:check` viejo contra
   prod se retiró del job `quality`.)
 
+### Migración primero, UI después (previews funcionales)
+
+El Vercel Preview apunta a la base de **prod** y las migraciones se aplican **al
+mergear** → un preview cuya UI depende de schema nuevo nunca funciona antes del
+merge. Norma (2026-07-01): si la feature de UI depende de una migración,
+**separar en dos PRs** — primero el PR de la migración (mergea y aplica el schema
+a prod; DDL aditivo sin UI no rompe nada), después el PR de UI, cuyo preview ya
+corre contra el schema real. No aplica si la UI no necesita el schema nuevo para
+renderear. Detalle en `supabase/GOVERNANCE.md` §4.
+
 ### Aplicar migración por MCP → registrar de una vez (anti-drift del ledger)
 
 > Norma 2026-06-17 (Beto): cortar de raíz el drift del historial de migraciones.
@@ -221,9 +231,11 @@ db:regen` (regenera `SCHEMA_REF.md` + `types/supabase.ts` desde las migraciones;
 > **⚠️ MODELO CAMBIADO (`derivados-sin-drift` S3).** El flujo normal ya **no** es
 > aplicar-por-MCP-y-reconciliar. Las migraciones se aplican a prod **al mergear**,
 > automáticamente, vía `db-push-on-merge.yml` (`supabase db push`) — **nunca por
-> MCP ni antes de mergear** (ver `supabase/GOVERNANCE.md` §4 + gate financiero D5:
-> en financieras CC avisa a Beto en el chat con resumen+riesgos y, tras su **"dale"**,
-> CC pone el label `finanzas-ok` y mergea — nunca sin ese OK). En operación
+> MCP ni antes de mergear** (ver `supabase/GOVERNANCE.md` §4 + gate financiero D5,
+> dos niveles desde 2026-07-01: financiera **aditiva** = auto-merge con aviso en el
+> chat; financiera **de riesgo** — DML/backfill de montos/destructivo/permisos — =
+> CC avisa con resumen+riesgos y, tras el **"dale"** de Beto, pone el label
+> `finanzas-ok` y mergea — nunca sin ese OK). En operación
 > normal **no toques el ledger**: `db push` lo registra con el timestamp del
 > archivo. Lo de abajo aplica SOLO al **hotfix de emergencia por `psql` directo**
 > (raro) — ahí sí reconciliá el ledger en la misma sesión.

--- a/docs/planning/derivados-sin-drift.md
+++ b/docs/planning/derivados-sin-drift.md
@@ -7,7 +7,7 @@
 **Próximo hito:** — (iniciativa cerrada 2026-06-27)
 **Dueño:** Beto
 **Creada:** 2026-06-26
-**Última actualización:** 2026-06-27 (CERRADA — modelo completo en main: schema desde shadow + INITIATIVES fuera del PR + db push al merge con gate financiero D5; los 3 checks required en `main`; gate operativo con label `finanzas-ok`)
+**Última actualización:** 2026-07-01 (post-cierre: gate D5 recalibrado a dos niveles — aditiva auto-mergea con aviso, riesgo espera `finanzas-ok`; norma "migración primero, UI después" para previews)
 
 ## Problema
 
@@ -92,6 +92,24 @@ imposible** mientras se respete el apply-post-merge.
 - **D6 — El nuevo `schema-check` corre con paths-filter `supabase/migrations/**`**
 (gratis para PRs de UI), como `drift-check.yml`. No carga el job `quality` de cada
   PR con el boot de Docker.
+- **D5-bis (2026-07-01) — El gate financiero pasa a DOS NIVELES.** El clasificador
+  amplio original bloqueaba todo lo financiero; el volumen de aprobaciones triviales
+  hizo que Beto aprobara sin leer (gate = teatro). Recalibración: financiera
+  **aditiva** (`notify` — CREATE TABLE/ADD COLUMN/índices/funciones nuevas) auto-mergea
+  con aviso en el chat; financiera **de riesgo** (`block` — DML sobre tablas
+  financieras, backfills de montos, DROP/TRUNCATE/ALTER destructivo, `CREATE OR
+REPLACE`/`DROP` de RPCs financieras, GRANT/REVOKE fuera del boilerplate, RLS off,
+  policies mutadas o expuestas a anon) sigue exigiendo "dale" + label `finanzas-ok`.
+  Extras: comentarios SQL ya no clasifican (falso positivo documentado) y `REVOKE …
+FROM PUBLIC/anon` cuenta como endurecimiento, no bloquea. Convención derivada: RPC
+  financiera nueva = `CREATE FUNCTION` (sin OR REPLACE). Calibrado contra las últimas
+  25 migraciones reales: 15 bloqueos con la regla vieja → 6 con la nueva, y los 6 son
+  genuinamente de riesgo. **Decidida con Beto en chat (2026-07-01).**
+- **D7 (2026-07-01) — Norma "migración primero, UI después".** El Vercel Preview
+  apunta a prod y las migraciones se aplican al merge → un preview cuya UI depende de
+  schema nuevo nunca funciona antes del merge (con o sin gate). Cuando la UI dependa
+  de una migración, se separa en dos PRs: migración primero (auto-merge, schema en
+  prod en ~2 min), UI después con preview funcional. Sin cambio de tooling.
 
 ## Riesgos
 
@@ -223,3 +241,15 @@ NOT EXISTS ... REFERENCES/DEFAULT` (no reproducible). `SCHEMA_REF`/`types`
   local con `npm run initiatives:gen` cuando haga falta; el camino del PAT queda
   documentado en `initiatives-regen.yml`. Memorias de migración actualizadas al modelo
   nuevo.
+- **2026-07-01 — Recalibración post-cierre del gate D5 (D5-bis) + norma D7.** Beto
+  reportó que aprobaba `finanzas-ok` sin leer (demasiadas aprobaciones triviales) y
+  que los previews de features con migración nueva no funcionan. Cambios: (1)
+  `classify-financial-migration.ts` reescrito a dos niveles (`notify` aditiva
+  auto-mergea con aviso / `block` DML-destructivo-permisos espera "dale"), con strip
+  de comentarios SQL y `REVOKE FROM PUBLIC/anon` exento como endurecimiento; exit
+  codes 0/2/3, fail-closed en el workflow. (2) `financial-migration-guard.yml`
+  publica `pending` solo en nivel `block`. (3) Test unitario nuevo
+  (`classify-financial-migration.test.ts`, 20 casos) lockea la frontera notify/block.
+  (4) Norma "migración primero, UI después" documentada en `GOVERNANCE.md` §4 y
+  `CLAUDE.md`. Calibración contra las 25 migraciones más recientes: 15 bloqueos
+  (regla vieja) → 6 (nueva), todos de riesgo genuino.

--- a/scripts/classify-financial-migration.test.ts
+++ b/scripts/classify-financial-migration.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+
+import { classifySql, levelOf, stripSqlComments, type Level } from './classify-financial-migration';
+
+/**
+ * Tests del clasificador de dos niveles del gate financiero D5
+ * (recalibración 2026-07-01):
+ *
+ *   - `notify` — superficie financiera pero DDL aditivo → auto-merge con aviso.
+ *   - `block`  — mueve dinero o permisos → espera label `finanzas-ok`.
+ *
+ * La intención es lockear la frontera notify/block: si un patrón nuevo la
+ * mueve, este test obliga a decidirlo conscientemente.
+ */
+
+function level(sql: string): Level {
+  return levelOf(classifySql(sql));
+}
+
+describe('stripSqlComments', () => {
+  it('remueve comentarios de línea y de bloque', () => {
+    const sql = `-- toca dilesa.ventas\n/* y erp.facturas */\nCREATE TABLE core.notas (id uuid);`;
+    const out = stripSqlComments(sql);
+    expect(out).not.toContain('dilesa.ventas');
+    expect(out).not.toContain('erp.facturas');
+    expect(out).toContain('CREATE TABLE core.notas');
+  });
+});
+
+describe('nivel none — sin superficie financiera', () => {
+  it('migración no-financiera común', () => {
+    expect(level(`ALTER TABLE dilesa.unidades ADD COLUMN frente_id uuid;`)).toBe('none');
+  });
+
+  it('mención de tabla financiera SOLO en comentario no dispara el gate', () => {
+    expect(
+      level(
+        `-- este índice acelera el join contra dilesa.ventas\nCREATE INDEX idx_uni ON dilesa.unidades (estado);`
+      )
+    ).toBe('none');
+  });
+
+  it('REVOKE FROM anon/PUBLIC es endurecimiento, no bloquea', () => {
+    expect(level(`REVOKE SELECT ON rdb.v_inventario_stock FROM anon;`)).toBe('none');
+    expect(level(`REVOKE ALL ON core.notas FROM PUBLIC, anon;`)).toBe('none');
+  });
+});
+
+describe('nivel notify — superficie financiera aditiva', () => {
+  it('CREATE TABLE financiera nueva', () => {
+    expect(level(`CREATE TABLE erp.cxc_documentos (id uuid PRIMARY KEY, monto numeric);`)).toBe(
+      'notify'
+    );
+  });
+
+  it('ADD COLUMN sobre tabla financiera', () => {
+    expect(level(`ALTER TABLE dilesa.ventas ADD COLUMN motivo_descuento text;`)).toBe('notify');
+  });
+
+  it('término de dinero en DDL aditivo', () => {
+    expect(level(`ALTER TABLE dilesa.unidades ADD COLUMN sobreprecio numeric;`)).toBe('notify');
+  });
+
+  it('función financiera NUEVA (CREATE FUNCTION sin OR REPLACE) con boilerplate de grants', () => {
+    const sql = `
+      CREATE FUNCTION dilesa.fn_calcular_precio_lote(p_id uuid) RETURNS numeric
+      LANGUAGE sql SECURITY DEFINER AS $$ SELECT 1 $$;
+      REVOKE ALL ON FUNCTION dilesa.fn_calcular_precio_lote(uuid) FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION dilesa.fn_calcular_precio_lote(uuid) TO authenticated;
+    `;
+    expect(level(sql)).toBe('notify');
+  });
+});
+
+describe('nivel block — mueve dinero o permisos', () => {
+  it('UPDATE sobre tabla financiera', () => {
+    expect(level(`UPDATE dilesa.ventas SET estado = 'terminada' WHERE id = '…';`)).toBe('block');
+  });
+
+  it('DELETE sobre tabla financiera', () => {
+    expect(level(`DELETE FROM erp.pagos WHERE id = '…';`)).toBe('block');
+  });
+
+  it('INSERT (backfill/seed) sobre tabla financiera', () => {
+    expect(level(`INSERT INTO erp.facturas (id) VALUES ('…');`)).toBe('block');
+  });
+
+  it('backfill de columna de montos fuera de las tablas listadas', () => {
+    expect(level(`UPDATE dilesa.unidades SET sobreprecio = precio * 0.06;`)).toBe('block');
+  });
+
+  it('DROP TABLE financiera', () => {
+    expect(level(`DROP TABLE IF EXISTS erp.presupuesto_obra;`)).toBe('block');
+  });
+
+  it('DROP COLUMN sobre tabla financiera', () => {
+    expect(level(`ALTER TABLE dilesa.ventas DROP COLUMN sobreprecio;`)).toBe('block');
+  });
+
+  it('CREATE OR REPLACE de RPC financiera (redefinición de algo vivo)', () => {
+    expect(
+      level(
+        `CREATE OR REPLACE FUNCTION dilesa.fn_registrar_pago(p uuid) RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;`
+      )
+    ).toBe('block');
+  });
+
+  it('GRANT fuera del boilerplate (a anon / sobre tablas)', () => {
+    expect(level(`GRANT SELECT ON erp.facturas TO anon;`)).toBe('block');
+    expect(level(`GRANT USAGE ON SCHEMA erp TO anon;`)).toBe('block');
+  });
+
+  it('REVOKE a roles de la app (puede romper acceso, no es tightening)', () => {
+    expect(level(`REVOKE SELECT ON core.notas FROM authenticated;`)).toBe('block');
+  });
+
+  it('RLS deshabilitado', () => {
+    expect(level(`ALTER TABLE core.notas DISABLE ROW LEVEL SECURITY;`)).toBe('block');
+  });
+
+  it('DROP POLICY sobre tabla financiera', () => {
+    expect(level(`DROP POLICY ventas_empresa ON dilesa.ventas;`)).toBe('block');
+  });
+
+  it('policy nueva que expone a anon', () => {
+    expect(level(`CREATE POLICY abierta ON core.notas FOR SELECT TO anon USING (true);`)).toBe(
+      'block'
+    );
+  });
+});

--- a/scripts/classify-financial-migration.ts
+++ b/scripts/classify-financial-migration.ts
@@ -6,76 +6,218 @@
  * Regla de Beto (control financiero): nada que mueva dinero o permisos se aplica
  * a prod sin su confirmación explícita. Con el modelo nuevo las migraciones se
  * aplican a prod AL MERGEAR (workflow `db-push-on-merge.yml`), así que el gate
- * vive en el merge: las migraciones financieras NO llevan auto-merge — las
- * revisa y mergea Dirección a mano (el merge ES la confirmación). El workflow
- * `financial-migration-guard.yml` usa este clasificador para bloquear el
- * auto-merge de PRs con migraciones financieras hasta que Dirección apruebe.
+ * vive en el merge. El workflow `financial-migration-guard.yml` usa este
+ * clasificador para decidir si el PR puede auto-mergear.
+ *
+ * DOS NIVELES (recalibración 2026-07-01 — antes todo lo financiero bloqueaba,
+ * el volumen de aprobaciones triviales convertía el gate en teatro):
+ *
+ *   - `notify` — superficie financiera pero SOLO DDL aditivo (CREATE TABLE,
+ *     ADD COLUMN, índices, funciones nuevas). Auto-mergea; CC avisa en el chat
+ *     con resumen, sin esperar OK. Reversible y no mueve dinero.
+ *   - `block`  — lo que sí puede costar dinero o abrir permisos: DML sobre
+ *     tablas financieras, backfills de columnas de montos, DROP/TRUNCATE/ALTER
+ *     destructivo sobre superficie financiera, redefinición (`CREATE OR
+ *     REPLACE`/`DROP`) de RPCs financieras existentes, GRANT/REVOKE fuera del
+ *     boilerplate de funciones, RLS deshabilitado o policies mutadas/expuestas
+ *     a anon. NO auto-mergea: espera el "dale" de Beto + label `finanzas-ok`.
+ *
+ * Convención que esto habilita: una función financiera NUEVA se escribe con
+ * `CREATE FUNCTION` (sin OR REPLACE) → notify. `CREATE OR REPLACE` sobre una
+ * fn financiera se lee como redefinición de algo vivo → block.
+ *
+ * Los comentarios SQL (de línea `--` y de bloque) se eliminan antes de
+ * clasificar: citar una tabla financiera en un comentario no dispara el gate.
  *
  * Uso:  npx tsx scripts/classify-financial-migration.ts <a.sql> [<b.sql> ...]
  *
- * Imprime los archivos financieros (con el patrón que los marcó) y sale con
- * código 1 si AL MENOS uno es financiero; 0 si ninguno. La heurística es
- * DELIBERADAMENTE amplia: preferimos falsos positivos (Dirección revisa de más)
- * a falsos negativos (una migración financiera auto-aplicada a prod sin gate).
+ * Exit codes (el workflow mapea cualquier código inesperado a block, fail-closed):
+ *   0 — ninguna migración toca superficie financiera
+ *   2 — superficie financiera aditiva (notify): auto-merge con aviso
+ *   3 — al menos una migración de riesgo (block): requiere label `finanzas-ok`
  */
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export type Level = 'none' | 'notify' | 'block';
+
+export interface Finding {
+  level: 'notify' | 'block';
+  label: string;
+}
+
+// Tablas financieras (fuente única para superficie y para targets de DML/DDL).
+const FIN_TABLES_SRC = String.raw`(?:erp\.(?:facturas|gastos|cxc_\w+|cxp_\w+|pagos|movimientos_bancarios|ordenes_compra|estados_cuenta|conciliaci\w+|presupuesto\w*)|dilesa\.(?:ventas|estimaciones|obra_estimaciones|contratos\w*))`;
+
+// Nombres de RPCs financieras.
+const FIN_FN_SRC = String.raw`fn_\w*(?:pago|factura|cxc|cxp|comision|precio|cuadratura|avaluo|abono|presupuesto)\w*`;
+
+// Columnas/términos de montos (para detectar backfills fuera de las tablas listadas).
+const MONEY_COL_SRC = String.raw`(?:monto|importe|precio|saldo|descuento|comisi[oó]n|sobreprecio|enganche|abono|anticipo|finiquito|retenci[oó]n|valor_\w+)`;
 
 interface Pattern {
   re: RegExp;
   label: string;
 }
 
-const PATTERNS: Pattern[] = [
-  { re: /\bGRANT\b|\bREVOKE\b/i, label: 'GRANT/REVOKE (cambia permisos)' },
-  { re: /SECURITY\s+DEFINER/i, label: 'función SECURITY DEFINER (privilegiada)' },
-  {
-    re: /\berp\.(facturas|gastos|cxc_\w+|cxp_\w+|pagos|movimientos_bancarios|ordenes_compra|estados_cuenta|conciliaci\w+|presupuesto\w*)/i,
-    label: 'tabla financiera de erp.*',
-  },
-  {
-    re: /\bdilesa\.(ventas|estimaciones|obra_estimaciones|contratos\w*)/i,
-    label: 'tabla dilesa.* de montos/contratos',
-  },
+// ── Nivel notify: superficie financiera (sin operación de riesgo) ────────────
+const SURFACE_PATTERNS: Pattern[] = [
+  { re: new RegExp(String.raw`\b${FIN_TABLES_SRC}`, 'i'), label: 'tabla financiera' },
   {
     re: /\b(comisi[oó]n|finiquito|anticipo|retenci[oó]n|sobreprecio|enganche|pagar[ée]|abono|aval[uú]o)\w*/i,
     label: 'término de dinero',
   },
   { re: /\bpld\b|aviso[_\s]?pld|lavado/i, label: 'PLD / antilavado' },
-  {
-    re: /fn_\w*(pago|factura|cxc|cxp|comision|precio|cuadratura|avaluo|abono|presupuesto)\w*/i,
-    label: 'RPC financiera fn_*',
-  },
+  { re: new RegExp(String.raw`\b${FIN_FN_SRC}`, 'i'), label: 'RPC financiera fn_*' },
+  { re: /SECURITY\s+DEFINER/i, label: 'función SECURITY DEFINER (privilegiada)' },
 ];
 
-function classify(path: string): string[] {
-  let sql: string;
-  try {
-    sql = readFileSync(path, 'utf8');
-  } catch {
-    return [];
+// ── Nivel block: mueve dinero o permisos ─────────────────────────────────────
+const BLOCK_PATTERNS: Pattern[] = [
+  {
+    re: new RegExp(
+      String.raw`\b(?:UPDATE|DELETE\s+FROM|INSERT\s+INTO|MERGE\s+INTO)\s+(?:ONLY\s+)?${FIN_TABLES_SRC}`,
+      'i'
+    ),
+    label: 'DML sobre tabla financiera',
+  },
+  {
+    re: new RegExp(String.raw`\bUPDATE\s+[\w."]+\s+SET\b[^;]*\b${MONEY_COL_SRC}\s*=`, 'is'),
+    label: 'backfill de columna de montos (UPDATE … SET <monto>)',
+  },
+  {
+    re: new RegExp(
+      String.raw`\b(?:DROP\s+TABLE|TRUNCATE(?:\s+TABLE)?)\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?${FIN_TABLES_SRC}`,
+      'i'
+    ),
+    label: 'DROP/TRUNCATE de tabla financiera',
+  },
+  {
+    re: new RegExp(
+      String.raw`\bALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?${FIN_TABLES_SRC}[^;]*\b(?:DROP\s+COLUMN|TYPE\s)`,
+      'is'
+    ),
+    label: 'ALTER destructivo sobre tabla financiera (DROP COLUMN / cambio de TYPE)',
+  },
+  {
+    re: new RegExp(
+      String.raw`\b(?:CREATE\s+OR\s+REPLACE\s+FUNCTION|DROP\s+FUNCTION)\s+(?:IF\s+EXISTS\s+)?[\w."]*${FIN_FN_SRC}`,
+      'i'
+    ),
+    label: 'redefinición/DROP de RPC financiera existente',
+  },
+  {
+    re: /\bDISABLE\s+ROW\s+LEVEL\s+SECURITY\b/i,
+    label: 'RLS deshabilitado',
+  },
+  {
+    re: new RegExp(
+      String.raw`\b(?:ALTER|DROP)\s+POLICY\b[^;]*\bON\s+(?:ONLY\s+)?${FIN_TABLES_SRC}`,
+      'is'
+    ),
+    label: 'policy mutada/borrada sobre tabla financiera',
+  },
+  {
+    re: /\bCREATE\s+POLICY\b[^;]*\bTO\b[^;]*\banon\b/is,
+    label: 'policy que expone a anon',
+  },
+  { re: /\bALTER\s+ROLE\b|\bALTER\s+DEFAULT\s+PRIVILEGES\b/i, label: 'permisos de rol/default' },
+];
+
+// GRANT/REVOKE que NO cuentan como cambio de permisos riesgoso:
+//   - `REVOKE … FROM PUBLIC/anon` (cualquier objeto) — endurecimiento: QUITA
+//     acceso, nunca lo abre.
+//   - `GRANT EXECUTE ON FUNCTION … TO authenticated/service_role` — boilerplate
+//     estándar de RPCs nuevas.
+// Se remueven del SQL y cualquier GRANT/REVOKE restante sí bloquea (GRANT a
+// anon, GRANT sobre tablas/schemas, REVOKE a roles de la app, etc.).
+const GRANT_BOILERPLATE: RegExp[] = [
+  /\bREVOKE\b[^;]*\bFROM\s+(?:PUBLIC|anon)(?:\s*,\s*(?:PUBLIC|anon))*\s*;/gis,
+  /\bGRANT\s+EXECUTE\s+ON\s+FUNCTION\b[^;]*\bTO\s+(?:authenticated|service_role)(?:\s*,\s*(?:authenticated|service_role))*\s*;/gis,
+];
+
+/** Elimina comentarios SQL (de línea y de bloque) para no clasificar prosa. */
+export function stripSqlComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+}
+
+export function classifySql(rawSql: string): Finding[] {
+  const sql = stripSqlComments(rawSql);
+  const findings: Finding[] = [];
+
+  for (const p of BLOCK_PATTERNS) {
+    if (p.re.test(sql)) findings.push({ level: 'block', label: p.label });
   }
-  return PATTERNS.filter((p) => p.re.test(sql)).map((p) => p.label);
+
+  const sinBoilerplate = GRANT_BOILERPLATE.reduce((s, re) => s.replace(re, ' '), sql);
+  if (/\b(GRANT|REVOKE)\b/i.test(sinBoilerplate)) {
+    findings.push({
+      level: 'block',
+      label: 'GRANT/REVOKE fuera del boilerplate de funciones (cambia permisos)',
+    });
+  }
+
+  for (const p of SURFACE_PATTERNS) {
+    if (p.re.test(sql)) findings.push({ level: 'notify', label: p.label });
+  }
+
+  return findings;
+}
+
+export function levelOf(findings: Finding[]): Level {
+  if (findings.some((f) => f.level === 'block')) return 'block';
+  if (findings.length > 0) return 'notify';
+  return 'none';
 }
 
 function main(): void {
   const files = process.argv.slice(2).filter((f) => f.endsWith('.sql'));
-  const financial: { file: string; reasons: string[] }[] = [];
+  let overall: Level = 'none';
+  const report: { file: string; level: Level; findings: Finding[] }[] = [];
+
   for (const f of files) {
-    const reasons = classify(f);
-    if (reasons.length) financial.push({ file: f, reasons });
+    let sql: string;
+    try {
+      sql = readFileSync(f, 'utf8');
+    } catch {
+      continue;
+    }
+    const findings = classifySql(sql);
+    const level = levelOf(findings);
+    if (level !== 'none') report.push({ file: f, level, findings });
+    if (level === 'block' || (level === 'notify' && overall === 'none')) overall = level;
   }
 
-  if (financial.length === 0) {
+  if (overall === 'none') {
     console.log('✓ Ninguna migración nueva toca superficie financiera.');
     process.exit(0);
   }
 
-  console.log('⚠️  Migración(es) FINANCIERA(s) detectada(s):');
-  for (const { file, reasons } of financial) {
-    console.log(`  - ${file}`);
-    for (const r of reasons) console.log(`      · ${r}`);
+  for (const { file, level, findings } of report) {
+    console.log(`${level === 'block' ? '⛔ BLOCK' : '⚠️  NOTIFY'}  ${file}`);
+    for (const fi of findings) console.log(`      · [${fi.level}] ${fi.label}`);
   }
-  process.exit(1);
+
+  if (overall === 'block') {
+    console.log(
+      '\n⛔ Migración financiera de RIESGO: requiere "dale" de Beto + label finanzas-ok.'
+    );
+    process.exit(3);
+  }
+  console.log('\n⚠️  Financiera ADITIVA: auto-mergea; CC avisa en el chat con resumen.');
+  process.exit(2);
 }
 
-main();
+// Ejecutar solo cuando se invoca directamente (no al importar desde tests).
+const isMainModule = (() => {
+  try {
+    const invoked = process.argv[1] ? path.resolve(process.argv[1]) : '';
+    return invoked === path.resolve(__filename);
+  } catch {
+    return false;
+  }
+})();
+
+if (isMainModule) {
+  main();
+}

--- a/supabase/GOVERNANCE.md
+++ b/supabase/GOVERNANCE.md
@@ -109,19 +109,46 @@ el timestamp del archivo; muere el baile de `migration repair`).
 
 ### Gate financiero (D5) — confirmación explícita de Dirección en el chat
 
+Dos niveles (recalibración 2026-07-01 — antes todo lo financiero bloqueaba y el
+volumen de aprobaciones triviales convertía el gate en teatro; el universo de
+"espera OK" se recortó a lo que genuinamente puede costar dinero o abrir permisos):
+
 - **No-financieras** → auto-merge → al mergear, `db-push-on-merge.yml` las aplica.
   CC hace todo de punta a punta; Beto no interviene ni tiene que acordarse de nada.
-- **Financieras** (mueven dinero o permisos) → el check `financial-migration-guard`
-  las detecta y **bloquea el auto-merge**. Flujo (norma Beto 2026-06-27):
-  1. CC corre el clasificador al crear la migración; si es financiera, **avisa a Beto
-     en el chat** con el resumen + riesgos (no espera a que él se acuerde).
+- **Financieras ADITIVAS (`notify`)** — superficie financiera pero solo DDL aditivo
+  (CREATE TABLE, ADD COLUMN, índices, funciones **nuevas** con `CREATE FUNCTION`
+  sin OR REPLACE) → **auto-merge**. CC **avisa a Beto en el chat** con el resumen,
+  sin esperar OK. Reversible y no mueve dinero.
+- **Financieras de RIESGO (`block`)** — DML sobre tablas financieras, backfills de
+  columnas de montos, DROP/TRUNCATE/ALTER destructivo sobre superficie financiera,
+  `CREATE OR REPLACE`/`DROP` de RPCs financieras existentes, GRANT/REVOKE fuera
+  del boilerplate (el hardening `REVOKE … FROM PUBLIC/anon` no cuenta), RLS
+  deshabilitado o policies mutadas/expuestas a anon → el check
+  `financial-migration-guard` **bloquea el auto-merge**. Flujo (norma Beto
+  2026-06-27):
+  1. CC corre el clasificador al crear la migración; si es de riesgo, **avisa a
+     Beto en el chat** con el resumen + riesgos (no espera a que él se acuerde).
   2. Beto da el **OK verbal explícito** para ESA migración ("dale").
   3. Recién entonces CC pone el label `finanzas-ok` y mergea (lo que la aplica a prod).
 
   **CC NUNCA pone `finanzas-ok` sin el "dale" de Beto para esa migración específica.**
   El "dale" en el chat es la confirmación explícita que exige el control financiero; el
   bloqueo técnico (sin label no hay auto-merge) es la red de seguridad que evita que una
-  financiera se cuele a prod sin pasar por ese OK.
+  financiera de riesgo se cuele a prod sin pasar por ese OK.
+
+  Convención derivada: una RPC financiera **nueva** se escribe con `CREATE FUNCTION`
+  (sin `OR REPLACE`) para clasificar como aditiva; `CREATE OR REPLACE` sobre una fn
+  financiera se lee como redefinición de algo vivo y bloquea.
+
+### Migración primero, UI después (previews funcionales)
+
+El Vercel Preview apunta a la base de **prod**, y las migraciones se aplican **al
+mergear** — un preview cuya UI depende de schema nuevo NUNCA funciona antes del
+merge, con o sin gate. La norma (2026-07-01): cuando una feature de UI depende de
+una migración, **separar en dos PRs** — el PR de la migración mergea primero
+(schema aplicado a prod en ~2 min; para DDL aditivo es seguro: schema nuevo sin UI
+no rompe nada), y el PR de UI se abre después con su preview funcionando contra el
+schema real. No aplica cuando la UI no necesita el schema nuevo para renderear.
 
 ### Procedimiento normal
 


### PR DESCRIPTION
## Qué cambia

Recalibración del gate `finanzas-ok` (norma Beto 2026-07-01, decidida en chat): el clasificador amplio bloqueaba **todo** lo financiero y el volumen de aprobaciones triviales convertía el gate en teatro.

### Gate de dos niveles

| Nivel | Qué matchea | Qué pasa |
|---|---|---|
| `notify` | Superficie financiera pero solo DDL aditivo (CREATE TABLE, ADD COLUMN, índices, funciones nuevas con `CREATE FUNCTION`) | **Auto-merge**; CC avisa en el chat con resumen, sin esperar OK |
| `block` | DML sobre tablas financieras, backfills de columnas de montos, DROP/TRUNCATE/ALTER destructivo, `CREATE OR REPLACE`/`DROP` de RPCs financieras, GRANT/REVOKE fuera del boilerplate, RLS off, policies mutadas/expuestas a anon | **Bloquea auto-merge**: espera "dale" de Beto + label `finanzas-ok` |

Extras del clasificador:
- Los comentarios SQL ya no clasifican (mata el falso positivo documentado de citar `dilesa.ventas` en un comentario).
- `REVOKE … FROM PUBLIC/anon` cuenta como endurecimiento (quita acceso) y no bloquea.
- Exit codes 0/2/3; el workflow mapea cualquier código inesperado a `block` (fail-closed).
- Convención derivada: RPC financiera **nueva** = `CREATE FUNCTION` (sin OR REPLACE).

### Calibración contra migraciones reales

Últimas 25 migraciones: **15 bloqueos con la regla vieja → 6 con la nueva**, y los 6 son genuinamente de riesgo (generación de cargos CxC, limpieza de saldos, redefinición de RPCs de pago, descuento al valor base).

### Norma "migración primero, UI después"

El Vercel Preview apunta a prod y las migraciones se aplican al merge → un preview cuya UI depende de schema nuevo nunca funciona antes del merge (con o sin gate). Norma nueva en `GOVERNANCE.md` §4 + `CLAUDE.md`: UI que depende de una migración va en PR separado, después de mergear el PR de la migración.

## Archivos

- `scripts/classify-financial-migration.ts` — clasificador de dos niveles
- `scripts/classify-financial-migration.test.ts` — 20 casos que lockean la frontera notify/block
- `.github/workflows/financial-migration-guard.yml` — `pending` solo en nivel `block`
- `supabase/GOVERNANCE.md`, `CLAUDE.md`, `docs/planning/derivados-sin-drift.md` (D5-bis, D7)

Sin migraciones en este PR (el propio gate reporta success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)