### PR TITLE
chore(tooling): excluir .Codex/ (worktrees de Codex CLI) de vitest, eslint y prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,7 +9,9 @@ out/
 node_modules/
 
 # Git worktrees created by agents — never format checked-out copies of the repo.
+# (.claude/ = Claude Code, .Codex/ = Codex CLI.)
 .claude/worktrees/
+.Codex/worktrees/
 
 # Untracked ad-hoc scratch folder.
 tmp/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,9 @@ const eslintConfig = [
       '**/.next/**',
       'node_modules/**',
       // Git worktrees created by agents — never lint checked-out copies of the repo.
+      // (.claude/ = Claude Code, .Codex/ = Codex CLI.)
       '.claude/worktrees/**',
+      '.Codex/worktrees/**',
       // Untracked ad-hoc scratch folder. Already .gitignore'd; mirror here so
       // local lint matches CI.
       'tmp/**',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,8 +43,10 @@ export default defineConfig({
       // `test:run` desde la raíz escanea sus `*.test.ts` y produce fallos
       // espurios (módulos ausentes en el checkout actual). CI no se afecta
       // (corre en checkout limpio sin `.claude/`). Ver
-      // reference_vitest_worktrees_scan.
+      // reference_vitest_worktrees_scan. `.Codex/` es el equivalente para
+      // worktrees de Codex CLI — mismo problema, misma exclusión.
       '**/.claude/**',
+      '**/.Codex/**',
       'tests/e2e/**',
       'tests/integration/**',
       '**/*.integration.test.ts',
@@ -57,6 +59,7 @@ export default defineConfig({
         '**/*.test.ts',
         '**/*.d.ts',
         '**/.claude/**',
+        '**/.Codex/**',
         // Helpers internos que solo sirven a tests.
         'app/api/**/_test-helpers.ts',
       ],


### PR DESCRIPTION
## Qué

Replica para `.Codex/` (worktrees de Codex CLI, untracked en `/Users/Beto/BSOP`) la misma exclusión que #772 hizo para `.claude/`:

- **vitest.config.ts**: `**/.Codex/**` en `test.exclude` y `coverage.exclude`
- **eslint.config.mjs**: `.Codex/worktrees/**` en `ignores`
- **.prettierignore**: `.Codex/worktrees/`

## Por qué

Las corridas locales pre-push escaneaban `.Codex/worktrees/sanren-panel/`: `test:coverage` fallaba 2 tests (lib/peptides.test.ts, lib/permissions-deps.test.ts) y `prettier --check .` reportaba ~19 archivos. CI no lo ve (checkout limpio), pero rompía la verificación local que exige BSOP/CLAUDE.md.

## Verificación

Fixture temporal `.Codex/worktrees/fake-session/` con un test que falla + archivo mal formateado: vitest no lo levanta (2332 tests pass), prettier no lo reporta, eslint lo marca ignorado. Checks locales de CI en verde (typecheck, test:coverage, lint, format:check, initiatives:validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)