### PR TITLE
feat(cxp): liga al PDF de la estimación en bandeja "en espera del XML"

### DIFF
--- a/components/cxp/cxp-facturas-module.tsx
+++ b/components/cxp/cxp-facturas-module.tsx
@@ -26,6 +26,7 @@ import {
   CalendarClock,
   Check,
   Copy,
+  FileText,
   FileUp,
   Link2,
   RefreshCw,
@@ -968,6 +969,21 @@ export function CxpFacturasModule({ empresaId, empresa }: CxpFacturasModuleProps
                         );
                       })()}{' '}
                       · neto {formatCurrency(f.total)}
+                      {f.estimacion_id ? (
+                        <>
+                          {' · '}
+                          <a
+                            href={`/api/dilesa/estimaciones/${f.estimacion_id}/pdf`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-0.5 align-text-bottom hover:underline"
+                            title="Descargar PDF de la estimación"
+                          >
+                            <FileText className="h-3 w-3" />
+                            PDF
+                          </a>
+                        </>
+                      ) : null}
                     </div>
                   </div>
                   <Button size="sm" className="gap-2" onClick={() => setRecibirTarget(f)}>


### PR DESCRIPTION
## Qué cambia

En **Cuentas por Pagar → Facturas**, la bandeja ámbar *"Facturas en espera del XML"* ahora incluye, en cada fila de destajo, una liga **PDF** que descarga la estimación correspondiente (`/api/dilesa/estimaciones/[id]/pdf`) — sin tener que entrar al detalle de la estimación.

- Aplica a filas con `estimacion_id` (destajos de vivienda).
- Las **estimaciones de obra** (`obra_estimacion_id`) no tienen PDF propio — viven dentro del contrato — así que conservan solo la liga al contrato, sin cambio.

## Checks locales

- ✅ typecheck · lint · format:check · initiatives:check
- ✅ test:coverage — 2310 tests, 183 files

Cambio UI visible → sin auto-merge, para revisar en el Vercel Preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)