### PR TITLE
fix(dilesa-resumen-consejo): escrituras del mes por fecha_escritura + tile «registradas hoy»

### DIFF
--- a/app/api/cron/dilesa-resumen-consejo/route.ts
+++ b/app/api/cron/dilesa-resumen-consejo/route.ts
@@ -159,6 +159,7 @@ export async function GET(req: NextRequest) {
     ),
     escrituras_mes_n: data.asignaciones.reduce((s, a) => s + a.escrituras_mes, 0),
     escrituras_mes_monto: data.asignaciones.reduce((s, a) => s + a.monto_escrituras, 0),
+    escrituras_hoy_fechas_reales: data.escrituras_hoy_fechas_reales,
     cxp_por_pagar: (cxpRes.data ?? []).reduce(
       (s: number, p: { monto_total: number | null }) => s + Number(p.monto_total ?? 0),
       0

--- a/docs/planning/dilesa-resumen-consejo-rediseno.md
+++ b/docs/planning/dilesa-resumen-consejo-rediseno.md
@@ -7,7 +7,7 @@
 **Próximo hito:** Sprint 5 — cutover + closeout (smoke E2E lado a lado + revisar preview con Beto + cerrar iniciativa). Sprint 4 (absorción + meses de inventario + backlog de escrituración) en preview de revisión de Beto.
 **Dueño:** Beto
 **Creada:** 2026-06-13
-**Última actualización:** 2026-06-19 (fix del pipeline vivo: valor de escrituración con fallback a precio_asignación en fases previas a Dictaminada — antes salía $0 en Asignada/Formalizada)
+**Última actualización:** 2026-07-01 (base híbrida de escrituras: mes por fecha_escritura, tile «registradas hoy» con nota de fechas reales)
 
 > **Continuación de** [`dilesa-resumen-consejo`](dilesa-resumen-consejo.md) (cerrada 2026-06-08, v1 = paridad 1:1 con Coda). Aquella es la **referencia técnica** del correo (7 bloques, vistas, cron, guard de domingo, fechas DST). Esta iniciativa es la **Fase 2** que aquel doc dejó anotada: pasar de "réplica de Coda" a un reporte que el Consejo espere a diario.
 
@@ -140,6 +140,21 @@ Bloque "⚠️ Requiere atención" que **solo aparece si dispara algo** (cero al
 - 100% de envíos trazables en `core.notification_log` (heredado de v1).
 
 ## Bitácora
+
+- **2026-07-01 (base híbrida de escrituras — registro vs fecha real)** — En el
+  primer correo tras el fix de TZ (iniciativa `fechas-tz`), Beto notó "7
+  escrituras hoy" que se REGISTRARON hoy pero cuyas escrituras reales son de
+  junio (y 2 con `fecha_escritura` futura, 25/27-jul — firmas programadas o
+  error de captura, se revisan aparte). Regla de Beto: **los reportes siempre
+  cuentan por la fecha de la escritura, no la del registro** (alineado con el
+  módulo de Reportes, #1140). Decisión (opción híbrida, elegida por Beto):
+  el **mes** (tile, tabla por prototipo y asunto) se cuenta por
+  `ventas.fecha_escritura` en [inicio de mes, hoy] — las futuras aún no
+  cuentan; el tile **"hoy" pasa a "Escrituras registradas hoy"** (pulso
+  operativo, única forma de que el consejo vea registros tardíos de meses ya
+  cerrados) con nota "f. reales: …" cuando difieren, y el asunto dice
+  "N escrituras registradas". Asignaciones siguen por fase 2 (evento interno,
+  su fecha es la real).
 
 - **2026-06-19 (fix del pipeline vivo — valor desde la asignación)** — Beto notó que
   en el correo las primeras fases (Solicitud de Asignación, Asignada) y parte de

--- a/lib/dilesa/resumen-consejo-email.test.ts
+++ b/lib/dilesa/resumen-consejo-email.test.ts
@@ -68,6 +68,7 @@ const DATA_DEMO: ResumenConsejoData = {
   tuberiaHistorico: { clientes: 0, valor: 0 },
   asignaciones: [],
   backlog: { comprometidas_n: 0, comprometido_monto: 0 },
+  escrituras_hoy_fechas_reales: [],
   avances: [],
   absorcion: [],
   prototipos: [],
@@ -81,6 +82,7 @@ const EMPTY: ResumenConsejoData = {
   tuberiaHistorico: { clientes: 0, valor: 0 },
   asignaciones: [],
   backlog: { comprometidas_n: 0, comprometido_monto: 0 },
+  escrituras_hoy_fechas_reales: [],
   avances: [],
   absorcion: [],
   prototipos: [],
@@ -621,6 +623,35 @@ describe('renderTarjetaEjecutiva + correo con cabecera', () => {
     expect(html).toContain('Cobrado hoy');
     expect(html).toContain('vencido $47.5M');
     expect(html).toContain('2 con hito vencido');
+  });
+
+  it('el tile de escrituras distingue registro vs fecha real (base híbrida)', () => {
+    const html = renderTarjetaEjecutiva(CAB_DEMO, DATA_DEMO, HOY);
+    // "hoy" = registradas hoy; "mes" = por fecha de escritura.
+    expect(html).toContain('Escrituras registradas hoy');
+    expect(html).toContain('mes (f. escritura):');
+    // Sin fechas reales distintas al día → sin nota.
+    expect(html).not.toContain('f. reales:');
+  });
+
+  it('muestra las fechas reales cuando difieren del día de registro, recortadas a 3', () => {
+    const cab: Cabecera = {
+      ...CAB_DEMO,
+      escrituras_hoy_fechas_reales: [
+        '2026-06-22',
+        '2026-06-23',
+        '2026-06-26',
+        '2026-06-30',
+        HOY, // una registrada el mismo día NO va en la nota
+      ],
+    };
+    const html = renderTarjetaEjecutiva(cab, DATA_DEMO, HOY);
+    expect(html).toContain('f. reales: 22 jun, 23 jun, 26 jun +1');
+  });
+
+  it('el asunto dice "registradas" para no leerse como firmas del día', () => {
+    const asunto = armarAsunto(CAB_DEMO, '13 jun', { ...DATA_DEMO, saldos: [] }, HOY);
+    expect(asunto).toContain('2 escrituras registradas');
   });
 
   it('renderResumenConsejoHtml con cabecera incluye tarjeta, alertas y línea CxC', () => {

--- a/lib/dilesa/resumen-consejo-email.ts
+++ b/lib/dilesa/resumen-consejo-email.ts
@@ -280,6 +280,12 @@ export type ResumenConsejoData = {
   tuberiaHistorico: { clientes: number; valor: number };
   asignaciones: AsignacionRow[];
   backlog: BacklogEscrituracion;
+  /**
+   * Fechas REALES de escritura (`ventas.fecha_escritura`) de las fases 11
+   * registradas HOY — para la nota del tile cuando difieren del día de registro
+   * (lo normal: el registro en BSOP va días después de la firma).
+   */
+  escrituras_hoy_fechas_reales: string[];
   // ③ Proyectos
   avances: AvanceRow[];
   absorcion: AbsorcionRow[];
@@ -299,6 +305,8 @@ export type Cabecera = {
   cobrado_mes: number;
   escrituras_mes_n: number;
   escrituras_mes_monto: number;
+  /** Fechas reales de las escrituras registradas hoy (nota del tile). */
+  escrituras_hoy_fechas_reales?: string[];
   cxp_por_pagar: number;
   /**
    * CxC en reconciliación: la carga histórica de pagos (sobre todo los
@@ -511,6 +519,15 @@ export function renderTarjetaEjecutiva(
     return d != null && d > SALDO_STALE_DIAS;
   }).length;
   const venc = data.construccion.vencidas;
+  // Nota del tile de escrituras: fechas REALES del acto cuando difieren del
+  // día de registro (recortada a 3 para no desbordar la tarjeta).
+  const fechasReales = (cab.escrituras_hoy_fechas_reales ?? []).filter((f) => f !== hoyISO);
+  const escriturasNota = fechasReales.length
+    ? `<br/>f. reales: ${fechasReales
+        .slice(0, 3)
+        .map((f) => fechaCortaDe(f))
+        .join(', ')}${fechasReales.length > 3 ? ` +${fechasReales.length - 3}` : ''}`
+    : '';
   const cards = [
     cardCell(
       'Ventas hoy',
@@ -519,9 +536,9 @@ export function renderTarjetaEjecutiva(
       ventasColor
     ),
     cardCell(
-      'Escrituras hoy',
+      'Escrituras registradas hoy',
       `${k.escrituras_hoy_n} · ${fmtMoneyCompact(k.escrituras_hoy_monto)}`,
-      `mes: ${cab.escrituras_mes_n} · ${fmtMoneyCompact(cab.escrituras_mes_monto)}`,
+      `mes (f. escritura): ${cab.escrituras_mes_n} · ${fmtMoneyCompact(cab.escrituras_mes_monto)}${escriturasNota}`,
       '#64748b'
     ),
     cardCell(
@@ -611,7 +628,9 @@ export function armarAsunto(
       : 'sin ventas hoy'
   );
   if (k.escrituras_hoy_n > 0)
-    segs.push(`${k.escrituras_hoy_n} escritura${k.escrituras_hoy_n > 1 ? 's' : ''}`);
+    segs.push(
+      `${k.escrituras_hoy_n} escritura${k.escrituras_hoy_n > 1 ? 's' : ''} registrada${k.escrituras_hoy_n > 1 ? 's' : ''}`
+    );
   if (!cab.cxc_preliminar && k.cxc_vencido > 0)
     segs.push(`CxC venc. ${fmtMoneyCompact(k.cxc_vencido)}`);
   const stale = data.saldos
@@ -907,6 +926,8 @@ export async function fetchResumenConsejoData(
     saldosRes,
     asign3mRes,
     movHoyRes,
+    escriturasMesRes,
+    fasesHoy11Res,
   ] = await Promise.all([
     dilesa.from('proyectos').select('id,nombre').eq('empresa_id', empresaId).is('deleted_at', null),
     dilesa.from('v_proyecto_avances').select('*').eq('empresa_id', empresaId),
@@ -931,7 +952,7 @@ export async function fetchResumenConsejoData(
       .eq('empresa_id', empresaId)
       .is('deleted_at', null)
       .gte('fecha', inicioMes)
-      .in('posicion', [2, 11]),
+      .eq('posicion', 2),
     dilesa.from('v_contratista_obra').select('*').eq('empresa_id', empresaId),
     erp.from('v_cuenta_saldo_actual').select('*').eq('empresa_id', empresaId),
     dilesa
@@ -946,6 +967,24 @@ export async function fetchResumenConsejoData(
       .select('posicion')
       .eq('empresa_id', empresaId)
       .is('deleted_at', null)
+      .eq('fecha', hoyISO),
+    // Escrituras del mes por la fecha REAL del acto (ventas.fecha_escritura),
+    // no por la fecha de registro de la fase — regla de reportes (cf. #1140).
+    // Corte a hoy: una fecha_escritura futura (firma programada) aún no cuenta.
+    dilesa
+      .from('ventas')
+      .select('id,unidad_id,valor_escrituracion,fecha_escritura')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .gte('fecha_escritura', inicioMes)
+      .lte('fecha_escritura', hoyISO),
+    // Fases 11 registradas HOY (para la nota de fechas reales del tile).
+    dilesa
+      .from('venta_fases')
+      .select('venta_id')
+      .eq('empresa_id', empresaId)
+      .is('deleted_at', null)
+      .eq('posicion', 11)
       .eq('fecha', hoyISO),
   ]);
 
@@ -999,59 +1038,87 @@ export async function fetchResumenConsejoData(
     movHoyPorPos
   );
 
-  // Asignaciones/escrituras del mes: por venta_fases del mes, agrupadas por prototipo.
-  // Requiere resolver venta → unidad → producto. Se hace con un fetch puntual de las
-  // ventas involucradas (rara vez son muchas en un mes).
+  // Asignaciones del mes: por venta_fases (fase 2 = evento interno del sistema,
+  // su fecha ES la real). Escrituras del mes: por ventas.fecha_escritura — la
+  // fecha del acto ante notario, no la del registro en BSOP (el registro suele
+  // ir días después; regla de reportes, cf. #1140). Ambas agrupadas por
+  // prototipo resolviendo venta → unidad → producto.
+  const escriturasMesRows = (escriturasMesRes.data ?? []) as {
+    id: string;
+    unidad_id: string | null;
+    valor_escrituracion: number | null;
+  }[];
   const ventaIds = [
-    ...new Set((fasesMesRes.data ?? []).map((f: { venta_id: string }) => f.venta_id)),
+    ...new Set([
+      ...(fasesMesRes.data ?? []).map((f: { venta_id: string }) => f.venta_id),
+      ...(fasesHoy11Res.data ?? []).map((f: { venta_id: string }) => f.venta_id),
+    ]),
   ];
+  const ventasMes = ventaIds.length
+    ? await dilesa
+        .from('ventas')
+        .select('id,unidad_id,precio_asignacion,valor_escrituracion,fecha_escritura')
+        .in('id', ventaIds)
+    : { data: [] };
+  const unidadIds = [
+    ...new Set(
+      [...((ventasMes.data ?? []) as { unidad_id: string | null }[]), ...escriturasMesRows]
+        .map((v) => v.unidad_id)
+        .filter(Boolean)
+    ),
+  ] as string[];
+  const unidades = unidadIds.length
+    ? await dilesa.from('unidades').select('id,producto_id').in('id', unidadIds)
+    : { data: [] };
+  const unidadProto = new Map<string, string>(
+    (unidades.data ?? []).map((u: { id: string; producto_id: string | null }) => [
+      u.id,
+      u.producto_id ?? '',
+    ])
+  );
+  const ventaInfo = new Map(
+    (ventasMes.data ?? []).map((v: Record<string, unknown>) => [v.id as string, v])
+  );
   const asignaciones: AsignacionRow[] = [];
-  if (ventaIds.length) {
-    const ventasMes = await dilesa
-      .from('ventas')
-      .select('id,unidad_id,precio_asignacion,valor_escrituracion')
-      .in('id', ventaIds);
-    const unidadIds = [
-      ...new Set(
-        (ventasMes.data ?? []).map((v: { unidad_id: string | null }) => v.unidad_id).filter(Boolean)
-      ),
-    ] as string[];
-    const unidades = unidadIds.length
-      ? await dilesa.from('unidades').select('id,producto_id').in('id', unidadIds)
-      : { data: [] };
-    const unidadProto = new Map<string, string>(
-      (unidades.data ?? []).map((u: { id: string; producto_id: string | null }) => [
-        u.id,
-        u.producto_id ?? '',
-      ])
-    );
-    const ventaInfo = new Map(
-      (ventasMes.data ?? []).map((v: Record<string, unknown>) => [v.id as string, v])
-    );
-    const acc = new Map<string, AsignacionRow>();
-    for (const f of fasesMesRes.data ?? []) {
-      const ff = f as { venta_id: string; posicion: number | null };
-      const v = ventaInfo.get(ff.venta_id) as Record<string, unknown> | undefined;
-      if (!v) continue;
-      const proto = protoNombre.get(unidadProto.get(v.unidad_id as string) ?? '') ?? '—';
-      const row = acc.get(proto) ?? {
-        nombre: proto,
-        asignaciones_mes: 0,
-        monto_asignaciones: 0,
-        escrituras_mes: 0,
-        monto_escrituras: 0,
-      };
-      if (ff.posicion === 2) {
-        row.asignaciones_mes += 1;
-        row.monto_asignaciones += Number(v.precio_asignacion ?? 0);
-      } else if (ff.posicion === 11) {
-        row.escrituras_mes += 1;
-        row.monto_escrituras += Number(v.valor_escrituracion ?? 0);
-      }
-      acc.set(proto, row);
-    }
-    asignaciones.push(...[...acc.values()].sort((x, y) => x.nombre.localeCompare(y.nombre)));
+  const acc = new Map<string, AsignacionRow>();
+  const rowDe = (proto: string): AsignacionRow => {
+    const row = acc.get(proto) ?? {
+      nombre: proto,
+      asignaciones_mes: 0,
+      monto_asignaciones: 0,
+      escrituras_mes: 0,
+      monto_escrituras: 0,
+    };
+    acc.set(proto, row);
+    return row;
+  };
+  for (const f of fasesMesRes.data ?? []) {
+    const v = ventaInfo.get((f as { venta_id: string }).venta_id) as
+      | Record<string, unknown>
+      | undefined;
+    if (!v) continue;
+    const row = rowDe(protoNombre.get(unidadProto.get(v.unidad_id as string) ?? '') ?? '—');
+    row.asignaciones_mes += 1;
+    row.monto_asignaciones += Number(v.precio_asignacion ?? 0);
   }
+  for (const v of escriturasMesRows) {
+    const row = rowDe(protoNombre.get(unidadProto.get(v.unidad_id ?? '') ?? '') ?? '—');
+    row.escrituras_mes += 1;
+    row.monto_escrituras += Number(v.valor_escrituracion ?? 0);
+  }
+  asignaciones.push(...[...acc.values()].sort((x, y) => x.nombre.localeCompare(y.nombre)));
+
+  // Fechas reales de las escrituras registradas hoy (nota del tile).
+  const escrituras_hoy_fechas_reales = [
+    ...new Set(
+      (fasesHoy11Res.data ?? [])
+        .map((f: { venta_id: string }) => {
+          const v = ventaInfo.get(f.venta_id) as { fecha_escritura?: string | null } | undefined;
+          return v?.fecha_escritura ?? null;
+        })
+        .filter((d): d is string => Boolean(d))
+    ),
+  ].sort();
 
   // Construcción: línea de excepción. "Casas en obra" cuenta UNIDADES distintas
   // en obra física (suma de v_proyecto_avances.casas_en_construccion) — misma
@@ -1130,6 +1197,7 @@ export async function fetchResumenConsejoData(
   return {
     saldos,
     tuberiaViva,
+    escrituras_hoy_fechas_reales,
     tuberiaHistorico,
     asignaciones,
     backlog,


### PR DESCRIPTION
## Problema

En el correo de hoy (el primero tras el fix de TZ de `fechas-tz`) aparecieron **"Escrituras hoy: 7 · \$8.9M"** — las 7 se **registraron** hoy en BSOP, pero 5 se firmaron en junio (22, 23, 26×2, 30) y 2 traen `fecha_escritura` futura (25/27-jul). El KPI contaba por `venta_fases.fecha` (día de registro), y la regla de reportes es contar por la **fecha del acto** (`ventas.fecha_escritura`) — como ya hace el módulo de Reportes (#1140).

## Solución — base híbrida (elegida por Beto)

- **Mes** (tile, tabla por prototipo, asunto): por `fecha_escritura` en `[inicio de mes local, hoy]`. Fechas futuras (firmas programadas) no cuentan hasta que llegan.
- **Tile "hoy"** → **"Escrituras registradas hoy"**: sigue siendo el pulso operativo (es la única forma de que el consejo vea registros tardíos de meses ya cerrados) y agrega nota `f. reales: 22 jun, 23 jun, 26 jun +1` cuando difieren.
- **Asunto**: "N escrituras registradas" (no se lee como firmas del día).
- **Asignaciones** siguen por fase 2 — evento interno del sistema, su fecha es la real.

## Notas

- Las 2 ventas con `fecha_escritura` futura (25-jul \$979K y 27-jul \$3.14M) quedan señaladas para revisión operativa — o son firmas programadas capturadas como fecha de escritura o error de captura.
- 4 tests nuevos (tile híbrido, nota de fechas reales con recorte, asunto).

## Verificación

- `typecheck` / `lint` / `format:check` / `initiatives:validate` ✅
- `test:coverage`: 182 files, 2,291 tests ✅
- Sin migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)