### PR TITLE
feat(blindaje-financiero): S2 — suite de integración financiera en CI (RPCs de dinero vs shadow)

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -41,7 +41,7 @@ jobs:
           BASE="${{ github.event.pull_request.base.sha }}"
           if [ -z "$BASE" ]; then BASE="HEAD~1"; fi
           if git diff --name-only "$BASE" HEAD \
-            | grep -qE '^supabase/migrations/|^supabase/SCHEMA_REF\.md|^supabase/FUNCTIONS_REF\.md|^\.github/workflows/schema-check\.yml|^scripts/gen-schema-ref\.ts|^scripts/gen-functions-ref\.ts'; then
+            | grep -qE '^supabase/migrations/|^supabase/SCHEMA_REF\.md|^supabase/FUNCTIONS_REF\.md|^\.github/workflows/schema-check\.yml|^scripts/gen-schema-ref\.ts|^scripts/gen-functions-ref\.ts|^tests/integration/|^vitest\.integration\.config\.ts'; then
             echo "db_touched=true" >> "$GITHUB_OUTPUT"
             echo "El PR toca DB/schema → se valida contra la shadow."
           else
@@ -75,6 +75,14 @@ jobs:
             echo "::error::supabase start falló — alguna migración no reproduce desde cero. Ver GOVERNANCE.md §1/§3."
             exit 1
           }
+
+      # Suite de integración financiera (blindaje-financiero S2): ejercita las
+      # RPCs de dinero (CxC FIFO, CxP comprometido/gate Dirección) contra la
+      # shadow assertando SALDOS + el caso anon-negativo del perímetro Sprint 0.
+      # La shadow ya está arriba — la suite corre en ~1s.
+      - name: Suite de integración financiera (RPCs de dinero vs shadow)
+        if: steps.changes.outputs.db_touched == 'true'
+        run: npm run test:integration
 
       - name: Regenerar SCHEMA_REF + types desde la shadow
         if: steps.changes.outputs.db_touched == 'true'

--- a/docs/planning/blindaje-financiero.md
+++ b/docs/planning/blindaje-financiero.md
@@ -4,10 +4,10 @@
 **Empresas:** todas (el modelo financiero vive en `erp.*` compartido)
 **Schemas afectados:** `erp` (RPCs financieras, `audit_log`, grants), `dilesa` (gate de fase/PLD, `venta_fases`), `core` (identidad `usuarios`↔`auth.users`), Supabase Storage (bucket `adjuntos`)
 **Estado:** in_progress
-**Próximo hito:** mergear S1 (gen-functions-ref + drift-guard en schema-check.yml) → arrancar Sprint 2 (suite de integración SQL de las RPCs de dinero contra la shadow)
+**Próximo hito:** mergear S2 (suite de integración financiera en CI) → arrancar Sprint 3 (cierre de fase como RPC transaccional con gate)
 **Dueño:** Beto
 **Creada:** 2026-06-12
-**Última actualización:** 2026-07-02 (Beto aprobó alcance v1; arranca Sprint 1)
+**Última actualización:** 2026-07-02 (S1 mergeado #1206; S2 en PR)
 
 ## Problema
 
@@ -33,7 +33,7 @@ El Sprint 0 (ya aplicado a prod) cerró el perímetro `anon` (RPCs financieras +
 ## Alcance v1 (sprints propuestos — pendientes de aprobación)
 
 - [x] **Sprint 1 — Fuente canónica de funciones + drift-guard (ataca la clase FIFO).** Generador `gen-functions-ref` (hermano de `schema:ref`): dump versionado de `pg_get_functiondef` de todas las funciones de negocio (182) + triggers/CHECKs. Drift-guard en `schema-check.yml` (shadow) que falla el PR si la definición que producen las migraciones difiere del snapshot. Convención: toda redefinición parte de ese archivo, nunca de la migración anterior.
-- [ ] **Sprint 2 — Suite de integración SQL.** `vitest.integration.config.ts` contra `supabase start` que ejercita las ~10 RPCs de dinero (cxc/cxp/presupuesto) assertando saldos + un **caso anon-negativo** (anon-key directo → 42501). Corre en CI en PRs que tocan `supabase/migrations/**` (trigger ya existe en `drift-check.yml`).
+- [x] **Sprint 2 — Suite de integración SQL.** `vitest.integration.config.ts` contra `supabase start` que ejercita las RPCs de dinero (CxC FIFO/cancelar/re-aplicar/ajustar + movimiento espejo; CxP comprometido vivo/dedup/gate Dirección con usuarios auth reales) assertando saldos + **caso anon-negativo estricto** (anon → 42501, un error de negocio = anon alcanzó el cuerpo). 39 tests, ~1s. Corre en CI dentro de `schema-check.yml` (la shadow ya está arriba en ese job) en PRs que tocan migraciones/derivados/la suite. Residual a S3/S4: RPCs de presupuesto (baseline/órdenes de cambio) y cierre de fase.
 - [ ] **Sprint 3 — Cierre de fase como RPC transaccional.** `fn_cerrar_fase` (`SECURITY DEFINER`) que valida permiso de módulo + gate PLD en DB y commitea `adjuntos`+`ventas`+`venta_fases` juntos (absorbe `marcarFase`). Restringe INSERT directo a `venta_fases` / UPDATE de `fase_actual` a esa RPC.
 - [ ] **Sprint 4 — Gate interno + revoke amplio de anon (defensa en profundidad).** `IF NOT fn_is_admin() AND NOT fn_has_empresa(...) THEN RAISE 42501` al inicio de cada RPC mutadora (partiendo de `pg_get_functiondef`, con el snapshot de S1 y el test de S2 como red). Revoke de `anon` de todas las funciones/tablas/defaults de negocio, no solo las 30 del Sprint 0.
 - [ ] **Sprint 5 — Audit trail uniforme + identidad.** FK a `core.usuarios` en todos los `*_por`; `created_by`/`registrado_por` en `erp.facturas` y `erp.movimientos_bancarios` con backfill; FK `core.usuarios.id → auth.users(id)` (o `auth_user_id NOT NULL UNIQUE`). ADR corto del patrón único de autoría.
@@ -60,5 +60,6 @@ El Sprint 0 (ya aplicado a prod) cerró el perímetro `anon` (RPCs financieras +
 
 ## Bitácora
 
+- **2026-07-02** — **Sprint 2 ejecutado**: suite de integración financiera contra la shadow (39 tests, ~1s): `finanzas-cxc` (FIFO por vencimiento sin filtrar fuente — regresión directa del incidente; cancelar revierte saldos; re-aplicar reemplaza y valida Σ ≤ abono; ajustar respeta piso de pagado; movimiento bancario espejo ADR-037 D4), `finanzas-cxp` (comprometido vivo al programar; liberar al cancelar; dedup `uuid_sat`; **gate Dirección de `cxp_pago_aprobar` con usuarios auth reales** — con rol aprueba y audita, sin rol/otra-empresa/service-role truena), `perimetro-anon` (9 RPCs mutadoras → 42501 estricto + lecturas `v_partida_control`/`cxc_pagos`/`movimientos_bancarios`). Harness en `tests/integration/helpers.ts` (fixtures con `runTag` único; `crearUsuarioConRol` crea auth user con `core.usuarios.id = auth.uid()` — requisito de `fn_user_has_role` y del FK de `audit_log`). CI: paso nuevo en `schema-check.yml` (la shadow ya está arriba; +~1s) + triggers ampliados a `tests/integration/` y el config. Docs `integration-setup.md` des-staleados (bootstrap chicken-egg ya no aplica; "211 migrations" fuera). S1 mergeado en [#1206](https://github.com/beto-sudo/BSOP/pull/1206).
 - **2026-07-02** — Beto aprobó alcance v1 (`proposed → in_progress`). **Sprint 1 ejecutado**: `scripts/gen-functions-ref.ts` (hermano de `gen-schema-ref.ts`, formatter puro + tests de determinismo/orden/render) genera `supabase/FUNCTIONS_REF.md` (182 funciones + 166 triggers + 226 CHECKs de 11 schemas, desde la shadow); `npm run functions:ref`/`functions:check`; `db:regen` lo incluye; `schema-check.yml` lo valida (regen + artifact + diff). Convención documentada en `GOVERNANCE.md` §3 y `CLAUDE.md` (Reglas DB): toda redefinición parte de `FUNCTIONS_REF.md`. Helper `.env.local` extraído a `scripts/lib/env-local.ts` (compartido con `gen-schema-ref.ts`).
 - **2026-06-12** — Promovida desde la revisión general 2026-06-12 (auditoría ultracode). El Sprint 0 de perímetro (REVOKE anon en 30 RPCs + `v_partida_control` con `security_invoker` + expediente PLD a RESTRICT) ya está aplicado y verificado en prod (PR [#877](https://github.com/beto-sudo/BSOP/pull/877)). Esta iniciativa recoge el resto de la dimensión db-seguridad + testing-calidad del reporte.

--- a/docs/testing/integration-setup.md
+++ b/docs/testing/integration-setup.md
@@ -1,154 +1,88 @@
 # Integration testing setup
 
-> Establecido en Sprint 3C de `tech-debt-h1-2026`. Pipeline de tests
-> contra una **DB real** (Supabase local stack) que detecta drift de
-> RPCs PL/pgSQL, RLS policies, triggers y constraints. Los unit tests
-> con mocks no detectan estas regresiones — los integration tests sí.
+> Establecido en Sprint 3C de `tech-debt-h1-2026`; promovido a **CI** en
+> `blindaje-financiero` S2. Pipeline de tests contra una **DB real**
+> (Supabase local stack / shadow) que detecta drift de RPCs PL/pgSQL, RLS
+> policies, triggers y constraints. Los unit tests con mocks no detectan
+> estas regresiones — los integration tests sí.
 
-## Cuándo correrlos
+## Cuándo corren
 
-- **Antes de mergear PRs** que tocan migrations (`supabase/migrations/`).
-- **Antes de mergear PRs** que tocan código financiero
-  (`app/rdb/cortes/`, `app/rdb/inventario/levantamientos/`,
-  `app/rdb/productos/recetas/`).
-- **Periódicamente** sobre `main` para confirmar que la DB local
-  reproduce el schema de producción.
+- **En CI, automáticamente** (desde `blindaje-financiero` S2): el workflow
+  `schema-check.yml` corre `npm run test:integration` contra la shadow DB en
+  todo PR que toca `supabase/migrations/`, los derivados
+  (`SCHEMA_REF`/`FUNCTIONS_REF`), los generadores, `tests/integration/` o el
+  config. La shadow ya está arriba en ese job — la suite agrega ~1s.
+- **Local, antes de push** en PRs que tocan migraciones o código financiero:
+  `supabase start && npm run test:integration`.
 
-No corren en CI default (Sprint 3C los dejó opt-in para no penalizar
-el tiempo de CI). Si más adelante decidimos escalar a CI nightly o
-gate por archivo, se documenta el cambio en este archivo.
+## Pre-requisitos (local)
 
-## Pre-requisitos
-
-1. **Docker** corriendo. Cualquiera funciona:
-   - [OrbStack](https://orbstack.dev/) (recomendado para Mac, más
-     liviano: `brew install --cask orbstack`).
-   - [Docker Desktop](https://www.docker.com/products/docker-desktop/).
-2. **Supabase CLI** ≥ 2.0:
-   ```bash
-   brew install supabase/tap/supabase
-   supabase --version
-   ```
-3. El repo clonado y dependencias instaladas (`npm ci`).
+1. **Docker** corriendo (OrbStack recomendado en Mac: `brew install --cask orbstack`).
+2. **Supabase CLI** ≥ 2.0 (`brew install supabase/tap/supabase`).
+3. `npm ci`.
 
 ## Cómo correrlos
 
-### Workaround inicial (chicken-egg con schemas)
-
-Hay un detalle del setup: nuestro `supabase/config.toml` declara
-`api.schemas = ["public", "core", "erp", ...]` para que producción
-exponga esos schemas vía PostgREST. Pero localmente, antes de aplicar
-migrations, esos schemas no existen — y `supabase start` falla
-porque PostgREST no puede cargar el schema cache.
-
-**Bootstrap inicial** (una sola vez por máquina o tras `supabase stop --no-backup`):
-
 ```bash
-# 1) Edita supabase/config.toml temporalmente: cambia
-#    `schemas = ["public", "core", ...]` a `schemas = ["public"]`.
-
-# 2) Levanta el stack local (primera vez ~5-10 min descargando
-#    ~2GB de imágenes; las siguientes ~10-15 segundos).
-supabase start
-
-# 3) Aplica las 211 migrations — ahora los schemas core/erp/etc
-#    se crean en la DB local.
-supabase db reset
-
-# 4) Restaura supabase/config.toml a la lista completa de schemas.
-
-# 5) Restart de PostgREST para que recoja los schemas nuevos.
-supabase stop  # SIN --no-backup, preserva el DB con migrations
-supabase start
-
-# 6) Ya puedes correr los integration tests.
+supabase start          # levanta el stack local y aplica las migraciones
 npm run test:integration
 ```
 
-### Uso normal (después del bootstrap)
-
-```bash
-supabase start          # 10-15s — DB persiste entre stop/start sin --no-backup
-npm run test:integration
-```
-
-### Reset clean
-
-```bash
-supabase stop --no-backup   # destruye el DB volume
-# Después tienes que repetir el bootstrap completo arriba.
-```
-
-Para detener:
-
-```bash
-supabase stop
-# o `supabase stop --no-backup` si no quieres preservar el state.
-```
+Si el stack ya estaba corriendo con estado viejo (las migraciones nuevas no
+se re-aplican a una stack viva): `supabase db reset`, o
+`supabase stop --no-backup && supabase start` para reconstruir desde cero.
 
 ## Estructura
 
 ```
 tests/integration/
-├── smoke.integration.test.ts       # Valida que el pipeline está OK.
-└── (futuros tests aquí)
+├── helpers.ts                            # clientes (service/anon), fixtures
+│                                         # financieras, usuarios auth con rol
+├── smoke.integration.test.ts             # el pipeline está OK (stack, schemas, RPCs)
+├── finanzas-cxc.integration.test.ts      # FIFO, cancelar revierte, re-aplicar,
+│                                         # ajustar cargo, movimiento espejo
+├── finanzas-cxp.integration.test.ts      # comprometido vivo, dedup uuid_sat,
+│                                         # gate Dirección de cxp_pago_aprobar
+└── perimetro-anon.integration.test.ts    # anon-negativo: RPCs de dinero = 42501
+                                          # (red del Sprint 0 de la revisión 2026-06-12)
 ```
 
-`vitest.integration.config.ts` usa `singleFork: true` para que los
-tests corran serialmente — la DB es compartida y paralelizar genera
-race conditions con SELECT/INSERT del mismo registro.
+`vitest.integration.config.ts` usa `singleFork: true` — la DB es compartida
+y paralelizar genera race conditions.
+
+## Convenciones para tests nuevos
+
+1. Archivo en `tests/integration/{feature}.integration.test.ts`.
+2. Fixtures vía `helpers.ts` (`crearFixturesFinancieras` crea empresa/
+   cliente/proveedor/cuenta con `runTag` único — las corridas no chocan
+   entre sí y no hace falta cleanup: la shadow es desechable).
+3. **Assertar comportamiento (saldos, estados, audit), no existencia.** El
+   objetivo es que una migración que redefina mal una RPC truene aquí.
+4. Para gates por rol: `crearUsuarioConRol` crea un usuario de auth REAL con
+   `core.usuarios.id = auth.uid()` (requisito de `core.fn_user_has_role` y
+   del FK de `core.audit_log`) y devuelve un cliente autenticado.
+5. Para probar el perímetro: cliente `anonClient()` y assertar **42501 /
+   permission denied** — un error de negocio significa que anon alcanzó el
+   cuerpo de la función.
+6. Las llaves hardcodeadas en `helpers.ts` son los JWTs demo públicos del
+   CLI local (iss `supabase-demo`) — no son secrets.
 
 ## Troubleshooting
 
-### `supabase start` falla con "Cannot connect to Docker daemon"
-
-Docker no está corriendo. Abre OrbStack/Docker Desktop primero.
-
-### `supabase start` cuelga descargando
-
-Primera vez tarda. Si lleva >15 min sin avanzar, `supabase stop` y
-re-intentar.
-
-### Tests fallan con "PGRST202: function does not exist"
-
-Las migrations no se aplicaron al DB local. Corre:
-
-```bash
-supabase db reset
-```
-
-### El smoke test pasa pero un test específico falla
-
-Probable drift del schema entre producción y migrations: alguna RPC
-en producción se modificó sin migration. Investigar con
-`supabase/SCHEMA_REF.md` y comparar con la signature que el RPC tenía
-cuando el test fue escrito.
-
-### Quiero ver el state actual de la DB local
-
-```bash
-# Studio (UI web) en http://localhost:54323
-supabase status
-```
-
-## Cómo agregar tests nuevos
-
-1. Archivo en `tests/integration/{feature}.integration.test.ts`.
-2. Import del cliente desde el archivo (los defaults de `supabase
-start` están en el smoke test como referencia).
-3. **Cleanup obligatorio entre tests**: usa `beforeEach` para
-   resetear el state que tu test necesita. La DB persiste entre
-   tests del mismo run.
-4. **Sin paralelismo**: el config force-a `singleFork`. Si tu test
-   asume serialidad, está bien.
-5. **Usar service role key** para crear fixtures (no necesitas auth
-   real para validar lógica DB). Si tu test específicamente prueba
-   RLS, usa anon key + JWT generado.
+- **"Cannot connect to Docker daemon"** → abre OrbStack/Docker Desktop.
+- **PGRST202 "function does not exist"** → migraciones sin aplicar:
+  `supabase db reset`.
+- **Un test financiero falla tras tocar una migración** → probablemente
+  detectó exactamente lo que debe detectar: la RPC cambió de comportamiento.
+  Compara el cuerpo contra `supabase/FUNCTIONS_REF.md` (fuente canónica) y
+  decide si el cambio es intencional (actualiza el test) o una regresión
+  (arregla la migración partiendo del cuerpo canónico).
+- **Studio local**: http://localhost:54323 (`supabase status`).
 
 ## Referencias
 
-- Sprint 3C de `tech-debt-h1-2026` (planning doc).
-- ADR pendiente: documentar este setup en
-  `docs/adr/NNNN_integration_testing.md` cuando el patrón se
-  estabilice tras 2-3 sprints de uso.
+- `docs/planning/blindaje-financiero.md` (S2) y
+  `docs/strategy/REVISION-GENERAL-BSOP-2026-06-12.md` (hallazgo C5b).
+- `supabase/GOVERNANCE.md` §3 (modelo shadow / derivados sin drift).
 - [Supabase CLI docs](https://supabase.com/docs/guides/cli/local-development).

--- a/tests/integration/finanzas-cxc.integration.test.ts
+++ b/tests/integration/finanzas-cxc.integration.test.ts
@@ -1,0 +1,331 @@
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  serviceClient,
+  crearFixturesFinancieras,
+  crearCargo,
+  leerCargo,
+  type FixturasFinancieras,
+} from './helpers';
+
+/**
+ * Tests de COMPORTAMIENTO del subledger CxC (`blindaje-financiero` S2).
+ *
+ * Ejercitan las RPCs de dinero contra el stack local assertando SALDOS —
+ * no existencia. Son la red de seguridad de la clase del incidente FIFO:
+ * si una migración redefine `cxc_pago_registrar` partiendo de una versión
+ * vieja (p.ej. reintroduce el AND que filtraba por fuente), estos tests
+ * truenan en CI antes del merge.
+ *
+ * Invariantes lockeadas:
+ *   - FIFO por fecha_vencimiento/numero, SIN filtrar por fuente
+ *     (decisión 20260601180854: la fuente es etiqueta de reportería).
+ *   - Cancelar un abono revierte los saldos de los cargos (trigger recalc).
+ *   - Re-aplicar valida Σ aplicaciones ≤ monto del abono.
+ *   - Ajustar un cargo respeta el piso de lo ya pagado y deriva el estado.
+ *   - Registrar con cuenta bancaria emite el movimiento espejo (ADR-037 D4).
+ */
+
+let svc: SupabaseClient;
+let fx: FixturasFinancieras;
+
+beforeAll(async () => {
+  svc = serviceClient();
+  fx = await crearFixturesFinancieras(svc);
+});
+
+/** RPC helper — truena el test si la RPC regresa error (para el camino feliz). */
+async function rpc<T>(fn: string, args: Record<string, unknown>): Promise<T> {
+  const { data, error } = await svc.schema('erp').rpc(fn, args);
+  if (error) throw new Error(`${fn}: ${error.message}`);
+  return data as T;
+}
+
+describe('cxc_pago_registrar — auto-aplicación FIFO', () => {
+  const ventaId = randomUUID();
+  let cargo1: string, cargo2: string, cargo3: string;
+  let abono1: string;
+
+  beforeAll(async () => {
+    // 3 cargos escalonados: 100 (vence primero), 200, 300.
+    cargo1 = await crearCargo(svc, fx, {
+      origenId: ventaId,
+      numero: 1,
+      monto: 100,
+      fechaVencimiento: '2026-01-15',
+    });
+    cargo2 = await crearCargo(svc, fx, {
+      origenId: ventaId,
+      numero: 2,
+      monto: 200,
+      fechaVencimiento: '2026-02-15',
+    });
+    cargo3 = await crearCargo(svc, fx, {
+      origenId: ventaId,
+      numero: 3,
+      monto: 300,
+      fechaVencimiento: '2026-03-15',
+    });
+  });
+
+  it('aplica FIFO: liquida el cargo más viejo y deja parcial el siguiente', async () => {
+    abono1 = await rpc<string>('cxc_pago_registrar', {
+      p_empresa_id: fx.empresaId,
+      p_persona_id: fx.clienteId,
+      p_origen_id: ventaId,
+      p_monto: 250,
+    });
+    expect(abono1).toBeTruthy();
+
+    const c1 = await leerCargo(svc, cargo1);
+    expect(c1).toMatchObject({ monto_pagado: 100, saldo: 0, estado: 'liquidado' });
+
+    const c2 = await leerCargo(svc, cargo2);
+    expect(c2).toMatchObject({ monto_pagado: 150, saldo: 50, estado: 'parcial' });
+
+    const c3 = await leerCargo(svc, cargo3);
+    expect(c3).toMatchObject({ monto_pagado: 0, saldo: 300, estado: 'pendiente' });
+  });
+
+  it('un abono de OTRA fuente baja el mismo saldo (sin filtrar por fuente)', async () => {
+    // Regresión directa del incidente FIFO: el AND por fuente dejaba cargos
+    // pendientes para siempre. Un abono de la institución debe saldar los
+    // cargos del cliente también.
+    await rpc<string>('cxc_pago_registrar', {
+      p_empresa_id: fx.empresaId,
+      p_persona_id: fx.clienteId,
+      p_origen_id: ventaId,
+      p_monto: 50,
+      p_fuente: 'institucion',
+    });
+    const c2 = await leerCargo(svc, cargo2);
+    expect(c2).toMatchObject({ monto_pagado: 200, saldo: 0, estado: 'liquidado' });
+  });
+
+  it('el excedente del abono queda SIN aplicar (no infla cargos)', async () => {
+    // Cargos restantes: solo cargo3 con saldo 300. Abono de 400 → aplica 300.
+    const abonoGrande = await rpc<string>('cxc_pago_registrar', {
+      p_empresa_id: fx.empresaId,
+      p_persona_id: fx.clienteId,
+      p_origen_id: ventaId,
+      p_monto: 400,
+    });
+
+    const c3 = await leerCargo(svc, cargo3);
+    expect(c3).toMatchObject({ monto_pagado: 300, saldo: 0, estado: 'liquidado' });
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: apps } = await (svc.schema('erp') as any)
+      .from('cxc_pago_aplicaciones')
+      .select('monto_aplicado')
+      .eq('pago_id', abonoGrande);
+    const aplicado = (apps ?? []).reduce(
+      (s: number, a: { monto_aplicado: string | number }) => s + Number(a.monto_aplicado),
+      0
+    );
+    expect(aplicado).toBe(300); // 100 quedan como saldo a favor, sin aplicación.
+  });
+
+  it('rechaza monto <= 0', async () => {
+    const { error } = await svc.schema('erp').rpc('cxc_pago_registrar', {
+      p_empresa_id: fx.empresaId,
+      p_persona_id: fx.clienteId,
+      p_origen_id: ventaId,
+      p_monto: 0,
+    });
+    expect(error?.message).toMatch(/debe ser > 0/);
+  });
+
+  it('cancelar el abono revierte los saldos de los cargos', async () => {
+    // abono1 (250) cubría: cargo1 100 + cargo2 150.
+    await rpc('cxc_pago_cancelar', { p_pago_id: abono1, p_motivo: 'test revert' });
+
+    const c1 = await leerCargo(svc, cargo1);
+    expect(c1).toMatchObject({ monto_pagado: 0, saldo: 100, estado: 'pendiente' });
+
+    // cargo2 conserva SOLO el abono de institución (50).
+    const c2 = await leerCargo(svc, cargo2);
+    expect(c2).toMatchObject({ monto_pagado: 50, saldo: 150, estado: 'parcial' });
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: pago } = await (svc.schema('erp') as any)
+      .from('cxc_pagos')
+      .select('deleted_at')
+      .eq('id', abono1)
+      .single();
+    expect(pago?.deleted_at).not.toBeNull();
+  });
+
+  it('cancelar dos veces truena (ya está cancelado)', async () => {
+    const { error } = await svc
+      .schema('erp')
+      .rpc('cxc_pago_cancelar', { p_pago_id: abono1, p_motivo: 'doble' });
+    expect(error?.message).toMatch(/no existe o ya está cancelado/);
+  });
+});
+
+describe('cxc_pago_aplicar — re-aplicación manual', () => {
+  const ventaId = randomUUID();
+  let cargoA: string, cargoB: string;
+  let pagoId: string;
+
+  beforeAll(async () => {
+    cargoA = await crearCargo(svc, fx, {
+      origenId: ventaId,
+      numero: 1,
+      monto: 500,
+      fechaVencimiento: '2026-01-01',
+    });
+    cargoB = await crearCargo(svc, fx, {
+      origenId: ventaId,
+      numero: 2,
+      monto: 500,
+      fechaVencimiento: '2026-02-01',
+    });
+    pagoId = await rpc<string>('cxc_pago_registrar', {
+      p_empresa_id: fx.empresaId,
+      p_persona_id: fx.clienteId,
+      p_origen_id: ventaId,
+      p_monto: 600,
+      p_auto_aplicar: false, // sin FIFO — la aplicación es manual en este flujo
+    });
+  });
+
+  it('sin auto-aplicar, los cargos quedan intactos', async () => {
+    const a = await leerCargo(svc, cargoA);
+    expect(a).toMatchObject({ monto_pagado: 0, estado: 'pendiente' });
+  });
+
+  it('re-aplica reemplazando (no acumulando) y recalcula saldos', async () => {
+    await rpc('cxc_pago_aplicar', {
+      p_pago_id: pagoId,
+      p_aplicaciones: [
+        { cargo_id: cargoA, monto: 400 },
+        { cargo_id: cargoB, monto: 200 },
+      ],
+    });
+    expect((await leerCargo(svc, cargoA)).monto_pagado).toBe(400);
+    expect((await leerCargo(svc, cargoB)).monto_pagado).toBe(200);
+
+    // Segunda aplicación REEMPLAZA (delete + insert), no suma.
+    await rpc('cxc_pago_aplicar', {
+      p_pago_id: pagoId,
+      p_aplicaciones: [{ cargo_id: cargoA, monto: 600 }],
+    });
+    const a = await leerCargo(svc, cargoA);
+    expect(a).toMatchObject({ monto_pagado: 600, estado: 'liquidado' });
+    expect((await leerCargo(svc, cargoB)).monto_pagado).toBe(0);
+  });
+
+  it('rechaza Σ aplicaciones > monto del abono', async () => {
+    const { error } = await svc.schema('erp').rpc('cxc_pago_aplicar', {
+      p_pago_id: pagoId,
+      p_aplicaciones: [
+        { cargo_id: cargoA, monto: 500 },
+        { cargo_id: cargoB, monto: 500 },
+      ],
+    });
+    expect(error?.message).toMatch(/excede el monto del abono/);
+  });
+});
+
+describe('cxc_cargo_ajustar — gobierno del monto', () => {
+  const ventaId = randomUUID();
+  let cargoId: string;
+
+  beforeAll(async () => {
+    cargoId = await crearCargo(svc, fx, {
+      origenId: ventaId,
+      numero: 1,
+      monto: 1000,
+      fechaVencimiento: '2026-01-01',
+    });
+    await rpc('cxc_pago_registrar', {
+      p_empresa_id: fx.empresaId,
+      p_persona_id: fx.clienteId,
+      p_origen_id: ventaId,
+      p_monto: 400,
+    });
+  });
+
+  it('rechaza bajar el monto por debajo de lo ya pagado', async () => {
+    const { error } = await svc.schema('erp').rpc('cxc_cargo_ajustar', {
+      p_cargo_id: cargoId,
+      p_nuevo_monto: 300,
+      p_motivo: 'test',
+    });
+    expect(error?.message).toMatch(/no puede ser menor a lo ya pagado/);
+  });
+
+  it('ajustar el monto al pagado exacto lo deja liquidado', async () => {
+    await rpc('cxc_cargo_ajustar', { p_cargo_id: cargoId, p_nuevo_monto: 400, p_motivo: 'test' });
+    const c = await leerCargo(svc, cargoId);
+    expect(c).toMatchObject({ monto: 400, saldo: 0, estado: 'liquidado' });
+  });
+
+  it('subir el monto lo regresa a parcial', async () => {
+    await rpc('cxc_cargo_ajustar', { p_cargo_id: cargoId, p_nuevo_monto: 900, p_motivo: 'test' });
+    const c = await leerCargo(svc, cargoId);
+    expect(c).toMatchObject({ monto: 900, monto_pagado: 400, saldo: 500, estado: 'parcial' });
+  });
+});
+
+describe('cxc_pago_registrar — gancho de tesorería (ADR-037 D4)', () => {
+  it('con cuenta bancaria emite el movimiento espejo tipo abono', async () => {
+    const ventaId = randomUUID();
+    await crearCargo(svc, fx, {
+      origenId: ventaId,
+      numero: 1,
+      monto: 750,
+      fechaVencimiento: '2026-01-01',
+    });
+    const pagoId = await rpc<string>('cxc_pago_registrar', {
+      p_empresa_id: fx.empresaId,
+      p_persona_id: fx.clienteId,
+      p_origen_id: ventaId,
+      p_monto: 750,
+      p_cuenta_bancaria_id: fx.cuentaBancariaId,
+      p_referencia: 'SPEI-TEST-1',
+    });
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: movs } = await (svc.schema('erp') as any)
+      .from('movimientos_bancarios')
+      .select('tipo, monto, referencia_tipo, referencia_id, cuenta_id, conciliado')
+      .eq('referencia_tipo', 'cxc_pago')
+      .eq('referencia_id', pagoId);
+    expect(movs).toHaveLength(1);
+    expect(movs![0]).toMatchObject({
+      tipo: 'abono',
+      referencia_tipo: 'cxc_pago',
+      cuenta_id: fx.cuentaBancariaId,
+      conciliado: false,
+    });
+    expect(Number(movs![0].monto)).toBe(750);
+  });
+
+  it('sin cuenta bancaria NO emite movimiento', async () => {
+    const ventaId = randomUUID();
+    await crearCargo(svc, fx, {
+      origenId: ventaId,
+      numero: 1,
+      monto: 100,
+      fechaVencimiento: '2026-01-01',
+    });
+    const pagoId = await rpc<string>('cxc_pago_registrar', {
+      p_empresa_id: fx.empresaId,
+      p_persona_id: fx.clienteId,
+      p_origen_id: ventaId,
+      p_monto: 100,
+    });
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: movs } = await (svc.schema('erp') as any)
+      .from('movimientos_bancarios')
+      .select('id')
+      .eq('referencia_tipo', 'cxc_pago')
+      .eq('referencia_id', pagoId);
+    expect(movs).toHaveLength(0);
+  });
+});

--- a/tests/integration/finanzas-cxp.integration.test.ts
+++ b/tests/integration/finanzas-cxp.integration.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  serviceClient,
+  crearFixturesFinancieras,
+  crearUsuarioConRol,
+  type FixturasFinancieras,
+  type UsuarioDePrueba,
+} from './helpers';
+
+/**
+ * Tests de COMPORTAMIENTO del subledger CxP (`blindaje-financiero` S2).
+ *
+ * Además de los saldos, aquí se lockea el GATE de autorización de
+ * `cxp_pago_aprobar` (admin global O rol Dirección de la empresa — política
+ * 2026-06-10) con usuarios de auth REALES: uno con rol Dirección, uno sin
+ * rol. Es el patrón correcto que el reporte 2026-06-12 pide replicar al
+ * resto de las RPCs mutadoras (Sprint 4).
+ */
+
+let svc: SupabaseClient;
+let fx: FixturasFinancieras;
+let direccion: UsuarioDePrueba;
+let sinRol: UsuarioDePrueba;
+
+beforeAll(async () => {
+  svc = serviceClient();
+  fx = await crearFixturesFinancieras(svc);
+  direccion = await crearUsuarioConRol(svc, fx.empresaId, 'Dirección', fx.runTag);
+  sinRol = await crearUsuarioConRol(svc, fx.empresaId, null, fx.runTag);
+});
+
+async function rpc<T>(fn: string, args: Record<string, unknown>): Promise<T> {
+  const { data, error } = await svc.schema('erp').rpc(fn, args);
+  if (error) throw new Error(`${fn}: ${error.message}`);
+  return data as T;
+}
+
+async function altaFactura(total: number): Promise<string> {
+  return rpc<string>('cxp_factura_alta', {
+    p_empresa_id: fx.empresaId,
+    p_proveedor_id: fx.proveedorId,
+    p_total: total,
+  });
+}
+
+describe('cxp_factura_alta + cxp_pago_programar — comprometido vivo', () => {
+  let facturaId: string;
+
+  beforeAll(async () => {
+    facturaId = await altaFactura(1000);
+  });
+
+  it('la factura nace por_pagar con el total correcto', async () => {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: f } = await (svc.schema('erp') as any)
+      .from('facturas')
+      .select('estado_cxp, total, flujo')
+      .eq('id', facturaId)
+      .single();
+    expect(f).toMatchObject({ estado_cxp: 'por_pagar', flujo: 'egreso' });
+    expect(Number(f.total)).toBe(1000);
+  });
+
+  it('programa un pago parcial y valida el comprometido vivo en el segundo', async () => {
+    const pago1 = await rpc<string>('cxp_pago_programar', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: facturaId, monto: 700 }],
+    });
+    expect(pago1).toBeTruthy();
+
+    // Solo quedan 300 por programar: 400 debe tronar.
+    const { error } = await svc.schema('erp').rpc('cxp_pago_programar', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: facturaId, monto: 400 }],
+    });
+    expect(error?.message).toMatch(/excede lo disponible por programar/);
+
+    // 300 exactos sí pasan.
+    const pago2 = await rpc<string>('cxp_pago_programar', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: facturaId, monto: 300 }],
+    });
+    expect(pago2).toBeTruthy();
+  });
+
+  it('cancelar un pago libera lo comprometido (se puede reprogramar)', async () => {
+    const factura = await altaFactura(500);
+    const pago = await rpc<string>('cxp_pago_programar', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: factura, monto: 500 }],
+    });
+
+    // Comprometida al 100%: no cabe ni un peso más.
+    const { error: llena } = await svc.schema('erp').rpc('cxp_pago_programar', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: factura, monto: 1 }],
+    });
+    expect(llena?.message).toMatch(/excede lo disponible/);
+
+    await rpc('cxp_pago_cancelar', { p_pago_id: pago, p_motivo: 'test' });
+
+    // Liberada: el total vuelve a estar disponible.
+    const reprogramado = await rpc<string>('cxp_pago_programar', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: factura, monto: 500 }],
+    });
+    expect(reprogramado).toBeTruthy();
+  });
+
+  it('rechaza factura de otra empresa', async () => {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: otraEmpresa } = await (svc.schema('core') as any)
+      .from('empresas')
+      .insert({ nombre: `Otra ${fx.runTag}`, slug: `test-otra-${fx.runTag}` })
+      .select('id')
+      .single();
+    const { error } = await svc.schema('erp').rpc('cxp_pago_programar', {
+      p_empresa_id: otraEmpresa.id,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: facturaId, monto: 10 }],
+    });
+    expect(error?.message).toMatch(/no existe o es de otra empresa/);
+  });
+
+  it('dedup por uuid_sat: la misma factura no entra dos veces', async () => {
+    const uuidSat = `TEST-UUID-${fx.runTag}`;
+    await rpc<string>('cxp_factura_alta', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_total: 100,
+      p_uuid_sat: uuidSat,
+    });
+    const { error } = await svc.schema('erp').rpc('cxp_factura_alta', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_total: 100,
+      p_uuid_sat: uuidSat,
+    });
+    expect(error?.message).toMatch(/Ya existe una factura con uuid_sat/);
+  });
+});
+
+describe('cxp_pago_aprobar — gate de autorización (admin O Dirección)', () => {
+  let pagoId: string;
+
+  beforeAll(async () => {
+    const factura = await altaFactura(2500);
+    pagoId = await rpc<string>('cxp_pago_programar', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: factura, monto: 2500 }],
+    });
+  });
+
+  it('un usuario SIN rol no puede aprobar', async () => {
+    const { error } = await sinRol.client.schema('erp').rpc('cxp_pago_aprobar', {
+      p_pago_id: pagoId,
+    });
+    expect(error?.message).toMatch(/Solo admin o un usuario con rol Dirección/);
+  });
+
+  it('service role sin sesión tampoco (el gate no asume contexto)', async () => {
+    const { error } = await svc.schema('erp').rpc('cxp_pago_aprobar', { p_pago_id: pagoId });
+    expect(error?.message).toMatch(/Solo admin o un usuario con rol Dirección/);
+  });
+
+  it('un usuario con rol Dirección de la empresa SÍ aprueba (y queda auditado)', async () => {
+    const { error } = await direccion.client.schema('erp').rpc('cxp_pago_aprobar', {
+      p_pago_id: pagoId,
+    });
+    expect(error).toBeNull();
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: pago } = await (svc.schema('erp') as any)
+      .from('cxp_pagos')
+      .select('estado, aprobado_por, aprobado_at')
+      .eq('id', pagoId)
+      .single();
+    expect(pago.estado).toBe('aprobado');
+    expect(pago.aprobado_por).toBe(direccion.userId);
+    expect(pago.aprobado_at).not.toBeNull();
+
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: audit } = await (svc.schema('core') as any)
+      .from('audit_log')
+      .select('usuario_id, accion')
+      .eq('accion', 'cxp_pago_aprobado')
+      .eq('registro_id', pagoId);
+    expect(audit).toHaveLength(1);
+    expect(audit![0].usuario_id).toBe(direccion.userId);
+  });
+
+  it('aprobar dos veces truena (ya no está programado)', async () => {
+    const { error } = await direccion.client.schema('erp').rpc('cxp_pago_aprobar', {
+      p_pago_id: pagoId,
+    });
+    expect(error?.message).toMatch(/no está en estado programado/);
+  });
+
+  it('el rol Dirección de OTRA empresa no autoriza en ésta', async () => {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data: otraEmpresa } = await (svc.schema('core') as any)
+      .from('empresas')
+      .insert({ nombre: `Ajena ${fx.runTag}`, slug: `test-ajena-${fx.runTag}` })
+      .select('id')
+      .single();
+    const direccionAjena = await crearUsuarioConRol(svc, otraEmpresa.id, 'Dirección', fx.runTag);
+
+    const factura = await altaFactura(100);
+    const pago = await rpc<string>('cxp_pago_programar', {
+      p_empresa_id: fx.empresaId,
+      p_proveedor_id: fx.proveedorId,
+      p_aplicaciones: [{ factura_id: factura, monto: 100 }],
+    });
+
+    const { error } = await direccionAjena.client.schema('erp').rpc('cxp_pago_aprobar', {
+      p_pago_id: pago,
+    });
+    expect(error?.message).toMatch(/Solo admin o un usuario con rol Dirección/);
+  });
+});

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -1,0 +1,218 @@
+import { randomUUID } from 'node:crypto';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Helpers compartidos de la suite de integración financiera
+ * (`blindaje-financiero` S2). Corren contra el stack LOCAL de Supabase
+ * (`supabase start`) — nunca contra prod.
+ *
+ * Las llaves son los JWTs demo estándar del CLI de Supabase para stacks
+ * locales (iss `supabase-demo`, públicos y documentados) — NO son secrets.
+ * Mismo patrón que `smoke.integration.test.ts`.
+ */
+
+export const SUPABASE_LOCAL_URL = process.env.SUPABASE_LOCAL_URL ?? 'http://127.0.0.1:54321';
+
+export const SERVICE_ROLE_KEY =
+  process.env.SUPABASE_LOCAL_SERVICE_KEY ??
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+export const ANON_KEY =
+  process.env.SUPABASE_LOCAL_ANON_KEY ??
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+
+export function serviceClient(): SupabaseClient {
+  return createClient(SUPABASE_LOCAL_URL, SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export function anonClient(): SupabaseClient {
+  return createClient(SUPABASE_LOCAL_URL, ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+// ── Fixtures financieras ──────────────────────────────────────────────────────
+
+export interface FixturasFinancieras {
+  empresaId: string;
+  clienteId: string;
+  proveedorId: string;
+  cuentaBancariaId: string;
+  /** Marca única de esta corrida — los fixtures no chocan entre corridas. */
+  runTag: string;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- inserts ad-hoc de
+   fixtures: los types generados no cubren el patrón .schema() dinámico. */
+
+/**
+ * Crea el mundo mínimo para ejercitar las RPCs de dinero: una empresa de
+ * prueba, un cliente, un proveedor y una cuenta bancaria. Idempotente entre
+ * corridas por slug único (no limpia lo de corridas anteriores: la shadow es
+ * desechable y en local no estorba).
+ */
+export async function crearFixturesFinancieras(svc: SupabaseClient): Promise<FixturasFinancieras> {
+  const runTag = randomUUID().slice(0, 8);
+
+  const { data: empresa, error: eErr } = await (svc.schema('core') as any)
+    .from('empresas')
+    .insert({ nombre: `Test Blindaje ${runTag}`, slug: `test-blindaje-${runTag}` })
+    .select('id')
+    .single();
+  if (eErr) throw new Error(`fixture empresa: ${eErr.message}`);
+
+  const { data: cliente, error: cErr } = await (svc.schema('erp') as any)
+    .from('personas')
+    .insert({ empresa_id: empresa.id, nombre: `Cliente Test ${runTag}`, tipo: 'cliente' })
+    .select('id')
+    .single();
+  if (cErr) throw new Error(`fixture cliente: ${cErr.message}`);
+
+  const { data: proveedor, error: pErr } = await (svc.schema('erp') as any)
+    .from('personas')
+    .insert({ empresa_id: empresa.id, nombre: `Proveedor Test ${runTag}`, tipo: 'proveedor' })
+    .select('id')
+    .single();
+  if (pErr) throw new Error(`fixture proveedor: ${pErr.message}`);
+
+  const { data: cuenta, error: cbErr } = await (svc.schema('erp') as any)
+    .from('cuentas_bancarias')
+    .insert({ empresa_id: empresa.id, nombre: `Cuenta Test ${runTag}`, banco: 'Banco Test' })
+    .select('id')
+    .single();
+  if (cbErr) throw new Error(`fixture cuenta: ${cbErr.message}`);
+
+  return {
+    empresaId: empresa.id,
+    clienteId: cliente.id,
+    proveedorId: proveedor.id,
+    cuentaBancariaId: cuenta.id,
+    runTag,
+  };
+}
+
+/**
+ * Crea un cargo CxC directo (fixture, no vía RPC — el plan de cargos lo
+ * origina la venta en prod; aquí solo necesitamos el adeudo).
+ */
+export async function crearCargo(
+  svc: SupabaseClient,
+  fx: FixturasFinancieras,
+  args: {
+    origenId: string;
+    numero: number;
+    monto: number;
+    fechaVencimiento: string;
+    tipoCargo?: string;
+  }
+): Promise<string> {
+  const { data, error } = await (svc.schema('erp') as any)
+    .from('cxc_cargos')
+    .insert({
+      empresa_id: fx.empresaId,
+      persona_id: fx.clienteId,
+      origen_tipo: 'venta_dilesa',
+      origen_id: args.origenId,
+      // CHECK cxc_cargos_tipo_cargo_check: enganche|mensualidad|credito|contado|otro|renta|deposito|penalizacion
+      tipo_cargo: args.tipoCargo ?? 'enganche',
+      numero: args.numero,
+      monto: args.monto,
+      fecha_vencimiento: args.fechaVencimiento,
+    })
+    .select('id')
+    .single();
+  if (error) throw new Error(`fixture cargo: ${error.message}`);
+  return data.id;
+}
+
+export interface CargoEstado {
+  id: string;
+  monto: number;
+  monto_pagado: number;
+  saldo: number;
+  estado: string;
+}
+
+export async function leerCargo(svc: SupabaseClient, cargoId: string): Promise<CargoEstado> {
+  const { data, error } = await (svc.schema('erp') as any)
+    .from('cxc_cargos')
+    .select('id, monto, monto_pagado, saldo, estado')
+    .eq('id', cargoId)
+    .single();
+  if (error) throw new Error(`leerCargo: ${error.message}`);
+  return {
+    ...data,
+    monto: Number(data.monto),
+    monto_pagado: Number(data.monto_pagado),
+    saldo: Number(data.saldo),
+  };
+}
+
+// ── Usuarios autenticados con rol ─────────────────────────────────────────────
+
+export interface UsuarioDePrueba {
+  userId: string;
+  email: string;
+  client: SupabaseClient;
+}
+
+/**
+ * Crea un usuario REAL de auth (GoTrue local) + su fila en `core.usuarios`
+ * con **id = auth.uid()** (requisito de `core.fn_user_has_role`, que matchea
+ * `usuarios_empresas.usuario_id = auth.uid()`; el FK de `core.audit_log`
+ * también apunta a `core.usuarios.id`) y, si se pide, un rol por nombre en
+ * la empresa. Devuelve un cliente AUTENTICADO (anon key + sesión password).
+ */
+export async function crearUsuarioConRol(
+  svc: SupabaseClient,
+  empresaId: string,
+  rolNombre: string | null,
+  runTag: string
+): Promise<UsuarioDePrueba> {
+  const marker = randomUUID().slice(0, 8);
+  const email = `test-${rolNombre ? rolNombre.toLowerCase().replace(/\W+/g, '-') : 'sin-rol'}-${runTag}-${marker}@blindaje.test`;
+  const password = `pw-${randomUUID()}`;
+
+  const { data: created, error: auErr } = await svc.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (auErr || !created.user) throw new Error(`auth createUser: ${auErr?.message}`);
+  const userId = created.user.id;
+
+  const { error: uErr } = await (svc.schema('core') as any).from('usuarios').insert({
+    id: userId, // MISMO uuid que auth.users — ver docstring.
+    email,
+    rol: 'viewer',
+    activo: true,
+    first_name: 'Test',
+    last_name: rolNombre ?? 'SinRol',
+  });
+  if (uErr) throw new Error(`fixture core.usuarios: ${uErr.message}`);
+
+  if (rolNombre) {
+    const { data: rol, error: rErr } = await (svc.schema('core') as any)
+      .from('roles')
+      .insert({ nombre: rolNombre, empresa_id: empresaId })
+      .select('id')
+      .single();
+    if (rErr) throw new Error(`fixture rol: ${rErr.message}`);
+
+    const { error: ueErr } = await (svc.schema('core') as any).from('usuarios_empresas').insert({
+      usuario_id: userId,
+      empresa_id: empresaId,
+      rol_id: rol.id,
+      activo: true,
+    });
+    if (ueErr) throw new Error(`fixture usuarios_empresas: ${ueErr.message}`);
+  }
+
+  const client = anonClient();
+  const { error: siErr } = await client.auth.signInWithPassword({ email, password });
+  if (siErr) throw new Error(`signIn: ${siErr.message}`);
+
+  return { userId, email, client };
+}

--- a/tests/integration/perimetro-anon.integration.test.ts
+++ b/tests/integration/perimetro-anon.integration.test.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from 'node:crypto';
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { anonClient } from './helpers';
+
+/**
+ * Caso ANON-NEGATIVO (`blindaje-financiero` S2 — red del Sprint 0).
+ *
+ * El Sprint 0 de la revisión 2026-06-12 (PRs #876/#877 + migración
+ * 20260613032841) revocó EXECUTE de `anon` en las RPCs financieras y el
+ * default grant que lo perpetuaba. Antes de eso, un cliente con la anon key
+ * (pública, viaja en el bundle de Vercel) INSERTÓ un cxc_pago real en prod.
+ *
+ * Estos tests son la red de regresión de ese perímetro: si una migración
+ * futura re-otorga EXECUTE a anon (o un default grant nuevo lo revive),
+ * truenan en CI. La aserción es estricta: el error debe ser de PERMISO
+ * (42501 / permission denied) — NO de lógica de negocio, porque eso
+ * significaría que anon ALCANZÓ a ejecutar el cuerpo de la función.
+ */
+
+let anon: SupabaseClient;
+
+beforeAll(() => {
+  anon = anonClient();
+});
+
+/** Las RPCs mutadoras de dinero que el Sprint 0 cerró a anon. */
+const RPCS_MUTADORAS: Array<{ fn: string; args: Record<string, unknown> }> = [
+  {
+    fn: 'cxc_pago_registrar',
+    args: {
+      p_empresa_id: randomUUID(),
+      p_persona_id: randomUUID(),
+      p_origen_id: randomUUID(),
+      p_monto: 1,
+    },
+  },
+  {
+    fn: 'cxc_pago_aplicar',
+    args: { p_pago_id: randomUUID(), p_aplicaciones: [] },
+  },
+  {
+    fn: 'cxc_pago_cancelar',
+    args: { p_pago_id: randomUUID(), p_motivo: 'x' },
+  },
+  {
+    fn: 'cxc_cargo_ajustar',
+    args: { p_cargo_id: randomUUID(), p_nuevo_monto: 1, p_motivo: 'x' },
+  },
+  {
+    fn: 'cxp_factura_alta',
+    args: { p_empresa_id: randomUUID(), p_proveedor_id: randomUUID(), p_total: 1 },
+  },
+  {
+    fn: 'cxp_pago_programar',
+    args: { p_empresa_id: randomUUID(), p_proveedor_id: randomUUID(), p_aplicaciones: [] },
+  },
+  { fn: 'cxp_pago_aprobar', args: { p_pago_id: randomUUID() } },
+  { fn: 'cxp_pago_cancelar', args: { p_pago_id: randomUUID(), p_motivo: 'x' } },
+  { fn: 'fn_aplicar_levantamiento', args: { p_levantamiento_id: randomUUID() } },
+];
+
+describe('perímetro anon — RPCs mutadoras de dinero', () => {
+  for (const { fn, args } of RPCS_MUTADORAS) {
+    it(`anon NO puede ejecutar erp.${fn}`, async () => {
+      const { error } = await anon.schema('erp').rpc(fn, args);
+      // Debe fallar...
+      expect(error, `anon ejecutó erp.${fn} sin error`).not.toBeNull();
+      // ...y fallar por PERMISO, no por lógica interna (42501 = insufficient
+      // privilege). Un error de negocio ("no existe", "debe ser > 0")
+      // significaría que anon entró al cuerpo de la función.
+      expect(
+        error!.code === '42501' || /permission denied/i.test(error!.message),
+        `erp.${fn}: anon alcanzó el cuerpo de la función — error inesperado: [${error!.code}] ${error!.message}`
+      ).toBe(true);
+    });
+  }
+});
+
+describe('perímetro anon — lecturas financieras', () => {
+  it('anon NO lee erp.v_partida_control (regresión C2, security_invoker)', async () => {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data, error } = await (anon.schema('erp') as any)
+      .from('v_partida_control')
+      .select('*')
+      .limit(1);
+    // Aceptamos dos desenlaces seguros: error de permiso o 0 filas (RLS).
+    // Lo que NO puede pasar: filas con montos.
+    if (error) {
+      expect(error.code === '42501' || /permission denied/i.test(error.message)).toBe(true);
+    } else {
+      expect(data).toHaveLength(0);
+    }
+  });
+
+  it('anon NO lee erp.cxc_pagos', async () => {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data, error } = await (anon.schema('erp') as any)
+      .from('cxc_pagos')
+      .select('id')
+      .limit(1);
+    if (error) {
+      expect(error.code === '42501' || /permission denied/i.test(error.message)).toBe(true);
+    } else {
+      expect(data).toHaveLength(0);
+    }
+  });
+
+  it('anon NO lee erp.movimientos_bancarios', async () => {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const { data, error } = await (anon.schema('erp') as any)
+      .from('movimientos_bancarios')
+      .select('id')
+      .limit(1);
+    if (error) {
+      expect(error.code === '42501' || /permission denied/i.test(error.message)).toBe(true);
+    } else {
+      expect(data).toHaveLength(0);
+    }
+  });
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -11,17 +11,17 @@ import path from 'node:path';
  *     paralelizar para evitar race conditions.
  *   - **Sin coverage** — los integration tests cubren paths que ya
  *     están en el coverage del unit test config; no doble-contamos.
- *   - **Opt-in**: corre con `npm run test:integration`, NO con
- *     `npm run test:run`. CI default no los corre.
+ *   - Corre con `npm run test:integration` (NO con `npm run test:run`).
+ *     En CI corre dentro de `schema-check.yml` contra la shadow DB, en
+ *     PRs que tocan migraciones/derivados/esta suite (blindaje-financiero S2).
  *
- * Pre-requisitos para correr (ver `docs/testing/integration-setup.md`):
+ * Pre-requisitos para correr local (ver `docs/testing/integration-setup.md`):
  *   1. Docker corriendo (OrbStack / Docker Desktop).
- *   2. `supabase start` levantado en localhost:54321.
- *   3. `supabase db reset` aplicó las 211 migrations al DB local.
+ *   2. `supabase start` levantado en localhost:54321 (aplica las
+ *      migraciones del repo a la DB local desde cero).
  *
- * Las env vars apuntan a la instancia local (no a producción) — los
- * defaults del CLI de Supabase generan llaves predecibles que se
- * inyectan en `tests/integration/setup.ts`.
+ * Las llaves apuntan a la instancia local (no a producción) — son los JWTs
+ * demo estándar del CLI de Supabase, definidos en `tests/integration/helpers.ts`.
  */
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Qué hace

Sprint 2 de `blindaje-financiero` (S1: #1206). Las RPCs de dinero pasan de "cero tests de comportamiento" (hallazgo C5b de la revisión 2026-06-12) a una suite de integración que **asserta saldos** contra la shadow DB y **corre en CI** en todo PR que toca migraciones.

### Suite (39 tests, ~1s)

| Archivo | Lockea |
|---|---|
| `finanzas-cxc.integration.test.ts` | FIFO por vencimiento **sin filtrar por fuente** (la regresión exacta del incidente FIFO de 11 días), cancelar revierte saldos, re-aplicar reemplaza + valida Σ ≤ abono, ajustar cargo respeta el piso de lo pagado, movimiento bancario espejo (ADR-037 D4) |
| `finanzas-cxp.integration.test.ts` | Comprometido vivo al programar (no sobre-programa), cancelar libera, dedup `uuid_sat`, y el **gate Dirección** de `cxp_pago_aprobar` con usuarios de auth reales: con rol aprueba y queda auditado; sin rol, Dirección de otra empresa y service role truenan |
| `perimetro-anon.integration.test.ts` | Las 9 RPCs mutadoras con anon key → **42501 estricto** (si el error es de negocio, anon alcanzó el cuerpo = el REVOKE se perdió) + `v_partida_control`/`cxc_pagos`/`movimientos_bancarios` cerradas a anon. Red de regresión permanente del Sprint 0 (#877) |

### Harness

`tests/integration/helpers.ts`: fixtures financieras con `runTag` único (corridas no chocan, sin cleanup — la shadow es desechable) y `crearUsuarioConRol` que crea el usuario de auth con `core.usuarios.id = auth.uid()` — requisito real de `core.fn_user_has_role` (matchea `usuarios_empresas.usuario_id = auth.uid()`) y del FK de `core.audit_log.usuario_id`.

### CI

Paso nuevo en `schema-check.yml` después de levantar la shadow (costo marginal ~1s); triggers ampliados para que PRs que tocan `tests/integration/**` o el config también validen. `docs/testing/integration-setup.md` actualizado (CI ya los corre; el bootstrap chicken-egg de config.toml ya no aplica; fuera el "211 migrations").

## Sin cambios de schema

Solo tests + workflow + docs. No hay migración.

## Checks locales

typecheck ✓ · test:coverage 2358/2358 ✓ · test:integration **39/39** ✓ · lint 0 errores ✓ · format:check ✓ · initiatives:validate ✓

Sigue: **Sprint 3** — cierre de fase como RPC transaccional con gate PLD en DB (absorbe `marcarFase`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)