### PR TITLE
fix(dilesa-portafolio-predios): parcelas ejidales al municipio de Nava

### DIFF
--- a/docs/planning/dilesa-portafolio-predios.md
+++ b/docs/planning/dilesa-portafolio-predios.md
@@ -4,10 +4,10 @@
 **Empresas:** DILESA
 **Schemas afectados:** `dilesa` (nuevas `cuentas_prediales`, `prediales_ejercicios`, `prediales_convenios`, `activo_movimientos`; INSERT masivo en `activos`; sub-slug RBAC `dilesa.portafolio.prediales` en `core.modulos`/`core.permisos_rol`). `erp` (lectura `documentos`/`adjuntos` para escrituras y KMZ). UI: retiro del drawer de detalle → página expediente `/dilesa/portafolio/activo/[id]`, tab Prediales en el hub, visor KMZ, ficha comercial PDF.
 **Estado:** in_progress
-**Próximo hito:** dale de Beto al PR #1177 (RPCs zona, falso positivo del gate) + arrancar S5 (subdivisiones/fusiones + ADR)
+**Próximo hito:** arrancar S5 (subdivisiones/fusiones + ADR; piloto = relotificación del área verde)
 **Dueño:** Beto
 **Creada:** 2026-07-01
-**Última actualización:** 2026-07-02 (S1-S4 entregados en tramo autónomo nocturno)
+**Última actualización:** 2026-07-02 (S1-S4 en prod; dale a #1177; parcelas corregidas a Nava)
 
 > **Sucede a** [`dilesa-portafolio-expediente`](dilesa-portafolio-expediente.md) (cerrada). El visor interactivo multi-capa (fraccionamientos, avances de urbanización/ventas sobre plano) sigue viviendo en la iniciativa hermana [`mapas-interactivos`](mapas-interactivos.md) — aquí solo el render del KMZ del activo.
 
@@ -86,3 +86,4 @@ El Portafolio se vuelve la fuente de verdad de **todos** los inmuebles DILESA co
   - **#1177 (BLOQUEADO por gate, espera dale de Beto)** — RPCs `fn_alta/actualizar_activo` aprenden `zona` (falso positivo del clasificador; sin esto no se edita zona desde la UI, lo demás opera).
   - **Checklist KMZ/escrituras** entregado a Beto (Excel, 118 predios, en Downloads).
   - **Excepciones de datos reportadas**: clave duplicada `0022220051` (Lomas del Sol #53/#57, se conservó una), `0301000042` (#39) sin montos ni marca PAGADO, montos idénticos sospechosos entre Deportivo RDB y Business Park #43 ($186,092.55/$273,090.82 — ¿copy-paste en el Excel?), folio 31066 repetido en 3 predios (folio de recibo, no identificador). **Pregunta abierta**: ¿el convenio 60% aplica también a las parcelas ejidales? (se cargaron sin convenio).
+- **2026-07-02 — Respuestas de Beto (mañana):** dale al #1177 (label `finanzas-ok`, mergea). Las parcelas ejidales están en el municipio de **Nava** (no Piedras Negras) — corrección de datos en migración `20260702131512` (25 activos / 27 cuentas → Nava; se asumió que los 2 ranchos del mismo Excel también son Nava — corregir si no). El convenio 60% es solo con Piedras Negras: las parcelas ya estaban sin convenio, sin cambios.

--- a/supabase/migrations/20260702131512_dilesa_prediales_municipio_nava.sql
+++ b/supabase/migrations/20260702131512_dilesa_prediales_municipio_nava.sql
@@ -1,0 +1,40 @@
+-- ╭─ 20260702131512_dilesa_prediales_municipio_nava ─╮
+-- Iniciativa `dilesa-portafolio-predios` — corrección de datos (Beto,
+-- 2026-07-02): las parcelas ejidales de Villa de Fuente están en el
+-- municipio de NAVA, no en Piedras Negras (el loader de S1 asumió Piedras
+-- Negras para todo). Se corrigen los activos del Excel de parcelas (zona
+-- Ejido Villa de Fuente + los 2 ranchos del mismo listado) y sus cuentas
+-- prediales. El convenio 60% NO les aplica (es con el municipio de Piedras
+-- Negras) — ya estaban cargadas sin convenio, no hay nada que revertir.
+
+BEGIN;
+
+WITH objetivo AS (
+  SELECT a.id
+  FROM dilesa.activos a
+  JOIN core.empresas e ON e.id = a.empresa_id AND e.slug = 'dilesa'
+  WHERE a.deleted_at IS NULL
+    AND (a.zona = 'Ejido Villa de Fuente'
+         OR a.clave_interna IN ('RANCHO-SANTA-MONICA', 'RANCHO-SAN-MARCOS'))
+)
+UPDATE dilesa.activos a
+SET municipio = 'Nava'
+FROM objetivo o
+WHERE a.id = o.id AND a.municipio IS DISTINCT FROM 'Nava';
+
+WITH objetivo AS (
+  SELECT a.id
+  FROM dilesa.activos a
+  JOIN core.empresas e ON e.id = a.empresa_id AND e.slug = 'dilesa'
+  WHERE a.deleted_at IS NULL
+    AND (a.zona = 'Ejido Villa de Fuente'
+         OR a.clave_interna IN ('RANCHO-SANTA-MONICA', 'RANCHO-SAN-MARCOS'))
+)
+UPDATE dilesa.cuentas_prediales cp
+SET municipio = 'Nava'
+FROM objetivo o
+WHERE cp.activo_id = o.id AND cp.municipio IS DISTINCT FROM 'Nava';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
Corrección de datos (Beto 2026-07-02): las parcelas del Ejido Villa de Fuente están en el municipio de **Nava**, no Piedras Negras (el loader de S1 asumió Piedras Negras para todo).

- `UPDATE` de `municipio` en `dilesa.activos` y `dilesa.cuentas_prediales` para la zona Ejido Villa de Fuente + los 2 ranchos del mismo Excel: **25 activos / 27 cuentas → Nava** (verificado en shadow; los 93 urbanos quedan en Piedras Negras).
- El convenio 60% es **solo** con Piedras Negras — las parcelas ya estaban cargadas sin convenio, no hay nada que revertir.
- Nota: se asumió que los ranchos Santa Mónica y San Marcos (mismo listado) también son Nava; corregir si no.
- Gate financiero: exit 0. Incluye bitácora en el planning doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)