### PR TITLE
fix(juntas): catálogo de tipos de junta filtrado por empresa

### DIFF
--- a/components/juntas/admin-juntas-list-module.tsx
+++ b/components/juntas/admin-juntas-list-module.tsx
@@ -40,6 +40,7 @@ import { Badge } from '@/components/ui/badge';
 import { FieldLabel } from '@/components/ui/field-label';
 import { Plus, Search, RefreshCw, Loader2, CalendarDays, Play } from 'lucide-react';
 import { JUNTA_ESTADO_CONFIG as ESTADO_CONFIG, type JuntaEstado } from '@/lib/status-tokens';
+import { TIPO_CONFIG, tipoOptionsForEmpresa } from '@/lib/juntas/tipos';
 
 type Junta = {
   id: string;
@@ -56,34 +57,6 @@ type Junta = {
   created_at: string;
   updated_at: string | null;
 };
-
-const TIPO_OPTIONS: { value: string; label: string; icon: string }[] = [
-  { value: 'Comité Ejecutivo', label: 'Comité Ejecutivo', icon: '👔' },
-  { value: 'Consejo', label: 'Consejo', icon: '🏢' },
-  { value: 'Ventas', label: 'Ventas', icon: '💰' },
-  { value: 'Atención PosVenta', label: 'Atención PosVenta', icon: '🔧' },
-  { value: 'Administración', label: 'Administración', icon: '📁' },
-  { value: 'Mercadotecnia', label: 'Mercadotecnia', icon: '📣' },
-  { value: 'Construcción', label: 'Construcción', icon: '🏗️' },
-  { value: 'Compras y Admon. Inventario', label: 'Compras y Admon. Inv.', icon: '📦' },
-  { value: 'Maquinaria', label: 'Maquinaria', icon: '🚜' },
-  { value: 'Proyectos', label: 'Proyectos', icon: '🗂️' },
-  { value: 'Rincón del Bosque', label: 'Rincón del Bosque', icon: '🌲' },
-  { value: 'Extraordinaria', label: 'Extraordinaria', icon: '🚨' },
-  { value: 'Otro', label: 'Otro', icon: '📌' },
-];
-
-const TIPO_CONFIG: Record<string, { label: string; icon: string }> = Object.fromEntries([
-  ...TIPO_OPTIONS.map((t) => [t.value, { label: t.label, icon: t.icon }]),
-  // Legacy aliases from Coda import (DILESA migración).
-  ['Comite Ejecutivo', { label: 'Comité Ejecutivo', icon: '👔' }],
-  ['Junta Operativa', { label: 'Comité Ejecutivo', icon: '👔' }],
-  ['Junta de Área', { label: 'Junta de Área', icon: '📋' }],
-  ['operativa', { label: 'Operativa', icon: '⚙️' }],
-  ['directiva', { label: 'Directiva', icon: '🏛️' }],
-  ['seguimiento', { label: 'Seguimiento', icon: '📊' }],
-  ['emergencia', { label: 'Emergencia', icon: '🚨' }],
-]);
 
 function formatDateTime(dt: string) {
   return new Date(dt).toLocaleString('es-MX', {
@@ -189,6 +162,8 @@ export function AdminJuntasListModule({
 }: AdminJuntasListModuleProps) {
   const router = useRouter();
   const supabase = createSupabaseERPClient();
+
+  const tipoOptions = useMemo(() => tipoOptionsForEmpresa(empresaSlug), [empresaSlug]);
 
   const [juntas, setJuntas] = useState<Junta[]>([]);
   const [loading, setLoading] = useState(true);
@@ -551,7 +526,7 @@ export function AdminJuntasListModule({
           <FilterCombobox
             value={filterTipo}
             onChange={setFilterTipo}
-            options={TIPO_OPTIONS.map((t) => ({
+            options={tipoOptions.map((t) => ({
               id: t.value,
               label: `${t.icon} ${t.label}`,
             }))}
@@ -632,7 +607,7 @@ export function AdminJuntasListModule({
               <Combobox
                 value={createTipo}
                 onChange={setCreateTipo}
-                options={TIPO_OPTIONS.map((t) => ({
+                options={tipoOptions.map((t) => ({
                   value: t.value,
                   label: `${t.icon} ${t.label}`,
                 }))}

--- a/components/juntas/junta-detail-module.tsx
+++ b/components/juntas/junta-detail-module.tsx
@@ -31,6 +31,7 @@ import {
   UPDATE_TIPO_CONFIG,
 } from '@/components/tasks/tasks-shared';
 import { JUNTA_ESTADO_CONFIG as ESTADO_JUNTA } from '@/lib/status-tokens';
+import { tipoOptionsForEmpresa } from '@/lib/juntas/tipos';
 import { Badge } from '@/components/ui/badge';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -121,22 +122,6 @@ type TaskUpdate = {
     fecha_vence: string | null;
   } | null;
 };
-
-const TIPO_OPTIONS: { value: string; label: string; icon: string }[] = [
-  { value: 'Comité Ejecutivo', label: 'Comité Ejecutivo', icon: '👔' },
-  { value: 'Consejo', label: 'Consejo', icon: '🏢' },
-  { value: 'Ventas', label: 'Ventas', icon: '💰' },
-  { value: 'Atención PosVenta', label: 'Atención PosVenta', icon: '🔧' },
-  { value: 'Administración', label: 'Administración', icon: '📁' },
-  { value: 'Mercadotecnia', label: 'Mercadotecnia', icon: '📣' },
-  { value: 'Construcción', label: 'Construcción', icon: '🏗️' },
-  { value: 'Compras y Admon. Inventario', label: 'Compras y Admon. Inv.', icon: '📦' },
-  { value: 'Maquinaria', label: 'Maquinaria', icon: '🚜' },
-  { value: 'Proyectos', label: 'Proyectos', icon: '🗂️' },
-  { value: 'Rincón del Bosque', label: 'Rincón del Bosque', icon: '🌲' },
-  { value: 'Extraordinaria', label: 'Extraordinaria', icon: '🚨' },
-  { value: 'Otro', label: 'Otro', icon: '📌' },
-];
 
 function toDatetimeLocal(iso: string) {
   const d = new Date(iso);
@@ -1178,7 +1163,7 @@ export function JuntaDetailModule({ empresaSlug }: JuntaDetailModuleProps) {
             <Combobox
               value={tipo ?? ''}
               onChange={(v) => setTipo(v)}
-              options={TIPO_OPTIONS.map((t) => ({
+              options={tipoOptionsForEmpresa(empresaSlug, tipo).map((t) => ({
                 value: t.value,
                 label: `${t.icon} ${t.label}`,
               }))}

--- a/lib/juntas/tipos.ts
+++ b/lib/juntas/tipos.ts
@@ -1,0 +1,71 @@
+/**
+ * Catálogo de tipos de junta — fuente única para lista y detalle
+ * (components/juntas/admin-juntas-list-module.tsx y junta-detail-module.tsx).
+ *
+ * El catálogo se filtra por empresa: los tipos de obra/desarrollo
+ * (Construcción, Maquinaria, Proyectos, …) no aplican al club deportivo y
+ * "Rincón del Bosque" no aplica a DILESA. Sin el filtro, las juntas se daban
+ * de alta en la empresa equivocada (caso 2026-07-02: junta semanal de RDB
+ * capturada bajo DILESA).
+ */
+
+export type JuntaEmpresaSlug = 'rdb' | 'dilesa';
+
+export type TipoOption = { value: string; label: string; icon: string };
+
+export const TIPO_OPTIONS: TipoOption[] = [
+  { value: 'Comité Ejecutivo', label: 'Comité Ejecutivo', icon: '👔' },
+  { value: 'Consejo', label: 'Consejo', icon: '🏢' },
+  { value: 'Ventas', label: 'Ventas', icon: '💰' },
+  { value: 'Atención PosVenta', label: 'Atención PosVenta', icon: '🔧' },
+  { value: 'Administración', label: 'Administración', icon: '📁' },
+  { value: 'Mercadotecnia', label: 'Mercadotecnia', icon: '📣' },
+  { value: 'Construcción', label: 'Construcción', icon: '🏗️' },
+  { value: 'Compras y Admon. Inventario', label: 'Compras y Admon. Inv.', icon: '📦' },
+  { value: 'Maquinaria', label: 'Maquinaria', icon: '🚜' },
+  { value: 'Proyectos', label: 'Proyectos', icon: '🗂️' },
+  { value: 'Rincón del Bosque', label: 'Rincón del Bosque', icon: '🌲' },
+  { value: 'Extraordinaria', label: 'Extraordinaria', icon: '🚨' },
+  { value: 'Otro', label: 'Otro', icon: '📌' },
+];
+
+/** Tipos que NO aplican a cada empresa (se ocultan de dropdowns y filtros). */
+const TIPOS_EXCLUIDOS: Record<JuntaEmpresaSlug, string[]> = {
+  dilesa: ['Rincón del Bosque'],
+  rdb: ['Atención PosVenta', 'Construcción', 'Maquinaria', 'Proyectos'],
+};
+
+/**
+ * Tipos disponibles para una empresa. Si `currentTipo` viene y no está en el
+ * catálogo filtrado (junta legacy o capturada antes del filtro), se agrega al
+ * final para que el dropdown de edición pueda mostrar el valor vigente.
+ */
+export function tipoOptionsForEmpresa(
+  empresaSlug: JuntaEmpresaSlug,
+  currentTipo?: string | null
+): TipoOption[] {
+  const excluidos = TIPOS_EXCLUIDOS[empresaSlug];
+  const options = TIPO_OPTIONS.filter((t) => !excluidos.includes(t.value));
+  if (currentTipo && !options.some((t) => t.value === currentTipo)) {
+    const cfg = TIPO_CONFIG[currentTipo];
+    options.push({
+      value: currentTipo,
+      label: cfg?.label ?? currentTipo,
+      icon: cfg?.icon ?? '📌',
+    });
+  }
+  return options;
+}
+
+/** Lookup para render de badges/labels — incluye alias legacy del import de Coda. */
+export const TIPO_CONFIG: Record<string, { label: string; icon: string }> = Object.fromEntries([
+  ...TIPO_OPTIONS.map((t) => [t.value, { label: t.label, icon: t.icon }]),
+  // Legacy aliases from Coda import (DILESA migración).
+  ['Comite Ejecutivo', { label: 'Comité Ejecutivo', icon: '👔' }],
+  ['Junta Operativa', { label: 'Comité Ejecutivo', icon: '👔' }],
+  ['Junta de Área', { label: 'Junta de Área', icon: '📋' }],
+  ['operativa', { label: 'Operativa', icon: '⚙️' }],
+  ['directiva', { label: 'Directiva', icon: '🏛️' }],
+  ['seguimiento', { label: 'Seguimiento', icon: '📊' }],
+  ['emergencia', { label: 'Emergencia', icon: '🚨' }],
+]);


### PR DESCRIPTION
## Problema
Los dropdowns de tipo de junta (crear, editar, filtro) mostraban el mismo catálogo completo en DILESA y RDB. Eso permitió que la junta semanal de RDB del 2026-07-02 se capturara bajo DILESA con tipo «Rincón del Bosque» (y la minuta saliera por el flujo de DILESA).

## Cambio
- Nuevo `lib/juntas/tipos.ts`: fuente única del catálogo (`TIPO_OPTIONS` + `TIPO_CONFIG` con alias legacy de Coda) y `tipoOptionsForEmpresa(slug, currentTipo?)` con exclusiones por empresa:
  - **DILESA** oculta: Rincón del Bosque
  - **RDB** oculta: Construcción, Maquinaria, Proyectos, Atención PosVenta
- `admin-juntas-list-module.tsx` y `junta-detail-module.tsx` consumen el catálogo filtrado (antes cada uno tenía su copia local).
- El dropdown de edición conserva el tipo vigente de la junta aunque ya no esté en el catálogo de su empresa (juntas legacy / capturadas antes del filtro).

## Datos (no incluido en este PR)
Queda 1 junta mal archivada en prod: `erp.juntas f9b214f9` (DILESA, 2026-07-02, tipo Rincón del Bosque) — mover a RDB requiere remapear participantes/tareas; pendiente de decisión de Beto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)