### PR TITLE
fix(auth): allowlist explícita de magic links en el proxy + test de contrato

### DIFF
--- a/lib/auth/public-paths.test.ts
+++ b/lib/auth/public-paths.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { isPublicPath } from './public-paths';
+
+/**
+ * Contrato de la allowlist pública del proxy.
+ *
+ * Si un test de PP1-PP3 rompe, un magic link enviado a un tercero (cliente,
+ * notario, valuador) va a redirigir a /login — revisar antes de mergear.
+ */
+describe('isPublicPath', () => {
+  // PP1 — magic links: página + API públicas para cada superficie firmada.
+  it.each([
+    '/dilesa/encuesta/eyJ2IjoiLi4ifQ.c2ln',
+    '/dilesa/notario/dictamen/eyJ2IjoiLi4ifQ.c2ln',
+    '/dilesa/valuador/avaluo/eyJ2IjoiLi4ifQ.c2ln',
+    '/api/dilesa/encuesta/eyJ2IjoiLi4ifQ.c2ln',
+    '/api/dilesa/notario/dictamen/eyJ2IjoiLi4ifQ.c2ln',
+    '/api/dilesa/valuador/avaluo/eyJ2IjoiLi4ifQ.c2ln',
+  ])('PP1: magic link público — %s', (path) => {
+    expect(isPublicPath(path)).toBe(true);
+  });
+
+  // PP2 — infraestructura pública: auth, crons, ingesta de salud, assets.
+  it.each([
+    '/login',
+    '/auth/callback',
+    '/api/auth/google',
+    '/api/cron/daily-briefing',
+    '/api/health/ingest',
+    '/_next/static/chunk.js',
+    '/favicon.ico',
+    '/brand/dilesa/logo.svg',
+  ])('PP2: infraestructura pública — %s', (path) => {
+    expect(isPublicPath(path)).toBe(true);
+  });
+
+  // PP3 — todo lo demás exige sesión. Incluye los padres de los magic links
+  // (sin token no hay acceso) y rutas de app operativa.
+  it.each([
+    '/',
+    '/dilesa',
+    '/dilesa/ventas',
+    '/dilesa/encuesta', // sin token ni slash final → privada
+    '/dilesa/notario/dictamen',
+    '/dilesa/valuador/avaluo',
+    '/api/dilesa/ventas/abc/encuesta', // API interna (genera el link) — privada
+    '/rdb/pos',
+    '/settings/acceso',
+    '/api/impersonate',
+  ])('PP3: privada — %s', (path) => {
+    expect(isPublicPath(path)).toBe(false);
+  });
+
+  // PP4 — /compartir/ se retiró de la allowlist (la ruta no existe en app/).
+  it('PP4: /compartir/ ya no es pública', () => {
+    expect(isPublicPath('/compartir/loquesea')).toBe(false);
+  });
+});

--- a/lib/auth/public-paths.ts
+++ b/lib/auth/public-paths.ts
@@ -1,0 +1,58 @@
+/**
+ * Allowlist de rutas públicas del proxy (middleware de auth).
+ *
+ * Única fuente de verdad de qué URLs se sirven SIN sesión de Supabase.
+ * `proxy.ts` la consume; el contrato vive en `public-paths.test.ts`.
+ *
+ * Revisión general 2026-06 (§5 Limpieza): antes los magic links funcionaban
+ * de chiripa — los tokens firmados llevan un punto (`payload.signature`) y el
+ * matcher del proxy (`/((?!.*\\..*).*)`) excluye paths con punto, así que
+ * nunca pasaban por el middleware. Esta allowlist los hace explícitos: si el
+ * matcher cambia, los links de terceros (clientes, notarios, valuadores)
+ * siguen vivos.
+ *
+ * Reglas para agregar una entrada:
+ *   - Páginas/APIs de magic link: SOLO si la ruta valida su propio token
+ *     firmado server-side (patrón `lib/dilesa/*-token.ts`).
+ *   - `/api/cron/*`: protegidas por header secret de Vercel Cron, no por
+ *     sesión.
+ *   - Assets/branding: estáticos sin datos.
+ */
+
+/** Rutas públicas por igualdad exacta. */
+const PUBLIC_EXACT_PATHS = new Set([
+  '/login',
+  '/auth/callback',
+  '/api/auth/google',
+  // Ingesta de Health Auto Export (iPhone) — autentica por token propio.
+  '/api/health/ingest',
+  '/favicon.ico',
+  '/logo-bs.png',
+  '/logo-bs.jpg',
+  '/logo-bsop.jpg',
+]);
+
+/** Prefijos públicos (la ruta y todo lo que cuelgue de ella). */
+const PUBLIC_PREFIXES = [
+  // Magic links firmados — cada superficie verifica su token server-side:
+  //   encuesta de satisfacción (cliente), dictamen notarial (notario),
+  //   carga de avalúo (valuador). Página + API por cada uno.
+  '/dilesa/encuesta/',
+  '/dilesa/notario/dictamen/',
+  '/dilesa/valuador/avaluo/',
+  '/api/dilesa/encuesta/',
+  '/api/dilesa/notario/dictamen/',
+  '/api/dilesa/valuador/avaluo/',
+  // Crons de Vercel — validan su propio secret.
+  '/api/cron/',
+  // Assets de Next y branding.
+  '/_next',
+  '/brand/',
+];
+
+export function isPublicPath(pathname: string): boolean {
+  return (
+    PUBLIC_EXACT_PATHS.has(pathname) ||
+    PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
 import { createClient } from '@supabase/supabase-js';
 import { PREVIEW_COOKIE_NAME } from '@/lib/auth/preview-guard';
+import { isPublicPath } from '@/lib/auth/public-paths';
 // NOTE: The 'core' schema must be listed in Supabase Dashboard → Settings → API → Exposed Schemas.
 
 const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
@@ -12,23 +13,6 @@ const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
  * ("stop") and could not switch targets ("impersonate" again).
  */
 const PREVIEW_EXEMPT_API_PATHS = new Set(['/api/impersonate', '/api/impersonate/stop']);
-
-function isPublicPath(pathname: string) {
-  return (
-    pathname === '/login' ||
-    pathname === '/auth/callback' ||
-    pathname === '/api/auth/google' ||
-    pathname.startsWith('/compartir/') ||
-    pathname.startsWith('/api/cron/') ||
-    pathname === '/api/health/ingest' ||
-    pathname.startsWith('/_next') ||
-    pathname === '/favicon.ico' ||
-    pathname === '/logo-bs.png' ||
-    pathname === '/logo-bs.jpg' ||
-    pathname === '/logo-bsop.jpg' ||
-    pathname.startsWith('/brand/')
-  );
-}
 
 export default async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
PR suelto de la limpieza del ultrareview 2026-06 (§5 / Sprint 0 item 4).

## Problema
Los magic links de terceros (encuesta de cliente, dictamen de notario, carga de avalúo) funcionaban **de chiripa**: sus tokens firmados llevan un punto (`payload.signature`) y el matcher del proxy (`/((?!.*\..*).*)`)  excluye paths con punto, así que nunca pasaban por el middleware. Si alguien ajusta el matcher, los links enviados a terceros mueren en /login. Además `/compartir/` estaba allowlisteado y esa ruta **no existe** en `app/`.

## Qué hace
- `lib/auth/public-paths.ts` nuevo: única fuente de verdad de rutas públicas, con reglas documentadas para agregar entradas (magic links solo si validan token firmado server-side — las 3 superficies lo hacen: `lib/dilesa/{encuesta,dictamen,avaluo}-token.ts`).
- Se retira `/compartir/`; se listan explícitos `/dilesa/{encuesta,notario/dictamen,valuador/avaluo}/` + sus `/api`.
- `public-paths.test.ts`: contrato PP1-PP4 (25 casos) — magic links públicos, infraestructura pública, todo lo demás privado, /compartir/ fuera.
- `proxy.ts` consume la lib (sin cambio de comportamiento para rutas privadas).

Nota: `components/app-shell/app-shell.tsx:31` aún referencia `/compartir/` (short-circuit del shell) — dead code inofensivo, fuera de alcance aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)