### PR TITLE
fix(dilesa-ventas): Fase 11 — fecha de escritura nunca futura y sella venta_fases.fecha

### DIFF
--- a/app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/11-escriturada/page.tsx
@@ -5,10 +5,11 @@
  *
  * Tras la firma en notaría, las escrituras llegan a Dirección (Beto, o quien
  * de Dirección esté) para firmar. Se registra:
- *   - `fecha_escritura` → fecha de la escritura
+ *   - `fecha_escritura` → fecha de la escritura (nunca futura; también sella
+ *     `venta_fases.fecha` de la posición 11 — captura y corrección)
  *   - `numero_escritura` → número de instrumento público del NOTARIO
  *     (no el folio interno — la revisión PLD de F13 lo cruza contra el
- *     aviso). Corrige post-cierre sin tocar venta_fases.
+ *     aviso). Corrige post-cierre.
  *   - `numero_cheque_notaria` → número del cheque enviado a la notaría
  *   - `monto_cheque_notaria` → monto del cheque (parte de la cuadratura)
  *
@@ -31,6 +32,7 @@ import { useToast } from '@/components/ui/toast';
 import { getSupabaseErrorMessage } from '@/lib/supabase-error';
 import { CapturarFaseHeader } from '@/components/dilesa/capturar-fase-header';
 import { marcarFase } from '@/lib/dilesa/captura/marcar-fase';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 import {
   IndicadorAutoguardado,
   useAutoguardadoCampos,
@@ -75,8 +77,11 @@ function CapturarFase11Body() {
 
   const [numeroEscritura, setNumeroEscritura] = useState<string>('');
   // En blanco a propósito: la fecha de escritura debe seleccionarse a mano
-  // (no asumir "hoy") para que sea la fecha real del instrumento.
+  // (no asumir "hoy") para que sea la fecha real del instrumento. Y nunca
+  // futura (`max` + validación): la escritura ya se firmó cuando se captura —
+  // una fecha adelante casi siempre es un error de mes en el date picker.
   const [fechaEscritura, setFechaEscritura] = useState<string>('');
+  const hoy = hoyISOMatamoros();
   const [numeroCheque, setNumeroCheque] = useState<string>('');
   const [montoCheque, setMontoCheque] = useState<string>('');
   // Autoguardado (ADR-051): firma de lo último persistido (arranca = lo cargado).
@@ -163,6 +168,9 @@ function CapturarFase11Body() {
     claveGuardada: JSON.stringify(guardado),
     habilitado: !!venta && !yaCerrada,
     guardar: async () => {
+      if (fechaEscritura && fechaEscritura > hoy) {
+        return { ok: false, error: 'La fecha de escritura no puede ser futura.' };
+      }
       const { error: upErr } = await sb
         .schema('dilesa')
         .from('ventas')
@@ -188,6 +196,14 @@ function CapturarFase11Body() {
         toast.add({
           title: 'Falta la fecha de escritura',
           description: 'Captura la fecha de la escritura.',
+          type: 'error',
+        });
+        return;
+      }
+      if (fechaEscritura > hoy) {
+        toast.add({
+          title: 'La fecha de escritura no puede ser futura',
+          description: 'Revisa el mes y el año seleccionados en el calendario.',
           type: 'error',
         });
         return;
@@ -234,6 +250,9 @@ function CapturarFase11Body() {
         },
         notas: null,
         registradoPor: userId,
+        // La fase se sella con la fecha REAL de la escritura, no con la fecha
+        // de captura: el reporte "Ventas por fase" cuenta por venta_fases.fecha.
+        fecha: fechaEscritura,
       });
 
       setSubmitting(false);
@@ -262,12 +281,15 @@ function CapturarFase11Body() {
 
       router.push(`/dilesa/ventas/${venta.id}`);
     },
-    [fechaEscritura, montoCheque, numeroCheque, numeroEscritura, router, sb, toast, venta]
+    [fechaEscritura, hoy, montoCheque, numeroCheque, numeroEscritura, router, sb, toast, venta]
   );
 
-  // ── Corrección post-cierre (no toca venta_fases — patrón F8) ─────
+  // ── Corrección post-cierre (patrón F8) ───────────────────────────
   // Las ventas migradas traen folio interno en numero_escritura; la
-  // revisión PLD de F13 exige el instrumento real del notario.
+  // revisión PLD de F13 exige el instrumento real del notario. La fecha SÍ
+  // sincroniza venta_fases (posición 11): esa fila se sella con la fecha de
+  // la escritura y el reporte "Ventas por fase" cuenta por ella — si solo
+  // corrigiéramos ventas.fecha_escritura quedarían en meses distintos.
   const onActualizarEscritura = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
@@ -275,6 +297,14 @@ function CapturarFase11Body() {
       if (!fechaEscritura) {
         toast.add({
           title: 'Falta la fecha de escritura',
+          type: 'error',
+        });
+        return;
+      }
+      if (fechaEscritura > hoy) {
+        toast.add({
+          title: 'La fecha de escritura no puede ser futura',
+          description: 'Revisa el mes y el año seleccionados en el calendario.',
           type: 'error',
         });
         return;
@@ -295,11 +325,30 @@ function CapturarFase11Body() {
           numero_escritura: numeroEscritura.trim(),
         })
         .eq('id', venta.id);
-      setSubmitting(false);
       if (upErr) {
+        setSubmitting(false);
         toast.add({
           title: 'No se pudieron actualizar los datos',
           description: getSupabaseErrorMessage(upErr, 'Reintenta.'),
+          type: 'error',
+        });
+        return;
+      }
+      const { error: faseErr } = await sb
+        .schema('dilesa')
+        .from('venta_fases')
+        .update({ fecha: fechaEscritura })
+        .eq('venta_id', venta.id)
+        .eq('posicion', 11)
+        .is('deleted_at', null);
+      setSubmitting(false);
+      if (faseErr) {
+        toast.add({
+          title: 'Venta actualizada, pero la fase no',
+          description: getSupabaseErrorMessage(
+            faseErr,
+            'La fecha de la fase Escriturada no se sincronizó; reintenta.'
+          ),
           type: 'error',
         });
         return;
@@ -310,7 +359,7 @@ function CapturarFase11Body() {
         type: 'success',
       });
     },
-    [venta, fechaEscritura, numeroEscritura, sb, toast]
+    [venta, fechaEscritura, hoy, numeroEscritura, sb, toast]
   );
 
   // ── Render ───────────────────────────────────────────────────────
@@ -358,6 +407,7 @@ function CapturarFase11Body() {
                     value={fechaEscritura}
                     onChange={(e) => setFechaEscritura(e.target.value)}
                     required
+                    max={hoy}
                   />
                 </Field>
                 <Field label="Número de instrumento público (escritura) *">
@@ -419,6 +469,7 @@ function CapturarFase11Body() {
                   value={fechaEscritura}
                   onChange={(e) => setFechaEscritura(e.target.value)}
                   required
+                  max={hoy}
                 />
               </Field>
               <Field label="Número de instrumento público (escritura) *">

--- a/lib/dilesa/captura/marcar-fase.test.ts
+++ b/lib/dilesa/captura/marcar-fase.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 import { marcarFase, FASES_PIPELINE } from './marcar-fase';
+import { hoyISOMatamoros } from '@/lib/fecha-mx';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 function mockClient(opts?: {
@@ -14,7 +15,10 @@ function mockClient(opts?: {
   /** fase_posicion actual de la venta (default 2: previa de la fase 3 base). */
   fasePosicionActual?: number;
   /** captura los campos que recibe el UPDATE de ventas (undefined si no se llamó). */
-  capture?: { ventaUpdateCampos?: Record<string, unknown> };
+  capture?: {
+    ventaUpdateCampos?: Record<string, unknown>;
+    faseInsertCampos?: Record<string, unknown>;
+  };
 }): SupabaseClient {
   const storageOk = !opts?.storageUploadError;
   const adjuntoOk = !opts?.adjuntoInsertError;
@@ -64,15 +68,18 @@ function mockClient(opts?: {
       }
       if (s === 'dilesa' && table === 'venta_fases') {
         return {
-          insert: vi.fn(() => ({
-            select: vi.fn(() => ({
-              single: vi.fn(async () =>
-                faseOk
-                  ? { data: { id: 'fase-id-123' }, error: null }
-                  : { data: null, error: { message: opts!.faseInsertError } }
-              ),
-            })),
-          })),
+          insert: vi.fn((campos: Record<string, unknown>) => {
+            if (opts?.capture) opts.capture.faseInsertCampos = campos;
+            return {
+              select: vi.fn(() => ({
+                single: vi.fn(async () =>
+                  faseOk
+                    ? { data: { id: 'fase-id-123' }, error: null }
+                    : { data: null, error: { message: opts!.faseInsertError } }
+                ),
+              })),
+            };
+          }),
         };
       }
       return {};
@@ -182,6 +189,22 @@ describe('marcarFase', () => {
     });
     expect(r.ok).toBe(true);
     expect(capture.ventaUpdateCampos).not.toHaveProperty('fase_posicion');
+  });
+
+  it('sin `fecha`, la fase se sella con hoy (fecha de captura)', async () => {
+    const capture: { faseInsertCampos?: Record<string, unknown> } = {};
+    const sb = mockClient({ capture });
+    const r = await marcarFase(sb, baseInput);
+    expect(r.ok).toBe(true);
+    expect(capture.faseInsertCampos).toMatchObject({ fecha: hoyISOMatamoros() });
+  });
+
+  it('con `fecha` (ej. Fase 11: fecha real de la escritura), la fase se sella con ella', async () => {
+    const capture: { faseInsertCampos?: Record<string, unknown> } = {};
+    const sb = mockClient({ capture });
+    const r = await marcarFase(sb, { ...baseInput, fecha: '2026-06-25' });
+    expect(r.ok).toBe(true);
+    expect(capture.faseInsertCampos).toMatchObject({ fecha: '2026-06-25' });
   });
 
   it('múltiples docs se suben en orden', async () => {

--- a/lib/dilesa/captura/marcar-fase.ts
+++ b/lib/dilesa/captura/marcar-fase.ts
@@ -4,8 +4,9 @@
  * Una "captura de fase" es la transacción que cierra una fase del pipeline:
  *   1. Sube los archivos a Supabase Storage (bucket `adjuntos`) → 1 path por archivo.
  *   2. Inserta filas en `erp.adjuntos` (entidad_tipo='venta', rol=<rol>) con el path.
- *   3. Inserta fila en `dilesa.venta_fases` con la fecha (today) — esa fila es la
- *      señal "fase cerrada" que destraba la siguiente.
+ *   3. Inserta fila en `dilesa.venta_fases` con la fecha (today, u override
+ *      vía `input.fecha`) — esa fila es la señal "fase cerrada" que destraba
+ *      la siguiente.
  *   4. Opcionalmente, hace UPDATE en `dilesa.ventas` para los campos de la fase
  *      (ej. precio_asignacion en Fase 3, monto_avaluo en Fase 5, etc.).
  *
@@ -50,6 +51,14 @@ export type MarcarFaseInput = {
   notas?: string | null;
   /** Usuario que captura, para `venta_fases.registrado_por`. */
   registradoPor: string | null;
+  /**
+   * Fecha (ISO `YYYY-MM-DD`) para `venta_fases.fecha`. Default: hoy (fecha de
+   * captura). Las fases cuyo hito ocurre ANTES de capturarse (ej. Fase 11:
+   * la escritura se firma en notaría y se captura después) deben pasar la
+   * fecha real del evento — el reporte "Ventas por fase" cuenta por esta
+   * columna.
+   */
+  fecha?: string | null;
 };
 
 export type MarcarFaseResult = {
@@ -67,7 +76,7 @@ export async function marcarFase(
   sb: SupabaseClient,
   input: MarcarFaseInput
 ): Promise<MarcarFaseResult> {
-  const { ventaId, faseposicion, docs, camposVenta, notas, registradoPor } = input;
+  const { ventaId, faseposicion, docs, camposVenta, notas, registradoPor, fecha } = input;
   let adjuntosCreados = 0;
 
   // 1) Subir archivos a Storage + 2) insertar en erp.adjuntos
@@ -169,7 +178,7 @@ export async function marcarFase(
       venta_id: ventaId,
       fase: nombreFase(faseposicion),
       posicion: faseposicion,
-      fecha: hoyISOMatamoros(),
+      fecha: fecha ?? hoyISOMatamoros(),
       registrado_por: registradoPor,
       notas: notas ?? null,
     })


### PR DESCRIPTION
## Contexto

Dos ventas aparecieron en "Ventas del periodo" con fecha de escritura en julio 2026 (futuro): al capturar la Fase 11 se seleccionó el día correcto pero el mes equivocado en el date picker, y nada lo detuvo. Además, la fila de `venta_fases` (posición 11) se sellaba con la fecha de captura ("hoy"), no con la fecha real de la escritura — el reporte "Ventas por fase" cuenta por esa columna, así que quedaba en un mes distinto al del reporte del periodo.

(Los datos de esas 2 ventas ya se corrigieron directo en prod: `fecha_escritura` y `venta_fases.fecha` → 2026-06-27 y 2026-06-25.)

## Cambios

- **Fecha de escritura nunca futura**: validación `fecha <= hoy` (TZ Matamoros) en la captura, en la corrección post-cierre y en el autoguardado, + `max={hoy}` en ambos date inputs. El error de mes ahora se detiene con un toast claro.
- **`marcarFase` acepta override de `fecha`**: la Fase 11 sella `venta_fases.fecha` con la fecha real de la escritura (default sigue siendo hoy para las demás fases).
- **La corrección post-cierre sincroniza `venta_fases.fecha`** (posición 11) además de `ventas.fecha_escritura`, para que ambos reportes cuenten el mismo mes.

Los 4 campos de la fase ya eran obligatorios (required + validación en submit) — eso no necesitó cambio.

## Tests

- 2 tests nuevos en `marcar-fase.test.ts`: default = hoy, override = fecha pasada.
- Suite completa verde (2319 tests), typecheck/lint/format OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)