### PR TITLE
feat(rdb-ventas): filtro por tipo de pago en reportes de ventas

### DIFF
--- a/components/ventas/summary-bar.tsx
+++ b/components/ventas/summary-bar.tsx
@@ -1,14 +1,29 @@
 'use client';
 
-import { ShoppingBag, Receipt } from 'lucide-react';
+import { ShoppingBag, Receipt, Banknote, CreditCard, Globe, CircleDollarSign } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import type { Pedido } from './types';
 import { formatCurrency } from './utils';
 import { ventaCobrada } from './venta-cobrada';
+import { sumarMontosPorTipo, TIPO_PAGO_LABELS, TIPOS_PAGO, type TipoPago } from './tipo-pago';
+
+const TIPO_PAGO_ICONS: Record<TipoPago, LucideIcon> = {
+  efectivo: Banknote,
+  tarjeta: CreditCard,
+  stripe: Globe,
+  otro: CircleDollarSign,
+};
 
 export function SummaryBar({ pedidos }: { pedidos: Pedido[] }) {
   const total = pedidos.reduce((acc, p) => acc + ventaCobrada(p), 0);
+  // Montos por método desde waitry_pagos: un pago dividido reparte su dinero
+  // al bucket correcto. La suma de los métodos puede diferir ligeramente del
+  // Total (venta cobrada) — propinas embebidas o pagos incompletos en Waitry.
+  const porTipo = sumarMontosPorTipo(pedidos.map((p) => p.montos_pago));
+  const tiposConMonto = TIPOS_PAGO.filter((t) => porTipo[t] > 0);
+
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-2">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
       <div className="rounded-xl border bg-card px-4 py-3">
         <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
           <ShoppingBag className="h-3.5 w-3.5" />
@@ -23,6 +38,20 @@ export function SummaryBar({ pedidos }: { pedidos: Pedido[] }) {
         </div>
         <div className="mt-1 text-2xl font-semibold tabular-nums">{formatCurrency(total)}</div>
       </div>
+      {tiposConMonto.map((tipo) => {
+        const Icon = TIPO_PAGO_ICONS[tipo];
+        return (
+          <div key={tipo} className="rounded-xl border bg-card px-4 py-3">
+            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              <Icon className="h-3.5 w-3.5" />
+              {TIPO_PAGO_LABELS[tipo]}
+            </div>
+            <div className="mt-1 text-xl font-semibold tabular-nums">
+              {formatCurrency(porTipo[tipo])}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/components/ventas/tipo-pago.test.ts
+++ b/components/ventas/tipo-pago.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { clasificarMetodoPago, matchTipoPago, type TipoPago } from './tipo-pago';
+import {
+  clasificarMetodoPago,
+  matchTipoPago,
+  sumarMontosPorTipo,
+  type TipoPago,
+} from './tipo-pago';
 
 describe('clasificarMetodoPago', () => {
   it('cash → efectivo', () => {
@@ -48,5 +53,21 @@ describe('matchTipoPago', () => {
   it('pedido sin pagos registrados no matchea filtros específicos', () => {
     expect(matchTipoPago(undefined, 'efectivo')).toBe(false);
     expect(matchTipoPago(new Set(), 'efectivo')).toBe(false);
+  });
+});
+
+describe('sumarMontosPorTipo', () => {
+  it('acumula por bucket a través de pedidos, ignorando undefined', () => {
+    const res = sumarMontosPorTipo([
+      { efectivo: 100, tarjeta: 250 }, // pago dividido: cada monto a su bucket
+      { efectivo: 50 },
+      undefined, // pedido sin pagos registrados
+      { stripe: 300 },
+    ]);
+    expect(res).toEqual({ efectivo: 150, tarjeta: 250, stripe: 300, otro: 0 });
+  });
+
+  it('sin pedidos devuelve ceros', () => {
+    expect(sumarMontosPorTipo([])).toEqual({ efectivo: 0, tarjeta: 0, stripe: 0, otro: 0 });
   });
 });

--- a/components/ventas/tipo-pago.test.ts
+++ b/components/ventas/tipo-pago.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { clasificarMetodoPago, matchTipoPago, type TipoPago } from './tipo-pago';
+
+describe('clasificarMetodoPago', () => {
+  it('cash → efectivo', () => {
+    expect(clasificarMetodoPago('cash')).toBe('efectivo');
+  });
+
+  it('variantes credit_card* → tarjeta (valores reales de prod)', () => {
+    expect(clasificarMetodoPago('credit_card')).toBe('tarjeta');
+    expect(clasificarMetodoPago('credit_card_visa')).toBe('tarjeta');
+    expect(clasificarMetodoPago('credit_card_master')).toBe('tarjeta');
+  });
+
+  it('POS → tarjeta (terminal, mismo bucket que en rdb.v_cortes_totales)', () => {
+    expect(clasificarMetodoPago('POS')).toBe('tarjeta');
+    expect(clasificarMetodoPago('pos')).toBe('tarjeta');
+  });
+
+  it('STRIPE → stripe (case-insensitive)', () => {
+    expect(clasificarMetodoPago('STRIPE')).toBe('stripe');
+    expect(clasificarMetodoPago('stripe')).toBe('stripe');
+  });
+
+  it('other / desconocidos / null → otro', () => {
+    expect(clasificarMetodoPago('other')).toBe('otro');
+    expect(clasificarMetodoPago('transferencia')).toBe('otro');
+    expect(clasificarMetodoPago(null)).toBe('otro');
+    expect(clasificarMetodoPago(undefined)).toBe('otro');
+    expect(clasificarMetodoPago('')).toBe('otro');
+  });
+});
+
+describe('matchTipoPago', () => {
+  const tipos = new Set<TipoPago>(['efectivo', 'tarjeta']);
+
+  it("filtro 'all' pasa siempre, incluso sin pagos registrados", () => {
+    expect(matchTipoPago(tipos, 'all')).toBe(true);
+    expect(matchTipoPago(undefined, 'all')).toBe(true);
+  });
+
+  it('pago dividido matchea por cualquiera de sus tipos', () => {
+    expect(matchTipoPago(tipos, 'efectivo')).toBe(true);
+    expect(matchTipoPago(tipos, 'tarjeta')).toBe(true);
+    expect(matchTipoPago(tipos, 'stripe')).toBe(false);
+  });
+
+  it('pedido sin pagos registrados no matchea filtros específicos', () => {
+    expect(matchTipoPago(undefined, 'efectivo')).toBe(false);
+    expect(matchTipoPago(new Set(), 'efectivo')).toBe(false);
+  });
+});

--- a/components/ventas/tipo-pago.ts
+++ b/components/ventas/tipo-pago.ts
@@ -11,12 +11,18 @@ import type { createSupabaseBrowserClient } from '@/lib/supabase-browser';
  */
 export type TipoPago = 'efectivo' | 'tarjeta' | 'stripe' | 'otro';
 
+export const TIPOS_PAGO: TipoPago[] = ['efectivo', 'tarjeta', 'stripe', 'otro'];
+
+export const TIPO_PAGO_LABELS: Record<TipoPago, string> = {
+  efectivo: 'Efectivo',
+  tarjeta: 'Tarjeta',
+  stripe: 'Stripe',
+  otro: 'Otro',
+};
+
 export const TIPO_PAGO_OPTIONS: Array<{ value: string; label: string }> = [
   { value: 'all', label: 'Todos los pagos' },
-  { value: 'efectivo', label: 'Efectivo' },
-  { value: 'tarjeta', label: 'Tarjeta' },
-  { value: 'stripe', label: 'Stripe' },
-  { value: 'otro', label: 'Otro' },
+  ...TIPOS_PAGO.map((t) => ({ value: t, label: TIPO_PAGO_LABELS[t] })),
 ];
 
 export function clasificarMetodoPago(method: string | null | undefined): TipoPago {
@@ -28,38 +34,66 @@ export function clasificarMetodoPago(method: string | null | undefined): TipoPag
 }
 
 /**
- * Tipos de pago usados por cada pedido, desde `rdb.waitry_pagos`.
+ * Pagos de un pedido, agregados por tipo. `tipos` alimenta el filtro y la
+ * columna de la tabla; `montoPorTipo` alimenta los KPI por método (los
+ * montos vienen de `waitry_pagos.amount`, así un pago dividido reparte su
+ * dinero al bucket correcto — mismo criterio que rdb.v_cortes_totales).
+ */
+export type PagosPedido = {
+  tipos: Set<TipoPago>;
+  montoPorTipo: Partial<Record<TipoPago, number>>;
+};
+
+/**
+ * Pagos por pedido desde `rdb.waitry_pagos`.
  *
  * Un pedido con pago dividido (p.ej. efectivo + tarjeta) trae ambos tipos y
- * matchea el filtro por cualquiera de los dos — se reporta completo, no se
- * parte el monto por método.
+ * matchea el filtro por cualquiera de los dos — en el filtro se reporta
+ * completo; en los montos por tipo, cada pago suma a su propio bucket.
  *
  * Chunked a 500 ids por el límite de longitud de URL de PostgREST (mismo
  * patrón que las líneas en los tabs Por producto / Por categoría).
  */
-export async function fetchTiposPagoPorPedido(
+export async function fetchPagosPorPedido(
   supabase: ReturnType<typeof createSupabaseBrowserClient>,
   orderIds: string[]
-): Promise<Map<string, Set<TipoPago>>> {
+): Promise<Map<string, PagosPedido>> {
   const CHUNK = 500;
-  const map = new Map<string, Set<TipoPago>>();
+  const map = new Map<string, PagosPedido>();
   for (let i = 0; i < orderIds.length; i += CHUNK) {
     const chunk = orderIds.slice(i, i + CHUNK);
     const { data, error } = await supabase
       .schema('rdb')
       .from('waitry_pagos')
-      .select('order_id, payment_method')
+      .select('order_id, payment_method, amount')
       .in('order_id', chunk)
       .limit(10000);
     if (error) throw error;
     for (const pago of data ?? []) {
       if (!pago.order_id) continue;
-      const tipos = map.get(pago.order_id) ?? new Set<TipoPago>();
-      tipos.add(clasificarMetodoPago(pago.payment_method));
-      map.set(pago.order_id, tipos);
+      const tipo = clasificarMetodoPago(pago.payment_method);
+      const entry = map.get(pago.order_id) ?? { tipos: new Set<TipoPago>(), montoPorTipo: {} };
+      entry.tipos.add(tipo);
+      entry.montoPorTipo[tipo] = (entry.montoPorTipo[tipo] ?? 0) + Number(pago.amount ?? 0);
+      map.set(pago.order_id, entry);
     }
   }
   return map;
+}
+
+/**
+ * Acumula los montos por tipo de un conjunto de pedidos (para los KPI del
+ * summary). Los pedidos sin pagos registrados (undefined) no aportan.
+ */
+export function sumarMontosPorTipo(
+  montos: Array<Partial<Record<TipoPago, number>> | undefined>
+): Record<TipoPago, number> {
+  const acc: Record<TipoPago, number> = { efectivo: 0, tarjeta: 0, stripe: 0, otro: 0 };
+  for (const m of montos) {
+    if (!m) continue;
+    for (const t of TIPOS_PAGO) acc[t] += m[t] ?? 0;
+  }
+  return acc;
 }
 
 /**

--- a/components/ventas/tipo-pago.ts
+++ b/components/ventas/tipo-pago.ts
@@ -1,0 +1,72 @@
+import type { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+
+/**
+ * Tipo de pago — buckets del filtro de /rdb/ventas.
+ *
+ * Espeja la clasificación que ya usa el módulo de Cortes en DB
+ * (rdb.v_cortes_totales, migración 20260409220000): `cash` → efectivo,
+ * `credit_card%` / `pos` → tarjeta, `stripe` → stripe, resto → otro.
+ * Valores reales en prod (2026-07-02): cash, credit_card_visa, credit_card,
+ * credit_card_master, POS, STRIPE, other.
+ */
+export type TipoPago = 'efectivo' | 'tarjeta' | 'stripe' | 'otro';
+
+export const TIPO_PAGO_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'all', label: 'Todos los pagos' },
+  { value: 'efectivo', label: 'Efectivo' },
+  { value: 'tarjeta', label: 'Tarjeta' },
+  { value: 'stripe', label: 'Stripe' },
+  { value: 'otro', label: 'Otro' },
+];
+
+export function clasificarMetodoPago(method: string | null | undefined): TipoPago {
+  const m = (method ?? '').trim().toLowerCase();
+  if (m === 'cash') return 'efectivo';
+  if (m.startsWith('credit_card') || m === 'pos') return 'tarjeta';
+  if (m === 'stripe') return 'stripe';
+  return 'otro';
+}
+
+/**
+ * Tipos de pago usados por cada pedido, desde `rdb.waitry_pagos`.
+ *
+ * Un pedido con pago dividido (p.ej. efectivo + tarjeta) trae ambos tipos y
+ * matchea el filtro por cualquiera de los dos — se reporta completo, no se
+ * parte el monto por método.
+ *
+ * Chunked a 500 ids por el límite de longitud de URL de PostgREST (mismo
+ * patrón que las líneas en los tabs Por producto / Por categoría).
+ */
+export async function fetchTiposPagoPorPedido(
+  supabase: ReturnType<typeof createSupabaseBrowserClient>,
+  orderIds: string[]
+): Promise<Map<string, Set<TipoPago>>> {
+  const CHUNK = 500;
+  const map = new Map<string, Set<TipoPago>>();
+  for (let i = 0; i < orderIds.length; i += CHUNK) {
+    const chunk = orderIds.slice(i, i + CHUNK);
+    const { data, error } = await supabase
+      .schema('rdb')
+      .from('waitry_pagos')
+      .select('order_id, payment_method')
+      .in('order_id', chunk)
+      .limit(10000);
+    if (error) throw error;
+    for (const pago of data ?? []) {
+      if (!pago.order_id) continue;
+      const tipos = map.get(pago.order_id) ?? new Set<TipoPago>();
+      tipos.add(clasificarMetodoPago(pago.payment_method));
+      map.set(pago.order_id, tipos);
+    }
+  }
+  return map;
+}
+
+/**
+ * ¿El pedido pasa el filtro de tipo de pago? Con filtro 'all' siempre.
+ * Un pedido sin pagos registrados solo aparece bajo 'all'.
+ */
+export function matchTipoPago(tipos: Set<TipoPago> | undefined, pagoFilter: string): boolean {
+  if (pagoFilter === 'all') return true;
+  return tipos?.has(pagoFilter as TipoPago) ?? false;
+}

--- a/components/ventas/types.ts
+++ b/components/ventas/types.ts
@@ -1,3 +1,5 @@
+import type { TipoPago } from './tipo-pago';
+
 export type CorteOption = {
   id: string;
   corte_nombre: string | null;
@@ -49,6 +51,11 @@ export type Pedido = {
   // canónica `rdb.v_waitry_pedidos` siempre devuelve `es_fantasma=false`.
   superseded_by_order_id?: string | null;
   es_fantasma?: boolean | null;
+  // Enriquecido client-side desde rdb.waitry_pagos (VentasView): tipos de
+  // pago del pedido (columna "Pago" + filtro) y monto por tipo (KPIs del
+  // summary). undefined mientras carga o si el pedido no tiene pagos.
+  tipos_pago?: TipoPago[];
+  montos_pago?: Partial<Record<TipoPago, number>>;
   // lazy-loaded
   pagos?: Pago[];
   items?: PedidoItem[];

--- a/components/ventas/ventas-filters.tsx
+++ b/components/ventas/ventas-filters.tsx
@@ -9,6 +9,7 @@ import { ActiveFiltersChip } from '@/components/module-page';
 import type { CorteOption } from './types';
 import { STATUS_OPTIONS } from './types';
 import { formatDate } from './utils';
+import { TIPO_PAGO_OPTIONS } from './tipo-pago';
 
 export type VentasFiltersProps = {
   search: string;
@@ -18,6 +19,8 @@ export type VentasFiltersProps = {
   corteFilter: string;
   onCorteFilterChange: (value: string) => void;
   cortes: CorteOption[];
+  pagoFilter: string;
+  onPagoFilterChange: (value: string) => void;
   dateFrom: string;
   dateTo: string;
   onDateFromChange: (value: string) => void;
@@ -42,6 +45,8 @@ export function VentasFilters({
   corteFilter,
   onCorteFilterChange,
   cortes,
+  pagoFilter,
+  onPagoFilterChange,
   dateFrom,
   dateTo,
   onDateFromChange,
@@ -90,6 +95,16 @@ export function VentasFilters({
         searchPlaceholder="Buscar corte..."
         clearLabel="Todos los cortes"
         className="w-52"
+      />
+
+      {/* Tipo de pago — buckets espejo de rdb.v_cortes_totales (efectivo /
+          tarjeta / stripe / otro). Un pedido con pago dividido matchea por
+          cualquiera de sus métodos. */}
+      <Combobox
+        value={pagoFilter}
+        onChange={(v) => onPagoFilterChange(v || 'all')}
+        options={TIPO_PAGO_OPTIONS}
+        className="w-44"
       />
 
       <div className="flex items-center gap-2">

--- a/components/ventas/ventas-por-categoria.tsx
+++ b/components/ventas/ventas-por-categoria.tsx
@@ -12,7 +12,7 @@ import { TZ } from './utils';
 import { CategoriaBadge } from './categoria-badge';
 import type { CategoriaFilter } from './types';
 import { prorratearLineas, ventaCobrada } from './venta-cobrada';
-import { fetchTiposPagoPorPedido, matchTipoPago } from './tipo-pago';
+import { fetchPagosPorPedido, matchTipoPago } from './tipo-pago';
 
 // Las líneas de venta cuyo producto no resuelve a una categoría del
 // catálogo (product_id sin match en erp.productos.codigo, o producto sin
@@ -98,12 +98,12 @@ export function VentasPorCategoria({
       // pedido matchea si alguno de sus pagos usa ese tipo, y se reporta
       // completo (no se parte el monto por método).
       if (pagoFilter !== 'all') {
-        const tiposPago = await fetchTiposPagoPorPedido(
+        const pagosPorPedido = await fetchPagosPorPedido(
           supabase,
           validPedidos.map((p) => p.order_id as string)
         );
         validPedidos = validPedidos.filter((p) =>
-          matchTipoPago(tiposPago.get(p.order_id as string), pagoFilter)
+          matchTipoPago(pagosPorPedido.get(p.order_id as string)?.tipos, pagoFilter)
         );
       }
 

--- a/components/ventas/ventas-por-categoria.tsx
+++ b/components/ventas/ventas-por-categoria.tsx
@@ -12,6 +12,7 @@ import { TZ } from './utils';
 import { CategoriaBadge } from './categoria-badge';
 import type { CategoriaFilter } from './types';
 import { prorratearLineas, ventaCobrada } from './venta-cobrada';
+import { fetchTiposPagoPorPedido, matchTipoPago } from './tipo-pago';
 
 // Las líneas de venta cuyo producto no resuelve a una categoría del
 // catálogo (product_id sin match en erp.productos.codigo, o producto sin
@@ -43,6 +44,7 @@ export type VentasPorCategoriaProps = {
   dateFrom: string;
   dateTo: string;
   corteFilter: string;
+  pagoFilter: string;
   search: string;
   onSearchChange: (value: string) => void;
   onCategoriaClick: (categoria: CategoriaFilter) => void;
@@ -52,6 +54,7 @@ export function VentasPorCategoria({
   dateFrom,
   dateTo,
   corteFilter,
+  pagoFilter,
   search,
   onSearchChange,
   onCategoriaClick,
@@ -87,9 +90,23 @@ export function VentasPorCategoria({
       const { data: pedidos, error: pedidosErr } = await pedidosQuery;
       if (pedidosErr) throw pedidosErr;
 
-      const validPedidos = (pedidos ?? []).filter(
+      let validPedidos = (pedidos ?? []).filter(
         (p) => !!p.order_id && !(p.status ?? '').toLowerCase().includes('cancel')
       );
+
+      // Filtro por tipo de pago — mismo criterio que el tab Pedidos: el
+      // pedido matchea si alguno de sus pagos usa ese tipo, y se reporta
+      // completo (no se parte el monto por método).
+      if (pagoFilter !== 'all') {
+        const tiposPago = await fetchTiposPagoPorPedido(
+          supabase,
+          validPedidos.map((p) => p.order_id as string)
+        );
+        validPedidos = validPedidos.filter((p) =>
+          matchTipoPago(tiposPago.get(p.order_id as string), pagoFilter)
+        );
+      }
+
       const validOrderIds = validPedidos.map((p) => p.order_id as string);
 
       if (validOrderIds.length === 0) {
@@ -172,7 +189,7 @@ export function VentasPorCategoria({
     } finally {
       setLoading(false);
     }
-  }, [dateFrom, dateTo, corteFilter]);
+  }, [dateFrom, dateTo, corteFilter, pagoFilter]);
 
   useEffect(() => {
     void fetchData();

--- a/components/ventas/ventas-por-producto.tsx
+++ b/components/ventas/ventas-por-producto.tsx
@@ -12,7 +12,7 @@ import { TZ } from './utils';
 import { CategoriaBadge } from './categoria-badge';
 import type { CategoriaFilter } from './types';
 import { prorratearLineas, ventaCobrada } from './venta-cobrada';
-import { fetchTiposPagoPorPedido, matchTipoPago } from './tipo-pago';
+import { fetchPagosPorPedido, matchTipoPago } from './tipo-pago';
 
 type ProductoAgg = {
   product_id: string;
@@ -96,12 +96,12 @@ export function VentasPorProducto({
       // pedido matchea si alguno de sus pagos usa ese tipo, y se reporta
       // completo (no se parte el monto por método).
       if (pagoFilter !== 'all') {
-        const tiposPago = await fetchTiposPagoPorPedido(
+        const pagosPorPedido = await fetchPagosPorPedido(
           supabase,
           validPedidos.map((p) => p.order_id as string)
         );
         validPedidos = validPedidos.filter((p) =>
-          matchTipoPago(tiposPago.get(p.order_id as string), pagoFilter)
+          matchTipoPago(pagosPorPedido.get(p.order_id as string)?.tipos, pagoFilter)
         );
       }
 

--- a/components/ventas/ventas-por-producto.tsx
+++ b/components/ventas/ventas-por-producto.tsx
@@ -12,6 +12,7 @@ import { TZ } from './utils';
 import { CategoriaBadge } from './categoria-badge';
 import type { CategoriaFilter } from './types';
 import { prorratearLineas, ventaCobrada } from './venta-cobrada';
+import { fetchTiposPagoPorPedido, matchTipoPago } from './tipo-pago';
 
 type ProductoAgg = {
   product_id: string;
@@ -41,6 +42,7 @@ export type VentasPorProductoProps = {
   dateFrom: string;
   dateTo: string;
   corteFilter: string;
+  pagoFilter: string;
   search: string;
   onSearchChange: (value: string) => void;
   categoriaFilter: CategoriaFilter | null;
@@ -51,6 +53,7 @@ export function VentasPorProducto({
   dateFrom,
   dateTo,
   corteFilter,
+  pagoFilter,
   search,
   onSearchChange,
   categoriaFilter,
@@ -85,9 +88,23 @@ export function VentasPorProducto({
       const { data: pedidos, error: pedidosErr } = await pedidosQuery;
       if (pedidosErr) throw pedidosErr;
 
-      const validPedidos = (pedidos ?? []).filter(
+      let validPedidos = (pedidos ?? []).filter(
         (p) => !!p.order_id && !(p.status ?? '').toLowerCase().includes('cancel')
       );
+
+      // Filtro por tipo de pago — mismo criterio que el tab Pedidos: el
+      // pedido matchea si alguno de sus pagos usa ese tipo, y se reporta
+      // completo (no se parte el monto por método).
+      if (pagoFilter !== 'all') {
+        const tiposPago = await fetchTiposPagoPorPedido(
+          supabase,
+          validPedidos.map((p) => p.order_id as string)
+        );
+        validPedidos = validPedidos.filter((p) =>
+          matchTipoPago(tiposPago.get(p.order_id as string), pagoFilter)
+        );
+      }
+
       const validOrderIds = validPedidos.map((p) => p.order_id as string);
 
       if (validOrderIds.length === 0) {
@@ -180,7 +197,7 @@ export function VentasPorProducto({
     } finally {
       setLoading(false);
     }
-  }, [dateFrom, dateTo, corteFilter]);
+  }, [dateFrom, dateTo, corteFilter, pagoFilter]);
 
   useEffect(() => {
     void fetchData();

--- a/components/ventas/ventas-table.tsx
+++ b/components/ventas/ventas-table.tsx
@@ -7,6 +7,7 @@ import { formatCurrency, formatDate } from '@/lib/format';
 import type { Pedido } from './types';
 import { statusVariant } from './utils';
 import { ventaCobrada } from './venta-cobrada';
+import { TIPO_PAGO_LABELS } from './tipo-pago';
 
 const columns: Column<Pedido>[] = [
   {
@@ -76,6 +77,25 @@ const columns: Column<Pedido>[] = [
         formatCurrency(cobrado)
       );
     },
+  },
+  {
+    // Enriquecido client-side desde rdb.waitry_pagos (VentasView). '—'
+    // mientras carga o si el pedido no tiene pagos registrados.
+    key: 'tipos_pago',
+    label: 'Pago',
+    accessor: (p) => (p.tipos_pago ?? []).map((t) => TIPO_PAGO_LABELS[t]).join(', '),
+    render: (p) =>
+      p.tipos_pago?.length ? (
+        <span className="inline-flex flex-wrap gap-1">
+          {p.tipos_pago.map((t) => (
+            <Badge key={t} variant="outline" className="px-1.5 py-0 text-[11px] font-normal">
+              {TIPO_PAGO_LABELS[t]}
+            </Badge>
+          ))}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
   },
   {
     key: 'status',

--- a/components/ventas/ventas-view.tsx
+++ b/components/ventas/ventas-view.tsx
@@ -30,6 +30,7 @@ import { VentasPorCategoria } from './ventas-por-categoria';
 import { VentasComparativo } from './ventas-comparativo';
 import type { CategoriaFilter, CorteOption, Pedido } from './types';
 import { TZ, rangeForPreset, todayRange } from './utils';
+import { fetchTiposPagoPorPedido, matchTipoPago, type TipoPago } from './tipo-pago';
 
 type VentasTab = 'pedidos' | 'por-producto' | 'por-categoria' | 'comparativo';
 
@@ -43,6 +44,11 @@ export function VentasView() {
   const [categoriaSearch, setCategoriaSearch] = useState('');
   const [categoriaFilter, setCategoriaFilter] = useState<CategoriaFilter | null>(null);
   const [cortes, setCortes] = useState<CorteOption[]>([]);
+  // Tipos de pago por pedido (rdb.waitry_pagos) — se carga lazy, solo cuando
+  // el filtro "Tipo de pago" está activo, para no duplicar requests en el
+  // caso común (filtro en "Todos los pagos").
+  const [tiposPago, setTiposPago] = useState<Map<string, Set<TipoPago>> | null>(null);
+  const [loadingPagos, setLoadingPagos] = useState(false);
 
   // URL-synced filter defaults are captured once at mount (today's date range).
   // Re-opening a stale tab the next day keeps the previous defaults; that's
@@ -54,6 +60,7 @@ export function VentasView() {
       search: '',
       statusFilter: 'all',
       corteFilter: 'all',
+      pagoFilter: 'all',
       dateFrom: today.from,
       dateTo: today.to,
       presetKey: 'hoy',
@@ -61,8 +68,16 @@ export function VentasView() {
     };
   }, []);
   const { filters, setFilter, setFilters, clearAll, activeCount } = useUrlFilters(filterDefaults);
-  const { search, statusFilter, corteFilter, dateFrom, dateTo, presetKey, showDuplicados } =
-    filters;
+  const {
+    search,
+    statusFilter,
+    corteFilter,
+    pagoFilter,
+    dateFrom,
+    dateTo,
+    presetKey,
+    showDuplicados,
+  } = filters;
   const showFantasmas = showDuplicados === 'on';
 
   const handlePreset = (preset: string | null) => {
@@ -162,6 +177,34 @@ export function VentasView() {
     void fetchPedidos();
   }, [fetchPedidos]);
 
+  // Con el filtro de tipo de pago activo, resolver los métodos de pago de los
+  // pedidos cargados. Se refresca cuando cambia el conjunto de pedidos.
+  useEffect(() => {
+    if (pagoFilter === 'all') return;
+    const orderIds = pedidos.map((p) => p.order_id).filter((id): id is string => !!id);
+    if (orderIds.length === 0) {
+      setTiposPago(new Map());
+      return;
+    }
+    let cancelled = false;
+    setLoadingPagos(true);
+    fetchTiposPagoPorPedido(createSupabaseBrowserClient(), orderIds)
+      .then((map) => {
+        if (!cancelled) setTiposPago(map);
+      })
+      .catch(() => {
+        // non-fatal: sin el mapa, el filtro no matchea nada y la tabla queda
+        // vacía; el usuario puede reintentar con "Actualizar".
+        if (!cancelled) setTiposPago(new Map());
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingPagos(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pagoFilter, pedidos]);
+
   const openDetail = async (pedido: Pedido) => {
     setSelected(pedido);
     setDrawerOpen(true);
@@ -198,6 +241,11 @@ export function VentasView() {
 
   const filtered = pedidos.filter((p) => {
     if (statusFilter !== 'all' && p.status?.toLowerCase() !== statusFilter) return false;
+    if (
+      pagoFilter !== 'all' &&
+      !matchTipoPago(p.order_id ? tiposPago?.get(p.order_id) : undefined, pagoFilter)
+    )
+      return false;
     if (!search) return true;
     const q = search.toLowerCase();
     return (
@@ -273,13 +321,15 @@ export function VentasView() {
           corteFilter={corteFilter}
           onCorteFilterChange={(value) => setFilter('corteFilter', value)}
           cortes={cortes}
+          pagoFilter={pagoFilter}
+          onPagoFilterChange={(value) => setFilter('pagoFilter', value)}
           dateFrom={dateFrom}
           dateTo={dateTo}
           onDateFromChange={(value) => setFilters({ dateFrom: value, presetKey: 'custom' })}
           onDateToChange={(value) => setFilters({ dateTo: value, presetKey: 'custom' })}
           presetKey={presetKey}
           onPresetChange={handlePreset}
-          loading={loading}
+          loading={loading || loadingPagos}
           onRefresh={() => void fetchPedidos()}
           count={filtered.length}
           activeCount={activeCount}
@@ -297,7 +347,7 @@ export function VentasView() {
         <>
           <VentasTable
             pedidos={filtered}
-            loading={loading}
+            loading={loading || loadingPagos}
             onRowClick={(pedido) => void openDetail(pedido)}
           />
           <OrderDetail
@@ -313,6 +363,7 @@ export function VentasView() {
           dateFrom={dateFrom}
           dateTo={dateTo}
           corteFilter={corteFilter}
+          pagoFilter={pagoFilter}
           search={productoSearch}
           onSearchChange={setProductoSearch}
           categoriaFilter={categoriaFilter}
@@ -324,6 +375,7 @@ export function VentasView() {
           dateFrom={dateFrom}
           dateTo={dateTo}
           corteFilter={corteFilter}
+          pagoFilter={pagoFilter}
           search={categoriaSearch}
           onSearchChange={setCategoriaSearch}
           onCategoriaClick={handleCategoriaClick}

--- a/components/ventas/ventas-view.tsx
+++ b/components/ventas/ventas-view.tsx
@@ -30,7 +30,7 @@ import { VentasPorCategoria } from './ventas-por-categoria';
 import { VentasComparativo } from './ventas-comparativo';
 import type { CategoriaFilter, CorteOption, Pedido } from './types';
 import { TZ, rangeForPreset, todayRange } from './utils';
-import { fetchTiposPagoPorPedido, matchTipoPago, type TipoPago } from './tipo-pago';
+import { fetchPagosPorPedido, type PagosPedido } from './tipo-pago';
 
 type VentasTab = 'pedidos' | 'por-producto' | 'por-categoria' | 'comparativo';
 
@@ -44,10 +44,10 @@ export function VentasView() {
   const [categoriaSearch, setCategoriaSearch] = useState('');
   const [categoriaFilter, setCategoriaFilter] = useState<CategoriaFilter | null>(null);
   const [cortes, setCortes] = useState<CorteOption[]>([]);
-  // Tipos de pago por pedido (rdb.waitry_pagos) — se carga lazy, solo cuando
-  // el filtro "Tipo de pago" está activo, para no duplicar requests en el
-  // caso común (filtro en "Todos los pagos").
-  const [tiposPago, setTiposPago] = useState<Map<string, Set<TipoPago>> | null>(null);
+  // Pagos por pedido (rdb.waitry_pagos) — alimenta la columna "Pago", los
+  // KPIs por método del summary y el filtro de tipo de pago. Se carga tras
+  // cada fetch de pedidos.
+  const [pagosPorPedido, setPagosPorPedido] = useState<Map<string, PagosPedido> | null>(null);
   const [loadingPagos, setLoadingPagos] = useState(false);
 
   // URL-synced filter defaults are captured once at mount (today's date range).
@@ -177,25 +177,25 @@ export function VentasView() {
     void fetchPedidos();
   }, [fetchPedidos]);
 
-  // Con el filtro de tipo de pago activo, resolver los métodos de pago de los
-  // pedidos cargados. Se refresca cuando cambia el conjunto de pedidos.
+  // Resolver los pagos de los pedidos cargados. Se refresca cuando cambia el
+  // conjunto de pedidos.
   useEffect(() => {
-    if (pagoFilter === 'all') return;
     const orderIds = pedidos.map((p) => p.order_id).filter((id): id is string => !!id);
     if (orderIds.length === 0) {
-      setTiposPago(new Map());
+      setPagosPorPedido(new Map());
       return;
     }
     let cancelled = false;
     setLoadingPagos(true);
-    fetchTiposPagoPorPedido(createSupabaseBrowserClient(), orderIds)
+    fetchPagosPorPedido(createSupabaseBrowserClient(), orderIds)
       .then((map) => {
-        if (!cancelled) setTiposPago(map);
+        if (!cancelled) setPagosPorPedido(map);
       })
       .catch(() => {
-        // non-fatal: sin el mapa, el filtro no matchea nada y la tabla queda
-        // vacía; el usuario puede reintentar con "Actualizar".
-        if (!cancelled) setTiposPago(new Map());
+        // non-fatal: sin el mapa, la columna "Pago" y los KPIs por método
+        // quedan vacíos y el filtro específico no matchea nada; el usuario
+        // puede reintentar con "Actualizar".
+        if (!cancelled) setPagosPorPedido(new Map());
       })
       .finally(() => {
         if (!cancelled) setLoadingPagos(false);
@@ -203,7 +203,7 @@ export function VentasView() {
     return () => {
       cancelled = true;
     };
-  }, [pagoFilter, pedidos]);
+  }, [pedidos]);
 
   const openDetail = async (pedido: Pedido) => {
     setSelected(pedido);
@@ -239,12 +239,21 @@ export function VentasView() {
     }
   };
 
-  const filtered = pedidos.filter((p) => {
+  // Pedidos enriquecidos con sus tipos/montos de pago — la columna "Pago" de
+  // la tabla y los KPIs del summary leen estos campos.
+  const pedidosConPagos = useMemo(
+    () =>
+      pedidos.map((p) => {
+        const pagosPedido = p.order_id ? pagosPorPedido?.get(p.order_id) : undefined;
+        if (!pagosPedido) return p;
+        return { ...p, tipos_pago: [...pagosPedido.tipos], montos_pago: pagosPedido.montoPorTipo };
+      }),
+    [pedidos, pagosPorPedido]
+  );
+
+  const filtered = pedidosConPagos.filter((p) => {
     if (statusFilter !== 'all' && p.status?.toLowerCase() !== statusFilter) return false;
-    if (
-      pagoFilter !== 'all' &&
-      !matchTipoPago(p.order_id ? tiposPago?.get(p.order_id) : undefined, pagoFilter)
-    )
+    if (pagoFilter !== 'all' && !(p.tipos_pago as string[] | undefined)?.includes(pagoFilter))
       return false;
     if (!search) return true;
     const q = search.toLowerCase();


### PR DESCRIPTION
## Qué

Nuevo filtro **«Tipo de pago»** en `/rdb/ventas`, junto al filtro de corte. Aplica a los tabs **Pedidos**, **Por producto** y **Por categoría** (el Comparativo mantiene su ventana fija de 6 semanas, igual que con los demás filtros globales).

## Buckets

Espejo de la clasificación que ya usa Cortes en DB (`rdb.v_cortes_totales`, migración 20260409220000):

| Filtro | `waitry_pagos.payment_method` |
|---|---|
| Efectivo | `cash` |
| Tarjeta | `credit_card*`, `POS` |
| Stripe | `STRIPE` |
| Otro | `other` y cualquier valor no reconocido |

## Semántica

- Un pedido con **pago dividido** (p.ej. efectivo + tarjeta) matchea por cualquiera de sus métodos y se reporta **completo** — no se parte el monto por método.
- Los métodos se resuelven de `rdb.waitry_pagos` con fetch chunked (500 ids), **solo cuando el filtro está activo** — cero requests extra en el caso común.
- El filtro es URL-synced como los demás (`?pagoFilter=efectivo`) y entra al conteo de "filtros activos" / Limpiar filtros.
- La invariante del PR #1184 se mantiene: con el mismo filtro aplicado, los tres tabs suman lo mismo (mismo conjunto de pedidos, líneas prorrateadas a la venta cobrada).

## Verificación

- `typecheck` ✓ (0 errores fuera de `.next/` stale local) · tests de ventas 51 ✓ · suite completa: los únicos 2 fails son de `.Codex/worktrees/` (untracked, CI no lo ve) · `format` ✓
- Sin cambios de DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)