### PR TITLE
docs(rdb-pos-propio): S0 — ADR-056 modelo del POS propio de RDB

### DIFF
--- a/docs/adr/056_rdb_pos_modelo.md
+++ b/docs/adr/056_rdb_pos_modelo.md
@@ -1,0 +1,144 @@
+# ADR-056 — Modelo del POS propio de RDB (datos, estados, RPCs, identidad)
+
+**Status:** Accepted
+**Fecha:** 2026-07-02
+**Iniciativa:** [`rdb-pos-propio`](../planning/rdb-pos-propio.md)
+**Relacionados:** ADR-005/006/008 (supabase/adr, saga Waitry), ADR-031/035/036
+(dedup/fantasmas), ADR-014 (módulos RBAC), ADR-030 (sub-slugs), ADR-023
+(activity log), ADR-054 (timezone).
+
+## Contexto
+
+RDB reemplaza el POS SaaS Waitry por un módulo propio (ver planning doc: por
+qué, alcance v1 y decisiones de negocio). Este ADR fija el modelo técnico que
+implementa S1: tablas, máquinas de estados, contratos de escritura, identidad
+en tablets compartidas e integración con cortes/inventario/reportería. Las
+lecciones vienen de la saga Waitry: los duplicados nacieron de doble-tap +
+re-cierres sin idempotencia de origen, y la reportería sufrió por leer tablas
+crudas sin capa canónica.
+
+## Decisión
+
+### 1. Tablas nuevas en `rdb` (no generalizar `waitry_*`)
+
+```
+pos_estaciones   -- punto de captura físico: mostrador, tablet cancha, kds
+                 -- (id, empresa_id, nombre, tipo, activa)
+pos_cuentas      -- la "cuenta" (mesa/cancha/mostrador): estado, ubicación,
+                 -- corte de apertura, totales server-side, playtomic_folio
+pos_rondas       -- momentos de captura dentro de una cuenta; inmutables
+                 -- (cuenta_id, numero, capturada_por, client_action_id)
+pos_items        -- líneas con SNAPSHOT (producto_id + nombre, precio,
+                 -- categoria, va_a_cocina, receta_version); estado KDS
+pos_pagos        -- pagos INMUTABLES (cuenta_id, metodo, monto, propina,
+                 -- corte_id al momento del cobro, voucher_ref, reversa_de)
+pos_eventos      -- audit trail append-only (ADR-023): evento, actor
+                 -- (empleado + dispositivo), datos_antes/despues, razon
+```
+
+- Waitry es un pipeline de ingesta webhook con semántica propia (`superseded`,
+  dedup, external ids); mezclar fuentes en una tabla es nullable-hell y
+  arriesga doble descuento de inventario. **Cada venta vive en UNA tabla.**
+- `rdb.waitry_*` queda histórico read-only tras el cutover; no se migra.
+- El catálogo NO se duplica: `pos_items.producto_id` → catálogo existente de
+  productos RDB, con flag nuevo **`va_a_cocina`** a nivel producto/categoría
+  (todo el club vende por el POS; solo lo preparable aparece en el KDS).
+
+### 2. Máquinas de estados mínimas
+
+```
+pos_cuentas.estado: abierta → en_cobro → pagada
+                    abierta → cancelada          (sin pagos; con pagos = reembolso)
+pos_items.estado:   capturado → en_cocina → listo → entregado
+                    capturado → void             (antes de en_cocina)
+                    en_cocina|listo → void_merma (post-preparación: merma auditada)
+```
+
+- Transiciones validadas por trigger; todo lo demás se rechaza.
+- Items que NO van a cocina nacen `entregado` (renta de cancha, tiendita).
+- Editar un item enviado a cocina está prohibido: se hace void + línea nueva.
+- Reabrir cuenta `pagada`/`cancelada` está bloqueado; una corrección crea
+  cuenta nueva ligada (`cuenta_origen_id`).
+
+### 3. Escrituras solo por RPC transaccional + idempotencia de origen
+
+Toda mutación pasa por RPCs `SECURITY DEFINER` (`fn_pos_*`): abrir cuenta,
+agregar ronda, void, cobrar, cancelar. Nada de INSERT/UPDATE directo desde el
+cliente (RLS de escritura lo bloquea).
+
+- **`client_action_id` (uuid generado en el cliente por tap)** con UNIQUE en
+  la operación: el retry/doble-tap devuelve el resultado original en vez de
+  duplicar. El bug fundacional de la saga Waitry muere por diseño.
+- Totales **server-side siempre**; el cliente solo muestra.
+- Cobro exige `corte_id` activo y lo congela en el pago (el dinero pertenece
+  al corte donde se cobra). Cierre de corte bloqueado con cuentas abiertas
+  relevantes o tarjeta sin voucher (gate #1149 vigente).
+- Pagos inmutables: corregir = fila de reversa (`reversa_de`), nunca UPDATE.
+- Descuento sobre umbral (config) exige PIN de autorizador + razón; cortesía
+  y venta tipo `empleado` siempre con razón. Todo queda en `pos_eventos`.
+
+### 4. Identidad: dispositivo + PIN de operador
+
+- La tablet/monitor se autentica como **cuenta de dispositivo** (Supabase
+  Auth) ligada a `pos_estaciones`, con permisos mínimos (solo RPCs del POS).
+- Cada acción lleva **PIN corto de empleado** (hash en tabla de operadores
+  POS) que resuelve al empleado real → `pos_eventos.actor_empleado_id`. El
+  audit trail nunca se atribuye a "la tablet".
+- El PIN identifica al operador de turno; NO sustituye auth de admin. Config,
+  estaciones y auditoría requieren sesión personal normal con RBAC.
+
+### 5. Inventario por evento de línea
+
+Trigger espejo de `fn_trg_waitry_to_movimientos`: al pasar un item a estado
+consumido descuenta en `erp.movimientos_inventario` (motor de recetas +
+conversión, `lib/unidades.ts`) con `referencia_tipo='venta_pos'` e id de
+línea; `void` pre-preparación revierte; `void_merma` post-preparación deja la
+salida como merma auditada. Idempotente por id de línea.
+
+### 6. Vista canónica y reportería
+
+`rdb.v_ventas_canonicas` une `pos_*` (post-cutover) + `v_waitry_pedidos`
+(histórico, ya filtrado de fantasmas) con columna `source`. **Nadie lee
+tablas crudas**: `/rdb/ventas`, `/rdb/home` y la conciliación Playtomic
+migran a la vista. `pos_cuentas.playtomic_folio` conserva la referencia
+`P-XXXXXX` que hoy se captura a mano.
+
+### 7. KDS: tabla real + Realtime con ACK
+
+El KDS lee `pos_items` (filtro `va_a_cocina`) por Supabase Realtime con
+**fallback a polling** (5-10 s) y ACK de cocina (`en_cocina`). El insert en
+DB precede al "éxito" en la UI del capturista. Cancelación post-envío exige
+confirmación de cocina en el KDS (alerta sonora).
+
+### 8. RLS y RBAC
+
+- RLS lectura: empresa-scoped set-membership
+  (`empresa_id IN (SELECT fn_current_empresa_ids())`) con InitPlan wrap —
+  patrón obligado tras los timeouts de `rdb`/`playtomic` (#1151/#1181).
+- RLS escritura: deny-all; solo RPCs.
+- Módulos (ADR-014/030): **`rdb.pos`** umbrella + sub-slugs
+  **`rdb.pos.captura`** (mostrador/meseros), **`rdb.pos.kds`** (cocina),
+  **`rdb.pos.admin`** (estaciones, PINs, umbrales, auditoría). Migración con
+  INSERT + backfill defensivo de permisos, 5 lugares del checklist ADR-014.
+
+## Alternativas consideradas
+
+1. **Generalizar `waitry_*` con discriminador `origen`** — rechazada:
+   semánticas incompatibles, nullable-hell, riesgo de doble descuento.
+2. **Sesiones Supabase individuales por mesero con quick-switch** —
+   rechazada: re-auth lenta en cambio de manos, y una sesión olvidada
+   atribuye ventas a la persona equivocada (audit trail falso).
+3. **KDS como vista sobre pedidos** — rechazada: sin estado propio por línea
+   no hay ACK ni métricas de cocina; Realtime requiere tabla publicable.
+4. **Detectores de duplicados estilo Waitry para el POS** — innecesarios:
+   la idempotencia por `client_action_id` previene en origen (los detectores
+   existentes quedan vivos para el histórico Waitry).
+
+## Consecuencias
+
+- S1 implementa exactamente este modelo (migración + RPCs + vista + tests).
+- La UI de captura es "tonta": muestra estado del servidor, nunca calcula.
+- Costo aceptado: PIN agrega un paso por acción sensible (no por item) — el
+  precio de un audit trail honesto en tablets compartidas.
+- Post-cutover (S6): apagar `waitry-webhook` (incl. espejo a Coda), export
+  final de Waitry, y las 4 iniciativas de dedup quedan sin materia prima.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -347,20 +347,21 @@ Ver [reglas SS1-SS7 en ADR-030](../adr/030_submodule_permissions.md).
 
 ### Cross-cutting
 
-| Tema                               | ADR                                                     | Patrón canónico                                                                      |
-| ---------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| Módulos compartidos cross-empresa  | [ADR-011](../adr/011_shared_modules_cross_empresa.md)   | thin page → `<XModule empresaSlug>` (SM1-SM6)                                        |
-| Responsive                         | [ADR-019](../adr/019_responsive_policy.md)              | JSDoc `@responsive` + `<DesktopOnlyNotice>` (R1-R5)                                  |
-| A11y baseline                      | [ADR-020](../adr/020_a11y_baseline.md)                  | WCAG 2.1 AA + `@axe-core/playwright` (A1-A6)                                         |
-| Access denied                      | [ADR-024](../adr/024_access_denied_ux.md)               | `<AccessDenied>` + `<RequireAccess>` (AD1-AD5)                                       |
-| Read-only "viendo como"            | [ADR-027](../adr/027_viendo_como_readonly.md)           | cookie `bsop_preview_as` + `assertNotInPreview()` (V1-V5)                            |
-| Sub-module permissions (sub-slugs) | [ADR-030](../adr/030_submodule_permissions.md)          | sub-slugs `<padre>.<sub>` + `<RoutedModuleTabs module>` filter (SS1-SS7)             |
-| Workflow CC owns planning          | [ADR-012](../adr/012_workflow_cc_owns_planning.md)      | meta-decisión sobre roles                                                            |
-| Manual de usuario in-app           | [ADR-043](../adr/043_manual_usuario_in_app.md)          | markdown versionado + `<HelpButton>` contextual + PDF on-demand (M1-M8)              |
-| Capa única de acceso a IA          | [ADR-046](../adr/046_capa_unica_acceso_ia.md)           | `lib/ai` único entry point + registry + drift-guard (registro-ia)                    |
-| Reportes (preset + vista + PDF)    | [ADR-047](../adr/047_reportes_preset_vista_pdf.md)      | registry + `<ReporteCatalogo>`/`<ReporteShell>` + hub-índice + PDF (dilesa-reportes) |
-| Timezone: "hoy" = Matamoros        | [ADR-054](../adr/054_timezone_convencion.md)            | `lib/fecha-mx.ts` (`hoyISOMatamoros`) + lint guard; `Etc/GMT+6` solo Playtomic/holds |
-| Movimientos catastrales de predios | [ADR-055](../adr/055_portafolio_movimientos_activos.md) | subdivisión/fusión append-only + RPC atómica; orígenes se desincorporan (linaje)     |
+| Tema                               | ADR                                                     | Patrón canónico                                                                         |
+| ---------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Módulos compartidos cross-empresa  | [ADR-011](../adr/011_shared_modules_cross_empresa.md)   | thin page → `<XModule empresaSlug>` (SM1-SM6)                                           |
+| Responsive                         | [ADR-019](../adr/019_responsive_policy.md)              | JSDoc `@responsive` + `<DesktopOnlyNotice>` (R1-R5)                                     |
+| A11y baseline                      | [ADR-020](../adr/020_a11y_baseline.md)                  | WCAG 2.1 AA + `@axe-core/playwright` (A1-A6)                                            |
+| Access denied                      | [ADR-024](../adr/024_access_denied_ux.md)               | `<AccessDenied>` + `<RequireAccess>` (AD1-AD5)                                          |
+| Read-only "viendo como"            | [ADR-027](../adr/027_viendo_como_readonly.md)           | cookie `bsop_preview_as` + `assertNotInPreview()` (V1-V5)                               |
+| Sub-module permissions (sub-slugs) | [ADR-030](../adr/030_submodule_permissions.md)          | sub-slugs `<padre>.<sub>` + `<RoutedModuleTabs module>` filter (SS1-SS7)                |
+| Workflow CC owns planning          | [ADR-012](../adr/012_workflow_cc_owns_planning.md)      | meta-decisión sobre roles                                                               |
+| Manual de usuario in-app           | [ADR-043](../adr/043_manual_usuario_in_app.md)          | markdown versionado + `<HelpButton>` contextual + PDF on-demand (M1-M8)                 |
+| Capa única de acceso a IA          | [ADR-046](../adr/046_capa_unica_acceso_ia.md)           | `lib/ai` único entry point + registry + drift-guard (registro-ia)                       |
+| Reportes (preset + vista + PDF)    | [ADR-047](../adr/047_reportes_preset_vista_pdf.md)      | registry + `<ReporteCatalogo>`/`<ReporteShell>` + hub-índice + PDF (dilesa-reportes)    |
+| Timezone: "hoy" = Matamoros        | [ADR-054](../adr/054_timezone_convencion.md)            | `lib/fecha-mx.ts` (`hoyISOMatamoros`) + lint guard; `Etc/GMT+6` solo Playtomic/holds    |
+| Movimientos catastrales de predios | [ADR-055](../adr/055_portafolio_movimientos_activos.md) | subdivisión/fusión append-only + RPC atómica; orígenes se desincorporan (linaje)        |
+| POS propio de RDB                  | [ADR-056](../adr/056_rdb_pos_modelo.md)                 | `rdb.pos_*` + RPCs idempotentes (`client_action_id`) + dispositivo+PIN + vista canónica |
 
 ### Data / DB
 

--- a/docs/planning/rdb-pos-propio.md
+++ b/docs/planning/rdb-pos-propio.md
@@ -4,10 +4,10 @@
 **Empresas:** RDB
 **Schemas afectados:** `rdb` (nuevas `pos_cuentas`, `pos_rondas`, `pos_items`, `pos_pagos`, `pos_estaciones`, `pos_eventos`; vista canónica `v_ventas_canonicas`; sub-slugs RBAC `rdb.pos.*` en `core.modulos`/`core.permisos_rol`). `erp` (escritura en `movimientos_inventario` vía trigger espejo; lectura/escritura `cortes_caja`/`cortes_vouchers`). Post-cutover: `rdb.waitry_*` queda histórico read-only y el edge function `waitry-webhook` (incl. espejo a Coda) se apaga.
 **Estado:** in_progress
-**Próximo hito:** cerrar S0 (spec operativa + ADR + slugs RBAC) y abrir el PR de schema (S1)
+**Próximo hito:** S1 — migración del schema POS + RPCs + vista canónica + tests (PR propio)
 **Dueño:** Beto
 **Creada:** 2026-07-02
-**Última actualización:** 2026-07-02 (promoción)
+**Última actualización:** 2026-07-02 (S0 cerrado: ADR-056 + slugs RBAC)
 
 > **Sucede a** la saga Waitry: [`rdb-waitry-ingesta-dedup`](rdb-waitry-ingesta-dedup.md),
 > [`rdb-waitry-deduplicacion`](rdb-waitry-deduplicacion.md),
@@ -161,7 +161,12 @@ hacer.
 
 ## Bitácora
 
-- **2026-07-02** — Promoción. Evaluación pre-promoción con 6 revisores
+- **2026-07-02** — **S0 cerrado**: [ADR-056](../adr/056_rdb_pos_modelo.md)
+  fija el modelo técnico (tablas `pos_*`, máquinas de estados, RPCs con
+  `client_action_id`, identidad dispositivo+PIN, inventario por evento de
+  línea, vista canónica, RLS/RBAC con slugs `rdb.pos`/`.captura`/`.kds`/`.admin`).
+  Índice de ARCHITECTURE.md §5 actualizado. Próximo: S1 (migración).
+- **2026-07-02** — Promoción (PR #1189). Evaluación pre-promoción con 6 revisores
   independientes (5 agentes: arquitectura de datos, UX operativa,
   seguridad/anti-fraude, rollout/piloto, completitud; + codex/gpt-5.5 como
   arquitecto externo). Consenso: build correcto con alcance brutal; KDS se


### PR DESCRIPTION
## Qué hace

Cierra **S0** de la iniciativa `rdb-pos-propio` (promovida en #1189):

- **ADR-056** — modelo técnico del POS: tablas `rdb.pos_*` (cuentas/rondas/items/pagos/estaciones/eventos), máquinas de estados mínimas, escrituras solo por RPC transaccional con idempotencia por `client_action_id` (el doble-tap muere por diseño), identidad dispositivo+PIN para audit trail honesto en tablets compartidas, inventario por evento de línea con reversa, vista canónica `v_ventas_canonicas` (nadie lee tablas crudas), RLS set-membership+InitPlan y slugs RBAC `rdb.pos`/`.captura`/`.kds`/`.admin` (ADR-014/030).
- Planning doc: header a próximo hito S1 + bitácora.
- ARCHITECTURE.md §5: línea de índice para ADR-056.

Docs-only. Siguiente: S1 (PR de migración separado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)