### PR TITLE
fix(dilesa-cobranza): excepción declarada al XML del recibo + búsqueda por número de crédito

### DIFF
--- a/app/dilesa/cobranza/page.tsx
+++ b/app/dilesa/cobranza/page.tsx
@@ -3,9 +3,13 @@
 /**
  * Cobranza · Pagos — captura de abonos desde administración (CxC Sprint 3).
  *
- * El equipo de administración busca una venta por cliente/unidad y registra
- * el abono sin entrar al detalle de la venta. Reusa <AbonoCaptureDrawer>
- * (mismo form + comprobante + FIFO que el detalle de venta).
+ * El equipo de administración busca una venta por nombre del cliente o por
+ * número de crédito (titular/cotitular, `dilesa.ventas.credito_*_ref`) y
+ * registra el abono sin entrar al detalle de la venta. La búsqueda por
+ * crédito es por contención: las transferencias de las instituciones vienen
+ * referenciadas con el número recortado (p.ej. "6090129" ⊂ "INFONAVIT
+ * 0526090129"). Reusa <AbonoCaptureDrawer> (mismo form + comprobante + FIFO
+ * que el detalle de venta).
  *
  * @responsive desktop-only — captura administrativa en escritorio.
  */
@@ -36,6 +40,8 @@ type Resultado = {
   personaId: string;
   cliente: string;
   unidad: string | null;
+  /** Número de crédito del titular (dilesa.ventas.credito_titular_ref). */
+  credito: string | null;
   saldo: number;
   estado: string;
 };
@@ -76,20 +82,33 @@ function PagosBody() {
     setError(null);
     const sb = createSupabaseBrowserClient();
 
-    // 1. Personas que matchean el nombre.
-    const { data: personas, error: pErr } = await sb
-      .schema('erp')
-      .from('personas')
-      .select('id, nombre, apellido_paterno, apellido_materno')
-      .or(
-        `nombre.ilike.%${termino}%,apellido_paterno.ilike.%${termino}%,apellido_materno.ilike.%${termino}%`
-      )
-      .limit(40);
-    if (pErr) {
-      setError(getSupabaseErrorMessage(pErr, 'No se pudo buscar.'));
+    // 1a. Personas que matchean el nombre. 1b. Ventas que matchean el número
+    // de crédito (titular o cotitular) — las transferencias de las
+    // instituciones vienen referenciadas así (p.ej. "6090129" matchea
+    // "INFONAVIT 0526090129" por contención).
+    const [personasRes, ventasCreditoRes] = await Promise.all([
+      sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .or(
+          `nombre.ilike.%${termino}%,apellido_paterno.ilike.%${termino}%,apellido_materno.ilike.%${termino}%`
+        )
+        .limit(40),
+      sb
+        .schema('dilesa')
+        .from('ventas')
+        .select('id, empresa_id, persona_id, unidad_id, estado, credito_titular_ref')
+        .or(`credito_titular_ref.ilike.%${termino}%,credito_cotitular_ref.ilike.%${termino}%`)
+        .is('deleted_at', null)
+        .limit(40),
+    ]);
+    if (personasRes.error) {
+      setError(getSupabaseErrorMessage(personasRes.error, 'No se pudo buscar.'));
       setLoading(false);
       return;
     }
+    const personas = personasRes.data;
     const personaIds = (personas ?? []).map((p) => p.id);
     const nombrePorPersona = new Map(
       (personas ?? []).map((p) => [
@@ -98,26 +117,57 @@ function PagosBody() {
           '(sin nombre)',
       ])
     );
-    if (personaIds.length === 0) {
+
+    type VentaRow = {
+      id: string;
+      empresa_id: string;
+      persona_id: string;
+      unidad_id: string | null;
+      estado: string | null;
+      credito_titular_ref?: string | null;
+    };
+    const ventasPorCredito = (ventasCreditoRes.data ?? []) as VentaRow[];
+
+    // 2. Ventas de las personas por nombre + unión con las de crédito (dedupe).
+    let ventasPorNombre: VentaRow[] = [];
+    if (personaIds.length > 0) {
+      const { data } = await sb
+        .schema('dilesa')
+        .from('ventas')
+        .select('id, empresa_id, persona_id, unidad_id, estado, credito_titular_ref')
+        .in('persona_id', personaIds)
+        .is('deleted_at', null);
+      ventasPorNombre = (data ?? []) as VentaRow[];
+    }
+    const ventasPorId = new Map<string, VentaRow>();
+    for (const v of [...ventasPorNombre, ...ventasPorCredito]) ventasPorId.set(v.id, v);
+    const ventas = Array.from(ventasPorId.values());
+    const ventaIds = ventas.map((v) => v.id);
+    if (ventaIds.length === 0) {
       setResultados([]);
       setBuscado(true);
       setLoading(false);
       return;
     }
 
-    // 2. Ventas de esas personas.
-    const { data: ventas } = await sb
-      .schema('dilesa')
-      .from('ventas')
-      .select('id, empresa_id, persona_id, unidad_id, estado')
-      .in('persona_id', personaIds)
-      .is('deleted_at', null);
-    const ventaIds = (ventas ?? []).map((v) => v.id);
-    if (ventaIds.length === 0) {
-      setResultados([]);
-      setBuscado(true);
-      setLoading(false);
-      return;
+    // Nombres de los clientes de ventas encontradas por crédito (no vinieron
+    // en la búsqueda por nombre).
+    const personasFaltantes = Array.from(
+      new Set(ventas.map((v) => v.persona_id).filter((id) => !nombrePorPersona.has(id)))
+    );
+    if (personasFaltantes.length > 0) {
+      const { data: extra } = await sb
+        .schema('erp')
+        .from('personas')
+        .select('id, nombre, apellido_paterno, apellido_materno')
+        .in('id', personasFaltantes);
+      for (const p of extra ?? []) {
+        nombrePorPersona.set(
+          p.id,
+          [p.nombre, p.apellido_paterno, p.apellido_materno].filter(Boolean).join(' ') ||
+            '(sin nombre)'
+        );
+      }
     }
 
     // 3. Saldo por venta (suma de cxc_cargos abiertos) + 4. unidad.
@@ -135,7 +185,7 @@ function PagosBody() {
         .select('id, identificador')
         .in(
           'id',
-          (ventas ?? []).map((v) => v.unidad_id).filter((x): x is string => !!x)
+          ventas.map((v) => v.unidad_id).filter((x): x is string => !!x)
         ),
     ]);
     const saldoPorVenta = new Map<string, number>();
@@ -146,15 +196,16 @@ function PagosBody() {
       (unidades ?? []).map((u) => [u.id as string, u.identificador as string])
     );
 
-    const res: Resultado[] = (ventas ?? [])
+    const res: Resultado[] = ventas
       .map((v) => ({
         ventaId: v.id,
         empresaId: v.empresa_id,
         personaId: v.persona_id,
         cliente: nombrePorPersona.get(v.persona_id) ?? '(sin nombre)',
         unidad: v.unidad_id ? (unidadPorId.get(v.unidad_id) ?? null) : null,
+        credito: v.credito_titular_ref ?? null,
         saldo: saldoPorVenta.get(v.id) ?? 0,
-        estado: (v.estado as string) ?? 'activa',
+        estado: v.estado ?? 'activa',
       }))
       // Cobrables (activas, etc.) primero; desasignadas/expiradas al final
       // para que el operador vea primero las relevantes.
@@ -176,8 +227,9 @@ function PagosBody() {
       <div className="hidden px-4 pb-8 sm:block sm:px-6">
         <h1 className="mb-1 text-lg font-semibold text-[var(--text)]">Captura de pagos</h1>
         <p className="mb-4 text-sm text-[var(--text)]/60">
-          Busca al cliente o la unidad y registra el abono. Se aplica solo a los cargos abiertos de
-          esa venta.
+          Busca por nombre del cliente o por número de crédito (como viene referenciada la
+          transferencia de la institución) y registra el abono. Se aplica solo a los cargos abiertos
+          de esa venta.
         </p>
 
         <form
@@ -190,7 +242,7 @@ function PagosBody() {
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            placeholder="Nombre del cliente..."
+            placeholder="Nombre del cliente o número de crédito..."
             className="w-full max-w-md rounded-lg border border-[var(--border)] bg-[var(--panel)] px-3 py-2 text-sm text-[var(--text)]"
           />
           <button
@@ -214,6 +266,7 @@ function PagosBody() {
               <tr className="border-b border-[var(--border)] text-left text-xs uppercase tracking-wide text-[var(--text)]/50">
                 <th className="py-1 pr-2 font-medium">Cliente</th>
                 <th className="py-1 pr-2 font-medium">Unidad</th>
+                <th className="py-1 pr-2 font-medium">Crédito</th>
                 <th className="py-1 pr-2 text-right font-medium">Saldo</th>
                 <th className="py-1 pl-2 font-medium"></th>
               </tr>
@@ -239,6 +292,7 @@ function PagosBody() {
                       </span>
                     </td>
                     <td className="py-1.5 pr-2">{r.unidad ?? '—'}</td>
+                    <td className="py-1.5 pr-2 text-xs">{r.credito ?? '—'}</td>
                     <td className="py-1.5 pr-2 text-right tabular-nums">
                       {moneyFmt.format(r.saldo)}
                     </td>

--- a/app/dilesa/cobranza/page.tsx
+++ b/app/dilesa/cobranza/page.tsx
@@ -40,7 +40,7 @@ type Resultado = {
   personaId: string;
   cliente: string;
   unidad: string | null;
-  /** Número de crédito del titular (dilesa.ventas.credito_titular_ref). */
+  /** Número(s) de crédito — titular y cotitular si existe (dilesa.ventas.credito_*_ref). */
   credito: string | null;
   saldo: number;
   estado: string;
@@ -98,7 +98,9 @@ function PagosBody() {
       sb
         .schema('dilesa')
         .from('ventas')
-        .select('id, empresa_id, persona_id, unidad_id, estado, credito_titular_ref')
+        .select(
+          'id, empresa_id, persona_id, unidad_id, estado, credito_titular_ref, credito_cotitular_ref'
+        )
         .or(`credito_titular_ref.ilike.%${termino}%,credito_cotitular_ref.ilike.%${termino}%`)
         .is('deleted_at', null)
         .limit(40),
@@ -125,6 +127,7 @@ function PagosBody() {
       unidad_id: string | null;
       estado: string | null;
       credito_titular_ref?: string | null;
+      credito_cotitular_ref?: string | null;
     };
     const ventasPorCredito = (ventasCreditoRes.data ?? []) as VentaRow[];
 
@@ -134,7 +137,9 @@ function PagosBody() {
       const { data } = await sb
         .schema('dilesa')
         .from('ventas')
-        .select('id, empresa_id, persona_id, unidad_id, estado, credito_titular_ref')
+        .select(
+          'id, empresa_id, persona_id, unidad_id, estado, credito_titular_ref, credito_cotitular_ref'
+        )
         .in('persona_id', personaIds)
         .is('deleted_at', null);
       ventasPorNombre = (data ?? []) as VentaRow[];
@@ -203,7 +208,8 @@ function PagosBody() {
         personaId: v.persona_id,
         cliente: nombrePorPersona.get(v.persona_id) ?? '(sin nombre)',
         unidad: v.unidad_id ? (unidadPorId.get(v.unidad_id) ?? null) : null,
-        credito: v.credito_titular_ref ?? null,
+        credito:
+          [v.credito_titular_ref, v.credito_cotitular_ref].filter(Boolean).join(' / ') || null,
         saldo: saldoPorVenta.get(v.id) ?? 0,
         estado: v.estado ?? 'activa',
       }))

--- a/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
+++ b/app/dilesa/ventas/[id]/capturar/12-detonada/page.tsx
@@ -256,9 +256,11 @@ function GuiaCobranza({ ventaId }: { ventaId: string }) {
           </p>
           <p className="text-[var(--text)]/70">
             Registra el abono de la institución en el estado de cuenta de la venta — con su
-            comprobante y el XML del recibo de caja (ambos obligatorios). Al registrarlo, esta fase
-            se cierra sola y el comprobante se copia al expediente. Con coacreditados (p. ej.
-            Infonavit Unamos), registra un abono por cada depósito, cada uno con su comprobante.
+            comprobante (siempre obligatorio) y el XML del recibo de caja; si el pago salda la deuda
+            y su CFDI se emite con la factura de la escrituración, decláralo en la captura. Al
+            registrarlo, esta fase se cierra sola y el comprobante se copia al expediente. Con
+            coacreditados (p. ej. Infonavit Unamos), registra un abono por cada depósito, cada uno
+            con su comprobante.
           </p>
         </div>
       </div>

--- a/components/dilesa/abono-capture-drawer.tsx
+++ b/components/dilesa/abono-capture-drawer.tsx
@@ -21,7 +21,12 @@
  * fallback a nombre). Desde 2026-07-01 (decisión de Beto) el XML y el
  * comprobante del depósito son OBLIGATORIOS: ningún abono queda en blanco —
  * sin comprobante no hay nada que copiar al expediente al detonar (caso
- * Salas), y la fecha del abono gobierna la fecha de detonación/comisiones. Mismatch de receptor exige confirmación explícita
+ * Salas), y la fecha del abono gobierna la fecha de detonación/comisiones.
+ * Excepción declarada (2026-07-02, operación real de Michelle): el pago que
+ * SALDA la deuda no lleva recibo de caja propio — el CFDI se emite con la
+ * factura de la escrituración (fase 13). Una casilla lo declara, desbloquea
+ * el registro sin XML y deja constancia en las notas del abono. El
+ * comprobante del depósito NO tiene excepción. Mismatch de receptor exige confirmación explícita
  * (con coacreditados el recibo puede venir a nombre del cónyuge). El folio
  * fiscal va a `cxc_pagos.uuid_sat` (unique parcial: un recibo = un abono).
  *
@@ -132,6 +137,9 @@ export function AbonoCaptureDrawer({
   const [comprobante, setComprobante] = useState<File | null>(null);
   const [recibo, setRecibo] = useState<File | null>(null);
   const [reciboXml, setReciboXml] = useState<File | null>(null);
+  // El pago que salda la deuda no lleva recibo de caja propio (el CFDI sale
+  // con la factura de la escrituración) — la casilla lo declara y se audita.
+  const [sinReciboCfdi, setSinReciboCfdi] = useState(false);
   const [parsed, setParsed] = useState<ReciboPagoParsed | null>(null);
   const [verif, setVerif] = useState<VerificacionRecibo | null>(null);
   const [confirmaOtroReceptor, setConfirmaOtroReceptor] = useState(false);
@@ -267,6 +275,7 @@ export function AbonoCaptureDrawer({
     setVerif(null);
     setConfirmaOtroReceptor(false);
     setEditManual(false);
+    setSinReciboCfdi(false);
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -330,12 +339,15 @@ export function AbonoCaptureDrawer({
     }
     // XML + comprobante obligatorios (2026-07-01): la fecha del abono gobierna
     // la detonación/comisiones y el comprobante viaja al expediente — ninguno
-    // puede quedar en blanco.
-    if (!reciboXml || !parsed) {
+    // puede quedar en blanco. Excepción declarada (2026-07-02, caso Michelle):
+    // el pago que SALDA la deuda ya no lleva recibo de caja propio — el CFDI
+    // se emite con la factura de la escrituración (fase 13). Ese caso se marca
+    // con la casilla y queda auditado en las notas del abono.
+    if (!reciboXml && !sinReciboCfdi) {
       toast.add({
         title: 'Falta el XML del recibo de caja',
         description:
-          'Sube el CFDI del recibo de caja (XML) — es la fuente de fecha, monto y referencia del abono.',
+          'Sube el CFDI del recibo (fuente de fecha, monto y referencia) — o marca la casilla si este pago no lleva recibo porque el CFDI se emite con la factura de la escrituración.',
         type: 'error',
       });
       return;
@@ -364,6 +376,9 @@ export function AbonoCaptureDrawer({
       values.notas || '',
       parsed && verif && !verif.receptorCoincide
         ? `[Recibo a nombre de ${parsed.receptorNombre ?? parsed.receptorRfc} (${parsed.receptorRfc}) — receptor distinto confirmado por quien captura]`
+        : '',
+      !reciboXml && sinReciboCfdi
+        ? '[Sin recibo de caja CFDI al registrar — el CFDI se emite con la factura de la escrituración; declarado por quien captura]'
         : '',
     ]
       .filter(Boolean)
@@ -553,6 +568,18 @@ export function AbonoCaptureDrawer({
               onChange={(f) => void handleXmlChange(f)}
               accept=".xml,text/xml,application/xml"
             />
+            {!reciboXml ? (
+              <label className="mt-2 flex cursor-pointer items-start gap-2 text-xs text-[var(--text)]/70">
+                <input
+                  type="checkbox"
+                  checked={sinReciboCfdi}
+                  onChange={(e) => setSinReciboCfdi(e.target.checked)}
+                  className="mt-0.5"
+                />
+                Este pago no lleva recibo de caja: es el pago que salda la deuda y el CFDI se emite
+                con la factura de la escrituración. (Queda registrado en las notas del abono.)
+              </label>
+            ) : null}
             {parsed && verif ? (
               <div
                 className={`mt-2 rounded-lg border p-3 text-xs ${


### PR DESCRIPTION
## Contexto (reporte de Michelle, 2026-07-02)

1. El pago (cliente o institución) que **salda** la deuda ya no lleva recibo de caja con CFDI — el CFDI se emite hasta la **factura de la escrituración** (fase 13). El candado de XML obligatorio (#1172) bloqueaba ese registro.
2. Las transferencias de las instituciones vienen referenciadas por **número de crédito** del titular, y Cobranza · Pagos solo buscaba por nombre.

## Qué hace

### Drawer de abonos
- El XML sigue siendo obligatorio **por default**, pero una casilla declara la excepción: _"Este pago no lleva recibo de caja: es el pago que salda la deuda y el CFDI se emite con la factura de la escrituración"_. Al usarla queda **constancia en las notas del abono** (audit trail).
- El **comprobante del depósito sigue obligatorio sin excepción** (es lo que viaja al expediente al detonar).

### Cobranza · Pagos
- Búsqueda por número de crédito (titular y cotitular) además de nombre — match por contención: `6090129` encuentra `INFONAVIT 0526090129` (así llega recortada la referencia bancaria).
- Columna **Crédito** en los resultados para confirmar el match.
- Cobertura actual en prod: 45/119 ventas vivas con `credito_titular_ref` capturado — las que no lo tengan seguirán encontrándose solo por nombre.

## Verificación
- typecheck / lint / format / 2347 tests verdes local. UI-only, sin migraciones.

**Sin auto-merge** (UI): revisa el preview — en Cobranza · Pagos busca `6090129` (venta de Eduardo Salas) y abre "Registrar abono" para ver la casilla del XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)