### PR TITLE
ci(db-push-on-merge): --include-all para migraciones out-of-order de PRs detenidos

### DIFF
--- a/.github/workflows/db-push-on-merge.yml
+++ b/.github/workflows/db-push-on-merge.yml
@@ -10,8 +10,19 @@ name: DB Push on Merge
 #     aplican solas aquí); financieras las mergea Dirección a mano tras el
 #     `financial-migration-guard` (el merge es la confirmación explícita).
 #
-# Si `db push` falla (out-of-order, SQL inválido que el schema-check no atrapó),
-# main quedó mergeado pero prod atrás → falla ruidoso para re-correr/arreglar.
+# `db push` corre con `--include-all`: un PR detenido (p.ej. esperando el label
+# `finanzas-ok`) mientras mergean otros con timestamps posteriores deja su
+# migración out-of-order al mergear — sin el flag, `db push` la rechaza ("Found
+# local migration files to be inserted before the last migration on remote
+# database"; caso real: PR #1177). El riesgo es bajo: todo archivo en
+# `supabase/migrations/` de `main` DEBE terminar aplicado (invariante 1:1 del
+# ledger) y ya pasó CI en shadow. Matiz: la migración rezagada se ejecuta en
+# prod DESPUÉS de las de timestamp posterior (orden ≠ shadow); si conflictúa,
+# falla ruidoso igual. Ver GOVERNANCE.md §4.
+#
+# Si `db push` falla (SQL inválido que el schema-check no atrapó, drift de
+# ledger), main quedó mergeado pero prod atrás → falla ruidoso para
+# re-correr/arreglar.
 
 on:
   push:
@@ -49,12 +60,13 @@ jobs:
           fi
           echo "Migraciones pendientes según el ledger de prod:"
           supabase migration list --db-url "$SUPABASE_DB_URL" 2>&1 | tail -20 || true
-          echo "── db push ──"
-          if supabase db push --db-url "$SUPABASE_DB_URL"; then
+          echo "── db push (--include-all: aplica también migraciones out-of-order de PRs detenidos, ver header) ──"
+          if supabase db push --include-all --db-url "$SUPABASE_DB_URL"; then
             echo "✓ Migraciones aplicadas a prod. Ledger registrado con el timestamp del archivo."
           else
             echo "::error::supabase db push FALLÓ. Prod puede haber quedado atrás de main."
-            echo "Revisar el log (out-of-order / SQL / drift de ledger) y re-correr este workflow"
-            echo "(workflow_dispatch) o aplicar manualmente. NO uses MCP (genera huérfanas)."
+            echo "Causas probables: SQL inválido que el schema-check no atrapó, o drift de ledger"
+            echo "(comparar 'supabase migration list' arriba). Arreglar y re-correr este workflow"
+            echo "(workflow_dispatch). NO apliques por MCP (genera huérfanas en el ledger)."
             exit 1
           fi

--- a/supabase/GOVERNANCE.md
+++ b/supabase/GOVERNANCE.md
@@ -101,11 +101,30 @@ necesitás Docker** — en el modelo nuevo ya no hay atajo contra prod.
 
 **Regla dura (modelo `derivados-sin-drift` S3):** las migraciones se aplican a
 prod **al mergear el PR a `main`**, automáticamente, vía el workflow
-`db-push-on-merge.yml` (`supabase db push`). **No** se aplican antes de mergear,
-**ni** por `mcp__supabase__apply_migration`, **ni** con `psql`/`db push` manual a
-prod. Una sola vía. Así prod nunca se adelanta a `main` (muere el drift de
-SCHEMA_REF que rompía PRs ajenos) y el ledger no deriva (`db push` registra con
-el timestamp del archivo; muere el baile de `migration repair`).
+`db-push-on-merge.yml` (`supabase db push --include-all`). **No** se aplican
+antes de mergear, **ni** por `mcp__supabase__apply_migration`, **ni** con
+`psql`/`db push` manual a prod. Una sola vía. Así prod nunca se adelanta a
+`main` (muere el drift de SCHEMA_REF que rompía PRs ajenos) y el ledger no
+deriva (`db push` registra con el timestamp del archivo; muere el baile de
+`migration repair`).
+
+### Out-of-order: `--include-all` (norma 2026-07-02)
+
+Un PR con migración puede quedar detenido (típicamente esperando el label
+`finanzas-ok` del gate D5) mientras otros PRs con timestamps **posteriores**
+mergean y se aplican. Al mergear el detenido, su migración queda out-of-order
+(timestamp < último aplicado en prod) y `supabase db push` a secas la rechaza:
+`Found local migration files to be inserted before the last migration on
+remote database` (caso real: PR #1177, migración `20260702033009`, 2026-07-02).
+
+Por eso el workflow corre **siempre** con `--include-all`. Es seguro en este
+modelo porque el invariante es que **todo** archivo en `supabase/migrations/`
+de `main` termina aplicado (ledger 1:1, sin "archivos viejos intencionalmente
+sin aplicar") y ya pasó el schema-check en shadow. Matiz asumido: la migración
+rezagada se ejecuta en prod **después** de las de timestamp posterior (orden
+distinto al de la shadow, que aplica por timestamp). Riesgo bajo — las que
+mergearon antes no pueden depender de la detenida — y si conflictúa, `db push`
+falla ruidoso igual que cualquier SQL inválido.
 
 ### Gate financiero (D5) — confirmación explícita de Dirección en el chat
 


### PR DESCRIPTION
## Problema

Un PR con migración detenido (típicamente esperando el label `finanzas-ok` del gate D5) mientras otros PRs con timestamps **posteriores** mergean y se aplican, queda **out-of-order** al mergear: su timestamp es menor al último aplicado en prod y `supabase db push` a secas lo rechaza:

> Found local migration files to be inserted before the last migration on remote database

**Caso real:** PR #1177 (migración `20260702033009`), resuelto a mano con `supabase db push --include-all` el 2026-07-02. El escenario es estructural al gate de dos niveles, así que iba a repetirse.

## Cambio

- `db-push-on-merge.yml` corre **siempre** con `--include-all`. Es seguro en este modelo: todo archivo en `supabase/migrations/` de `main` debe terminar aplicado (invariante ledger 1:1 — no existen archivos viejos intencionalmente sin aplicar) y ya pasó el schema-check en shadow.
- Mensaje de error del workflow actualizado (out-of-order deja de ser causa de falla; quedan SQL inválido y drift de ledger).
- `GOVERNANCE.md` §4 documenta la norma (2026-07-02) y el matiz asumido: la migración rezagada corre en prod **después** de las de timestamp posterior (orden ≠ shadow); riesgo bajo — las que mergearon antes no pueden depender de la detenida — y si conflictúa, falla ruidoso igual.

Se descartó el input `include_all` en `workflow_dispatch`: requeriría intervención manual exactamente en el caso que queremos automatizar, y no hay escenario en este modelo donde `--include-all` sea incorrecto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)